### PR TITLE
Fix loading internal functions with namespaced names.

### DIFF
--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -352,7 +352,7 @@ class CodeBase
             if (!$this->hasFunctionWithFQSEN($function_fqsen)) {
                 // Force loading these even if automatic loading failed.
                 // (Shouldn't happen, the function list is fetched from reflection by callers.
-                foreach (FunctionFactory::functionListFromReflectionFunction($this, $function_fqsen, new \ReflectionFunction($function_fqsen->getName()))
+                foreach (FunctionFactory::functionListFromReflectionFunction($this, $function_fqsen, new \ReflectionFunction($function_fqsen->getNamespacedName()))
                     as $function
                 ) {
                     $this->addFunction($function);

--- a/src/Phan/Language/Element/FunctionFactory.php
+++ b/src/Phan/Language/Element/FunctionFactory.php
@@ -43,7 +43,7 @@ class FunctionFactory {
 
         $function = new Func(
             $context,
-            $fqsen->getName(),
+            $fqsen->getNamespacedName(),
             new UnionType(),
             0,
             $fqsen
@@ -85,7 +85,7 @@ class FunctionFactory {
 
         $func = new Func(
             $context,
-            $fqsen->getName(),
+            $fqsen->getNamespacedName(),
             $return_type,
             0,
             $fqsen

--- a/src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php
@@ -225,7 +225,7 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN
     /**
      * @return string
      * The namespace+name associated with this FQSEN.
-     * (e.g. '\ast\parse_code')
+     * (e.g. 'ast\parse_code')
      */
     public function getNamespacedName() : string {
         if ($this->namespace === '\\') {


### PR DESCRIPTION
E.g. `ast\parse_code`