### PR TITLE
Implement @return $this as an alias for @return static

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,9 @@ Phan NEWS
 
 ?? ??? 2017, Phan 0.10.1
 
+New Features(Analysis)
++ Support `@return $this` in phpdoc for methods and magic methods (but not elsewhere. E.g. `@param $this $varName` is not supported) (#634)
+
 New Features (CLI, Configs)
 
 + Add Language Server Protocol support (Experimental) (#821)

--- a/src/Phan/Language/Element/Comment.php
+++ b/src/Phan/Language/Element/Comment.php
@@ -458,7 +458,7 @@ class Comment
 
         if (preg_match('/@return\s+/', $line)) {
             // TODO: Is `@return &array` valid phpdoc2?
-            if (preg_match('/@return\s+(&\s*)?(' . UnionType::union_type_regex . '+)/', $line, $match)) {
+            if (preg_match('/@return\s+(&\s*)?(' . UnionType::union_type_regex_or_this . '+)/', $line, $match)) {
                 $return_union_type_string = $match[2];
             }
             // Not emitting any issues about failing to extract, e.g. `@return - Description of what this returns` is a valid comment.
@@ -714,9 +714,9 @@ class Comment
         //    Assumes the parameters end at the first ")" after "("
         //    As an exception, allows one level of matching brackets
         //    to support old style arrays such as $x = array(), $x = array(2) (Default values are ignored)
-        if (preg_match('/@method(\s+(static))?((\s+(' . UnionType::union_type_regex . '))?)\s+' . self::word_regex . '\s*\((([^()]|\([()]*\))*)\)\s*(.*)/', $line, $match)) {
+        if (preg_match('/@method(\s+(static))?((\s+(' . UnionType::union_type_regex_or_this . '))?)\s+' . self::word_regex . '\s*\((([^()]|\([()]*\))*)\)\s*(.*)/', $line, $match)) {
             $is_static = $match[2] === 'static';
-            $return_union_type_string = $match[4];
+            $return_union_type_string = $match[5];
             if ($return_union_type_string !== '') {
                 $return_union_type =
                     UnionType::fromStringInContext(
@@ -729,9 +729,9 @@ class Comment
                 // > When the intended method does not have a return value then the return type MAY be omitted; in which case 'void' is implied.
                 $return_union_type = VoidType::instance(false)->asUnionType();
             }
-            $method_name = $match[31];
+            $method_name = $match[33];
 
-            $arg_list = trim($match[32]);
+            $arg_list = trim($match[34]);
             $comment_params = [];
             // Special check if param list has 0 params.
             if ($arg_list !== '') {

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -37,6 +37,16 @@ class UnionType implements \Serializable
         . '(\|' . Type::type_regex . ')*';
 
     /**
+     * @var string
+     * A list of one or more types delimited by the '|'
+     * character (e.g. 'int|DateTime|string[]' or 'null|$this')
+     * This may be used for return types.
+     */
+    const union_type_regex_or_this =
+        Type::type_regex_or_this
+        . '(\|' . Type::type_regex_or_this . ')*';
+
+    /**
      * @var Type[] - [int $type_object_id => Type $type]
      */
     private $type_set;

--- a/tests/Phan/Language/TypeTest.php
+++ b/tests/Phan/Language/TypeTest.php
@@ -1,0 +1,95 @@
+<?php declare(strict_types = 1);
+namespace Phan\Tests\Language;
+
+use Phan\Tests\BaseTest;
+use Phan\Language\Context;
+use Phan\Language\Type;
+use Phan\Language\Type\ArrayType;
+use Phan\Language\Type\BoolType;
+use Phan\Language\Type\CallableType;
+use Phan\Language\Type\ClosureType;
+use Phan\Language\Type\FalseType;
+use Phan\Language\Type\FloatType;
+use Phan\Language\Type\GenericArrayType;
+use Phan\Language\Type\IntType;
+use Phan\Language\Type\IterableType;
+use Phan\Language\Type\MixedType;
+use Phan\Language\Type\NativeType;
+use Phan\Language\Type\NullType;
+use Phan\Language\Type\ObjectType;
+use Phan\Language\Type\ResourceType;
+use Phan\Language\Type\StaticType;
+use Phan\Language\Type\StringType;
+use Phan\Language\Type\TemplateType;
+use Phan\Language\Type\TrueType;
+use Phan\Language\Type\VoidType;
+
+/**
+ * Unit tests of Type
+ */
+class TypeTest extends BaseTest
+{
+    private function makePHPDocType(string $type) : Type
+    {
+        return Type::fromStringInContext($type, new Context(), Type::FROM_PHPDOC);
+    }
+
+
+    public function testBasicTypes()
+    {
+        $this->assertSame(ArrayType::instance(false), self::makePHPDocType('array'));
+        $this->assertSame(ArrayType::instance(true), self::makePHPDocType('?array'));
+        $this->assertSame(ArrayType::instance(true), self::makePHPDocType('?ARRAY'));
+        $this->assertSame(BoolType::instance(false), self::makePHPDocType('bool'));
+        $this->assertSame(CallableType::instance(false), self::makePHPDocType('callable'));
+        $this->assertSame(ClosureType::instance(false), self::makePHPDocType('Closure'));
+        $this->assertSame(FalseType::instance(false), self::makePHPDocType('false'));
+        $this->assertSame(FloatType::instance(false), self::makePHPDocType('float'));
+        $this->assertSame(IntType::instance(false), self::makePHPDocType('int'));
+        $this->assertSame(IterableType::instance(false), self::makePHPDocType('iterable'));
+        $this->assertSame(MixedType::instance(false), self::makePHPDocType('mixed'));
+        $this->assertSame(ObjectType::instance(false), self::makePHPDocType('object'));
+        $this->assertSame(ResourceType::instance(false), self::makePHPDocType('resource'));
+        $this->assertSame(StaticType::instance(false), self::makePHPDocType('static'));
+        $this->assertSame(StringType::instance(false), self::makePHPDocType('string'));
+        $this->assertSame(TrueType::instance(false), self::makePHPDocType('true'));
+        $this->assertSame(VoidType::instance(false), self::makePHPDocType('void'));
+    }
+
+    private function assertSameType(Type $expected, Type $actual)
+    {
+        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testUnionTypeOfThis()
+    {
+        $this->assertSameType(StaticType::instance(false), self::makePHPDocType('$this'));
+        $this->assertSameType(StaticType::instance(true), self::makePHPDocType('?$this'));
+    }
+
+    public function testGenericArray()
+    {
+        $genericArrayType = self::makePHPDocType('int[][]');
+        $expectedGenericArrayType = GenericArrayType::fromElementType(
+            GenericArrayType::fromElementType(
+                IntType::instance(false),
+                false
+            ),
+            false
+        );
+        $this->assertSame($expectedGenericArrayType, $genericArrayType);
+        $this->assertSame('int[][]', (string)$expectedGenericArrayType);
+    }
+
+    public function testTemplateTypes()
+    {
+        $type = self::makePHPDocType('TypeTestClass<A1,B2>');
+        $this->assertSame('\\', $type->getNamespace());
+        $this->assertSame('TypeTestClass', $type->getName());
+        $parts = $type->getTemplateParameterTypeList();
+        $this->assertCount(2, $parts);
+        $this->assertTrue($parts[0]->isType(self::makePHPDocType('A1')));
+        $this->assertTrue($parts[1]->isType(self::makePHPDocType('B2')));
+    }
+}

--- a/tests/files/expected/0253_return_type_match.php.expected
+++ b/tests/files/expected/0253_return_type_match.php.expected
@@ -5,3 +5,4 @@
 %s:47 PhanTypeMismatchDeclaredReturnNullable Doc-block of a11 has declared return type int which is not a permitted replacement of the nullable return type ?int declared in the signature ('?T' should be documented as 'T|null' or '?T')
 %s:57 PhanTypeMismatchDeclaredReturn Doc-block of f6 contains declared return type \C253_1 which is incompatible with the return type \C253_2 declared in the signature
 %s:61 PhanTypeMismatchDeclaredReturn Doc-block of f7 contains declared return type \C253_1 which is incompatible with the return type \C253_2 declared in the signature
+%s:69 PhanTypeMismatchDeclaredReturn Doc-block of h4 contains declared return type static which is incompatible with the return type iterable declared in the signature

--- a/tests/files/expected/0282_forbid_undeclared_magic_methods.php.expected
+++ b/tests/files/expected/0282_forbid_undeclared_magic_methods.php.expected
@@ -1,7 +1,9 @@
-%s:27 PhanTypeMismatchArgument Argument 1 (arg) is string but \Magic282::instanceMethod() takes ?int defined at %s:8
-%s:28 PhanUndeclaredMethod Call to undeclared method \Magic282::missingMethod
-%s:29 PhanParamTooFew Call with 0 arg(s) to \Magic282::instanceMethod() which requires 1 arg(s) defined at %s:8
-%s:30 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is array but \intdiv() takes int
-%s:32 PhanTypeMismatchArgument Argument 1 (arg) is int but \Magic282::static_method() takes string defined at %s:8
-%s:34 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is string but \intdiv() takes int
-%s:36 PhanUndeclaredStaticMethod Static call to undeclared method \Magic282::undeclared_magic_static_method
+%s:23 PhanUndeclaredVariable Variable $this is undeclared
+%s:32 PhanTypeMismatchArgument Argument 1 (arg) is string but \Magic282::instanceMethod() takes ?int defined at %s:9
+%s:33 PhanUndeclaredMethod Call to undeclared method \Magic282::missingMethod
+%s:34 PhanParamTooFew Call with 0 arg(s) to \Magic282::instanceMethod() which requires 1 arg(s) defined at %s:9
+%s:35 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is array but \intdiv() takes int
+%s:37 PhanTypeMismatchArgument Argument 1 (arg) is int but \Magic282::static_method() takes string defined at %s:9
+%s:39 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is string but \intdiv() takes int
+%s:41 PhanUndeclaredStaticMethod Static call to undeclared method \Magic282::undeclared_magic_static_method
+%s:43 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \Magic282 but \intdiv() takes int

--- a/tests/files/src/0253_return_type_match.php
+++ b/tests/files/src/0253_return_type_match.php
@@ -61,4 +61,12 @@ class C253_2 extends C253_1 {
     public function f7() : self {
         return new static();
     }
+    /** @return $this (narrowing, allowed) */
+    public function h3() : C253_1 {
+        return $this;
+    }
+    /** @return $this (incompatible, not allowed) */
+    public function h4() : iterable {
+        throw new RuntimeException('not implemented');
+    }
 }

--- a/tests/files/src/0282_forbid_undeclared_magic_methods.php
+++ b/tests/files/src/0282_forbid_undeclared_magic_methods.php
@@ -2,6 +2,7 @@
 
 /**
  * @method array instanceMethod(?int $arg)
+ * @method $this instanceMethodReturningThis(string $arg)
  * @method static string static_method(string $arg)
  * @phan-forbid-undeclared-magic-methods
  */
@@ -16,6 +17,10 @@ class Magic282 {
     public static function __callStatic(string $name, array $args) {
         if ($name == 'static_method') {
             return 'prefix' . $args[0];
+        }
+        if ($name == 'static_method_returning_this') {
+            echo 'prefix' . $args[0];
+            return $this;
         }
         throw new RuntimeException("Bad static method name");
     }
@@ -34,4 +39,6 @@ function test282() {
     echo intdiv($s, 2);  // warn about passing string, expect int
     // Should warn about undeclared static methods because of @phan-forbid-undeclared-magic-methods
     Magic282::undeclared_magic_static_method();
+    $m2 = $m->instanceMethodReturningThis('str');
+    echo intdiv($m2, 2); // warn about passing Magic282, want int
 }


### PR DESCRIPTION
(?$this and $this|string and $this[] are also supported)

TODO: warn about @return $this in static methods and static magic methods
in another PR (low priority)

Fixes #634