### PR TITLE
Fixes #1186: Improve inferences for shorthand ternary operator (?:)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -34,6 +34,7 @@ Bug Fixes
 + Change the behavior of the `-d` flag, make it change the current working directory to the provided directory.
 + Properly set the real param type and return types of internal functions, in rare cases where that exists.
 + Support analyzing the rare case of namespaced internal global functions (e.g. `\ast\parse_code($code, $version)`)
++ Improve analysis of shorthand ternary operator: Remove false/null from cond_expr in `(cond_expr) ?: (false_expr)` (#1186)
 
 24 Sep 2017, Phan 0.10.0
 -----------------------

--- a/tests/files/expected/0257_null_conditional.php.expected
+++ b/tests/files/expected/0257_null_conditional.php.expected
@@ -1,1 +1,1 @@
-%s:9 PhanTypeMismatchArgument Argument 1 (p) is \NS257\C1|bool|null but \NS257\C2::f2() takes string defined at %s:11
+%s:9 PhanTypeMismatchArgument Argument 1 (p) is \NS257\C1|null|true but \NS257\C2::f2() takes string defined at %s:11

--- a/tests/files/expected/0372_ternary_shorthand.php.expected
+++ b/tests/files/expected/0372_ternary_shorthand.php.expected
@@ -1,0 +1,2 @@
+%s:21 PhanTypeMismatchArgument Argument 1 (x) is string but \expect_int382() takes int defined at %s:17
+%s:22 PhanTypeMismatchArgument Argument 1 (x) is string|string[] but \expect_int382() takes int defined at %s:17

--- a/tests/files/src/0372_ternary_shorthand.php
+++ b/tests/files/src/0372_ternary_shorthand.php
@@ -1,0 +1,23 @@
+<?php
+
+function foo382() : ?string {
+    return 'x';
+}
+
+/** @return string|false */
+function bar382() {
+    if (rand() % 2 > 0) {
+        return 'x';
+    } else {
+        return false;
+    }
+}
+
+/** @param int $x */
+function expect_int382($x) {
+}
+
+function test() {
+    echo expect_int382(foo382() ?: '');
+    echo expect_int382(bar382() ?: ['x']);
+}


### PR DESCRIPTION
If there is no separate expression for true, then remove null and false
from the cond_expr of `cond_expr ?: false_expr`