### PR TITLE
Fixes #1225: Bugs in PrintfCheckerPlugin

### DIFF
--- a/.phan/plugins/PregRegexCheckerPlugin.php
+++ b/.phan/plugins/PregRegexCheckerPlugin.php
@@ -9,7 +9,11 @@ use Phan\PluginV2\AnalyzeFunctionCallCapability;
 use ast\Node;
 
 /**
- * This plugin checks for invalid regexes in preg_match.
+ * This plugin checks for invalid regexes in calls to preg_match. (And all of the other internal PCRE functions).
+ *
+ * This plugin performs this check by attempting to match the empty string,
+ * then checking if PHP emitted a warning (Instead of failing to match)
+ * (PHP doesn't have preg_validate())
  *
  * - getAnalyzeFunctionCallClosures
  *   This method returns a map from function/method FQSEN to closures that are called on invocations of those closures.

--- a/.phan/plugins/PrintfCheckerPlugin.php
+++ b/.phan/plugins/PrintfCheckerPlugin.php
@@ -5,6 +5,7 @@ namespace Phan\Plugin\PrintfCheckerPlugin;  // Don't pollute the global namespac
 use Phan\AST\ContextNode;
 use Phan\AST\UnionTypeVisitor;
 use Phan\CodeBase;
+use Phan\Exception\CodeBaseException;
 use Phan\Issue;
 use Phan\Language\Context;
 use Phan\Language\Element\Func;
@@ -24,8 +25,6 @@ use function var_export;
  * This plugin checks for invalid format strings and invalid uses of format strings in printf and sprintf, etc.
  * e.g. for printf("literal format %s", $arg)
  *
- * TODO: Take advantage of Phan's ability to resolve union types, warn about printf("%d", $strVar)
- *
  * This uses ConversionSpec as a best effort at determining the the positions used by PHP format strings.
  * Some edge cases may have been overlooked.
  *
@@ -36,9 +35,8 @@ use function var_export;
  *
  * This analyzes printf, sprintf, and fprintf.
  *
- * TODO: Analyze vprintf, vsprintf, and vfprintf (and any other built in class methods?)
- *
  * TODO: Add optional verbose warnings about unanalyzable strings
+ * TODO: Check if arg can cast to string.
  */
 class PrintfCheckerPlugin extends PluginV2 implements AnalyzeFunctionCallCapability {
 
@@ -470,6 +468,24 @@ class PrintfCheckerPlugin extends PluginV2 implements AnalyzeFunctionCallCapabil
                 if ($actual_union_type->canCastToUnionType($expected_union_type)) {
                     continue;
                 }
+                if (isset($expected_set['string'])) {
+                    $can_cast_to_string = false;
+                    // Allow passing objects with __toString() to printf whether or not strict types are used in the caller.
+                    // TODO: Move into a common helper method?
+                    try {
+                        foreach ($actual_union_type->asExpandedTypes($code_base)->asClassList($code_base, $context) as $clazz) {
+                            if ($clazz->hasMethodWithName($code_base, '__toString')) {
+                                $can_cast_to_string = true;
+                                break;
+                            }
+                        }
+                    } catch (CodeBaseException $e) {
+                        // Swallow "Cannot find class", go on to emit issue.
+                    }
+                    if ($can_cast_to_string) {
+                        continue;
+                    }
+                }
 
                 $expected_union_type_string = (string)$expected_union_type;
                 if ($this->canWeakCast($actual_union_type, $expected_set)) {
@@ -636,11 +652,30 @@ class ConversionSpec {
      */
     protected function __construct(array $match)
     {
-        list($this->directive, $position_str, $this->padding_char, $this->width, $this->alignment, $precision, $this->arg_type) = $match;
+        list($this->directive, $position_str, $this->padding_char, $this->alignment, $this->width, $precision, $this->arg_type) = $match;
         if ($position_str !== "") {
             $this->position = \intval(\substr($position_str, 0, -1));
         }
     }
+
+    // A padding string regex may be a space or 0.
+    // Alternate padding specifiers may be specified by prefixing it with a single quote.
+    const padding_string_regex_part ='[0 ]?|\'.';
+
+    /**
+     * Based on https://secure.php.net/manual/en/function.sprintf.php
+     */
+    const format_string_inner_regex_part =
+        '%'  // Every format string begins with a percent
+        . '(\d+\$)?'  // Optional n$ position specifier must go immediately after percent
+        . '(' . self::padding_string_regex_part . ')'  // optional padding specifier
+        . '([+-]?)' // optional alignment specifier
+        . '(\d*)'  // optional width specifier
+        . '(\.\d*)?'   // Optional precision specifier in the form of a period followed by an optional decimal digit string
+        . '([bcdeEfFgGosuxX])';  // A type specifier
+
+
+    const format_string_regex = '/%%|' . self::format_string_inner_regex_part . '/';
 
     /**
      * Extract a list of directives from a format string.
@@ -651,7 +686,7 @@ class ConversionSpec {
     {
         // echo "format is $fmt_str\n";
         $directives = [];
-        $n = \preg_match_all('/%%|%(\d+\$)?([0 ]?)(\d*)([+-]?)(\.\d*)?([bcdeEfFgGosuxX])/', (string) $fmt_str, $matches, PREG_SET_ORDER);
+        $n = \preg_match_all(self::format_string_regex, (string) $fmt_str, $matches, PREG_SET_ORDER);
         // var_export($matches); return;
         $unnamed_count = 0;
         foreach ($matches as $match) {

--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,15 @@ Phan NEWS
 
 ?? ??? 2017, Phan 0.10.2 (dev)
 
+New Features(Analysis)
++ Support less ambiguous `?(T[])` and `(?T)[]` in phpdoc (#1213)
+  Note that `(S|T)[]` is **not** supported yet.
++ Support alternate syntax `array<T>` and `array<Key, T>` in phpdoc (PR #1213)
+  Note that Phan ignores the provided value of `Key` completely right now (i.e. same as `T[]`); Key types may be supported later.
+
+Bug Fixes
++ Fixes bugs in PrintfCheckerPlugin: Alignment goes before width, and objects with __toString() can cast to %s. (#1225)
+
 20 Oct 2017, Phan 0.10.1
 ------------------------
 

--- a/tests/plugin_test/expected/all_output.expected
+++ b/tests/plugin_test/expected/all_output.expected
@@ -134,3 +134,6 @@ src/010_printf_types.php:12 PhanPluginPrintfIncompatibleArgumentTypeWeak Format 
 src/010_printf_types.php:12 PhanPluginPrintfIncompatibleArgumentType Format string "Hello, %f %s" refers to argument #1 as %f, so type float is expected, but printf was passed incompatible type string
 src/010_printf_types.php:13 PhanPluginPrintfIncompatibleArgumentType Format string "Hello, %1$d %1$f" refers to argument #1 as %1$d,%1$f, so type float|int is expected, but printf was passed incompatible type string
 src/010_printf_types.php:13 PhanPluginPrintfIncompatibleSpecifier Format string "Hello, %1$d %1$f" refers to argument #1 in different ways: %1$d,%1$f
+src/010_printf_types.php:15 PhanPluginPrintfUnusedArgument Format string "Hello, %-10d,%+3d" does not use provided argument #3
+src/010_printf_types.php:26 PhanPluginPrintfIncompatibleArgumentType Format string "Hello, %s\n" refers to argument #1 as %s, so type string is expected, but printf was passed incompatible type \Bar
+src/010_printf_types.php:26 PhanTypeMismatchArgumentInternal Argument 2 (args) is \Bar but \printf() takes float|int|string

--- a/tests/plugin_test/src/010_printf_types.php
+++ b/tests/plugin_test/src/010_printf_types.php
@@ -11,3 +11,16 @@ printf("Hello, %s", false);
 printf("Hello, %s", []);
 printf("Hello, %f %s", "World", 2);
 printf('Hello, %1$d %1$f', 'x');
+printf('Hello, %-10d,%+3d', 2, 4);  // left aligned and right aligned
+printf('Hello, %-10d,%+3d', 2, 4, 5);  // Extra
+class Foo {
+    public function __toString() {
+        return 'world';
+    }
+}
+class Bar {
+}
+$foo = new Foo();
+printf("Hello, %s\n", $foo);
+$bar = new Bar();
+printf("Hello, %s\n", $bar);


### PR DESCRIPTION
- PrintfCheckerPlugin should parse alignment before width
  (in the format string) (E.g. `%-10d`)
- PrintfCheckerPlugin should not warn about objects defining __toString()

Also, document the parts of the regex used to parse the format string.
