### PR TITLE
Optimize memory usage by converting Context to FileRef where possible

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -16,13 +16,14 @@ New Features (CLI, Configs)
   it will try again with a parser which tolerates a few types of errors, and analyze the statements that could be parsed.
   Useful in combination with daemon mode.
 
-
 Maintenance
 + Increased minimum `ext-ast` version constraint to 0.1.5, switched to AST version 50.
 + Update links to project from github.com/etsy/phan to github.com/phan/phan.
 + Use the native `spl_object_id` function if it is available for the union type implementation.
   This will make phan 10% faster in PHP 7.2.
   (for PHP 7.1, https://github.com/runkit7/runkit_object_id 1.1.0+ also provides a native implementation of `spl_object_id`)
++ Reduce memory usage by around 5% by tracking only the file and lines associated with variables, instead of a full Context object.
+
 
 Plugins
 + Increased minimum `ext-ast` version constraint to 0.1.5, switched to AST version 50.

--- a/src/Phan/AST/Visitor/KindVisitorImplementation.php
+++ b/src/Phan/AST/Visitor/KindVisitorImplementation.php
@@ -2,6 +2,8 @@
 namespace Phan\AST\Visitor;
 
 use ast\Node;
+use Phan\AST\Visitor\Element;
+use Phan\Debug;
 
 /**
  * A visitor of AST nodes based on the node's kind value
@@ -18,7 +20,14 @@ abstract class KindVisitorImplementation implements KindVisitor
      */
     public function __invoke(Node $node)
     {
-        return Element::acceptNodeAndKindVisitor($node, $this);
+        $fn_name = Element::VISIT_LOOKUP_TABLE[$node->kind] ?? 'handleMissingNodeKind';
+        return $this->{$fn_name}($node);
+    }
+
+    private function handleMissingNodeKind(Node $node)
+    {
+        Debug::printNode($node);
+        assert(false, 'All node kinds must match');
     }
 
     public function visitArgList(Node $node)

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -415,6 +415,7 @@ class AssignmentVisitor extends AnalysisVisitor
                 );
                 return $this->context;
             }
+            // TODO: Iterate over individual types, don't look at the whole type at once?
 
             // If we're assigning to an array element then we don't
             // know what the constitutation of the parameter is

--- a/src/Phan/Language/Element/Parameter.php
+++ b/src/Phan/Language/Element/Parameter.php
@@ -6,6 +6,7 @@ use Phan\Config;
 use Phan\Exception\IssueException;
 use Phan\Issue;
 use Phan\Language\Context;
+use Phan\Language\FileRef;
 use Phan\Language\Type;
 use Phan\Language\Type\ArrayType;
 use Phan\Language\Type\BoolType;
