### PR TITLE
Create the phan 0.9.5 release

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,7 +1,14 @@
 Phan NEWS
 
-?? ??? 2017, Phan 0.9.5 (dev)
+24 Sep 2017, Phan 0.9.5
 -----------------------
+
+Future releases (0.8.8+, 0.9.6+, 0.10.0+, etc.) will be published to phan/phan instead of etsy/phan on packagist.
+
+If you are using phan 0.9.x, it's recommended to switch to phan 0.10.0 releases
+(0.10.x depends on php-ast 0.1.5+ for AST version 50).
+Phan 0.9.x will be supported for only a few more patch versions.
+(and Phan 0.8.x will switch to AST version 50 after that)
 
 New Features(Analysis)
 + Check types of dimensions when using array access syntax (#406, #1093)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ composer require --dev etsy/phan
 With Phan installed, you'll want to [create a `.phan/config.php` file](https://github.com/phan/phan/wiki/Getting-Started#creating-a-config-file) in
 your project to tell Phan how to analyze your source code. Once configured, you can run it via `./vendor/bin/phan`.
 
-This version (branch) of Phan depends on PHP 7.1.x with the [php-ast](https://github.com/nikic/php-ast) extension (0.1.4 or newer, uses AST version 50) and supports PHP version 7.1+ syntax.
+This version (branch) of Phan depends on PHP 7.1.x with the [php-ast](https://github.com/nikic/php-ast) extension (0.1.4 or newer, uses AST version 40) and supports PHP version 7.1+ syntax.
 Installation instructions for php-ast can be found [here](https://github.com/nikic/php-ast#installation).
 The 0.10.x releases are more up to date, but require newer versions of php-ast (0.1.5 or newer. These releases may not work with older third party phan plugins)
 For PHP 7.0.x use the [0.8 branch](https://github.com/phan/phan/tree/0.8).

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -16,7 +16,7 @@ class CLI
     /**
      * This should be updated to x.y.z-dev after every release, and x.y.z before a release.
      */
-    const PHAN_VERSION = '0.9.5-dev';
+    const PHAN_VERSION = '0.9.5';
 
     /**
      * @var OutputInterface


### PR DESCRIPTION
The 0.9.5 release works with php-ast 0.1.4+ (including 0.1.5)

If you are using phan 0.9.x, it's recommended to upgrade to phan 0.10.0 releases
(depends on php-ast 0.1.5+).
Phan 0.9.x will be supported for only a few more releases.
(and Phan 0.8.x will require php-ast 0.1.5+ in a few months)

For #1107