### PR TITLE
Refactoring tests

### DIFF
--- a/tests/Phan/Language/ContextTest.php
+++ b/tests/Phan/Language/ContextTest.php
@@ -49,10 +49,10 @@ class ContextTest extends BaseTest
             )
         );
 
-        $this->assertTrue(!empty($context));
-        $this->assertTrue(!empty($context_namespace));
-        $this->assertTrue(!empty($context_class));
-        $this->assertTrue(!empty($context_method));
+        $this->assertNotEmpty($context);
+        $this->assertNotEmpty($context_namespace);
+        $this->assertNotEmpty($context_class);
+        $this->assertNotEmpty($context_method);
     }
 
     public function testClassContext()

--- a/tests/Phan/Language/Element/CommentTest.php
+++ b/tests/Phan/Language/Element/CommentTest.php
@@ -53,16 +53,16 @@ class CommentTest extends BaseTest
             1,
             Comment::ON_METHOD
         );
-        $this->assertSame(false, $comment->isDeprecated());
-        $this->assertSame(false, $comment->isOverrideIntended());
-        $this->assertSame(false, $comment->isNSInternal());
+        $this->assertFalse($comment->isDeprecated());
+        $this->assertFalse($comment->isOverrideIntended());
+        $this->assertFalse($comment->isNSInternal());
         $this->assertSame('', (string)$comment->getReturnType());
-        $this->assertSame(false, $comment->hasReturnUnionType());
+        $this->assertFalse($comment->hasReturnUnionType());
         $this->assertInstanceOf(None::class, $comment->getClosureScopeOption());
         $this->assertSame([], $comment->getParameterList());
         $this->assertSame([], $comment->getParameterMap());
         $this->assertSame([], $comment->getSuppressIssueList());
-        $this->assertSame(false, $comment->hasParameterWithNameOrOffset('bar', 0));
+        $this->assertFalse($comment->hasParameterWithNameOrOffset('bar', 0));
         $this->assertSame([], $comment->getVariableList());
     }
 
@@ -80,11 +80,11 @@ class CommentTest extends BaseTest
         $this->assertSame([], $comment->getParameterList());
         $my_param_doc = $parameter_map['myParam'];
         $this->assertSame('int $myParam', (string)$my_param_doc);
-        $this->assertSame(false, $my_param_doc->isOptional());
-        $this->assertSame(true, $my_param_doc->isRequired());
-        $this->assertSame(false, $my_param_doc->isVariadic());
+        $this->assertFalse($my_param_doc->isOptional());
+        $this->assertTrue($my_param_doc->isRequired());
+        $this->assertFalse($my_param_doc->isVariadic());
         $this->assertSame('myParam', $my_param_doc->getName());
-        $this->assertSame(false, $my_param_doc->isOutputReference());
+        $this->assertFalse($my_param_doc->isOutputReference());
     }
 
     public function testGetParameterMapReferenceIgnored()
@@ -101,11 +101,11 @@ class CommentTest extends BaseTest
         $this->assertSame([], $comment->getParameterList());
         $my_param_doc = $parameter_map['myParam'];
         $this->assertSame('int $myParam', (string)$my_param_doc);
-        $this->assertSame(false, $my_param_doc->isOptional());
-        $this->assertSame(true, $my_param_doc->isRequired());
-        $this->assertSame(false, $my_param_doc->isVariadic());
+        $this->assertFalse($my_param_doc->isOptional());
+        $this->assertTrue($my_param_doc->isRequired());
+        $this->assertFalse($my_param_doc->isVariadic());
         $this->assertSame('myParam', $my_param_doc->getName());
-        $this->assertSame(false, $my_param_doc->isOutputReference());
+        $this->assertFalse($my_param_doc->isOutputReference());
     }
 
     public function testGetVariadicParameterMap()
@@ -122,11 +122,11 @@ class CommentTest extends BaseTest
         $this->assertSame([], $comment->getParameterList());
         $my_param_doc = $parameter_map['args'];
         $this->assertSame('int|string ...$args', (string)$my_param_doc);
-        $this->assertSame(true, $my_param_doc->isOptional());
-        $this->assertSame(false, $my_param_doc->isRequired());
-        $this->assertSame(true, $my_param_doc->isVariadic());
+        $this->assertTrue($my_param_doc->isOptional());
+        $this->assertFalse($my_param_doc->isRequired());
+        $this->assertTrue($my_param_doc->isVariadic());
         $this->assertSame('args', $my_param_doc->getName());
-        $this->assertSame(false, $my_param_doc->isOutputReference());
+        $this->assertFalse($my_param_doc->isOutputReference());
     }
 
     public function testGetOutputParameter()
@@ -260,17 +260,17 @@ EOT;
         $this->assertSame([], $comment->getParameterList());
         $my_param_doc = $parameter_map['myParam'];
         $this->assertSame('string[] $myParam', (string)$my_param_doc);
-        $this->assertSame(false, $my_param_doc->isOptional());
-        $this->assertSame(true, $my_param_doc->isRequired());
-        $this->assertSame(false, $my_param_doc->isVariadic());
+        $this->assertFalse($my_param_doc->isOptional());
+        $this->assertTrue($my_param_doc->isRequired());
+        $this->assertFalse($my_param_doc->isVariadic());
         $this->assertSame('myParam', $my_param_doc->getName());
 
         // Argument #2, #3, etc. passed by callers are arrays of stdClasses
         $restDoc = $parameter_map['rest'];
         $this->assertSame('\stdClass[] ...$rest', (string)$restDoc);
-        $this->assertSame(true, $restDoc->isOptional());
-        $this->assertSame(false, $restDoc->isRequired());
-        $this->assertSame(true, $restDoc->isVariadic());
+        $this->assertTrue($restDoc->isOptional());
+        $this->assertFalse($restDoc->isRequired());
+        $this->assertTrue($restDoc->isVariadic());
         $this->assertSame('rest', $restDoc->getName());
     }
 

--- a/tests/Phan/Library/FileCacheTest.php
+++ b/tests/Phan/Library/FileCacheTest.php
@@ -39,7 +39,7 @@ class FileCacheTest extends BaseTest
     public function testLRU()
     {
         $expectedPaths = [];
-        $this->assertTrue(FileCache::MINIMUM_CACHE_SIZE >= 5);
+        $this->assertGreaterThanOrEqual(5, FileCache::MINIMUM_CACHE_SIZE);
         for ($i = 0; $i < FileCache::MINIMUM_CACHE_SIZE; $i++) {
             $path = "/path/to/$i";
             $expectedPaths[] = $path;


### PR DESCRIPTION
I've refactored some tests, using:
- `assertNotEmpty` instead of `empty` function;
- `assertFalse` instead of strict comparison with `false` keyword;
- `assertTrue` instead of strict comparison with `true` keyword;
- `assertGreaterThanOrEqual` for mathematical comparison.