### PR TITLE
 Fix false positives in self-analysis (unreferenced constants) 

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -176,6 +176,7 @@ return [
     // here to inhibit them from being reported
     'suppress_issue_types' => [
         'PhanPluginMixedKeyNoKey',  // FunctionSignatureMap.php has many of these, intentionally.
+        'PhanUnreferencedClosure',  // False positives seen with closures in arrays, TODO: move closure checks closer to what is done by unused variable plugin
         // 'PhanUndeclaredMethod',
     ],
 

--- a/NEWS
+++ b/NEWS
@@ -47,6 +47,8 @@ Plugins
 Maintenance
 + Used PHP_CodeSniffer to automatically make Phan's source directory adhere closely to PSR-1 and PSR-2, making minor changes to many files.
   (e.g. which line each brace goes on, etc.)
++ Stop tracking references to internal (non user-defined) elements (constants, properties, functions, classes, and methods) during dead code detection.
+  (Dead code detection now requires an extra 15MB instead of 17MB for self-analysis)
 
 20 Oct 2017, Phan 0.10.1
 ------------------------

--- a/internal/phpcbf
+++ b/internal/phpcbf
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# This has been tested with phpcbf.phar 3.1.1 (3.1.1 or newer is suggested)
+set -eu
+if [[ "$#" != 0 ]]; then
+	echo "Executing phpcbf.phar --standard=ruleset.xml $@"  1>&2
+	phpcbf.phar --standard=ruleset.xml "$@"
+else
+	# Automatically fix PSR-2 syntax issues in Phan itself
+	phpcbf.phar --standard=ruleset.xml tests/Phan src
+fi

--- a/internal/phpcs
+++ b/internal/phpcs
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# This has been tested with phpcs.phar 3.1.1 (3.1.1 or newer is suggested)
+set -xu
+# Automatically detect PSR-2 syntax issues in Phan itself
+if [[ "$#" != 0 ]]; then
+	echo "Executing phpcs.phar --standard=ruleset.xml $@"  1>&2
+	phpcs.phar --standard=ruleset.xml "$@"
+else
+	# Automatically fix PSR-2 syntax issues in Phan itself
+	phpcs.phar --standard=ruleset.xml tests/Phan src
+fi

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1970,10 +1970,10 @@ class UnionTypeVisitor extends AnalysisVisitor
      * @param CodeBase $code_base
      * @param Context $context
      * @param string|Node $node the node to fetch CallableType instances for.
-     * @param bool $unused_log_error whether or not to log errors while searching (TODO: use)
      * @return FullyQualifiedFunctionLikeName[]
+     * @suppress PhanUnreferencedPublicMethod may be used in the future.
      */
-    public static function functionLikeFQSENListFromNodeAndContext(CodeBase $code_base, Context $context, $node, bool $unused_log_error) : array
+    public static function functionLikeFQSENListFromNodeAndContext(CodeBase $code_base, Context $context, $node) : array
     {
         return (new UnionTypeVisitor($code_base, $context, true))->functionLikeFQSENListFromNode($node);
     }

--- a/src/Phan/AST/Visitor/Element.php
+++ b/src/Phan/AST/Visitor/Element.php
@@ -216,7 +216,7 @@ class Element
      * Accepts a visitor that differentiates on the flag value
      * of the AST node.
      *
-     * @suppress PhanUnreferencedMethod
+     * @suppress PhanUnreferencedPublicMethod
      */
     public function acceptClassFlagVisitor(FlagVisitor $visitor)
     {
@@ -245,7 +245,7 @@ class Element
      * Accepts a visitor that differentiates on the flag value
      * of the AST node.
      *
-     * @suppress PhanUnreferencedMethod
+     * @suppress PhanUnreferencedPublicMethod
      */
     public function acceptNameFlagVisitor(FlagVisitor $visitor)
     {
@@ -270,7 +270,7 @@ class Element
      * Accepts a visitor that differentiates on the flag value
      * of the AST node.
      *
-     * @suppress PhanUnreferencedMethod
+     * @suppress PhanUnreferencedPublicMethod
      */
     public function acceptParamFlagVisitor(FlagVisitor $visitor)
     {
@@ -293,7 +293,7 @@ class Element
      * Accepts a visitor that differentiates on the flag value
      * of the AST node.
      *
-     * @suppress PhanUnreferencedMethod
+     * @suppress PhanUnreferencedPublicMethod
      */
     public function acceptTypeFlagVisitor(FlagVisitor $visitor)
     {
@@ -328,7 +328,7 @@ class Element
      * Accepts a visitor that differentiates on the flag value
      * of the AST node.
      *
-     * @suppress PhanUnreferencedMethod
+     * @suppress PhanUnreferencedPublicMethod
      */
     public function acceptUnaryFlagVisitor(FlagVisitor $visitor)
     {
@@ -357,7 +357,7 @@ class Element
      * Accepts a visitor that differentiates on the flag value
      * of the AST node.
      *
-     * @suppress PhanUnreferencedMethod
+     * @suppress PhanUnreferencedPublicMethod
      */
     public function acceptExecFlagVisitor(FlagVisitor $visitor)
     {
@@ -386,7 +386,7 @@ class Element
      * Accepts a visitor that differentiates on the flag value
      * of the AST node.
      *
-     * @suppress PhanUnreferencedMethod
+     * @suppress PhanUnreferencedPublicMethod
      */
     public function acceptMagicFlagVisitor(FlagVisitor $visitor)
     {
@@ -421,7 +421,7 @@ class Element
      * Accepts a visitor that differentiates on the flag value
      * of the AST node.
      *
-     * @suppress PhanUnreferencedMethod
+     * @suppress PhanUnreferencedPublicMethod
      */
     public function acceptUseFlagVisitor(FlagVisitor $visitor)
     {
@@ -446,7 +446,7 @@ class Element
      * Accepts a visitor that differentiates on the flag value
      * of the AST node.
      *
-     * @suppress PhanUnreferencedMethod
+     * @suppress PhanUnreferencedPublicMethod
      */
     public function acceptAnyFlagVisitor(FlagVisitor $visitor)
     {

--- a/src/Phan/Analysis/ArgumentVisitor.php
+++ b/src/Phan/Analysis/ArgumentVisitor.php
@@ -206,7 +206,7 @@ class ArgumentVisitor extends KindVisitorImplementation
      */
     public function visitMethodCall(Node $node)
     {
-        return $this->visitCall($node);
+        $this->visitCall($node);
     }
 
     /**
@@ -217,6 +217,6 @@ class ArgumentVisitor extends KindVisitorImplementation
      */
     public function visitStaticCall(Node $node)
     {
-        return $this->visitCall($node);
+        $this->visitCall($node);
     }
 }

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -496,17 +496,15 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             $nameNode = $node->children['name'];
             // Based on UnionTypeVisitor::visitConst
             if ($nameNode->kind == \ast\AST_NAME) {
-                if (defined($nameNode->children['name'])) {
-                    // Do nothing, this is an internal type such as `true` or `\ast\AST_NAME`
-                } else {
-                    $constant = (new ContextNode(
-                        $this->code_base,
-                        $this->context,
-                        $node
-                    ))->getConst();
+                $constant = (new ContextNode(
+                    $this->code_base,
+                    $this->context,
+                    $node
+                ))->getConst();
 
-                    // Mark that this constant has been referenced from
-                    // this context
+                // Mark that this constant has been referenced from
+                // this context
+                if (!$constant->isPHPInternal()) {
                     $constant->addReference($this->context);
                 }
             }

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -492,21 +492,20 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
      */
     public function visitConst(Node $node) : Context
     {
+        $context = $this->context;
         try {
             $nameNode = $node->children['name'];
             // Based on UnionTypeVisitor::visitConst
             if ($nameNode->kind == \ast\AST_NAME) {
                 $constant = (new ContextNode(
                     $this->code_base,
-                    $this->context,
+                    $context,
                     $node
                 ))->getConst();
 
                 // Mark that this constant has been referenced from
                 // this context
-                if (!$constant->isPHPInternal()) {
-                    $constant->addReference($this->context);
-                }
+                $constant->addReference($context);
             }
         } catch (IssueException $exception) {
             // We need to do this in order to check keys and (after the first 5) values in AST arrays.
@@ -514,7 +513,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             // (This issue may be a duplicate)
             Issue::maybeEmitInstance(
                 $this->code_base,
-                $this->context,
+                $context,
                 $exception->getIssueInstance()
             );
         } catch (\Exception $exception) {
@@ -526,7 +525,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         // constant
         $this->analyzeNoOp($node, Issue::NoopConstant);
 
-        return $this->context;
+        return $context;
     }
 
     /**

--- a/src/Phan/Bootstrap.php
+++ b/src/Phan/Bootstrap.php
@@ -60,7 +60,7 @@ function with_disabled_phan_error_handler(Closure $closure)
  * The error handler for PHP notices, etc.
  * This is a named function instead of a closure to make stack traces easier to read.
  *
- * @suppress PhanUnreferencedMethod
+ * @suppress PhanUnreferencedFunction
  */
 function phan_error_handler($errno, $errstr, $errfile, $errline)
 {

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -31,7 +31,7 @@ class CLI
     /**
      * @return OutputInterface
      */
-    public function getOutput():OutputInterface
+    public function getOutput() : OutputInterface
     {
         return $this->output;
     }

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -50,6 +50,7 @@ use ReflectionClass;
  *     $internal_class_name_list,
  *     $internal_interface_name_list,
  *     $internal_trait_name_list,
+ *     CodeBase::getPHPInternalConstantNameList(),
  *     $internal_function_name_list
  *  );
  *
@@ -1258,5 +1259,21 @@ class CodeBase
     {
         // TODO: ...
         return [];
+    }
+
+    /**
+     * @return string[] every constant name except user-defined constants.
+     */
+    public static function getPHPInternalConstantNameList() : array
+    {
+        // Unit tests call this on every test case. Cache the **internal** constants in a static variable for efficiency; those won't change.
+        static $constant_name_list = null;
+        if ($constant_name_list === null) {
+            // 'true', 'false', and 'null' aren't actually defined constants, they're keywords? Add them so that analysis won't break.
+            $constant_name_list = \array_keys(\array_merge(['true' => true, 'false' => false, 'null' => null], ...\array_values(
+                \array_diff_key(\get_defined_constants(true), ['user' => []])
+            )));
+        }
+        return $constant_name_list;
     }
 }

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -25,7 +25,7 @@ class Config
      * and the results of version_compare.
      * PluginV2 will correspond to 2.x.y, PluginV3 will correspond to 3.x.y, etc.
      * New features increment minor versions, and bug fixes increment patch versions.
-     * @suppress PhanUnreferencedConstant
+     * @suppress PhanUnreferencedPublicClassConstant
      */
     const PHAN_PLUGIN_VERSION = '2.2.0';
 
@@ -517,8 +517,16 @@ class Config
             // 'PhanUnextractableAnnotationPart',
             // 'PhanUnreferencedClass',
             // 'PhanUnreferencedConstant',
-            // 'PhanUnreferencedMethod',
-            // 'PhanUnreferencedProperty',
+            // 'PhanUnreferencedPublicClassConstant',
+            // 'PhanUnreferencedProtectedClassConstant',
+            // 'PhanUnreferencedPrivateClassConstant',
+            // 'PhanUnreferencedPublicMethod',
+            // 'PhanUnreferencedProtectedMethod',
+            // 'PhanUnreferencedPrivateMethod',
+            // 'PhanUnreferencedPublicMethod',
+            // 'PhanUnreferencedPublicProperty',
+            // 'PhanUnreferencedProtectedProperty',
+            // 'PhanUnreferencedPublicProperty',
             // 'PhanVariableUseClause',
         ],
 
@@ -792,7 +800,7 @@ class Config
      * @return string
      * The relative path appended to the project root directory.
      *
-     * @suppress PhanUnreferencedMethod
+     * @suppress PhanUnreferencedPublicMethod
      */
     public static function projectPath(string $relative_path)
     {

--- a/src/Phan/Debug.php
+++ b/src/Phan/Debug.php
@@ -19,7 +19,7 @@ class Debug
      * Print a lil' something to the console to
      * see if a thing is called
      *
-     * @suppress PhanUnreferencedMethod
+     * @suppress PhanUnreferencedPublicMethod
      */
     public static function mark()
     {
@@ -34,7 +34,7 @@ class Debug
      *
      * @return void
      *
-     * @suppress PhanUnreferencedMethod
+     * @suppress PhanUnreferencedPublicMethod
      */
     public static function printNode($node)
     {
@@ -44,7 +44,7 @@ class Debug
     /**
      * Print the name of a node to the terminal
      *
-     * @suppress PhanUnreferencedMethod
+     * @suppress PhanUnreferencedPublicMethod
      */
     public static function printNodeName($node, $indent = 0)
     {
@@ -56,7 +56,7 @@ class Debug
     /**
      * Print a thing with the given indent level
      *
-     * @suppress PhanUnreferencedMethod
+     * @suppress PhanUnreferencedPublicMethod
      */
     public static function print(string $message, int $indent = 0)
     {
@@ -203,7 +203,7 @@ class Debug
      * @return void
      * Pretty-printer for debug_backtrace
      *
-     * @suppress PhanUnreferencedMethod
+     * @suppress PhanUnreferencedPublicMethod
      */
     public static function backtrace(int $levels = 0)
     {

--- a/src/Phan/Exception/CodeBaseException.php
+++ b/src/Phan/Exception/CodeBaseException.php
@@ -28,7 +28,7 @@ class CodeBaseException extends \Exception
      * @return bool
      * True if we have an FQSEN defined
      *
-     * @suppress PhanUnreferencedMethod
+     * @suppress PhanUnreferencedPublicMethod
      */
     public function hasFQSEN() : bool
     {

--- a/src/Phan/Exception/NodeException.php
+++ b/src/Phan/Exception/NodeException.php
@@ -30,7 +30,7 @@ class NodeException extends \Exception
      * @return Node
      * The node for which we have an exception
      *
-     * @suppress PhanUnreferencedMethod
+     * @suppress PhanUnreferencedPublicMethod
      */
     public function getNode() : Node
     {

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -2216,6 +2216,7 @@ class Issue
      * message
      *
      * @return void
+     * @suppress PhanUnreferencedPublicMethod
      */
     public static function emit(
         string $type,

--- a/src/Phan/Language/Element/AddressableElement.php
+++ b/src/Phan/Language/Element/AddressableElement.php
@@ -182,6 +182,12 @@ abstract class AddressableElement extends TypedElement implements AddressableEle
     public function addReference(FileRef $file_ref)
     {
         if (Config::get_track_references()) {
+            // Currently, we don't need to track references to PHP-internal methods/functions/constants
+            // such as PHP_VERSION, strlen(), Closure::bind(), etc.
+            // This may change in the future.
+            if ($this->isPHPInternal()) {
+                return;
+            }
             $this->reference_list[(string)$file_ref] = $file_ref;
         }
     }

--- a/src/Phan/Language/Element/Comment.php
+++ b/src/Phan/Language/Element/Comment.php
@@ -939,7 +939,7 @@ class Comment
     /**
      * @return CommentParameter[] (The leftover parameters without a name)
      *
-     * @suppress PhanUnreferencedMethod
+     * @suppress PhanUnreferencedPublicMethod
      */
     public function getParameterList() : array
     {
@@ -949,7 +949,7 @@ class Comment
     /**
      * @return CommentParameter[] (maps the names of parameters to their values. Does not include parameters which didn't provide names)
      *
-     * @suppress PhanUnreferencedMethod
+     * @suppress PhanUnreferencedPublicMethod
      */
     public function getParameterMap() : array
     {
@@ -976,7 +976,7 @@ class Comment
 
     /**
      * @return string[]
-     * A set of issue names like 'PhanUnreferencedMethod' to suppress
+     * A set of issue names like 'PhanUnreferencedPublicMethod' to suppress
      */
     public function getSuppressIssueList() : array
     {

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -394,18 +394,6 @@ class UnionType implements \Serializable
 
     /**
      * @return bool
-     * True if this union type has any types that are generic
-     * types.
-     */
-    private function hasGenericType() : bool
-    {
-        return ArraySet::exists($this->type_set, function (Type $type) : bool {
-            return $type->hasTemplateParameterTypes();
-        });
-    }
-
-    /**
-     * @return bool
      * True if this union type has any types that are bool/false/true types
      */
     public function hasTypeInBoolFamily() : bool
@@ -1131,6 +1119,7 @@ class UnionType implements \Serializable
      * @return bool
      * True if this union type represents types that are arrays
      * or generic arrays, but nothing else.
+     * @suppress PhanUnreferencedPublicMethod
      */
     public function isExclusivelyArray() : bool
     {
@@ -1297,6 +1286,8 @@ class UnionType implements \Serializable
      *
      * @return UnionType
      * A UnionType with generic array types filtered out
+     *
+     * @suppress PhanUnreferencedPublicMethod
      */
     public function nonGenericArrayTypes() : UnionType
     {
@@ -1399,8 +1390,9 @@ class UnionType implements \Serializable
      * @return bool
      * A UnionType with known callable types kept, other types filtered out.
      *
-     * @see nonGenericArrayTypes
-     * @see genericArrayElementTypes
+     * @see $this->callableTypes()
+     *
+     * @suppress PhanUnreferencedPublicMethod
      */
     public function hasCallableType() : bool
     {

--- a/src/Phan/LanguageServer/FileMapping.php
+++ b/src/Phan/LanguageServer/FileMapping.php
@@ -32,12 +32,7 @@ class FileMapping
      */
     public function addOverrideURI(string $uri, $new_contents)
     {
-        $path = Utils::uriToPath($uri);
-        if ($new_contents === null) {
-            $this->removeOverride($path);
-            return;
-        }
-        $this->overrides[$path] = $new_contents;
+        $this->addOverride(Utils::uriToPath($uri), $new_contents);
     }
 
     /**

--- a/src/Phan/LanguageServer/Utils.php
+++ b/src/Phan/LanguageServer/Utils.php
@@ -15,7 +15,10 @@ use Throwable;
  */
 class Utils
 {
-    /** @return void */
+    /**
+     * @return void
+     * @suppress PhanUnreferencedPublicMethod
+     */
     public static function crash(Throwable $err)
     {
         Loop\nextTick(function () use ($err) {

--- a/src/Phan/Library/ArraySet.php
+++ b/src/Phan/Library/ArraySet.php
@@ -18,6 +18,7 @@ final class ArraySet
     /**
      * @param Type $object
      * @return Type[]
+     * @suppress PhanUnreferencedPublicMethod callers inlined this for performanced.
      */
     public static function singleton($object) : array
     {
@@ -91,6 +92,8 @@ final class ArraySet
      * Just use array_filter - array_filter preserves keys.
      * @param Type[] $object_set
      * @param \Closure $cb
+     * @deprecated
+     * @suppress PhanUnreferencedPublicMethod callers inlined this for performanced.
      */
     public static function filter(array $object_set, \Closure $cb) : array
     {
@@ -150,6 +153,7 @@ final class ArraySet
      * Helper function for assertions.
      * @param Type[] $object_set
      * @return bool - Whether or not this is an object set.
+     * @suppress PhanUnreferencedPublicMethod this is only used as a sanity check
      */
     public static function is_array_set(array $object_set)
     {

--- a/src/Phan/Library/Set.php
+++ b/src/Phan/Library/Set.php
@@ -77,7 +77,7 @@ class Set extends \SplObjectStorage
      * A new set which contains only items in this
      * Set and the given Set.
      *
-     * @suppress PhanUnreferencedMethod
+     * @suppress PhanUnreferencedPublicMethod
      */
     public function union(Set $other) : Set
     {

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -1110,7 +1110,7 @@ class ParseVisitor extends ScopeVisitor
         Node $node,
         string $name,
         $value,
-        int $flags = 0,
+        int $flags,
         string $comment_string
     ) {
         // Give it a fully-qualified name

--- a/src/codebase.php
+++ b/src/codebase.php
@@ -4,11 +4,6 @@
 $internal_class_name_list = get_declared_classes();
 $internal_interface_name_list = get_declared_interfaces();
 $internal_trait_name_list = get_declared_traits();
-// Get everything except user-defined constants
-$internal_const_name_list = array_keys(array_merge(['true' => true, 'false' => false, 'null' => null], ...array_values(
-    array_diff_key(get_defined_constants(true), ['user' => []])
-)));
-
 $internal_function_name_list = get_defined_functions()['internal'];
 
 if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
@@ -25,6 +20,6 @@ return new CodeBase(
     $internal_class_name_list,
     $internal_interface_name_list,
     $internal_trait_name_list,
-    $internal_const_name_list,
+    CodeBase::getPHPInternalConstantNameList(),
     $internal_function_name_list
 );

--- a/tests/Phan/AbstractPhanFileTest.php
+++ b/tests/Phan/AbstractPhanFileTest.php
@@ -26,7 +26,7 @@ abstract class AbstractPhanFileTest extends BaseTest implements CodeBaseAwareTes
     abstract public function getTestFiles();
 
     /**
-     * Setup our state before running reach test
+     * Setup our state before running each test
      *
      * @return void
      */

--- a/tests/Phan/AnalyzerTest.php
+++ b/tests/Phan/AnalyzerTest.php
@@ -6,9 +6,6 @@ namespace Phan\Tests;
 $internal_class_name_list = get_declared_classes();
 $internal_interface_name_list = get_declared_interfaces();
 $internal_trait_name_list = get_declared_traits();
-$internal_const_name_list = array_keys(array_merge(...array_values(
-    array_diff_key(get_defined_constants(true), ['user' => []])
-)));
 $internal_function_name_list = get_defined_functions()['internal'];
 
 use Phan\Analysis;
@@ -41,7 +38,7 @@ class AnalyzerTest extends BaseTest
         $this->class_name_list = $internal_class_name_list;
         $this->interface_name_list = $internal_interface_name_list;
         $this->trait_name_list = $internal_trait_name_list;
-        $this->const_name_list = $internal_const_name_list;
+        $this->const_name_list = CodeBase::getPHPInternalConstantNameList();
         $this->function_name_list = $internal_function_name_list;
 
 

--- a/tests/Phan/Language/UnionTypeTest.php
+++ b/tests/Phan/Language/UnionTypeTest.php
@@ -27,9 +27,6 @@ use Phan\Language\Type\VoidType;
 $internal_class_name_list = get_declared_classes();
 $internal_interface_name_list = get_declared_interfaces();
 $internal_trait_name_list = get_declared_traits();
-$internal_const_name_list = array_keys(array_merge(...array_values(
-    array_diff_key(get_defined_constants(true), ['user' => []])
-)));
 $internal_function_name_list = get_defined_functions()['internal'];
 
 use Phan\CodeBase;
@@ -66,7 +63,6 @@ class UnionTypeTest extends BaseTest
         global $internal_class_name_list;
         global $internal_interface_name_list;
         global $internal_trait_name_list;
-        global $internal_const_name_list;
         global $internal_function_name_list;
 
         if (self::$code_base === null) {
@@ -74,7 +70,7 @@ class UnionTypeTest extends BaseTest
                 $internal_class_name_list,
                 $internal_interface_name_list,
                 $internal_trait_name_list,
-                $internal_const_name_list,
+                CodeBase::getPHPInternalConstantNameList(),
                 $internal_function_name_list
             );
         }

--- a/tests/Phan/PhanTestListener.php
+++ b/tests/Phan/PhanTestListener.php
@@ -4,16 +4,11 @@ namespace Phan\Tests;
 global $internal_class_name_list;
 global $internal_interface_name_list;
 global $internal_trait_name_list;
-global $internal_const_name_list;
 global $internal_function_name_list;
 
 $internal_class_name_list = get_declared_classes();
 $internal_interface_name_list = get_declared_interfaces();
 $internal_trait_name_list = get_declared_traits();
-// Get everything except user-defined constants
-$internal_const_name_list = array_keys(array_merge(...array_values(
-    array_diff_key(get_defined_constants(true), ['user' => []])
-)));
 $internal_function_name_list = get_defined_functions()['internal'];
 
 use Phan\CodeBase;
@@ -39,14 +34,13 @@ class PhanTestListener extends BaseTestListener
                 global $internal_class_name_list;
                 global $internal_interface_name_list;
                 global $internal_trait_name_list;
-                global $internal_const_name_list;
                 global $internal_function_name_list;
 
                 $code_base = new CodeBase(
                     $internal_class_name_list,
                     $internal_interface_name_list,
                     $internal_trait_name_list,
-                    $internal_const_name_list,
+                    CodeBase::getPHPInternalConstantNameList(),  // Get everything except user-defined constants
                     $internal_function_name_list
                 );
             }


### PR DESCRIPTION
Use $constant->isPHPInternal() instead of defined('constant_name') to check if a constant is internal before marking a constant as referenced.
Phan's own constants were treated as internal and not marked as used, which meant dead code detection checks behaved incorrectly for those constants.