@@ -35,8 +36,8 @@ class Parameter extends Variable
     private $default_value = null;
 
     /**
-     * @param Context $context
-     * The context in which the structural element lives
+     * @param FileRef $file_ref
+     * The file and lines in which the unaddressable element lives
      *
      * @param string $name
      * The name of the typed structural element
@@ -52,13 +53,13 @@ class Parameter extends Variable
      * a certain kind has a meaningful flags value.
      */
     public function __construct(
-        Context $context,
+        FileRef $file_ref,
         string $name,
         UnionType $type,
         int $flags
     ) {
         parent::__construct(
-            $context,
+            $file_ref,
             $name,
             $type,
             $flags
@@ -390,7 +391,7 @@ class Parameter extends Variable
         // e.g. $this->getUnionType() is of type T[]
         //      $this->non_variadic->getUnionType() is of type T
         return new Parameter(
-            $this->getContext(),
+            $this->getFileRef(),
             $this->getName(),
             $this->getNonVariadicUnionType(),
             Flags::bitVectorWithState($this->getFlags(), \ast\flags\PARAM_VARIADIC, false)
@@ -516,11 +517,11 @@ class Parameter extends Variable
 
         $string .= "\${$this->getName()}";
 
-        if ($this->hasDefaultValue()) {
+        if ($this->hasDefaultValue() && !$this->isVariadic()) {
             if ($this->getDefaultValue() instanceof \ast\Node) {
                 $string .= ' = null';
             } else {
-                $string .= ' = ' . (string)$this->getDefaultValue();
+                $string .= ' = ' . var_export($this->getDefaultValue(), true);
             }
         }
 

--- a/src/Phan/Language/Element/PassByReferenceVariable.php
+++ b/src/Phan/Language/Element/PassByReferenceVariable.php
@@ -21,9 +21,10 @@ class PassByReferenceVariable extends Variable
     /** @var TypedElement */
     private $element;
 
+    /** @param TypedElement|UnaddressableTypedElement $element */
     public function __construct(
         Variable $parameter,
-        TypedElement $element
+        $element
     ) {
         $this->parameter = $parameter;
         $this->element = $element;

--- a/src/Phan/Language/Element/UnaddressableTypedElement.php
+++ b/src/Phan/Language/Element/UnaddressableTypedElement.php
@@ -1,0 +1,299 @@
+<?php declare(strict_types=1);
+namespace Phan\Language\Element;
+
+use Phan\CodeBase;
+use Phan\Language\Context;
+use Phan\Language\FileRef;
+use Phan\Language\UnionType;
+
+/**
+ * Any PHP structural element that also has a type and is
+ * does not store a reference to its context (such as a variable).
+ */
+abstract class UnaddressableTypedElement
+{
+    /**
+     * @var FileRef
+     */
+    private $file_ref;
+
+    /**
+     * @var string
+     * The name of the typed structural element
+     */
+    private $name;
+
+    /**
+     * @var UnionType|null
+     * A set of types satisfyped by this typed structural
+     * element.
+     */
+    private $type = null;
+
+    /**
+     * @var int
+     * The flags property contains node specific flags. It is
+     * always defined, but for most nodes it is always zero.
+     * ast\kind_uses_flags() can be used to determine whether
+     * a certain kind has a meaningful flags value.
+     */
+    private $flags = 0;
+
+    /**
+     * @var int
+     * The Phan flags property contains node specific flags that
+     * are internal to Phan.
+     */
+    private $phan_flags = 0;
+
+    /**
+     * @var int[]
+     * A set of issues types to be suppressed
+     */
+    private $suppress_issue_list = [];
+
+    /**
+     * @param FileRef $file_ref
+     * The Context or FileRef in which the structural element lives
+     * (Will be converted to FileRef, to avoid creating a reference
+     * cycle that can't be garbage collected)
+     *
+     * @param string $name
+     * The name of the typed structural element
+     *
+     * @param UnionType $type
+     * A '|' delimited set of types satisfyped by this
+     * typed structural element.
+     *
+     * @param int $flags
+     * The flags property contains node specific flags. It is
+     * always defined, but for most nodes it is always zero.
+     * ast\kind_uses_flags() can be used to determine whether
+     * a certain kind has a meaningful flags value.
+     */
+    public function __construct(
+        FileRef $file_ref,
+        string $name,
+        UnionType $type,
+        int $flags
+    ) {
+        $this->file_ref = FileRef::copyFileRef($file_ref);
+        $this->name = $name;
+        $this->type = $type;
+        $this->flags = $flags;
+    }
+
+    /**
+     * After a clone is called on this object, clone our
+     * type and fqsen so that they survive copies intact
+     *
+     * @return null
+     */
+    public function __clone()
+    {
+        $this->type = $this->type
+            ? clone($this->type)
+            : $this->type;
+    }
+
+    /**
+     * @return string
+     * The (not fully-qualified) name of this element.
+     */
+    public function getName() : string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return UnionType
+     * Get the type of this structural element
+     */
+    public function getUnionType() : UnionType
+    {
+        return $this->type;
+    }
+
+    /**
+     * @param UnionType $type
+     * Set the type of this element
+     *
+     * @return void
+     */
+    public function setUnionType(UnionType $type)
+    {
+        $this->type = clone($type);
+    }
+
+    /**
+     * @return void
+     */
+    protected function convertToNonVariadic()
+    {
+        // Avoid a redundant clone of toGenericArray()
+        $this->type = $this->getUnionType();
+    }
+
+    /**
+     * @return void
+     */
+    protected function convertToNullable()
+    {
+        // Avoid a redundant clone of nonNullableClone()
+        $type = $this->type;
+        if ($type->isEmpty() || $type->containsNullable()) {
+            return;
+        }
+        $this->type = $type->nullableClone();
+    }
+
+    /**
+     * Variables can't be variadic. This is the same as getUnionType for
+     * variables, but not necessarily for subclasses. Method will return
+     * the element type (such as `DateTime`) for variadic parameters.
+     */
+    public function getNonVariadicUnionType() : UnionType {
+        return $this->getUnionType();
+    }
+
+    /**
+     * @return int
+     */
+    public function getFlags() : int
+    {
+        return $this->flags;
+    }
+
+    /**
+     * @param int $flags
+     *
+     * @return void
+     */
+    public function setFlags(int $flags)
+    {
+        $this->flags = $flags;
+    }
+
+    /**
+     * @return int
+     */
+    public function getPhanFlags() : int
+    {
+        return $this->phan_flags;
+    }
+
+    /**
+     * @param int $phan_flags
+     *
+     * @return void
+     */
+    public function setPhanFlags(int $phan_flags)
+    {
+        $this->phan_flags = $phan_flags;
+    }
+
+    /**
+     * @return FileRef
+     * A reference to where this element was found
+     */
+    public function getFileRef() : FileRef
+    {
+        return $this->file_ref;
+    }
+
+    /**
+     * @return bool
+     * True if this element is marked as deprecated
+     */
+    public function isDeprecated() : bool
+    {
+        return Flags::bitVectorHasState(
+            $this->phan_flags,
+            Flags::IS_DEPRECATED
+        );
+    }
+
+    /**
+     * @param bool $is_deprecated
+     * Set this element as deprecated
+     *
+     * @return void
+     */
+    public function setIsDeprecated(bool $is_deprecated)
+    {
+        $this->setPhanFlags(Flags::bitVectorWithState(
+            $this->getPhanFlags(),
+            Flags::IS_DEPRECATED,
+            $is_deprecated
+        ));
+    }
+
+    /**
+     * @param string[] $suppress_issue_list
+     * Set the set of issue names to suppress
+     *
+     * @return void
+     */
+    public function setSuppressIssueList(array $suppress_issue_list)
+    {
+        $this->suppress_issue_list = [];
+        foreach ($suppress_issue_list as $issue_name) {
+            $this->suppress_issue_list[$issue_name] = 0;
+        }
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getSuppressIssueList() : array
+    {
+        return $this->suppress_issue_list ?: [];
+    }
+
+    /**
+     * return bool
+     * True if this element would like to suppress the given
+     * issue name
+     */
+    public function hasSuppressIssue(string $issue_name) : bool
+    {
+        return isset($this->suppress_issue_list[$issue_name]);
+    }
+
+    /**
+     * @return bool
+     * True if this was an internal PHP object
+     */
+    public function isPHPInternal() : bool
+    {
+        return Flags::bitVectorHasState(
+            $this->getPhanFlags(),
+            Flags::IS_PHP_INTERNAL
+        );
+    }
+
+    /**
+     * @return void
+     */
+    private function setIsPHPInternal(bool $is_internal)
+    {
+        $this->setPhanFlags(
+            Flags::bitVectorWithState(
+                $this->getPhanFlags(),
+                Flags::IS_PHP_INTERNAL,
+                $is_internal
+            )
+        );
+    }
+
+    /**
+     * This method must be called before analysis
+     * begins.
+     *
+     * @return void
+     */
+    public function hydrate(CodeBase $unused_code_base)
+    {
+        // Do nothing unless overridden
+    }
+}

--- a/src/Phan/Language/Element/Variable.php
+++ b/src/Phan/Language/Element/Variable.php
@@ -5,11 +5,12 @@ use Phan\AST\ContextNode;
 use Phan\CodeBase;
 use Phan\Config;
 use Phan\Language\Context;
+use Phan\Language\FileRef;
 use Phan\Language\Type;
 use Phan\Language\UnionType;
 use ast\Node;
 
-class Variable extends TypedElement
+class Variable extends UnaddressableTypedElement
 {
     /**
      * @access private
@@ -44,8 +45,8 @@ class Variable extends TypedElement
     ];
 
     /**
-     * @param Context $context
-     * The context in which the structural element lives
+     * @param FileRef $file_ref
+     * The file and lines in which the unaddressable element lives
      *
      * @param string $name
      * The name of the typed structural element
@@ -61,13 +62,13 @@ class Variable extends TypedElement
      * a certain kind has a meaningful flags value.
      */
     public function __construct(
-        Context $context,
+        FileRef $file_ref,
         string $name,
         UnionType $type,
         int $flags
     ) {
         parent::__construct(
-            $context,
+            $file_ref,
             $name,
             $type,
             $flags
@@ -197,6 +198,7 @@ class Variable extends TypedElement
             // More efficient than using context.
             return UnionType::fromFullyQualifiedString(self::_BUILTIN_GLOBAL_TYPES[$name]);
         }
+
         if (\array_key_exists($name, Config::getValue('globals_type_map'))
             || \in_array($name, Config::getValue('runkit_superglobals'))
         ) {

--- a/src/Phan/Language/FQSEN/FullyQualifiedClassElement.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedClassElement.php
@@ -284,8 +284,7 @@ abstract class FullyQualifiedClassElement extends AbstractFQSEN
         string $name,
         int $alternate_id
     ) : string {
-        $fqsen_string = (string)$fqsen;
-        $fqsen_string .= '::' . $name;
+        $fqsen_string = ((string)$fqsen) . '::' . $name;
 
         if ($alternate_id) {
             $fqsen_string .= ",$alternate_id";

--- a/src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php
@@ -300,6 +300,9 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN
         return $fqsen_string;
     }
 
+    /** @var string|null */
+    private $asString = null;
+
     /**
      * @return string
      * A string representation of this fully-qualified
@@ -307,12 +310,15 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN
      */
     public function __toString() : string
     {
-        return $this->memoize(__METHOD__, function () {
-            return static::toString(
+        $asString = $this->asString;
+        if ($asString === null) {
+            $asString = static::toString(
                 $this->getNamespace(),
                 $this->getName(),
                 $this->getAlternateId()
             );
-        });
+            $this->asString = $asString;
+        }
+        return $asString;
     }
 }

--- a/src/Phan/Language/FileRef.php
+++ b/src/Phan/Language/FileRef.php
@@ -150,4 +150,17 @@ class FileRef implements \Serializable
         $this->line_number_start = (int)$map[1];
         $this->line_number_end = (int)($map[2] ?? 0);
     }
+
+    /**
+     * @param FileRef $other - An instance of FileRef or a subclass such as Context
+     * @return FileRef - A plain file ref, with no other information
+     */
+    public static function copyFileRef(FileRef $other) : FileRef
+    {
+        $file_ref = new FileRef();
+        $file_ref->file = $other->file;
+        $file_ref->line_number_start = $other->line_number_start;
+        $file_ref->line_number_end = $other->line_number_end;
+        return $file_ref;
+    }
 }

--- a/src/Phan/Language/Type/NativeType.php
+++ b/src/Phan/Language/Type/NativeType.php
@@ -1,7 +1,6 @@
 <?php declare(strict_types=1);
 namespace Phan\Language\Type;
 
-use Phan\Config;
 use Phan\Language\Type;
 
 abstract class NativeType extends Type

--- a/tests/files/expected/0124_override_signature.php.expected
+++ b/tests/files/expected/0124_override_signature.php.expected
@@ -10,8 +10,8 @@
 %s:25 PhanParamSignatureRealMismatchReturnType Declaration of function g() : int should be compatible with function g() : string (method returning 'int' cannot override method returning 'string') defined in %s:22
 %s:28 PhanParamSignatureRealMismatchReturnType Declaration of function g() should be compatible with function g() : string (method returning '' cannot override method returning 'string') defined in %s:22
 %s:35 PhanParamSignatureRealMismatchHasParamType Declaration of function h(int $a) should be compatible with function h($a) (parameter #1 of has type 'int' cannot replace original parameter with no type) defined in %s:32
-%s:50 PhanParamSignatureMismatch Declaration of function i($a) should be compatible with function i($a, mixed|string $b = default) defined in %s:46
-%s:50 PhanParamSignatureRealMismatchTooFewParameters Declaration of function i($a) should be compatible with function i($a, $b = default) (the method override accepts 1 parameter(s), but the overridden method can accept 2) defined in %s:46
+%s:50 PhanParamSignatureMismatch Declaration of function i($a) should be compatible with function i($a, mixed|string $b = 'default') defined in %s:46
+%s:50 PhanParamSignatureRealMismatchTooFewParameters Declaration of function i($a) should be compatible with function i($a, $b = 'default') (the method override accepts 1 parameter(s), but the overridden method can accept 2) defined in %s:46
 %s:58 PhanParamSignatureMismatch Declaration of function j() should be compatible with function &j() defined in %s:54
 %s:67 PhanParamSignatureMismatch Declaration of function k(&$a) should be compatible with function k($a) defined in %s:62
 %s:67 PhanParamSignatureRealMismatchParamIsReference Declaration of function k(&$a) should be compatible with function k($a) (parameter #1 is a reference parameter overriding a non-reference parameter) defined in %s:62


### PR DESCRIPTION
Context had references in the local variables in the scope
(e.g. scope for conditional branch) where the context was instantiated.
This resulted in values that couldn't be garbage collected (Phan
disabled garbage collection of loops for performance.
Because the context also contained the set of variables, that created a GC cycle)

- Optimize memory usage by only storing the file and line number
- Make constructors of Variable, etc. expect FileRef
- In addition to TypedElement (Which is an AddressableElement),
  add an UnaddressableTypedElement as a base class.

Also, change representation of default string values in test output
(Quote string defaults)

Small performance enhancement in KindVisitorImplementation::__invoke,
skip a function call to acceptNodeAndKindVisitor

`./phan --print-memory-usage-summary` shows a 5% reduction in memory usage.
Before this change: 186MB/215MB (Used/Max)
After this change:  174MB/203MB