### PR TITLE
Don't add types from assignment to internal PHP classes' properties

### DIFF
--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -451,6 +451,11 @@ class AssignmentVisitor extends AnalysisVisitor
                     }
                 }
                 return $this->context;
+            } else if ($clazz->isPHPInternal() && $clazz->getFQSEN() !== FullyQualifiedClassName::getStdClassFQSEN()) {
+                // We don't want to modify the types of internal classes such as \ast\Node even if they are compatible
+                // This would result in unpredictable results, and types which are more specific than they really are.
+                // stdClass is an exception to this, for issues such as https://github.com/etsy/phan/pull/700
+                return $this->context;
             } else {
                 if (!$this->right_type->canCastToExpandedUnionType(
                         $property_union_type,
@@ -467,7 +472,6 @@ class AssignmentVisitor extends AnalysisVisitor
                         "{$clazz->getFQSEN()}::{$property->getName()}",
                         (string)$property_union_type
                     );
-
                     return $this->context;
                 }
             }


### PR DESCRIPTION
Other than for stdClass, we should use the types provided by the
Reflection default properties and from phan's type signature maps.
It would be confusing to have one file's usage of an internal class
affect another file's analysis, and internal types should theoretically have a fixed set of types.

Thoughts?