### PR TITLE
Fixes #1093 and #406 : Check types of dimensions when using array access syntax

### DIFF
--- a/.phan/plugins/DemoLegacyPlugin.php
+++ b/.phan/plugins/DemoLegacyPlugin.php
@@ -103,7 +103,7 @@ class DemoLegacyPlugin extends PluginImplementation {
                 $code_base,
                 $class->getContext(),
                 'DemoPluginClassName',
-                "Class {CLASS} cannot be called `Class`"
+                "Class {CLASS} cannot be called `Class`",
                 [(string)$class->getFQSEN()]
             );
         }

--- a/.phan/plugins/DemoPlugin.php
+++ b/.phan/plugins/DemoPlugin.php
@@ -87,7 +87,7 @@ class DemoPlugin extends PluginV2 implements
                 $code_base,
                 $class->getContext(),
                 'DemoPluginClassName',
-                "Class {CLASS} cannot be called `Class`"
+                "Class {CLASS} cannot be called `Class`",
                 [(string)$class->getFQSEN()]
             );
         }

--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,10 @@ Phan NEWS
 ?? ??? 2017, Phan 0.10.0 (dev)
 -----------------------
 
+New Features(Analysis)
++ Check types of dimensions when using array access syntax (#406, #1093)
+  (E.g. for an `array`, check that the array dimension can cast to `int|string`)
+
 Maintenance
 + Increased minimum `ext-ast` version constraint to 0.1.5, switched to AST version 50.
 + Update links to project from github.com/etsy/phan to github.com/phan/phan.

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -61,6 +61,9 @@ class Issue
     const TypeMismatchArgument      = 'PhanTypeMismatchArgument';
     const TypeMismatchArgumentInternal = 'PhanTypeMismatchArgumentInternal';
     const TypeMismatchDefault       = 'PhanTypeMismatchDefault';
+    const TypeMismatchDimAssignment = 'PhanTypeMismatchDimAssignment';
+    const TypeMismatchDimEmpty      = 'PhanTypeMismatchDimEmpty';
+    const TypeMismatchDimFetch      = 'PhanTypeMismatchDimFetch';
     const TypeMismatchVariadicComment = 'PhanMismatchVariadicComment';
     const TypeMismatchVariadicParam = 'PhanMismatchVariadicParam';
     const TypeMismatchForeach       = 'PhanTypeMismatchForeach';
@@ -882,6 +885,30 @@ class Issue
                 'Found an instanceof class name of type {TYPE}, but class name must be a valid object or a string',
                 self::REMEDIATION_B,
                 10029
+            ),
+            new Issue(
+                self::TypeMismatchDimAssignment,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                'When appending to a value of type {TYPE}, found an array access index of type {TYPE}, but expected the index to be of type {TYPE}',
+                self::REMEDIATION_B,
+                10030
+            ),
+            new Issue(
+                self::TypeMismatchDimEmpty,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                'Assigning to an empty array index of a value of type {TYPE}, but expected the index to exist and be of type {TYPE}',
+                self::REMEDIATION_B,
+                10031
+            ),
+            new Issue(
+                self::TypeMismatchDimFetch,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                'When fetching an array index from a value of type {TYPE}, found an array index of type {TYPE}, but expected the index to be of type {TYPE}',
+                self::REMEDIATION_B,
+                10032
             ),
             // Issue::CATEGORY_VARIABLE
             new Issue(

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -1066,9 +1066,24 @@ class UnionType implements \Serializable
             return false;
         }
 
-        // TODO: change check to "any", not "each"?
-        return !ArraySet::exists($this->type_set, function (Type $type) : bool {
-            return !$type->isArrayLike();
+        return ArraySet::exists($this->type_set, function (Type $type) : bool {
+            return $type->isArrayLike();
+        });
+    }
+
+    /**
+     * @return bool
+     * True if this union has array-like types (is of type array, is
+     * a generic array, or implements ArrayAccess).
+     */
+    public function hasGenericArray() : bool
+    {
+        if ($this->isEmpty()) {
+            return false;
+        }
+
+        return ArraySet::exists($this->type_set, function (Type $type) : bool {
+            return $type->isGenericArray();
         });
     }
 
@@ -1083,7 +1098,6 @@ class UnionType implements \Serializable
             return false;
         }
 
-        // TODO: change check to "any", not "each"?
         return ArraySet::exists($this->type_set, function (Type $type) : bool {
             return $type->isArrayAccess();
         });
