### PR TITLE
Workaround for #294 : Add 'phpdoc_type_mapping' setting

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -100,6 +100,20 @@ return [
     // This will also check if final methods are overridden, etc.
     'analyze_signature_compatibility' => true,
 
+    // This setting maps case insensitive strings to union types.
+    // This is useful if a project uses phpdoc that differs from the phpdoc2 standard.
+    // If the corresponding value is the empty string, Phan will ignore that union type (E.g. can ignore 'the' in `@return the value`)
+    // If the corresponding value is not empty, Phan will act as though it saw the corresponding unionTypes(s) when the keys show up in a UnionType of @param, @return, @var, @property, etc.
+    //
+    // This matches the **entire string**, not parts of the string.
+    // (E.g. `@return the|null` will still look for a class with the name `the`, but `@return the` will be ignored with the below setting)
+    //
+    // (These are not aliases, this setting is ignored outside of doc comments).
+    // (Phan does not check if classes with these names exist)
+    //
+    // Example setting: ['unknown' => '', 'number' => 'int|float', 'char' => 'string', 'long' => 'int', 'the' => '']
+    'phpdoc_type_mapping' => [ ],
+
     // Set to true in order to attempt to detect dead
     // (unreferenced) code. Keep in mind that the
     // results will only be a guess given that classes,

--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,9 @@ New Features (CLI, Configs)
 + Add CLI flag `--use-fallback-parser` (Experimental).  If this flags is provided, then when Phan analyzes a syntactically invalid file,
   it will try again with a parser which tolerates a few types of errors, and analyze the statements that could be parsed.
   Useful in combination with daemon mode.
++ Add `phpdoc_type_mapping` config setting.
+  Projects can override this to make Phan ignore or substitute non-standard phpdoc2 types and common typos (#294)
+  (E.g. `'phpdoc_type_mapping' => ['the' => '', 'unknown_type' => '', 'number' => 'int|float']`)
 
 Maintenance
 + Increased minimum `ext-ast` version constraint to 0.1.5, switched to AST version 50.

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -293,6 +293,20 @@ class Config
         // types expressed in code.
         'read_type_annotations' => true,
 
+        // This setting maps case insensitive strings to union types.
+        // This is useful if a project uses phpdoc that differs from the phpdoc2 standard.
+        // If the corresponding value is the empty string, Phan will ignore that union type (E.g. can ignore 'the' in `@return the value`)
+        // If the corresponding value is not empty, Phan will act as though it saw the corresponding unionTypes(s) when the keys show up in a UnionType of @param, @return, @var, @property, etc.
+        //
+        // This matches the **entire string**, not parts of the string.
+        // (E.g. `@return the|null` will still look for a class with the name `the`, but `@return the` will be ignored with the below setting)
+        //
+        // (These are not aliases, this setting is ignored outside of doc comments).
+        // (Phan does not check if classes with these names exist)
+        //
+        // Example setting: ['unknown' => '', 'number' => 'int|float', 'char' => 'string', 'long' => 'int', 'the' => '']
+        'phpdoc_type_mapping' => [ ],
+
         // Set to true in order to ignore issue suppression.
         // This is useful for testing the state of your code, but
         // unlikely to be useful outside of that.

--- a/src/Phan/Language/Element/Comment.php
+++ b/src/Phan/Language/Element/Comment.php
@@ -457,6 +457,8 @@ class Comment
             }
             // Not emitting any issues about failing to extract, e.g. `@return - Description of what this returns` is a valid comment.
         }
+        $return_union_type_string = self::rewritePHPDocType($return_union_type_string);
+
         $return_union_type = UnionType::fromStringInContext(
             $return_union_type_string,
             $context,
@@ -464,6 +466,17 @@ class Comment
         );
 
         return $return_union_type;
