### PR TITLE
Implement Language Server Protocol support (Experimental)

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -378,8 +378,11 @@ return [
     'directory_list' => [
         'src',
         'tests/Phan',
+        'vendor/felixfbecker/advanced-json-rpc/lib',
+        'vendor/netresearch/jsonmapper/src',
         'vendor/nikic/php-parser/lib',
         'vendor/phpunit/phpunit/src',
+        'vendor/sabre/event/lib',
         'vendor/symfony/console',
         '.phan/plugins',
         '.phan/stubs',
@@ -427,5 +430,4 @@ return [
         //       Phan is run on a single core (-j1).
         // '.phan/plugins/UnusedSuppressionPlugin.php',
     ],
-
 ];

--- a/LICENSE.LANGUAGE_SERVER
+++ b/LICENSE.LANGUAGE_SERVER
@@ -1,0 +1,20 @@
+The code implementing support for the open Language Server Protocol
+is based on code from https://github.com/felixfbecker/php-language-server.
+
+Phan's language server implementation also uses the composer dependency felixfbecker/advanced-json-rpc
+
+ISC License
+
+Copyright (c) 2016, Felix Frederick Becker
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,14 @@
 Phan NEWS
 
-?? ??? 2016, Phan 0.10.1
+?? ??? 2017, Phan 0.10.1
+
+New Features (CLI, Configs)
+
++ Add Language Server Protocol support (Experimental) (#821)
+  Compatibility: Unix, Linux (depends on php pcntl extension).
+  This has the same analysis capabilities provided by [daemon mode](https://github.com/phan/phan/wiki/Using-Phan-Daemon-Mode#using-phan_client-from-an-editor).
+  Supporting a standard protocol should make it easier to write extensions supporting Phan in various IDEs.
+  See https://github.com/Microsoft/language-server-protocol/blob/master/README.md
 
 Bug Fixes
 + Properly check for undeclared classes in arrays within phpdoc @param, @property, @method, @var, and @return types.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ Phan is able to perform the following kinds of analysis.
 * Supports indicating the class to which a closure will be bound, via `@phan-closure-scope` ([example](tests/files/src/0264_closure_override_context.php))
 * Offers extensive configuration for weakening the analysis to make it useful on large sloppy code bases
 * Can be run on many cores. (requires `pcntl`)
-* [Can run in the background (daemon mode)](https://github.com/phan/phan/wiki/Using-Phan-Daemon-Mode), to then quickly respond to requests to analyze the latest version of a file. (requires `pcntl`)
+* [Can run in the background (daemon mode)](https://github.com/phan/phan/wiki/Using-Phan-Daemon-Mode), to then quickly respond to requests to analyze the latest version of a file.
+  Phan also has experimental support for the language server protocol.
+* In progress: can use open language server protocol(requires `pcntl`). Parts of the code are based on https://github.com/felixfbecker/php-language-server (requires `pcntl`)
 * Output is emitted in text, checkstyle, json or codeclimate formats.
 * Can run user plugins on source for checks specific to your code.
 
@@ -236,6 +238,17 @@ Usage: ./phan [options] [files...]
  --daemonize-tcp-port <default|1024-65535>
   TCP port for Phan to listen for JSON requests on, in daemon mode.
   (e.g. 'default', which is an alias for port 4846.)
+  `phan_client` can be used to communicate with the Phan Daemon.
+
+ --language-server-on-stdin
+  Start the language server (For the Language Server protocol).
+  This is a different protocol from --daemonize, clients for various IDEs already exist.
+
+ --language-server-tcp-server <addr>
+  Start the language server listening for TCP connections on <addr> (e.g. 127.0.0.1:<port>)
+
+ --language-server-tcp-connect <addr>
+  Start the language server and connect to the client listening on <addr> (e.g. 127.0.0.1:<port>)
 
  -v, --version
   Print phan's version number

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,9 @@
     "require": {
         "php": "~7.1.0 || ~7.2.0",
         "ext-ast": "^0.1.5",
+        "felixfbecker/advanced-json-rpc": "^2.0",
         "nikic/PHP-Parser": "~3.1.1",
+        "sabre/event": "^5.0",
         "symfony/console": "~2.3|~3.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,91 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "274e2417d71a3143bbde7364d8e0978e",
+    "content-hash": "87137433e13a7a0618d1ea4ef10e617b",
     "packages": [
+        {
+            "name": "felixfbecker/advanced-json-rpc",
+            "version": "v2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/felixfbecker/php-advanced-json-rpc.git",
+                "reference": "543ffb38b9af47f16404ab2daec5aaf225dcb531"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/felixfbecker/php-advanced-json-rpc/zipball/543ffb38b9af47f16404ab2daec5aaf225dcb531",
+                "reference": "543ffb38b9af47f16404ab2daec5aaf225dcb531",
+                "shasum": ""
+            },
+            "require": {
+                "netresearch/jsonmapper": "^1.0",
+                "php": ">=7.0",
+                "phpdocumentor/reflection-docblock": "^3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "AdvancedJsonRpc\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Felix Becker",
+                    "email": "felix.b@outlook.com"
+                }
+            ],
+            "description": "A more advanced JSONRPC implementation",
+            "time": "2017-06-22T12:18:44+00:00"
+        },
+        {
+            "name": "netresearch/jsonmapper",
+            "version": "v1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweiske/jsonmapper.git",
+                "reference": "b94ffe5b237a697253f06f5a57d9b22292bfffb3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/b94ffe5b237a697253f06f5a57d9b22292bfffb3",
+                "reference": "b94ffe5b237a697253f06f5a57d9b22292bfffb3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.2.*",
+                "squizlabs/php_codesniffer": "~1.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "JsonMapper": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "OSL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Weiske",
+                    "email": "cweiske@cweiske.de",
+                    "homepage": "http://github.com/cweiske/jsonmapper/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Map nested JSON structures onto PHP classes",
+            "time": "2017-08-14T07:26:24+00:00"
+        },
         {
             "name": "nikic/php-parser",
             "version": "v3.1.1",
@@ -58,6 +141,152 @@
             "time": "2017-09-02T17:10:46+00:00"
         },
         {
+            "name": "phpdocumentor/reflection-common",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "time": "2017-09-11T18:02:19+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "48eb1f629d55621f03ca72195fe04d05d463b807"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/48eb1f629d55621f03ca72195fe04d05d463b807",
+                "reference": "48eb1f629d55621f03ca72195fe04d05d463b807",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "phpdocumentor/reflection-common": "^1.0.0",
+                "phpdocumentor/type-resolver": "^0.4.0",
+                "webmozart/assert": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^4.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "time": "2017-09-11T18:06:56+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "0.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0",
+                "phpdocumentor/reflection-common": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^5.2||^4.8.24"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "time": "2017-07-14T14:27:02+00:00"
+        },
+        {
             "name": "psr/log",
             "version": "1.0.2",
             "source": {
@@ -103,6 +332,66 @@
                 "psr-3"
             ],
             "time": "2016-10-10T12:19:37+00:00"
+        },
+        {
+            "name": "sabre/event",
+            "version": "5.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/fruux/sabre-event.git",
+                "reference": "3cb619803d5e3e38ed7c309250da5589676aedc8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/fruux/sabre-event/zipball/3cb619803d5e3e38ed7c309250da5589676aedc8",
+                "reference": "3cb619803d5e3e38ed7c309250da5589676aedc8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=6",
+                "sabre/cs": "~1.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Sabre\\Event\\": "lib/"
+                },
+                "files": [
+                    "lib/coroutine.php",
+                    "lib/Loop/functions.php",
+                    "lib/Promise/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Evert Pot",
+                    "email": "me@evertpot.com",
+                    "homepage": "http://evertpot.com/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "sabre/event is a library for lightweight event-based programming",
+            "homepage": "http://sabre.io/event/",
+            "keywords": [
+                "EventEmitter",
+                "async",
+                "coroutine",
+                "eventloop",
+                "events",
+                "hooks",
+                "plugin",
+                "promise",
+                "reactor",
+                "signal"
+            ],
+            "time": "2017-06-10T09:11:18+00:00"
         },
         {
             "name": "symfony/console",
@@ -286,6 +575,56 @@
                 "shim"
             ],
             "time": "2017-06-14T15:44:48+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "time": "2016-11-23T20:04:58+00:00"
         }
     ],
     "packages-dev": [
@@ -486,152 +825,6 @@
             ],
             "description": "Library for handling version information and constraints",
             "time": "2017-03-05T17:38:23+00:00"
-        },
-        {
-            "name": "phpdocumentor/reflection-common",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
-                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.6"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jaap van Otterdijk",
-                    "email": "opensource@ijaap.nl"
-                }
-            ],
-            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
-            "homepage": "http://www.phpdoc.org",
-            "keywords": [
-                "FQSEN",
-                "phpDocumentor",
-                "phpdoc",
-                "reflection",
-                "static analysis"
-            ],
-            "time": "2017-09-11T18:02:19+00:00"
-        },
-        {
-            "name": "phpdocumentor/reflection-docblock",
-            "version": "4.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "2d3d238c433cf69caeb4842e97a3223a116f94b2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/2d3d238c433cf69caeb4842e97a3223a116f94b2",
-                "reference": "2d3d238c433cf69caeb4842e97a3223a116f94b2",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0",
-                "phpdocumentor/reflection-common": "^1.0@dev",
-                "phpdocumentor/type-resolver": "^0.4.0",
-                "webmozart/assert": "^1.0"
-            },
-            "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^4.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                }
-            ],
-            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-08-30T18:51:59+00:00"
-        },
-        {
-            "name": "phpdocumentor/type-resolver",
-            "version": "0.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
-                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.5 || ^7.0",
-                "phpdocumentor/reflection-common": "^1.0"
-            },
-            "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^5.2||^4.8.24"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                }
-            ],
-            "time": "2017-07-14T14:27:02+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -948,16 +1141,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.3.0",
+            "version": "6.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "9501bab711403a1ab5b8378a8adb4ec3db3debdb"
+                "reference": "c0ff817b36a827e64bf5f57bc72278150cf30a77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9501bab711403a1ab5b8378a8adb4ec3db3debdb",
-                "reference": "9501bab711403a1ab5b8378a8adb4ec3db3debdb",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c0ff817b36a827e64bf5f57bc72278150cf30a77",
+                "reference": "c0ff817b36a827e64bf5f57bc72278150cf30a77",
                 "shasum": ""
             },
             "require": {
@@ -1028,7 +1221,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-08-04T05:20:39+00:00"
+            "time": "2017-09-24T07:25:54+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -1687,56 +1880,6 @@
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "time": "2017-04-07T12:08:54+00:00"
-        },
-        {
-            "name": "webmozart/assert",
-            "version": "1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.3 || ^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.6",
-                "sebastian/version": "^1.0.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\Assert\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "Assertions to validate method input/output with nice error messages.",
-            "keywords": [
-                "assert",
-                "check",
-                "validate"
-            ],
-            "time": "2016-11-23T20:04:58+00:00"
         }
     ],
     "aliases": [],

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -94,6 +94,10 @@ class CLI
                 'use-fallback-parser',
                 'daemonize-socket:',
                 'daemonize-tcp-port:',
+                'language-server-on-stdin',
+                'language-server-tcp-server:',
+                'language-server-tcp-connect:',
+                'language-server-verbose',
                 'extended-help',
             ]
         );
@@ -290,6 +294,19 @@ class CLI
                     } else {
                         $this->usage("daemonize-tcp-port must be the string 'default' or a value between 1024 and 65535, got '$value'", 1);
                     }
+                    break;
+                case 'language-server-on-stdin':
+                    Config::setValue('language_server_config', ['stdin' => true]);
+                    break;
+                case 'language-server-tcp-server':
+                    // TODO: could validate?
+                    Config::setValue('language_server_config', ['tcp-server' => $value]);
+                    break;
+                case 'language-server-tcp-connect':
+                    Config::setValue('language_server_config', ['tcp' => $value]);
+                    break;
+                case 'language-server-verbose':
+                    Config::setValue('language_server_debug_level', 'info');
                     break;
                 case 'x':
                 case 'dead-code-detection':
@@ -538,6 +555,17 @@ Usage: {$argv[0]} [options] [files...]
  --daemonize-tcp-port <default|1024-65535>
   TCP port for Phan to listen for JSON requests on, in daemon mode.
   (e.g. 'default', which is an alias for port 4846.)
+  `phan_client` can be used to communicate with the Phan Daemon.
+
+ --language-server-on-stdin
+  Start the language server (For the Language Server protocol).
+  This is a different protocol from --daemonize, clients for various IDEs already exist.
+
+ --language-server-tcp-server <addr>
+  Start the language server listening for TCP connections on <addr> (e.g. 127.0.0.1:<port>)
+
+ --language-server-tcp-connect <addr>
+  Start the language server and connect to the client listening on <addr> (e.g. 127.0.0.1:<port>)
 
  -v, --version
   Print phan's version number
@@ -571,6 +599,10 @@ Extended help:
 
  --markdown-issue-messages
   Emit issue messages with markdown formatting.
+
+ --language-server-verbose
+  Emit verbose logging messages related to the language server implementation to stderr.
+  This is useful when developing or debugging language server clients.
 
 EOB;
         }

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -269,11 +269,12 @@ class CodeBase
 
     /**
      * @param string[] $new_file_list
+     * @param string[] $file_mapping_contents maps relative path to absolute paths
      * @return string[] - Subset of $new_file_list which changed on disk and has to be parsed again. Automatically unparses the old versions of files which were modified.
      */