@@ -1404,21 +1418,6 @@ class UnionType implements \Serializable
 
     /**
      * @return bool
-     * True if this type has any generic types
-     */
-    public function hasGenericArray() : bool
-    {
-        if ($this->isEmpty()) {
-            return false;
-        }
-
-        return ArraySet::exists($this->type_set, function (Type $type) : bool {
-            return $type->isGenericArray();
-        });
-    }
-
-    /**
-     * @return bool
      * True if any of the types in this UnionType made $matcher_callback return true
      */
     public function hasTypeMatchingCallback(\Closure $matcher_callback) : bool
@@ -1662,6 +1661,7 @@ class UnionType implements \Serializable
      *
      * @param Type[] $type_set (Containing only non-nullable values)
      * return Type[] possibly modified $type_set
+     * @var int $bool_id
      */
     private static function asTypeSetWithNormalizedNonNullableBools(array $type_set) : array
     {
@@ -1675,6 +1675,9 @@ class UnionType implements \Serializable
             $bool_type = BoolType::instance(false);
             $bool_id = \runkit_object_id($bool_type);
         }
+        \assert(\is_int($bool_id));
+        \assert(\is_int($true_id));
+        \assert(\is_int($false_id));
         unset($type_set[$true_id]);
         unset($type_set[$false_id]);
         if (!isset($type_set[$bool_id])) {
@@ -1702,6 +1705,9 @@ class UnionType implements \Serializable
             $bool_type = BoolType::instance(true);
             $bool_id = \runkit_object_id($bool_type);
         }
+        \assert(\is_int($bool_id));
+        \assert(\is_int($true_id));
+        \assert(\is_int($false_id));
         unset($type_set[$true_id]);
         unset($type_set[$false_id]);
         if (!isset($type_set[$bool_id])) {

--- a/tests/files/expected/0354_string_index.php.expected
+++ b/tests/files/expected/0354_string_index.php.expected
@@ -1,0 +1,12 @@
+%s:9 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is string but \intdiv() takes int
+%s:10 PhanTypeMismatchDimEmpty Assigning to an empty array index of a value of type string, but expected the index to exist and be of type int
+%s:10 PhanTypeMismatchProperty Assigning string[] to property but \A354::foo is string
+%s:13 PhanTypeMismatchArgumentInternal Argument 1 (var) is string but \count() takes \Countable|array
+%s:14 PhanTypeMismatchDimEmpty Assigning to an empty array index of a value of type string, but expected the index to exist and be of type int
+%s:16 PhanTypeMismatchDimAssignment When appending to a value of type string, found an array access index of type string, but expected the index to be of type int
+%s:16 PhanTypeMismatchDimFetch When fetching an array index from a value of type string, found an array index of type string, but expected the index to be of type int
+%s:22 PhanTypeMismatchDimFetch When fetching an array index from a value of type string, found an array index of type array, but expected the index to be of type int
+%s:23 PhanTypeMismatchDimFetch When fetching an array index from a value of type string, found an array index of type string, but expected the index to be of type int
+%s:24 PhanTypeMismatchDimFetch When fetching an array index from a value of type string, found an array index of type null, but expected the index to be of type int
+%s:27 PhanTypeMismatchDimFetch When fetching an array index from a value of type string[], found an array index of type array, but expected the index to be of type int|string
+%s:28 PhanTypeMismatchDimFetch When fetching an array index from a value of type string[], found an array index of type null, but expected the index to be of type int|string

--- a/tests/files/src/0354_string_index.php
+++ b/tests/files/src/0354_string_index.php
@@ -1,0 +1,31 @@
+<?php
+
+class A354 {
+    /** @var string */
+    public $foo = 'aaa';
+
+    public function test() {
+        $this->foo[1] = 'x';
+        intdiv($this->foo, 2);
+        $this->foo[] = 'x';  // should warn
+        $x = 'aaa';
+        $x[2] = '1';
+        echo count($x);  // should warn.
+        $x[] = 'c';  // should warn
+        $y = 'aaa';
+        $y['offset'] = 'c';
+    }
+
+    public function testFetch() {
+        $str = 'abc';
+        $x = $str[0];
+        $y = $str[[]];  // wrong
+        $z = $str['offset'];  // wrong
+        $a = $str[null];  // wrong
+        $arr = ['offset' => 'c'];
+        $b = $arr['offset'];
+        $c = $arr[[]];  // wrong
+        $c = $arr[null];  // wrong
+        $c = $arr[0];  // Phan isn't able to tell that this is wrong.
+    }
+}


### PR DESCRIPTION
Perform these checks both for assignment and for retrieval.

1. Check arrays are passed `int|string` as dimensions
2. For now, be permissive about `ArrayAccess` interface, allow any
   dimension.
3. Check strings are passed `int` as dimensions (string offset)
4. Warn about empty array access assignment to `string`

Fix a bug noticed in demo plugin (probably unreachable for valid php code)