+    }
+
+    private static function rewritePHPDocType(
+        string $original_type
+    ) : string {
+        // TODO: Would need to pass in CodeBase to emit an issue:
+        $type = Config::get()->phpdoc_type_mapping[strtolower($original_type)] ?? null;
+        if (is_string($type)) {
+            return $type;
+        }
+        return $original_type;
     }
 
     /**
@@ -497,7 +510,7 @@ class Comment
     ) {
         $match = [];
         if (preg_match('/@(param|var)\s+(' . UnionType::union_type_regex . ')(\s+(\.\.\.)?\s*(\\$' . self::word_regex . '))?/', $line, $match)) {
-            $type = $match[2];
+            $original_type = $match[2];
 
             $is_variadic = ($match[29] ?? '') === '...';
 
@@ -505,6 +518,13 @@ class Comment
                 $variable_name = '';  // "@var int ...$x" is nonsense and invalid phpdoc.
             } else {
                 $variable_name = $match[31] ?? '';
+            }
+            // If the parameter has a type which is labelled as a typo (type maps to ''),
+            // then treat it the same way as a parameter without a type in the doc comment.
+            // Otherwise, continue with the (possibly renamed) type.
+            $type = self::rewritePHPDocType($original_type);
+            if ($type !== $original_type && $type === '') {
+                return new CommentParameter('', new UnionType());
             }
 
             // If the type looks like a variable name, make it an
@@ -543,7 +563,7 @@ class Comment
             }
         }
 
-        return  new CommentParameter('', new UnionType());
+        return new CommentParameter('', new UnionType());
     }
 
     /**

--- a/tests/fallback_test/test.sh
+++ b/tests/fallback_test/test.sh
@@ -2,7 +2,7 @@
 EXPECTED_PATH=expected/all_output.expected
 ACTUAL_PATH=all_output.actual
 if [ ! -e $EXPECTED_PATH ]; then
-	echo "Error: must run this script from tests/plugin_test folder" 1>&2
+	echo "Error: must run this script from tests/fallback_test folder" 1>&2
 	exit 1
 fi
 echo "Running phan in '$PWD' ..."

--- a/tests/rewriting_test/.phan/config.php
+++ b/tests/rewriting_test/.phan/config.php
@@ -10,8 +10,7 @@ use \Phan\Issue;
  * @see src/Phan/Config.php
  * See Config for all configurable options.
  *
- * This is a config file which tests all built in plugins,
- * in addition to testing backwards compatibility checks and dead code detection.
+ * This is a config file which tests AST rewriting and phpdoc_type_mapping.
  */
 return [
 
@@ -63,6 +62,12 @@ return [
     'directory_list' => ['src'],
 
     'analyzed_file_extensions' => ['php'],
+
+    // An unrelated form of rewriting to AST rewriting.
+    'phpdoc_type_mapping' => [
+        'number' => 'int|float',
+        'unknown_type' => '',
+    ],
 
     // A list of plugin files to execute
     'plugins' => [ ],

--- a/tests/rewriting_test/expected/all_output.expected
+++ b/tests/rewriting_test/expected/all_output.expected
@@ -1,2 +1,4 @@
 src/000_ast_rewriting_check.php:11 PhanTypeMismatchArgumentInternal Argument 1 (string) is int but \strlen() takes string
 src/000_ast_rewriting_check.php:24 PhanTypeMismatchArgumentInternal Argument 1 (string) is int but \strlen() takes string
+src/001_phpdoc_rewriting_test.php:8 PhanUndeclaredTypeParameter Parameter of undeclared type \missingClass
+src/001_phpdoc_rewriting_test.php:9 PhanTypeMismatchArgumentInternal Argument 1 (string) is float|int but \strlen() takes string

--- a/tests/rewriting_test/src/001_phpdoc_rewriting_test.php
+++ b/tests/rewriting_test/src/001_phpdoc_rewriting_test.php
@@ -1,0 +1,10 @@
+<?php
+
+/**
+ * @param number $x (See .phan/config.php for this test case, has phpdoc_type_mapping overridden)
+ * @param unknown_type $y (in phpdoc_type_mapping)
+ * @param missingClass $z
+ */
+function accepts_number($x, $y, $z) : int {
+    return strlen($x);
+}

--- a/tests/rewriting_test/test.sh
+++ b/tests/rewriting_test/test.sh
@@ -2,7 +2,7 @@
 EXPECTED_PATH=expected/all_output.expected
 ACTUAL_PATH=all_output.actual
 if [ ! -e $EXPECTED_PATH ]; then
-	echo "Error: must run this script from tests/plugin_test folder" 1>&2
+	echo "Error: must run this script from tests/rewriting_test folder" 1>&2
 	exit 1
 fi
 echo "Running phan in '$PWD' ..."


### PR DESCRIPTION
E.g. if a codebase frequently uses `@param number $x`, then the
maintainers may wish to add the following line to .phan/config.php

`'phpdoc_type_mapping' => ['number' => 'int|float'],`

Add test case to the rewriting_test folder.