### PR TITLE
Improved generic array types inferences of array literals.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -31,6 +31,19 @@ New Features(Analysis)
 
   Emit `PhanTypeMismatchUnpackValue` when passing values that aren't iterables or arrays to the unpacking operator.
   (See https://secure.php.net/manual/en/migration56.new-features.php#migration56.new-features.splat)
++ When determining the union type of an array literal,
+  base it on the union types of **all** of the values (and all of the keys) instead of just the first 5 array elements.
++ When determining the union type of the possible value types of a array literal,
+  combine the generic types into a union type instead of simplifying the types to `array`.
+  In practical terms, this means that `[1,2,'a']` is seen as `array<int,int|string>`,
+  which Phan represents as `array<int,int>|array<int,string>`.
+
+  In the previous phan release, that would be represented as `int[]|string[]`,
+  which is equivalent to `array<mixed,int>|array<mixed,string>`
+
+  Another example: `[$strKey => new MyClass(), $strKey2 => $unknown]` will be represented as
+  `array<string,MyClass>|array<string,mixed>`.
+  (If phan can't infer a type of a key or value, `mixed` gets added to that key or value.)
 
 Bug fixes
 + Warn when attempting to call an instance method on an expression with type string (#1314).

--- a/README.md
+++ b/README.md
@@ -344,6 +344,15 @@ class C {
 Just like in PHP, any type can be nulled in the function declaration which also
 means a null is allowed to be passed in for that parameter.
 
+In the next release (0.10.4+ and other minor version releases on the same date):
+Phan checks the type of every single element of arrays (Including keys and values).
+In practical terms, this means that `[1,2,'a']` is seen as `array<int,int|string>`,
+which Phan represents as `array<int,int>|array<int,string>`.
+`[$strKey => new MyClass(), $strKey2 => $unknown]` will be represented as
+`array<string,MyClass>|array<string,mixed>`.
+(Note that Phan also started tracking the key types of generic arrays in 0.10.4)
+
+In older versions (<= 0.10.3 and other minor version releases from the same date):
 By default, and completely arbitrarily, for things like `int[]` it checks the first 5
 elements. If the first 5 are of the same type, it assumes the rest are as well. If it can't
 determine the array sub-type it just becomes `array` which will pass through most type

--- a/tests/Phan/Language/UnionTypeTest.php
+++ b/tests/Phan/Language/UnionTypeTest.php
@@ -115,7 +115,7 @@ class UnionTypeTest extends BaseTest
     {
         $this->assertUnionTypeStringEqual(
             '[1, "string"]',
-            'array'
+            'array<int,int>|array<int,string>'
         );
     }
 

--- a/tests/files/expected/0253_keys_in_lists.php.expected
+++ b/tests/files/expected/0253_keys_in_lists.php.expected
@@ -1,3 +1,7 @@
+%s:16 PhanTypeMismatchArgument Argument 1 (p1) is int|string but \f253_1() takes bool defined at %s:2
+%s:17 PhanTypeMismatchArgument Argument 1 (p1) is int|string but \f253_1() takes bool defined at %s:2
+%s:20 PhanTypeMismatchArgument Argument 1 (p1) is int|string but \f253_1() takes bool defined at %s:2
+%s:21 PhanTypeMismatchArgument Argument 1 (p1) is int|string but \f253_1() takes bool defined at %s:2
 %s:26 PhanTypeMismatchArgument Argument 1 (p1) is int but \f253_1() takes bool defined at %s:2
 %s:27 PhanTypeMismatchArgument Argument 1 (p1) is int but \f253_1() takes bool defined at %s:2
 %s:30 PhanTypeMismatchArgument Argument 1 (p1) is int but \f253_1() takes bool defined at %s:2


### PR DESCRIPTION
Get rid of the 5 element limit.
Analyze the union types of all array elements instead of just the first 5.
Add `mixed` to the types of keys/values when a single element can't be
inferred.

This is being done in preparation for supporting array shapes such as
`array{fieldName:string}`.
(The alternative would be to have the same/different limitation on array
shape sizes.)

This slows down Phan somewhat.

Fixes #985 