### PR TITLE
Fix bug checking for unused suppressions, improve property analysis feature.

### DIFF
--- a/.phan/plugins/DemoPlugin.php
+++ b/.phan/plugins/DemoPlugin.php
@@ -6,17 +6,19 @@ use Phan\Language\Context;
 use Phan\Language\Element\Clazz;
 use Phan\Language\Element\Func;
 use Phan\Language\Element\Method;
+use Phan\Language\Element\Property;
 use Phan\PluginV2;
 use Phan\PluginV2\AnalyzeClassCapability;
 use Phan\PluginV2\AnalyzeFunctionCapability;
 use Phan\PluginV2\AnalyzeMethodCapability;
+use Phan\PluginV2\AnalyzePropertyCapability;
 use Phan\PluginV2\AnalyzeNodeCapability;
 use Phan\PluginV2\PluginAwareAnalysisVisitor;
 use ast\Node;
 
 /**
  * This file demonstrates plugins for Phan.
- * This Plugin hooks into four events;
+ * This Plugin hooks into five events;
  *
  * - getAnalyzeNodeVisitorClassName
  *   This method returns a class that is called on every AST node from every
@@ -33,6 +35,10 @@ use ast\Node;
  * - analyzeFunction
  *   Once all functions have been parsed, this method will
  *   be called on every function in the code base.
+ *
+ * - analyzeProperty
+ *   Once all functions have been parsed, this method will
+ *   be called on every property in the code base.
  *
  * A plugin file must
  *
@@ -53,7 +59,8 @@ class DemoPlugin extends PluginV2 implements
     AnalyzeClassCapability,
     AnalyzeFunctionCapability,
     AnalyzeMethodCapability,
-    AnalyzeNodeCapability {
+    AnalyzeNodeCapability,
+    AnalyzePropertyCapability {
 
     /**
      * @return string - The name of the visitor that will be called (formerly analyzeNode)
@@ -150,6 +157,33 @@ class DemoPlugin extends PluginV2 implements
         }
     }
 
+    /**
+     * @param CodeBase $code_base
+     * The code base in which the function exists
+     *
+     * @param Property $property
+     * A function being analyzed
+     *
+     * @return void
+     *
+     * @override
+     */
+    public function analyzeProperty(
+        CodeBase $code_base,
+        Property $property
+    ) {
+        // As an example, we test to see if the name of the
+        // function is `foo`, and emit an issue if it is.
+        if ($property->getName() == 'property') {
+            $this->emitIssue(
+                $code_base,
+                $property->getContext(),
+                'DemoPluginPropertyName',
+                "Property {PROPERTY} should not be called `property`",
+                [(string)$property->getFQSEN()]
+            );
+        }
+    }
 }
 
 /**

--- a/.phan/plugins/UnusedSuppressionPlugin.php
+++ b/.phan/plugins/UnusedSuppressionPlugin.php
@@ -3,13 +3,15 @@
 use Phan\AST\AnalysisVisitor;
 use Phan\CodeBase;
 use Phan\Language\Context;
+use Phan\Language\Element\AddressableElement;
 use Phan\Language\Element\Clazz;
 use Phan\Language\Element\Func;
 use Phan\Language\Element\Method;
-use Phan\Language\Element\AddressableElement;
+use Phan\Language\Element\Property;
 use Phan\PluginV2;
 use Phan\PluginV2\AnalyzeClassCapability;
 use Phan\PluginV2\AnalyzeFunctionCapability;
+use Phan\PluginV2\AnalyzePropertyCapability;
 use Phan\PluginV2\AnalyzeMethodCapability;
 use ast\Node;
 
@@ -22,7 +24,8 @@ use ast\Node;
 class UnusedSuppressionPlugin extends PluginV2 implements
     AnalyzeClassCapability,
     AnalyzeFunctionCapability,
-    AnalyzeMethodCapability {
+    AnalyzeMethodCapability,
+    AnalyzePropertyCapability {
 
     /**
      * @param CodeBase $code_base
@@ -116,6 +119,23 @@ class UnusedSuppressionPlugin extends PluginV2 implements
         $this->analyzeAddressableElement($code_base, $function);
     }
 
+    /**
+     * @param CodeBase $code_base
+     * The code base in which the function exists
+     *
+     * @param Property $property
+     * A property being analyzed
+     *
+     * @return void
+     *
+     * @override
+     */
+    public function analyzeProperty(
+        CodeBase $code_base,
+        Property $property
+    ) {
+        $this->analyzeAddressableElement($code_base, $property);
+    }
 }
 
 // Every plugin needs to return an instance of itself at the

