### PR TITLE
Fixes #1333 : Properly check if properties are accessible within clas…

### DIFF
--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -575,12 +575,15 @@ class Clazz extends AddressableElement
      * A possibly defined type used to define template
      * parameter types when importing the property
      *
+     * @param bool $from_trait
+     *
      * @return void
      */
     public function addProperty(
         CodeBase $code_base,
         Property $property,
-        $type_option
+        $type_option,
+        bool $from_trait = false
     ) {
         // Ignore properties we already have
         // TODO: warn about private properties in subclass overriding ancestor private property.
@@ -611,6 +614,13 @@ class Clazz extends AddressableElement
         if ($property->getFQSEN() !== $property_fqsen) {
             $property = clone($property);
             $property->setFQSEN($property_fqsen);
+
+            // Private properties of traits are accessible from the class that used that trait
+            // (as well as from within the trait itself).
+            // Also, for inheritance purposes, treat protected properties the same way.
+            if ($from_trait && !$property->isPublic()) {
+                $property->setDefiningFQSEN($property_fqsen);
+            }
 
             try {
                 // If we have a parent type defined, map the property's
@@ -758,6 +768,52 @@ class Clazz extends AddressableElement
     }
 
     /**
+     * Checks if a given property can be accessed by the class in the current Context
+     * (if any)
+     *
+     * @param CodeBase $code_base
+     * A reference to the entire code base in which the
+     * property exists.
+     *
+     * @param Property $property
+     * A property with the given name
+     *
+     * @param Context $context
+     * The context of the caller requesting the property
+     *
+     * @return bool - is $property accessible from $context
+     */
+    private function isPropertyAccessible(
+        CodeBase $code_base,
+        Property $property,
+        Context $context
+    ) : bool {
+        if ($property->isPublic()) {
+            return true;
+        }
+        if (!$context->isInClassScope()) {
+            return false;
+        }
+        // NOTE: This gets the **unexpanded** union type (Should be 1 class and no parent classes).
+        $type_of_class_of_property = $property->getDefiningClassFQSEN()->asUnionType();
+
+        // We are in a class scope, and the property is either private or protected.
+        if ($property->isPrivate()) {
+            $accessing_class_type = $context->getClassFQSEN()->asUnionType();
+            return $accessing_class_type->canCastToUnionType(
+                $type_of_class_of_property
+            );
+        } else {
+            // TODO: Remove, should be unnecessary
+            $accessing_class_type = $context->getClassFQSEN()->asUnionType();
+            // If the definition of the property is protected, then the subclasses of the defining class can access it.
+            return $accessing_class_type->asExpandedTypes($code_base)->canCastToUnionType(
+                $type_of_class_of_property
+            );
+        }
+    }
+
+    /**
      * @param CodeBase $code_base
      * A reference to the entire code base in which the
      * property exists.
@@ -821,19 +877,7 @@ class Clazz extends AddressableElement
                 }
             }
 
-            $is_remote_access = (
-                !$context->isInClassScope()
-                || !$context->getClassInScope($code_base)
-                    ->getUnionType()->canCastToExpandedUnionType(
-                        $this->getUnionType(),
-                        $code_base
-                    )
-            );
-
-            $is_property_accessible = (
-                !$is_remote_access
-                || $property->isPublic()
-            );
+            $is_property_accessible = $this->isPropertyAccessible($code_base, $property, $context);
         }
 
         // If the property exists and is accessible, return it
@@ -846,6 +890,7 @@ class Clazz extends AddressableElement
             $method = $this->getMethodByName($code_base, '__get');
 
             // Make sure the magic method is accessible
+            // TODO: Add defined at %s:%d for the property definition
             if ($method->isPrivate()) {
                 throw new IssueException(
                     Issue::fromType(Issue::AccessPropertyPrivate)(
@@ -878,6 +923,7 @@ class Clazz extends AddressableElement
         } elseif ($has_property) {
             // If we have a property, but its inaccessible, emit
             // an issue
+            // TODO: Add defined at %s:%d for the property definition - see https://github.com/phan/phan/issues/1375
             if ($property->isPrivate()) {
                 throw new IssueException(
                     Issue::fromType(Issue::AccessPropertyPrivate)(
@@ -1968,7 +2014,8 @@ class Clazz extends AddressableElement
             $this->addProperty(
                 $code_base,
                 $property,
-                $type_option
+                $type_option,
+                $is_trait
             );
         }
 

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -350,6 +350,8 @@ class Type
      * It's important to clear asExpandedTypes(),
      * as the parent classes may have changed since the last parse attempt.
      *
+     * This gets called immediately after the parse phase but before the analysis phase.
+     *
      * @return void
      */
     public static function clearAllMemoizations()
@@ -1410,7 +1412,6 @@ class Type
                     $alias_fqsen->asUnionType()
                 );
             }
-            // TODO: Investigate caching this and returning clones after analysis is done.
 
             return $recursive_union_type;
         });

--- a/src/Phan/Phan.php
+++ b/src/Phan/Phan.php
@@ -2,6 +2,7 @@
 namespace Phan;
 
 use Phan\Daemon\Request;
+use Phan\Language\Type;
 use Phan\LanguageServer\LanguageServer;
 use Phan\LanguageServer\Logger as LanguageServerLogger;
 use Phan\Library\FileCache;
@@ -172,6 +173,7 @@ class Phan implements IgnoredFilesFilterInterface
         $temporary_file_mapping = [];
 
         $request = null;
