### PR TITLE
Warn about undeclared internal functions by default

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -393,6 +393,12 @@ return [
     // (e.g. PHP is compiled with --enable-debug or when using XDebug)
     'skip_slow_php_options_warning' => false,
 
+    // Set this to false to emit PhanUndeclaredFunction issues for internal functions that Phan has signatures for,
+    // but aren't available in the codebase, or the internal functions used to run phan (may lead to false positives if an extension isn't loaded)
+    // If this is true(default), then Phan will not warn.
+    // (Would like to override to false for phan self-analysis, but Windows self-tests would fail)
+    'ignore_undeclared_functions_with_known_signatures' => true,
+
     // A list of plugin files to execute
     'plugins' => [
         '.phan/plugins/AlwaysReturnPlugin.php',

--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,10 @@ Phan NEWS
 New Features(Analysis)
 + Check types of dimensions when using array access syntax (#406, #1093)
   (E.g. for an `array`, check that the array dimension can cast to `int|string`)
++ Add option `ignore_undeclared_functions_with_known_signatures` which can be set to `false`
+  to always warn about global functions Phan has signatures for
+  but are unavailable in the current PHP process (and enabled extensions, and the project being analyzed) (#1080)
+  The default was/is to not warn, to reduce false positives.
 
 Maintenance
 + Increased minimum `ext-ast` version constraint to 0.1.5, switched to AST version 50.

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -715,8 +715,10 @@ class CodeBase
             return $has_function;
         }
 
-        // Check to see if this is an internal function that hasn't
-        // been loaded yet.
+        // Make the following checks:
+        //
+        // 1. this is an internal function that hasn't been loaded yet.
+        // 2. Unless 'ignore_undeclared_functions_with_known_signatures' is true, require that the current php binary or it's extensions define this function before that.
         return $this->hasInternalFunctionWithFQSEN($fqsen);
     }
 
@@ -959,10 +961,17 @@ class CodeBase
             return false;
         }
 
+        if (!Config::get()->ignore_undeclared_functions_with_known_signatures) {
+            // Act as though functions don't exist if they aren't loaded into the php binary
+            // running phan (or that binary's extensions), even if the signature map contains them.
+            // (All of the functions were loaded during initialization)
+            return false;
+        }
+
         // For elements in the root namespace, check to see if
         // there's a static method signature for something that
         // hasn't been loaded into memory yet and create a
-        // method out of it as its requested
+        // method out of it as it's requested
 
         $function_signature_map =
             UnionType::internalFunctionSignatureMap();

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -551,6 +551,11 @@ class Config
         // (e.g. PHP is compiled with --enable-debug or when using XDebug)
         'skip_slow_php_options_warning' => false,
 
+        // Set this to false to emit PhanUndeclaredFunction issues for internal functions that Phan has signatures for,
+        // but aren't available in the codebase, or the internal functions used to run phan (may lead to false positives if an extension isn't loaded)
+        // If this is true(default), then Phan will not warn.
+        'ignore_undeclared_functions_with_known_signatures' => true,
+
         // Path to a unix socket for a daemon to listen to files to analyze. Use command line option instead.
         'daemonize_socket' => false,
 

--- a/tests/.phan/config.php
+++ b/tests/.phan/config.php
@@ -44,6 +44,12 @@ return [
     // a call to parent::__construct() is required.
     'parent_constructor_required' => ['Child283'],
 
+    // Set this to false to emit PhanUndeclaredFunction issues for internal functions that Phan has signatures for,
+    // but aren't available in the codebase, or the internal functions used to run phan (may lead to false positives if an extension isn't loaded)
+    // If this is true(default), then Phan will not warn.
+    // This is set to true for a unit test.
+    'ignore_undeclared_functions_with_known_signatures' => true,
+
     // If true, Phan will read `class_alias` calls in the global scope,
     // then (1) create aliases from the *parsed* files if no class definition was found,
     // and (2) emit issues in the global scope if the source or target class is invalid.


### PR DESCRIPTION
(even if they aren't available in the binary used to run phan.)

Proposed fix for #1080

The bug that #74 is meant to fix (e.g. for `apache_request_headers`) may affect
only a small fraction of use cases, and can be worked around by adding
a stub function implementation to the parsed files (e.g. in .phan/stubs).

- old(current) behavior is inconsistent with what Phan does for classes and methods