### PR TITLE
Warn about passing int/string as array indices when string/int expected

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,8 @@ New Features(Analysis)
   Mixed union types in keys can cast to/from any key type.
 
   - To allow casting `array<int,T>` to `array<string,T>`, enable `scalar_array_key_cast` in your `.phan/config.php`.
+
+  Warn when fetching with the wrong type of array keys (E.g. string key for `array<int,T>`) (Issue #1390)
 + Infer array key types of `int`, `string`, or `int|string` in foreach over arrays. (#1300)
   (Phan's type system doesn't support inferring key types for `iterable` or `Traversable` right now)
 + Support **parsing** PHPDoc array shapes

--- a/src/Phan/Language/Internal/PropertyMap.php
+++ b/src/Phan/Language/Internal/PropertyMap.php
@@ -401,14 +401,14 @@ return [
         'kind' => 'int',
         'flags' => 'int',
         'lineno' => 'int',
-        'children' => 'array',  // NOTE: in the latest version, this is consistently an array, even for edge cases like statement lists of single statements.
+        'children' => 'ast\Node\Decl[]|ast\Node[]|array[]|int[]|string[]|float[]|bool[]|null[]',  // NOTE: in the latest version, this is consistently an array, even for edge cases like statement lists of single statements.
         'endLineno' => 'int',
     ],
     'ast\node\decl' => [
         'kind' => 'int',
         'flags' => 'int',
         'lineno' => 'int',
-        'children' => 'array',  // NOTE: in the latest version, this is consistently an array, even for edge cases like statement lists of single statements.
+        'children' => 'ast\Node\Decl[]|ast\Node[]|array[]|int[]|string[]|float[]|bool[]|null[]',  // NOTE: in the latest version, this is consistently an array, even for edge cases like statement lists of single statements.
         'endLineno' => 'int',
         'name' => '?string',
         'docComment' => '?string',

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -330,10 +330,12 @@ final class GenericArrayType extends ArrayType
         return $key_types ?: self::KEY_MIXED;
     }
 
+    const CONVERT_KEY_MIXED_TO_EMPTY_UNION_TYPE = 0;
+    const CONVERT_KEY_MIXED_TO_INT_OR_STRING_UNION_TYPE = 1;
     /**
      * @return UnionType
      */
-    public static function unionTypeForKeyType(int $key_type) : UnionType
+    public static function unionTypeForKeyType(int $key_type, int $behavior = self::CONVERT_KEY_MIXED_TO_INT_OR_STRING_UNION_TYPE) : UnionType
     {
         switch ($key_type) {
             case self::KEY_INT:
@@ -341,6 +343,9 @@ final class GenericArrayType extends ArrayType
             case self::KEY_STRING:
                 return StringType::instance(false)->asUnionType();
             default:
+                if ($behavior === self::CONVERT_KEY_MIXED_TO_INT_OR_STRING_UNION_TYPE) {
+                    return new UnionType([IntType::instance(false), StringType::instance(false)], true);
+                }
                 return new UnionType();
         }
     }

--- a/tests/files/expected/0354_string_index.php.expected
+++ b/tests/files/expected/0354_string_index.php.expected
@@ -8,5 +8,6 @@
 %s:22 PhanTypeMismatchDimFetch When fetching an array index from a value of type string, found an array index of type array, but expected the index to be of type int
 %s:23 PhanTypeMismatchDimFetch When fetching an array index from a value of type string, found an array index of type string, but expected the index to be of type int
 %s:24 PhanTypeMismatchDimFetch When fetching an array index from a value of type string, found an array index of type null, but expected the index to be of type int
-%s:27 PhanTypeMismatchDimFetch When fetching an array index from a value of type array<string,string>, found an array index of type array, but expected the index to be of type int|string
-%s:28 PhanTypeMismatchDimFetch When fetching an array index from a value of type array<string,string>, found an array index of type null, but expected the index to be of type int|string
+%s:27 PhanTypeMismatchDimFetch When fetching an array index from a value of type array<string,string>, found an array index of type array, but expected the index to be of type string
+%s:28 PhanTypeMismatchDimFetch When fetching an array index from a value of type array<string,string>, found an array index of type null, but expected the index to be of type string
+%s:29 PhanTypeMismatchDimFetch When fetching an array index from a value of type array<string,string>, found an array index of type int, but expected the index to be of type string

--- a/tests/files/expected/0399_array_key.php.expected
+++ b/tests/files/expected/0399_array_key.php.expected
@@ -1,0 +1,3 @@
+%s:8 PhanTypeMismatchDimFetch When fetching an array index from a value of type array<string,string>, found an array index of type int, but expected the index to be of type string
+%s:9 PhanTypeMismatchDimFetch When fetching an array index from a value of type array<string,string>, found an array index of type array, but expected the index to be of type string
+%s:10 PhanTypeMismatchDimFetch When fetching an array index from a value of type array<int,string>, found an array index of type string, but expected the index to be of type int

--- a/tests/files/src/0354_string_index.php
+++ b/tests/files/src/0354_string_index.php
@@ -26,6 +26,6 @@ class A354 {
         $b = $arr['offset'];
         $c = $arr[[]];  // wrong
         $c = $arr[null];  // wrong
-        $c = $arr[0];  // Phan isn't able to tell that this is wrong.
+        $c = $arr[0];  // Phan can tell that this is wrong, by tracking that the keys are strings.
     }
 }

--- a/tests/files/src/0399_array_key.php
+++ b/tests/files/src/0399_array_key.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * @param array<string,string> $a
+ * @param array<int, string> $b
+ * @param array<int, string> $c
+ */
+function test399(array $a, array $b, array $c) {
+    echo $a[0];  // wrong
+    echo $a[[]];  // wrong
+    echo $b['key'];  // wrong
+    $c['key'] = 'new value';  // should not warn.
+    echo $c['key'];  // should not warn.
+}


### PR DESCRIPTION
(E.g. when passing `int` to `array<string,T>`)

Fixes #1390

Don't warn about assigning new array keys to an array.