### PR TITLE
Split out issue type PhanUnreferencedClosure for closures

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,7 @@ New Features(Analysis)
   Analysis will now warn if a callable no longer exists.
   This change also reduces false positives in dead code detection.
 + Warn if attempting to read/write to an property or constant when the expression is a non-object (or not a class name, for static elements) (#1268)
++ Split `PhanUnreferencedClosure` out of `PhanUnreferencedFunction` (Emitted by `--dead-code-detection`)
 
 New Features (CLI, Configs)
 + Improve default update rate of `--progress-bar` (Update it every 0.10 seconds)
@@ -33,7 +34,7 @@ Bug Fixes
 
 Plugins
 + Make DuplicateArrayKeyPlugin start warning about duplicate values of known global constants and class constants. (#1139)
-+ Support 'plugins' => ['AlwaysReturnPlugin'] as shorthand for full relative path to a bundled plugin such as AlwaysReturnPlugin.php (#1209)
++ Support `'plugins' => ['AlwaysReturnPlugin']` as shorthand for full relative path to a bundled plugin such as AlwaysReturnPlugin.php (#1209)
 
 20 Oct 2017, Phan 0.10.1
 ------------------------

--- a/src/Phan/Analysis/ReferenceCountsAnalyzer.php
+++ b/src/Phan/Analysis/ReferenceCountsAnalyzer.php
@@ -292,6 +292,9 @@ class ReferenceCountsAnalyzer
                     if (\strcasecmp($element->getName(), "__autoload") === 0) {
                         return;
                     }
+                    if ($element->getFQSEN()->isClosure()) {
+                        $issue_type = Issue::UnreferencedClosure;
+                    }
                 }
 
                 // If there are duplicate declarations, display issues for unreferenced elements on each declaration.

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -170,6 +170,7 @@ class Issue
     const UnreferencedMethod        = 'PhanUnreferencedMethod';
     const UnreferencedProperty      = 'PhanUnreferencedProperty';
     const UnreferencedConstant      = 'PhanUnreferencedConstant';
+    const UnreferencedClosure       = 'PhanUnreferencedClosure';
 
     // Issue::CATEGORY_REDEFINE
     const RedefineClass             = 'PhanRedefineClass';
@@ -1547,6 +1548,14 @@ class Issue
                 "Possibly zero references to function {FUNCTION}",
                 self::REMEDIATION_B,
                 6009
+            ),
+            new Issue(
+                self::UnreferencedClosure,
+                self::CATEGORY_NOOP,
+                self::SEVERITY_NORMAL,
+                "Possibly zero references to closure {FUNCTION}",
+                self::REMEDIATION_B,
+                6010
             ),
 
             // Issue::CATEGORY_REDEFINE

--- a/src/Phan/Library/Composer/IniHelper.php
+++ b/src/Phan/Library/Composer/IniHelper.php
@@ -66,20 +66,4 @@ class IniHelper
 
         return $paths;
     }
-
-    /**
-     * Describes the location of the loaded php.ini file
-     *
-     * @return string
-     */
-    public static function getMessage()
-    {
-        $paths = self::getAll();
-
-        if (empty($paths[0])) {
-            return 'A php.ini file does not exist. You will have to create one.';
-        }
-
-        return 'The php.ini used by your command-line PHP is: '.$paths[0];
-    }
 }

--- a/tests/plugin_test/expected/017_unreferenced_closure.php.expected
+++ b/tests/plugin_test/expected/017_unreferenced_closure.php.expected
@@ -1,0 +1,1 @@
+src/017_unreferenced_closure.php:10 PhanUnreferencedClosure Possibly zero references to closure \closure_%s

--- a/tests/plugin_test/src/006_preg_regex.php
+++ b/tests/plugin_test/src/006_preg_regex.php
@@ -7,7 +7,7 @@ echo preg_replace('@foo(@', 'foobar', $x);
 preg_match('/\w\+/', '  words', $matches);
 var_export($matches);
 
-/** @suppress PhanUnreferencedFunction */
+/** @suppress PhanUnreferencedClosure */
 call_user_func(function() {
     echo preg_replace_callback_array(['@a@' => function($x) { return 'i'; }], 'bad');
     echo preg_replace_callback_array(['@a' => function($x) { return 'i'; }], 'bad');

--- a/tests/plugin_test/src/017_unreferenced_closure.php
+++ b/tests/plugin_test/src/017_unreferenced_closure.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Simple test of Phan's ability to infer if a closure is unused.
+ * Phan has false positives with arrays, as well as closures being returned from functions.
+ * @suppress PhanNoopArray
+ */
+function test17() {
+    [
+        (function(string $x) { echo "$x\n"; })('test'),
+        [function(string $x) { echo "$x\n"; }],
+    ];
+}
+test17();

--- a/tests/plugin_test/test.sh
+++ b/tests/plugin_test/test.sh
@@ -14,6 +14,8 @@ fi
 echo "Running phan in '$PWD' ..."
 rm $ACTUAL_PATH -f || exit 1
 ../../phan --memory-limit 1G | tee $ACTUAL_PATH
+sed -i 's,\<closure_[0-9a-f]\{12\}\>,closure_%s,g' $ACTUAL_PATH
+sed -i 's,\<closure_[0-9a-f]\{12\}\>,closure_%s,g' $EXPECTED_PATH
 # diff returns a non-zero exit code if files differ or are missing
 # This outputs the difference between actual and expected output.
 echo


### PR DESCRIPTION
(out of PhanUnreferencedFunction)

Give users granular options in analyzing and fixing these issues.