### PR TITLE
Speed up phan analysis on small projects, reduce memory usage

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,11 @@ New Features(Analysis)
   Note that `(S|T)[]` is **not** supported yet.
 + Support alternate syntax `array<T>` and `array<Key, T>` in phpdoc (PR #1213)
   Note that Phan ignores the provided value of `Key` completely right now (i.e. same as `T[]`); Key types may be supported later.
++ Speed up phan analysis on small projects, reduce memory usage (Around 0.15 seconds and 15MB)
+  This was done by deferring loading the information about internal classes and functions until that information was needed for analysis.
+
+New Features (CLI, Configs)
++ Improve default update rate of `--progress-bar` (Update it every 0.10 seconds)
 
 Bug Fixes
 + Fixes bugs in PrintfCheckerPlugin: Alignment goes before width, and objects with __toString() can cast to %s. (#1225)

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -2080,10 +2080,7 @@ class UnionTypeVisitor extends AnalysisVisitor
             return $class->getParentClassFQSEN();  // may or may not exist.
         default:
             // TODO: Reject invalid/empty class names earlier
-            if (\substr($class_name, 0, 1) === '\\') {
-                $class_name = \substr($class_name, 1);
-            }
-            return FullyQualifiedClassName::make('', $class_name);
+            return FullyQualifiedClassName::makeFromExtractedNamespaceAndName($class_name);
         }
     }
 

--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -11,6 +11,7 @@ use Phan\Analysis\ReferenceCountsAnalyzer;
 use Phan\Language\Context;
 use Phan\Language\Element\Clazz;
 use Phan\Language\Element\Func;
+use Phan\Language\Element\FunctionInterface;
 use Phan\Language\Element\Method;
 use Phan\Language\FQSEN\FullyQualifiedFunctionName;
 use Phan\Language\FQSEN\FullyQualifiedMethodName;
@@ -231,28 +232,20 @@ class Analysis
     {
         $plugin_set = ConfigPluginSet::instance();
         $has_function_or_method_plugins = $plugin_set->hasAnalyzeFunctionPlugins() || $plugin_set->hasAnalyzeMethodPlugins();
-        $function_and_method_set = $code_base->getFunctionAndMethodSet();
         $show_progress = CLI::shouldShowProgress();
-        $i = 0;
-
-        if ($show_progress) { CLI::progress('method', 0.0); }
-
-        foreach ($function_and_method_set as $function_or_method)
-        {
-            if ($show_progress) {
-                // I suspect that method analysis is hydrating some of the classes,
-                // adding even more inherited methods to the end of the set.
-                // This recalculation is needed so that the progress bar is accurate.
-                CLI::progress('method', (++$i)/(\count($function_and_method_set)));
-            }
-
+        $analyze_function_or_method = function(FunctionInterface $function_or_method) use (
+            $code_base,
+            $plugin_set,
+            $has_function_or_method_plugins,
+            $file_filter
+        ) {
             if ($function_or_method->isPHPInternal()) {
-                continue;
+                return;
             }
 
             // If there is an array limiting the set of files, skip this file if it's not in the list,
             if (\is_array($file_filter) && !isset($file_filter[$function_or_method->getContext()->getFile()])) {
-                continue;
+                return;
             }
 
             DuplicateFunctionAnalyzer::analyzeDuplicateFunction(
@@ -284,6 +277,36 @@ class Analysis
                     );
                 }
             }
+        };
+
+        // Analyze user-defined method declarations.
+        // Plugins may also analyze user-defined methods here.
+        $i = 0;
+        if ($show_progress) { CLI::progress('function', 0.0); }
+        $function_map = $code_base->getFunctionMap();
+        $internal_count = 0;
+        foreach ($function_map as $function)  // iterate, ignoring $fqsen
+        {
+            if ($show_progress) {
+                CLI::progress('function', (++$i)/(\count($function_map)));
+            }
+            $analyze_function_or_method($function);
+        }
+
+        // Analyze user-defined method declarations.
+        // Plugins may also analyze user-defined methods here.
+        $i = 0;
+        $method_set = $code_base->getMethodSet();
+        if ($show_progress) { CLI::progress('method', 0.0); }
+        foreach ($method_set as $method)
+        {
+            if ($show_progress) {
+                // I suspect that method analysis is hydrating some of the classes,
+                // adding even more inherited methods to the end of the set.
+                // This recalculation is needed so that the progress bar is accurate.
+                CLI::progress('method', (++$i)/(\count($method_set)));
+            }
+            $analyze_function_or_method($method);
         }
     }
 
