### PR TITLE
Fixes #1187 : Lookup of callable failed for namespaced callable.

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -436,7 +436,7 @@ return [
         '.phan/plugins/DemoPlugin.php',
         '.phan/plugins/DollarDollarPlugin.php',
         '.phan/plugins/UnreachableCodePlugin.php',
-        // NOTE: src/Phan/Language/Internal/FunctionSignatureMap.php mixes value without key as return type with values having keys deliberately.
+        // NOTE: src/Phan/Language/Internal/FunctionSignatureMap.php mixes value without keys (as return type) with values having keys deliberately.
         '.phan/plugins/DuplicateArrayKeyPlugin.php',
 
         // NOTE: This plugin only produces correct results when

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ version: '{branch}.{build}'
 clone_folder: C:\projects\phan
 # Don't include full git history
 clone_depth: 1
-# Test 32-builds
+# Test 32-bit builds
 platform: x86
 
 branches:

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -2036,6 +2036,10 @@ class UnionTypeVisitor extends AnalysisVisitor
             }
             return $class->getParentClassFQSEN();  // may or may not exist.
         default:
+            // TODO: Reject invalid/empty class names earlier
+            if (\substr($class_name, 0, 1) === '\\') {
+                $class_name = \substr($class_name, 1);
+            }
             return FullyQualifiedClassName::make('', $class_name);
         }
     }

--- a/tests/files/expected/0371_callable_in_namespace.php.expected
+++ b/tests/files/expected/0371_callable_in_namespace.php.expected
@@ -1,0 +1,19 @@
+%s:20 PhanTypeMismatchReturn Returning type int[] but my_test371B() is declared to return string[]
+%s:26 PhanTypeMismatchArgument Argument 1 (x) is \stdClass but \Foo\NS371\strlen371() takes string defined at %s:4
+%s:32 PhanTypeMismatchArgument Argument 1 (x) is \stdClass but \Foo\NS371\C371::strlen371() takes string defined at %s:8
+%s:38 PhanTypeMismatchReturn Returning type int[] but my_test371E() is declared to return string[]
+%s:62 PhanTypeMismatchReturn Returning type \stdClass[] but test371C() is declared to return string[]
+%s:68 PhanTypeMismatchReturn Returning type \stdClass[] but test371C2() is declared to return string[]
+%s:74 PhanUndeclaredClassInCallable Reference to undeclared class \Foo\Bar\Missing371 in callable \Foo\Bar\Missing371::createObject
+%s:80 PhanUndeclaredClassInCallable Reference to undeclared class \C371 in callable \C371::createObject
+%s:86 PhanUndeclaredClassConstant Reference to constant class from undeclared class \Foo\Bar\Missing371
+%s:86 PhanUndeclaredClassInCallable Reference to undeclared class \Foo\Bar\Missing371 in callable \Foo\Bar\Missing371::createObject
+%s:92 PhanTypeMismatchArgument Argument 1 (x) is string but \Foo\Bar\C371::createArray() takes int defined at %s:54
+%s:92 PhanTypeMismatchReturn Returning type int[][] but test371D() is declared to return string[]
+%s:101 PhanParamTooManyCallable Call with 1 arg(s) to \Foo\Bar\accepts_no_args() (As a provided callable) which only takes 0 arg(s) defined at %s:95
+%s:111 PhanParamTooFewCallable Call with 1 arg(s) to \Foo\Bar\accepts_twoargs() (as a provided callable) which requires 2 arg(s) defined at %s:104
+%s:122 PhanUndeclaredFunctionInCallable Call to undeclared function \accepts_enough_args in callable
+%s:128 PhanUndeclaredMethodInCallable Call to undeclared method missingMethod in callable. Possible object type(s) for that method are \Foo\Bar\C371
+%s:134 PhanTypeMismatchReturn Returning type \ast\Node[] but test371GNamespacedValid() is declared to return string[]
+%s:140 PhanUndeclaredStaticMethodInCallable Reference to undeclared static method \Foo\Bar\C371::missing_static_method in callable
+%s:146 PhanUndeclaredClassInCallable Reference to undeclared class \C371 in callable \C371::missing_static_method2

