### PR TITLE
Analyze callables passed to internal and user-defined functions.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,9 @@ New Features(Analysis)
   Note that Phan ignores the provided value of `Key` completely right now (i.e. same as `T[]`); Key types may be supported later.
 + Speed up phan analysis on small projects, reduce memory usage (Around 0.15 seconds and 15MB)
   This was done by deferring loading the information about internal classes and functions until that information was needed for analysis.
++ Analyze existence and usage of callables passed to (internal and user-defined) function&methods expecting callable. (#1194)
+  Analysis will now warn if a callable no longer exists.
+  This change also reduces false positives in dead code detection.
 
 New Features (CLI, Configs)
 + Improve default update rate of `--progress-bar` (Update it every 0.10 seconds)

--- a/src/Phan/AST/ASTConverter.php
+++ b/src/Phan/AST/ASTConverter.php
@@ -7,11 +7,10 @@ use PhpParser;
 use PhpParser\ParserFactory;
 
 /**
- * TODO: Move this into its own composer package in a future release?
- *
  * Source: https://github.com/TysonAndre/php-parser-to-php-ast
  * Uses PhpParser to create an instance of ast\Node.
  * Useful if the php-ast extension isn't actually installed.
+ * @author Tyson Andre
  *
  * This is implemented as a collection of static methods for performance,
  * but functionality is provided through instance methods.
@@ -1896,13 +1895,13 @@ final class ASTConverter {
             ];
             $doc_comment = self::extractPhpdocComment($declare->getAttribute('comments')) ?? $first_doc_comment;
             $first_doc_comment = null;
-            if (self::$ast_version >= 45) {
+            if (self::$ast_version >= 50) {
                 if (PHP_VERSION_ID >= 70100) {
                     $children['docComment'] = $doc_comment;
                 }
             }
             $node = new ast\Node(ast\AST_CONST_ELEM, 0, $children, $declare->getAttribute('startLine'));
-            if (self::$ast_version < 45 && is_string($doc_comment)) {
+            if (self::$ast_version < 50 && is_string($doc_comment)) {
                 if (PHP_VERSION_ID >= 70100) {
                     $node->docComment = $doc_comment;
                 }

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -1375,11 +1375,48 @@ class UnionType implements \Serializable
      */
     public function callableTypes() : UnionType
     {
-        // TODO: is_scalar(null) is false, account for that in analysis.
         $types = \array_filter($this->type_set, function (Type $type) : bool {
             return $type->isCallable();
         });
         return new UnionType($types, true);
+    }
+
+    /**
+     * Returns true if this has one or more callable types
+     * TODO: Check for __invoke()?
+     * Takes "Closure|false" and returns true
+     * Takes "?MyClass" and returns false
+     *
+     * @return bool
+     * A UnionType with known callable types kept, other types filtered out.
+     *
+     * @see nonGenericArrayTypes
+     * @see genericArrayElementTypes
+     */
+    public function hasCallableType() : bool
+    {
+        return ArraySet::exists($this->type_set, function (Type $type) : bool {
+            return $type->isCallable();
+        });
+    }
+
+    /**
+     * Returns true if every type in this type is callable.
+     * TODO: Check for __invoke()?
+     * Takes "callable" and returns true
+     * Takes "callable|false" and returns false
+     *
+     * @return bool
+     * A UnionType with known callable types kept, other types filtered out.
+     *
+     * @see nonGenericArrayTypes
+     * @see genericArrayElementTypes
+     */
+    public function isExclusivelyCallable() : bool
+    {
+        return !ArraySet::exists($this->type_set, function (Type $type) : bool {
+            return !$type->isCallable();
+        });
     }
 
     /**

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -14,6 +14,7 @@ use Phan\Language\Element\Method;
 use Phan\Language\Element\Property;
 use Phan\Plugin;
 use Phan\Plugin\Internal\ArrayReturnTypeOverridePlugin;
+use Phan\Plugin\Internal\CallableParamPlugin;
 use Phan\Plugin\Internal\ClosureReturnTypeOverridePlugin;
 use Phan\Plugin\PluginImplementation;
 use Phan\PluginV2;
@@ -388,7 +389,12 @@ final class ConfigPluginSet extends PluginV2 implements
         );
         // Add internal plugins. Can be disabled by disable_internal_return_type_plugins.
         if (Config::getValue('enable_internal_return_type_plugins')) {
-            $plugin_set = array_merge([new ArrayReturnTypeOverridePlugin(), new ClosureReturnTypeOverridePlugin()], $plugin_set);
+            $internal_return_type_plugins = [
+                new CallableParamPlugin(),
+                new ArrayReturnTypeOverridePlugin(),
+                new ClosureReturnTypeOverridePlugin(),
+            ];
+            $plugin_set = array_merge($internal_return_type_plugins, $plugin_set);
         }
 
         // Register the entire set.

--- a/src/Phan/Plugin/Internal/CallableParamPlugin.php
+++ b/src/Phan/Plugin/Internal/CallableParamPlugin.php
@@ -1,0 +1,137 @@
+<?php declare(strict_types=1);
+namespace Phan\Plugin\Internal;
+
+use Phan\CodeBase;
+use Phan\Analysis\ArgumentType;
+use Phan\Analysis\PostOrderAnalysisVisitor;
+use Phan\AST\UnionTypeVisitor;
+use Phan\Config;
+use Phan\Issue;
+use Phan\Language\Context;
+use Phan\Language\Element\Func;
+use Phan\Language\Element\FunctionInterface;
+use Phan\Language\Element\Method;
+use Phan\Language\Type\CallableType;
+use Phan\Language\Type;
+use Phan\Language\UnionType;
+use Phan\Library\ArraySet;
+use Phan\PluginV2\ReturnTypeOverrideCapability;
+use Phan\PluginV2\AnalyzeFunctionCallCapability;
+use Phan\PluginV2;
+use ast\Node;
+
+/**
+ * NOTE: This is automatically loaded by phan. Do not include it in a config.
+ *
+ * TODO: Analyze returning callables (function() : callable) for any callables that are returned as literals?
+ * This would be difficult.
+ */
+final class CallableParamPlugin extends PluginV2 implements
+    AnalyzeFunctionCallCapability {
+
+    /**
+     * @param int[] $params
+     */
+    private static function generateClosure(array $params) : \Closure
+    {
+        $key = \json_encode($params);
+        static $cache = [];
+        $closure = $cache[$key] ?? null;
+        if ($closure !== null) {
+            return $closure;
+        }
+        $closure = function(
+            CodeBase $code_base,
+            Context $context,
+            FunctionInterface $function,
+            array $args
+        ) use ($params) {
+            // TODO: Implement support for variadic callable arguments.
+            foreach ($params as $i) {
+                $arg = $args[$i] ?? null;
+
+                // Fetch possible functions. As a side effect, this warns about invalid callables.
+                // TODO: Check if the signature allows non-array callables? Not sure of desired semantics.
+                $function_like_list = UnionTypeVisitor::functionLikeListFromNodeAndContext($code_base, $context, $arg, true);
+                if (\count($function_like_list) === 0) {
+                    // Nothing to do
+                    return;
+                }
+
+                if (Config::get_track_references()) {
+                    foreach ($function_like_list as $function) {
+                        $function->addReference($context);
+                    }
+                }
+                // self::analyzeFunctionAndNormalArgumentList($code_base, $context, $function_like_list, $arguments);
+            }
+        };
+
+        $cache[$key] = $closure;
+        return $closure;
+    }
+
+    /**
+     * @return \Closure[]
+     */
+    private function getAnalyzeFunctionCallClosuresStatic(CodeBase $code_base) : array
+    {
+        $result = [];
+        $add_callable_checker_closure = function(FunctionInterface $function) use (&$result) {
+            $params = [];
+            foreach ($function->getParameterList() as $i => $param) {
+                // If there's a type such as Closure|string|int, don't automatically assume that any string or array passed in is meant to be a callable.
+                // Explicitly require at least one type to be `callable`
+                if ($param->getUnionType()->hasTypeMatchingCallback(function (Type $type) : bool {
+                    return $type instanceof CallableType;
+                })) {
+                    $params[] = $i;
+                }
+            }
+            if (\count($params) === 0) {
+                return;
+            }
+            // Generate a de-duplicated closure.
+            // fqsen can be global_function or ClassName::method
+            $result[(string)$function->getFQSEN()] = self::generateClosure($params);
+        };
+
+        foreach ($code_base->getFunctionMap() as $function) {
+            $add_callable_checker_closure($function);
+        }
+        foreach ($code_base->getMethodSet() as $function) {
+            $add_callable_checker_closure($function);
+        }
+
+        // new ReflectionFunction('my_func') is a usage of my_func()
+        // See https://github.com/phan/phan/issues/1204 for note on function_exists() (not supported right now)
+        $result['\\ReflectionFunction::__construct'] = self::generateClosure([0]);
+
+        // When a codebase calls function_exists(string|callable) is to **check** if a function exists,
+        // don't emit PhanUndeclaredFunctionInCallable as a side effect.
+        unset($result['\\function_exists']);
+
+        // Don't do redundant work extracting function definitions for commonly invoked functions.
+        // TODO: Get actual statistics on how frequently used these are
+        unset($result['\\call_user_func']);
+        unset($result['\\call_user_func_array']);
+        unset($result['\\array_map']);
+        unset($result['\\array_filter']);
+        // End of commonly used functions.
+
+        return $result;
+    }
+
+    /**
+     * @return \Closure[]
+     */
+    public function getAnalyzeFunctionCallClosures(CodeBase $code_base) : array
+    {
+        // Unit tests invoke this repeatedly. Cache it.
+        static $analyzers = null;
+        if ($analyzers === null) {
+            $analyzers = self::getAnalyzeFunctionCallClosuresStatic($code_base);
+        }
+        return $analyzers;
+    }
+}

--- a/src/Phan/Plugin/Internal/ClosureReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ClosureReturnTypeOverridePlugin.php
@@ -70,6 +70,11 @@ final class ClosureReturnTypeOverridePlugin extends PluginV2 implements
                     $element_types->addUnionType($function_like->getUnionType());
                 }
             }