-    public function updateFileList(array $new_file_list) {
+    public function updateFileList(array $new_file_list, array $file_mapping_contents = []) {
         if ($this->undo_tracker) {
-            return $this->undo_tracker->updateFileList($this, $new_file_list);
+            return $this->undo_tracker->updateFileList($this, $new_file_list, $file_mapping_contents);
         }
         throw new \RuntimeException("Calling updateFileList without undo tracker");
     }

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -584,6 +584,16 @@ class Config
         // TCP port(from 1024 to 65535) for a daemon to listen to files to analyze. Use command line option instead.
         'daemonize_tcp_port' => false,
 
+        // If this is an array, it configures the way clients will communicate with the Phan language server.
+        // Possibilities: Exactly one of
+        // ['stdin' => true],
+        // ['tcp-server' => string (address this server should listen on)],
+        // ['tcp' => string (address client is listening on)
+        'language_server_config' => false,
+
+        // Valid values: null, 'info'. Used when developing or debugging a language server client of Phan.
+        'language_server_debug_level' => null,
+
         // A list of plugin files to execute
         'plugins' => [
         ],

--- a/src/Phan/Daemon/Request.php
+++ b/src/Phan/Daemon/Request.php
@@ -1,12 +1,14 @@
 <?php declare(strict_types=1);
 namespace Phan\Daemon;
 
+use Closure;
 use Phan\Analysis;
 use Phan\CodeBase;
 use Phan\Config;
 use Phan\Daemon;
 use Phan\Language\FileRef;
 use Phan\Language\Type;
+use Phan\LanguageServer\FileMapping;
 use Phan\Library\FileCache;
 use Phan\Output\IssuePrinterInterface;
 use Phan\Output\PrinterFactory;
@@ -35,13 +37,13 @@ class Request {
     const STATUS_INVALID_REQUEST = 'invalid_request';  // expected a valid string for 'files'/'file'
 
     /** @var resource|null - Null after the response is sent. */
-    private $conn;
+    private $response_connection;
 
     /** @var array */
     private $config;
 
     /** @var BufferedOutput */
-    private $bufferedOutput;
+    private $buffered_output;
 
     /** @var string */
     private $method;
@@ -54,21 +56,55 @@ class Request {
     private static $exited_pid_status = [];
 
     /**
-     * @param resource $conn
+     * @param resource $response_connection
      * @param array $config
      */
-    private function __construct($conn, array $config) {
-        $this->conn = $conn;
+    private function __construct($response_connection, array $config)
+    {
+        $this->response_connection = $response_connection;
         $this->config = $config;
-        $this->bufferedOutput = new BufferedOutput();
+        $this->buffered_output = new BufferedOutput();
         $this->method = $config[self::PARAM_METHOD];
-        // TODO: constants.
         if ($this->method === self::METHOD_ANALYZE_FILES) {
             $this->files = $config[self::PARAM_FILES];
         }
     }
 
-    public function getPrinter() : IssuePrinterInterface {
+    /**
+     * @param resource $response_connection a socket to write a response on
+     * @param string[] $filenames absolute path of file(s) to analyze
+     * @param CodeBase $code_base (for refreshing parse state)
+     * @param Closure $file_path_lister (for refreshing parse state)
+     * @param FileMapping $file_mapping object tracking the overrides made by a client.
+     */
+    public static function makeLanguageServerAnalysisRequest(
+        $response_connection,
+        array $filenames,
+        CodeBase $code_base,
+        Closure $file_path_lister,
+        FileMapping $file_mapping
+    ) : Request {
+        FileCache::clear();
+        $file_mapping_contents = self::normalizeFileMappingContents($file_mapping->getOverrides(), $error_message);
+        // Use the temporary contents if they're available
+        Request::reloadFilePathListForDaemon($code_base, $file_path_lister, $file_mapping_contents);
+        if ($error_message !== null) {
+            Daemon::debugf($error_message);
+        };
+        $result = new self(
+            $response_connection,
+            [
+                self::PARAM_FORMAT => 'json',
+                self::PARAM_METHOD => self::METHOD_ANALYZE_FILES,
+                self::PARAM_FILES => $filenames,
+                self::PARAM_TEMPORARY_FILE_MAPPING_CONTENTS => $file_mapping_contents,
+            ]
+        );
+        return $result;
+    }
+
+    public function getPrinter() : IssuePrinterInterface
+    {
         // TODO: check $this->config['format']
         $factory = new PrinterFactory();
         $format = $this->config['format'] ?? 'json';
@@ -78,21 +114,23 @@ class Request {
             ]);
             exit(0);
         }
-        return $factory->getPrinter($format, $this->bufferedOutput);
+        return $factory->getPrinter($format, $this->buffered_output);
     }
 
     /**
      * Respond with issues in the requested format
+     * @return void
      */
-    public function respondWithIssues(int $issueCount) {
-        $rawIssues = $this->bufferedOutput->fetch();
+    public function respondWithIssues(int $issueCount)
+    {
+        $raw_issues = $this->buffered_output->fetch();
         if (($this->config[self::PARAM_FORMAT] ?? null) === 'json') {
-            $issues = json_decode($rawIssues, true);
+            $issues = json_decode($raw_issues, true);
             if (!\is_array($issues)) {
-                $issues = "(Failed to decode) " . json_last_error_msg() . ': ' . $rawIssues;
+                $issues = "(Failed to decode) " . json_last_error_msg() . ': ' . $raw_issues;
             }
         } else {
-            $issues = $rawIssues;
+            $issues = $raw_issues;
         }
         $this->sendJSONResponse([
             "status" => self::STATUS_OK,
@@ -101,7 +139,11 @@ class Request {
         ]);
     }
 
-    public function respondWithNoFilesToAnalyze() {
+    /**
+     * @return void
+     */
+    public function respondWithNoFilesToAnalyze()
+    {
         // The mentioned file wasn't in .phan/config.php's list of files to analyze.
         // TODO: Send the client that list of files.
         $this->sendJSONResponse([
@@ -114,8 +156,8 @@ class Request {
      * @param string[] $analyze_file_path_list
      * @return string[]
      */
-    public function filterFilesToAnalyze(array $analyze_file_path_list) : array {
-
+    public function filterFilesToAnalyze(array $analyze_file_path_list) : array
+    {
         if (\is_null($this->files)) {
             Daemon::debugf("No files to filter in filterFilesToAnalyze");
             return $analyze_file_path_list;
@@ -143,7 +185,8 @@ class Request {
      * TODO: convert absolute path to relative paths.
      * @return string[] - Maps original relative file paths to contents.
      */
-    public function getTemporaryFileMapping() : array {
+    public function getTemporaryFileMapping() : array
+    {
         $mapping = $this->config[self::PARAM_TEMPORARY_FILE_MAPPING_CONTENTS] ?? [];
         Daemon::debugf("Have the following files in mapping: %s", json_encode(array_keys($mapping)));
         return $mapping;
@@ -157,32 +200,35 @@ class Request {
      * @param array $response
      * @return void
      */
-    public function sendJSONResponse(array $response) {
-        self::sendJSONResponseOverSocket($this->conn, $response);
-        $this->conn = null;
+    public function sendJSONResponse(array $response)
+    {
+        self::sendJSONResponseOverSocket($this->response_connection, $response);
+        $this->response_connection = null;
     }
 
     /**
-     * @param resource $conn
+     * @param resource $response_connection
      * @param array $response
      * @return void
      */
-    public static function sendJSONResponseOverSocket($conn, array $response) {
-        if (!$conn) {
+    public static function sendJSONResponseOverSocket($response_connection, array $response)
+    {
+        if (!$response_connection) {
             Daemon::debugf("Already sent response");
             return;
         }
-        fwrite($conn, json_encode($response) . "\n");
+        fwrite($response_connection, json_encode($response) . "\n");
         // disable further receptions and transmissions
         // Note: This is likely a giant hack,
         // and pcntl and sockets may break in the future if used together. (multiple processes owning a single resource).
         // Not sure how to do that safely.
-        stream_socket_shutdown($conn, STREAM_SHUT_RDWR);
-        fclose($conn);
+        stream_socket_shutdown($response_connection, STREAM_SHUT_RDWR);
+        fclose($response_connection);
     }
 
-    public function __destruct() {
-        if (isset($this->conn)) {
+    public function __destruct()
+    {
+        if (isset($this->response_connection)) {
             $this->sendJSONResponse([
                 'status' => self::STATUS_ERROR_UNKNOWN,
                 'message' => 'failed to send a response - Possibly encountered an exception. See daemon output.',
@@ -197,7 +243,8 @@ class Request {
      * @return void
      * @suppress PhanUndeclaredConstant pcntl unavailable on windows
      */
-    public static function childSignalHandler($signo, $status = null, $pid = null) {
+    public static function childSignalHandler($signo, $status = null, $pid = null)
+    {
         if ($signo !== SIGCHLD) {
             return;
         }
@@ -224,31 +271,56 @@ class Request {
     }
 
     /**
+     * @param string[] $file_mapping_contents
+     * @param ?string &$error_message
+     */
+    public static function normalizeFileMappingContents($file_mapping_contents, &$error_message) : array
+    {
+        $error_message = null;
+        if (!\is_array($file_mapping_contents)) {
+            $error_message = 'Invalid value of temporary_file_mapping_contents';
+        }
+        $new_file_mapping_contents = [];
+        foreach ($file_mapping_contents ?? [] as $file => $contents) {
+            if (!\is_string($file)) {
+                $error_message = 'Passed non-string in list of files to map';
+                return [];
+            } else if (!\is_string($contents)) {
+                $error_message = 'Passed non-string in as new file contents';
+                return [];
+            }
+            $new_file_mapping_contents[FileRef::getProjectRelativePathForPath($file)] = $contents;
+        }
+        return $new_file_mapping_contents;
+    }
+    /**
      * @param CodeBase $code_base
      * @param \Closure $file_path_lister
-     * @param resource $conn
+     * @param resource $response_connection
      * @return Request|null - non-null if this is a worker process with work to do. null if request failed or this is the master.
      * @suppress PhanUndeclaredConstant (pcntl unavailable on windows)
      */
-    public static function accept(CodeBase $code_base, \Closure $file_path_lister, $conn) {
+    public static function accept(CodeBase $code_base, \Closure $file_path_lister, $response_connection)
+    {
         FileCache::clear();
         Daemon::debugf("Got a connection");  // debugging code
         // Efficient for large strings, e.g. long file lists.
         $data = [];
-        while (!feof($conn)) {
-            $data[] = fgets($conn);
+        while (!feof($response_connection)) {
+            $data[] = fgets($response_connection);
         }
         $request_bytes = implode('', $data);
         $request = json_decode($request_bytes, true);
 
         if (!\is_array($request)) {
             Daemon::debugf("Received invalid request, expected JSON: %s", json_encode($request_bytes));
-            self::sendJSONResponseOverSocket($conn, [
+            self::sendJSONResponseOverSocket($response_connection, [
                 'status'  => self::STATUS_INVALID_REQUEST,
                 'message' => 'malformed JSON',
             ]);
             return null;
         }
+        $new_file_mapping_contents = [];
         $method = $request['method'] ?? null;
         switch($method) {
         case 'analyze_all':
@@ -280,24 +352,12 @@ class Request {
             }
             if (\is_null($error_message)) {
                 $file_mapping_contents = $request[self::PARAM_TEMPORARY_FILE_MAPPING_CONTENTS] ?? [];
-                if (!\is_array($file_mapping_contents)) {
-                    $error_message = 'Invalid value of temporary_file_mapping_contents';
-                }
-                $new_file_mapping_contents = [];
-                foreach ($file_mapping_contents ?? [] as $file => $contents) {
-                    $new_file_mapping_contents[FileRef::getProjectRelativePathForPath($file)] = $contents;
-                    if (!\is_string($file)) {
-                        $error_message = 'Passed non-string in list of files to map';
-                        break;
-                    } else if (!\is_string($contents)) {
-                        $error_message = 'Passed non-string in as new file contents';
-                    }
-                }
+                $new_file_mapping_contents = self::normalizeFileMappingContents($file_mapping_contents, $error_message);
                 $request[self::PARAM_TEMPORARY_FILE_MAPPING_CONTENTS] = $new_file_mapping_contents;
             }
             if ($error_message !== null) {
                 Daemon::debugf($error_message);
-                self::sendJSONResponseOverSocket($conn, [
+                self::sendJSONResponseOverSocket($response_connection, [
                     'status'  => self::STATUS_INVALID_FILES,
                     'message' => $error_message,
                 ]);
@@ -308,14 +368,14 @@ class Request {
         default:
             $message = sprintf("expected method to be analyze_all or analyze_files, got %s", json_encode($method));
             Daemon::debugf($message);
-            self::sendJSONResponseOverSocket($conn, [
+            self::sendJSONResponseOverSocket($response_connection, [
                 'status'  => self::STATUS_INVALID_METHOD,
                 'message' => $message,
             ]);
             return null;
         }
 
-        self::reloadFilePathListForDaemon($code_base, $file_path_lister);
+        self::reloadFilePathListForDaemon($code_base, $file_path_lister, $new_file_mapping_contents);
         $receivedSignal = false;
 
         $fork_result = pcntl_fork();
@@ -325,7 +385,7 @@ class Request {
             Daemon::debugf("This is the fork");
             self::$child_pids = [];
             // TODO: Re-parse the file list.
-            $request_obj = new self($conn, $request);
+            $request_obj = new self($response_connection, $request);
             $temporary_file_mapping = $request_obj->getTemporaryFileMapping();
             if (count($temporary_file_mapping) > 0) {
                 self::applyTemporaryFileMappingForParsePhase($code_base, $temporary_file_mapping);
@@ -355,8 +415,9 @@ class Request {
      * Reloads the file path list.
      * @return void
      */
-    private static function reloadFilePathListForDaemon(CodeBase $code_base, \Closure $file_path_lister) {
-        $oldCount = $code_base->getParsedFilePathCount();
+    public static function reloadFilePathListForDaemon(CodeBase $code_base, \Closure $file_path_lister, array $file_mapping_contents)
+    {
+        $old_count = $code_base->getParsedFilePathCount();
 
         $file_list = $file_path_lister();
 
@@ -367,9 +428,9 @@ class Request {
             sort($file_list, SORT_STRING);
         }
 
-        $changed_or_added_files = $code_base->updateFileList($file_list);
-        Daemon::debugf("Parsing modified files: New files = %s", json_encode($changed_or_added_files));
-        if (count($changed_or_added_files) > 0 || $code_base->getParsedFilePathCount() !== $oldCount) {
+        $changed_or_added_files = $code_base->updateFileList($file_list, $file_mapping_contents);
+        // Daemon::debugf("Parsing modified files: New files = %s", json_encode($changed_or_added_files));
+        if (count($changed_or_added_files) > 0 || $code_base->getParsedFilePathCount() !== $old_count) {
             // Only clear memoizations if it is determined at least one file to parse was added/removed/modified.
             // - file path count changes if files were deleted or added
             // - changed_or_added_files has an entry for every added/modified file.
@@ -390,7 +451,7 @@ class Request {
             Daemon::debugf("Parsing %s yet again", $file_path);
             try {
                 // Parse the file
-                Analysis::parseFile($code_base, $file_path);
+                Analysis::parseFile($code_base, $file_path, false, $file_mapping_contents[$file_path] ?? null);
             } catch (\Throwable $throwable) {
                 error_log(sprintf("Analysis::parseFile threw %s for %s: %s\n%s", get_class($throwable), $file_path, $throwable->getMessage(), $throwable->getTraceAsString()));
             }
@@ -404,8 +465,9 @@ class Request {
      *
      * @return void
      */
-    private static function applyTemporaryFileMappingForParsePhase(CodeBase $code_base, array $temporary_file_mapping_contents) {
-        $oldCount = $code_base->getParsedFilePathCount();
+    private static function applyTemporaryFileMappingForParsePhase(CodeBase $code_base, array $temporary_file_mapping_contents)
+    {
+        $old_count = $code_base->getParsedFilePathCount();
         if (count($temporary_file_mapping_contents) === 0) {
             return;
         }
@@ -413,19 +475,19 @@ class Request {
         // too verbose
         Daemon::debugf("Parsing temporary file mapping contents: New contents = %s", json_encode($temporary_file_mapping_contents));
 
-        $changesToAdd = [];
+        $changes_to_add = [];
         foreach ($temporary_file_mapping_contents as $file_name => $contents) {
             if ($code_base->beforeReplaceFileContents($file_name, $contents)) {
-                $changesToAdd[$file_name] = $contents;
+                $changes_to_add[$file_name] = $contents;
             }
         }
-        Daemon::debugf("Done setting temporary file contents: Will replace contents of the following files: %s", json_encode(array_keys($changesToAdd)));
-        if (count($changesToAdd) === 0) {
+        Daemon::debugf("Done setting temporary file contents: Will replace contents of the following files: %s", json_encode(array_keys($changes_to_add)));
+        if (count($changes_to_add) === 0) {
             return;
         }
         Type::clearAllMemoizations();
 
-        foreach ($changesToAdd as $file_path => $newContents) {
+        foreach ($changes_to_add as $file_path => $new_contents) {
             // Kick out anything we read from the former version
             // of this file
             $code_base->flushDependenciesForFile($file_path);
@@ -438,7 +500,7 @@ class Request {
             Daemon::debugf("Parsing temporary file instead of %s", $file_path);
             try {
                 // Parse the file
-                Analysis::parseFile($code_base, $file_path, false, $newContents);
+                Analysis::parseFile($code_base, $file_path, false, $new_contents);
             } catch (\Throwable $throwable) {
                 error_log(sprintf("Analysis::parseFile threw %s for %s: %s\n%s", get_class($throwable), $file_path, $throwable->getMessage(), $throwable->getTraceAsString()));
             }

--- a/src/Phan/LanguageServer/Client/TextDocument.php
+++ b/src/Phan/LanguageServer/Client/TextDocument.php
@@ -1,0 +1,66 @@
+<?php
+declare(strict_types = 1);
+
+namespace Phan\LanguageServer\Client;
+
+use Phan\LanguageServer\ClientHandler;
+use Phan\LanguageServer\Protocol\{Diagnostic, Message, TextDocumentItem, TextDocumentIdentifier};
+use Sabre\Event\Promise;
+use JsonMapper;
+
+/**
+ * Provides method handlers for all textDocument/* methods
+ *
+ * Source: https://github.com/felixfbecker/php-language-server/tree/master/src/Protocol/TextDocument.php
+ * See ../../../../LICENSE.LANGUAGE_SERVER
+ */
+class TextDocument
+{
+    /**
+     * @var ClientHandler
+     */
+    private $handler;
+
+    /**
+     * @var JsonMapper
+     */
+    private $mapper;
+
+    public function __construct(ClientHandler $handler, JsonMapper $mapper)
+    {
+        $this->handler = $handler;
+        $this->mapper = $mapper;
+    }
+
+    /**
+     * Diagnostics notification are sent from the server to the client to signal results of validation runs.
+     *
+     * @param string $uri
+     * @param Diagnostic[] $diagnostics
+     * @return Promise <void>
+     */
+    public function publishDiagnostics(string $uri, array $diagnostics): Promise
+    {
+        return $this->handler->notify('textDocument/publishDiagnostics', [
+            'uri' => $uri,
+            'diagnostics' => $diagnostics
+        ]);
+    }
+
+    /**
+     * The content request is sent from a server to a client
+     * to request the current content of a text document identified by the URI
+     *
+     * @param TextDocumentIdentifier $textDocument The document to get the content for
+     * @return Promise <TextDocumentItem> The document's current content
+     */
+    public function xcontent(TextDocumentIdentifier $textDocument): Promise
+    {
+        return $this->handler->request(
+            'textDocument/xcontent',
+            ['textDocument' => $textDocument]
+        )->then(function ($result) {
+            return $this->mapper->map($result, new TextDocumentItem);
+        });
+    }
+}

--- a/src/Phan/LanguageServer/ClientHandler.php
+++ b/src/Phan/LanguageServer/ClientHandler.php
@@ -1,0 +1,88 @@
+<?php
+declare(strict_types = 1);
+
+namespace Phan\LanguageServer;
+
+use AdvancedJsonRpc;
+use Sabre\Event\Promise;
+
+/**
+ * Source: https://github.com/felixfbecker/php-language-server/tree/master/src/ClientHandler.php
+ * See ../../../LICENSE.LANGUAGE_SERVER
+ */
+class ClientHandler
+{
+    /**
+     * @var ProtocolReader
+     */
+    public $protocolReader;
+
+    /**
+     * @var ProtocolWriter
+     */
+    public $protocolWriter;
+
+    /**
+     * @var IdGenerator
+     */
+    public $idGenerator;
+
+    public function __construct(ProtocolReader $protocolReader, ProtocolWriter $protocolWriter)
+    {
+        $this->protocolReader = $protocolReader;
+        $this->protocolWriter = $protocolWriter;
+        $this->idGenerator = new IdGenerator;
+    }
+
+    /**
+     * Sends a request to the client and returns a promise that is resolved with the result or rejected with the error
+     *
+     * @param string $method The method to call
+     * @param array|object $params The method parameters
+     * @return Promise <mixed> Resolved with the result of the request or rejected with an error
+     */
+    public function request(string $method, $params): Promise
+    {
+        $id = $this->idGenerator->generate();
+        return $this->protocolWriter->write(
+            new Protocol\Message(
+                new AdvancedJsonRpc\Request($id, $method, (object)$params)
+            )
+        )->then(function () use ($id) {
+            $promise = new Promise;
+            /**
+             * @suppress PhanUndeclaredProperty taken care of by isResponse checks on msg->body
+             */
+            $listener = function (Protocol\Message $msg) use ($id, $promise, &$listener) {
+                if (AdvancedJsonRpc\Response::isResponse($msg->body) && $msg->body->id === $id) {
+                    // Received a response
+                    $this->protocolReader->removeListener('message', $listener);
+                    if (AdvancedJsonRpc\SuccessResponse::isSuccessResponse($msg->body)) {
+                        $promise->fulfill($msg->body->result);
+                    } else {
+                        $promise->reject($msg->body->error);
+                    }
+                }
+            };
+            $this->protocolReader->on('message', $listener);
+            return $promise;
+        });
+    }
+
+    /**
+     * Sends a notification to the client
+     *
+     * @param string $method The method to call
+     * @param array|object $params The method parameters
+     * @return Promise <null> Will be resolved as soon as the notification has been sent
+     */
+    public function notify(string $method, $params): Promise
+    {
+        $id = $this->idGenerator->generate();
+        return $this->protocolWriter->write(
+            new Protocol\Message(
+                new AdvancedJsonRpc\Notification($method, (object)$params)
+            )
+        );
+    }
+}

--- a/src/Phan/LanguageServer/FileMapping.php
+++ b/src/Phan/LanguageServer/FileMapping.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types = 1);
+
+namespace Phan\LanguageServer;
+
+/**
+ * A class to keep track of overrides by language server clients with open files.
+ * Created for Phan.
+ *
+ * TODO: remove all overrides when a language server disconnects.
+ */
+class FileMapping {
+    /**
+     * @var string[] maps the absolute paths on disks to the currently edited versions of those files.
+     * TODO: Won't work with more than one client.
+     */
+    private $overrides = [];
+
+    public function __construct() {
+    }
+
+    public function getOverrides() {
+        return $this->overrides;
+    }
+
+    /**
+     * @param string $uri
+     * @param ?string $new_contents
+     * @return void
+     */
+    public function addOverrideURI(string $uri, $new_contents) {
+        $path = Utils::uriToPath($uri);
+        if ($new_contents === null) {
+            $this->removeOverride($path);
+            return;
+        }
+        $this->overrides[$path] = $new_contents;
+    }
+
+    /**
+     * @param string $path
+     * @param ?string $new_contents
+     * @return void
+     */
+    public function addOverride(string $path, $new_contents) {
+        if ($new_contents === null) {
+            $this->removeOverride($path);
+            return;
+        }
+        $this->overrides[$path] = $new_contents;
+    }
+
+    /**
+     * @return void
+     */
+    public function removeOverrideURI(string $uri) {
+        $path = Utils::uriToPath($uri);
+        $this->removeOverride($path);
+    }
+
+    /**
+     * @return void
+     */
+    public function removeOverride(string $path) {
+        unset($this->overrides[$path]);
+    }
+}

--- a/src/Phan/LanguageServer/IdGenerator.php
+++ b/src/Phan/LanguageServer/IdGenerator.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types = 1);
+
+namespace Phan\LanguageServer;
+
+/**
+ * Generates unique, incremental IDs for use as request IDs
+ *
+ * Source: https://github.com/felixfbecker/php-language-server/tree/master/src/IdGenerator.php
+ * See ../../../../LICENSE.LANGUAGE_SERVER
+ */
+class IdGenerator
+{
+    /**
+     * @var int
+     */
+    public $counter = 1;
+
+    /**
+     * Returns a unique ID
+     *
+     * @return int
+     */
+    public function generate()
+    {
+        return $this->counter++;
+    }
+}

--- a/src/Phan/LanguageServer/LanguageClient.php
+++ b/src/Phan/LanguageServer/LanguageClient.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types = 1);
+
+namespace Phan\LanguageServer;
+
+use JsonMapper;
+
+/**
+ * Source: https://github.com/felixfbecker/php-language-server/tree/master/src/LanguageClient.php
+ * See ../../../LICENSE.LANGUAGE_SERVER
+ */
+class LanguageClient
+{
+    /**
+     * Handles textDocument/* methods
+     *
+     * @var Client\TextDocument
+     */
+    public $textDocument;
+
+    /**
+     *
+     */
+    public function __construct(ProtocolReader $reader, ProtocolWriter $writer)
+    {
+        $handler = new ClientHandler($reader, $writer);
+        $mapper = new JsonMapper;
+
+        $this->textDocument = new Client\TextDocument($handler, $mapper);
+    }
+}

--- a/src/Phan/LanguageServer/LanguageServer.php
+++ b/src/Phan/LanguageServer/LanguageServer.php
@@ -1,0 +1,575 @@
+<?php declare(strict_types=1);
+namespace Phan\LanguageServer;
+
+use AdvancedJsonRpc;
+use Closure;
+use Phan\CodeBase;
+use Phan\Config;
+use Phan\Daemon\Request;
+use Phan\Issue;
+use Phan\Language\FileRef;
+use Phan\LanguageServer\Protocol\ClientCapabilities;
+use Phan\LanguageServer\Protocol\Diagnostic;
+use Phan\LanguageServer\Protocol\DiagnosticSeverity;
+use Phan\LanguageServer\Protocol\InitializeResult;
+use Phan\LanguageServer\Protocol\Message;
+use Phan\LanguageServer\Protocol\Position;
+use Phan\LanguageServer\Protocol\Range;
+use Phan\LanguageServer\Protocol\ServerCapabilities;
+use Phan\LanguageServer\Protocol\TextDocumentIdentifier;
+use Phan\LanguageServer\Protocol\TextDocumentSyncKind;
+use Phan\LanguageServer\Server\TextDocument;
+use Phan\LanguageServer\ProtocolReader;
+use Phan\LanguageServer\ProtocolWriter;
+use Phan\LanguageServer\ProtocolStreamReader;
+use Phan\LanguageServer\ProtocolStreamWriter;
+use Sabre\Event\Loop;
+use Sabre\Event\Promise;
+use function Sabre\Event\coroutine;
+use Throwable;
+
+/**
+ * Based on https://github.com/felixfbecker/php-language-server/blob/master/bin/php-language-server.php
+ * and https://github.com/felixfbecker/php-language-server/blob/master/src/LanguageServer.php (for language server protocol implementation)
+ *
+ * This is similar to Phan daemon mode, but it's possible for it to receive concurrent events, or more than one type of event.
+ * (in addition to file notifications, etc.)
+ *
+ * What will do in the most common case (checking for errors in a file):
+ *
+ * 0. Phan completes the parse phase, on the initial version of the codebase
+ * 1. Phan starts a Sabre event loop and listens for requests and responses: see http://sabre.io/event/loop/
+ *    It registers addReadStream and addWriteStream (See ProtocolStreamReader and ProtocolStreamWriter)
+ * 2. Phan receives a notification that a file changed/was added/was removed
+ * 3. If the files are within the phan project (contains .phan directory),
+ *    then phan removes the old parse state of removed/changed files, then adds the new parse state of changed/added files.
+ * 4. The main phan process (managing the event loop) fork, the fork shuts down the event loop without receiving any more events or touching the stream(will this work?)
+ * 5. The forked process runs the analysis.
+ * 6. The forked process reports the analysis result to the main process via IPC (similar to what \Phan\ForkPool does), along with the id of the request
+ * 7. Phan notifies the client of the new issues ("diagnostic" in the open Language Server Protocol)
+ *    See https://github.com/Microsoft/language-server-protocol#language-server-protocol
+ *
+ * TODO: support a memory limit
+ * TODO: Make waiting for analysis async, but continue rate limiting
+ *
+ * TODO: support textDocument rename
+ *
+ * TODO: Does it make sense for everything (data structures without code) in the Protocol folder to be a composer project? Check.
+ *       (NOTE: The way we represent the project state and the parse state varies between projects. The callbacks used also vary.)
+ */
+class LanguageServer extends AdvancedJsonRpc\Dispatcher {
+    /**
+     * Handles workspace/* method calls
+     *
+     * @var Server\Workspace
+     */
+    public $workspace;
+
+    /**
+     * @var ProtocolReader
+     */
+    protected $protocolReader;
+
+    /**
+     * @var ProtocolWriter
+     */
+    protected $protocolWriter;
+
+    /**
+     * @var LanguageClient
+     */
+    protected $client;
+
+    /**
+     * Handles textDocument/* method calls
+     * (e.g. whenever a text document is opened, saved, or closed)
+     *
+     * @var TextDocument
+     */
+    public $textDocument;
+
+    /**
+     * @var Request|null
+     */
+    protected $most_recent_request;
+
+    /**
+     * @var CodeBase
+     */
+    protected $code_base;
+
+    /**
+     * @var Closure
+     */
+    protected $file_path_lister;
+
+    /**
+     * @var FileMapping
+     */
+    protected $file_mapping;
+
+    public function __construct(ProtocolReader $reader, ProtocolWriter $writer, CodeBase $code_base, Closure $file_path_lister)
+    {
+        parent::__construct($this, '/');
+        $this->protocolReader = $reader;
+        $this->file_mapping = new FileMapping();
+        $reader->on('close', function() {
+            $this->shutdown();
+            $this->exit();
+        });
+        /** @suppress PhanUndeclaredClassMethod https://github.com/fruux/sabre-event/pull/52 */
+        $reader->on('message', function (Message $msg) {
+            /** @suppress PhanUndeclaredProperty Request->body->id is a request with an id */
+            coroutine(function () use ($msg) {
+                // Ignore responses, this is the handler for requests and notifications
+                if (AdvancedJsonRpc\Response::isResponse($msg->body)) {
+                    return;
+                }
+                Logger::logInfo('Received message in coroutine: ' . (string)$msg->body);
+                $result = null;
+                $error = null;
+                try {
+                    // Invoke the method handler to get a result
+                    $result = yield $this->dispatch($msg->body);
+                } catch (AdvancedJsonRpc\Error $e) {
+                    Logger::logInfo('Saw error: ' . $e->getMessage());
+                    // If a ResponseError is thrown, send it back in the Response
+                    $error = $e;
+                } catch (\Throwable $e) {
+                    Logger::logInfo('Saw throwable: ' . get_class($e) . ': ' . $e->getMessage() . "\n" . $e->getTraceAsString());
+                    // If an unexpected error occurred, send back an INTERNAL_ERROR error response
+                    $error = new AdvancedJsonRpc\Error(
+                        (string)$e,
+                        AdvancedJsonRpc\ErrorCode::INTERNAL_ERROR,
+                        null,
+                        $e
+                    );
+                }
+                // Only send a Response for a Request
+                // Notifications do not send Responses
+                if (AdvancedJsonRpc\Request::isRequest($msg->body)) {
+                    if ($error !== null) {
+                        $responseBody = new AdvancedJsonRpc\ErrorResponse($msg->body->id, $error);
+                    } else {
+                        $responseBody = new AdvancedJsonRpc\SuccessResponse($msg->body->id, $result);
+                    }
+                    $this->protocolWriter->write(new Message($responseBody));
+                }
+            })->otherwise('\\Phan\\LanguageServer\\Utils::crash');
+        });
+        $this->protocolWriter = $writer;
+        // We create a client to send diagnostics, etc. to the IDE
+        $this->client = new LanguageClient($reader, $writer);
+        // We create a workspace to receive change notifications.
+        $this->workspace = new Server\Workspace($this->client, $this, $this->file_mapping);
+
+        // Phan specific code
+        $this->code_base = $code_base;
+        $this->file_path_lister = $file_path_lister;
+    }
+
+    /**
+     * This creates an analyzing daemon, to be used by IDEs.
+     * Format:
+     *
+     * - Read over TCP socket with JSONRPC 2
+     * - Respond over TCP socket with JSONRPC 2
+     *
+     * @param CodeBase $code_base (Must have undo tracker enabled)
+     *
+     * @param \Closure $file_path_lister
+     * Returns string[] - A list of files to scan. This may be different from the previous contents.
+     *
+     * @param array $options (leave empty for stdout)
+     *
+     * @return Request|null - A writeable request, which has been fully read from.
+     * Callers should close after they are finished writing.
+     *
+     * @suppress PhanUndeclaredConstant (pcntl unavailable on Windows)
+     */
+    public static function run(CodeBase $code_base, \Closure $file_path_lister, array $options) {
+        \assert($code_base->isUndoTrackingEnabled());
+
+        $receivedSignal = false;
+        $make_language_server = function(ProtocolStreamReader $in, ProtocolStreamWriter $out) use ($code_base, $file_path_lister) : LanguageServer {
+            return new LanguageServer(
+                $in,
+                $out,
+                $code_base,
+                $file_path_lister
+            );
+        };
+        // example requests over TCP
+        // Assumes that clients send and close the their requests quickly, then wait for a response.
+
+        // {"method":"analyze","files":["/path/to/file1.php","/path/to/file2.php"]}
+
+        // FIXME add re-parsing files to actions taken during loop
+        /*
+        $socket_server = self::createDaemonStreamSocketServer();
+        // TODO: Limit the maximum number of active processes to a small number(4?)
+        // TODO: accept SIGCHLD when child terminates, somehow?
+        try {
+            $gotSignal = false;
+            pcntl_signal(SIGCHLD, function(...$args) use(&$gotSignal) {
+                $gotSignal = true;
+                Request::childSignalHandler(...$args);
+            });
+            while (true) {
+                $gotSignal = false;  // reset this.
+                // We get an error from stream_socket_accept. After the RuntimeException is thrown, pcntl_signal is called.
+				$previousErrorHandler = set_error_handler(function ($severity, $message, $file, $line) use (&$previousErrorHandler) {
+                    self::debugf("In new error handler '$message'");
+					if (!preg_match('/stream_socket_accept/i', $message)) {
+						return $previousErrorHandler($severity, $message, $file, $line);
+					}
+                    throw new \RuntimeException("Got signal");
+				});
+
+                $conn = false;
+                try {
+                    $conn = stream_socket_accept($socket_server, -1);
+                } catch(\RuntimeException $e) {
+                    self::debugf("Got signal");
+                    pcntl_signal_dispatch();
+                    self::debugf("done processing signals");
+                    if ($gotSignal) {
+                        continue;  // Ignore notices from stream_socket_accept if it's due to being interrupted by a child process terminating.
+                    }
+                } finally {
+                    restore_error_handler();
+                }
+
+                if (!\is_resource($conn)) {
+                    // If we didn't get a connection, and it wasn't due to a signal from a child process, then stop the daemon.
+                    break;
+                }
+                $request = Request::accept($code_base, $file_path_lister, $conn);
+                if ($request instanceof Request) {
+                    return $request;  // We forked off a worker process successfully, and this is the worker process
+                }
+            }
+            error_log("Stopped accepting connections");
+        } finally {
+            restore_error_handler();
+        }
+        return null;
+         */
+        if (!empty($options['tcp'])) {
+            // Connect to a TCP server
+            $address = $options['tcp'];
+            $socket = stream_socket_client('tcp://' . $address, $errno, $errstr);
+            if ($socket === false) {
+                fwrite(STDERR, "Could not connect to language client. Error $errno\n$errstr");
+                exit(1);
+            }
+            stream_set_blocking($socket, false);
+            $ls = $make_language_server(new ProtocolStreamReader($socket), new ProtocolStreamWriter($socket));
+            Logger::logInfo("Connected to $address to receive requests");
+            Loop\run();
+            Logger::logInfo("Finished connecting to $address to receive requests");
+            return $ls->most_recent_request;
+        } else if (!empty($options['tcp-server'])) {
+            // Run a TCP Server
+            $address = $options['tcp-server'];
+            $tcpServer = stream_socket_server('tcp://' . $address, $errno, $errstr);
+            if ($tcpServer === false) {
+                fwrite(STDERR, "Could not listen on $address. Error $errno\n$errstr");
+                exit(1);
+            }
+            fwrite(STDOUT, "Server listening on $address\n");
+            if (!extension_loaded('pcntl')) {
+                fwrite(STDERR, "PCNTL is not available. Only a single connection will be accepted\n");
+            }
+            while ($socket = stream_socket_accept($tcpServer, -1)) {
+                fwrite(STDOUT, "Connection accepted\n");
+                stream_set_blocking($socket, false);
+                /**if (false && extension_loaded('pcntl')) {  // FIXME re-enable, this was disabled to simplify testing
+                    // TODO: This will work, but does it make sense?
+
+                    // If PCNTL is available, fork a child process for the connection
+                    // An exit notification will only terminate the child process
+                    $pid = pcntl_fork();
+                    if ($pid === -1) {
+                        fwrite(STDERR, "Could not fork\n");
+                        exit(1);
+                    } else if ($pid === 0) {
+                        // Child process
+                        $reader = new ProtocolStreamReader($socket);
+                        $writer = new ProtocolStreamWriter($socket);
+                        $reader->on('close', function () {
+                            fwrite(STDOUT, "Connection closed\n");
+                        });
+                        $ls = $make_language_server($reader, $writer);
+                        Logger::logInfo("Worker started accepting requests on $address");
+                        Loop\run();
+                        Logger::logInfo("Worker finished accepting requests on $address");
+                        return $ls->most_recent_request;
+                    }
+                } else {*/
+                    // To avoid edge cases, we only accept one connection.
+                    // If PCNTL is not available, we only accept one connection.
+                    // An exit notification will terminate the server
+                    $ls = $make_language_server(
+                        new ProtocolStreamReader($socket),
+                        new ProtocolStreamWriter($socket)
+                    );
+                    Logger::logInfo("Started listening on stdin");
+                    Loop\run();
+                    Logger::logInfo("Finished listening on stdin");
+                    return $ls->most_recent_request;
+                /* } */
+            }
+        } else {
+            assert($options['stdin'] === true);
+            // Use STDIO
+            stream_set_blocking(STDIN, false);
+            $ls = $make_language_server(
+                new ProtocolStreamReader(STDIN),
+                new ProtocolStreamWriter(STDOUT)
+            );
+            Logger::logInfo("Started listening on stdin");
+            Loop\run();
+            Logger::logInfo("Finished listening on stdin");
+            return $ls->most_recent_request;
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function analyzeURI(string $uri)
+    {
+        Logger::logInfo("Called analyzeURI, uri=$uri");
+        $path_to_analyze = Utils::uriToPath($uri);
+        $relative_path_to_analyze = FileRef::getProjectRelativePathForPath($path_to_analyze);
+        $file_path_list = ($this->file_path_lister)();
+        if (!\in_array($uri, $file_path_list) && !\in_array($relative_path_to_analyze, $file_path_list)) {
+            Logger::logInfo("URI '$uri' not in parse list, skipping");
+            return;
+        }
+        Logger::logInfo("Going to analyze this file list: $path_to_analyze");
+        // TODO: check if $path_to_analyze can be analyzed first.
+        $sockets = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
+        if (!$sockets) {
+            error_log("unable to create stream socket pair");
+            exit(EXIT_FAILURE);
+        }
+        $pid = 0;
+
+        $this->most_recent_request = null;
+
+        if (($pid = pcntl_fork()) < 0) {
+            error_log(posix_strerror(posix_get_last_error()));
+            exit(EXIT_FAILURE);
+        }
+
+        // Parent
+        // FIXME: make this async as well, and rate limit it.
+        if ($pid > 0) {
+            $is_parent = true;
+            $read_stream = self::streamForParent($sockets);
+            $concatenated = '';
+            while (!feof($read_stream)) {
+                $buffer = fread($read_stream, 1024);
+                if (strlen($buffer) > 0) {
+                    $concatenated .= $buffer;
+                }
+            }
+            $json_contents = json_decode($concatenated, true);
+            if (!\is_array($json_contents)) {
+                Logger::logInfo("Fetched non-json: " . $concatenated);
+                return;
+            }
+            if (!\array_key_exists('issues', $json_contents)) {
+                Logger::logInfo("Failed to fetch 'issues' from JSON:" . $concatenated);
+                return;
+            }
+            $diagnostics = [];
+            // Normalize the uri so that it will be the same as URIs phan would send for diagnostics.
+            // E.g. "file:///path/path%.php" will be normalized to "file:///path/path%25.php"
+            $normalized_requested_uri = Utils::pathToUri(Utils::uriToPath($uri));
+            $diagnostics[$normalized_requested_uri] = [];  // send an empty diagnostic list on failure.
+            foreach ($json_contents['issues'] ?? [] as $issue) {
+                [$issue_uri, $diagnostic] = self::generateDiagnostic($issue);
+                if ($diagnostic instanceof Diagnostic) {
+                    $diagnostics[$issue_uri][] = $diagnostic;
+                }
+            }
+            foreach ($diagnostics as $diagnostics_uri => $diagnostics_list) {
+                $this->client->textDocument->publishDiagnostics($diagnostics_uri, $diagnostics_list);
+            }
+            return;
+        }
+
+        $child_stream = self::streamForChild($sockets);
+        $this->most_recent_request = Request::makeLanguageServerAnalysisRequest($child_stream, [$path_to_analyze], $this->code_base, $this->file_path_lister, $this->file_mapping);
+        // FIXME update the parsed file lists before and after (e.g. add to analyzeURI). See Daemon\Request::accept()
+        //    TODO: refactor accept() to make it easier to work with.
+        // TODO: add unit tests
+        Loop\stop();  // abort the loop (without closing streams?)
+    }
+
+    /**
+     * @param array $issue
+     * @return null[]|string[]|Diagnostic[] - On success, returns [string $uri, Diagnostic $diagnostic]
+     */
+    private static function generateDiagnostic($issue) : array
+    {
+        if ($issue['type'] !== 'issue') {
+            return [null, null];
+        }
+        //$check_name = $issue['check_name'];
+        $description = $issue['description'];
+        $severity = $issue['severity'];
+        $path = Config::projectPath($issue['location']['path']);
+        $issue_uri = Utils::pathToUri($path);
+        $start_line = $issue['location']['lines']['begin'];
+        $start_line = max($start_line, 1);
+        $end_line = $issue['location']['lines']['end'] ?? $start_line;
+        $end_line = max($end_line, 1);
+        // Language server has 0 based lines and columns, phan has 1-based lines and columns.
+        $range = new Range(new Position($start_line - 1, 0), new Position($start_line, 0));
+        switch ($severity) {
+        case Issue::SEVERITY_LOW:
+            $diagnostic_severity = DiagnosticSeverity::INFORMATION;
+            break;
+        case Issue::SEVERITY_NORMAL:
+            $diagnostic_severity = DiagnosticSeverity::WARNING;
+            break;
+        case Issue::SEVERITY_CRITICAL:
+        default:
+            $diagnostic_severity = DiagnosticSeverity::ERROR;
+            break;
+        }
+        // TODO: copy issue code in 'json' format
+        return [$issue_uri, new Diagnostic($description, $range, $issue['type_id'], $diagnostic_severity, 'Phan')];
+    }
+
+    /**
+     * Prepare the socket pair to be used in a parent process and
+     * return the stream the parent will use to read results.
+     *
+     * @param resource[] $sockets the socket pair for IPC
+     * @return resource
+     */
+    private static function streamForParent(array $sockets)
+    {
+        list($for_read, $for_write) = $sockets;
+
+        // The parent will not use the write channel, so it
+        // must be closed to prevent deadlock.
+        fclose($for_write);
+
+        // stream_select will be used to read multiple streams, so these
+        // must be set to non-blocking mode.
+        if (!stream_set_blocking($for_read, false)) {
+            error_log('unable to set read stream to non-blocking');
+            exit(EXIT_FAILURE);
+        }
+
+        return $for_read;
+    }
+
+    /**
+     * Prepare the socket pair to be used in a child process and return
+     * the stream the child will use to write results.
+     *
+     * @param resource[] $sockets the socket pair for IPC.
+     * @return resource
+     */
+    private static function streamForChild(array $sockets)
+    {
+        list($for_read, $for_write) = $sockets;
+
+        // The while will not use the read channel, so it must
+        // be closed to prevent deadlock.
+        fclose($for_read);
+        return $for_write;
+    }
+
+
+    /**
+     * The initialize request is sent as the first request from the client to the server.
+     *
+     * @param ClientCapabilities $capabilities The capabilities provided by the client (editor)
+     * @param string|null $rootPath The rootPath of the workspace. Is null if no folder is open.
+     * @param int|null $processId The process Id of the parent process that started the server. Is null if the process has not been started by another process. If the parent process is not alive then the server should exit (see exit notification) its process.
+     * @return Promise <InitializeResult>
+     */
+    public function initialize(ClientCapabilities $capabilities, string $rootPath = null, int $processId = null): Promise
+    {
+        return coroutine(function () use ($capabilities, $rootPath, $processId) : \Generator {
+            // Eventually, this might block on something. Leave it as a generator.
+            if (false) { yield; }
+
+            // There would be an asynchronous indexing step, but the startup already did the indexing.
+            if ($this->textDocument === null) {
+                $this->textDocument = new TextDocument(
+                    $this->client,
+                    $this,
+                    $this->file_mapping
+                );
+            }
+
+            $serverCapabilities = new ServerCapabilities();
+            // Ask the client to return always return full documents (because we need to rebuild the AST from scratch)
+            // TODO: use the full documents
+            $serverCapabilities->textDocumentSync = TextDocumentSyncKind::FULL;
+            // TODO: Support "Find all symbols"?
+            //$serverCapabilities->documentSymbolProvider = true;
+            // TODO: Support "Find all symbols in workspace"?
+            //$serverCapabilities->workspaceSymbolProvider = true;
+            // XXX do this next?
+            // TODO: Support "Go to definition" (reasonably practical, should be able to infer types in many cases)
+            // $serverCapabilities->definitionProvider = false;
+            // TODO: (probably impractical, slow) Support "Find all references"? (We don't track this, except when checking for dead code elimination possibilities.
+            // $serverCapabilities->referencesProvider = false;
+            // Can't support "Hover" without phpdoc for internal functions, such as those from phpstorm
+            // Also redundant if php.
+            // $serverCapabilities->hoverProvider = false;
+            // XXX support completion next?
+            // Requires php-parser-to-php-ast (or tolerant php-parser)
+            // Support "Completion"
+            // $serverCapabilities->completionProvider = new CompletionOptions;
+            // $serverCapabilities->completionProvider->resolveProvider = false;
+            // $serverCapabilities->completionProvider->triggerCharacters = ['$', '>'];
+            // Can't support global references at the moment, I think.
+            //$serverCapabilities->xworkspaceReferencesProvider = true;
+            //$serverCapabilities->xdefinitionProvider = true;
+            //$serverCapabilities->xdependenciesProvider = true;
+
+            return new InitializeResult($serverCapabilities);
+        });
+    }
+
+    public function initialized()
+    {
+        Logger::logInfo("Called initialized on language server, currently a no-op");
+    }
+
+    /**
+     * The shutdown request is sent from the client to the server. It asks the server to shut down, but to not exit
+     * (otherwise the response might not be delivered correctly to the client). There is a separate exit notification that
+     * asks the server to exit.
+     *
+     * @return void
+     */
+    public function shutdown()
+    {
+        // TODO: Does phan need to do anything else except respond?
+        Logger::logInfo("Called shutdown on language server");
+    }
+
+    /**
+     * A notification to ask the server to exit its process.
+     *
+     * @return void
+     */
+    public function exit()
+    {
+        // TODO: Properly exit when a tcp server forked the process that is receiving *this* message?
+        Logger::logInfo("Called exit on language server");
+        exit(0);
+    }
+}

--- a/src/Phan/LanguageServer/Logger.php
+++ b/src/Phan/LanguageServer/Logger.php
@@ -1,0 +1,74 @@
+<?php
+declare(strict_types = 1);
+
+namespace Phan\LanguageServer;
+
+use Phan\Config;
+use Phan\LanguageServer\Protocol\Message;
+use AdvancedJsonRpc\Message as MessageBody;
+use Sabre\Event\Emitter;
+use Sabre\Event\Loop;
+
+/**
+ * A logger used by Phan for developing or debugging the language server.
+ * Logs to stderr.
+ */
+class Logger {
+    /** @var resource|false */
+    public static $file;
+
+    public static function shouldLog() : bool {
+        return Config::getValue('language_server_debug_level') === 'info';
+    }
+
+    /** @return void */
+    public static function logRequest(array $headers, string $buffer) {
+        if (!self::shouldLog()) {
+            return;
+        }
+        self::logInfo(sprintf("Request:\n%s\nData:\n%s\n\n", json_encode($headers), $buffer));
+    }
+
+    /** @return void */
+    public static function logResponse(array $headers, string $buffer) {
+        if (!self::shouldLog()) {
+            return;
+        }
+        self::logInfo(sprintf("Response:\n%s\nData:\n%s\n\n", json_encode($headers), $buffer));
+    }
+
+    /** @return void */
+    public static function logInfo(string $msg) {
+        if (!self::shouldLog()) {
+            return;
+        }
+        $file = self::getLogFile();
+        fwrite($file, $msg . "\n");
+    }
+
+    /**
+     * @return resource
+     */
+    private static function getLogFile() {
+        if (self::$file === null) {
+            self::$file = STDERR;
+        }
+        return self::$file;
+    }
+
+    /**
+     * @param resource $newFile
+     * @return void
+     */
+    public static function setLogFile($newFile) {
+        assert(is_resource($newFile));
+        if (is_resource(self::$file)) {
+            if (self::$file === $newFile) {
+                return;
+            }
+            fclose(self::$file);
+            self::$file = false;
+        }
+        self::$file = $newFile;
+    }
+}

--- a/src/Phan/LanguageServer/Protocol/ClientCapabilities.php
+++ b/src/Phan/LanguageServer/Protocol/ClientCapabilities.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Phan\LanguageServer\Protocol;
+
+/**
+ * Source: https://github.com/felixfbecker/php-language-server/tree/master/src/Protocol/ClientCapabilities.php
+ */
+class ClientCapabilities
+{
+    /**
+     * The client supports workspace/xfiles requests
+     *
+     * @var bool|null
+     */
+    public $xfilesProvider;
+
+    /**
+     * The client supports textDocument/xcontent requests
+     *
+     * @var bool|null
+     */
+    public $xcontentProvider;
+
+    /**
+     * The client supports xcache/* requests
+     *
+     * @var bool|null
+     */
+    public $xcacheProvider;
+}

--- a/src/Phan/LanguageServer/Protocol/Diagnostic.php
+++ b/src/Phan/LanguageServer/Protocol/Diagnostic.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Phan\LanguageServer\Protocol;
+
+/**
+ * Represents a diagnostic, such as a compiler error or warning. Diagnostic objects are only valid in the scope of a
+ * resource.
+ *
+ * Source: https://github.com/felixfbecker/php-language-server/tree/master/src/Protocol/Diagnostic.php
+ * See ../../../../LICENSE.LANGUAGE_SERVER
+ */
+class Diagnostic
+{
+    /**
+     * The range at which the message applies.
+     *
+     * @var Range
+     */
+    public $range;
+
+    /**
+     * The diagnostic's severity. Can be omitted. If omitted it is up to the
+     * client to interpret diagnostics as error, warning, info or hint.
+     *
+     * @var int|null
+     */
+    public $severity;
+
+    /**
+     * The diagnostic's code. Can be omitted.
+     *
+     * @var int|string|null
+     */
+    public $code;
+
+    /**
+     * A human-readable string describing the source of this
+     * diagnostic, e.g. 'typescript' or 'super lint'.
+     *
+     * @var string|null
+     */
+    public $source;
+
+    /**
+     * The diagnostic's message.
+     *
+     * @var string
+     */
+    public $message;
+
+    /**
+     * @param  string $message  The diagnostic's message
+     * @param  Range  $range    The range at which the message applies
+     * @param  int    $code     The diagnostic's code
+     * @param  int    $severity DiagnosticSeverity
+     * @param  string $source   A human-readable string describing the source of this diagnostic
+     * @suppress PhanTypeMismatchProperty
+     * @suppress PhanTypeMismatchDeclaredParamNullable
+     */
+    public function __construct(string $message = null, Range $range = null, int $code = null, int $severity = null, string $source = null)
+    {
+        $this->message = $message;
+        $this->range = $range;
+        $this->code = $code;
+        $this->severity = $severity;
+        $this->source = $source;
+    }
+}

--- a/src/Phan/LanguageServer/Protocol/DiagnosticSeverity.php
+++ b/src/Phan/LanguageServer/Protocol/DiagnosticSeverity.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Phan\LanguageServer\Protocol;
+
+/**
+ * Source: https://github.com/felixfbecker/php-language-server/tree/master/src/Protocol/DiagnosticSeverity.php
+ * See ../../../../LICENSE.LANGUAGE_SERVER
+ */
+abstract class DiagnosticSeverity
+{
+    /**
+     * Reports an error.
+     */
+    const ERROR = 1;
+
+    /**
+     * Reports a warning.
+     */
+    const WARNING = 2;
+
+    /**
+     * Reports an information.
+     */
+    const INFORMATION = 3;
+
+    /**
+     * Reports a hint.
+     */
+    const HINT = 4;
+}

--- a/src/Phan/LanguageServer/Protocol/FileChangeType.php
+++ b/src/Phan/LanguageServer/Protocol/FileChangeType.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Phan\LanguageServer\Protocol;
+
+/**
+ * The file event type. Enum
+ *
+ * Source: https://github.com/felixfbecker/php-language-server/tree/master/src/Protocol/FileChangeType.php
+ * See ../../../../LICENSE.LANGUAGE_SERVER
+ */
+abstract class FileChangeType
+{
+    /**
+     * The file got created.
+     */
+    const CREATED = 1;
+
+    /**
+     * The file got changed.
+     */
+    const CHANGED = 2;
+
+    /**
+     * The file got deleted.
+     */
+    const DELETED = 3;
+}

--- a/src/Phan/LanguageServer/Protocol/FileEvent.php
+++ b/src/Phan/LanguageServer/Protocol/FileEvent.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Phan\LanguageServer\Protocol;
+
+/**
+ * An event describing a file change.
+ *
+ * Source: https://github.com/felixfbecker/php-language-server/tree/master/src/Protocol/FileEvent.php
+ * See ../../../../LICENSE.LANGUAGE_SERVER
+ */
+class FileEvent
+{
+    /**
+     * The file's URI.
+     *
+     * @var string
+     */
+    public $uri;
+
+    /**
+     * The change type.
+     *
+     * @var int
+     */
+    public $type;
+
+    /**
+     * @param string $uri
+     * @param int $type
+     */
+    public function __construct(string $uri, int $type)
+    {
+        $this->uri = $uri;
+        $this->type = $type;
+    }
+}

--- a/src/Phan/LanguageServer/Protocol/InitializeResult.php
+++ b/src/Phan/LanguageServer/Protocol/InitializeResult.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Phan\LanguageServer\Protocol;
+
+/**
+ * Source: https://github.com/felixfbecker/php-language-server/tree/master/src/Protocol/InitializeResult.php
+ * See ../../../../LICENSE.LANGUAGE_SERVER
+ */
+class InitializeResult
+{
+    /**
+     * The capabilities the language server provides.
+     *
+     * @var ServerCapabilities
+     */
+    public $capabilities;
+
+    /**
+     * @param ?ServerCapabilities $capabilities
+     */
+    public function __construct(ServerCapabilities $capabilities = null)
+    {
+        $this->capabilities = $capabilities ?? new ServerCapabilities();
+    }
+}

--- a/src/Phan/LanguageServer/Protocol/Message.php
+++ b/src/Phan/LanguageServer/Protocol/Message.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types = 1);
+
+namespace Phan\LanguageServer\Protocol;
+
+use AdvancedJsonRpc\Message as MessageBody;
+
+/**
+ * Source: https://github.com/felixfbecker/php-language-server/tree/master/src/Protocol/Message.php
+ */
+class Message
+{
+    /**
+     * @var ?\AdvancedJsonRpc\Message
+     */
+    public $body;
+
+    /**
+     * @var string[]
+     */
+    public $headers;
+
+    /**
+     * Parses a message
+     *
+     * @param string $msg
+     * @return Message
+     */
+    public static function parse(string $msg): Message
+    {
+        $obj = new self;
+        $parts = explode("\r\n", $msg);
+        $obj->body = MessageBody::parse(array_pop($parts));
+        foreach ($parts as $line) {
+            if ($line) {
+                $pair = explode(': ', $line);
+                $obj->headers[$pair[0]] = $pair[1];
+            }
+        }
+        return $obj;
+    }
+
+    /**
+     * @param ?\AdvancedJsonRpc\Message $body
+     * @param string[] $headers
+     */
+    public function __construct(MessageBody $body = null, array $headers = [])
+    {
+        $this->body = $body;
+        if (!isset($headers['Content-Type'])) {
+            $headers['Content-Type'] = 'application/vscode-jsonrpc; charset=utf8';
+        }
+        $this->headers = $headers;
+    }
+
+    public function __toString(): string
+    {
+        $body = (string)$this->body;
+        $contentLength = strlen($body);
+        $this->headers['Content-Length'] = $contentLength;
+        $headers = '';
+        foreach ($this->headers as $name => $value) {
+            $headers .= "$name: $value\r\n";
+        }
+        return $headers . "\r\n" . $body;
+    }
+}

--- a/src/Phan/LanguageServer/Protocol/Position.php
+++ b/src/Phan/LanguageServer/Protocol/Position.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Phan\LanguageServer\Protocol;
+
+/**
+ * Position in a text document expressed as zero-based line and character offset.
+ *
+ * Source: https://github.com/felixfbecker/php-language-server/tree/master/src/Protocol/Position.php
+ * See ../../../../LICENSE.LANGUAGE_SERVER
+ */
+class Position
+{
+    /**
+     * Line position in a document (zero-based).
+     *
+     * @var int
+     */
+    public $line;
+
+    /**
+     * Character offset on a line in a document (zero-based).
+     *
+     * @var int
+     */
+    public $character;
+
+    /**
+     * @suppress PhanTypeMismatchProperty
+     */
+    public function __construct(int $line = null, int $character = null)
+    {
+        $this->line = $line;
+        $this->character = $character;
+    }
+
+    /**
+     * Compares this position to another position
+     * Returns
+     *  - 0 if the positions match
+     *  - a negative number if $this is before $position
+     *  - a positive number otherwise
+     *
+     * @param Position $position
+     * @return int
+     */
+    public function compare(Position $position): int
+    {
+        if ($this->line === $position->line && $this->character === $position->character) {
+            return 0;
+        }
+
+        if ($this->line !== $position->line) {
+            return $this->line - $position->line;
+        }
+
+        return $this->character - $position->character;
+    }
+
+    /**
+     * Returns the offset of the position in a string
+     *
+     * @param string $content
+     * @return int
+     */
+    public function toOffset(string $content): int
+    {
+        $lines = explode("\n", $content);
+        $slice = array_slice($lines, 0, $this->line);
+        return array_sum(array_map('strlen', $slice)) + count($slice) + $this->character;
+    }
+}

--- a/src/Phan/LanguageServer/Protocol/Range.php
+++ b/src/Phan/LanguageServer/Protocol/Range.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Phan\LanguageServer\Protocol;
+
+/**
+ * A range in a text document expressed as (zero-based) start and end positions.
+ *
+ * Source: https://github.com/felixfbecker/php-language-server/tree/master/src/Protocol/Range.php
+ * See ../../../../LICENSE.LANGUAGE_SERVER
+ */
+class Range
+{
+    /**
+     * The range's start position.
+     *
+     * @var Position
+     */
+    public $start;
+
+    /**
+     * The range's end position.
+     *
+     * @var Position
+     */
+    public $end;
+
+    public function __construct(Position $start = null, Position $end = null)
+    {
+        $this->start = $start;
+        $this->end = $end;
+    }
+
+    /**
+     * Checks if a position is within the range
+     *
+     * @param Position $position
+     * @return bool
+     */
+    public function includes(Position $position): bool
+    {
+        return $this->start->compare($position) <= 0 && $this->end->compare($position) >= 0;
+    }
+}

--- a/src/Phan/LanguageServer/Protocol/ServerCapabilities.php
+++ b/src/Phan/LanguageServer/Protocol/ServerCapabilities.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Phan\LanguageServer\Protocol;
+
+/**
+ * Based on https://github.com/felixfbecker/php-language-server/tree/master/src/Protocol/ServerCapabilities.php
+ * FIXME: Hook up capabilities for
+ */
+class ServerCapabilities
+{
+    /**
+     * Defines how text documents are synced.
+     *
+     * @var int|null
+     */
+    public $textDocumentSync;
+
+    /**
+     * FIXME: Make the server provide completion support, and re-integrate work on TysonAndre/php-parser-to-php-ast
+     *
+     * @var CompletionOptions|null
+     */
+    // public $completionProvider;
+
+    /**
+     * The server provides find references support.
+     *
+     * @var bool|null
+     */
+    // public $referencesProvider;
+
+    /**
+     * The server provides document highlight support.
+     *
+     * @var bool|null
+     */
+    // public $documentHighlightProvider;
+
+    /**
+     * The server provides document symbol support.
+     *
+     * @var bool|null
+     */
+    // public $documentSymbolProvider;
+
+    /**
+     * The server provides workspace symbol support.
+     *
+     * @var bool|null
+     */
+    // public $workspaceSymbolProvider;
+
+    /**
+     * The server provides code actions.
+     *
+     * @var bool|null
+     */
+    //public $codeActionProvider;
+
+    /**
+     * The server provides code lens.
+     *
+     * @var CodeLensOptions|null
+     */
+    //public $codeLensProvider;
+
+    /**
+     * The server provides document formatting.
+     *
+     * @var bool|null
+     */
+    //public $documentFormattingProvider;
+
+    /**
+     * The server provides document range formatting.
+     *
+     * @var bool|null
+     */
+    //public $documentRangeFormattingProvider;
+
+    /**
+     * The server provides document formatting on typing.
+     *
+     * @var DocumentOnTypeFormattingOptions|null
+     */
+    //public $documentOnTypeFormattingProvider;
+
+    /**
+     * The server provides rename support.
+     *
+     * @var bool|null
+     */
+    //public $renameProvider;
+
+    /**
+     * The server provides workspace references exporting support.
+     *
+     * @var bool|null
+     */
+    //public $xworkspaceReferencesProvider;
+
+    /**
+     * The server provides extended text document definition support.
+     *
+     * @var bool|null
+     */
+    //public $xdefinitionProvider;
+
+    /**
+     * TODO: The server provides workspace dependencies support.
+     *
+     * @var bool|null
+     */
+    //public $dependenciesProvider;
+}

--- a/src/Phan/LanguageServer/Protocol/TextDocumentContentChangeEvent.php
+++ b/src/Phan/LanguageServer/Protocol/TextDocumentContentChangeEvent.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Phan\LanguageServer\Protocol;
+
+/**
+ * An event describing a change to a text document. If range and rangeLength are omitted
+ * the new text is considered to be the full content of the document.
+ *
+ * Source: https://github.com/felixfbecker/php-language-server/tree/master/src/Protocol/TextDocumentContentChangeEvent.php
+ * See ../../../../LICENSE.LANGUAGE_SERVER
+ */
+class TextDocumentContentChangeEvent
+{
+    /**
+     * The range of the document that changed.
+     *
+     * @var Range|null
+     */
+    public $range;
+
+    /**
+     * The length of the range that got replaced.
+     *
+     * @var int|null
+     */
+    public $rangeLength;
+
+    /**
+     * The new text of the document.
+     *
+     * @var string
+     */
+    public $text;
+}

--- a/src/Phan/LanguageServer/Protocol/TextDocumentIdentifier.php
+++ b/src/Phan/LanguageServer/Protocol/TextDocumentIdentifier.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Phan\LanguageServer\Protocol;
+
+/**
+ * Source: https://github.com/felixfbecker/php-language-server/tree/master/src/Protocol/TextDocumentIdentifier.php
+ * See ../../../../LICENSE.LANGUAGE_SERVER
+ */
+class TextDocumentIdentifier
+{
+    /**
+     * The text document's URI.
+     *
+     * @var string|null
+     */
+    public $uri;
+
+    /**
+     * @param string|null $uri The text document's URI.
+     */
+    public function __construct(string $uri = null)
+    {
+        $this->uri = $uri;
+    }
+}

--- a/src/Phan/LanguageServer/Protocol/TextDocumentItem.php
+++ b/src/Phan/LanguageServer/Protocol/TextDocumentItem.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Phan\LanguageServer\Protocol;
+
+/**
+ * An item to transfer a text document from the client to the server.
+ *
+ * Source: https://github.com/felixfbecker/php-language-server/tree/master/src/Protocol/TextDocumentItem.php
+ * See ../../../../LICENSE.LANGUAGE_SERVER
+ */
+class TextDocumentItem
+{
+    /**
+     * The text document's URI.
+     *
+     * @var string
+     */
+    public $uri;
+
+    /**
+     * The text document's language identifier.
+     *
+     * @var string
+     */
+    public $languageId;
+
+    /**
+     * The version number of this document (it will strictly increase after each
+     * change, including undo/redo).
+     *
+     * @var int
+     */
+    public $version;
+
+    /**
+     * The content of the opened text document.
+     *
+     * @var string
+     */
+    public $text;
+}

--- a/src/Phan/LanguageServer/Protocol/TextDocumentSyncKind.php
+++ b/src/Phan/LanguageServer/Protocol/TextDocumentSyncKind.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Phan\LanguageServer\Protocol;
+
+/**
+ * Defines how the host (editor) should sync document changes to the language server.
+ *
+ * Source: https://github.com/felixfbecker/php-language-server/tree/master/src/Protocol/TextDocumentSyncKind.php
+ * See ../../../../LICENSE.LANGUAGE_SERVER
+ */
+abstract class TextDocumentSyncKind
+{
+    /**
+     * Documents should not be synced at all.
+     */
+    const NONE = 0;
+
+    /**
+     * Documents are synced by always sending the full content of the document.
+     */
+    const FULL = 1;
+
+    /*
+     * Documents are synced by sending the full content on open. After that only
+     * incremental updates to the document are sent.
+     */
+    const INCREMENTAL = 2;
+}

--- a/src/Phan/LanguageServer/Protocol/VersionedTextDocumentIdentifier.php
+++ b/src/Phan/LanguageServer/Protocol/VersionedTextDocumentIdentifier.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Phan\LanguageServer\Protocol;
+
+/**
+ * Source: https://github.com/felixfbecker/php-language-server/tree/master/src/Protocol/VersionedTextDocumentIdentifier.php
+ * See ../../../../LICENSE.LANGUAGE_SERVER
+ */
+class VersionedTextDocumentIdentifier extends TextDocumentIdentifier
+{
+    /**
+     * The version number of this document.
+     *
+     * @var int
+     */
+    public $version;
+}

--- a/src/Phan/LanguageServer/ProtocolReader.php
+++ b/src/Phan/LanguageServer/ProtocolReader.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types = 1);
+
+namespace Phan\LanguageServer;
+
+use Sabre\Event\EmitterInterface;
+
+/**
+ * Must emit a "message" event with a Protocol\Message object as parameter
+ * when a message comes in
+ *
+ * Must emit a "close" event when the stream closes
+ *
+ * Source: https://github.com/felixfbecker/php-language-server/tree/master/src/ProtocolReader.php
+ * See ../../../LICENSE.LANGUAGE_SERVER
+ */
+interface ProtocolReader extends EmitterInterface
+{
+
+}

--- a/src/Phan/LanguageServer/ProtocolStreamReader.php
+++ b/src/Phan/LanguageServer/ProtocolStreamReader.php
@@ -1,0 +1,83 @@
+<?php
+declare(strict_types = 1);
+
+namespace Phan\LanguageServer;
+
+use Phan\LanguageServer\Logger;
+use Phan\LanguageServer\Protocol\Message;
+use AdvancedJsonRpc\Message as MessageBody;
+use Sabre\Event\Loop;
+use Sabre\Event\Emitter;
+use Exception;
+
+/**
+ * Source: https://github.com/felixfbecker/php-language-server/tree/master/src/ProtocolStreamReader.php
+ */
+class ProtocolStreamReader extends Emitter implements ProtocolReader
+{
+    const PARSE_HEADERS = 1;
+    const PARSE_BODY = 2;
+
+    /** @var resource */
+    private $input;
+    /** @var int */
+    private $parsingMode = self::PARSE_HEADERS;
+    /** @var string */
+    private $buffer = '';
+    /** @var string[] */
+    private $headers = [];
+    /** @var int */
+    private $contentLength;
+
+    /**
+     * @param resource $input
+     */
+    public function __construct($input)
+    {
+        $this->input = $input;
+
+        $this->on('close', function () {
+            Loop\removeReadStream($this->input);
+        });
+
+        Loop\addReadStream($this->input, function () {
+            if (feof($this->input)) {
+                // If stream_select reported a status change for this stream,
+                // but the stream is EOF, it means it was closed.
+                $this->emit('close');
+                return;
+            }
+            $c = '';
+            while (($c = fgetc($this->input)) !== false && $c !== '') {
+                $this->buffer .= $c;
+                switch ($this->parsingMode) {
+                    case self::PARSE_HEADERS:
+                        if ($this->buffer === "\r\n") {
+                            $this->parsingMode = self::PARSE_BODY;
+                            $this->contentLength = (int)$this->headers['Content-Length'];
+                            $this->buffer = '';
+                        } else if (substr($this->buffer, -2) === "\r\n") {
+                            $parts = explode(':', $this->buffer);
+                            $this->headers[$parts[0]] = trim($parts[1]);
+                            $this->buffer = '';
+                        }
+                        break;
+                    case self::PARSE_BODY:
+                        if (strlen($this->buffer) === $this->contentLength) {
+                            Logger::logRequest($this->headers, $this->buffer);
+                            // MessageBody::parse can throw an Error, maybe log an error?
+                            try {
+                                $msg = new Message(MessageBody::parse($this->buffer), $this->headers);
+                            } catch (\Exception $e) {
+                            }
+                            $this->emit('message', [$msg]);
+                            $this->parsingMode = self::PARSE_HEADERS;
+                            $this->headers = [];
+                            $this->buffer = '';
+                        }
+                        break;
+                }
+            }
+        });
+    }
+}

--- a/src/Phan/LanguageServer/ProtocolStreamWriter.php
+++ b/src/Phan/LanguageServer/ProtocolStreamWriter.php
@@ -1,0 +1,92 @@
+<?php
+declare(strict_types = 1);
+
+namespace Phan\LanguageServer;
+
+use Phan\LanguageServer\Protocol\Message;
+use Phan\LanguageServer\Logger;
+use Sabre\Event\Loop;
+use Sabre\Event\Promise;
+use RuntimeException;
+
+/**
+ * Source: https://github.com/felixfbecker/php-language-server/tree/master/src/ProtocolStreamWriter.php
+ */
+class ProtocolStreamWriter implements ProtocolWriter
+{
+    /**
+     * @var resource $output
+     */
+    private $output;
+
+    /**
+     * @var array $messages
+     */
+    private $messages = [];
+
+    /**
+     * @param resource $output
+     */
+    public function __construct($output)
+    {
+        $this->output = $output;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function write(Message $msg): Promise
+    {
+        // if the message queue is currently empty, register a write handler.
+        if (empty($this->messages)) {
+            Loop\addWriteStream($this->output, function () {
+                $this->flush();
+            });
+        }
+
+        Logger::logResponse($msg->headers, (string)$msg->body);
+
+        $promise = new Promise();
+        $this->messages[] = [
+            'message' => (string)$msg,
+            'promise' => $promise
+        ];
+        return $promise;
+    }
+
+    /**
+     * Writes pending messages to the output stream.
+     *
+     * @return void
+     */
+    private function flush()
+    {
+        $keepWriting = true;
+        while ($keepWriting) {
+            $message = $this->messages[0]['message'];
+            $promise = $this->messages[0]['promise'];
+
+            $bytesWritten = @fwrite($this->output, $message);
+
+            if ($bytesWritten > 0) {
+                $message = substr($message, $bytesWritten);
+            }
+
+            // Determine if this message was completely sent
+            if (strlen($message) === 0) {
+                array_shift($this->messages);
+
+                // This was the last message in the queue, remove the write handler.
+                if (count($this->messages) === 0) {
+                    Loop\removeWriteStream($this->output);
+                    $keepWriting = false;
+                }
+
+                $promise->fulfill();
+            } else {
+                $this->messages[0]['message'] = $message;
+                $keepWriting = false;
+            }
+        }
+    }
+}

--- a/src/Phan/LanguageServer/ProtocolWriter.php
+++ b/src/Phan/LanguageServer/ProtocolWriter.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types = 1);
+
+namespace Phan\LanguageServer;
+
+use Phan\LanguageServer\Protocol\Message;
+use Sabre\Event\Promise;
+
+/**
+ * Source: https://github.com/felixfbecker/php-language-server/tree/master/src/ProtocolWriter.php
+ */
+interface ProtocolWriter
+{
+    /**
+     * Sends a Message to the client
+     *
+     * @param Message $msg
+     * @return Promise Resolved when the message has been fully written out to the output stream
+     */
+    public function write(Message $msg): Promise;
+}

--- a/src/Phan/LanguageServer/Server/TextDocument.php
+++ b/src/Phan/LanguageServer/Server/TextDocument.php
@@ -1,0 +1,188 @@
+<?php declare(strict_types = 1);
+
+namespace Phan\LanguageServer\Server;
+
+use Phan\LanguageServer\FileMapping;
+use Phan\LanguageServer\Index\ReadableIndex;
+use Phan\LanguageServer\LanguageClient;
+use Phan\LanguageServer\LanguageServer;
+use Phan\LanguageServer\Logger;
+use Phan\LanguageServer\Protocol\Position;
+use Phan\LanguageServer\Protocol\Range;
+use Phan\LanguageServer\Protocol\TextDocumentContentChangeEvent;
+use Phan\LanguageServer\Protocol\TextDocumentIdentifier;
+use Phan\LanguageServer\Protocol\TextDocumentItem;
+use Phan\LanguageServer\Protocol\VersionedTextDocumentIdentifier;
+use Sabre\Event\Promise;
+use Sabre\Uri;
+use function Sabre\Event\coroutine;
+
+/**
+ * Provides method handlers for all textDocument/* methods
+ * Source: https://github.com/felixfbecker/php-language-server/blob/master/src/Server/TextDocument.php
+ */
+class TextDocument
+{
+    /**
+     * The language client object to call methods on the client
+     *
+     * @var LanguageClient
+     */
+    protected $client;
+
+    /**
+     * The language client object to call methods on the server
+     *
+     * @var LanguageServer
+     */
+    protected $server;
+
+    /**
+     * Maps paths of files on disk to overrides.
+     * @var FileMapping
+     */
+    protected $file_mapping;
+
+    /**
+     * @param LanguageClient $client
+     * @param FileMapping $file_mapping
+     */
+    public function __construct(
+        LanguageClient $client,
+        LanguageServer $server,
+        FileMapping $file_mapping
+    ) {
+        $this->client = $client;
+        $this->server = $server;
+        $this->file_mapping = $file_mapping;
+    }
+
+
+    /**
+     * The document symbol request is sent from the client to the server to list all symbols found in a given text
+     * document.
+     * FIXME: reintroduce when support is added back
+     *
+     * @param TextDocumentIdentifier $textDocument
+     * @return Promise <SymbolInformation[]>
+     */
+    /*
+    public function documentSymbol(TextDocumentIdentifier $textDocument): Promise
+    {
+        return $this->documentLoader->getOrLoad($textDocument->uri)->then(function (PhpDocument $document) {
+            $symbols = [];
+            foreach ($document->getDefinitions() as $fqn => $definition) {
+                $symbols[] = $definition->symbolInformation;
+            }
+            return $symbols;
+        });
+    }
+     */
+
+    /**
+     * The document open notification is sent from the client to the server to signal newly opened text documents. The
+     * document's truth is now managed by the client and the server must not try to read the document's truth using the
+     * document's uri.
+     *
+     * @param TextDocumentItem $textDocument The document that was opened.
+     * @return void
+     */
+    public function didOpen(TextDocumentItem $textDocument)
+    {
+        $this->file_mapping->addOverrideURI($textDocument->uri, $textDocument->text);
+        Logger::logInfo("Called didOpen, uri={$textDocument->uri}");
+        $this->server->analyzeURI($textDocument->uri);
+
+        //$document = $this->documentLoader->open($textDocument->uri, $textDocument->text);
+        // TODO: make this trigger re-analysis
+        // TODO: Check based on parse and analyze directories and Phan supported file extensions if this file affects Phan's analysis.
+        // TODO:   Add functions to quickly check if a relative/absolute path is within the parse or analysis list of a project
+        // TODO:   Maybe allow reloading .phan/config, at least the files and directories to parse/analyze
+
+        // if (!isVendored($document, $this->composerJson)) {
+        //     $this->client->textDocument->publishDiagnostics($textDocument->uri, $document->getDiagnostics());
+        // }
+    }
+
+    /**
+     * The document save notification is sent from the client to the server when the document was saved in the client.
+     * TODO: Should this use willSave instead
+     * TODO: Why is this not triggering on Ctrl+S
+     *
+     * @param VersionedTextDocumentIdentifier $textDocument
+     * @param string|null $text (NOTE: can't use ?T here)
+     * @suppress PhanTypeMismatchArgument
+     * @return void
+     */
+    public function didSave(TextDocumentIdentifier $textDocument, string $text = null) {
+        $this->file_mapping->addOverrideURI($textDocument->uri, $text);
+        Logger::logInfo("Called didSave, uri={$textDocument->uri} len(text)=" . strlen($text ?? ''));
+        $this->server->analyzeURI($textDocument->uri);
+    }
+
+    /**
+     * The document change notification is sent from the client to the server to signal changes to a text document.
+     *
+     * @param VersionedTextDocumentIdentifier $textDocument
+     * @param TextDocumentContentChangeEvent[] $contentChanges
+     * @return void
+     */
+    public function didChange(VersionedTextDocumentIdentifier $textDocument, array $contentChanges)
+    {
+        foreach ($contentChanges as $change) {
+            $this->file_mapping->addOverrideURI($textDocument->uri, $change->text);
+        }
+        Logger::logInfo("Called didChange, uri={$textDocument->uri} version={$textDocument->version}");
+        // TODO: Check based on parse and analyze directories and Phan supported file extensions if this file affects Phan's analysis.
+        $this->server->analyzeURI($textDocument->uri);
+
+        // TODO:   Add functions to quickly check if a relative/absolute path is within the parse or analysis list of a project
+        // TODO:   Maybe allow reloading .phan/config, at least the files and directories to parse/analyze
+        // TODO: make this trigger re-analysis
+        //$document = $this->documentLoader->get($textDocument->uri);
+        //$document->updateContent($contentChanges[0]->text);
+
+        // XXX hook into getDiagnostics for Phan event publishing
+        //$this->client->textDocument->publishDiagnostics($textDocument->uri, $document->getDiagnostics());
+    }
+
+    /**
+     * The document close notification is sent from the client to the server when the document got closed in the client.
+     * The document's truth now exists where the document's uri points to (e.g. if the document's uri is a file uri the
+     * truth now exists on disk).
+     *
+     * @param TextDocumentIdentifier $textDocument The document that was closed
+     * @return void
+     */
+    public function didClose(TextDocumentIdentifier $textDocument)
+    {
+        $this->file_mapping->removeOverrideURI($textDocument->uri);
+        Logger::logInfo("Called didClose, uri={$textDocument->uri}");
+    }
+
+    /**
+     * The Completion request is sent from the client to the server to compute completion items at a given cursor
+     * position. Completion items are presented in the IntelliSense user interface. If computing full completion items
+     * is expensive, servers can additionally provide a handler for the completion item resolve request
+     * ('completionItem/resolve'). This request is sent when a completion item is selected in the user interface. A
+     * typically use case is for example: the 'textDocument/completion' request doesn't fill in the documentation
+     * property for returned completion items since it is expensive to compute. When the item is selected in the user
+     * interface then a 'completionItem/resolve' request is sent with the selected completion item as a param. The
+     * returned completion item should have the documentation property filled in.
+     *
+     * @param TextDocumentIdentifier The text document
+     * @param Position $position The position
+     * @return Promise <CompletionItem[]|CompletionList>
+     * TODO: reintroduce this after support gets added to Phan
+     */
+    /*
+        public function completion(TextDocumentIdentifier $textDocument, Position $position): Promise
+        {
+            return coroutine(function () use ($textDocument, $position) {
+                $document = yield $this->documentLoader->getOrLoad($textDocument->uri);
+                return $this->completionProvider->provideCompletion($document, $position);
+            });
+        }
+     */
+
+}

--- a/src/Phan/LanguageServer/Server/Workspace.php
+++ b/src/Phan/LanguageServer/Server/Workspace.php
@@ -1,0 +1,80 @@
+<?php
+declare(strict_types = 1);
+
+namespace Phan\LanguageServer\Server;
+
+use Phan\LanguageServer\FileMapping;
+use Phan\LanguageServer\LanguageClient;
+use Phan\LanguageServer\LanguageServer;
+use Phan\LanguageServer\Protocol\FileChangeType;
+use Phan\LanguageServer\Protocol\FileEvent;
+
+/**
+ * Provides method handlers for all workspace/* methods
+ *
+ * Source: https://github.com/felixfbecker/php-language-server/tree/master/src/Server/Workspace.php
+ * See ../../../../LICENSE.LANGUAGE_SERVER
+ */
+class Workspace
+{
+    /**
+     * @var LanguageClient
+     */
+    public $client;
+
+    /**
+     * @var LanguageServer
+     */
+    public $server;
+
+    /**
+     * @var FileMapping
+     */
+    public $file_mapping;
+
+    /**
+     * @param LanguageClient    $client            LanguageClient instance used to signal updated results
+     * FIXME: Rewrite to avoid static methods?
+     */
+    public function __construct(
+        LanguageClient $client,
+        LanguageServer $server,
+        FileMapping $file_mapping
+    ) {
+        $this->client = $client;
+        $this->server = $server;
+        $this->file_mapping = $file_mapping;
+    }
+
+    /**
+     * The watched files notification is sent from the client to the server when the client detects changes to files watched by the language client.
+     *
+     * @param FileEvent[] $changes
+     * @return void
+     */
+    public function didChangeWatchedFiles(array $changes)
+    {
+        // invalidate Phan's cache for these files if changed, added, or modified outside of the IDE
+        foreach ($changes as $change) {
+            $this->file_mapping->removeOverrideURI($change->uri);
+        }
+        // Trigger diagnostics. TODO: Is that necessary?
+        foreach ($changes as $change) {
+            if ($change->type === FileChangeType::DELETED) {
+                $this->client->textDocument->publishDiagnostics($change->uri, []);
+            }
+        }
+        // TODO: more than one file
+        foreach ($changes as $change) {
+            if ($change->type === FileChangeType::CHANGED) {
+                $uri = $change->uri;
+                $this->server->analyzeURI($uri);
+            }
+        }
+    }
+
+    // no-op for now. Stop the JSON RPC2 framework from warning about this method being undefined.
+    public function didChangeConfiguration($settings)
+    {
+    }
+}

--- a/src/Phan/LanguageServer/Utils.php
+++ b/src/Phan/LanguageServer/Utils.php
@@ -1,0 +1,68 @@
+<?php declare(strict_types=1);
+
+namespace Phan\LanguageServer;
+
+use InvalidArgumentException;
+use Sabre\Event\Loop;
+use Throwable;
+
+/**
+ * Taken from code by Felix Frederick Becker
+ *
+ * Source: https://github.com/felixfbecker/php-language-server
+ *
+ * Mostly from src/utils.php
+ */
+class Utils {
+    /** @return void */
+    public static function crash(Throwable $err) {
+        Loop\nextTick(function () use ($err) {
+            throw $err;
+        });
+    }
+
+    /**
+     * Transforms an absolute file path into a URI as used by the language server protocol.
+     *
+     * @param string $filepath
+     * @return string
+     */
+    public static function pathToUri(string $filepath) : string
+    {
+        $filepath = \trim(\str_replace('\\', '/', $filepath), '/');
+        $parts = \explode('/', $filepath);
+        // Don't %-encode the colon after a Windows drive letter
+        $first = \array_shift($parts);
+        if (substr($first, -1) !== ':') {
+            $first = \rawurlencode($first);
+        }
+        $parts = \array_map('rawurlencode', $parts);
+        array_unshift($parts, $first);
+        $filepath = \implode('/', $parts);
+        return 'file:///' . $filepath;
+    }
+
+    /**
+     * Transforms URI into file path
+     *
+     * @param string $uri
+     * @return string
+     * @throws InvalidArgumentException
+     */
+    public static function uriToPath(string $uri) : string
+    {
+        $fragments = \parse_url($uri);
+        if ($fragments === null || !isset($fragments['scheme']) || $fragments['scheme'] !== 'file') {
+            throw new InvalidArgumentException("Not a valid file URI: $uri");
+        }
+        $filepath = \urldecode($fragments['path']);
+        if (strpos($filepath, ':') !== false) {
+            if ($filepath[0] === '/') {
+                $filepath = \substr($filepath, 1);
+            }
+            $filepath = \str_replace('/', '\\', $filepath);
+        }
+        return $filepath;
+    }
+
+}

--- a/src/Phan/Output/Printer/JSONPrinter.php
+++ b/src/Phan/Output/Printer/JSONPrinter.php
@@ -18,14 +18,16 @@ final class JSONPrinter implements BufferedPrinterInterface
     /** @param IssueInstance $instance */
     public function print(IssueInstance $instance)
     {
+        $issue = $instance->getIssue();
         $this->messages[] = [
             'type' => 'issue',
-            'check_name' => $instance->getIssue()->getType(),
+            'type_id' => $issue->getTypeId(),
+            'check_name' => $issue->getType(),
             'description' =>
-                Issue::getNameForCategory($instance->getIssue()->getCategory()) . ' ' .
-                $instance->getIssue()->getType() . ' ' .
+                Issue::getNameForCategory($issue->getCategory()) . ' ' .
+                $issue->getType() . ' ' .
                 $instance->getMessage(),
-            'severity' => $instance->getIssue()->getSeverity(),
+            'severity' => $issue->getSeverity(),
             'location' => [
                 'path' => preg_replace('/^\/code\//', '', $instance->getFile()),
                 'lines' => [

--- a/src/prep.php
+++ b/src/prep.php
@@ -33,7 +33,6 @@ $visit_node = function(\ast\Node $node, string $file_path) {
                 print "$file_path:{$node->lineno} $name\n";
             }
         }
-
     }
 
 };

--- a/tests/Phan/LanguageServer/LICENSE.txt
+++ b/tests/Phan/LanguageServer/LICENSE.txt
@@ -1,0 +1,19 @@
+The code implementing support for the open Language Server Protocol
+(and the tests of that support)
+are based on code from https://github.com/felixfbecker/php-language-server
+
+ISC License
+
+Copyright (c) 2016, Felix Frederick Becker
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.

--- a/tests/Phan/LanguageServer/LanguageServerTest.php
+++ b/tests/Phan/LanguageServer/LanguageServerTest.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types = 1);
+namespace Phan\Tests\LanguageServer;
+
+use Phan\CodeBase;
+use Phan\Tests\BaseTest;
+use Phan\LanguageServer\LanguageServer;
+use Phan\LanguageServer\Protocol\InitializeResult;
+use Phan\LanguageServer\Protocol\ClientCapabilities;
+use Phan\LanguageServer\Protocol\ServerCapabilities;
+use Phan\LanguageServer\Protocol\TextDocumentSyncKind;
+
+/**
+ * Test functionality of the Language Server
+ */
+class LanguageServerTest extends BaseTest
+{
+    public function testInitialize()
+    {
+        $mock_file_path_lister = function() { return []; };
+        $code_base = new CodeBase([], [], [], [], []);
+        $server = new LanguageServer(new MockProtocolStream, new MockProtocolStream, $code_base, $mock_file_path_lister);
+        $result = $server->initialize(new ClientCapabilities, __DIR__, getmypid())->wait();
+
+        $server_capabilities = new ServerCapabilities();
+        $server_capabilities->textDocumentSync = TextDocumentSyncKind::FULL;
+
+        $this->assertEquals(new InitializeResult($server_capabilities), $result);
+    }
+
+    // TODO: Test the ability to create a Request
+}

--- a/tests/Phan/LanguageServer/MockProtocolStream.php
+++ b/tests/Phan/LanguageServer/MockProtocolStream.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types = 1);
+
+namespace Phan\Tests\LanguageServer;
+
+use Phan\LanguageServer\ProtocolReader;
+use Phan\LanguageServer\ProtocolWriter;
+use Phan\LanguageServer\Protocol\Message;
+use Sabre\Event\{Loop, Emitter, Promise};
+
+/**
+ * A fake duplex protocol stream
+ */
+class MockProtocolStream extends Emitter implements ProtocolReader, ProtocolWriter
+{
+    /**
+     * Sends a Message to the client
+     *
+     * @param Message $msg
+     * @return Promise<void>
+     */
+    public function write(Message $msg): Promise
+    {
+        Loop\nextTick(function () use ($msg) {
+            $this->emit('message', [Message::parse((string)$msg)]);
+        });
+        return Promise\resolve(null);
+    }
+}


### PR DESCRIPTION
Fixes #821

Compatibility: Unix, Linux (depends on php pcntl extension)

This is based on the implementation from
https://github.com/felixfbecker/php-language-server
for the server, client, and protocol files
(properties, methods, method implementations, phpdoc, etc)

- While php-language-server supports autocompletion, refactoring, etc., it does not have as much support as phan for static analysis.
  This PR only supports static analysis (emitting Phan issues as language server `Diagnostic`s).
- This is experimental, the code may have bugs.
- This is also based on the Phan's daemon mode and fork pool for
  forking off a process to analyze files.
- This is similar to https://github.com/TysonAndre/flycheck-phanclient
  in the provided functionality.
- Phan issues are emitted as `Diagnostic`s,
  with severity mapping to `DiagnosticSeverity`, etc.
  This works in VS code with https://github.com/tysonandre/vscode-php-phan

The language server protocol is documented in
https://github.com/Microsoft/language-server-protocol/blob/master/README.md

This works on integrating Language Server Protocol in a
way similar to daemon mode.
This should make it easier to develop plugins for IDEs and editors.

- Install sabre/event for asynchronous requests/response

  Future PRs may make generation of phan errors more asynchronous.
  Currently, this blocks to receive errors (limiting the number of
  active analysis phases to 1)
- Possibly more than needed for requests and responses at the moment.
- Copy necessary files for the language server protocol from
  https://github.com/felixfbecker/php-language-server

  These are needed for JSON RPC2 to work as expected.

  There isn't a separate repository with just those interfaces,
  and parts would be implementation specific (e.g. how the
  representation of project state is modified)

  Add LICENSE.LANGUAGE_SERVER with the ISC license.
- handle file deletion, modification, and addition notifications.

  IDEs may have a temporary copy of a file that hasn't been saved to
  disk yet. Use FileMapper to store the contents, and remove it when the
  IDE stops managing that file (didClose).
- Normalize of URIs to paths using php-language-server's src/utils.php
- Add missing files, update links to source of protocol files
- uses stderr for optional verbose debugging


![vscode_phan_plugin_example](https://user-images.githubusercontent.com/1904430/31051889-7b381772-a629-11e7-838b-3330f98d39ae.png)
