### PR TITLE
Fix AST version in readme for 0.9 branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ composer require --dev etsy/phan
 With Phan installed, you'll want to [create a `.phan/config.php` file](https://github.com/phan/phan/wiki/Getting-Started#creating-a-config-file) in
 your project to tell Phan how to analyze your source code. Once configured, you can run it via `./vendor/bin/phan`.
 
-This version (branch) of Phan depends on PHP 7.1.x with the [php-ast](https://github.com/nikic/php-ast) extension (0.1.4 or newer, uses AST version 50) and supports PHP version 7.1+ syntax.
+This version (branch) of Phan depends on PHP 7.1.x with the [php-ast](https://github.com/nikic/php-ast) extension (0.1.4 or newer, uses AST version 40) and supports PHP version 7.1+ syntax.
 Installation instructions for php-ast can be found [here](https://github.com/nikic/php-ast#installation).
 The 0.10.x releases are more up to date, but require newer versions of php-ast (0.1.5 or newer. These releases may not work with older third party phan plugins)
 For PHP 7.0.x use the [0.8 branch](https://github.com/phan/phan/tree/0.8).


### PR DESCRIPTION
This was copied from the master branch's readme