### PR TITLE
DateTimeZone::getOffset accepts DateTimeInterface

### DIFF
--- a/src/Phan/Language/Internal/FunctionSignatureMap.php
+++ b/src/Phan/Language/Internal/FunctionSignatureMap.php
@@ -1174,7 +1174,7 @@ return [
 'date_timezone_get' => ['DateTimeZone', 'obj'=>'DateTime'],
 'DateTimeZone::getLocation' => ['array'],
 'DateTimeZone::getName' => ['string'],
-'DateTimeZone::getOffset' => ['int', 'datetime'=>'DateTime'],
+'DateTimeZone::getOffset' => ['int', 'datetime'=>'DateTimeInterface'],
 'DateTimeZone::getTransitions' => ['array', 'timestamp_begin='=>'int', 'timestamp_end='=>'int'],
 'DateTimeZone::listAbbreviations' => ['array'],
 'DateTimeZone::listIdentifiers' => ['array', 'what='=>'int', 'country='=>'string'],


### PR DESCRIPTION
Since PHP 7 DateTimeZone::getOffset accepts a DateTimeInterface instead of DateTime. See https://github.com/php/php-src/commit/9680829389aefc5bee2f0cdeacd34cbef6b66bbd