--- a/tests/files/src/0371_callable_in_namespace.php
+++ b/tests/files/src/0371_callable_in_namespace.php
@@ -1,0 +1,147 @@
+<?php
+namespace Foo\NS371;
+
+function strlen371(string $x) : int {
+    return \strlen($x);
+}
+class C371 {
+    public static function strlen371(string $x) : int {
+        return \strlen($x);
+    }
+}
+
+namespace Foo\Bar;
+
+use stdClass;
+
+/** @return string[] (incorrect) */
+function my_test371B() {
+    $str = 'x';
+    return array_map('Foo\NS371\strlen371', [$str]);
+}
+
+/** @return int[] (correct) */
+function my_test371C() {
+    $obj = new stdClass();
+    return array_map('\Foo\NS371\strlen371', [$obj]);
+}
+
+/** @return int[] (correct) */
+function my_test371D() {
+    $obj = new stdClass();
+    return array_map('\Foo\NS371\C371::strlen371', [$obj]);
+}
+
+/** @return string[] (incorrect) */
+function my_test371E() {
+    $str = 'x';
+    return array_map('Foo\NS371\C371::strlen371', [$str]);
+}
+
+my_test371E();
+my_test371D();
+my_test371C();
+my_test371B();
+
+class C371 {
+    public static function createObject(string $x) : stdClass {
+        return (object)['key' => $x];
+    }
+
+    /**
+     * @return int[]
+     */
+    public function createArray(int $x) {
+        return [$x];
+    }
+}
+
+/** @return string[] (incorrect, returns stdClass[]) */
+function test371C() {
+    $str = 'x';
+    return array_map('Foo\Bar\C371::createObject', [$str]);
+}
+
+/** @return string[] (incorrect, returns stdClass[]) */
+function test371C2() {
+    $str = 'x';
+    return array_map([C371::class, 'createObject'], [$str]);
+}
+
+/** @return string[] */
+function missingClass371C() {
+    $str = 'x';
+    return array_map('Foo\Bar\Missing371::createObject', [$str]);
+}
+
+/** @return string[] */
+function missingClass371C2() {
+    $str = 'x';
+    return array_map('C371::createObject', [$str]);
+}
+
+/** @return string[] */
+function missingClass371C3() {
+    $str = 'x';
+    return array_map([Missing371::class, 'createObject'], [$str]);
+}
+
+/** @return string[] (incorrect) */
+function test371D() {
+    $str = 'x';
+    return array_map([new C371, 'createArray'], [$str]);
+}
+
+function accepts_no_args() {
+}
+
+/** @return array */
+function test371E() {
+    $str = 'x';
+    return array_map('Foo\Bar\accepts_no_args', [$str]);
+}
+
+function accepts_twoargs($x, $y) : array {
+    return [$x, $y];
+}
+
+/** @return array */
+function test371ETooFew() {
+    $str = 'x';
+    return array_map('\Foo\bar\accepts_twoargs', [$str]);
+}
+
+/** @return string[] */
+function accepts_enough_args($x = 'default', $y = 'other_default') : array {
+    return [$x, $y];
+}
+
+/** @return int[] (incorrect, actually string[][])*/
+function test371EEnough() {
+    $str = 'x';
+    return array_map('\accepts_enough_args', [$str]);
+}
+
+/** @return string[] (incorrect) */
+function test371F() {
+    $str = 'x';
+    return array_map([new C371, 'missingMethod'], [$str]);
+}
+
+/** @return string[] (actually Node[]) */
+function test371GNamespacedValid() {
+    $str = '<?php 2; ?>';
+    return array_map('ast\parse_code', [$str], [50]);
+}
+
+/** @return string[] */
+function test371H() {
+    $str = 'x';
+    return array_map([C371::class, 'missing_static_method'], [$str]);
+}
+
+/** @return string[] */
+function test371HString() {
+    $str = 'x';
+    return array_map('C371::missing_static_method2', [$str]);
+}


### PR DESCRIPTION
If a namespaced callable literal class name had a leading `\\`,
Phan would fail to look it up.
This commit fixes that.

Also, nit on code comments