### PR TITLE
Fix LSP check logic for phpdoc param types of methods

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -17,6 +17,8 @@ Bug Fixes
 + Fixes bugs in PrintfCheckerPlugin: Alignment goes before width, and objects with __toString() can cast to %s. (#1225)
 + Reduce false positives in analysis of gotos, blocks containing gotos anywhere may do something other than return or throw. (#1222)
 + Fix a crash when a magic method with a return type has the same name as a real method.
++ Allow methods to have weaker PHPdoc types than the overridden method in `PhanParamSignatureMismatch`. (#1253)
+  `PhanParamSignatureRealMismatch*` is unaffected, and will continue working the same way in Phan releases analyzing PHP < 7.2.
 
 20 Oct 2017, Phan 0.10.1
 ------------------------

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -266,6 +266,9 @@ class ParameterTypesAnalyzer
 
         // If parameter counts match, check their types
         } else {
+            $real_parameter_list = $method->getRealParameterList();
+            $o_real_parameter_list = $o_method->getRealParameterList();
+
             foreach ($method->getParameterList() as $i => $parameter) {
 
                 if (!isset($o_parameter_list[$i])) {
@@ -281,25 +284,36 @@ class ParameterTypesAnalyzer
                     break;
                 }
 
+                // Variadic parameters must match up.
+                if ($o_parameter->isVariadic() !== $parameter->isVariadic()) {
+                    $signatures_match = false;
+                    break;
+                }
+
+                // Check for the presence of real types first, warn if the override has a type but the original doesn't.
+                $o_real_parameter = $o_real_parameter_list[$i] ?? null;
+                $real_parameter = $real_parameter_list[$i] ?? null;
+                if ($o_real_parameter !== null && $real_parameter !== null && !$real_parameter->getUnionType()->isEmpty() && $o_real_parameter->getUnionType()->isEmpty()) {
+                    $signatures_match = false;
+                    break;
+                }
+
                 // A stricter type on an overriding method is cool
-                // TODO: This doesn't match the definition of LSP.
-                // - If you use a stricter param type, you can't call the subclass with args you could call the base class with.
-                if ($o_parameter->getUnionType()->isEmpty()
-                    || $o_parameter->getUnionType()->isType(MixedType::instance(false))
+                if ($parameter->getUnionType()->isEmpty()
+                    || $parameter->getUnionType()->isType(MixedType::instance(false))
                 ) {
                     continue;
                 }
 
-                // TODO: check variadic.
+                if ($o_parameter->getUnionType()->isEmpty() || $o_parameter->getUnionType()->isType(MixedType::instance(false))) {
+                    continue;
+                }
 
-                // Its not OK to have a more relaxed type on an
-                // overriding method
+                // In php 7.2, it's ok to have a more relaxed type on an overriding method.
+                // In earlier versions it isn't.
+                // Because this check is analyzing phpdoc types, so it's fine for php < 7.2 as well. Use `PhanParamSignatureRealMismatch*` for detecting **real** mismatches.
                 //
                 // https://3v4l.org/XTm3P
-                if ($parameter->getUnionType()->isEmpty()) {
-                    $signatures_match = false;
-                    break;
-                }
 
                 // If we have types, make sure they line up
                 //
@@ -318,6 +332,8 @@ class ParameterTypesAnalyzer
 
         // Return types should be mappable for LSP
         // Note: PHP requires return types to be identical
+        // The return type should be stricter than or identical to the overridden union type.
+        // E.g. there is no issue if the overridden return type is empty.
         if (!$o_return_union_type->isEmpty()) {
 
             if (!$method->getUnionType()->asExpandedTypes($code_base)->canCastToUnionType(

--- a/tests/files/expected/0124_override_signature.php.expected
+++ b/tests/files/expected/0124_override_signature.php.expected
@@ -4,11 +4,11 @@
 %s:12 PhanParamSignatureRealMismatchTooManyRequiredParameters Declaration of function f(int $a, int $b) should be compatible with function f(int $a) (the method override requires 2 parameter(s), but the overridden method requires only 1) defined in %s:3
 %s:15 PhanParamSignatureMismatch Declaration of function f(string $a) should be compatible with function f(int $a) defined in %s:3
 %s:15 PhanParamSignatureRealMismatchParamType Declaration of function f(string $a) should be compatible with function f(int $a) (parameter #1 of type 'string' cannot replace original parameter of type 'int') defined in %s:3
-%s:18 PhanParamSignatureMismatch Declaration of function f($a) should be compatible with function f(int $a) defined in %s:3
 %s:18 PhanParamSignatureRealMismatchHasNoParamType Declaration of function f($a) should be compatible with function f(int $a) (parameter #1 with no type cannot replace original parameter with type 'int') defined in %s:3
 %s:25 PhanParamSignatureMismatch Declaration of function g() : int should be compatible with function g() : string defined in %s:22
 %s:25 PhanParamSignatureRealMismatchReturnType Declaration of function g() : int should be compatible with function g() : string (method returning 'int' cannot override method returning 'string') defined in %s:22
 %s:28 PhanParamSignatureRealMismatchReturnType Declaration of function g() should be compatible with function g() : string (method returning '' cannot override method returning 'string') defined in %s:22
+%s:35 PhanParamSignatureMismatch Declaration of function h(int $a) should be compatible with function h($a) defined in %s:32
 %s:35 PhanParamSignatureRealMismatchHasParamType Declaration of function h(int $a) should be compatible with function h($a) (parameter #1 of has type 'int' cannot replace original parameter with no type) defined in %s:32
 %s:50 PhanParamSignatureMismatch Declaration of function i($a) should be compatible with function i($a, mixed|string $b = 'default') defined in %s:46
 %s:50 PhanParamSignatureRealMismatchTooFewParameters Declaration of function i($a) should be compatible with function i($a, $b = 'default') (the method override accepts 1 parameter(s), but the overridden method can accept 2) defined in %s:46

--- a/tests/files/expected/0126_override_signature.php.expected
+++ b/tests/files/expected/0126_override_signature.php.expected
@@ -1,4 +1,3 @@
-%s:12 PhanParamSignatureMismatch Declaration of function f($p) should be compatible with function f(\CB $p) defined in %s:8
 %s:12 PhanParamSignatureRealMismatchHasNoParamType Declaration of function f($p) should be compatible with function f(\CB $p) (parameter #1 with no type cannot replace original parameter with type '\CB') defined in %s:8
 %s:16 PhanParamSignatureMismatch Declaration of function f(\CC $p) should be compatible with function f(\CB $p) defined in %s:8
 %s:16 PhanParamSignatureRealMismatchParamType Declaration of function f(\CC $p) should be compatible with function f(\CB $p) (parameter #1 of type '\CC' cannot replace original parameter of type '\CB') defined in %s:8


### PR DESCRIPTION
foo($x) should be able to override foo(string $x) in phpdoc checks - It
accepts every input that the overridden method would.

This affects only PhanParamSignatureMismatch
- This also makes PhanParamSignatureMismatch start checking for variadic mismatches.

Fixes #1253