### PR TITLE
 Allow union types to be template type arguments. 

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -36,6 +36,10 @@ New Features(Analysis)
   `PhanTypeExpectedObject`, and `PhanTypeExpectedObjectOrClassName
 + Emit more accurate line numbers for phpdoc comments, when warning about phpdoc in doc comments being invalid. (#1294)
   This gives up and uses the element's line number if the phpdoc ends over 10 lines before the start of the element.
++ Work on allowing union types to be part of template types in doc comments,
+  as well as types with template syntax.
+  (e.g. `array<int|string>` is now equivalent to `int[]|string[]`,
+  and `MyClass<T1|T2,T3|T4>` can now be parsed in doc comments)
 
 New Features (CLI, Configs)
 + Improve default update rate of `--progress-bar` (Update it every 0.10 seconds)

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -1754,41 +1754,42 @@ class ContextNode
         return $this->getValueForMagicConstByNode($this->node);
     }
 
-    public function getValueForMagicConstByNode(Node $node) {
+    public function getValueForMagicConstByNode(Node $node)
+    {
         $context = $this->context;
         switch ($node->flags) {
-        case ast\flags\MAGIC_CLASS:
-            if ($context->isInClassScope()) {
-                return (string)$context->getClassFQSEN();
-            }
-            return $node;
-        case ast\flags\MAGIC_FUNCTION:
-            if ($context->isInFunctionLikeScope()) {
-                $fqsen = $context->getFunctionLikeFQSEN();
-                return $fqsen->isClosure() ? '{closure}' : $fqsen->getName();
-            }
-            return $node;
-        case ast\flags\MAGIC_METHOD:
-            // TODO: Is this right?
-            if ($context->isInMethodScope()) {
-                return \ltrim((string)$context->getFunctionLikeFQSEN(), '\\');
-            }
-            return $node;
-        case ast\flags\MAGIC_DIR:
-            // TODO: Absolute directory?
-            return \dirname($context->getFile());
-        case ast\flags\MAGIC_FILE:
-            return $context->getFile();
-        case ast\flags\MAGIC_LINE:
-            return $node->lineno ?? $context->getLineNumberStart();
-        case ast\flags\MAGIC_NAMESPACE:
-            return \ltrim($context->getNamespace(), '\\');
-        case ast\flags\MAGIC_TRAIT:
-            // TODO: Could check if in trait, low importance.
-            if ($context->isInClassScope()) {
-                return (string)$context->getClassFQSEN();
-            }
-            return $node;
+            case ast\flags\MAGIC_CLASS:
+                if ($context->isInClassScope()) {
+                    return (string)$context->getClassFQSEN();
+                }
+                return $node;
+            case ast\flags\MAGIC_FUNCTION:
+                if ($context->isInFunctionLikeScope()) {
+                    $fqsen = $context->getFunctionLikeFQSEN();
+                    return $fqsen->isClosure() ? '{closure}' : $fqsen->getName();
+                }
+                return $node;
+            case ast\flags\MAGIC_METHOD:
+                // TODO: Is this right?
+                if ($context->isInMethodScope()) {
+                    return \ltrim((string)$context->getFunctionLikeFQSEN(), '\\');
+                }
+                return $node;
+            case ast\flags\MAGIC_DIR:
+                // TODO: Absolute directory?
+                return \dirname($context->getFile());
+            case ast\flags\MAGIC_FILE:
+                return $context->getFile();
+            case ast\flags\MAGIC_LINE:
+                return $node->lineno ?? $context->getLineNumberStart();
+            case ast\flags\MAGIC_NAMESPACE:
+                return \ltrim($context->getNamespace(), '\\');
+            case ast\flags\MAGIC_TRAIT:
+                // TODO: Could check if in trait, low importance.
+                if ($context->isInClassScope()) {
+                    return (string)$context->getClassFQSEN();
+                }
+                return $node;
         }
         return $node;
     }

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -2141,7 +2141,7 @@ class UnionTypeVisitor extends AnalysisVisitor
         $context = $this->context;
 
         if (!\is_string($method_name)) {
-            if (!($method_name instanceof Node))  {
+            if (!($method_name instanceof Node)) {
                 // TODO: Warn about int/float here
                 return [];
             }

--- a/src/Phan/Language/Element/Comment.php
+++ b/src/Phan/Language/Element/Comment.php
@@ -223,7 +223,8 @@ class Comment
         }
     }
 
-    private static function guessActualLineLocation(Context $context, int $declaration_lineno, int $i, int $comment_lines_count, string $line) {
+    private static function guessActualLineLocation(Context $context, int $declaration_lineno, int $i, int $comment_lines_count, string $line)
+    {
         $path = Config::projectPath($context->getFile());
         $entry = FileCache::getEntry($path);
         if (!$entry) {

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -1410,7 +1410,7 @@ class Type
             $clazz = $code_base->getClassByFQSEN($class_fqsen);
 
             $union_type->addUnionType(
-                 $clazz->getUnionType()
+                $clazz->getUnionType()
             );
 
             // Recurse up the tree to include all types

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -11,6 +11,7 @@ use Phan\Language\Type\ClosureType;
 use Phan\Language\Type\FalseType;
 use Phan\Language\Type\FloatType;
 use Phan\Language\Type\GenericArrayType;
+use Phan\Language\Type\GenericMultiArrayType;
 use Phan\Language\Type\IntType;
 use Phan\Language\Type\IterableType;
 use Phan\Language\Type\MixedType;
@@ -106,9 +107,9 @@ class Type
         . '(' . self::simple_type_regex . ')'  // 2 patterns
         . '(?:<'
           . '('
-            . '(?-4)'
+            . '(?-4)(?:\|(?-4))*'
             . '(\s*,\s*'
-              . '(?-6)'
+              . '(?-5)(?:\|(?-5))*'
             . ')*'
           . ')'
         . '>)?'
@@ -128,9 +129,9 @@ class Type
           . '(' . self::simple_type_regex_or_this . ')'  // 3 patterns
           . '(?:<'
             . '('
-              . '(?-6)'  // We use relative references instead of named references so that more than one one type_regex can be used in a regex.
+              . '(?-6)(?:\|(?-6))*'  // We use relative references instead of named references so that more than one one type_regex can be used in a regex.
               . '(\s*,\s*'
-                . '(?-7)'
+                . '(?-7)(?:\|(?-7))*'
               . ')*'
             . ')'
           . '>)?'
@@ -294,7 +295,7 @@ class Type
     protected static function make(
         string $namespace,
         string $type_name,
-        $template_parameter_type_list,
+        array $template_parameter_type_list,
         bool $is_nullable,
         int $source
     ) : Type {
@@ -412,7 +413,7 @@ class Type
      */
     public static function fromType(
         Type $type,
-        $template_parameter_type_list
+        array $template_parameter_type_list
     ) : Type {
         return self::make(
             $type->getNamespace(),
@@ -622,7 +623,7 @@ class Type
     public static function fromNamespaceAndName(
         string $namespace,
         string $type_name,
-        bool  $is_nullable
+        bool $is_nullable
     ) : Type {
         return self::make($namespace, $type_name, [], $is_nullable, Type::FROM_NODE);
     }
@@ -684,7 +685,7 @@ class Type
         // Map the names of the types to actual types in the
         // template parameter type list
         $template_parameter_type_list = \array_map(function (string $type_name) {
-            return Type::fromFullyQualifiedString($type_name)->asUnionType();
+            return UnionType::fromFullyQualifiedString($type_name);
         }, $template_parameter_type_name_list);
 
         if (0 !== strpos($namespace, '\\')) {
@@ -762,7 +763,7 @@ class Type
         // template parameter type list
         $template_parameter_type_list =
             array_map(function (string $type_name) use ($context, $source) {
-                return Type::fromStringInContext($type_name, $context, $source)->asUnionType();
+                return UnionType::fromStringInContext($type_name, $context, $source);
             }, $template_parameter_type_name_list);
 
         // @var bool
@@ -848,6 +849,8 @@ class Type
                         $types = $template_parameter_type_list[$template_count - 1]->getTypeSet();
                         if (\count($types) === 1) {
                             return GenericArrayType::fromElementType(\reset($types), $is_nullable);
+                        } elseif (\count($types) > 1) {
+                            return new GenericMultiArrayType($types, $is_nullable);
                         }
                     }
                 }

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -192,7 +192,7 @@ final class GenericArrayType extends ArrayType
         $clazz = $code_base->getClassByFQSEN($class_fqsen);
 
         $union_type->addUnionType(
-             $clazz->getUnionType()->asGenericArrayTypes()
+            $clazz->getUnionType()->asGenericArrayTypes()
         );
 
         // Recurse up the tree to include all types
@@ -217,12 +217,11 @@ final class GenericArrayType extends ArrayType
         foreach ($fqsen_aliases as $alias_fqsen_record) {
             $alias_fqsen = $alias_fqsen_record->alias_fqsen;
             $recursive_union_type->addUnionType(
-                 $alias_fqsen->asUnionType()->asGenericArrayTypes()
+                $alias_fqsen->asUnionType()->asGenericArrayTypes()
             );
         }
         // TODO: Investigate caching this and returning clones after analysis is done.
 
         return $recursive_union_type;
     }
-
 }

--- a/src/Phan/Language/Type/GenericMultiArrayType.php
+++ b/src/Phan/Language/Type/GenericMultiArrayType.php
@@ -1,0 +1,172 @@
+<?php declare(strict_types=1);
+namespace Phan\Language\Type;
+
+use Phan\Language\Type;
+use Phan\Language\UnionType;
+use Phan\Language\FQSEN\FullyQualifiedClassName;
+use Phan\CodeBase;
+
+/**
+ * Callers should split this up into multiple GenericArrayType instances
+ *
+ * This is generated from phpdoc array<int, T1|T2> where callers expect a subclass of Type.
+ */
+final class GenericMultiArrayType extends ArrayType
+{
+    /** @phan-override */
+    const NAME = 'array';
+
+    /**
+     * @var Type[]
+     * The list of possible types of every element in this array (2 or more)
+     */
+    private $element_types = [];
+
+    /**
+     * @param Type[] $types
+     * The 2 or more possible types of every element in this array
+     *
+     * @param bool $is_nullable
+     * Set to true if the type should be nullable, else pass false
+     */
+    protected function __construct(array $types, bool $is_nullable)
+    {
+        \assert(\count($types) >= 2);
+        // Could de-duplicate, but callers should be able to do that as well when converting to UnionType.
+        // E.g. array<int|int> is int[].
+        parent::__construct('\\', self::NAME, [], false);
+        $this->element_types = $types;
+        $this->is_nullable = $is_nullable;
+    }
+
+    /**
+     * @param bool $is_nullable
+     * Set to true if the type should be nullable, else pass
+     * false
+     *
+     * @return Type
+     * A new type that is a copy of this type but with the
+     * given nullability value.
+     */
+    public function withIsNullable(bool $is_nullable) : Type
+    {
+        if ($is_nullable === $this->is_nullable) {
+            return $this;
+        }
+
+        return GenericMultiArrayType::fromElementTypes(
+            $this->element_types,
+            $is_nullable
+        );
+    }
+
+    /**
+     * @return GenericArrayType[]
+     */
+    public function asGenericArrayTypeInstances() : array
+    {
+        return \array_map(function(Type $type) {
+            return GenericArrayType::fromElementType($type, $this->is_nullable);
+        }, $this->element_types);
+    }
+
+    /**
+     * @param Type[] $element_types
+     * @param bool $is_nullable
+     * @return GenericMultiArrayType
+     */
+    public static function fromElementTypes(
+        array $element_types,
+        bool $is_nullable
+    ) : GenericMultiArrayType {
+        return new self($element_types, $is_nullable);
+    }
+
+    /**
+     * @return bool
+     * True if this Type can be cast to the given Type
+     * cleanly
+     */
+    protected function canCastToNonNullableType(Type $type) : bool
+    {
+        if ($type instanceof GenericArrayType) {
+            foreach ($this->genericArrayElementTypes() as $inner_type) {
+                if ($type->canCastToType($type->genericArrayElementType())) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        if ($type->isArrayLike()) {
+            return true;
+        }
+
+        $d = \strtolower((string)$type);
+        if ($d[0] == '\\') {
+            $d = \substr($d, 1);
+        }
+        if ($d === 'callable') {
+            return true;
+        }
+
+        return parent::canCastToNonNullableType($type);
+    }
+
+    public function isGenericArray() : bool
+    {
+        return true;
+    }
+
+    /**
+     * @return Type[]
+     * A variation of this type that is not generic.
+     * i.e. 'int[]' becomes 'int'.
+     */
+    public function genericArrayElementTypes() : array
+    {
+        return $this->element_types;
+    }
+
+    public function __toString() : string
+    {
+        $string = 'array<' . \implode('|', $this->element_types) . '>';
+        if ($this->is_nullable) {
+            $string = '?' . $string;
+        }
+        return $string;
+    }
+
+    /**
+     * @param CodeBase
+     * The code base to use in order to find super classes, etc.
+     *
+     * @param $recursion_depth
+     * This thing has a tendency to run-away on me. This tracks
+     * how bad I messed up by seeing how far the expanded types
+     * go
+     *
+     * @return UnionType
+     * Expands class types to all inherited classes returning
+     * a superset of this type.
+     * @override
+     */
+    public function asExpandedTypes(
+        CodeBase $code_base,
+        int $recursion_depth = 0
+    ) : UnionType {
+        // We're going to assume that if the type hierarchy
+        // is taller than some value we probably messed up
+        // and should bail out.
+        \assert(
+            $recursion_depth < 20,
+            "Recursion has gotten out of hand"
+        );
+        // TODO: Use UnionType::merge from a future change?
+        $result = new UnionType();
+        foreach ($this->element_types as $type) {
+            $result->addUnionType(GenericArrayType::fromElementType($type, $this->is_nullable)->asExpandedTypes($code_base, $recursion_depth + 1));
+        }
+        return $result;
+    }
+}

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -195,7 +195,8 @@ class UnionType implements \Serializable
      * @return string[]
      * @see Type::extractTemplateParameterTypeNameList (Similar method)
      */
-    private static function mergeTypeParts(array $parts) : array {
+    private static function mergeTypeParts(array $parts) : array
+    {
         $prev_parts = [];
         $delta = 0;
         $results = [];

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -15,6 +15,7 @@ use Phan\Language\Type\BoolType;
 use Phan\Language\Type\FalseType;
 use Phan\Language\Type\FloatType;
 use Phan\Language\Type\GenericArrayType;
+use Phan\Language\Type\GenericMultiArrayType;
 use Phan\Language\Type\IntType;
 use Phan\Language\Type\MixedType;
 use Phan\Language\Type\NullType;
@@ -95,10 +96,12 @@ class UnionType implements \Serializable
         $type_set = $memoize_map[$fully_qualified_string] ?? null;
 
         if (!isset($type_set)) {
-            // TODO: Support brackets, template types within <>, etc.
-            $type_set = ArraySet::from_list(\array_map(function (string $type_name) {
+            $types = \array_map(function (string $type_name) {
                 return Type::fromFullyQualifiedString($type_name);
-            }, \explode('|', $fully_qualified_string)));
+            }, self::extractTypeParts($fully_qualified_string));
+
+            // TODO: Support brackets, template types within <>, etc.
+            $type_set = ArraySet::from_list(self::normalizeGenericMultiArrayTypes($types));
             $memoize_map[$fully_qualified_string] = $type_set;
         }
 
@@ -134,23 +137,94 @@ class UnionType implements \Serializable
                 $type_string
             )->asUnionType();
         }
-
-        return new UnionType(
-            \array_map(function (string $type_name) use ($context, $source) {
+        $types = \array_map(
+            function (string $type_name) use ($context, $source) : Type {
                 \assert($type_name !== '', "Type cannot be empty.");
                 return Type::fromStringInContext(
                     $type_name,
                     $context,
                     $source
                 );
-            }, \array_filter(\array_map(function (string $type_name) {
-                return \trim($type_name);
-            }, explode('|', $type_string)), function(string $type_name) {
+            },
+            \array_filter(self::extractTypeParts($type_string), function(string $type_name) {
                 // Exclude empty type names
                 // Exclude namespaces without type names (e.g. `\`, `\NS\`)
                 return $type_name !== '' && \preg_match('@\\\\[\[\]]*$@', $type_name) === 0;
-            }))
+            })
         );
+
+        return new UnionType(self::normalizeGenericMultiArrayTypes($types));
+    }
+
+    /**
+     * @return string[]
+     */
+    private static function extractTypeParts(string $type_string) : array
+    {
+        $parts = \array_map('trim', \explode('|', $type_string));
+        if (\count($parts) <= 1) {
+            return $parts;
+        }
+        if (!\preg_match('/[<(]/', $type_string)) {
+            return $parts;
+        }
+        return self::mergeTypeParts($parts);
+    }
+
+    /**
+     * Expands any GenericMultiArrayType instances in $types if necessary.
+     *
+     * @param Type[] $types
+     * @return Type[]
+     */
+    private static function normalizeGenericMultiArrayTypes(array $types) : array
+    {
+        foreach ($types as $i => $type) {
+            if ($type instanceof GenericMultiArrayType) {
+                foreach ($type->asGenericArrayTypeInstances() as $new_type) {
+                    $types[] = $new_type;
+                }
+                unset($types[$i]);
+            }
+        }
+        return $types;
+    }
+
+    /**
+     * @param string[] $parts (already trimmed)
+     * @return string[]
+     * @see Type::extractTemplateParameterTypeNameList (Similar method)
+     */
+    private static function mergeTypeParts(array $parts) : array {
+        $prev_parts = [];
+        $delta = 0;
+        $results = [];
+        foreach ($parts as $part) {
+            if (\count($prev_parts) > 0) {
+                $prev_parts[] = $part;
+                $delta += \substr_count($part, '<') + \substr_count($part, '(') - \substr_count($part, '>') - \substr_count($part, ')');
+                if ($delta <= 0) {
+                    if ($delta === 0) {
+                        $results[] = \implode('|', $prev_parts);
+                    }  // ignore unparseable data such as "<T,T2>>"
+                    $prev_parts = [];
+                    $delta = 0;
+                    continue;
+                }
+            }
+            $bracket_count = \substr_count($part, '<') + \substr_count($part, '(');
+            if ($bracket_count === 0) {
+                $results[] = $part;
+                continue;
+            }
+            $delta = $bracket_count - \substr_count($part, '>') - \substr_count($part, ')');
+            if ($delta === 0) {
+                $results[] = $part;
+            } elseif ($delta > 0) {
+                $prev_parts[] = $part;
+            }  // otherwise ignore unparseable data such as ">" (should be impossible)
+        }
+        return $results;
     }
 
     /**

--- a/tests/Phan/Language/UnionTypeTest.php
+++ b/tests/Phan/Language/UnionTypeTest.php
@@ -250,4 +250,22 @@ class UnionTypeTest extends BaseTest
         $this->assertTrue($parts[0]->isType(self::makePHPDocType('A1')));
         $this->assertTrue($parts[1]->isType(self::makePHPDocType('B2')));
     }
+
+    public function testTemplateNullableTypes()
+    {
+        $this->assertSame(1, preg_match('/^' . Type::type_regex . '$/', 'TypeTestClass<A1|null,B2|null>'), 'type_regex does not support nested pipes');
+        $this->assertSame(1, preg_match('/^' . Type::type_regex_or_this . '$/', 'TypeTestClass<A1|null>'), 'type_regex_or_this does not support nested pipes');
+        $this->assertSame(1, preg_match('/^' . Type::type_regex_or_this . '$/', 'TypeTestClass<A1|null,B2|null>'), 'type_regex_or_this does not support nested pipes');
+        $union_type = self::makePHPDocUnionType('TypeTestClass<A1,B2|null>');
+        $this->assertSame(1, $union_type->typeCount());
+        $types = $union_type->getTypeSet();
+        $type = reset($types);
+
+        $this->assertSame('\\', $type->getNamespace());
+        $this->assertSame('TypeTestClass', $type->getName());
+        $parts = $type->getTemplateParameterTypeList();
+        $this->assertCount(2, $parts);
+        $this->assertTrue($parts[0]->isType(self::makePHPDocType('A1')));
+        $this->assertTrue($parts[1]->isEqualTo(self::makePHPDocUnionType('B2|null')));
+    }
 }

--- a/tests/files/expected/0386_multi_union_type.php.expected
+++ b/tests/files/expected/0386_multi_union_type.php.expected
@@ -1,0 +1,1 @@
+%s:8 PhanTypeMismatchReturn Returning type \stdClass[] but testPipeInTemplate386() is declared to return bool[]|null[]

--- a/tests/files/src/0386_multi_union_type.php
+++ b/tests/files/src/0386_multi_union_type.php
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * @return array<int,bool|null>
+ */
+function testPipeInTemplate386() {
+    if (rand() % 2 > 0) {
+        return [new stdClass()];
+    } else {
+        return [false, true, null];
+    }
+}


### PR DESCRIPTION
E.g. `array<int, T1|T2>`, `MyClass<A|B,C|D>`.