### PR TITLE
Allow widening an overriding method's param types in php 7.2 branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ composer.phar
 /build
 samples
 all_output.*
+*.swp
+/tags
+.phan/config.local.php

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -100,6 +100,12 @@ return [
     // This will also check if final methods are overridden, etc.
     'analyze_signature_compatibility' => true,
 
+    // Set this to true to allow contravariance in real parameter types of method overrides (Introduced in php 7.2)
+    // See https://secure.php.net/manual/en/migration72.new-features.php#migration72.new-features.param-type-widening
+    // (Users may enable this if analyzing projects that support only php 7.2+)
+    // This is false by default. (Will warn if real parameter types are omitted in an override)
+    'allow_method_param_type_widening' => false,
+
     // This setting maps case insensitive strings to union types.
     // This is useful if a project uses phpdoc that differs from the phpdoc2 standard.
     // If the corresponding value is the empty string, Phan will ignore that union type (E.g. can ignore 'the' in `@return the value`)

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ php:
 # PhanTest (tests/files) is the slowest test (~20 seconds).
 # Group the remaining tests into groups.
 env:
-  - TEST_SUITES="PhanTest"
-  - TEST_SUITES="UtilTest PHP72Test RasmusTest LanguageTest"
+  - TEST_SUITES="PhanTest UtilTest PHP72Test RasmusTest LanguageTest"
   - TEST_SUITES="__FakeSelfTest __FakeRewritingTest __FakePluginTest __FakeFallbackTest"
 
 sudo: false

--- a/NEWS
+++ b/NEWS
@@ -3,7 +3,10 @@ Phan NEWS
 ------------------------
 
 New Features (Analysis of PHP 7.2)
-+ Support analyzing the 'object' type hint in real function/method signatures. (Issue #995)
++ Support analyzing the 'object' type hint in real function/method signatures. (#995)
++ Allow widening an overriding method's param types in php 7.2 branch (#1256)
+  Phan continues warning about `ParamSignatureRealMismatchHasNoParamType` by default, in case a project needs to work with older php releases.
+  Add `'allow_method_param_type_widening' => true` if you wish for Phan to stop emitting that issue category.
 
 New Features(Analysis)
 + Support less ambiguous `?(T[])` and `(?T)[]` in phpdoc (#1213)

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -540,20 +540,23 @@ class ParameterTypesAnalyzer
             $o_parameter_union_type = $o_parameter->getUnionType();
             $parameter_union_type = $parameter->getUnionType();
             if ($parameter_union_type->isEmpty() != $o_parameter_union_type->isEmpty()) {
-                $is_possibly_compatible = false;
                 if ($parameter_union_type->isEmpty()) {
-                    self::emitSignatureRealMismatchIssue(
-                        $code_base,
-                        $method,
-                        $o_method,
-                        Issue::ParamSignatureRealMismatchHasNoParamType,
-                        Issue::ParamSignatureRealMismatchHasNoParamTypeInternal,
-                        Issue::ParamSignaturePHPDocMismatchHasNoParamType,
-                        $offset,
-                        (string)$o_parameter_union_type
-                    );
+                    if (Config::getValue('allow_method_param_type_widening') === false) {
+                        $is_possibly_compatible = false;
+                        self::emitSignatureRealMismatchIssue(
+                            $code_base,
+                            $method,
+                            $o_method,
+                            Issue::ParamSignatureRealMismatchHasNoParamType,
+                            Issue::ParamSignatureRealMismatchHasNoParamTypeInternal,
+                            Issue::ParamSignaturePHPDocMismatchHasNoParamType,
+                            $offset,
+                            (string)$o_parameter_union_type
+                        );
+                    }
                     continue;
                 } else {
+                    $is_possibly_compatible = false;
                     self::emitSignatureRealMismatchIssue(
                         $code_base,
                         $method,

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -162,6 +162,13 @@ class Config
         // This will also check if final methods are overridden, etc.
         'analyze_signature_compatibility' => true,
 
+        // Set this to true to allow contravariance in real parameter types of method overrides
+        // (Users may enable this if analyzing projects that support only php 7.2+)
+        // See https://secure.php.net/manual/en/migration72.new-features.php#migration72.new-features.param-type-widening
+        // This is false by default. (Will warn if real parameter types are omitted in an override)
+        // TODO: If 'target_php_version' is implemented, automatically infer this if null/not provided.
+        'allow_method_param_type_widening' => false,
+
         // If enabled, inherit any missing phpdoc for types from
         // the parent method if none is provided.
         //

--- a/tests/Phan/Language/Element/CommentTest.php
+++ b/tests/Phan/Language/Element/CommentTest.php
@@ -18,7 +18,6 @@ class CommentTest extends BaseTest
     /** @var CodeBase|null */
     protected $code_base = null;
 
-    /** @var bool */
     const overrides = [
         'read_type_annotations' => true,
         'read_magic_property_annotations' => true,

--- a/tests/Phan/PHP72Test.php
+++ b/tests/Phan/PHP72Test.php
@@ -2,8 +2,32 @@
 
 namespace Phan\Tests;
 
+use Phan\Config;
 
 class PHP72Test extends AbstractPhanFileTest {
+    const overrides = [
+        'allow_method_param_type_widening' => true,
+    ];
+
+    protected $old_values = [];
+
+    public function setUp()
+    {
+        parent::setUp();
+        foreach (self::overrides as $key => $value) {
+            $this->old_values[$key] = Config::getValue($key);
+            Config::setValue($key, $value);
+        }
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+        foreach ($this->old_values as $key => $value) {
+            Config::setValue($key, $value);
+        }
+    }
+
     /**
      * This reads all files in a test directory (e.g. `tests/files/src`), runs
      * the analyzer on each and compares the output

--- a/tests/php72_files/expected/0004_parameter_type_widening.php.expected
+++ b/tests/php72_files/expected/0004_parameter_type_widening.php.expected
@@ -1,0 +1,3 @@
+%s:33 PhanParamSignatureMismatch Declaration of function bar(\stdClass $x) should be compatible with function bar(\stdClass $x) : \stdClass defined in %s:24
+%s:33 PhanParamSignatureRealMismatchHasParamType Declaration of function bar(\stdClass $x) should be compatible with function bar($x) : \stdClass (parameter #1 of has type '\stdClass' cannot replace original parameter with no type) defined in %s:24
+%s:33 PhanParamSignatureRealMismatchReturnType Declaration of function bar(\stdClass $x) should be compatible with function bar($x) : \stdClass (method returning '' cannot override method returning '\stdClass') defined in %s:24

--- a/tests/php72_files/src/0004_parameter_type_widening.php
+++ b/tests/php72_files/src/0004_parameter_type_widening.php
@@ -1,0 +1,57 @@
+<?php
+namespace PHP72ParamCompat;
+use stdClass;
+use RuntimeException;
+
+class A1 {
+    function bar(stdClass $x) {
+        throw new RuntimeException("Not implemented");
+    }
+}
+
+class B1 extends A1 {
+    function bar($x) : stdClass {
+        return (object)['x' => $x];
+    }
+}
+
+// PHP 7.2 allows overriding abstract methods as well, with compatible signatures (Weaker param types, stricter return types).
+abstract class A2           {
+    abstract function bar(stdClass $x);
+}
+
+abstract class B2 extends A2 {
+    abstract function bar($x) : stdClass;
+}
+class C2 extends B2          {
+    function bar($x) : stdClass{
+        return (object)['y' => $x, 'label' => 'C'];
+    }
+}
+
+class Incompatible2 extends B2 {
+    function bar(stdClass $x) {}
+}
+
+interface A{
+    function doSomething();
+}
+
+interface B extends A{
+    function doSomethingElse();
+}
+
+abstract class AProxy implements A{
+    abstract protected function getOrigin(): A;
+    function doSomething() {
+        return $this->getOrigin()->doSomething();
+    }
+}
+
+abstract class BProxy extends AProxy implements B{
+    /** @return B */ // This is much better!
+    abstract protected function getOrigin(): A;
+    function doSomethingElse(){
+        return $this->getOrigin()->doSomethingElse();
+    }
+}

--- a/tests/run_all_tests
+++ b/tests/run_all_tests
@@ -5,8 +5,7 @@ if [ "$#" != 0 ]; then
 	exit 1
 fi
 
-TEST_SUITES="PhanTest"
-TEST_SUITES+=" UtilTest PHP72Test RasmusTest LanguageTest"
+TEST_SUITES="PhanTest UtilTest PHP72Test RasmusTest LanguageTest"
 TEST_SUITES+=" __FakeSelfTest __FakeRewritingTest __FakePluginTest __FakeFallbackTest"
 
 FAILURES=""


### PR DESCRIPTION
See
https://secure.php.net/manual/en/migration72.new-features.php#migration72.new-features.param-type-widening

For releases analyzing php 7.2, add a config option to stop warning
about foo(T $x) overriding foo($x). (`ParamSignatureRealMismatchHasNoParamType`)

- If you are analyzing a project that deliberately widens param types,
  add `'allow_method_param_type_widening' => true` to `.phan/config.php`

Fixes #1256