@@ -340,7 +363,7 @@ class Analysis
      */
     public static function analyzeClasses(CodeBase $code_base, array $path_filter = null)
     {
-        $classes = self::getUserDefinedClasses($code_base);
+        $classes = $code_base->getUserDefinedClassMap();
         if (\is_array($path_filter)) {
             // If a list of files is provided, then limit analysis to classes defined in those files.
             $old_classes = $classes;
@@ -354,21 +377,6 @@ class Analysis
         foreach ($classes as $class) {
             $class->analyze($code_base);
         }
-    }
-
-    /**
-     * Fetches all of the user defined classes in $code_base
-     * @return Clazz[]
-     */
-    private static function getUserDefinedClasses(CodeBase $code_base)
-    {
-        $classes = [];
-        foreach ($code_base->getClassMap() as $class) {
-            if (!$class->isPHPInternal()) {
-                $classes[] = $class;
-            }
-        }
-        return $classes;
     }
 
     /**

--- a/src/Phan/Analysis/ReferenceCountsAnalyzer.php
+++ b/src/Phan/Analysis/ReferenceCountsAnalyzer.php
@@ -66,7 +66,7 @@ class ReferenceCountsAnalyzer
         // Classes
         self::analyzeElementListReferenceCounts(
             $code_base,
-            $code_base->getClassMap(),
+            $code_base->getUserDefinedClassMap(),
             Issue::UnreferencedClass,
             $total_count,
             $i

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -757,14 +757,22 @@ EOB;
         // Bound the percentage to [0, 1]
         $p = min(max($p, 0.0), 1.0);
 
+        static $previous_update_time = 0.0;
+        $time = microtime(true);
+
+
         // Don't update every time when we're moving
         // super fast
         if ($p > 0.0
             && $p < 1.0
-            && rand(0, 1000) > (1000 * Config::getValue('progress_bar_sample_rate')
+            && (
+                // If it hasn't been enough time and we're unlucky, then stop early
+                ($time - $previous_update_time < Config::getValue('progress_bar_sample_interval'))
+              && (rand(0, 1000) > (1000 * Config::getValue('progress_bar_sample_rate')))
             )) {
             return;
         }
+        $previous_update_time = $time;
 
         // If we're on windows, just print a dot to show we're
         // working

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -332,7 +332,13 @@ class Config
         // is good for reducing network IO and filling up
         // your terminal's buffer when running phan on a
         // remote host.
-        'progress_bar_sample_rate' => 0.005,
+        // Set this to 0 to use *only* progress_bar_sample_interval.
+        'progress_bar_sample_rate' => 0.000,
+
+        // If this much time (in seconds) has passed since the last update,
+        // then update the progress bar (Ignores progress_bar_sample_rate).
+        // Set this to INF to only use progress_bar_sample_rate.
+        'progress_bar_sample_interval' => 0.1,
 
         // The number of processes to fork off during the analysis
         // phase.

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -170,16 +170,13 @@ class Clazz extends AddressableElement
         $context = new Context;
 
         $class_name = $class->getName();
-        $class_fqsen = FullyQualifiedClassName::fromStringInContext(
-            $class_name,
-            $context
-        );
+        $class_fqsen = FullyQualifiedClassName::fromFullyQualifiedString($class_name);
 
         // Build a base class element
         $clazz = new Clazz(
             $context,
             $class_name,
-            UnionType::fromStringInContext($class_name, $context, Type::FROM_TYPE),
+            UnionType::fromFullyQualifiedString('\\' . $class_name),
             $flags,
             $class_fqsen
         );

--- a/src/Phan/Language/Element/FunctionFactory.php
+++ b/src/Phan/Language/Element/FunctionFactory.php
@@ -20,8 +20,10 @@ class FunctionFactory {
         CodeBase $code_base,
         string $function_name
     ) : array {
+        $fqsen = FullyQualifiedFunctionName::makeFromExtractedNamespaceAndName($function_name);
         return self::functionListFromReflectionFunction(
             $code_base,
+            $fqsen,
             new \ReflectionFunction($function_name)
         );
     }
@@ -33,18 +35,11 @@ class FunctionFactory {
      */
     public static function functionListFromReflectionFunction(
         CodeBase $code_base,
+        FullyQualifiedFunctionName $fqsen,
         \ReflectionFunction $reflection_function
     ) : array {
 
         $context = new Context();
-
-        $parts = explode('\\', $reflection_function->getName());
-        $function_name = array_pop($parts);
-        $namespace = '\\' . implode('\\', $parts);
-
-        $fqsen = FullyQualifiedFunctionName::make(
-            $namespace, $function_name
-        );
 
         $function = new Func(
             $context,

--- a/src/Phan/Language/FQSEN/Alternatives.php
+++ b/src/Phan/Language/FQSEN/Alternatives.php
@@ -26,7 +26,7 @@ trait Alternatives
 
     /**
      * @var int
-     * An alternate ID for the elemnet for use when
+     * An alternate ID for the element for use when
      * there are multiple definitions of the element
      */
     protected $alternate_id = 0;

--- a/src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php
@@ -50,6 +50,23 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN
     }
 
     /**
+     * @param string $name
+     * The name of this structural element, may contain a namespace.
+     *
+     * @return static
+     */
+    public static function makeFromExtractedNamespaceAndName(string $name)
+    {
+        $name = \ltrim($name, '\\');
+        $i = \stripos($name, '\\');
+        if ($i === false) {
+            // Common case: no namespace
+            return self::make('\\', $name);
+        }
+        return self::make('\\' . \substr($name, 0, $i), \substr($name, $i+1));
+    }
+
+    /**
      * @param string $namespace
      * The namespace in this element's scope
      *
@@ -70,7 +87,7 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN
 
         // Transfer any relative namespace stuff from the
         // name to the namespace.
-        $name_parts= \explode('\\', $name);
+        $name_parts = \explode('\\', $name);
         $name = \array_pop($name_parts);
         $namespace = \implode('\\', \array_merge([$namespace], $name_parts));
         $namespace = self::cleanNamespace($namespace);
@@ -78,7 +95,7 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN
         // use the canonicalName for $name instead of strtolower - Some subclasses(constants) are case sensitive.
         $key = implode('|', [
             static::class,
-            static::toString(strtolower($namespace), static::canonicalLookupKey($name), $alternate_id)
+            static::toString(\strtolower($namespace), static::canonicalLookupKey($name), $alternate_id)
         ]);
 
         $fqsen = self::memoizeStatic($key, function () use ($namespace, $name, $alternate_id) {

--- a/src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php
@@ -27,7 +27,7 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN
      * The name of this structural element
      *
      * @param int $alternate_id
-     * An alternate ID for the elemnet for use when
+     * An alternate ID for the element for use when
      * there are multiple definitions of the element
      */
     protected function __construct(
@@ -74,7 +74,7 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN
      * The name of this structural element
      *
      * @param int $alternate_id
-     * An alternate ID for the elemnet for use when
+     * An alternate ID for the element for use when
      * there are multiple definitions of the element
      *
      * @return static

--- a/src/Phan/Language/Type/ArrayType.php
+++ b/src/Phan/Language/Type/ArrayType.php
@@ -19,3 +19,7 @@ class ArrayType extends IterableType
         return $this;
     }
 }
+// Trigger the autoloader for GenericArrayType so that it won't be called
+// before ArrayType.
+// This won't pass if GenericArrayType is in the process of being instantiated.
+\class_exists(GenericArrayType::class);

--- a/src/Phan/Language/Type/BoolType.php
+++ b/src/Phan/Language/Type/BoolType.php
@@ -4,11 +4,6 @@ namespace Phan\Language\Type;
 use Phan\Language\UnionType;
 use Phan\Language\Type;
 
-// Temporary hack to load FalseType and TrueType before BoolType::instance() is called
-// (Due to bugs in php static variables)
-assert(class_exists(FalseType::class));
-assert(class_exists(TrueType::class));
-
 final class BoolType extends ScalarType
 {
     /** @phan-override */
@@ -82,3 +77,8 @@ final class BoolType extends ScalarType
         return $this->is_nullable ? (self::_bit_nullable | self::_bit_true | self::_bit_false) : (self::_bit_true | self::_bit_false);
     }
 }
