### PR TITLE
Fix a crash when magic method and real method share a name

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -16,6 +16,7 @@ New Features (CLI, Configs)
 Bug Fixes
 + Fixes bugs in PrintfCheckerPlugin: Alignment goes before width, and objects with __toString() can cast to %s. (#1225)
 + Reduce false positives in analysis of gotos, blocks containing gotos anywhere may do something other than return or throw. (#1222)
++ Fix a crash when a magic method with a return type has the same name as a real method.
 
 20 Oct 2017, Phan 0.10.1
 ------------------------

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -1314,6 +1314,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             }
 
             if (!$method->isAbstract()
+                && !$method->isFromPHPDoc()
                 && !$has_interface_class
                 && !$return_type->isEmpty()
                 && !$method->getHasReturn()

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -223,7 +223,7 @@ class ParseVisitor extends ScopeVisitor
             $class->setParentType($inherited_type_option->get());
         }
 
-        // Add any implemeneted interfaces
+        // Add any implemented interfaces
         if (!empty($node->children['implements'])) {
             $interface_list = (new ContextNode(
                 $this->code_base,

--- a/tests/files/expected/0373_crash.php.expected
+++ b/tests/files/expected/0373_crash.php.expected
@@ -1,0 +1,1 @@
+%s:9 PhanRedefineFunction Function foo defined at %s:9 was previously defined at %s:7

--- a/tests/files/src/0373_crash.php
+++ b/tests/files/src/0373_crash.php
@@ -1,0 +1,10 @@
+<?php
+// Regression test for an uncaught error in Phan. The expected output may be empty in the future.
+
+abstract class A373 { }
+
+/** @method B373 foo() */
+abstract class B373 extends A373 {
+    /** @return B373 */
+    abstract protected function foo() : A373;
+}


### PR DESCRIPTION
This happened when checking if the method body had a return type
Phan's method instances generated from `@method` have no method body.