+            if (Config::get_track_references()) {
+                foreach ($function_like_list as $function_like) {
+                    $function_like->addReference($context);
+                }
+            }
             return $element_types;
         };
         $call_user_func_array_callback = static function(
@@ -95,6 +100,11 @@ final class ClosureReturnTypeOverridePlugin extends PluginV2 implements
                     $element_types->addUnionType($function_like->getDependentReturnType($code_base, $context, $arguments));
                 } else {
                     $element_types->addUnionType($function_like->getUnionType());
+                }
+            }
+            if (Config::get_track_references()) {
+                foreach ($function_like_list as $function_like) {
+                    $function_like->addReference($context);
                 }
             }
             if ($arguments !== null) {

--- a/src/spl_object_id.php
+++ b/src/spl_object_id.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * PHP Polyfill for spl_object_id() for PHP <= 7.1
  * This file will be included even in releases which will analyze PHP 7.2,
@@ -7,55 +8,59 @@
 if (function_exists('spl_object_id')) {
     return;
 }
-if (function_exists('runkit_object_id') && !(new ReflectionFunction('runkit_object_id'))->isUserDefined()) {
-    /**
-     * See https://github.com/runkit7/runkit_object_id for a faster native version (Improves phan's speed by 10% or so).
-     * runkit_object_id 1.1.0+ provides a fast native implementation spl_object_id() for php <= 7.1,
-     * in which case this file wouldn't be included.
-     *
-     * @param object $object
-     * @return int The object id
-     * @suppress PhanRedefineFunctionInternal
-     * @suppress PhanRedefineFunction
-     * @suppress PhanUndeclaredFunction
-     */
-    function spl_object_id($object) {
-        return runkit_object_id($object);
+// Workaround for global suppression
+call_user_func(/** @suppress PhanUndeclaredFunctionInCallable for ReflectionFunction */ function() {
+    if (function_exists('runkit_object_id') &&
+        !(new ReflectionFunction('runkit_object_id'))->isUserDefined()) {
+        /**
+         * See https://github.com/runkit7/runkit_object_id for a faster native version (Improves phan's speed by 10% or so).
+         * runkit_object_id 1.1.0+ provides a fast native implementation spl_object_id() for php <= 7.1,
+         * in which case this file wouldn't be included.
+         *
+         * @param object $object
+         * @return int The object id
+         * @suppress PhanRedefineFunctionInternal
+         * @suppress PhanRedefineFunction
+         * @suppress PhanUndeclaredFunction
+         */
+        function spl_object_id($object) {
+            return runkit_object_id($object);
+        }
+    } else if (PHP_INT_SIZE === 8) {
+        /**
+         * See https://github.com/runkit7/runkit_object_id for a faster native version (Improves phan's speed by 10% or so).
+         * spl_object_hash() exists, but spl_object_id() is only available in php 7.2+.
+         * Also, we currently get an object from var_dump(), but that isn't nicely exposed.
+         *
+         * @param object $object
+         * @return int (The object id, XORed with a random number)
+         * @suppress PhanRedefineFunctionInternal
+         * @suppress PhanRedefineFunction
+         */
+        function spl_object_id($object) {
+            $hash = spl_object_hash($object);
+            // Fit this into a php long (32-bit or 64-bit signed int).
+            // The first 16 hex digits (64 bytes) vary, the last 16 don't.
+            // Values are usually padded with 0s at the front.
+            return intval(substr($hash, 1, 15), 16);
+        }
+    } else {
+        /**
+         * See https://github.com/runkit7/runkit_object_id for a faster native version (Improves phan's speed by 10% or so).
+         * spl_object_hash() exists, but spl_object_id() is only available in php 7.2+.
+         * Also, we currently get an object from var_dump(), but that isn't nicely exposed.
+         *
+         * @param object $object
+         * @return int (The object id, XORed with a random number)
+         * @suppress PhanRedefineFunctionInternal
+         * @suppress PhanRedefineFunction
+         */
+        function spl_object_id($object) {
+            $hash = spl_object_hash($object);
+            // Fit this into a php long (32-bit or 64-bit signed int).
+            // The first 16 hex digits (64 bytes) vary, the last 16 don't.
+            // Values are usually padded with 0s at the front.
+            return intval(substr($hash, 9, 7), 16);
+        }
     }
-} else if (PHP_INT_SIZE === 8) {
-    /**
-     * See https://github.com/runkit7/runkit_object_id for a faster native version (Improves phan's speed by 10% or so).
-     * spl_object_hash() exists, but spl_object_id() is only available in php 7.2+.
-     * Also, we currently get an object from var_dump(), but that isn't nicely exposed.
-     *
-     * @param object $object
-     * @return int (The object id, XORed with a random number)
-     * @suppress PhanRedefineFunctionInternal
-     * @suppress PhanRedefineFunction
-     */
-    function spl_object_id($object) {
-        $hash = spl_object_hash($object);
-        // Fit this into a php long (32-bit or 64-bit signed int).
-        // The first 16 hex digits (64 bytes) vary, the last 16 don't.
-        // Values are usually padded with 0s at the front.
-        return intval(substr($hash, 1, 15), 16);
-    }
-} else {
-    /**
-     * See https://github.com/runkit7/runkit_object_id for a faster native version (Improves phan's speed by 10% or so).
-     * spl_object_hash() exists, but spl_object_id() is only available in php 7.2+.
-     * Also, we currently get an object from var_dump(), but that isn't nicely exposed.
-     *
-     * @param object $object
-     * @return int (The object id, XORed with a random number)
-     * @suppress PhanRedefineFunctionInternal
-     * @suppress PhanRedefineFunction
-     */
-    function spl_object_id($object) {
-        $hash = spl_object_hash($object);
-        // Fit this into a php long (32-bit or 64-bit signed int).
-        // The first 16 hex digits (64 bytes) vary, the last 16 don't.
-        // Values are usually padded with 0s at the front.
-        return intval(substr($hash, 9, 7), 16);
-    }
-}
+});

--- a/tests/plugin_test/expected/016_dead_code_callable.php.expected
+++ b/tests/plugin_test/expected/016_dead_code_callable.php.expected
@@ -1,0 +1,5 @@
+src/016_dead_code_callable.php:7 PhanUnreferencedFunction Possibly zero references to function \myfunc16unused
+src/016_dead_code_callable.php:12 PhanUnreferencedFunction Possibly zero references to function \double16unused
+src/016_dead_code_callable.php:20 PhanUnreferencedMethod Possibly zero references to method \MyClass16::static_func_unused
+src/016_dead_code_callable.php:26 PhanUnreferencedMethod Possibly zero references to method \MyClass16::instanceFuncUnused
+src/016_dead_code_callable.php:45 PhanUndeclaredFunctionInCallable Call to undeclared function undeclared_func_16 in callable

--- a/tests/plugin_test/src/016_dead_code_callable.php
+++ b/tests/plugin_test/src/016_dead_code_callable.php
@@ -1,0 +1,45 @@
+<?php
+
+function myfunc16() {
+    echo __FUNCTION__ . "Called\n";
+}
+
+function myfunc16unused() {
+    echo __FUNCTION__ . "Called\n";
+}
+
+function double16($x) { return $x * 2; }
+function double16unused($x) { return $x * 2; }
+
+function callable16() { return 16; }
+
+class MyClass16 {
+    public static function static_func_1() {
+        echo __METHOD__ . "\n";
+    }
+    public static function static_func_unused() {
+        echo __METHOD__ . "\n";
+    }
+    public function instanceFunc() {
+        echo __METHOD__ . "\n";
+    }
+    public function instanceFuncUnused() {
+        echo __METHOD__ . "\n";
+    }
+}
+
+function user_defined_caller(callable $x) {
+    call_user_func($x);
+}
+
+function main16() {
+    user_defined_caller('myfunc16');
+    user_defined_caller('MyClass16::static_func_1');
+    $m = new MyClass16();
+    user_defined_caller([$m, 'instanceFunc']);
+    var_export(array_map('double16', [3]));
+    return Closure::fromCallable('callable16');
+}
+main16();
+
+var_export(user_defined_caller('undeclared_func_16'));


### PR DESCRIPTION
Fixes #1194

Make dead code detection account for known callables.

Also, warn for undefined callables in user-defined and internal
functions. E.g. the below will now warn.

```
/** @param callable|string $x
function expects_callable($x) { /* ... */ }
expects_callable('undeclared_function');
```

Add unit tests.

Also, sync changes for ast converter