+
+// Temporary hack to load FalseType and TrueType before BoolType::instance() is called
+// (Due to bugs in php static variables)
+\class_exists(FalseType::class);
+\class_exists(TrueType::class);

--- a/src/Phan/Language/Type/IterableType.php
+++ b/src/Phan/Language/Type/IterableType.php
@@ -40,3 +40,5 @@ class IterableType extends NativeType
         return parent::canCastToNonNullableType($type);
     }
 }
+// Trigger autoloader for subclass before make() can get called.
+\class_exists(ArrayType::class);

--- a/src/Phan/Language/Type/NativeType.php
+++ b/src/Phan/Language/Type/NativeType.php
@@ -2,6 +2,7 @@
 namespace Phan\Language\Type;
 
 use Phan\Language\Type;
+use Phan\Language\Type\ArrayType;
 
 abstract class NativeType extends Type
 {
@@ -161,3 +162,4 @@ abstract class NativeType extends Type
         return $this->name;
     }
 }
+\class_exists(ArrayType::class);

--- a/src/Phan/Library/Map.php
+++ b/src/Phan/Library/Map.php
@@ -63,4 +63,31 @@ class Map extends \SplObjectStorage
         return $this->keyValueMap($clone, $clone);
     }
 
+    /**
+     * @return Set
+     * A new set with the unique values from this map.
+     * Precondition: values of this map are objects.
+     */
+    public function valueSet() : Set
+    {
+        $set = new Set();
+        foreach ($this as $value) {
+            $set->attach($value);
+        }
+        return $set;
+    }
+
+    /**
+     * @return Set
+     * A new set with the unique keys from this map.
+     * Precondition: values of this set are objects.
+     */
+    public function keySet() : Set
+    {
+        $set = new Set();
+        foreach ($this as $key => $_) {
+            $set->attach($key);
+        }
+        return $set;
+    }
 }