+        Type::clearAllMemoizations();
         if ($is_undoable_request) {
             \assert($code_base->isUndoTrackingEnabled());
             if ($is_daemon_request) {

--- a/tests/files/expected/0391_private_prop_of_this.php.expected
+++ b/tests/files/expected/0391_private_prop_of_this.php.expected
@@ -1,0 +1,5 @@
+%s:24 PhanAccessPropertyPrivate Cannot access private property \Subclass391::$_prop
+%s:25 PhanUndeclaredProperty Reference to undeclared property \Subclass391->_propOther
+%s:25 PhanUndeclaredProperty Reference to undeclared property \Trait391->_propOther
+%s:29 PhanAccessPropertyPrivate Cannot access private property \Subclass391::$_prop2
+%s:29 PhanUndeclaredProperty Reference to undeclared property \Trait391->_prop2Other

--- a/tests/files/expected/0392_protected_property_other_class.php.expected
+++ b/tests/files/expected/0392_protected_property_other_class.php.expected
@@ -1,0 +1,4 @@
+%s:18 PhanAccessPropertyProtected Cannot access protected property \A392::$prop1
+%s:19 PhanAccessPropertyPrivate Cannot access private property \A392::$prop2
+%s:21 PhanAccessPropertyProtected Cannot access protected property \A392::$prop1
+%s:22 PhanAccessPropertyPrivate Cannot access private property \A392::$prop2

--- a/tests/files/expected/0393_property_visibility_trait.php.expected
+++ b/tests/files/expected/0393_property_visibility_trait.php.expected
@@ -1,0 +1,2 @@
+%s:15 PhanAccessPropertyPrivate Cannot access private property \ExtendingClass393::$propPrivate
+%s:16 PhanUndeclaredProperty Reference to undeclared property \AbstractClass393->missingProp

--- a/tests/files/src/0391_private_prop_of_this.php
+++ b/tests/files/src/0391_private_prop_of_this.php
@@ -1,0 +1,33 @@
+<?php
+
+class Base391 {
+    private $_prop;
+    private $_prop2;
+}
+
+// Note that traits can't define constants.
+trait Trait391 {
+    // Trait inheritance of properties is different from class inheritance.
+    // The class using this trait can access this private property.
+    private $_propFromTrait;
+
+    public function accessTraitProp() {
+        echo "value = " . $this->_propFromTrait . "\n";
+    }
+}
+
+class Subclass391 extends Base391 {
+    use Trait391;
+
+    public function __construct($value) {
+        $this->_propFromTrait = $value;
+        $this->_prop = $value;
+        $this->_propOther = $value;
+    }
+
+    public function getter() {
+        return $this->_prop2 + $this->_prop2Other;
+    }
+}
+$c = new Subclass391('v');
+$c->accessTraitProp();

--- a/tests/files/src/0392_protected_property_other_class.php
+++ b/tests/files/src/0392_protected_property_other_class.php
@@ -1,0 +1,26 @@
+<?php
+
+// Test two classes that have a common base class attempting to access private/protected properties not on that base class.
+
+class Base392 {
+}
+
+class A392 extends Base392{
+    protected $prop1;
+    private $prop2;
+    public $prop3;
+}
+
+class B392 extends Base392 {
+    public function test() {
+        // Test phan's visibility checks for access and modification of properties
+        $b = new A392();
+        echo $b->prop1;
+        echo $b->prop2;
+        echo $b->prop3;  // valid
+        $b->prop1 = 'x';
+        $b->prop2 = 'y';
+        $b->prop3 = 'z';  // valid
+    }
+}
+(new B392())->test();

--- a/tests/files/src/0393_property_visibility_trait.php
+++ b/tests/files/src/0393_property_visibility_trait.php
@@ -1,0 +1,21 @@
+<?php
+
+abstract class AbstractClass393 {
+    use TraitClass393 { }
+}
+
+trait TraitClass393 {
+	protected $prop = 4;
+	private $propPrivate = 4;
+}
+
+class ExtendingClass393 extends AbstractClass393 {
+	public function other() {
+        printf("prop=%s\n", $this->prop);
+        printf("prop=%s\n", $this->propPrivate);  // should warn
+        printf("prop=%s\n", $this->missingProp);  // should warn
+	}
+}
+
+$traitClass = new ExtendingClass393();
+$traitClass->other();  // should not warn

--- a/tests/rasmus_files/expected/0037_properties2.php.expected
+++ b/tests/rasmus_files/expected/0037_properties2.php.expected
@@ -1,3 +1,3 @@
 %s:13 PhanTypeMismatchProperty Assigning int[] to property but \B::text is string
 %s:20 PhanAccessPropertyProtected Cannot access protected property \B::$text
-
+%s:30 PhanTypeMismatchProperty Assigning array to property but \B::text is string

--- a/tests/rasmus_files/src/0037_properties2.php
+++ b/tests/rasmus_files/src/0037_properties2.php
@@ -14,7 +14,7 @@ class B extends A {
 	}
 }
 
-class C {
+class C {  // Wrong because C doesn't extend A or B
 	static function test() {
 		$b = new B;
 		$b->text = [];
@@ -23,3 +23,12 @@ class C {
 }
 
 C::test();
+
+class D extends A {  // Correct because D extends A
+	static function test() {
+		$b = new B;
+		$b->text = [];
+		$b->test([1,2,3]);
+	}
+}
+D::test();


### PR DESCRIPTION
…s scope

There were a few edge bugs in the checks:

- Private properties were treated the same way as protected properties
  within the class for visibility checking.
- canCastToExpandedUnionType expands **both** of the union types before
  checking if the property is visible.

  However, we only want to expand the type of the class/trait of the method
  that's doing the accessing, to check if it contains the class
  declaring that property.

Rewrite a buggy unit tests where a property wasn't visible.