### PR TITLE
Fix a bug affecting `simplify_ast` and exit status checking.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -39,6 +39,7 @@ Plugins
 Bug Fixes
 + Fix a few incorrect property names for Phan's signatures of internal classes (#1085)
 + Fix bugs in lookup of relative and non-fully qualified class and function names (#1097)
++ Fix a bug affecting analysis of code when `simplify_ast` is true.
 
 15 Aug 2017, Phan 0.9.4
 -----------------------

--- a/src/Phan/Debug.php
+++ b/src/Phan/Debug.php
@@ -126,10 +126,6 @@ class Debug
             $string .= ':' . $endLineno;
         }
 
-        if (isset($node->children['name'])) {
-            $string .= ' name:' . $node->children['name'];
-        }
-
         $string .= "\n";
 
         foreach ($node->children ?? [] as $name => $child_node) {

--- a/tests/Phan/Analysis/BlockExitStatusCheckerTest.php
+++ b/tests/Phan/Analysis/BlockExitStatusCheckerTest.php
@@ -156,6 +156,14 @@ class BlockExitStatusCheckerTest extends BaseTest
                 'do {if (cond) continue; else if (foo()) { throw new RuntimeException("");}}while (1);',
             ],
             [
+                'return',
+                'if (cond) return 3; else if (foo()) {return 4;} else { return 5;}',
+            ],
+            [
+                'return',
+                'if (cond) return 3; else { if (foo()) {return 4;} return 5;}',
+            ],
+            [
                 'proceed/throw',
                 'foreach ($seq as $x) { if ($x) { throw new Exception("e"); }}',
             ],

--- a/tests/rewriting_test/.phan/config.php
+++ b/tests/rewriting_test/.phan/config.php
@@ -70,5 +70,7 @@ return [
     ],
 
     // A list of plugin files to execute
-    'plugins' => [ ],
+    'plugins' => [
+        '../../.phan/plugins/AlwaysReturnPlugin.php',  // may be affected by AST rewriting
+    ]
 ];

--- a/tests/rewriting_test/src/002_always_return.php
+++ b/tests/rewriting_test/src/002_always_return.php
@@ -1,0 +1,15 @@
+<?php
+
+class A2
+{
+    public function alwaysReturns() : int
+    {
+        $flags = rand() - 10;
+        if ($flags) {
+            return 4;
+        } else if ($flags > 0) {
+            return 3;
+        }
+        return 5;
+    }
+}


### PR DESCRIPTION
BlockExitStatusChecker assumes that nodes are immutable,
and re-uses the `$node->flags` for IF_STMT, IF_ELEM, STMT_LIST,
and other node types which don't have flags.

Add another test case to the rewriting_test folder.

This may have resulted in phan incorrectly inferring whether a given
block would return, which would mean it may incorrectly merge that
branch into the outer context when simplify_ast was on.