### PR TITLE
Fix TypeError when magic property has the same name as a property.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,7 @@ Phan NEWS
 Bug Fixes
 + Properly check for undeclared classes in arrays within phpdoc @param, @property, @method, @var, and @return types.
   Also, fix a bug in resolving namespaces of generic arrays that are nested 2 or more array levels deep.
++ Fix uncaught TypeError when magic property has the same name as a property. (#1141)
 
 24 Sep 2017, Phan 0.10.0
 -----------------------

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -648,13 +648,15 @@ class Clazz extends AddressableElement
      */
     public function setMagicPropertyMap(
         array $magic_property_map,
-        CodeBase $code_base,
-        Context $context
+        CodeBase $code_base
     ) : bool {
         if (count($magic_property_map) === 0) {
             return true;  // Vacuously true.
         }
         $class_fqsen = $this->getFQSEN();
+        $context = $this->getContext()->withScope(
+            $this->getInternalScope()
+        );
         foreach ($magic_property_map as $comment_parameter) {
             // $flags is the same as the flags for `public` and non-internal?
             // Or \ast\flags\MODIFIER_PUBLIC.
@@ -684,13 +686,15 @@ class Clazz extends AddressableElement
      */
     public function setMagicMethodMap(
         array $magic_method_map,
-        CodeBase $code_base,
-        Context $context
+        CodeBase $code_base
     ) : bool {
         if (count($magic_method_map) === 0) {
             return true;  // Vacuously true.
         }
         $class_fqsen = $this->getFQSEN();
+        $context = $this->getContext()->withScope(
+            $this->getInternalScope()
+        );
         foreach ($magic_method_map as $comment_method) {
             // $flags is the same as the flags for `public` and non-internal?
             // Or \ast\flags\MODIFIER_PUBLIC.

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -155,8 +155,7 @@ class ParseVisitor extends ScopeVisitor
         // are limited to classes with either __get or __set declared (or interface/abstract
         $class->setMagicPropertyMap(
             $comment->getMagicPropertyMap(),
-            $this->code_base,
-            $this->context
+            $this->code_base
         );
 
         // Depends on code_base for checking existence of __call or __callStatic.
@@ -164,8 +163,7 @@ class ParseVisitor extends ScopeVisitor
         // are limited to classes with either __get or __set declared (or interface/abstract)
         $class->setMagicMethodMap(
             $comment->getMagicMethodMap(),
-            $this->code_base,
-            $this->context
+            $this->code_base
         );
 
         // usually used together with magic @property annotations

--- a/tests/files/src/0361_magic_property_crash.php
+++ b/tests/files/src/0361_magic_property_crash.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * Entity.
+ *
+ * @property int $dataId
+ */
+class Entity
+{
+	/**
+	 * @var int
+	 */
+	protected $dataId;
+
+	/**
+	 * @var string
+	 */
+	protected $privilege;
+}


### PR DESCRIPTION
Fixes #1141 : The passed in context would not contain the class FQSEN,
so there would be a TypeError