### PR TITLE
Fix an uncaught IssueException in DuplicateArrayKeyPlugin

### DIFF
--- a/plugins/codeclimate/Dockerfile
+++ b/plugins/codeclimate/Dockerfile
@@ -88,6 +88,9 @@ ADD ast.ini /etc/php7/conf.d
 
 WORKDIR /usr/src/app
 
+# Increment the last digit when updating codeclimate docker images.
+ENV PHAN_ITERATION 0.10.2-dev-1
+
 RUN git clone https://github.com/phan/phan.git .
 COPY engine /usr/src/app/plugins/codeclimate/engine
 

--- a/tests/plugin_test/expected/013_duplicate_array_key_uncaught.php.expected
+++ b/tests/plugin_test/expected/013_duplicate_array_key_uncaught.php.expected
@@ -1,0 +1,2 @@
+src/013_duplicate_array_key_uncaught.php:7 PhanUndeclaredConstant Reference to undeclared constant \Bar13::B
+src/013_duplicate_array_key_uncaught.php:17 PhanUndeclaredConstant Reference to undeclared constant \Bar13::a

--- a/tests/plugin_test/src/013_duplicate_array_key_uncaught.php
+++ b/tests/plugin_test/src/013_duplicate_array_key_uncaught.php
@@ -1,0 +1,25 @@
+<?php  // Regression test for uncaught IssueException
+
+class Foo13 {
+    public static function my_method() {
+        return [
+            Bar13::A => 'a',
+            Bar13::B => 'a',
+            'x' => '1',
+            'x2' => '1',
+            'x3' => '1',
+            'x4' => '1',
+            'x5' => '1',
+            'x6' => '1',
+            'x7' => '1',
+            'x8' => '1',
+            'x9' => '1',
+            Bar13::a => 'a',
+        ];
+    }
+}
+class Bar13 {
+    const A = 'a';
+}
+
+var_export(Foo13::my_method());


### PR DESCRIPTION
This was caused by an undeclared class constant.

This bug wasn't in the previous release,
getting the class const's value was done for #1139.

Noticed during simulation of codeclimate self-analysis, with incorrect
config including tests/files