### PR TITLE
Warn where object/class was expected

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,7 @@ New Features(Analysis)
 + Analyze existence and usage of callables passed to (internal and user-defined) function&methods expecting callable. (#1194)
   Analysis will now warn if a callable no longer exists.
   This change also reduces false positives in dead code detection.
++ Warn if attempting to read/write to an property or constant when the expression is a non-object (or not a class name, for static elements) (#1268)
 
 New Features (CLI, Configs)
 + Improve default update rate of `--progress-bar` (Update it every 0.10 seconds)

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -369,19 +369,13 @@ class AssignmentVisitor extends AnalysisVisitor
      */
     public function visitProp(Node $node) : Context
     {
-        $property_name = $node->children['prop'];
-
-        // Things like $foo->$bar
-        if (!\is_string($property_name)) {
-            return $this->context;
-        }
-
+        // Get class list first, warn if the class list is invalid.
         try {
             $class_list = (new ContextNode(
                 $this->code_base,
                 $this->context,
                 $node->children['expr']
-            ))->getClassList();
+            ))->getClassList(false, ContextNode::CLASS_LIST_ACCEPT_OBJECT, Issue::TypeExpectedObjectPropAccess);
         } catch (CodeBaseException $exception) {
             // This really shouldn't happen since the code
             // parsed cleanly. This should fatal.
@@ -390,6 +384,13 @@ class AssignmentVisitor extends AnalysisVisitor
         } catch (\Exception $exception) {
             // If we can't figure out what kind of a class
             // this is, don't worry about it
+            return $this->context;
+        }
+
+        $property_name = $node->children['prop'];
+
+        // Things like $foo->$bar
+        if (!\is_string($property_name)) {
             return $this->context;
         }
 
@@ -566,7 +567,7 @@ class AssignmentVisitor extends AnalysisVisitor
                 $this->code_base,
                 $this->context,
                 $node->children['class']
-            ))->getClassList();
+            ))->getClassList(false, ContextNode::CLASS_LIST_ACCEPT_OBJECT_OR_CLASS_NAME, Issue::TypeExpectedObjectStaticPropAccess);
         } catch (CodeBaseException $exception) {
             // This really shouldn't happen since the code
             // parsed cleanly. This should fatal.

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -920,9 +920,10 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 false
             );
 
+            $class_list = $context_node->getClassList(false, ContextNode::CLASS_LIST_ACCEPT_OBJECT_OR_CLASS_NAME);
             // Add a reference to each class this method
             // could be called on
