### PR TITLE
Properly check for undeclared classes in generic array types

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,11 @@
 Phan NEWS
 
+?? ??? 2016, Phan 0.10.1
+
+Bug Fixes
++ Properly check for undeclared classes in arrays within phpdoc @param, @property, @method, @var, and @return types.
+  Also, fix a bug in resolving namespaces of generic arrays that are nested 2 or more array levels deep.
+
 24 Sep 2017, Phan 0.10.0
 -----------------------
 

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -10,6 +10,7 @@ use Phan\Language\Element\FunctionInterface;
 use Phan\Language\Element\Method;
 use Phan\Language\Element\Parameter;
 use Phan\Language\FQSEN\FullyQualifiedClassName;
+use Phan\Language\Type\GenericArrayType;
 use Phan\Language\Type\IterableType;
 use Phan\Language\Type\MixedType;
 use Phan\Language\Type\NullType;
@@ -38,7 +39,12 @@ class ParameterTypesAnalyzer
             $union_type = $parameter->getUnionType();
 
             // Look at each type in the parameter's Union Type
-            foreach ($union_type->getTypeSet() as $type) {
+            foreach ($union_type->getTypeSet() as $outer_type) {
+                $type = $outer_type;
+
+                while ($type instanceof GenericArrayType) {
+                    $type = $type->genericArrayElementType();
+                }
 
                 // If its a native type or a reference to
                 // self, its OK
@@ -68,7 +74,7 @@ class ParameterTypesAnalyzer
                             $method->getContext(),
                             Issue::UndeclaredTypeParameter,
                             $method->getFileRef()->getLineNumberStart(),
-                            (string)$type_fqsen
+                            (string)$outer_type
                         );
                     }
                 }

--- a/src/Phan/Analysis/PropertyTypesAnalyzer.php
+++ b/src/Phan/Analysis/PropertyTypesAnalyzer.php
@@ -6,6 +6,7 @@ use Phan\Exception\IssueException;
 use Phan\Issue;
 use Phan\Language\Element\Clazz;
 use Phan\Language\FQSEN\FullyQualifiedClassName;
+use Phan\Language\Type\GenericArrayType;
 use Phan\Language\Type\TemplateType;
 
 class PropertyTypesAnalyzer
@@ -31,7 +32,11 @@ class PropertyTypesAnalyzer
             }
 
             // Look at each type in the parameter's Union Type
-            foreach ($union_type->getTypeSet() as $type) {
+            foreach ($union_type->getTypeSet() as $outer_type) {
+                $type = $outer_type;
+                while ($type instanceof GenericArrayType) {
+                    $type = $type->genericArrayElementType();
+                }
 
                 // If its a native type or a reference to
                 // self, its OK
@@ -68,7 +73,7 @@ class PropertyTypesAnalyzer
                             Issue::UndeclaredTypeProperty,
                             $property->getFileRef()->getLineNumberStart(),
                             (string)$property->getFQSEN(),
-                            (string)$type_fqsen
+                            (string)$outer_type
                         );
                     }
                 }

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -16,7 +16,7 @@ class CLI
     /**
      * This should be updated to x.y.z-dev after every release, and x.y.z before a release.
      */
-    const PHAN_VERSION = '0.10.0';
+    const PHAN_VERSION = '0.10.1-dev';
 
     /**
      * @var OutputInterface

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -43,14 +43,14 @@ class Clazz extends AddressableElement
     private $parent_type = null;
 
     /**
-     * @var \Phan\Language\FullyQualifiedClassName[]
+     * @var FullyQualifiedClassName[]
      * A possibly empty list of interfaces implemented
      * by this class
      */
     private $interface_fqsen_list = [];
 
     /**
-     * @var \Phan\Language\FullyQualifiedClassName[]
+     * @var FullyQualifiedClassName[]
      * A possibly empty list of traits used by this class
      */
     private $trait_fqsen_list = [];

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -5,6 +5,7 @@ use Phan\CodeBase;
 use Phan\Config;
 use Phan\Issue;
 use Phan\Language\Context;
