### PR TITLE
Closes #1271 : Add test of array<Key, T> in namespace

### DIFF
--- a/tests/files/expected/0379_array_template.php.expected
+++ b/tests/files/expected/0379_array_template.php.expected
@@ -1,0 +1,1 @@
+%s:17 PhanTypeMismatchArgument Argument 1 (x) is float[] but \MyNS\TemplateArray379::keys() takes string[] defined at %s:9

--- a/tests/files/src/0379_array_template.php
+++ b/tests/files/src/0379_array_template.php
@@ -1,0 +1,17 @@
+<?php
+namespace MyNS;
+// Make sure that we don't interpret array<int, string> as MyNS\array<int, string>
+class TemplateArray379 {
+    /**
+     * @param array<int, string>
+     * @return array<int, int>
+     */
+    public function keys($x) {
+        return \array_keys($x);
+    }
+}
+
+$t = new TemplateArray379();
+
+var_export($t->keys(['x']));
+var_export($t->keys([3.5]));


### PR DESCRIPTION
`array<Key, T>` should not be parsed as `MyNS\array<Key, T>`.
The issue probably happened with an older checkout.