### PR TITLE
Improve analysis of callables for array_map/array_filter

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -17,6 +17,7 @@ New Features (CLI, Configs)
 + Document the --disable-plugins CLI flag.
 + Improve analysis of return types of `array_pop`,`array_shift`,`current`,`end`,`next`,`prev`,`reset`,`array_map`,`array_filter`, etc..
   See ArrayReturnTypeOverridePlugin.php.
+  Phan can analyze callables (for `array_map`/`array_filter`) of Closure form, as well as strings/2-part arrays that are inlined.
 
 Plugins
 + Add a new plugin type which can override the return type of functions and methods on a case by case basis.

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -21,6 +21,7 @@ use Phan\Language\Element\Variable;
 use Phan\Language\FQSEN\FullyQualifiedClassName;
 use Phan\Language\FQSEN\FullyQualifiedFunctionLikeName;
 use Phan\Language\FQSEN\FullyQualifiedFunctionName;
+use Phan\Language\FQSEN\FullyQualifiedMethodName;
 use Phan\Language\Scope\BranchScope;
 use Phan\Language\Scope\GlobalScope;
 use Phan\Language\Type;
@@ -36,6 +37,7 @@ use Phan\Language\Type\NullType;
 use Phan\Language\Type\ObjectType;
 use Phan\Language\Type\StringType;
 use Phan\Language\Type\StaticType;
+use Phan\Language\Type\TemplateType;
 use Phan\Language\Type\VoidType;
 use Phan\Language\UnionType;
 use Phan\Library\ArraySet;
@@ -1892,6 +1894,150 @@ class UnionTypeVisitor extends AnalysisVisitor
         return (new UnionTypeVisitor($code_base, $context, true))->functionLikeFQSENListFromNode($node, $log_error);
     }
 
