### PR TITLE
Fix NodeException analyzing complex variable as reference

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -40,6 +40,8 @@ Bug Fixes
 + Fix a few incorrect property names for Phan's signatures of internal classes (#1085)
 + Fix bugs in lookup of relative and non-fully qualified class and function names (#1097)
 + Fix a bug affecting analysis of code when `simplify_ast` is true.
++ Fix uncaught NodeException when analyzing complex variables as references (#1116),
+  e.g. `function_expecting_reference($$x)`.
 
 15 Aug 2017, Phan 0.9.4
 -----------------------

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -1695,14 +1695,18 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             // or create it if it doesn't.
             if ($parameter->isPassByReference()) {
                 if ($argument->kind == \ast\AST_VAR) {
-                    // We don't do anything with it; just create it
-                    // if it doesn't exist
-                    $variable = (new ContextNode(
-                        $this->code_base,
-                        $this->context,
-                        $argument
-                    ))->getOrCreateVariable();
-
+                    try {
+                        // We don't do anything with it; just create it
+                        // if it doesn't exist
+                        $variable = (new ContextNode(
+                            $this->code_base,
+                            $this->context,
+                            $argument
+                        ))->getOrCreateVariable();
+                    } catch (NodeException $e) {
+                        // E.g. `function_accepting_reference(${$varName})` - Phan can't analyze outer type of ${$varName}
+                        continue;
+                    }
                 } elseif ($argument->kind == \ast\AST_STATIC_PROP
                     || $argument->kind == \ast\AST_PROP
                 ) {
@@ -1768,11 +1772,16 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             $variable = null;
             if ($parameter->isPassByReference()) {
                 if ($argument->kind == \ast\AST_VAR) {
-                    $variable = (new ContextNode(
-                        $this->code_base,
-                        $this->context,
-                        $argument
-                    ))->getOrCreateVariable();
+                    try {
+                        $variable = (new ContextNode(
+                            $this->code_base,
+                            $this->context,
+                            $argument
+                        ))->getOrCreateVariable();
+                    } catch (NodeException $e) {
+                        // E.g. `function_accepting_reference(${$varName})` - Phan can't analyze outer type of ${$varName}
+                        continue;
+                    }
                 } elseif ($argument->kind == \ast\AST_STATIC_PROP
                     || $argument->kind == \ast\AST_PROP
                 ) {

--- a/tests/files/expected/0357_complex_var_as_reference.php.expected
+++ b/tests/files/expected/0357_complex_var_as_reference.php.expected
@@ -1,0 +1,1 @@
+%s:13 PhanTypeMismatchArgumentInternal Argument 1 (var) is string but \count() takes \Countable|array

--- a/tests/files/src/0357_complex_var_as_reference.php
+++ b/tests/files/src/0357_complex_var_as_reference.php
@@ -1,0 +1,13 @@
+<?php
+
+$testVariable = [
+    'Test Value One',
+];
+
+$variableName = 'testVariable';
+
+each($$variableName);  // Analyzing $$variableName passed to a function expecting a reference should not crash.
+list($key, $value) = each($$variableName);
+
+printf("%s %s\n", $key, $value);
+echo count($variableName);  // should warn.


### PR DESCRIPTION
Fixes #1116: Phan would throw a NodeException if $$varName
was passed to a function expecting a reference, such as `each`