### PR TITLE
Allow null to cast to mixed.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,9 @@ New Features(CLI, Configs)
 Maintenance
 + Make `phan_client` and the vim snippet in `plugins/vim/phansnippet.vim` more compatible with neovim
 
+Bug Fixes
++ Allow `null` to be passed in where a union type of `mixed` was expected.
+
 17 Nov 2017, Phan 0.10.2
 ------------------------
 

--- a/src/Phan/Language/Type/NullType.php
+++ b/src/Phan/Language/Type/NullType.php
@@ -80,6 +80,9 @@ final class NullType extends ScalarType
                 return true;
             }
         }
+        if ($type instanceof MixedType) {
+            return true;
+        }
 
         return false;
     }

--- a/tests/Phan/Language/TypeTest.php
+++ b/tests/Phan/Language/TypeTest.php
@@ -231,4 +231,26 @@ class TypeTest extends BaseTest
         $this->assertSameType($expectedStringArrayType, $stringArrayType);
         $this->assertSame('?float[]', (string)$stringArrayType);
     }
+
+    /**
+     * @dataProvider canCastToTypeProvider
+     */
+    public function testCanCastToType(string $fromTypeString, string $toTypeString)
+    {
+        $fromType = self::makePHPDocType($fromTypeString);
+        $toType = self::makePHPDocType($toTypeString);
+        $this->assertTrue($fromType->canCastToType($toType), "expected $fromTypeString to be able to cast to $toTypeString");
+    }
+
+    public function canCastToTypeProvider() : array
+    {
+        return [
+            ['int', 'int'],
+            ['int', 'float'],
+            ['int', 'mixed'],
+            ['mixed', 'int'],
+            ['null', 'mixed'],
+            ['null[]', 'mixed[]'],
+        ];
+    }
 }

--- a/tests/files/src/0387_mixed_accepts_null.php
+++ b/tests/files/src/0387_mixed_accepts_null.php
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * @param mixed $x
+ * @param ?mixed $y
+ */
+function expect_mixed387($x, $y) {
+    var_export($x);
+    var_export($y);
+}
+expect_mixed387(null, null);


### PR DESCRIPTION
This rule was overlooked, and wasn't covered by current unit tests.