+use Phan\Language\FQSEN;
 use Phan\Language\Type\MixedType;
 use Phan\Language\Type\NullType;
 use Phan\Language\UnionType;

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -414,7 +414,6 @@ class Type
             //'PHP_FLOAT_MAX'         => $int, // since 7.2.0
             'DEFAULT_INCLUDE_PATH'  => $string,
             'PEAR_INSTALL_DIR'      => $string,
-            'PEAR_EXTENSION_DIR'    => $string,
             'PHP_EXTENSION_DIR'     => $string,
             'PEAR_EXTENSION_DIR'    => $string,
             'PHP_PREFIX'            => $string,
@@ -695,6 +694,13 @@ class Type
         if ($namespace) {
             $non_generic_partially_qualified_array_type_name =
                 $namespace . '\\' . $non_generic_partially_qualified_array_type_name;
+        }
+
+        if ($is_generic_array_type && false !== \strrpos($non_generic_array_type_name, '[]')) {
+            return GenericArrayType::fromElementType(
+                Type::fromStringInContext($non_generic_partially_qualified_array_type_name, $context, $source),
+                $is_nullable
+            );
         }
         if ($context->hasNamespaceMapFor(
             \ast\flags\USE_NORMAL,

--- a/tests/files/expected/0226_internal_tostring_parameter_undeclared.php.expected
+++ b/tests/files/expected/0226_internal_tostring_parameter_undeclared.php.expected
@@ -1,1 +1,2 @@
+%s:7 PhanUndeclaredTypeReturnType Return type of foo is undeclared type \urlstring
 %s:9 PhanTypeMismatchArgumentInternal Argument 1 (message) is \urlstring but \error_log() takes string

--- a/tests/files/expected/0241_nullable_71.php.expected
+++ b/tests/files/expected/0241_nullable_71.php.expected
@@ -3,3 +3,4 @@
 %s:13 PhanTypeMismatchArgument Argument 1 (name) is int but \f241_3() takes ?string defined at %s:11
 %s:26 PhanTypeMismatchReturn Returning type int but f241_5() is declared to return ?string
 %s:41 PhanTypeMismatchReturn Returning type null but f241_10() is declared to return \Tuple<int,string>
+%s:41 PhanUndeclaredTypeReturnType Return type of f241_10 is undeclared type \Tuple<int,string>

--- a/tests/files/expected/0262_obj_cast_to_specific_obj.php.expected
+++ b/tests/files/expected/0262_obj_cast_to_specific_obj.php.expected
@@ -1,1 +1,2 @@
+%s:18 PhanUndeclaredTypeReturnType Return type of returns_nullable_class is undeclared type \NullableClass
 %s:26 PhanTypeMismatchReturn Returning type object but returns_array() is declared to return array

--- a/tests/files/expected/0263_alias_outside_phpdoc.php.expected
+++ b/tests/files/expected/0263_alias_outside_phpdoc.php.expected
@@ -1,6 +1,7 @@
 %s:4 PhanUndeclaredTypeParameter Parameter of undeclared type \boolean
 %s:4 PhanUndeclaredTypeParameter Parameter of undeclared type \callback
 %s:4 PhanUndeclaredTypeParameter Parameter of undeclared type \double
+%s:4 PhanUndeclaredTypeParameter Parameter of undeclared type \double[]
 %s:4 PhanUndeclaredTypeParameter Parameter of undeclared type \integer
 %s:4 PhanUndeclaredTypeReturnType Return type of foo263 is undeclared type \boolean
 %s:5 PhanTypeMismatchReturn Returning type false but foo263() is declared to return \boolean

--- a/tests/files/expected/0358_undeclared_class_in_generic_array.php.expected
+++ b/tests/files/expected/0358_undeclared_class_in_generic_array.php.expected
@@ -1,0 +1,4 @@
+%s:9 PhanUndeclaredTypeParameter Parameter of undeclared type \UndefClass357A[]
+%s:9 PhanUndeclaredTypeParameter Parameter of undeclared type \UndefClass357B[][][]
+%s:9 PhanUndeclaredTypeParameter Parameter of undeclared type \UndefClass357C
+%s:9 PhanUndeclaredTypeReturnType Return type of test358 is undeclared type \UndefClass357D[]

--- a/tests/files/expected/0359_undeclared_class_in_prop.php.expected
+++ b/tests/files/expected/0359_undeclared_class_in_prop.php.expected
@@ -1,0 +1,7 @@
+%s:7 PhanUndeclaredTypeParameter Parameter of undeclared type \Missing359H[]
+%s:7 PhanUndeclaredTypeProperty Property \A359::missing4 has undeclared type \Missing359E
+%s:7 PhanUndeclaredTypeProperty Property \A359::missing4 has undeclared type \Missing359F[][]
+%s:7 PhanUndeclaredTypeReturnType Return type of myInstanceMethod is undeclared type \Missing359G
+%s:9 PhanUndeclaredTypeProperty Property \A359::missing1 has undeclared type \Missing359
+%s:9 PhanUndeclaredTypeProperty Property \A359::missing1 has undeclared type \Missing359B[][]
+%s:11 PhanUndeclaredTypeProperty Property \A359::missing2 has undeclared type ?\Missing359C

--- a/tests/files/expected/0360_undeclared_array_class_in_namespace.php.expected
+++ b/tests/files/expected/0360_undeclared_array_class_in_namespace.php.expected
@@ -1,0 +1,3 @@
+%s:12 PhanUndeclaredTypeParameter Parameter of undeclared type \Foo\Baz\MissingClass[][][]
+%s:12 PhanUndeclaredTypeReturnType Return type of myMethod is undeclared type \Foo\Bat\OtherMissingClass[][]
+%s:18 PhanUndeclaredTypeProperty Property \Foo\Bar\MyClass::y has undeclared type \Foo\Bar\Closure[][]

--- a/tests/files/src/0358_undeclared_class_in_generic_array.php
+++ b/tests/files/src/0358_undeclared_class_in_generic_array.php
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * @param UndefClass357A[] $a
+ * @param UndefClass357B[][][] $b
+ * @param UndefClass357C $c
+ * @return UndefClass357D[]
+ */
+function test358(array $a, $b, $c) : array {
+    return [];
+}

--- a/tests/files/src/0359_undeclared_class_in_prop.php
+++ b/tests/files/src/0359_undeclared_class_in_prop.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @property-read Missing359E|Missing359F[][] $missing4
+ * @method Missing359G myInstanceMethod(Missing359H[] $param1)
+ */
+class A359 {
+    /** @var Missing359|Missing359B[][] */
+    public $missing1;
+    /** @var ?Missing359C */
+    protected $missing2;
+
+    public function __get($prop_name) {
+        throw new \RuntimeException("Not implemented");
+    }
+}

--- a/tests/files/src/0360_undeclared_array_class_in_namespace.php
+++ b/tests/files/src/0360_undeclared_array_class_in_namespace.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Foo\Bar;
+
+use Foo\Baz\MissingClass;
+use Foo\Bat\OtherMissingClass;
+
+/**
+ * @param MissingClass[][][] $x
+ * @return OtherMissingClass[][]
+ */
+function myMethod($x) : array {
+    return [];
+}
+
+class MyClass {
+    /** @var Closure[][] should warn */
+    public static $y;
+    /** @var \Closure[][] should not warn */
+    public static $z;
+}


### PR DESCRIPTION
(within phpdoc @param, @property, @method, @var, and @return types).

Also, fix the way that phan resolves the type of generic arrays that are
nested 2 or more array levels deep.

Fix invalid phpdoc found in phan self-test

Add tests, update NEWS