### PR TITLE
Allow casting `?T` to `T|null` for parameters, properties, etc.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,8 @@ Maintenance
 
 Bug Fixes
 + Allow `null` to be passed in where a union type of `mixed` was expected.
++ Don't warn when passing `?T` (PHPDoc or real) where the PHPDoc type was `T|null`. (#609, #1090, #1192, #1337)
+  This is useful for expressions used for property assignments, return statements, function calls, etc.
 
 17 Nov 2017, Phan 0.10.2
 ------------------------

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -1135,6 +1135,21 @@ class UnionType implements \Serializable
             }
         }
 
+        // Allow casting ?T to T|null for any type T. Check if null is part of this type first.
+        if ($target->hasType($null_type)) {
+            foreach ($this->type_set as $source_type) {
+                // Only redo this check for the nullable types, we already failed the checks for non-nullable types.
+                if ($source_type->getIsNullable()) {
+                    $non_null_source_type = $source_type->withIsNullable(false);
+                    foreach ($target->type_set as $target_type) {
+                        if ($non_null_source_type->canCastToType($target_type)) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+
         // Only if no source types can be cast to any target
         // types do we say that we cannot perform the cast
         return false;

--- a/tests/files/expected/0388_nullable_to_type_or_null.php.expected
+++ b/tests/files/expected/0388_nullable_to_type_or_null.php.expected
@@ -1,0 +1,2 @@
+%s:27 PhanTypeMismatchProperty Assigning ?int to property but \A388::prop2 is null|string
+%s:28 PhanTypeMismatchArgument Argument 2 (arg2) is ?int but \helper388() takes null|string defined at %s:16

--- a/tests/files/src/0388_nullable_to_type_or_null.php
+++ b/tests/files/src/0388_nullable_to_type_or_null.php
@@ -1,0 +1,30 @@
+<?php
+
+class A388 {
+    /** @var string|null */
+    public $prop1;
+
+    /** @var string|null */
+    public $prop2;
+}
+
+
+/**
+ * @param string|null $arg1
+ * @param string|null $arg2
+ */
+function helper388($arg1, $arg2) {
+    var_export($arg1);
+    var_export($arg2);
+}
+
+/**
+ * @return string|null
+ */
+function test388(?string $a1, ?int $a2, ?string $a3, ?int $a4, ?string $retval) {
+    $a = new A388();
+    $a->prop1 = $a1;
+    $a->prop2 = $a2;  // should warn
+    helper388($a3, $a4);
+    return $retval;
+}


### PR DESCRIPTION
Fixes #609
Fixes #1090
Fixes #1192
Fixes #1337