### PR TITLE
Fixes #1097: fix support for `namespace\elementName` in Phan

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -28,6 +28,7 @@ Plugins
 
 Bug Fixes
 + Fix a few incorrect property names for Phan's signatures of internal classes (#1085)
++ Fix bugs in lookup of relative and non-fully qualified class and function names (#1097)
 
 15 Aug 2017, Phan 0.9.4
 -----------------------

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -175,12 +175,13 @@ class ParseVisitor extends ScopeVisitor
         $class->setForbidUndeclaredMagicMethods($comment->getForbidUndeclaredMagicMethods());
 
         // Look to see if we have a parent class
-        if (!empty($node->children['extends'])) {
+        $extends_node = $node->children['extends'] ?? null;
+        if ($extends_node instanceof Node) {
             $parent_class_name =
-                $node->children['extends']->children['name'];
+                $extends_node->children['name'];
 
             // Check to see if the name isn't fully qualified
-            if ($node->children['extends']->flags & \ast\flags\NAME_NOT_FQ) {
+            if ($extends_node->flags & \ast\flags\NAME_NOT_FQ) {
                 if ($this->context->hasNamespaceMapFor(
                     \ast\flags\USE_NORMAL,
                     $parent_class_name
@@ -195,7 +196,11 @@ class ParseVisitor extends ScopeVisitor
                     $parent_class_name =
                         $this->context->getNamespace() . '\\' . $parent_class_name;
                 }
+            } else if ($extends_node->flags & \ast\flags\NAME_RELATIVE) {
+                $parent_class_name =
+                    $this->context->getNamespace() . '\\' . $parent_class_name;
             }
+            // $extends_node->flags is 0 when it is fully qualified?
 
             // The name is fully qualified. Make sure it looks
             // like it is

--- a/tests/files/expected/0355_namespace_relative.php.expected
+++ b/tests/files/expected/0355_namespace_relative.php.expected
@@ -1,0 +1,5 @@
+%s:32 PhanUndeclaredInterface Class implements undeclared interface \NS355\I355
+%s:34 PhanCommentOverrideOnNonOverrideMethod Saw an @override annotation for method \NS355\E355::functionOfI, but could not find an overridden method and it is not a magic method
+%s:46 PhanUndeclaredClassMethod Call to method __construct from undeclared class \NS355\B355
+%s:53 PhanTypeMismatchArgument Argument 1 (x) is \NS355\B355 but \NS355\accepts_B355() takes \B355 defined at %s:48
+%s:53 PhanUndeclaredClassMethod Call to method __construct from undeclared class \NS355\B355

--- a/tests/files/expected/0356_namespace_relative_function.php.expected
+++ b/tests/files/expected/0356_namespace_relative_function.php.expected
@@ -1,0 +1,7 @@
+%s:7 PhanTypeMismatchArgument Argument 1 (x) is int but \test356() takes string defined at %s:4
+%s:8 PhanTypeMismatchArgument Argument 1 (x) is int but \test356() takes string defined at %s:4
+%s:9 PhanTypeMismatchArgument Argument 1 (x) is int but \test356() takes string defined at %s:4
+%s:14 PhanTypeMismatchArgument Argument 1 (x) is int but \test356() takes string defined at %s:4
+%s:15 PhanTypeMismatchArgument Argument 1 (x) is int but \test356() takes string defined at %s:4
+%s:16 PhanUndeclaredFunction Call to undeclared function \NS355\test356()
+%s:23 PhanUndeclaredFunction Call to undeclared function \inNS356()

--- a/tests/files/src/0355_namespace_relative.php
+++ b/tests/files/src/0355_namespace_relative.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace {
+abstract class A355 {
+    abstract function foo();
+}
+
+interface I355 {
+    function functionOfI();
+}
+
+class B355 extends namespace\A355 implements namespace\I355 {
+    public function foo() {}
+    public function functionOfI() {}
+}
+}
+
+namespace NS355 {
+
+use B355;
+
+abstract class A355 {
+    abstract function fooInNamespace();
+}
+
+class D355 extends namespace\A355 {
+    public function fooInNamespace() {}
+    public function functionOfI() {}
+}
+
+// Phan should warn that the interface doesn't exist
+class E355 implements namespace\I355 {
+    /** @override */
+    public function functionOfI() {}
+}
+
+// Should not warn
+class F355 implements \I355 {
+    /** @override */
+    public function functionOfI() {}
+}
+
+$c = new D355();  // Should work
+
+$d = new B355();  // Should work
+$d = new namespace\B355();  // Should fail.
+
+function accepts_B355(B355 $x) {
+}
+
+accepts_B355(new B355());  // should work
+accepts_B355(new \B355());  // should work
+accepts_B355(new namespace\B355());  // should fail
+}

--- a/tests/files/src/0356_namespace_relative_function.php
+++ b/tests/files/src/0356_namespace_relative_function.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace {
+    function test356(string $x) {
+    }
+
+    \test356(2);  // should warn about types
+    test356(2);  // should warn about types
+    namespace\test356(2);  // should warn about types
+}
+
+namespace NS355 {
+    use function test356;
+    \test356(2);  // should warn about types
+    test356(2);  // should warn about types
+    namespace\test356(2);  // should fail
+
+    function inNS356(int $y) {
+        echo "$y\n";
+    }
+    inNS356(42);
+    namespace\inNS356(42);
+    \inNS356(42);  // should fail.
+}


### PR DESCRIPTION
Phan didn't attempt to handle this case. See
http://php.net/manual/en/language.namespaces.importing.php

Also, for fully qualified function calls (e.g. `\foo($x)`, just check
the global namespace. Don't check if `foo` is defined in the current namespace.
(Fixes false negatives).