-            foreach ($context_node->getClassList() as $class) {
+            foreach ($class_list as $class) {
                 $class->addReference($this->context);
                 if ($class->isDeprecated()) {
                     $this->emitIssue(
@@ -969,7 +970,6 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 $node
             );
 
-            $class_list = $context_node->getClassList();
             foreach ($class_list as $class) {
                 // Make sure we're not instantiating an abstract
                 // class
@@ -1021,11 +1021,12 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
     {
         try {
             // Fetch the class list, and emit warnings as a side effect.
+            // TODO: Unify UnionTypeVisitor, AssignmentVisitor, and PostOrderAnalysisVisitor
             (new ContextNode(
                 $this->code_base,
                 $this->context,
                 $node->children['class']
-            ))->getClassList();
+            ))->getClassList(false, ContextNode::CLASS_LIST_ACCEPT_OBJECT_OR_CLASS_NAME, Issue::TypeInvalidInstanceof);
         } catch (CodeBaseException $exception) {
             $this->emitIssue(
                 Issue::UndeclaredClassInstanceof,

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -613,7 +613,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
                 $this->code_base,
                 $this->context,
                 $node->children['class']
-            ))->getClassList();
+            ))->getClassList(false, ContextNode::CLASS_LIST_ACCEPT_OBJECT_OR_CLASS_NAME);
 
             foreach ($class_list as $class) {
                 $class->addReference($this->context);

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -84,6 +84,10 @@ class Issue
     const TypeInvalidCallableArraySize = 'PhanTypeInvalidCallableArraySize';
     const TypeInvalidCallableArrayKey = 'PhanTypeInvalidCallableArrayKey';
     const TypeInvalidCallableObjectOfMethod = 'PhanTypeInvalidCallableObjectOfMethod';
+    const TypeExpectedObject        = 'PhanTypeExpectedObject';
+    const TypeExpectedObjectOrClassName = 'PhanTypeExpectedObjectOrClassName';
+    const TypeExpectedObjectPropAccess = 'PhanTypeExpectedObjectPropAccess';
+    const TypeExpectedObjectStaticPropAccess = 'PhanTypeExpectedObjectStaticPropAccess';
 
     // Issue::CATEGORY_ANALYSIS
     const Unanalyzable              = 'PhanUnanalyzable';
@@ -977,6 +981,38 @@ class Issue
                 'In a place where phan was expecting a callable, saw a two-element array with a class or expression with an unexpected type {TYPE} (expected a class type or string). Method name was {METHOD}',
                 self::REMEDIATION_B,
                 10035
+            ),
+            new Issue(
+                self::TypeExpectedObject,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                'Expected an object instance but saw expression with type {TYPE}',
+                self::REMEDIATION_B,
+                10036
+            ),
+            new Issue(
+                self::TypeExpectedObjectOrClassName,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                'Expected an object instance or the name of a class but saw expression with type {TYPE}',
+                self::REMEDIATION_B,
+                10037
+            ),
+            new Issue(
+                self::TypeExpectedObjectPropAccess,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                'Expected an object instance when accessing an instance property, but saw an expression with type {TYPE}',
+                self::REMEDIATION_B,
+                10038
+            ),
+            new Issue(
+                self::TypeExpectedObjectStaticPropAccess,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                'Expected an object instance or a class name when accessing a static property, but saw an expression with type {TYPE}',
+                self::REMEDIATION_B,
+                10039
             ),
             // Issue::CATEGORY_VARIABLE
             new Issue(

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -1341,6 +1341,18 @@ class UnionType implements \Serializable
     }
 
     /**
+     * Returns true if objectTypes would be non-empty.
+     *
+     * @return bool
+     */
+    public function hasObjectTypes() : bool
+    {
+        return ArraySet::exists($this->type_set, (function (Type $type) : bool {
+            return $type->isObject();
+        }));
+    }
+
+    /**
      * Returns the types for which is_scalar($x) would be true.
      * This means null/nullable is removed.
      * Takes "MyClass|int|?bool|array|?object" and returns "int|bool"

--- a/tests/files/expected/0379_bad_prop_access.php.expected
+++ b/tests/files/expected/0379_bad_prop_access.php.expected
@@ -1,0 +1,5 @@
+%s:5 PhanTypeExpectedObjectPropAccess Expected an object instance when accessing an instance property, but saw an expression with type string
+%s:7 PhanTypeExpectedObjectPropAccess Expected an object instance when accessing an instance property, but saw an expression with type float
+%s:9 PhanTypeExpectedObjectStaticPropAccess Expected an object instance or a class name when accessing a static property, but saw an expression with type float
+%s:11 PhanTypeExpectedObjectPropAccess Expected an object instance when accessing an instance property, but saw an expression with type int
+%s:14 PhanTypeExpectedObjectOrClassName Expected an object instance or the name of a class but saw expression with type int

--- a/tests/files/src/0379_bad_prop_access.php
+++ b/tests/files/src/0379_bad_prop_access.php
@@ -1,0 +1,16 @@
+<?php
+function main379(string $value) {
+    $array = ['a' -> $value];  // Should be 'a' => $value
+    $str = 'a';
+    $str->$value = 33;  // Should warn about accessing property of a string.
+    $pi = 3.14;
+    $pi->value = 3.14159;  // should warn
+    $e = 2.718;
+    $e::$value = 2.71828;  // should warn
+    $four = 4;
+    $four->$value = 5;  // should warn about left hand side, even for dynamic property access
+
+    $eleven = 11;
+    echo $eleven::value . "\n";  // should warn
+    return $array;
+}


### PR DESCRIPTION
...but non-object/non-classes were provided.

This covers various places that expect a class instance or class name:
instanceof checks, assignment to properties,
fetches of properties, use of class constants, etc.

Fixes #1268