### PR TITLE
Fixes #1232: Support static::class in callable to refer to current class

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -25,6 +25,7 @@ Bug Fixes
 + For dead code detection, properly track uses of inherited class elements (methods, properties, classes) as uses of the original definition. (#1108)
   Fix the way that uses of private/protected methods from traits were tracked.
   Also, start warning about a subset of issues from interfaces and abstract classes (e.g. unused interface constants)
++ Properly handle `static::class` as a class name in an array callable, or `static::method_name` in a string callable (#1232)
 
 Plugins
 + Make DuplicateArrayKeyPlugin start warning about duplicate values of known global constants and class constants. (#1139)

--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -15,6 +15,7 @@ use Phan\Language\Element\FunctionInterface;
 use Phan\Language\Element\Method;
 use Phan\Language\FQSEN\FullyQualifiedFunctionName;
 use Phan\Language\FQSEN\FullyQualifiedMethodName;
+use Phan\Language\FQSEN\FullyQualifiedClassName;
 use Phan\Language\Type\NullType;
 use Phan\Language\UnionType;
 use Phan\Library\FileCache;
@@ -319,12 +320,17 @@ class Analysis
     {
         $plugin_set = ConfigPluginSet::instance();
         foreach ($plugin_set->getReturnTypeOverrides($code_base) as $fqsen_string => $closure) {
-            if (stripos($fqsen_string, '::') !== false) {
-                // This is an override of a method.
+            if (\stripos($fqsen_string, '::') !== false) {
                 $fqsen = FullyQualifiedMethodName::fromFullyQualifiedString($fqsen_string);
-                if ($code_base->hasMethodWithFQSEN($fqsen)) {
-                    $method = $code_base->getMethodByFQSEN($fqsen);
-                    $method->setDependentReturnTypeClosure($closure);
+                $class_fqsen = $fqsen->getFullyQualifiedClassName();
+                // We have to call hasClassWithFQSEN before calling hasMethodWithFQSEN in order to autoload the internal function signatures.
+                // TODO: Move class autoloading into hasMethodWithFQSEN()?
+                if ($code_base->hasClassWithFQSEN($class_fqsen)) {
+                    // This is an override of a method.
+                    if ($code_base->hasMethodWithFQSEN($fqsen)) {
+                        $method = $code_base->getMethodByFQSEN($fqsen);
+                        $method->setDependentReturnTypeClosure($closure);
+                    }
                 }
             } else {
                 // This is an override of a function.

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -97,6 +97,7 @@ class Issue
 
     // Issue::CATEGORY_CONTEXT
     const ContextNotObject          = 'PhanContextNotObject';
+    const ContextNotObjectInCallable = 'PhanContextNotObjectInCallable';
 
     // Issue::CATEGORY_DEPRECATED
     const DeprecatedClass           = 'PhanDeprecatedClass';
@@ -1005,6 +1006,14 @@ class Issue
                 "Cannot access {CLASS} when not in object context",
                 self::REMEDIATION_B,
                 4000
+            ),
+            new Issue(
+                self::ContextNotObjectInCallable,
+                self::CATEGORY_CONTEXT,
+                self::SEVERITY_NORMAL,
+                "Cannot access {CLASS} when not in object context, but code is using callable {METHOD}",
+                self::REMEDIATION_B,
+                4001
             ),
 
             // Issue::CATEGORY_DEPRECATED

--- a/tests/files/expected/0370_callable_edge_cases.php.expected
+++ b/tests/files/expected/0370_callable_edge_cases.php.expected
@@ -1,13 +1,12 @@
-%s:5 PhanTraitParentReference Reference to parent from trait \T2
-%s:18 PhanParentlessClass Reference to parent of class \Parent370 that does not extend anything
+%s:5 PhanUndeclaredStaticMethodInCallable Reference to undeclared static method \T2::foo in callable
 %s:33 PhanUndeclaredClassInCallable Reference to undeclared class \parent in callable \parent::foo
 %s:34 PhanUndeclaredClassInCallable Reference to undeclared class \static in callable \static::foo
 %s:35 PhanUndeclaredClassInCallable Reference to undeclared class \self in callable \self::foo
 %s:37 PhanTypeMismatchArgument Argument 1 (x) is array but \C370::foo() takes int defined at %s:41
 %s:38 PhanTypeMismatchArgument Argument 1 (x) is array but \C370::foo() takes int defined at %s:41
-%s:39 PhanTypeMismatchArgument Argument 1 (x) is array but \Parent370::foo() takes int defined at %s:11
-%s:47 PhanContextNotObject Cannot access self when not in object context
-%s:48 PhanContextNotObject Cannot access static when not in object context
-%s:49 PhanContextNotObject Cannot access parent when not in object context
+%s:39 PhanTypeMismatchArgument Argument 1 (x) is array but \C370::foo() takes int defined at %s:41
+%s:47 PhanContextNotObjectInCallable Cannot access self when not in object context, but code is using callable self::foo
+%s:48 PhanContextNotObjectInCallable Cannot access static when not in object context, but code is using callable static::foo
+%s:49 PhanContextNotObjectInCallable Cannot access parent when not in object context, but code is using callable parent::foo
 %s:50 PhanTypeMismatchArgument Argument 1 (x) is \stdClass but \C370::foo() takes int defined at %s:41
 %s:51 PhanTypeMismatchArgument Argument 1 (x) is \stdClass but \C370::foo() takes int defined at %s:41

--- a/tests/files/expected/0377_static_callable.php.expected
+++ b/tests/files/expected/0377_static_callable.php.expected
@@ -1,0 +1,4 @@
+%s:11 PhanTypeMismatchArgument Argument 1 (x) is \stdClass but \TestStaticCallable377::triple() takes int defined at %s:24
+%s:12 PhanTypeMismatchArgument Argument 1 (x) is \stdClass but \TestStaticCallable377::triple() takes int defined at %s:24
+%s:20 PhanTypeMismatchArgument Argument 1 (x) is \stdClass but \TestStaticCallable377::triple() takes int defined at %s:24
+%s:21 PhanTypeMismatchArgument Argument 1 (x) is \stdClass but \TestStaticCallable377::triple() takes int defined at %s:24

--- a/tests/files/src/0377_static_callable.php
+++ b/tests/files/src/0377_static_callable.php
@@ -1,0 +1,28 @@
+<?php
+
+class TestStaticCallable377 {
+    public static function main() {
+        var_export(array_map([static::class, 'triple'], [2, 3, -1]));
+        var_export(array_map(Closure::fromCallable([static::class, 'triple']), [2, 3, -1]));
+
+        var_export(array_map([self::class, 'triple'], [2, 3, -1]));
+        var_export(array_map(Closure::fromCallable([self::class, 'triple']), [2, 3, -1]));
+
+        var_export(array_map([self::class, 'triple'], [new stdClass()]));
+        var_export(array_map(Closure::fromCallable([self::class, 'triple']), [new stdClass()]));
+
+        var_export(array_map('self::triple', [2, 3, -1]));
+        var_export(array_map('static::triple', [2, 3, -1]));
+
+        var_export(array_map('self::triple', [[]]));
+        var_export(array_map('static::triple', [[]]));
+
+        var_export(array_map([static::class, 'triple'], [new stdClass()]));  // should warn
+        var_export(array_map(Closure::fromCallable([static::class, 'triple']), [new stdClass()]));  // should warn
+    }
+
+    public static function triple(int $x) : int {
+        return $x * 3;
+    }
+}
+TestStaticCallable377::main();


### PR DESCRIPTION
This is currently used only by internal global functions, so we don't
need to refer to other classes.

Eventually, will want to support `MyClass::doSomething('self::method_of_myclass')`

Add unit tests.