--- a/NEWS
+++ b/NEWS
@@ -14,6 +14,7 @@ Maintenance
 Plugins
 + Increased minimum `ext-ast` version constraint to 0.1.5, switched to AST version 50.
   Third party plugins will need to create a different version, Decls were changed into regular Nodes
++ Implement AnalyzePropertyCapability. Make UnusedSuppressionPlugin start using AnalyzePropertyCapability.
 
 Bug Fixes
 + Fix a few incorrect property names for Phan's signatures of internal classes (#1085)
@@ -65,6 +66,7 @@ Bug Fixes
   Additionally, fix false positive warnings about visibility of method aliases from traits.
 + Warn about instantiation of class with inaccessible constructor (Issue #1043)
 + Fix rare uncaught exceptions (Various)
++ Make issues and plugin issues on properties consistently use suppressions from the plugin doc comment.
 
 Changes In Emitted Issues
 + Improve `InvalidVariableIssetPlugin`. Change the names and messages for issue types.

--- a/NEWS
+++ b/NEWS
@@ -14,7 +14,10 @@ Maintenance
 Plugins
 + Increased minimum `ext-ast` version constraint to 0.1.5, switched to AST version 50.
   Third party plugins will need to create a different version, Decls were changed into regular Nodes
-+ Implement AnalyzePropertyCapability. Make UnusedSuppressionPlugin start using AnalyzePropertyCapability.
++ Implement `AnalyzePropertyCapability` and `FinalizeProcessCapability`.
+  Make `UnusedSuppressionPlugin` start using `AnalyzePropertyCapability` and `FinalizeProcessCapability`.
+  Fix bug where `UnusedSuppressionPlugin` could run before the suppressed issues would be emitted,
+  making it falsely emit that suppressions were unused.
 
 Bug Fixes
 + Fix a few incorrect property names for Phan's signatures of internal classes (#1085)

--- a/phan_client
+++ b/phan_client
@@ -282,6 +282,7 @@ EOB;
 
     /**
      * @suppress PhanParamTooManyInternal - `getopt` added an optional third parameter in php 7.1
+     * @suppress UnusedSuppression
      */
     public function __construct()  {
         global $argv;

--- a/src/Phan/Analysis/BlockExitStatusChecker.php
+++ b/src/Phan/Analysis/BlockExitStatusChecker.php
@@ -40,14 +40,6 @@ final class BlockExitStatusChecker extends KindVisitorImplementation {
         self::STATUS_THROW |
         self::STATUS_RETURN;
 
-    const STATUS_INTERESTING_SWITCH_BITMASK =
-        self::STATUS_THROW |
-        self::STATUS_RETURN;
-
-    const STATUS_INTERESTING_TRY_BITMASK =
-        self::STATUS_CONTINUE |
-        self::STATUS_BREAK;
-
     // Any status which doesn't lead to proceeding.
     const STATUS_NOT_PROCEED_BITMASK =
         self::STATUS_CONTINUE |

--- a/src/Phan/Analysis/CompositionAnalyzer.php
+++ b/src/Phan/Analysis/CompositionAnalyzer.php
@@ -82,7 +82,9 @@ class CompositionAnalyzer
                 }
 
                 // Don't emit an issue if the property suppresses the issue
+                // NOTE: The current context is the class, not either of the properties.
                 if ($property->hasSuppressIssue(Issue::IncompatibleCompositionProp)) {
+                    $property->incrementSuppressIssueCount(Issue::IncompatibleCompositionProp);
                     continue;
                 }
 

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -22,7 +22,7 @@ class Config
      * PluginV2 will correspond to 2.x.y, PluginV3 will correspond to 3.x.y, etc.
      * New features increment minor versions, and bug fixes increment patch versions.
      */
-    const PHAN_PLUGIN_VERSION = '2.0.0';
+    const PHAN_PLUGIN_VERSION = '2.1.0';
 
     /**
      * @var string|null

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -21,6 +21,7 @@ class Config
      * and the results of version_compare.
      * PluginV2 will correspond to 2.x.y, PluginV3 will correspond to 3.x.y, etc.
      * New features increment minor versions, and bug fixes increment patch versions.
+     * @suppress PhanUnreferencedConstant
      */
     const PHAN_PLUGIN_VERSION = '2.1.0';
 

--- a/src/Phan/Daemon/Request.php
+++ b/src/Phan/Daemon/Request.php
@@ -195,7 +195,6 @@ class Request {
      * @param array|null $status
      * @param int|null $pid
      * @return void
-     * @suppress PhanTypeMismatchArgumentInternal - bad function signature map - status is really an array
      * @suppress PhanUndeclaredConstant pcntl unavailable on windows
      */
     public static function childSignalHandler($signo, $status = null, $pid = null) {

--- a/src/Phan/Language/Element/ClosedScopeElement.php
+++ b/src/Phan/Language/Element/ClosedScopeElement.php
@@ -30,5 +30,4 @@ trait ClosedScopeElement {
     {
         return $this->internal_scope;
     }
-
 }

--- a/src/Phan/Language/Element/Property.php
+++ b/src/Phan/Language/Element/Property.php
@@ -4,11 +4,13 @@ namespace Phan\Language\Element;
 use Phan\Language\Context;
 use Phan\Language\FQSEN;
 use Phan\Language\FQSEN\FullyQualifiedPropertyName;
+use Phan\Language\Scope\PropertyScope;
 use Phan\Language\UnionType;
 
 class Property extends ClassElement
 {
     use ElementFutureUnionType;
+    use ClosedScopeElement;
 
     /**
      * @param Context $context
@@ -41,6 +43,13 @@ class Property extends ClassElement
             $flags,
             $fqsen
         );
+
+        // Set an internal scope, so that issue suppressions can be placed on property doc comments.
+        // (plugins acting on properties would then pick those up).
+        // $fqsen is used to locate this property.
+        $this->setInternalScope(new PropertyScope(
+            $context->getScope(), $fqsen
+        ));
     }
 
     public function __toString() : string

--- a/src/Phan/Language/Element/TypedElement.php
+++ b/src/Phan/Language/Element/TypedElement.php
@@ -267,6 +267,15 @@ abstract class TypedElement implements TypedElementInterface
     }
 
     /**
+     * Increments the number of times $issue_name was suppressed.
+     * @return void
+     */
+    public function incrementSuppressIssueCount(string $issue_name)
+    {
+        ++$this->suppress_issue_list[$issue_name];
+    }
+
+    /**
      * return bool
      * True if this element would like to suppress the given
      * issue name

--- a/src/Phan/Language/Element/TypedElementInterface.php
+++ b/src/Phan/Language/Element/TypedElementInterface.php
@@ -68,6 +68,17 @@ interface TypedElementInterface
     public function setSuppressIssueList(array $suppress_issue_list);
 
     /**
+     * @return int[]
+     */
+    public function getSuppressIssueList() : array;
+
+    /**
+     * Increments the number of times $issue_name was suppressed.
+     * @return void
+     */
+    public function incrementSuppressIssueCount(string $issue_name);
+
+    /**
      * return bool
      * True if this element would like to suppress the given
      * issue name

--- a/src/Phan/Language/FQSEN/Alternatives.php
+++ b/src/Phan/Language/FQSEN/Alternatives.php
@@ -68,7 +68,7 @@ trait Alternatives
     /**
      * @return static
      * A FQSEN with the given alternate_id set
-     * @suppress PhanTypeMismatchDeclaredReturn
+     * @suppress PhanTypeMismatchDeclaredReturn (static vs FQSEN)
      */
     abstract public function withAlternateId(
         int $alternate_id
@@ -79,7 +79,7 @@ trait Alternatives
      * Get the canonical (non-alternate) FQSEN associated
      * with this FQSEN
      *
-     * @suppress PhanTypeMismatchDeclaredReturn
+     * @suppress PhanTypeMismatchDeclaredReturn (static vs FQSEN)
      * @suppress PhanTypeMismatchReturn (Alternatives is a trait, cannot directly implement the FQSEN interface. Related to #800)
      */
     public function getCanonicalFQSEN() : FQSEN

--- a/src/Phan/Language/FQSEN/FullyQualifiedClassElement.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedClassElement.php
@@ -82,8 +82,6 @@ abstract class FullyQualifiedClassElement extends AbstractFQSEN
      * @return static
      * Get the canonical (non-alternate) FQSEN associated
      * with this FQSEN
-     *
-     * @suppress PhanTypeMismatchDeclaredReturn
      */
     public function getCanonicalFQSEN() : FQSEN
     {

--- a/src/Phan/Language/Scope.php
+++ b/src/Phan/Language/Scope.php
@@ -7,6 +7,7 @@ use Phan\Language\Element\Variable;
 use Phan\Language\FQSEN\FullyQualifiedClassName;
 use Phan\Language\FQSEN\FullyQualifiedFunctionName;
 use Phan\Language\FQSEN\FullyQualifiedMethodName;
+use Phan\Language\FQSEN\FullyQualifiedPropertyName;
 use Phan\Language\Type\TemplateType;
 
 abstract class Scope
@@ -104,6 +105,28 @@ abstract class Scope
             "Cannot get class FQSEN on scope");
 
         return $this->getParentScope()->getClassFQSEN();
+    }
+
+    /**
+     * @return bool
+     * True if we're in a property scope
+     */
+    public function isInPropertyScope() : bool
+    {
+        return $this->hasParentScope()
+            ? $this->getParentScope()->isInPropertyScope() : false;
+    }
+
+    /**
+     * @return FullyQualifiedPropertyName
+     * Crawl the scope hierarchy to get a class FQSEN.
+     */
+    public function getPropertyFQSEN() : FullyQualifiedPropertyName
+    {
+        \assert($this->hasParentScope(),
+            "Cannot get class FQSEN on scope");
+
+        return $this->getParentScope()->getPropertyFQSEN();
     }
 
     /**

--- a/src/Phan/Language/Scope/ClassScope.php
+++ b/src/Phan/Language/Scope/ClassScope.php
@@ -7,10 +7,20 @@ class ClassScope extends ClosedScope {
 
     /**
      * @return bool
-     * True if we're in a function scope
+     * True if we're in a class scope
+     * @override
      */
     public function isInClassScope() : bool {
         return true;
+    }
+
+    /**
+     * @return bool
+     * True if we're in a class scope
+     * @override
+     */
+    public function isInPropertyScope() : bool {
+        return false;
     }
 
     /**

--- a/src/Phan/Language/Scope/FunctionLikeScope.php
+++ b/src/Phan/Language/Scope/FunctionLikeScope.php
@@ -16,6 +16,14 @@ class FunctionLikeScope extends ClosedScope {
     }
 
     /**
+     * @return bool
+     * True if we're in a function scope
+     */
+    public function isInPropertyScope() : bool {
+        return false;
+    }
+
+    /**
      * @return FullyQualifiedMethodName|FullyQualifiedFunctionName
      * Get the FQSEN for the closure, method or function we're in
      */

--- a/src/Phan/Language/Scope/PropertyScope.php
+++ b/src/Phan/Language/Scope/PropertyScope.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+namespace Phan\Language\Scope;
+
+use Phan\Language\FQSEN\FullyQualifiedPropertyName;
+
+class PropertyScope extends ClosedScope {
+
+    /**
+     * @return bool
+     * True if we're in a property scope
+     * @override
+     */
+    public function isInPropertyScope() : bool {
+        return true;
+    }
+
+    /**
+     * @return bool
+     * True if we're in a class scope (True for properties)
+     * @override
+     */
+    public function isInClassScope() : bool {
+        return true;
+    }
+
+    /**
+     * @return FullyQualifiedPropertyName
+     * Get the FullyQualifiedPropertyName of the class who's scope
+     * we're in.
+     * @override
+     */
+    public function getPropertyFQSEN() : FullyQualifiedPropertyName
+    {
+        $fqsen = $this->getFQSEN();
+
+        if ($fqsen instanceof FullyQualifiedPropertyName) {
+            return $fqsen;
+        }
+
+        throw new \AssertionError("FQSEN must be a FullyQualifiedPropertyName");
+    }
+}

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -386,8 +386,6 @@ class ParseVisitor extends ScopeVisitor
      * @return Context
      * A new or an unchanged context resulting from
      * parsing the node
-     *
-     * @suppress PhanUndeclaredProperty - A property element can have a docComment - it's an exception
      */
     public function visitPropDecl(Node $node) : Context
     {
@@ -531,8 +529,6 @@ class ParseVisitor extends ScopeVisitor
      * A new or an unchanged context resulting from
      * parsing the node
      *
-     * @suppress PhanUndeclaredProperty - class const elements are exceptions, and can have docComment properties.
-     *                                    They can't have endLineno, but may have it in the future.
      */
     public function visitClassConstDecl(Node $node) : Context
     {
@@ -598,8 +594,6 @@ class ParseVisitor extends ScopeVisitor
      * @return Context
      * A new or an unchanged context resulting from
      * parsing the node
-     *
-     * @suppress PhanUndeclaredProperty - const elements are Nodes, but can have docComment.
      */
     public function visitConstDecl(Node $node) : Context
     {

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -356,7 +356,6 @@ final class ConfigPluginSet extends PluginV2 implements
 
     /**
      * @return \Closure[] - [function(CodeBase $code_base, Context $context, Node $node, Node $parent_node = null): void]
-     * @suppress PhanNonClassMethodCall
      */
     private static function filterPreAnalysisPlugins(array $plugin_set) : array
     {
@@ -412,7 +411,6 @@ final class ConfigPluginSet extends PluginV2 implements
     /**
      * @return \Closure[] - [function(CodeBase $code_base, Context $context, Node $node, Node $parent_node = null): void]
      * @var \Closure[][] $closures_for_kind
-     * @suppress PhanNonClassMethodCall
      */
     private static function filterAnalysisPlugins(array $plugin_set) : array
     {

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -4,10 +4,13 @@ namespace Phan\Plugin;
 use Phan\AST\Visitor\Element;
 use Phan\CodeBase;
 use Phan\Config;
+use Phan\Exception\IssueException;
+use Phan\Issue;
 use Phan\Language\Context;
 use Phan\Language\Element\Clazz;
 use Phan\Language\Element\Func;
 use Phan\Language\Element\Method;
+use Phan\Language\Element\Property;
 use Phan\Plugin;
 use Phan\Plugin\PluginImplementation;
 use Phan\PluginV2;
@@ -15,7 +18,9 @@ use Phan\PluginV2\AnalyzeNodeCapability;
 use Phan\PluginV2\PreAnalyzeNodeCapability;
 use Phan\PluginV2\AnalyzeClassCapability;
 use Phan\PluginV2\AnalyzeFunctionCapability;
+use Phan\PluginV2\AnalyzePropertyCapability;
 use Phan\PluginV2\AnalyzeMethodCapability;
+use Phan\PluginV2\FinalizeProcessCapability;
 use Phan\PluginV2\LegacyAnalyzeNodeCapability;
 use Phan\PluginV2\LegacyPreAnalyzeNodeCapability;
 use Phan\PluginV2\PluginAwareAnalysisVisitor;
@@ -33,6 +38,8 @@ final class ConfigPluginSet extends PluginV2 implements
     AnalyzeClassCapability,
     AnalyzeFunctionCapability,
     AnalyzeMethodCapability,
+    AnalyzePropertyCapability,
+    FinalizeProcessCapability,
     LegacyAnalyzeNodeCapability,
     LegacyPreAnalyzeNodeCapability {
 
@@ -51,8 +58,14 @@ final class ConfigPluginSet extends PluginV2 implements
     /** @var AnalyzeFunctionCapability[]|null */
     private $analyzeFunctionPluginSet;
 
+    /** @var AnalyzePropertyCapability[]|null */
+    private $analyzePropertyPluginSet;
+
     /** @var AnalyzeMethodCapability[]|null */
     private $analyzeMethodPluginSet;
+
+    /** @var FinalizeProcessCapability[]|null */
+    private $finalizeProcessPluginSet;
 
     /**
      * Call `ConfigPluginSet::instance()` instead.
@@ -87,6 +100,7 @@ final class ConfigPluginSet extends PluginV2 implements
      * The php-ast Node being analyzed.
      *
      * @return void
+     * @override
      */
     public function preAnalyzeNode(
         CodeBase $code_base,
@@ -119,6 +133,7 @@ final class ConfigPluginSet extends PluginV2 implements
      * The parent node of the given node (if one exists).
      *
      * @return void
+     * @override
      */
     public function analyzeNode(
         CodeBase $code_base,
@@ -145,6 +160,7 @@ final class ConfigPluginSet extends PluginV2 implements
      * A class being analyzed
      *
      * @return void
+     * @override
      */
     public function analyzeClass(
         CodeBase $code_base,
@@ -156,6 +172,11 @@ final class ConfigPluginSet extends PluginV2 implements
                 $class
             );
         }
+        if ($this->hasAnalyzePropertyPlugins()) {
+            foreach ($class->getPropertyList($code_base) as $property) {
+                $this->analyzeProperty($code_base, $property);
+            }
+        }
     }
 
     /**
@@ -166,6 +187,7 @@ final class ConfigPluginSet extends PluginV2 implements
      * A method being analyzed
      *
      * @return void
+     * @override
      */
     public function analyzeMethod(
         CodeBase $code_base,
@@ -187,6 +209,7 @@ final class ConfigPluginSet extends PluginV2 implements
      * A function being analyzed
      *
      * @return void
+     * @override
      */
     public function analyzeFunction(
         CodeBase $code_base,
@@ -197,6 +220,55 @@ final class ConfigPluginSet extends PluginV2 implements
                 $code_base,
                 $function
             );
+        }
+    }
+
+    /**
+     * @param CodeBase $code_base
+     * The code base in which the property exists
+     *
+     * @param Property $property
+     * A property being analyzed
+     *
+     * (Called by analyzeClass())
+     *
+     * @return void
+     * @override
+     */
+    public function analyzeProperty(
+        CodeBase $code_base,
+        Property $property
+    ) {
+        foreach ($this->analyzePropertyPluginSet as $plugin) {
+            try {
+                $plugin->analyzeProperty(
+                    $code_base,
+                    $property
+                );
+            } catch (IssueException $exception) {
+                // e.g. getUnionType() can throw, PropertyTypesAnalyzer is probably emitting duplicate issues
+                Issue::maybeEmitInstance(
+                    $code_base,
+                    $property->getContext(),
+                    $exception->getIssueInstance()
+                );
+                continue;
+            }
+        }
+    }
+
+    /**
+     * @param CodeBase $code_base
+     * The code base used for previous analysis steps
+     *
+     * @return void
+     * @override
+     */
+    public function finalizeProcess(
+        CodeBase $code_base
+    ) {
+        foreach ($this->finalizeProcessPluginSet as $plugin) {
+            $plugin->finalizeProcess($code_base);
         }
     }
 
@@ -223,6 +295,15 @@ final class ConfigPluginSet extends PluginV2 implements
     {
         \assert(!\is_null($this->pluginSet));
         return \count($this->analyzeMethodPluginSet) > 0;
+    }
+
+    /**
+     * Returns true if analyzeProperty() will execute any plugins.
+     */
+    private function hasAnalyzePropertyPlugins() : bool
+    {
+        \assert(!\is_null($this->pluginSet));
+        return \count($this->analyzePropertyPluginSet) > 0;
     }
 
     /** @return void */
@@ -252,7 +333,9 @@ final class ConfigPluginSet extends PluginV2 implements
         $this->analyzeNodePluginSet         = self::filterAnalysisPlugins($plugin_set);
         $this->analyzeMethodPluginSet       = self::filterOutEmptyMethodBodies(self::filterByClass($plugin_set, AnalyzeMethodCapability::class), 'analyzeMethod');
         $this->analyzeFunctionPluginSet     = self::filterOutEmptyMethodBodies(self::filterByClass($plugin_set, AnalyzeFunctionCapability::class), 'analyzeFunction');
+        $this->analyzePropertyPluginSet     = self::filterOutEmptyMethodBodies(self::filterByClass($plugin_set, AnalyzePropertyCapability::class), 'analyzeProperty');
         $this->analyzeClassPluginSet        = self::filterOutEmptyMethodBodies(self::filterByClass($plugin_set, AnalyzeClassCapability::class), 'analyzeClass');
+        $this->finalizeProcessPluginSet     = self::filterOutEmptyMethodBodies(self::filterByClass($plugin_set, FinalizeProcessCapability::class), 'finalizeProcess');
     }
 
     /**

--- a/src/Phan/PluginV2.php
+++ b/src/Phan/PluginV2.php
@@ -40,6 +40,10 @@ use ast\Node;
  *     Analyze (and modify) a property definition, after parsing and before analyzing.
  *     (implement \Phan\PluginV2\AnalyzePropertyCapability)
  *
+ *  6. public function finalize(CodeBase $code_base)
+ *     Analyze (and modify) a property definition, after parsing and before analyzing.
+ *     (implement \Phan\PluginV2\AnalyzePropertyCapability)
+ *
  * List of deprecated legacy capabilities
  *
  *  1. public static function analyzeNode(CodeBase $code_base, Context $context, Node $node, Node $parent_node = null)

--- a/src/Phan/PluginV2.php
+++ b/src/Phan/PluginV2.php
@@ -36,6 +36,10 @@ use ast\Node;
  *     Returns the name of a class extending PluginAwarePreAnalysisVisitor, which will be used to pre-analyze nodes in the analysis phase.
  *     (implement \Phan\PluginV2\PreAnalyzeNodeCapability)
  *
+ *  6. public function analyzeProperty(CodeBase $code_base, Property $property)
+ *     Analyze (and modify) a property definition, after parsing and before analyzing.
+ *     (implement \Phan\PluginV2\AnalyzePropertyCapability)
+ *
  * List of deprecated legacy capabilities
  *
  *  1. public static function analyzeNode(CodeBase $code_base, Context $context, Node $node, Node $parent_node = null)

--- a/src/Phan/PluginV2/AnalyzePropertyCapability.php
+++ b/src/Phan/PluginV2/AnalyzePropertyCapability.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+namespace Phan\PluginV2;
+
+use Phan\CodeBase;
+use Phan\Language\Element\Property;
+
+interface AnalyzePropertyCapability {
+    /**
+     * @param CodeBase $code_base
+     * The code base in which the property exists
+     *
+     * @param Property $property
+     * A property being analyzed
+     *
+     * @return void
+     */
+    public function analyzeProperty(
+        CodeBase $code_base,
+        Property $property
+    );
+}

--- a/src/Phan/PluginV2/FinalizeProcessCapability.php
+++ b/src/Phan/PluginV2/FinalizeProcessCapability.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+namespace Phan\PluginV2;
+
+use Phan\CodeBase;
+
+interface FinalizeProcessCapability {
+    /**
+     * This is called after the other forms of analysis are finished running.
+     * Useful if a PluginV2 needs to aggregate results of analysis.
+     * This may be used to emit additional issues.
+     *
+     * This is run once per forked analysis process.
+     * Some plugins using this, such as UnusedSuppressionPlugin,
+     * will not work as expected with more than one process.
+     * If possible, write plugins to emit issues immediately.
+     *
+     * @return void
+     */
+    public function finalizeProcess(CodeBase $code_base);
+}

--- a/src/Phan/Util.php
+++ b/src/Phan/Util.php
@@ -11,7 +11,6 @@ class Util
     /**
      * @param ?Node $node
      * @return ?int
-     * @suppress PhanUndeclaredProperty - The extension deliberately leaves it undeclared.
      */
     public static function getEndLineno($node)
     {

--- a/tests/files/expected/0207_incompatible_composition.php.expected
+++ b/tests/files/expected/0207_incompatible_composition.php.expected
@@ -1,1 +1,1 @@
-%s:8 PhanIncompatibleCompositionProp \C2 and \C1 define the same property (p) in the composition of \C2. However, the definition differs and is considered incompatible. Class was composed in %s on line 11
+%s:10 PhanIncompatibleCompositionProp \C2 and \C1 define the same property (p) in the composition of \C2. However, the definition differs and is considered incompatible. Class was composed in %s on line 15

--- a/tests/files/src/0207_incompatible_composition.php
+++ b/tests/files/src/0207_incompatible_composition.php
@@ -2,10 +2,14 @@
 
 class C1 {
     public $p = 42;
+    /** @suppress PhanIncompatibleCompositionProp (sanity check of suppression) */
+    public $v = 42;
 }
 
 trait T1 {
     public $p = 'string';
+    /** @suppress PhanIncompatibleCompositionProp (sanity check of suppression) */
+    public $v = 'string';
 }
 
 class C2 extends C1 {

--- a/tests/plugin_test/expected/all_output.expected
+++ b/tests/plugin_test/expected/all_output.expected
@@ -17,6 +17,8 @@ src/000_plugins.php:67 PhanUnreferencedConstant Possibly zero references to cons
 src/000_plugins.php:69 PhanPluginAlwaysReturnFunction Function \missingReturnType has a return type of int, but may fail to return a value
 src/000_plugins.php:77 PhanPluginAlwaysReturnMethod Method \ReturnChecks::missingReturnTypeSwitch has a return type of int, but may fail to return a value
 src/000_plugins.php:127 PhanTypeMismatchArgumentInternal Argument 1 (string) is int but \strlen() takes string
+src/000_plugins.php:138 DemoPluginMethodName Method \TestDemoPlugin::function cannot be called `function`
+src/000_plugins.php:139 DemoPluginPropertyName Property \TestDemoPlugin::property should not be called `property`
 src/001_globals_type_map.php:5 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \Exception|\Throwable but \intdiv() takes int
 src/001_globals_type_map.php:8 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \Error|\Throwable but \intdiv() takes int
 src/001_globals_type_map.php:12 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \Exception|\Throwable but \intdiv() takes int
@@ -26,3 +28,9 @@ src/002_unreachable_code.php:23 PhanPluginUnreachableCode Unreachable statement 
 src/002_unreachable_code.php:25 PhanPluginUnreachableCode Unreachable statement detected
 src/002_unreachable_code.php:40 PhanPluginUnreachableCode Unreachable statement detected
 src/002_unreachable_code.php:64 PhanPluginUnreachableCode Unreachable statement detected
+src/003_suppress_on_property.php:8 PhanPluginMixedKeyNoKey Should not mix array entries of the form [key => value,] with entries of the form [value,].
+src/003_suppress_on_property.php:17 PhanPluginDuplicateArrayKey Duplicate/Equivalent array key literal('key') detected in array - the earlier entry will be ignored.
+src/004_unused_suppression_plugin.php:6 UnusedSuppression Element \SuppressionTest suppresses issue PhanPluginNotARealIssue but does not use it
+src/004_unused_suppression_plugin.php:11 UnusedSuppression Element \SuppressionTest::foo suppresses issue PhanParamTooMany but does not use it
+src/004_unused_suppression_plugin.php:23 UnusedSuppression Element \suppression_test_fn suppresses issue PhanParamTooFew but does not use it
+src/004_unused_suppression_plugin.php:27 PhanTypeMismatchArgument Argument 1 (x) is array but \SuppressionTest::bar() takes int defined at src/004_unused_suppression_plugin.php:15

--- a/tests/plugin_test/src/000_plugins.php
+++ b/tests/plugin_test/src/000_plugins.php
@@ -132,3 +132,12 @@ ReturnChecks::missingReturnTypeSwitchGood(3);
 ReturnChecks::missingReturnTypeSwitch(5);
 ReturnChecks::generator(3);
 ReturnChecks::skippingWithBreak([3, 4, "strval"]);
+
+// Some of the demo warnings are valid code in php 7.
+class TestDemoPlugin {
+    function function() {}
+    public $property = 'x';
+}
+$tdp = new TestDemoPlugin();
+var_dump($tdp->property);
+var_dump($tdp->function());

--- a/tests/plugin_test/src/003_suppress_on_property.php
+++ b/tests/plugin_test/src/003_suppress_on_property.php
@@ -1,0 +1,24 @@
+<?php
+
+class A3 {
+    /**
+     * @suppress PhanPluginDuplicateArrayKey
+     */
+    public $x = [
+        'value',
+        'key' => 'otherValue',
+        'key' => 'redundant',
+    ];
+
+    /**
+     * @suppress PhanPluginMixedKeyNoKey
+     */
+    public $y = [
+        'value',
+        'key' => 'otherValue',
+        'key' => 'redundant',
+    ];
+}
+$a = new A3();
+var_dump($a->x);
+var_dump($a->y);

--- a/tests/plugin_test/src/004_unused_suppression_plugin.php
+++ b/tests/plugin_test/src/004_unused_suppression_plugin.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @suppress PhanPluginNotARealIssue
+ */
+class SuppressionTest {
+
+    /**
+     * @suppress PhanParamTooMany (This suppression is unused)
+     */
+    public function foo() {
+        $this->bar(2);
+    }
+
+    public function bar(int $x) {
+    }
+}
+
+/**
+ * @suppress PhanParamTooFew (This suppression is unused)
+ * @suppress PhanParamTooMany (this suppression is used)
+ */
+function suppression_test_fn() {
+    $c = new SuppressionTest();
+    $c->foo();
+    $c->foo('extra param');
+    $c->bar([]);  // should not be suppressed
+}
+suppression_test_fn();


### PR DESCRIPTION
Two bugs were found in tracking unused suppressions
    
- `++getArrayByValue()` doesn't modify the underlying array in Context.php.
- Accuracy should be improved if analysis is postponed until after the analysis is run.
  (I'm seeing some false positives combining this with dead code analysis)

Use the suppressions for properties when analyzing the properties'
their default values in the analysis phase.

- E.g. This allows PhanPluginMixedKeyNoKey to be suppressed for the values of properties.
    
Implement AnalyzePropertyCapability, which will make it easier for
plugin authors to analyze properties. (This is done at the same time as AnalayzeClassCapability)

$plugin->finalizeProcess() will be called once per forked process. This is now used by UnusedSuppressionPlugin, because we previously could emit more issues after UnusedSuppressionPlugin was invoked on an element.
