### PR TITLE
Allow compact to pass deeply nested strings

### DIFF
--- a/src/Phan/Language/Internal/FunctionSignatureMap.php
+++ b/src/Phan/Language/Internal/FunctionSignatureMap.php
@@ -894,7 +894,7 @@ return [
 'com_isenum' => ['bool', 'com_module'=>'variant'],
 'com_load_typelib' => ['bool', 'typelib_name'=>'string', 'case_insensitive='=>'int'],
 'com_message_pump' => ['bool', 'timeoutms='=>'int'],
-'compact' => ['array', '...var_names='=>'string|string[]'],
+'compact' => ['array', '...var_names='=>'mixed'],
 'COMPersistHelper::__construct' => ['void', 'com_object'=>'object'],
 'COMPersistHelper::GetCurFile' => ['string'],
 'COMPersistHelper::GetMaxStreamSize' => ['int'],

--- a/src/Phan/Language/Internal/FunctionSignatureMap.php
+++ b/src/Phan/Language/Internal/FunctionSignatureMap.php
@@ -894,7 +894,7 @@ return [
 'com_isenum' => ['bool', 'com_module'=>'variant'],
 'com_load_typelib' => ['bool', 'typelib_name'=>'string', 'case_insensitive='=>'int'],
 'com_message_pump' => ['bool', 'timeoutms='=>'int'],
-'compact' => ['array', '...var_names='=>'mixed'],
+'compact' => ['array', '...var_names='=>'string|array'],
 'COMPersistHelper::__construct' => ['void', 'com_object'=>'object'],
 'COMPersistHelper::GetCurFile' => ['string'],
 'COMPersistHelper::GetMaxStreamSize' => ['int'],


### PR DESCRIPTION
Because this is valid:
```php
$hello = "world";
var_dump(compact([[["hello"]]]));
```