### PR TITLE
Fixes #1224: trigger_error should affect inferred exit status

### DIFF
--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -626,10 +626,7 @@ class ContextNode
                     $this->code_base,
                     $this->context,
                     $expression
-                ))->getFunction(
-                    $expression->children['name']
-                        ?? $expression->children['method']
-                );
+                ))->getFunction($expression->children['name']);
             } catch (IssueException $exception) {
                 Issue::maybeEmitInstance(
                     $this->code_base,

--- a/src/Phan/Analysis/BlockExitStatusChecker.php
+++ b/src/Phan/Analysis/BlockExitStatusChecker.php
@@ -356,6 +356,72 @@ final class BlockExitStatusChecker extends KindVisitorImplementation {
         return self::STATUS_RETURN;
     }
 
+    // A trigger_error statement may or may not exit, depending on the constant and user configuration.
+    public function visitCall(Node $node)
+    {
+        $status = $node->flags & self::STATUS_BITMASK;
+        if ($status) {
+            return $status;
+        }
+        $status = $this->computeStatusOfCall($node);
+        $node->flags = $status;
+        return $status;
+    }
+
+    private function computeStatusOfCall(Node $node) : int
+    {
+        $expression = $node->children['expr'];
+        if ($expression instanceof Node) {
+            if ($expression->kind !== \ast\AST_NAME) {
+                return self::STATUS_PROCEED;  // best guess
+            }
+            $function_name = $expression->children['name'];
+            if (!\is_string($function_name)) {
+                return self::STATUS_PROCEED;
+            }
+        } else {
+            if (!\is_string($expression)) {
+                return self::STATUS_PROCEED;  // Probably impossible.
+            }
+            $function_name = $expression;
+        }
+        if (!$function_name) {
+            return self::STATUS_THROW;  // nonsense such as ''();
+        }
+        if ($function_name[0] === '\\') {
+            $function_name = \substr($function_name, 1);
+        }
+        if (\strcasecmp($function_name, 'trigger_error') === 0) {
+            return $this->computeTriggerErrorStatusCodeForConstant($node->children['args']->children[1] ?? null);
+        }
+        // TODO: Could allow .phan/config.php or plugins to define additional behaviors, e.g. for methods.
+        // E.g. if (!$var) {HttpFramework::generate_302_and_die(); }
+        return self::STATUS_PROCEED;
+    }
+
+    private function computeTriggerErrorStatusCodeForConstant($constant_ast) : int
+    {
+        // return PROCEED if this can't be determined.
+        if (!($constant_ast instanceof Node)) {
+            return self::STATUS_PROCEED;
+        }
+        if ($constant_ast->kind !== \ast\AST_CONST) {
+            return self::STATUS_PROCEED;
+        }
+        $name = $constant_ast->children['name']->children['name'] ?? null;
+        if (!\is_string($name)) {
+            return self::STATUS_PROCEED;
+        }
+        if (\in_array($name, ['E_ERROR', 'E_PARSE', 'E_CORE_ERROR', 'E_COMPILE_ERROR', 'E_USER_ERROR'])) {
+            return self::STATUS_RETURN;
+        }
+        if ($name === 'E_RECOVERABLE_ERROR') {
+            return self::STATUS_THROW;
+        }
+
+        return self::STATUS_PROCEED;  // Assume this is a warning or notice?
+    }
+
     /**
      * A statement list has the weakest return status out of all of the (non-PROCEEDing) statements.
      * FIXME: This is buggy, doesn't account for one statement having STATUS_CONTINUE some of the time but not all of it.

--- a/tests/Phan/Analysis/BlockExitStatusCheckerTest.php
+++ b/tests/Phan/Analysis/BlockExitStatusCheckerTest.php
@@ -258,6 +258,27 @@ class BlockExitStatusCheckerTest extends BaseTest
                 'proceed/goto/break',
                 'if (cond2()) { if (cond()) { goto end; } break; }  end: ;',
             ],
+            // trigger_error can make it throw/exit. The returned code for exit is 'return'
+            [
+                'return',
+                'trigger_error("err msg", E_USER_ERROR);',
+            ],
+            [
+                'throw',
+                'TRIGGER_ERROR("err msg", E_RECOVERABLE_ERROR);',
+            ],
+            [
+                'proceed',
+                'TRIGGER_ERROR_NOT("err msg", E_RECOVERABLE_ERROR);',
+            ],
+            [
+                'throw',
+                '\trigger_error("err msg", E_RECOVERABLE_ERROR);',
+            ],
+            [
+                'proceed',
+                'trigger_error("err msg", E_DEPRECATED);',
+            ],
         ];
     }
 }


### PR DESCRIPTION
The exit status depends on which of the E_* constants are passed in.
If this cannot be determined, assume the code proceeds.