### PR TITLE
support array<T>, array<Key,T>, `(?T)[]` and recursive templates in PHPDoc (Some edge cases remain)

### DIFF
--- a/src/Phan/Language/Element/Comment.php
+++ b/src/Phan/Language/Element/Comment.php
@@ -31,25 +31,19 @@ class Comment
     const ON_METHOD     = 5;
     const ON_FUNCTION   = 6;
 
-    // List of types that are method-like
+    // List of types that are function-like (e.g. have params and function body)
     const FUNCTION_LIKE = [
         self::ON_METHOD,
         self::ON_FUNCTION,
     ];
 
+    // Lists of types that can have (at)var annotations.
     const HAS_VAR_ANNOTATION = [
         self::ON_METHOD,
         self::ON_FUNCTION,
         self::ON_VAR,
         self::ON_PROPERTY,
-        self::ON_CLASS,
         self::ON_CONST,
-    ];
-
-    const VAR_LIKE = [
-        self::ON_VAR,
-        self::ON_PROPERTY,
-        self::ON_CLASS
     ];
 
     const NAME_FOR_TYPE = [
@@ -289,10 +283,13 @@ class Comment
                     $parameter_list[] =
                         self::parameterFromCommentLine($code_base, $context, $line, false, $lineno);
                 }
-            } elseif (\stripos($line, '@var') !== false && preg_match('/@var\b/i', $line)) {
+            } elseif (\stripos($line, '@var') !== false && \preg_match('/@var\b/i', $line)) {
                 $check_compatible('@var', Comment::HAS_VAR_ANNOTATION);
-                $variable_list[] =
-                    self::parameterFromCommentLine($code_base, $context, $line, true, $lineno);
+                $comment_var = self::parameterFromCommentLine($code_base, $context, $line, true, $lineno);
+                if ($comment_var->getName() !== '' || !\in_array($comment_type, self::FUNCTION_LIKE)) {
+                    $variable_list[] = $comment_var;
+                }
+
             } elseif (\stripos($line, '@template') !== false) {
 
                 // Make sure support for generic types is enabled
@@ -514,16 +511,15 @@ class Comment
         bool $is_var,
         int $lineno
     ) {
-        $match = [];
-        if (preg_match('/@(param|var)\s+(' . UnionType::union_type_regex . ')(\s+(\.\.\.)?\s*(\\$' . self::word_regex . '))?/', $line, $match)) {
+        if (preg_match('/@(param|var)\s+(' . UnionType::union_type_regex . ')(?:\s+(\.\.\.)?\s*(?:\\$' . self::word_regex . '))?/', $line, $match)) {
             $original_type = $match[2];
 
-            $is_variadic = ($match[29] ?? '') === '...';
+            $is_variadic = ($match[16] ?? '') === '...';
 
             if ($is_var && $is_variadic) {
                 $variable_name = '';  // "@var int ...$x" is nonsense and invalid phpdoc.
             } else {
-                $variable_name = $match[31] ?? '';
+                $variable_name = $match[17] ?? '';
             }
             // If the parameter has a type which is labelled as a typo (type maps to ''),
             // then treat it the same way as a parameter without a type in the doc comment.
@@ -588,6 +584,7 @@ class Comment
         string $line
     ) {
         $match = [];
+        // TODO: Just use word_regex? Backslashes or nested templates wouldn't make sense.
         if (preg_match('/@template\s+(' . Type::simple_type_regex. ')/', $line, $match)) {
             $template_type_identifier = $match[1];
             return new TemplateType($template_type_identifier);
@@ -661,7 +658,7 @@ class Comment
         // https://github.com/phpDocumentor/phpDocumentor2/pull/1271/files - phpdoc allows passing an default value.
         // Phan allows `=.*`, to indicate that a parameter is optional
         // TODO: in another PR, check that optional parameters aren't before required parameters.
-        if (preg_match('/^(' . UnionType::union_type_regex . ')?\s*((\.\.\.)\s*)?(\$' . self::word_regex . ')?((\s*=.*)?)$/', $param_string, $param_match)) {
+        if (preg_match('/^(' . UnionType::union_type_regex . ')?\s*(?:(\.\.\.)\s*)?(?:\$' . self::word_regex . ')?((?:\s*=.*)?)$/', $param_string, $param_match)) {
             // Note: a magic method parameter can be variadic, but it can't be pass-by-reference? (No support in __call)
             $union_type_string = $param_match[1];
             $union_type = UnionType::fromStringInContext(
@@ -669,8 +666,8 @@ class Comment
                 $context,
                 Type::FROM_PHPDOC
             );
-            $is_variadic = $param_match[28] === '...';
-            $default_str = $param_match[31];
+            $is_variadic = $param_match[15] === '...';
+            $default_str = $param_match[17];
             $has_default_value = $default_str !== '';
             if ($has_default_value) {
                 $default_value_repr = trim(explode('=', $default_str, 2)[1]);
@@ -678,7 +675,7 @@ class Comment
                     $union_type = $union_type->nullableClone();
                 }
             }
-            $var_name = $param_match[30];
+            $var_name = $param_match[16];
             if ($var_name === '') {
                 // placeholder names are p1, p2, ...
                 $var_name = 'p' . ($param_index + 1);
@@ -714,9 +711,9 @@ class Comment
         //    Assumes the parameters end at the first ")" after "("
         //    As an exception, allows one level of matching brackets
         //    to support old style arrays such as $x = array(), $x = array(2) (Default values are ignored)
-        if (preg_match('/@method(\s+(static))?((\s+(' . UnionType::union_type_regex_or_this . '))?)\s+' . self::word_regex . '\s*\((([^()]|\([()]*\))*)\)\s*(.*)/', $line, $match)) {
-            $is_static = $match[2] === 'static';
-            $return_union_type_string = $match[5];
+        if (preg_match('/@method(?:\s+(static))?(?:(?:\s+(' . UnionType::union_type_regex_or_this . '))?)\s+' . self::word_regex . '\s*\(((?:[^()]|\([()]*\))*)\)\s*(.*)/', $line, $match)) {
+            $is_static = $match[1] === 'static';
+            $return_union_type_string = $match[2];
             if ($return_union_type_string !== '') {
                 $return_union_type =
                     UnionType::fromStringInContext(
@@ -729,13 +726,14 @@ class Comment
                 // > When the intended method does not have a return value then the return type MAY be omitted; in which case 'void' is implied.
                 $return_union_type = VoidType::instance(false)->asUnionType();
             }
-            $method_name = $match[33];
+            $method_name = $match[20];
 
-            $arg_list = trim($match[34]);
+            $arg_list = trim($match[21]);
             $comment_params = [];
             // Special check if param list has 0 params.
             if ($arg_list !== '') {
                 // TODO: Would need to use a different approach if templates were ever supported
+                //       e.g. The magic method parsing doesn't support commas?
                 $params_strings = explode(',', $arg_list);
                 $failed = false;
                 foreach ($params_strings as $i => $param_string) {
@@ -792,10 +790,10 @@ class Comment
         // Note that the type of a property can be left out (@property $myVar) - This is equivalent to @property mixed $myVar
         // TODO: properly handle duplicates...
         // TODO: support read-only/write-only checks elsewhere in the codebase?
-        if (preg_match('/@(property|property-read|property-write)(\s+' . UnionType::union_type_regex . ')?(\s+(\\$' . self::word_regex . '))/', $line, $match)) {
-            $type = ltrim($match[2] ?? '');
+        if (\preg_match('/@(property|property-read|property-write)(?:\s+(' . UnionType::union_type_regex . '))?(?:\s+(?:\\$' . self::word_regex . '))/', $line, $match)) {
+            $type = $match[2] ?? '';
 
-            $property_name = $match[30] ?? '';
+            $property_name = $match[16] ?? '';
             if ($property_name === '') {
                 return null;
             }
@@ -847,7 +845,7 @@ class Comment
         // a Closure would be bound with bind() or bindTo(), so using a custom tag.
         //
         // TODO: Also add a version which forbids using $this in the closure?
-        if (preg_match('/@(PhanClosureScope|phan-closure-scope)\s+(' . UnionType::union_type_regex . '+)/', $line, $match)) {
+        if (preg_match('/@(PhanClosureScope|phan-closure-scope)\s+(' . UnionType::union_type_regex . ')/', $line, $match)) {
             $closure_scope_union_type_string = $match[2];
         }
 

--- a/src/Phan/Language/Element/Comment/Method.php
+++ b/src/Phan/Language/Element/Comment/Method.php
@@ -121,7 +121,11 @@ class Method
 
     public function __toString() : string
     {
-        $string = 'function ';
+        if ($this->isStatic()) {
+            $string = 'static function ';
+        } else {
+            $string = 'function ';
+        }
         // Magic methods can't be by ref?
         $string .= $this->getName();
 

--- a/src/Phan/Language/Element/Comment/Parameter.php
+++ b/src/Phan/Language/Element/Comment/Parameter.php
@@ -30,7 +30,7 @@ class Parameter
 
     /**
      * @var bool
-     * Whether or not the parameter is optional (Note: only applies to the comment for (at)method.
+     * Whether or not the parameter is optional (Note: only applies to the comment for (at)method.)
      */
     private $has_default_value;
 
@@ -152,7 +152,7 @@ class Parameter
             $string .= '...';
         }
 
-        $string .= $this->name;
+        $string .= '$' . $this->name;
 
         if ($this->has_default_value) {
             $string .= ' = default';

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -41,6 +41,8 @@ class UnionType implements \Serializable
      * A list of one or more types delimited by the '|'
      * character (e.g. 'int|DateTime|string[]' or 'null|$this')
      * This may be used for return types.
+     *
+     * TODO: Equivalent variants with no capturing? (May not improve performance much)
      */
     const union_type_regex_or_this =
         Type::type_regex_or_this
@@ -93,6 +95,7 @@ class UnionType implements \Serializable
         $type_set = $memoize_map[$fully_qualified_string] ?? null;
 
         if (!isset($type_set)) {
+            // TODO: Support brackets, template types within <>, etc.
             $type_set = ArraySet::from_list(\array_map(function (string $type_name) {
                 return Type::fromFullyQualifiedString($type_name);
             }, \explode('|', $fully_qualified_string)));

--- a/tests/Phan/Language/Element/CommentTest.php
+++ b/tests/Phan/Language/Element/CommentTest.php
@@ -1,0 +1,281 @@
+<?php declare(strict_types = 1);
+namespace Phan\Tests\Language\Element;
+
+use Phan\Tests\BaseTest;
+use Phan\CodeBase;
+use Phan\Config;
+use Phan\Language\Context;
+use Phan\Language\Element\Comment;
+use Phan\Language\Type;
+use Phan\Language\Type\StaticType;
+use Phan\Library\None;
+
+/**
+ * Unit tests of Type
+ */
+class CommentTest extends BaseTest
+{
+    /** @var CodeBase|null */
+    protected $code_base = null;
+
+    /** @var bool */
+    const overrides = [
+        'read_type_annotations' => true,
+        'read_magic_property_annotations' => true,
+        'read_magic_method_annotations' => true,
+    ];
+
+    protected $old_values = [];
+
+    protected function setUp()
+    {
+        $this->code_base = new CodeBase([], [], [], [], []);
+        foreach (self::overrides as $key => $value) {
+            $this->old_values[$key] = Config::getValue($key);
+            Config::setValue($key, $value);
+        }
+    }
+
+    protected function tearDown()
+    {
+        $this->code_base = null;
+        foreach ($this->old_values as $key => $value) {
+            Config::setValue($key, $value);
+        }
+    }
+
+    public function testEmptyComment()
+    {
+        $comment = Comment::fromStringInContext(
+            '/** foo */',
+            $this->code_base,
+            new Context(),
+            1,
+            Comment::ON_METHOD
+        );
+        $this->assertSame(false, $comment->isDeprecated());
+        $this->assertSame(false, $comment->isOverrideIntended());
+        $this->assertSame(false, $comment->isNSInternal());
+        $this->assertSame('', (string)$comment->getReturnType());
+        $this->assertSame(false, $comment->hasReturnUnionType());
+        $this->assertInstanceOf(None::class, $comment->getClosureScopeOption());
+        $this->assertSame([], $comment->getParameterList());
+        $this->assertSame([], $comment->getParameterMap());
+        $this->assertSame([], $comment->getSuppressIssueList());
+        $this->assertSame(false, $comment->hasParameterWithNameOrOffset('bar', 0));
+        $this->assertSame([], $comment->getVariableList());
+    }
+
+    public function testGetParameterMap()
+    {
+        $comment = Comment::fromStringInContext(
+            '/** @param int $myParam */',
+            $this->code_base,
+            new Context(),
+            1,
+            Comment::ON_METHOD
+        );
+        $parameter_map = $comment->getParameterMap();
+        $this->assertSame(['myParam'], \array_keys($parameter_map));
+        $this->assertSame([], $comment->getParameterList());
+        $my_param_doc = $parameter_map['myParam'];
+        $this->assertSame('int $myParam', (string)$my_param_doc);
+        $this->assertSame(false, $my_param_doc->isOptional());
+        $this->assertSame(true, $my_param_doc->isRequired());
+        $this->assertSame(false, $my_param_doc->isVariadic());
+        $this->assertSame('myParam', $my_param_doc->getName());
+    }
+
+    public function testGetVariadicParameterMap()
+    {
+        $comment = Comment::fromStringInContext(
+            '/** @param int|string ...$args */',
+            $this->code_base,
+            new Context(),
+            1,
+            Comment::ON_METHOD
+        );
+        $parameter_map = $comment->getParameterMap();
+        $this->assertSame(['args'], \array_keys($parameter_map));
+        $this->assertSame([], $comment->getParameterList());
+        $my_param_doc = $parameter_map['args'];
+        $this->assertSame('int|string ...$args', (string)$my_param_doc);
+        $this->assertSame(true, $my_param_doc->isOptional());
+        $this->assertSame(false, $my_param_doc->isRequired());
+        $this->assertSame(true, $my_param_doc->isVariadic());
+        $this->assertSame('args', $my_param_doc->getName());
+    }
+
+    public function testGetReturnType()
+    {
+        $comment = Comment::fromStringInContext(
+            '/** @return int|string */',
+            $this->code_base,
+            new Context(),
+            1,
+            Comment::ON_METHOD
+        );
+        $this->assertTrue($comment->hasReturnUnionType());
+        $return_type = $comment->getReturnType();
+        $this->assertSame('int|string', (string)$return_type);
+    }
+
+    public function testGetReturnTypeThis()
+    {
+        $comment = Comment::fromStringInContext(
+            '/** @return $this */',
+            $this->code_base,
+            new Context(),
+            1,
+            Comment::ON_METHOD
+        );
+        $this->assertTrue($comment->hasReturnUnionType());
+        $return_type = $comment->getReturnType();
+        $this->assertSame('static', (string)$return_type);
+        $this->assertTrue($return_type->hasType(StaticType::instance(false)));
+    }
+
+    public function testGetMagicProperty()
+    {
+        $comment = Comment::fromStringInContext(
+            '/** @property int|string   $myProp */',
+            $this->code_base,
+            new Context(),
+            1,
+            Comment::ON_CLASS
+        );
+        $this->assertTrue($comment->hasMagicPropertyWithName('myProp'));
+        $property = $comment->getMagicPropertyMap()['myProp'];
+        $this->assertSame('int|string $myProp', (string)$property);
+    }
+
+    public function testGetMagicMethod()
+    {
+        $commentText = <<<'EOT'
+/**
+ * @method static int|string my_method(int $x, stdClass ...$rest) description
+ * @method myInstanceMethod2(int, $other = 'myString') description
+ */
+EOT;
+        $comment = Comment::fromStringInContext(
+            $commentText,
+            $this->code_base,
+            new Context(),
+            1,
+            Comment::ON_CLASS
+        );
+        $methodMap = $comment->getMagicMethodMap();
+        $this->assertSame(['my_method', 'myInstanceMethod2'], \array_keys($methodMap));
+        $methodDefinition = $methodMap['my_method'];
+        $this->assertSame('static function my_method(int $x, \stdClass ...$rest) : int|string', (string)$methodDefinition);
+        $this->assertSame('my_method', $methodDefinition->getName());
+        $instanceMethodDefinition = $methodMap['myInstanceMethod2'];
+        $this->assertSame('function myInstanceMethod2(int $p1, $other = default) : void', (string)$instanceMethodDefinition);
+        $this->assertSame('myInstanceMethod2', $instanceMethodDefinition->getName());
+    }
+
+    public function testGetTemplateType()
+    {
+        $commentText = <<<'EOT'
+/**
+ * @template T1
+ * @template u
+ */
+EOT;
+        $comment = Comment::fromStringInContext(
+            $commentText,
+            $this->code_base,
+            new Context(),
+            1,
+            Comment::ON_CLASS
+        );
+        $templateTypes = $comment->getTemplateTypeList();
+        $this->assertCount(2, $templateTypes);
+        $t1Info = $templateTypes[0];
+        $this->assertSame('T1', $t1Info->getName());
+        $uInfo = $templateTypes[1];
+        $this->assertSame('u', $uInfo->getName());
+    }
+
+    public function testGetParameterArrayNew()
+    {
+        // Currently, we ignore the array key. This may change in a future release.
+        $commentText = <<<'EOT'
+/**
+ * @param array<mixed, string> $myParam
+ * @param array<string , stdClass> ...$rest
+ */
+EOT;
+        $comment = Comment::fromStringInContext(
+            $commentText,
+            $this->code_base,
+            new Context(),
+            1,
+            Comment::ON_METHOD
+        );
+        $parameter_map = $comment->getParameterMap();
+        $this->assertSame(['myParam', 'rest'], \array_keys($parameter_map));
+        $this->assertSame([], $comment->getParameterList());
+        $my_param_doc = $parameter_map['myParam'];
+        $this->assertSame('string[] $myParam', (string)$my_param_doc);
+        $this->assertSame(false, $my_param_doc->isOptional());
+        $this->assertSame(true, $my_param_doc->isRequired());
+        $this->assertSame(false, $my_param_doc->isVariadic());
+        $this->assertSame('myParam', $my_param_doc->getName());
+
+        // Argument #2, #3, etc. passed by callers are arrays of stdClasses
+        $restDoc = $parameter_map['rest'];
+        $this->assertSame('\stdClass[] ...$rest', (string)$restDoc);
+        $this->assertSame(true, $restDoc->isOptional());
+        $this->assertSame(false, $restDoc->isRequired());
+        $this->assertSame(true, $restDoc->isVariadic());
+        $this->assertSame('rest', $restDoc->getName());
+    }
+
+    public function testGetVarArrayNew()
+    {
+        // Currently, we ignore the array key. This may change in a future release.
+        $commentText = <<<'EOT'
+/**
+ * @var int $my_int
+ * @var array<string , stdClass> $array
+ * @var float (Unparseable)
+ */
+EOT;
+        $comment = Comment::fromStringInContext(
+            $commentText,
+            $this->code_base,
+            new Context(),
+            1,
+            Comment::ON_METHOD
+        );
+        $this->assertSame([], $comment->getParameterMap());
+        $this->assertSame([], $comment->getParameterList());
+        $var_map = $comment->getVariableList();
+        $this->assertSame([0, 1], \array_keys($var_map));
+        $my_int_doc = $var_map[0];
+        $this->assertSame('int $my_int', (string)$my_int_doc);
+        $this->assertSame('my_int', $my_int_doc->getName());
+
+        $array_doc = $var_map[1];
+        $this->assertSame('\stdClass[] $array', (string)$array_doc);
+        $this->assertSame('array', $array_doc->getName());
+    }
+
+    public function testGetClosureScope()
+    {
+        $comment = Comment::fromStringInContext(
+            '/** @phan-closure-scope MyNS\MyClass */',
+            $this->code_base,
+            new Context(),
+            1,
+            Comment::ON_FUNCTION  // ON_CLOSURE doesn't exist yet.
+        );
+        $scope_option = $comment->getClosureScopeOption();
+        $this->assertTrue($scope_option->isDefined());
+        $scope_type = $scope_option->get();
+        $expected_type = Type::fromFullyQualifiedString('MyNS\MyClass');
+        $this->assertEquals($expected_type, $scope_type);
+        $this->assertSame($expected_type, $scope_type);
+    }
+}

--- a/tests/files/expected/0258_variadic_comment_parsing.php.expected
+++ b/tests/files/expected/0258_variadic_comment_parsing.php.expected
@@ -1,7 +1,7 @@
-%s:8 PhanMismatchVariadicComment int ...x is variadic in comment, but not variadic in param ($x)
-%s:8 PhanMismatchVariadicParam array y is not variadic in comment, but variadic in param (...$y)
-%s:16 PhanMismatchVariadicParam int y is not variadic in comment, but variadic in param (...$y)
-%s:25 PhanMismatchVariadicComment int ...x is variadic in comment, but not variadic in param ($x)
-%s:25 PhanMismatchVariadicParam array y is not variadic in comment, but variadic in param (...$y)
-%s:32 PhanMismatchVariadicParam int z is not variadic in comment, but variadic in param (...$z)
+%s:8 PhanMismatchVariadicComment int ...$x is variadic in comment, but not variadic in param ($x)
+%s:8 PhanMismatchVariadicParam array $y is not variadic in comment, but variadic in param (...$y)
+%s:16 PhanMismatchVariadicParam int $y is not variadic in comment, but variadic in param (...$y)
+%s:25 PhanMismatchVariadicComment int ...$x is variadic in comment, but not variadic in param ($x)
+%s:25 PhanMismatchVariadicParam array $y is not variadic in comment, but variadic in param (...$y)
+%s:32 PhanMismatchVariadicParam int $z is not variadic in comment, but variadic in param (...$z)
 %s:36 PhanTypeMismatchArgument Argument 3 (y) is array but \badvariadic258b() takes int defined at %s:16

--- a/tests/files/expected/0301_comment_checks.php.expected
+++ b/tests/files/expected/0301_comment_checks.php.expected
@@ -1,5 +1,6 @@
 %s:17 PhanInvalidCommentForDeclarationType The phpdoc comment for @param cannot occur on a class
 %s:17 PhanInvalidCommentForDeclarationType The phpdoc comment for @return cannot occur on a class
+%s:17 PhanInvalidCommentForDeclarationType The phpdoc comment for @var cannot occur on a class
 %s:17 PhanMisspelledAnnotation Saw misspelled annotation @phan-forbid-this-is-a-typo, should be one of @phan-forbid-undeclared-magic-methods @phan-forbid-undeclared-magic-properties @phan-closure-scope @phan-override
 %s:17 PhanUnextractableAnnotationPart Saw unextractable annotation for a fragment of comment * @method foo(string$invalidType $param1): string$invalidType $param1
 %s:17 PhanUnextractableAnnotation Saw unextractable annotation for comment * @method unmatched(


### PR DESCRIPTION
Parse alternate array<T>/array<Key,T> syntax in phpdoc, support recursive templates

This is similar to
https://docs.hhvm.com/hack/collections/compared-to-arrays

Also, support brackets in union types (Currently just single brackets).

- Brackets can disambiguate `?(int)[]` and `(?int)[]`. The way `?int[]` is&was parsed is `?(int[])`

Additionally, this uses recursive regular expressions to support
template types which contain other template types.
(Needed to support `array<array<T2>>`)

TODO: Add integration tests of template types which use template types.
TODO: Add unit tests of remaining phpdoc comment locations
(`@var`, `@phan-closure-scope`, etc) (**DONE**)
TODO: In a future PR, allow space (after unmatched `(` or `<`) and '(T1|T2)[]' in phpdoc (**DONE**)
TODO: Make sure that `UnionType::fromFullyQualifiedString('array<int|string>')` works. It currently doesn't, due to `explode('|', $union_type_string)`