### PR TITLE
Include workaround for change in thrown ParseError

### DIFF
--- a/tests/fallback_test/expected/all_output.expected
+++ b/tests/fallback_test/expected/all_output.expected
@@ -1,4 +1,4 @@
-src/000_missing_semicolon_check.php:5 PhanSyntaxError syntax error, unexpected return (T_RETURN)
+src/000_missing_semicolon_check.php:5 PhanSyntaxError syntax error, unexpected 'return' (T_RETURN)
 src/000_missing_semicolon_check.php:5 PhanTypeMismatchArgumentInternal Argument 1 (string) is array but \strlen() takes string
 src/000_missing_semicolon_check.php:5 PhanTypeMismatchReturn Returning type int but test_missing_semicolon() is declared to return string
 src/001_missing_variable_check.php:3 PhanTypeMismatchArgumentInternal Argument 1 (string) is int but \strlen() takes string

--- a/tests/fallback_test/test.sh
+++ b/tests/fallback_test/test.sh
@@ -8,6 +8,8 @@ fi
 echo "Running phan in '$PWD' ..."
 rm $ACTUAL_PATH -f || exit 1
 ../../phan --use-fallback-parser | tee $ACTUAL_PATH
+# normalize output for https://github.com/phan/phan/issues/1130
+sed -i "s/ syntax error, unexpected return (T_RETURN)/ syntax error, unexpected 'return' (T_RETURN)/" $ACTUAL_PATH
 # diff returns a non-zero exit code if files differ or are missing
 # This outputs the 
 echo

--- a/tests/files/expected/0137_syntax_error.php.expected
+++ b/tests/files/expected/0137_syntax_error.php.expected
@@ -1,2 +1,1 @@
-%s:3 PhanSyntaxError syntax error, unexpected 'f' (T_STRING)
-%s:3 PhanSyntaxError syntax error, unexpected identifier (T_STRING)
+%s:3 PhanSyntaxError syntax error, unexpected ';'

--- a/tests/files/src/0137_syntax_error.php
+++ b/tests/files/src/0137_syntax_error.php
@@ -1,3 +1,3 @@
 <?php
 
-funcion f[] ( ... )
+$a = ;


### PR DESCRIPTION
7.1.11 will make ParseError messages consistently quote tokens.
Work around the differences in output.