--- a/src/Phan/Ordering.php
+++ b/src/Phan/Ordering.php
@@ -73,12 +73,7 @@ class Ordering
         $file_names_for_classes = [];
 
         // Iterate over each class extracting files
-        foreach ($this->code_base->getClassMap() as $fqsen => $class) {
-
-            // We won't be analyzing internal stuff
-            if ($class->isPHPInternal()) {
-                continue;
-            }
+        foreach ($this->code_base->getUserDefinedClassMap() as $class) {
 
             // Get the name of the file associated with the class
             $file_name = $class->getContext()->getFile();

--- a/src/Phan/Phan.php
+++ b/src/Phan/Phan.php
@@ -86,6 +86,9 @@ class Phan implements IgnoredFilesFilterInterface {
         $is_daemon_request = Config::getValue('daemonize_socket') || Config::getValue('daemonize_tcp_port');
         $language_server_config = Config::getValue('language_server_config');
         $is_undoable_request = is_array($language_server_config) || $is_daemon_request;
+        if ($is_daemon_request) {
+            $code_base->eagerlyLoadAllSignatures();
+        }
         if ($is_undoable_request) {
             $code_base->enableUndoTracking();
         }

--- a/src/codebase.php
+++ b/src/codebase.php
@@ -10,7 +10,6 @@ $internal_const_name_list = array_keys(array_merge(...array_values(
 )));
 $internal_function_name_list = get_defined_functions()['internal'];
 
-
 if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
   // This is the normal path when Phan is installed only in the scope of a project.
   require_once __DIR__ . '/../vendor/autoload.php';

--- a/tool/make_stubs
+++ b/tool/make_stubs
@@ -78,10 +78,6 @@ EOT;
         echo "// @phan-stub-for-extension $extension_name@$extension_version\n";
         echo "\n";
 
-        $class_map = $code_base->getClassMap();
-        $function_map = $code_base->getFunctionMap();
-        $const_map = $code_base->getGlobalConstantMap();
-
         foreach ($reflection_extension->getClassNames() as $class_name) {
             [$namespace, $name] = self::extractNamespaceAndName($class_name);
             $class_fqsen = FullyQualifiedClassName::make($namespace, $name);


### PR DESCRIPTION
hasClassWithFQSEN will be called when inheriting parent classes, traits,
and interfaces, so this should work with little modification.

- Daemon mode should be slightly faster (not by much)
  with user defined classes precomputed
  (Won't have to skip over as many internal classes)

Similarly, hasFunctionWithFQSEN is called on a minority of the internal
functions.

Memory usage and runtime are down on small projects(with 2 files to analyze):

- Maximum memory usage decreased from 32MB(max) to 17MB(max)
- Analysis time dropped from 0.23s to 0.07s.
  **NOTE: This is an absolute decrease** (not a percentage),
  large projects' resource usage might decrease from
  10.15s to 10s and 815M to 800M
- Unit tests are greatly sped up, due to not having to generate
  information for all of the methods and parameters of the
  internal functions and classes.

Continue to eagerly load classes and functions in daemon mode
- If there are issues creating functions and methods, know immediately.
  If analyzing a file would trigger Phan parsing many functions, that
  would increase the latency.

(Lazily loading internal constants would have negligible impact on speed,
so that wasn't done)

Unrelated: Fixes #1231 (Print progress 0.1 seconds since previous time by default)

This speeds up `tool/make_stubs`.

- Fix bug this caused when `iterable` was accessed before `array`