+    /**
+     * @param string|Node $class_or_expr
+     * @param string $method_name
+     *
+     * @return FullyQualifiedMethodName[]
+     * A list of CallableTypes associated with the given node
+     */
+    private function methodFQSENListFromObjectAndMethodName($class_or_expr, $method_name) : array {
+        $code_base = $this->code_base;
+        $context = $this->context;
+
+        $union_type = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $class_or_expr);
+        if ($union_type->isEmpty()) {
+            return [];
+        }
+        $object_types = $union_type->objectTypes();
+        if ($object_types->isEmpty()) {
+            if (!$union_type->canCastToUnionType(StringType::instance(false)->asUnionType())) {
+                $this->emitIssue(
+                    Issue::TypeInvalidCallableObjectOfMethod,
+                    $context->getLineNumberStart(),
+                    (string)$union_type,
+                    $method_name
+                );
+            }
+            return [];
+        }
+        $result_types = [];
+        $class = null;
+        foreach ($object_types->getTypeSet() as $object_type) {
+            // TODO: support templates here.
+            if ($object_type instanceof ObjectType || $object_type instanceof TemplateType) {
+                continue;
+            }
+            $class_fqsen = $object_type->asFQSEN();
+            if (!($class_fqsen instanceof FullyQualifiedClassName)) {
+                continue;
+            }
+            if (!$code_base->hasClassWithFQSEN($class_fqsen)) {
+                $this->emitIssue(
+                    Issue::UndeclaredClassInCallable,
+                    $context->getLineNumberStart(),
+                    (string)$class_fqsen,
+                    "$class_fqsen::$method_name"
+                );
+                continue;
+            }
+            $class = $code_base->getClassByFQSEN($class_fqsen);
+            if (!$class->hasMethodWithName($code_base, $method_name)) {
+                // emit error below
+                continue;
+            }
+            $method_fqsen = FullyQualifiedMethodName::make(
+                $class_fqsen,
+                $method_name
+            );
+            $result_types[] = $method_fqsen;
+        }
+        if (\count($result_types) === 0 && $class instanceof Clazz) {
+            $this->emitIssue(
+                Issue::UndeclaredMethodInCallable,
+                $context->getLineNumberStart(),
+                $method_name,
+                (string)$union_type
+            );
+        }
+        return $result_types;
+    }
+
+    /**
+     * @param string|Node $class_or_expr
+     * @param string $method_name
+     *
+     * @return FullyQualifiedMethodName[]
+     * A list of CallableTypes associated with the given node
+     */
+    private function methodFQSENListFromParts($class_or_expr, $method_name) : array
+    {
+        $code_base = $this->code_base;
+        $context = $this->context;
+
+        if (!\is_string($method_name)) {
+            // Currently only works with string literals.
+            // TODO: Check if union type is sane, e.g. callable ['MyClass', new stdClass()] is nonsense.
+            return [];
+        }
+
+        if (is_string($class_or_expr)) {
+            $class_fqsen = FullyQualifiedClassName::make('', $class_or_expr);
+        } else {
+            $class_fqsen = (new ContextNode($code_base, $context, $class_or_expr))->resolveClassNameInContext();
+            if (!$class_fqsen) {
+                return $this->methodFQSENListFromObjectAndMethodName($class_or_expr, $method_name);
+            }
+        }
+        if (!$code_base->hasClassWithFQSEN($class_fqsen)) {
+            $this->emitIssue(
+                Issue::UndeclaredClassInCallable,
+                $context->getLineNumberStart(),
+                (string)$class_fqsen,
+                "$class_fqsen::$method_name"
+            );
+            return [];
+        }
+        $class = $code_base->getClassByFQSEN($class_fqsen);
+        if (!$class->hasMethodWithName($code_base, $method_name)) {
+            $this->emitIssue(
+                Issue::UndeclaredStaticMethodInCallable,
+                $context->getLineNumberStart(),
+                "$class_fqsen::$method_name"
+            );
+            return [];
+        }
+        $method = $class->getMethodByName($code_base, $method_name);
+        if (!$method->isStatic()) {
+            $this->emitIssue(
+                Issue::StaticCallToNonStatic,
+                $context->getLineNumberStart(),
+                "{$class->getFQSEN()}::{$method_name}()",
+                (string)$method->getFQSEN(),
+                $method->getFileRef()->getFile(),
+                (string)$method->getFileRef()->getLineNumberStart()
+            );
+        }
+        return [$method->getFQSEN()];
+    }
+
+    /**
+     * @see ContextNode->getFunction() for a similar function
+     */
+    private function functionFQSENListFromFunctionName(string $function_name) : array
+    {
+        // TODO: Catch invalid code such as call_user_func('\\\\x\\\\y')
+        $function_fqsen = FullyQualifiedFunctionName::make('', \ltrim($function_name, '\\'));
+        if (!$this->code_base->hasFunctionWithFQSEN($function_fqsen)) {
+            $this->emitIssue(
+                Issue::UndeclaredFunctionInCallable,
+                $this->context->getLineNumberStart(),
+                $function_name
+            );
+            return [];
+        }
+        return [$function_fqsen];
+    }
 
     /**
      * @param string|Node $node
@@ -1905,10 +2051,44 @@ class UnionTypeVisitor extends AnalysisVisitor
      */
     private function functionLikeFQSENListFromNode($node, bool $log_error) : array
     {
-        if (is_string($node)) {
-            // TODO: implement.
+        if (\is_string($node)) {
+            if (\stripos($node, '::') !== false) {
+                list($class_name, $method_name) = \explode('::', $node, 2);
+                return $this->methodFQSENListFromParts($class_name, $method_name);
+            }
+            return $this->functionFQSENListFromFunctionName($node);
+        }
+        if (!($node instanceof Node)) {
+            // warning is probably redundant
             return [];
         }
+        if ($node->kind === \ast\AST_ARRAY) {
+            $elements = $node->children;
+            if (\count($elements) !== 2) {
+                $this->emitIssue(
+                    Issue::TypeInvalidCallableArraySize,
+                    $node->lineno ?? 0,
+                    \count($elements)
+                );
+                return [];
+            }
+            $parts = [];
+            foreach ($elements as $i => $elem) {
+                $key = $elem->children['key'];
+                $parts[] = $elem->children['value'];
+                if ($key !== null && $key !== $i) {
+                    $this->emitIssue(
+                        Issue::TypeInvalidCallableArraySize,
+                        $node->lineno ?? 0,
+                        $i
+                    );
+                    return [];
+                }
+            }
+            return $this->methodFQSENListFromParts($parts[0], $parts[1]);
+        }
+        // TODO: Look up functions by name.
+
         // Get the types associated with the node
         $union_type = self::unionTypeFromNode(
             $this->code_base,

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -42,6 +42,10 @@ class Issue
     const UndeclaredTypeProperty    = 'PhanUndeclaredTypeProperty';
     const UndeclaredVariable        = 'PhanUndeclaredVariable';
     const UndeclaredVariableDim     = 'PhanUndeclaredVariableDim';
+    const UndeclaredClassInCallable = 'PhanUndeclaredClassInCallable';
+    const UndeclaredStaticMethodInCallable = 'PhanUndeclaredStaticMethodInCallable';
+    const UndeclaredFunctionInCallable = 'PhanUndeclaredFunctionInCallable';
+    const UndeclaredMethodInCallable = 'PhanUndeclaredMethodInCallable';
 
     // Issue::CATEGORY_TYPE
     const NonClassMethodCall        = 'PhanNonClassMethodCall';
@@ -77,6 +81,9 @@ class Issue
     const TypeNonVarPassByRef       = 'PhanTypeNonVarPassByRef';
     const TypeParentConstructorCalled = 'PhanTypeParentConstructorCalled';
     const TypeVoidAssignment        = 'PhanTypeVoidAssignment';
+    const TypeInvalidCallableArraySize = 'PhanTypeInvalidCallableArraySize';
+    const TypeInvalidCallableArrayKey = 'PhanTypeInvalidCallableArrayKey';
+    const TypeInvalidCallableObjectOfMethod = 'PhanTypeInvalidCallableObjectOfMethod';
 
     // Issue::CATEGORY_ANALYSIS
     const Unanalyzable              = 'PhanUnanalyzable';
@@ -107,8 +114,10 @@ class Issue
     const ParamSpecial4             = 'PhanParamSpecial4';
     const ParamTooFew               = 'PhanParamTooFew';
     const ParamTooFewInternal       = 'PhanParamTooFewInternal';
+    const ParamTooFewCallable       = 'PhanParamTooFewCallable';
     const ParamTooMany              = 'PhanParamTooMany';
     const ParamTooManyInternal      = 'PhanParamTooManyInternal';
+    const ParamTooManyCallable      = 'PhanParamTooManyCallable';
     const ParamTypeMismatch         = 'PhanParamTypeMismatch';
     const ParamSignatureMismatch    = 'PhanParamSignatureMismatch';
     const ParamSignatureMismatchInternal = 'PhanParamSignatureMismatchInternal';
@@ -626,6 +635,38 @@ class Issue
                 self::REMEDIATION_B,
                 11029
             ),
+            new Issue(
+                self::UndeclaredClassInCallable,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_NORMAL,
+                "Reference to undeclared class {CLASS} in callable {METHOD}",
+                self::REMEDIATION_B,
+                11030
+            ),
+            new Issue(
+                self::UndeclaredStaticMethodInCallable,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_NORMAL,
+                "Reference to undeclared static method {METHOD} in callable",
+                self::REMEDIATION_B,
+                11031
+            ),
+            new Issue(
+                self::UndeclaredFunctionInCallable,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_NORMAL,
+                "Call to undeclared function {FUNCTION} in callable",
+                self::REMEDIATION_B,
+                11032
+            ),
+            new Issue(
+                self::UndeclaredMethodInCallable,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_NORMAL,
+                "Call to undeclared method {METHOD} in callable. Possible object type(s) of for that method are {TYPE}",
+                self::REMEDIATION_B,
+                11033
+            ),
 
             // Issue::CATEGORY_ANALYSIS
             new Issue(
@@ -910,6 +951,30 @@ class Issue
                 self::REMEDIATION_B,
                 10032
             ),
+            new Issue(
+                self::TypeInvalidCallableArraySize,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                'In a place where phan was expecting a callable, saw an array of size {COUNT}, but callable arrays must be of size 2',
+                self::REMEDIATION_B,
+                10033
+            ),
+            new Issue(
+                self::TypeInvalidCallableArrayKey,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                'In a place where phan was expecting a callable, saw an array with an unexpected key for element #{INDEX} (expected [$class_or_expr, $method_name])',
+                self::REMEDIATION_B,
+                10034
+            ),
+            new Issue(
+                self::TypeInvalidCallableObjectOfMethod,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                'In a place where phan was expecting a callable, saw a two-element array with a class or expression with an unexpected type {TYPE} (expected a class type or string). Method name was {METHOD}',
+                self::REMEDIATION_B,
+                10035
+            ),
             // Issue::CATEGORY_VARIABLE
             new Issue(
                 self::VariableUseClause,
@@ -1016,6 +1081,14 @@ class Issue
                 7002
             ),
             new Issue(
+                self::ParamTooManyCallable,
+                self::CATEGORY_PARAMETER,
+                self::SEVERITY_LOW,
+                "Call with {COUNT} arg(s) to {FUNCTIONLIKE}() (As a provided callable) which only takes {COUNT} arg(s) defined at {FILE}:{LINE}",
+                self::REMEDIATION_B,
+                7043
+            ),
+            new Issue(
                 self::ParamTooFew,
                 self::CATEGORY_PARAMETER,
                 self::SEVERITY_NORMAL,
@@ -1030,6 +1103,14 @@ class Issue
                 "Call with {COUNT} arg(s) to {FUNCTIONLIKE}() which requires {COUNT} arg(s)",
                 self::REMEDIATION_B,
                 7004
+            ),
+            new Issue(
+                self::ParamTooFewCallable,
+                self::CATEGORY_PARAMETER,
+                self::SEVERITY_LOW,
+                "Call with {COUNT} arg(s) to {FUNCTIONLIKE}() (as a provided callable) which requires {COUNT} arg(s) defined at {FILE}:{LINE}",
+                self::REMEDIATION_B,
+                7044
             ),
             new Issue(
                 self::ParamSpecial1,

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -8,7 +8,6 @@ use Phan\Exception\CodeBaseException;
 use Phan\Exception\IssueException;
 use Phan\Issue;
 use Phan\Language\Element\Clazz;
-use Phan\Language\FQSEN\FullyQualifiedClassName;
 use Phan\Language\FQSEN\FullyQualifiedFunctionName;
 use Phan\Language\FQSEN\FullyQualifiedMethodName;
 use Phan\Language\Type\ArrayType;

--- a/tests/files/expected/0365_array_map_callable.php.expected
+++ b/tests/files/expected/0365_array_map_callable.php.expected
@@ -1,0 +1,14 @@
+%s:7 PhanTypeMismatchReturn Returning type int[] but test365A() is declared to return string[]
+%s:13 PhanTypeMismatchReturn Returning type int[] but test365B() is declared to return string[]
+%s:32 PhanTypeMismatchReturn Returning type \stdClass[] but test365C() is declared to return string[]
+%s:38 PhanUndeclaredClassInCallable Reference to undeclared class \Missing365 in callable \Missing365::createObject
+%s:44 PhanTypeMismatchReturn Returning type int[][] but test365D() is declared to return string[]
+%s:53 PhanParamTooManyCallable Call with 1 arg(s) to \accepts_no_args() (As a provided callable) which only takes 0 arg(s) defined at %s:47
+%s:63 PhanParamTooFewCallable Call with 1 arg(s) to \accepts_twoargs() (as a provided callable) which requires 2 arg(s) defined at %s:56
+%s:74 PhanTypeMismatchReturn Returning type string[][] but test365EEnough() is declared to return int[]
+%s:80 PhanUndeclaredMethodInCallable Call to undeclared method missingMethod in callable. Possible object type(s) of for that method are \C365
+%s:86 PhanUndeclaredFunctionInCallable Call to undeclared function missing_global_function365 in callable
+%s:92 PhanUndeclaredFunctionInCallable Call to undeclared function MyNS\missing_global_function365 in callable
+%s:98 PhanTypeMismatchReturn Returning type \ast\Node[] but test365GNamespacedValid() is declared to return string[]
+%s:104 PhanUndeclaredStaticMethodInCallable Reference to undeclared static method \C365::missing_static_method in callable
+%s:110 PhanUndeclaredStaticMethodInCallable Reference to undeclared static method \C365::missing_static_method2 in callable

--- a/tests/files/src/0365_array_map_callable.php
+++ b/tests/files/src/0365_array_map_callable.php
@@ -1,0 +1,111 @@
+<?php
+
+/** @return string[] (incorrect) */
+function test365A() {
+    $str = 'x';
+    // Also providing the wrong type to array_map
+    return array_map(function(int $x) : int { return $x * 2; }, [$str]);
+}
+
+/** @return string[] (incorrect) */
+function test365B() {
+    $str = 'x';
+    return array_map('strlen', [$str]);
+}
+
+class C365 {
+    public static function createObject(string $x) : stdClass {
+        return (object)['key' => $x];
+    }
+
+    /**
+     * @return int[]
+     */
+    public function createArray(int $x) {
+        return [$x];
+    }
+}
+
+/** @return string[] (incorrect, returns stdClass[]) */
+function test365C() {
+    $str = 'x';
+    return array_map('C365::createObject', [$str]);
+}
+
+/** @return string[] */
+function missingClass365C() {
+    $str = 'x';
+    return array_map('Missing365::createObject', [$str]);
+}
+
+/** @return string[] (incorrect) */
+function test365D() {
+    $str = 'x';
+    return array_map([new C365, 'createArray'], [$str]);
+}
+
+function accepts_no_args() {
+}
+
+/** @return array */
+function test365E() {
+    $str = 'x';
+    return array_map('accepts_no_args', [$str]);
+}
+
+function accepts_twoargs($x, $y) : array {
+    return [$x, $y];
+}
+
+/** @return array */
+function test365ETooFew() {
+    $str = 'x';
+    return array_map('\accepts_twoargs', [$str]);
+}
+
+/** @return string[] */
+function accepts_enough_args($x = 'default', $y = 'other_default') : array {
+    return [$x, $y];
+}
+
+/** @return int[] (incorrect, actually string[][])*/
+function test365EEnough() {
+    $str = 'x';
+    return array_map('\accepts_enough_args', [$str]);
+}
+
+/** @return string[] (incorrect) */
+function test365F() {
+    $str = 'x';
+    return array_map([new C365, 'missingMethod'], [$str]);
+}
+
+/** @return string[] */
+function test365G() {
+    $str = 'x';
+    return array_map('missing_global_function365', [$str]);
+}
+
+/** @return string[] */
+function test365GNamespaced() {
+    $str = 'x';
+    return array_map('MyNS\\missing_global_function365', [$str]);
+}
+
+/** @return string[] (actually Node[]) */
+function test365GNamespacedValid() {
+    $str = '<?php 2; ?>';
+    return array_map('ast\parse_code', [$str], [50]);
+}
+
+/** @return string[] */
+function test365H() {
+    $str = 'x';
+    return array_map(['C365', 'missing_static_method'], [$str]);
+}
+
+/** @return string[] */
+function test365HString() {
+    $str = 'x';
+    return array_map('C365::missing_static_method2', [$str]);
+}


### PR DESCRIPTION
Phan can now analyze callables of Closure form,
as well as inlined strings/2-part array callables
(strings for global static methods and global functions)