### PR TITLE
Emit new issues type checking uses of splat operator `...`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -25,6 +25,12 @@ New Features(Analysis)
   - The field value types can be any union type.
   - Field keys are currently limited to keys matching the regex `[-_.a-zA-Z0-9\x7f-\xff]+`. (Identifiers, numbers, '-', and '.')
     Escape mechanisms such as backslashes (e.g. "\x20" for " ") may be supported in the future.
++ Add `PhanTypeMismatchUnpackKey` and `PhanTypeMismatchUnpackValue` to analyze array unpacking operator (also known as splat) (#1384)
+
+  Emit `PhanTypeMismatchUnpackKey` when passing iterables/arrays with invalid keys to the unpacking operator (i.e. `...`).
+
+  Emit `PhanTypeMismatchUnpackValue` when passing values that aren't iterables or arrays to the unpacking operator.
+  (See https://secure.php.net/manual/en/migration56.new-features.php#migration56.new-features.splat)
 
 Bug fixes
 + Warn when attempting to call an instance method on an expression with type string (#1314).

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -69,6 +69,8 @@ class Issue
     const TypeMismatchDimAssignment = 'PhanTypeMismatchDimAssignment';
     const TypeMismatchDimEmpty      = 'PhanTypeMismatchDimEmpty';
     const TypeMismatchDimFetch      = 'PhanTypeMismatchDimFetch';
+    const TypeMismatchUnpackKey     = 'PhanTypeMismatchUnpackKey';
+    const TypeMismatchUnpackValue   = 'PhanTypeMismatchUnpackValue';
     const TypeMismatchVariadicComment = 'PhanMismatchVariadicComment';
     const TypeMismatchVariadicParam = 'PhanMismatchVariadicParam';
     const TypeMismatchForeach       = 'PhanTypeMismatchForeach';
@@ -1037,6 +1039,22 @@ class Issue
                 'Expected an object instance when accessing an instance property, but saw an expression with type {TYPE}',
                 self::REMEDIATION_B,
                 10040
+            ),
+            new Issue(
+                self::TypeMismatchUnpackKey,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                'When unpacking a value of type {TYPE}, the value\'s keys were of type {TYPE}, but the keys should be consecutive integers starting from 0',
+                self::REMEDIATION_B,
+                10041
+            ),
+            new Issue(
+                self::TypeMismatchUnpackValue,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                'Attempting to unpack a value of type {TYPE} which does not contain any subtypes of iterable (such as array or Traversable)',
+                self::REMEDIATION_B,
+                10042
             ),
             // Issue::CATEGORY_VARIABLE
             new Issue(

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -1315,6 +1315,15 @@ class Type
     }
 
     /**
+     * @return bool - Returns true if this is \Traversable (nullable or not)
+     */
+    public function isTraversable() : bool
+    {
+        return (\strcasecmp($this->getName(), 'Traversable') === 0
+            && $this->getNamespace() === '\\');
+    }
+
+    /**
      * @param string $type_name
      * A non-namespaced type name like 'int[]'
      *

--- a/src/Phan/Language/Type/NativeType.php
+++ b/src/Phan/Language/Type/NativeType.php
@@ -57,6 +57,11 @@ abstract class NativeType extends Type
         return false;
     }
 
+    public function isTraversable() : bool
+    {
+        return false;
+    }
+
     public function isObject() : bool
     {
         return false;

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -1226,6 +1226,22 @@ class UnionType implements \Serializable
 
     /**
      * @return bool
+     * True if this union contains the Traversable type.
+     * (Call asExpandedTypes() first to check for subclasses of Traversable)
+     */
+    public function hasTraversable() : bool
+    {
+        if ($this->isEmpty()) {
+            return false;
+        }
+
+        return $this->hasTypeMatchingCallback(function (Type $type) : bool {
+            return $type->isTraversable();
+        });
+    }
+
+    /**
+     * @return bool
      * True if this union type represents types that are
      * array-like, and nothing else (e.g. can't be null).
      * If any of the array-like types are nullable, this returns false.

--- a/tests/files/expected/0401_varargs.php.expected
+++ b/tests/files/expected/0401_varargs.php.expected
@@ -1,0 +1,4 @@
+%s:13 PhanTypeMismatchUnpackKey When unpacking a value of type array<string,\stdClass>, the value's keys were of type string, but the keys should be consecutive integers starting from 0
+%s:14 PhanTypeMismatchArgument Argument 1 (a1) is int but \test_varargs401() takes \stdClass defined at %s:3
+%s:15 PhanTypeMismatchUnpackValue Attempting to unpack a value of type int which does not contain any subtypes of iterable (such as array or Traversable)
+%s:16 PhanTypeMismatchUnpackValue Attempting to unpack a value of type \stdClass which does not contain any subtypes of iterable (such as array or Traversable)

--- a/tests/files/src/0401_varargs.php
+++ b/tests/files/src/0401_varargs.php
@@ -1,0 +1,18 @@
+<?php
+
+function test_varargs401(stdClass $a1, stdClass ...$args) {
+    var_export($args);
+}
+
+/** @param array<string,stdClass> $args */
+function unpack_varargs401(array $args, iterable $iterable) {
+    $c = [2];
+    $int = 2;
+    $stdClass = new stdClass();
+    $arrayObject = new ArrayObject([new stdClass(), new stdClass()]);
+    test_varargs401(...$args);
+    test_varargs401(...$c);
+    test_varargs401(...$int);
+    test_varargs401(...$stdClass);
+    test_varargs401(...$iterable);
+}


### PR DESCRIPTION
Fixes #1384 (for generic arrays).

- Make Phan start warning about invalid types passed to the array
  unpacking/splat operator (See NEWS)