### PR TITLE
Fixes #1320 - $msg is undefined if parsing language server request fails

### DIFF
--- a/src/Phan/LanguageServer/ProtocolStreamReader.php
+++ b/src/Phan/LanguageServer/ProtocolStreamReader.php
@@ -69,8 +69,11 @@ class ProtocolStreamReader extends Emitter implements ProtocolReader
                             try {
                                 $msg = new Message(MessageBody::parse($this->buffer), $this->headers);
                             } catch (\Exception $e) {
+                                $msg = null;
                             }
-                            $this->emit('message', [$msg]);
+                            if ($msg) {
+                                $this->emit('message', [$msg]);
+                            }
                             $this->parsingMode = self::PARSE_HEADERS;
                             $this->headers = [];
                             $this->buffer = '';


### PR DESCRIPTION
Don't try to analyze JSON messages that aren't parsed successfully.

Not sure of the underlying cause - Could be invalid UTF-8?