### PR TITLE
Make UnionType immutable; cache computed UnionType of expressions; fix bugs; misc performance improvements

### DIFF
--- a/.phan/plugins/PrintfCheckerPlugin.php
+++ b/.phan/plugins/PrintfCheckerPlugin.php
@@ -468,7 +468,7 @@ class PrintfCheckerPlugin extends PluginV2 implements AnalyzeFunctionCallCapabil
                 }
                 $expected_union_type = new UnionType();
                 foreach ($expected_set as $type_name => $_) {
-                    $expected_union_type->addType(Type::fromFullyQualifiedString($type_name));
+                    $expected_union_type = $expected_union_type->withType(Type::fromFullyQualifiedString($type_name));
                 }
                 if ($actual_union_type->canCastToUnionType($expected_union_type)) {
                     continue;

--- a/NEWS
+++ b/NEWS
@@ -50,10 +50,16 @@ New Features(Analysis)
 
 Plugins
 + Fix bugs in NonBoolBranchPlugin and NonBoolInLogicalArithPlugin (#1413, #1410)
++ **Make UnionType instances immutable.**
+  This will affect plugins that used addType/addUnionType/removeType. withType/withUnionType/withoutType should be used instead.
+  To modify the type of elements(properties, method return types, parameters, variables, etc),
+  `Element->setUnionType(plugin_modifier_function(Element->getUnionType()))` should be used.
+
 
 Bug fixes
 + Warn when attempting to call an instance method on an expression with type string (#1314).
 + Fix a bug in `tool/make_stubs` when generating stubs of global functions.
++ Fix some bugs that occurred when Phan resolved inherited class constants in class elements such as properties. (#537 and #454)
 
 20 Jan 2018, Phan 0.10.3
 ------------------------
@@ -66,6 +72,7 @@ New Features(CLI, Configs)
   Keep `PHP-Parser` as a dependency for now for parsing strings.
 
 Maintenance
++ Various performance optimizations, including caching of inferred union types to avoid unnecessary recalculation.
 + Make `phan_client` and the vim snippet in `plugins/vim/phansnippet.vim` more compatible with neovim
 + Upgrade felixfbecker/advanced-json-rpc dependency to ^3.0.0 (#1354)
 + Performance improvements.

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -338,7 +338,7 @@ class ContextNode
             // This is nonsense. Give up, but check if it's a type other than int/string.
             // (e.g. to catch typos such as $$this->foo = bar;)
             try {
-                $name_node_type = (new UnionTypeVisitor($this->code_base, $this->context, true))($name_node);
+                $name_node_type = UnionTypeVisitor::unionTypeFromNode($this->code_base, $this->context, $name_node, true);
             } catch (IssueException $exception) {
                 Issue::maybeEmitInstance(
                     $this->code_base,

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -1178,7 +1178,7 @@ class ContextNode
         $property = new Property(
             $this->context,
             $property_name,
-            new UnionType(),
+            UnionType::empty(),
             $flags,
             $property_fqsen
         );

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -164,7 +164,7 @@ class ContextNode
 
         $adaptations_map = [];
         foreach ($trait_fqsen_list as $trait_fqsen) {
-            $adaptations_map[strtolower($trait_fqsen->__toString())] = new TraitAdaptations($trait_fqsen);
+            $adaptations_map[\strtolower($trait_fqsen->__toString())] = new TraitAdaptations($trait_fqsen);
         }
 
         foreach ($this->node->children ?? [] as $adaptation_node) {
@@ -216,7 +216,7 @@ class ContextNode
             return;
         }
 
-        $fqsen_key = strtolower($trait_fqsen->__toString());
+        $fqsen_key = \strtolower($trait_fqsen->__toString());
 
         $adaptations_info = $adaptations_map[$fqsen_key] ?? null;
         if ($adaptations_info === null) {
@@ -235,7 +235,7 @@ class ContextNode
         // Handle `use MyTrait { myMethod as private; }` by skipping the original method.
         // TODO: Do this a cleaner way.
         if (strcasecmp($trait_new_method_name, $trait_original_method_name) === 0) {
-            $adaptations_info->hidden_methods[strtolower($trait_original_method_name)] = true;
+            $adaptations_info->hidden_methods[\strtolower($trait_original_method_name)] = true;
         }
     }
 
@@ -264,7 +264,7 @@ class ContextNode
             throw new UnanalyzableException($trait_chosen_class_name_node, "This shouldn't happen. Could not determine trait fqsen for trait with higher precedence for method $trait_chosen_method_name");
         }
 
-        if (($adaptations_map[strtolower($trait_chosen_fqsen->__toString())] ?? null) === null) {
+        if (($adaptations_map[\strtolower($trait_chosen_fqsen->__toString())] ?? null) === null) {
             // This will probably correspond to a PHP fatal error, but keep going anyway.
             Issue::maybeEmit(
                 $this->code_base,
@@ -287,7 +287,7 @@ class ContextNode
                 throw new UnanalyzableException($trait_insteadof_class_name, "This shouldn't happen. Could not determine trait fqsen for trait with lower precedence for method $trait_chosen_method_name");
             }
 
-            $fqsen_key = strtolower($trait_insteadof_fqsen->__toString());
+            $fqsen_key = \strtolower($trait_insteadof_fqsen->__toString());
 
             $adaptations_info = $adaptations_map[$fqsen_key] ?? null;
             if ($adaptations_info === null) {

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -349,10 +349,7 @@ class ContextNode
             }
             static $int_or_string_type;
             if ($int_or_string_type === null) {
-                $int_or_string_type = new UnionType();
-                $int_or_string_type->addType(StringType::instance(false));
-                $int_or_string_type->addType(IntType::instance(false));
-                $int_or_string_type->addType(NullType::instance(false));
+                $int_or_string_type = new UnionType([StringType::instance(false), IntType::instance(false), NullType::instance(false)]);
             }
             if (!$name_node_type->canCastToUnionType($int_or_string_type)) {
                 Issue::maybeEmit($this->code_base, $this->context, Issue::TypeSuspiciousIndirectVariable, $name_node->lineno ?? 0, (string)$name_node_type);

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -40,6 +40,10 @@ use Phan\Library\Some;
 use ast\Node;
 use ast;
 
+if (!\function_exists('spl_object_id')) {
+    require_once __DIR__ . '/../../spl_object_id.php';
+}
+
 /**
  * Methods for an AST node in context
  */
@@ -87,7 +91,7 @@ class ContextNode
                 $this->context,
                 $name_node
             ))->getQualifiedName();
-        }, $this->node->children ?? []);
+        }, $this->node->children);
     }
 
     /**
@@ -117,7 +121,7 @@ class ContextNode
                 $this->context,
                 $name_node
             ))->getTraitFQSEN([]);
-        }, $this->node->children ?? []);
+        }, $this->node->children);
     }
 
     /**
@@ -167,7 +171,7 @@ class ContextNode
             $adaptations_map[\strtolower($trait_fqsen->__toString())] = new TraitAdaptations($trait_fqsen);
         }
 
-        foreach ($this->node->children ?? [] as $adaptation_node) {
+        foreach ($this->node->children as $adaptation_node) {
             \assert($adaptation_node instanceof Node);
             if ($adaptation_node->kind === ast\AST_TRAIT_ALIAS) {
                 $this->handleTraitAlias($adaptations_map, $adaptation_node);
@@ -322,7 +326,7 @@ class ContextNode
             && ($node->kind != ast\AST_STATIC)
             && ($node->kind != ast\AST_MAGIC_CONST)
         ) {
-            $node = \array_values($node->children ?? [])[0];
+            $node = \array_values($node->children)[0];
         }
 
         if (!($node instanceof ast\Node)) {
@@ -385,6 +389,9 @@ class ContextNode
     {
         $node = $this->node;
         if (!($node instanceof Node)) {
+            if (\is_string($node)) {
+                return [StringType::instance(false)->asUnionType(), []];
+            }
             return [UnionType::empty(), []];
         }
         $context = $this->context;

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -1468,7 +1468,7 @@ Node\SourceFileNode
 
     private static function phpParserIncludeTokenToAstIncludeFlags(Token $type) : int
     {
-        $type_name = strtolower(self::tokenToString($type));
+        $type_name = \strtolower(self::tokenToString($type));
         switch ($type_name) {
             case 'include':
                 return ast\flags\EXEC_INCLUDE;

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1985,7 +1985,7 @@ class UnionTypeVisitor extends AnalysisVisitor
         // have the constant we're looking for
         foreach ($union_type->nonNativeTypes()->getTypeSet() as $class_type) {
             // Get the class FQSEN
-            $class_fqsen = $class_type->asClassFQSEN();
+            $class_fqsen = FullyQualifiedClassName::fromType($class_type);
 
             // See if the class exists
             if (!$this->code_base->hasClassWithFQSEN($class_fqsen)) {

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -76,7 +76,10 @@ class UnionTypeVisitor extends AnalysisVisitor
         Context $context,
         bool $should_catch_issue_exception = true
     ) {
-        parent::__construct($code_base, $context);
+        // Inlined to be more efficient.
+        // parent::__construct($code_base, $context);
+        $this->code_base = $code_base;
+        $this->context = $context;
 
         $this->should_catch_issue_exception =
             $should_catch_issue_exception;
@@ -785,7 +788,7 @@ class UnionTypeVisitor extends AnalysisVisitor
         return (new BinaryOperatorFlagVisitor(
             $this->code_base,
             $this->context
-        ))($node);
+        ))->__invoke($node);
     }
 
     /**

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -5,6 +5,7 @@ use Phan\Analysis\AssignOperatorFlagVisitor;
 use Phan\Analysis\BinaryOperatorFlagVisitor;
 use Phan\Analysis\ConditionVisitor;
 use Phan\Analysis\NegatedConditionVisitor;
+use Phan\AST\Visitor\Element;
 use Phan\CodeBase;
 use Phan\Config;
 use Phan\Debug;
@@ -111,6 +112,7 @@ class UnionTypeVisitor extends AnalysisVisitor
         bool $should_catch_issue_exception = true
     ) : UnionType {
         if (!($node instanceof Node)) {
+            // TODO: String null shouldn't be a special case (or should be case insensitive)?
             if ($node === null || $node === 'null') {
                 return UnionType::empty();
             }
@@ -139,7 +141,7 @@ class UnionTypeVisitor extends AnalysisVisitor
             $code_base,
             $context,
             $should_catch_issue_exception
-        ))($node);
+        ))->{Element::VISIT_LOOKUP_TABLE[$node->kind] ?? 'handleMissingNodeKind'}($node);
     }
 
     /**

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1594,7 +1594,7 @@ class UnionTypeVisitor extends AnalysisVisitor
                     // once we're talking about the method's return
                     // type outside of its class
                     if ($union_type->hasStaticType()) {
-                        $union_type = $union_type->withType(\Phan\Language\Type\StaticType::instance(false));
+                        $union_type = $union_type->withoutType(\Phan\Language\Type\StaticType::instance(false));
                     }
 
                     if ($union_type->genericArrayElementTypes()->hasStaticType()) {

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -535,7 +535,7 @@ class UnionTypeVisitor extends AnalysisVisitor
             if ($cond->kind === \ast\AST_CONST) {
                 $name = $cond->children['name'];
                 if ($name->kind === \ast\AST_NAME) {
-                    switch (strtolower($name->children['name'])) {
+                    switch (\strtolower($name->children['name'])) {
                         case 'true':
                             return true;
                         case 'false':

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1333,7 +1333,7 @@ class UnionTypeVisitor extends AnalysisVisitor
                     $this->context,
                     $exception->getIssueInstance()
                 );
-                return new UnionType;
+                return UnionType::empty();
             }
 
             return $constant->getUnionType();
@@ -1824,7 +1824,7 @@ class UnionTypeVisitor extends AnalysisVisitor
         if ($node instanceof Node
             && $node->kind == \ast\AST_NAME_LIST
         ) {
-            $union_type = new UnionType;
+            $union_type = UnionType::empty();
             foreach ($node->children ?? [] as $child_node) {
                 $union_type = $union_type->withUnionType(
                     self::unionTypeFromClassNode(

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -179,6 +179,7 @@ class UnionTypeVisitor extends AnalysisVisitor
      */
     public function visitPostInc(Node $node) : UnionType
     {
+        // TODO: Check if union type is sane (string/int)
         return self::unionTypeFromNode(
             $this->code_base,
             $this->context,
@@ -199,6 +200,7 @@ class UnionTypeVisitor extends AnalysisVisitor
      */
     public function visitPostDec(Node $node) : UnionType
     {
+        // TODO: Check if union type is sane (string/int)
         return self::unionTypeFromNode(
             $this->code_base,
             $this->context,
@@ -219,6 +221,7 @@ class UnionTypeVisitor extends AnalysisVisitor
      */
     public function visitPreDec(Node $node) : UnionType
     {
+        // TODO: Check if union type is sane (string/int)
         return self::unionTypeFromNode(
             $this->code_base,
             $this->context,
@@ -239,6 +242,7 @@ class UnionTypeVisitor extends AnalysisVisitor
      */
     public function visitPreInc(Node $node) : UnionType
     {
+        // TODO: Check if union type is sane (string/int)
         return self::unionTypeFromNode(
             $this->code_base,
             $this->context,
@@ -259,6 +263,7 @@ class UnionTypeVisitor extends AnalysisVisitor
      */
     public function visitClone(Node $node) : UnionType
     {
+        // TODO: Check if union type is sane (Any object type)
         return self::unionTypeFromNode(
             $this->code_base,
             $this->context,

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -112,7 +112,7 @@ class UnionTypeVisitor extends AnalysisVisitor
     ) : UnionType {
         if (!($node instanceof Node)) {
             if ($node === null || $node === 'null') {
-                return new UnionType();
+                return UnionType::empty();
             }
 
             return Type::fromObject($node)->asUnionType();
@@ -131,7 +131,7 @@ class UnionTypeVisitor extends AnalysisVisitor
                     $context,
                     $exception->getIssueInstance()
                 );
-                return new UnionType();
+                return UnionType::empty();
             }
         }
 
@@ -161,7 +161,7 @@ class UnionTypeVisitor extends AnalysisVisitor
             . Debug::nodeName($node)
         );
         */
-        return new UnionType();
+        return UnionType::empty();
     }
 
     /**
@@ -311,7 +311,7 @@ class UnionTypeVisitor extends AnalysisVisitor
     {
         // require() can return arbitrary objects. Lets just
         // say that we don't know what it is and move on
-        return new UnionType();
+        return UnionType::empty();
     }
 
     /**
@@ -410,7 +410,7 @@ class UnionTypeVisitor extends AnalysisVisitor
                         );
                     }
 
-                    return new UnionType();
+                    return UnionType::empty();
                 }
             }
 
@@ -1068,10 +1068,10 @@ class UnionTypeVisitor extends AnalysisVisitor
         // If the only type is null, we don't know what
         // accessed items will be
         if ($union_type->isType($null_type)) {
-            return new UnionType();
+            return UnionType::empty();
         }
 
-        $element_types = new UnionType();
+        $element_types = UnionType::empty();
 
         // You can access string characters via array index,
         // so we'll add the string type to the result if we're
@@ -1262,7 +1262,7 @@ class UnionTypeVisitor extends AnalysisVisitor
             return $variable->getUnionType();
         }
 
-        return new UnionType();
+        return UnionType::empty();
     }
 
     /**
@@ -1339,7 +1339,7 @@ class UnionTypeVisitor extends AnalysisVisitor
             return $constant->getUnionType();
         }
 
-        return new UnionType();
+        return UnionType::empty();
     }
 
     /**
@@ -1373,7 +1373,7 @@ class UnionTypeVisitor extends AnalysisVisitor
             );
         }
 
-        return new UnionType();
+        return UnionType::empty();
     }
 
     /**
@@ -1453,7 +1453,7 @@ class UnionTypeVisitor extends AnalysisVisitor
             // just can't figure out.
         }
 
-        return new UnionType();
+        return UnionType::empty();
     }
 
     /**
@@ -1493,7 +1493,7 @@ class UnionTypeVisitor extends AnalysisVisitor
             $expression
         ))->getFunctionFromNode();
 
-        $possible_types = new UnionType();
+        $possible_types = UnionType::empty();
         foreach ($function_list_generator as $function) {
             assert($function instanceof FunctionInterface);
             if ($function->hasDependentReturnType()) {
@@ -1542,7 +1542,7 @@ class UnionTypeVisitor extends AnalysisVisitor
         // method name is a variable such as in
         // `$variable->$function_name()`.
         if ($method_name instanceof Node) {
-            return new UnionType();
+            return UnionType::empty();
         }
 
         // Method names can some times turn up being
@@ -1612,7 +1612,7 @@ class UnionTypeVisitor extends AnalysisVisitor
 
                     return $union_type;
                 } catch (IssueException $exception) {
-                    return new UnionType();
+                    return UnionType::empty();
                 }
             }
         } catch (IssueException $exception) {
@@ -1626,7 +1626,7 @@ class UnionTypeVisitor extends AnalysisVisitor
             );
         }
 
-        return new UnionType();
+        return UnionType::empty();
     }
 
     /**
@@ -1707,7 +1707,7 @@ class UnionTypeVisitor extends AnalysisVisitor
     {
         // Things of the form `new $class_name();`
         if ($node->kind == \ast\AST_VAR) {
-            return new UnionType();
+            return UnionType::empty();
         }
 
         // Anonymous class of form `new class { ... }`
@@ -1734,7 +1734,7 @@ class UnionTypeVisitor extends AnalysisVisitor
 
         // Things of the form `new $method->name()`
         if ($node->kind !== \ast\AST_NAME) {
-            return new UnionType();
+            return UnionType::empty();
         }
 
         // Get the name of the class
@@ -1759,7 +1759,7 @@ class UnionTypeVisitor extends AnalysisVisitor
                 $class_name
             );
 
-            return new UnionType();
+            return UnionType::empty();
         }
 
         // Reference to a parent class
@@ -1775,7 +1775,7 @@ class UnionTypeVisitor extends AnalysisVisitor
                     (string)$class->getFQSEN()
                 );
 
-                return new UnionType();
+                return UnionType::empty();
             }
 
             return Type::fromFullyQualifiedString(

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -897,7 +897,7 @@ class UnionTypeVisitor extends AnalysisVisitor
 
         // For any types that are templates, map them to concrete
         // types based on the parameters passed in.
-        return new UnionType(\array_map(function (Type $type) use ($node) {
+        return UnionType::of(\array_map(function (Type $type) use ($node) {
 
             // Get a fully qualified name for the type
             $fqsen = $type->asFQSEN();
@@ -2387,9 +2387,11 @@ class UnionTypeVisitor extends AnalysisVisitor
         }
         static $int_type;
         static $string_type;
+        static $int_or_string_type;
         if ($int_type === null) {
             $int_type = IntType::instance(false);
             $string_type = StringType::instance(false);
+            $int_or_string_type = new UnionType([$int_type, $string_type], true);
         }
         $key_enum_type = GenericArrayType::keyTypeFromUnionTypeKeys($union_type);
         switch ($key_enum_type) {
@@ -2409,7 +2411,7 @@ class UnionTypeVisitor extends AnalysisVisitor
                         return null;
                     }
                 }
-                return new UnionType([$int_type, $string_type], true);
+                return $int_or_string_type;
         }
     }
 }

--- a/src/Phan/AST/Visitor/Element.php
+++ b/src/Phan/AST/Visitor/Element.php
@@ -145,70 +145,46 @@ class Element
         }
     }
 
+    const VISIT_BINARY_LOOKUP_TABLE = [
+        \ast\flags\BINARY_ADD => 'visitBinaryAdd',
+        \ast\flags\BINARY_BITWISE_AND => 'visitBinaryBitwiseAnd',
+        \ast\flags\BINARY_BITWISE_OR => 'visitBinaryBitwiseOr',
+        \ast\flags\BINARY_BITWISE_XOR => 'visitBinaryBitwiseXor',
+        \ast\flags\BINARY_BOOL_XOR => 'visitBinaryBoolXor',
+        \ast\flags\BINARY_CONCAT => 'visitBinaryConcat',
+        \ast\flags\BINARY_DIV => 'visitBinaryDiv',
+        \ast\flags\BINARY_IS_EQUAL => 'visitBinaryIsEqual',
+        \ast\flags\BINARY_IS_IDENTICAL => 'visitBinaryIsIdentical',
+        \ast\flags\BINARY_IS_NOT_EQUAL => 'visitBinaryIsNotEqual',
+        \ast\flags\BINARY_IS_NOT_IDENTICAL => 'visitBinaryIsNotIdentical',
+        \ast\flags\BINARY_IS_SMALLER => 'visitBinaryIsSmaller',
+        \ast\flags\BINARY_IS_SMALLER_OR_EQUAL => 'visitBinaryIsSmallerOrEqual',
+        \ast\flags\BINARY_MOD => 'visitBinaryMod',
+        \ast\flags\BINARY_MUL => 'visitBinaryMul',
+        \ast\flags\BINARY_POW => 'visitBinaryPow',
+        \ast\flags\BINARY_SHIFT_LEFT => 'visitBinaryShiftLeft',
+        \ast\flags\BINARY_SHIFT_RIGHT => 'visitBinaryShiftRight',
+        \ast\flags\BINARY_SPACESHIP => 'visitBinarySpaceship',
+        \ast\flags\BINARY_SUB => 'visitBinarySub',
+        \ast\flags\BINARY_BOOL_AND => 'visitBinaryBoolAnd',
+        \ast\flags\BINARY_BOOL_OR => 'visitBinaryBoolOr',
+        \ast\flags\BINARY_COALESCE => 'visitBinaryCoalesce',
+        \ast\flags\BINARY_IS_GREATER => 'visitBinaryIsGreater',
+        \ast\flags\BINARY_IS_GREATER_OR_EQUAL => 'visitBinaryIsGreaterOrEqual',
+    ];
+
     /**
      * Accepts a visitor that differentiates on the flag value
      * of the AST node.
      */
-    public function acceptBinaryFlagVisitor(FlagVisitor $visitor)
+    public static function acceptBinaryFlagVisitor(Node $node, FlagVisitor $visitor)
     {
-        switch ($this->node->flags ?? 0) {
-            case \ast\flags\BINARY_ADD:
-                return $visitor->visitBinaryAdd($this->node);
-            case \ast\flags\BINARY_BITWISE_AND:
-                return $visitor->visitBinaryBitwiseAnd($this->node);
-            case \ast\flags\BINARY_BITWISE_OR:
-                return $visitor->visitBinaryBitwiseOr($this->node);
-            case \ast\flags\BINARY_BITWISE_XOR:
-                return $visitor->visitBinaryBitwiseXor($this->node);
-            case \ast\flags\BINARY_BOOL_XOR:
-                return $visitor->visitBinaryBoolXor($this->node);
-            case \ast\flags\BINARY_CONCAT:
-                return $visitor->visitBinaryConcat($this->node);
-            case \ast\flags\BINARY_DIV:
-                return $visitor->visitBinaryDiv($this->node);
-            case \ast\flags\BINARY_IS_EQUAL:
-                return $visitor->visitBinaryIsEqual($this->node);
-            case \ast\flags\BINARY_IS_IDENTICAL:
-                return $visitor->visitBinaryIsIdentical($this->node);
-            case \ast\flags\BINARY_IS_NOT_EQUAL:
-                return $visitor->visitBinaryIsNotEqual($this->node);
-            case \ast\flags\BINARY_IS_NOT_IDENTICAL:
-                return $visitor->visitBinaryIsNotIdentical($this->node);
-            case \ast\flags\BINARY_IS_SMALLER:
-                return $visitor->visitBinaryIsSmaller($this->node);
-            case \ast\flags\BINARY_IS_SMALLER_OR_EQUAL:
-                return $visitor->visitBinaryIsSmallerOrEqual($this->node);
-            case \ast\flags\BINARY_MOD:
-                return $visitor->visitBinaryMod($this->node);
-            case \ast\flags\BINARY_MUL:
-                return $visitor->visitBinaryMul($this->node);
-            case \ast\flags\BINARY_POW:
-                return $visitor->visitBinaryPow($this->node);
-            case \ast\flags\BINARY_SHIFT_LEFT:
-                return $visitor->visitBinaryShiftLeft($this->node);
-            case \ast\flags\BINARY_SHIFT_RIGHT:
-                return $visitor->visitBinaryShiftRight($this->node);
-            case \ast\flags\BINARY_SPACESHIP:
-                return $visitor->visitBinarySpaceship($this->node);
-            case \ast\flags\BINARY_SUB:
-                return $visitor->visitBinarySub($this->node);
-            case \ast\flags\BINARY_BOOL_AND:
-                return $visitor->visitBinaryBoolAnd($this->node);
-            case \ast\flags\BINARY_BOOL_OR:
-                return $visitor->visitBinaryBoolOr($this->node);
-            case \ast\flags\BINARY_COALESCE:
-                return $visitor->visitBinaryCoalesce($this->node);
-            case \ast\flags\BINARY_IS_GREATER:
-                return $visitor->visitBinaryIsGreater($this->node);
-            case \ast\flags\BINARY_IS_GREATER_OR_EQUAL:
-                return $visitor->visitBinaryIsGreaterOrEqual($this->node);
-            default:
-                \assert(
-                    false,
-                    "All flags must match. Found "
-                    . self::flagDescription($this->node)
-                );
-                break;
+        $fn_name = self::VISIT_BINARY_LOOKUP_TABLE[$node->flags] ?? null;
+        if (\is_string($fn_name)) {
+            return $visitor->{$fn_name}($node);
+        } else {
+            Debug::printNode($node);
+            \assert(false, "All flags must match. Found " . self::flagDescription($node));
         }
     }
 

--- a/src/Phan/AST/Visitor/Element.php
+++ b/src/Phan/AST/Visitor/Element.php
@@ -270,6 +270,8 @@ class Element
      * Accepts a visitor that differentiates on the flag value
      * of the AST node.
      *
+     * TODO: This is wrong, a parameter can be neither ref nor variadic, or both.
+     *
      * @suppress PhanUnreferencedPublicMethod
      */
     public function acceptParamFlagVisitor(FlagVisitor $visitor)

--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -162,14 +162,6 @@ class Analysis
      */
     public static function parseNodeInContext(CodeBase $code_base, Context $context, Node $node) : Context
     {
-        return self::parseNodeInContextInner($code_base, $context, $node);
-    }
-
-    /**
-     * @see self::parseNodeInContext
-     */
-    private static function parseNodeInContextInner(CodeBase $code_base, Context $context, Node $node) : Context
-    {
         // Save a reference to the outer context
         $outer_context = $context;
 
@@ -199,7 +191,7 @@ class Analysis
 
         // Recurse into each child node
         $child_context = $context;
-        foreach ($node->children ?? [] as $child_node) {
+        foreach ($node->children as $child_node) {
             // Skip any non Node children.
             if (!($child_node instanceof Node)) {
                 continue;
@@ -207,7 +199,7 @@ class Analysis
 
             // Step into each child node and get an
             // updated context for the node
-            $child_context = self::parseNodeInContextInner($code_base, $child_context, $child_node);
+            $child_context = self::parseNodeInContext($code_base, $child_context, $child_node);
 
             \assert(!empty($child_context), 'Context cannot be null');
         }

--- a/src/Phan/Analysis/ArgumentType.php
+++ b/src/Phan/Analysis/ArgumentType.php
@@ -47,7 +47,7 @@ class ArgumentType
         // better multi-signature error messages
         self::checkIsDeprecatedOrInternal($code_base, $context, $method);
         if ($method->hasFunctionCallAnalyzer()) {
-            $method->analyzeFunctionCall($code_base, $context->withLineNumberStart($node->lineno ?? 0), $node->children['args']->children ?? []);
+            $method->analyzeFunctionCall($code_base, $context->withLineNumberStart($node->lineno ?? 0), $node->children['args']->children);
         }
 
         if ($method->isPHPInternal()) {
@@ -401,7 +401,7 @@ class ArgumentType
             }
         }
 
-        foreach ($node->children ?? [] as $i => $argument) {
+        foreach ($node->children as $i => $argument) {
             // Get the parameter associated with this argument
             $parameter = $method->getParameterForCaller($i);
 

--- a/src/Phan/Analysis/AssignOperatorFlagVisitor.php
+++ b/src/Phan/Analysis/AssignOperatorFlagVisitor.php
@@ -48,7 +48,7 @@ class AssignOperatorFlagVisitor extends FlagVisitorImplementation
     {
         // AST_ASSIGN_OP uses \ast\flags\BINARY_* in ast versions >= 20.
         // NOTE: Some operations currently don't exist in any php version, such as `$x ||= 2;`, `$x xor= 2;`
-        return (new Element($node))->acceptBinaryFlagVisitor($this);
+        return Element::acceptBinaryFlagVisitor($node, $this);
     }
 
     /**

--- a/src/Phan/Analysis/AssignOperatorFlagVisitor.php
+++ b/src/Phan/Analysis/AssignOperatorFlagVisitor.php
@@ -89,7 +89,7 @@ class AssignOperatorFlagVisitor extends FlagVisitorImplementation
                 $right
             );
 
-            return new UnionType();
+            return UnionType::empty();
         } elseif ($left->hasType(IntType::instance(false))
             && $right->hasType(IntType::instance(false))
         ) {
@@ -184,7 +184,7 @@ class AssignOperatorFlagVisitor extends FlagVisitorImplementation
                 $right
             );
 
-            return new UnionType();
+            return UnionType::empty();
         } elseif ($left->hasType(IntType::instance(false))
             && $right->hasType(IntType::instance(false))
         ) {
@@ -277,7 +277,7 @@ class AssignOperatorFlagVisitor extends FlagVisitorImplementation
                 Issue::TypeInvalidRightOperand,
                 $node->lineno ?? 0
             );
-            return new UnionType();
+            return UnionType::empty();
         } elseif ($right_is_array
             && !$left->canCastToUnionType(ArrayType::instance(false)->asUnionType())
         ) {
@@ -287,7 +287,7 @@ class AssignOperatorFlagVisitor extends FlagVisitorImplementation
                 Issue::TypeInvalidLeftOperand,
                 $node->lineno ?? 0
             );
-            return new UnionType();
+            return UnionType::empty();
         } elseif ($left_is_array || $right_is_array) {
             // If it is a '+' and we know one side is an array
             // and the other is unknown, assume array

--- a/src/Phan/Analysis/AssignOperatorFlagVisitor.php
+++ b/src/Phan/Analysis/AssignOperatorFlagVisitor.php
@@ -100,10 +100,11 @@ class AssignOperatorFlagVisitor extends FlagVisitorImplementation
             return FloatType::instance(false)->asUnionType();
         }
 
-        return new UnionType([
+        static $int_or_float;
+        return $int_or_float ?? ($int_or_float = new UnionType([
             IntType::instance(false),
             FloatType::instance(false)
-        ]);
+        ]));
     }
 
     public function visitBinaryBitwiseAnd(Node $node)
@@ -294,9 +295,10 @@ class AssignOperatorFlagVisitor extends FlagVisitorImplementation
             return ArrayType::instance(false)->asUnionType();
         }
 
-        return new UnionType([
+        static $int_or_float;
+        return $int_or_float ?? ($int_or_float = new UnionType([
             IntType::instance(false),
             FloatType::instance(false)
-        ]);
+        ]));
     }
 }

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -535,7 +535,7 @@ class AssignmentVisitor extends AnalysisVisitor
     {
         $property_types = $property->getUnionType();
         if ($property_types->isEmpty()) {
-            $property_types->addUnionType($this->right_type);
+            $property->setUnionType($this->right_type);
             return;
         }
         if ($this->is_dim_assignment) {
@@ -545,12 +545,11 @@ class AssignmentVisitor extends AnalysisVisitor
         }
         // Don't add MixedType to a non-empty property - It makes inferences on that property useless.
         if ($new_types->hasType(MixedType::instance(false))) {
-            $new_types = clone($new_types);
-            $new_types->removeType(MixedType::instance(false));
+            $new_types = $new_types->withoutType(MixedType::instance(false));
         }
         // TODO: Add an option to check individual types, not just the whole union type?
         //       If that is implemented, verify that generic arrays will properly cast to regular arrays (public $x = [];)
-        $property_types->addUnionType($new_types);
+        $property->setUnionType($property_types->withUnionType($new_types));
     }
 
     /**
@@ -635,17 +634,17 @@ class AssignmentVisitor extends AnalysisVisitor
                 // its union type rather than replace it.
                 if ($this->is_dim_assignment) {
                     $right_type = $this->typeCheckDimAssignment($property->getUnionType(), $node);
-                    $property->getUnionType()->addUnionType(
+                    $property->setUnionType($property->getUnionType()->withUnionType(
                         $right_type
-                    );
+                    ));
                     return $this->context;
                 }
             }
 
             // After having checked it, add this type to it
-            $property->getUnionType()->addUnionType(
+            $property->setUnionType($property->getUnionType()->withUnionType(
                 $this->right_type
-            );
+            ));
 
             return $this->context;
         }
@@ -709,9 +708,9 @@ class AssignmentVisitor extends AnalysisVisitor
             // its union type rather than replace it.
             if ($this->is_dim_assignment) {
                 $right_type = $this->typeCheckDimAssignment($variable->getUnionType(), $node);
-                $variable->getUnionType()->addUnionType(
+                $variable->setUnionType($variable->getUnionType()->withUnionType(
                     $right_type
-                );
+                ));
             } else {
                 // If the variable isn't a pass-by-reference parameter
                 // we clone it so as to not disturb its previous types
@@ -751,9 +750,9 @@ class AssignmentVisitor extends AnalysisVisitor
         );
 
         // Set that type on the variable
-        $variable->getUnionType()->addUnionType(
+        $variable->setUnionType($variable->getUnionType()->withUnionType(
             $this->right_type
-        );
+        ));
 
         // Note that we're not creating a new scope, just
         // adding variables to the existing scope

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -204,7 +204,7 @@ class AssignmentVisitor extends AnalysisVisitor
         $element_type =
             $this->right_type->genericArrayElementTypes();
 
-        foreach ($node->children ?? [] as $child_node) {
+        foreach ($node->children as $child_node) {
             // Some times folks like to pass a null to
             // a list to throw the element away. I'm not
             // here to judge.

--- a/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
+++ b/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
@@ -96,10 +96,11 @@ class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
             return FloatType::instance(false)->asUnionType();
         }
 
-        return new UnionType([
+        static $int_or_float = null;
+        return $int_or_float ?? ($int_or_float = new UnionType([
             IntType::instance(false),
             FloatType::instance(false)
-        ]);
+        ]));
     }
 
     // Code can bitwise xor strings byte by byte in PHP

--- a/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
+++ b/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
@@ -46,7 +46,7 @@ class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
      */
     public function __invoke(Node $node)
     {
-        return (new Element($node))->acceptBinaryFlagVisitor($this);
+        return Element::acceptBinaryFlagVisitor($node, $this);
     }
 
     /**

--- a/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
+++ b/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
@@ -478,8 +478,6 @@ class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
      */
     public function visitBinaryCoalesce(Node $node) : UnionType
     {
-        $union_type = new UnionType();
-
         $left_type = UnionTypeVisitor::unionTypeFromNode(
             $this->code_base,
             $this->context,
@@ -498,14 +496,6 @@ class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
             $left_type = $left_type->nonNullableClone();
         }
 
-        $union_type->addUnionType(
-            $left_type
-        );
-
-        $union_type->addUnionType(
-            $right_type
-        );
-
-        return $union_type;
+        return $left_type->withUnionType($right_type);
     }
 }

--- a/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
+++ b/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
@@ -85,7 +85,7 @@ class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
                 $right
             );
 
-            return new UnionType();
+            return UnionType::empty();
         } elseif ($left->hasType(IntType::instance(false))
             && $right->hasType(IntType::instance(false))
         ) {
@@ -129,7 +129,7 @@ class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
                 $right
             );
 
-            return new UnionType();
+            return UnionType::empty();
         } elseif ($left->hasType(IntType::instance(false))
             && $right->hasType(IntType::instance(false))
         ) {
@@ -417,7 +417,7 @@ class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
                 Issue::TypeInvalidRightOperand,
                 $node->lineno ?? 0
             );
-            return new UnionType();
+            return UnionType::empty();
         } elseif ($right_is_array
             && !$left->canCastToUnionType(ArrayType::instance(false)->asUnionType())
         ) {
@@ -427,7 +427,7 @@ class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
                 Issue::TypeInvalidLeftOperand,
                 $node->lineno ?? 0
             );
-            return new UnionType();
+            return UnionType::empty();
         } elseif ($left_is_array || $right_is_array) {
             // If it is a '+' and we know one side is an array
             // and the other is unknown, assume array

--- a/src/Phan/Analysis/BlockExitStatusChecker.php
+++ b/src/Phan/Analysis/BlockExitStatusChecker.php
@@ -308,9 +308,9 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
     {
         $inner_status = $this->check($node->children['stmts']);
         // for loops have an expression list as a condition.
-        $cond_nodes = $node->children['cond']->children ?? [];
+        $cond_nodes = $node->children['cond']->children ?? [];  // NOTE: $node->children['cond'] is null for the expression `for (;;)`
         // TODO: Check for unconditionally false conditions.
-        if (count($cond_nodes) === 0 || self::isTruthyLiteral(end($cond_nodes))) {
+        if (count($cond_nodes) === 0 || self::isTruthyLiteral(\end($cond_nodes))) {
             // Use a special case to analyze "while (1) {exprs}" or "for (; true; ) {exprs}"
             // TODO: identify infinite loops, mark those as STATUS_NO_PROCEED or STATUS_RETURN.
             return $this->computeDerivedStatusOfInfiniteLoop($inner_status);
@@ -450,7 +450,7 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
         if ($status) {
             return $status;
         }
-        $status = $this->computeStatusOfBlock($node->children ?? []);
+        $status = $this->computeStatusOfBlock($node->children);
         $node->flags = $status;
         return $status;
     }

--- a/src/Phan/Analysis/BlockExitStatusChecker.php
+++ b/src/Phan/Analysis/BlockExitStatusChecker.php
@@ -429,7 +429,7 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
         if (!\is_string($name)) {
             return self::STATUS_PROCEED;
         }
-        if (\in_array($name, ['E_ERROR', 'E_PARSE', 'E_CORE_ERROR', 'E_COMPILE_ERROR', 'E_USER_ERROR'])) {
+        if (\in_array($name, ['E_ERROR', 'E_PARSE', 'E_CORE_ERROR', 'E_COMPILE_ERROR', 'E_USER_ERROR'], true)) {
             return self::STATUS_RETURN;
         }
         if ($name === 'E_RECOVERABLE_ERROR') {

--- a/src/Phan/Analysis/CompositionAnalyzer.php
+++ b/src/Phan/Analysis/CompositionAnalyzer.php
@@ -41,7 +41,7 @@ class CompositionAnalyzer
             try {
                 $property_union_type = $property->getUnionType();
             } catch (IssueException $exception) {
-                $property_union_type = new UnionType;
+                $property_union_type = UnionType::empty();
             }
 
             // Check for that property on each inherited

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -390,7 +390,7 @@ class ConditionVisitor extends KindVisitorImplementation
             return static function (Variable $variable, array $args) use ($type) {
                 // Otherwise, overwrite the type for any simple
                 // primitive types.
-                $variable->setUnionType(clone($type));
+                $variable->setUnionType($type);
             };
         };
 

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -259,7 +259,7 @@ class ConditionVisitor extends KindVisitorImplementation
             $context->setScope($context->getScope()->withVariable(new Variable(
                 $context->withLineNumberStart($var_node->lineno ?? 0),
                 $var_name,
-                new UnionType(),
+                UnionType::empty(),
                 $var_node->flags ?? 0
             )));
         }

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -538,7 +538,7 @@ class ConditionVisitor extends KindVisitorImplementation
              $map = self::initTypeModifyingClosuresForVisitCall();
         }
 
-        $function_name = strtolower($raw_function_name);
+        $function_name = \strtolower($raw_function_name);
         $type_modification_callback = $map[$function_name] ?? null;
         if ($type_modification_callback === null) {
             return $this->context;

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -360,16 +360,16 @@ class ConditionVisitor extends KindVisitorImplementation
         // (E.g. T|false becomes T, object|T[]|iterable|null becomes object)
         // TODO: Convert `iterable` to `Traversable`?
         // TODO: move to UnionType?
-        $newType = $variable->getUnionType()->objectTypes();
-        if ($newType->isEmpty()) {
-            $newType->addType(ObjectType::instance(false));
+        $new_type = $variable->getUnionType()->objectTypes();
+        if ($new_type->isEmpty()) {
+            $new_type = $new_type->withType(ObjectType::instance(false));
         } else {
             // Convert inferred ?MyClass to MyClass, ?object to object
-            if ($newType->containsNullable()) {
-                $newType = $newType->nonNullableClone();
+            if ($new_type->containsNullable()) {
+                $new_type = $new_type->nonNullableClone();
             }
         }
-        $variable->setUnionType($newType);
+        $variable->setUnionType($new_type);
     }
 
     /**
@@ -399,16 +399,16 @@ class ConditionVisitor extends KindVisitorImplementation
             // Change the type to match the is_a relationship
             // If we already have generic array types, then keep those
             // (E.g. T[]|false becomes T[], ?array|null becomes array
-            $newType = $variable->getUnionType()->genericArrayTypes();
-            if ($newType->isEmpty()) {
-                $newType->addType(ArrayType::instance(false));
+            $new_type = $variable->getUnionType()->genericArrayTypes();
+            if ($new_type->isEmpty()) {
+                $new_type = ArrayType::instance(false)->asUnionType();
             } else {
                 // Convert inferred (?T)[] to T[], ?array to array
-                if ($newType->containsNullable()) {
-                    $newType = $newType->nonNullableClone();
+                if ($new_type->containsNullable()) {
+                    $new_type = $new_type->nonNullableClone();
                 }
             }
-            $variable->setUnionType($newType);
+            $variable->setUnionType($new_type);
         };
 
         /** @return void */
@@ -416,16 +416,16 @@ class ConditionVisitor extends KindVisitorImplementation
             // Change the type to match the is_a relationship
             // If we already have the `object` type or generic object types, then keep those
             // (E.g. T|false becomes T, object|T[]|iterable|null becomes object)
-            $newType = $variable->getUnionType()->objectTypes();
-            if ($newType->isEmpty()) {
-                $newType->addType(ObjectType::instance(false));
+            $new_type = $variable->getUnionType()->objectTypes();
+            if ($new_type->isEmpty()) {
+                $new_type = ObjectType::instance(false)->asUnionType();
             } else {
                 // Convert inferred ?MyClass to MyClass, ?object to object
-                if ($newType->containsNullable()) {
-                    $newType = $newType->nonNullableClone();
+                if ($new_type->containsNullable()) {
+                    $new_type = $new_type->nonNullableClone();
                 }
             }
-            $variable->setUnionType($newType);
+            $variable->setUnionType($new_type);
         };
         /** @return void */
         $is_a_callback = function (Variable $variable, array $args) use ($object_callback) {
@@ -463,16 +463,16 @@ class ConditionVisitor extends KindVisitorImplementation
             // Change the type to match the is_a relationship
             // If we already have possible callable types, then keep those
             // (E.g. Closure|false becomes Closure)
-            $newType = $variable->getUnionType()->callableTypes();
-            if ($newType->isEmpty()) {
+            $new_type = $variable->getUnionType()->callableTypes();
+            if ($new_type->isEmpty()) {
                 // If there are no inferred types, or the only type we saw was 'null',
                 // assume there this can be any possible scalar.
                 // (Excludes `resource`, which is technically a scalar)
-                $newType->addType(CallableType::instance(false));
-            } elseif ($newType->containsNullable()) {
-                $newType = $newType->nonNullableClone();
+                $new_type = CallableType::instance(false)->asUnionType();
+            } elseif ($new_type->containsNullable()) {
+                $new_type = $new_type->nonNullableClone();
             }
-            $variable->setUnionType($newType);
+            $variable->setUnionType($new_type);
         };
 
         $float_callback = $make_basic_assertion_callback('float');

--- a/src/Phan/Analysis/ConditionVisitorUtil.php
+++ b/src/Phan/Analysis/ConditionVisitorUtil.php
@@ -292,10 +292,11 @@ trait ConditionVisitorUtil
             $name_node_type = (new UnionTypeVisitor($this->code_base, $context, true))($var_name_node);
             static $int_or_string_type;
             if ($int_or_string_type === null) {
-                $int_or_string_type = new UnionType();
-                $int_or_string_type->addType(StringType::instance(false));
-                $int_or_string_type->addType(IntType::instance(false));
-                $int_or_string_type->addType(NullType::instance(false));
+                $int_or_string_type = new UnionType([
+                    StringType::instance(false),
+                    IntType::instance(false),
+                    NullType::instance(false),
+                ]);
             }
             if (!$name_node_type->canCastToUnionType($int_or_string_type)) {
                 Issue::maybeEmit($this->code_base, $context, Issue::TypeSuspiciousIndirectVariable, $var_name_node->lineno ?? 0, (string)$name_node_type);

--- a/src/Phan/Analysis/ConditionVisitorUtil.php
+++ b/src/Phan/Analysis/ConditionVisitorUtil.php
@@ -289,7 +289,7 @@ trait ConditionVisitorUtil
         if ($var_name_node instanceof Node) {
             // This is nonsense. Give up, but check if it's a type other than int/string.
             // (e.g. to catch typos such as $$this->foo = bar;)
-            $name_node_type = (new UnionTypeVisitor($this->code_base, $context, true))($var_name_node);
+            $name_node_type = UnionTypeVisitor::unionTypeFromNode($this->code_base, $context, $var_name_node, true);
             static $int_or_string_type;
             if ($int_or_string_type === null) {
                 $int_or_string_type = new UnionType([

--- a/src/Phan/Analysis/ContextMergeVisitor.php
+++ b/src/Phan/Analysis/ContextMergeVisitor.php
@@ -137,7 +137,7 @@ class ContextMergeVisitor extends KindVisitorImplementation
         }, $this->child_context_list);
 
         $catch_scope_list = [];
-        $catch_nodes = $node->children['catches']->children ?? [];
+        $catch_nodes = $node->children['catches']->children;
         foreach ($catch_nodes as $i => $catch_node) {
             if (!BlockExitStatusChecker::willUnconditionallySkipRemainingStatements($catch_node)) {
                 $catch_scope_list[] = $scope_list[$i + 1];
@@ -210,7 +210,7 @@ class ContextMergeVisitor extends KindVisitorImplementation
         }, $this->child_context_list);
 
         $has_else = \array_reduce(
-            $node->children ?? [],
+            $node->children,
             function (bool $carry, $child_node) {
                 return $carry || (
                     $child_node instanceof Node

--- a/src/Phan/Analysis/ContextMergeVisitor.php
+++ b/src/Phan/Analysis/ContextMergeVisitor.php
@@ -165,9 +165,9 @@ class ContextMergeVisitor extends KindVisitorImplementation
                         $variable_name
                     );
 
-                    $variable->getUnionType()->addUnionType(
+                    $variable->setUnionType($variable->getUnionType()->withUnionType(
                         $catch_variable->getUnionType()
-                    );
+                    ));
                 }
             }
         }
@@ -178,9 +178,9 @@ class ContextMergeVisitor extends KindVisitorImplementation
                 $variable_name = (string)$variable_name;
                 if (!$try_scope->hasVariableWithName($variable_name)) {
                     // Note that it can be null
-                    $variable->getUnionType()->addType(
+                    $variable->setUnionType($variable->getUnionType()->withType(
                         NullType::instance(false)
-                    );
+                    ));
 
                     // Add it to the try scope
                     $try_scope->addVariable($variable);
@@ -315,12 +315,9 @@ class ContextMergeVisitor extends KindVisitorImplementation
                     $variable = clone($variable);
 
                     $variable->setUnionType(
-                        $union_type($name)
-                    );
-
-                    // TODO: convert to nullable?
-                    $variable->getUnionType()->addType(
-                        NullType::instance(false)
+                        $union_type($name)->withType(
+                            NullType::instance(false)
+                        )
                     );
 
                     // Add the variable to the outgoing scope

--- a/src/Phan/Analysis/NegatedConditionVisitor.php
+++ b/src/Phan/Analysis/NegatedConditionVisitor.php
@@ -380,20 +380,15 @@ class NegatedConditionVisitor extends KindVisitorImplementation
                     $new_type_builder = new UnionTypeBuilder();
                     $has_null = false;
                     $has_other_nullable_types = false;
-                    $modified = false;
                     // Add types which are not callable
                     foreach ($union_type->getTypeSet() as $type) {
                         if ($type->isCallable()) {
-                            $modified = true;
                             $has_null = $has_null || $type->getIsNullable();
                             continue;
                         }
                         assert($type instanceof Type);
                         $has_other_nullable_types = $has_other_nullable_types || $type->getIsNullable();
                         $new_type_builder->addType($type);
-                    }
-                    if (!$modified) {
-                        return $union_type;
                     }
                     // Add Null if some of the rejected types were were nullable, and none of the accepted types were nullable
                     if ($has_null && !$has_other_nullable_types) {

--- a/src/Phan/Analysis/NegatedConditionVisitor.php
+++ b/src/Phan/Analysis/NegatedConditionVisitor.php
@@ -471,14 +471,14 @@ class NegatedConditionVisitor extends KindVisitorImplementation
                     $context->setScope($context->getScope()->withVariable(new Variable(
                         $context->withLineNumberStart($var_node->lineno ?? 0),
                         $var_name,
-                        new UnionType(),
+                        UnionType::empty(),
                         $var_node->flags ?? 0
                     )));
                 }
                 $context->setScope($context->getScope()->withVariable(new Variable(
                     $context->withLineNumberStart($var_node->lineno ?? 0),
                     $var_name,
-                    new UnionType(),
+                    UnionType::empty(),
                     $var_node->flags ?? 0
                 )));
                 return $this->removeFalseyFromVariable($var_node, $context, true);

--- a/src/Phan/Analysis/NegatedConditionVisitor.php
+++ b/src/Phan/Analysis/NegatedConditionVisitor.php
@@ -247,7 +247,7 @@ class NegatedConditionVisitor extends KindVisitorImplementation
 
         $context = $this->context;
         if (self::isArgumentListWithVarAsFirstArgument($args)) {
-            $function_name = strtolower(ltrim($raw_function_name, '\\'));
+            $function_name = \strtolower(\ltrim($raw_function_name, '\\'));
             if (\count($args) !== 1) {
                 if (\strcasecmp($function_name, 'is_a') === 0) {
                     return $this->analyzeNegationOfVariableIsA($args, $context);

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -660,7 +660,7 @@ class ParameterTypesAnalyzer
                 if ($parent_parameter_type->isEmpty()) {
                     continue;
                 }
-                $parameter->setUnionType(clone($parent_parameter_type));
+                $parameter->setUnionType($parent_parameter_type);
             }
         }
 
@@ -668,7 +668,7 @@ class ParameterTypesAnalyzer
         if ($phpdoc_return_type->isEmpty()) {
             $parent_phpdoc_return_type = $o_method->getUnionType();
             if (!$parent_phpdoc_return_type->isEmpty()) {
-                $method->setUnionType(clone($parent_phpdoc_return_type));
+                $method->setUnionType($parent_phpdoc_return_type);
             }
         }
     }

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -874,9 +874,7 @@ class ParameterTypesAnalyzer
             return null;
         }
         // Create a clone, converting "T|S|null" to "T|S"
-        $phpdoc_param_union_type = $phpdoc_param_union_type->nullableClone();
-        $phpdoc_param_union_type->removeType(NullType::instance(false));
-        return $phpdoc_param_union_type;
+        return $phpdoc_param_union_type->nullableClone()->withoutType(NullType::instance(false));
     }
 
     /**

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -873,7 +873,7 @@ class ParameterTypesAnalyzer
             // Attempting to narrow nullable to non-nullable is usually a mistake, currently not supported.
             return null;
         }
-        // Create a clone, converting "T|S|null" to "T|S"
+        // Create a clone, converting "T|S|null" to "?T|?S"
         return $phpdoc_param_union_type->nullableClone()->withoutType(NullType::instance(false));
     }
 

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -1855,9 +1855,9 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                                 // Phan already warned about incompatible types.
                                 // But analyze the following statements as if it could have been the type expected,
                                 // to reduce false positives.
-                                $variable->getUnionType()->addUnionType(
+                                $variable->setUnionType($variable->getUnionType()->withUnionType(
                                     $reference_parameter_type
-                                );
+                                ));
                             }
                             // don't modify - assume the function takes the same type in that it returns,
                             // and we want to preserve generic array types for sorting functions (May change later on)
@@ -1867,9 +1867,9 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                         default:
                             // We have no idea what type of reference this is.
                             // Probably user defined code.
-                            $variable->getUnionType()->addUnionType(
+                            $variable->setUnionType($variable->getUnionType()->withUnionType(
                                 $reference_parameter_type
-                            );
+                            ));
                             break;
                     }
                 }
@@ -2139,10 +2139,11 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         // on the argument's type. We'll use this to
         // retest the method with the passed in types
         // TODO: if $argument_type is non-empty and !isType(NullType), instead use setUnionType?
-        $parameter->getNonVariadicUnionType()->addUnionType(
-            $argument_type
-        );
-
+        if (!$parameter->isCloneOfVariadic()) {
+            $parameter->setUnionType($parameter->getUnionType()->withUnionType(
+                $argument_type
+            ));
+        }
 
         // If we're passing by reference, get the variable
         // we're dealing with wrapped up and shoved into

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -652,7 +652,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
 
                     // Set the inferred type of the method based
                     // on what we're returning
-                    $method->getUnionType()->addUnionType($expression_type);
+                    $method->setUnionType($method->getUnionType()->withUnionType($expression_type));
                 }
 
                 // No point in comparing this type to the

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -34,13 +34,16 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
      * The context of the parser at the node for which we'd
      * like to determine a type
      */
+    /*
     public function __construct(
         CodeBase $code_base,
         Context $context
     ) {
         parent::__construct($code_base, $context);
     }
+     */
 
+    /** @param Node $unused_node implementation for unhandled nodes */
     public function visit(Node $unused_node) : Context
     {
         return $this->context;

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -463,7 +463,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
         $func->setHasYield(true);
         if ($func->getUnionType()->isEmpty()) {
             $func->setIsReturnTypeUndefined(true);
-            $func->getUnionType()->addUnionType(Type::fromNamespaceAndName('\\', 'Generator', false)->asUnionType());
+            $func->setUnionType($func->getUnionType()->withType(Type::fromNamespaceAndName('\\', 'Generator', false)));
         }
         if (!$func->isReturnTypeUndefined()) {
             $func_return_type = $func->getUnionType();

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -512,7 +512,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
             $expression_union_type->genericArrayElementTypes();
 
         if ($node->children['value']->kind == \ast\AST_ARRAY) {
-            foreach ($node->children['value']->children ?? [] as $child_node) {
+            foreach ($node->children['value']->children as $child_node) {
                 // $key_node = $child_node->children['key'] ?? null;
                 $value_node = $child_node->children['value'] ?? null;
 
@@ -645,7 +645,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
                 false
             );
 
-            $union_type->addType(Type::fromFullyQualifiedString('\Throwable'));
+            $union_type = $union_type->withType(Type::fromFullyQualifiedString('\Throwable'));
         }
 
         $variable_name = (new ContextNode(

--- a/src/Phan/Analysis/PropertyTypesAnalyzer.php
+++ b/src/Phan/Analysis/PropertyTypesAnalyzer.php
@@ -13,7 +13,7 @@ class PropertyTypesAnalyzer
 {
 
     /**
-     * Check to see if the given Clazz is a duplicate
+     * Check to see if the given properties have issues
      *
      * @return void
      */

--- a/src/Phan/Analysis/ScopeVisitor.php
+++ b/src/Phan/Analysis/ScopeVisitor.php
@@ -20,12 +20,14 @@ abstract class ScopeVisitor extends AnalysisVisitor
      * The context of the parser at the node for which we'd
      * like to determine a type
      */
+    /*
     public function __construct(
         CodeBase $code_base,
         Context $context
     ) {
         parent::__construct($code_base, $context);
     }
+     */
 
     /**
      * Default visitor for node kinds that do not have

--- a/src/Phan/Analysis/ScopeVisitor.php
+++ b/src/Phan/Analysis/ScopeVisitor.php
@@ -99,7 +99,7 @@ abstract class ScopeVisitor extends AnalysisVisitor
      */
     public function visitGroupUse(Node $node) : Context
     {
-        $children = $node->children ?? [];
+        $children = $node->children;
 
         $prefix = \array_shift($children);
 
@@ -171,7 +171,7 @@ abstract class ScopeVisitor extends AnalysisVisitor
         );
 
         $map = [];
-        foreach ($node->children ?? [] as $child_node) {
+        foreach ($node->children as $child_node) {
             $target = $child_node->children['name'];
 
             if (empty($child_node->children['alias'])) {

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -116,6 +116,34 @@ class BlockAnalysisVisitor extends AnalysisVisitor
         // Could invoke plugins, but not right now
         return $this->context;
     }
+
+    public function visitStmtList(Node $node) : Context
+    {
+        $context = $this->context;
+        $plugin_set = ConfigPluginSet::instance();
+        $plugin_set->preAnalyzeNode(
+            $this->code_base,
+            $context,
+            $node
+        );
+        foreach ($node->children as $child_node) {
+            // Skip any non Node children.
+            if (!($child_node instanceof Node)) {
+                continue;
+            }
+
+            // Step into each child node and get an
+            // updated context for the node
+            $context = $this->analyzeAndGetUpdatedContext($context, $node, $child_node);
+        }
+        $plugin_set->analyzeNode(
+            $this->code_base,
+            $context,
+            $node,
+            $this->parent_node
+        );
+        return $context;
+    }
     // end No-ops
 
     /**

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -131,6 +131,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
             if (!($child_node instanceof Node)) {
                 continue;
             }
+            $context->clearCachedUnionTypes();
 
             // Step into each child node and get an
             // updated context for the node

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -196,7 +196,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
         // With a context that is inside of the node passed
         // to this method, we analyze all children of the
         // node.
-        foreach ($node->children ?? [] as $child_node) {
+        foreach ($node->children as $child_node) {
             // Skip any non Node children.
             if (!($child_node instanceof Node)) {
                 continue;
@@ -284,7 +284,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
         // With a context that is inside of the node passed
         // to this method, we analyze all children of the
         // node.
-        foreach ($node->children ?? [] as $child_node) {
+        foreach ($node->children as $child_node) {
             // Skip any non Node children.
             if (!($child_node instanceof Node)) {
                 continue;
@@ -546,7 +546,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
         // With a context that is inside of the node passed
         // to this method, we analyze all children of the
         // node.
-        foreach ($node->children ?? [] as $child_node) {
+        foreach ($node->children as $child_node) {
             // Skip any non Node children.
             if (!($child_node instanceof Node)) {
                 continue;
@@ -603,7 +603,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
             $fallthrough_context = $context;
         }
 
-        $child_nodes = $node->children ?? [];
+        $child_nodes = $node->children;
         $excluded_elem_count = 0;
 
         // With a context that is inside of the node passed
@@ -739,7 +739,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
         // them
         $catch_context_list = [$try_context];
 
-        foreach ($node->children['catches']->children ?? [] as $catch_node) {
+        foreach ($node->children['catches']->children as $catch_node) {
             // Note: ContextMergeVisitor expects to get each individual catch
             assert($catch_node instanceof Node);
             // The conditions need to communicate to the outer

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -866,10 +866,11 @@ class BlockAnalysisVisitor extends AnalysisVisitor
         // with anything we learn and get a new context
         // indicating the state of the world within the
         // given node
+        // Equivalent to (new PostOrderAnalysisVisitor(...)($node)) but faster than using __invoke()
         $context = (new PreOrderAnalysisVisitor(
             $this->code_base,
             $context
-        ))($node);
+        ))->{Element::VISIT_LOOKUP_TABLE[$node->kind] ?? 'handleMissingNodeKind'}($node);
 
         // Let any configured plugins do a pre-order
         // analysis of the node.
@@ -898,11 +899,12 @@ class BlockAnalysisVisitor extends AnalysisVisitor
         // Now that we know all about our context (like what
         // 'self' means), we can analyze statements like
         // assignments and method calls.
+        // Equivalent to (new PostOrderAnalysisVisitor(...)($node)) but faster than using __invoke()
         $context = (new PostOrderAnalysisVisitor(
             $this->code_base,
             $context->withLineNumberStart($node->lineno ?? 0),
             $this->parent_node
-        ))($node);
+        ))->{Element::VISIT_LOOKUP_TABLE[$node->kind] ?? 'handleMissingNodeKind'}($node);
 
         // let any configured plugins analyze the node
         ConfigPluginSet::instance()->analyzeNode(

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -739,7 +739,6 @@ class CodeBase
      */
     public function addMethod(Method $method)
     {
-
         // Add the method to the map
         $this->getClassMapByFQSEN(
             $method->getFQSEN()
@@ -771,7 +770,9 @@ class CodeBase
     public function hasMethodWithFQSEN(
         FullyQualifiedMethodName $fqsen
     ) : bool {
-        return $this->getClassMapByFQSEN($fqsen)->hasMethodWithName(
+        return $this->getClassMapByFullyQualifiedClassName(
+            $fqsen->getFullyQualifiedClassName()
+        )->hasMethodWithName(
             $fqsen->getNameWithAlternateId()
         );
     }
@@ -786,7 +787,9 @@ class CodeBase
     public function getMethodByFQSEN(
         FullyQualifiedMethodName $fqsen
     ) : Method {
-        return $this->getClassMapByFQSEN($fqsen)->getMethodByName(
+        return $this->getClassMapByFullyQualifiedClassName(
+            $fqsen->getFullyQualifiedClassName()
+        )->getMethodByName(
             $fqsen->getNameWithAlternateId()
         );
     }
@@ -948,8 +951,8 @@ class CodeBase
      */
     public function addClassConstant(ClassConstant $class_constant)
     {
-        return $this->getClassMapByFQSEN(
-            $class_constant->getFQSEN()
+        return $this->getClassMapByFullyQualifiedClassName(
+            $class_constant->getClassFQSEN()
         )->addClassConstant($class_constant);
     }
 
@@ -960,8 +963,8 @@ class CodeBase
     public function hasClassConstantWithFQSEN(
         FullyQualifiedClassConstantName $fqsen
     ) : bool {
-        return $this->getClassMapByFQSEN(
-            $fqsen
+        return $this->getClassMapByFullyQualifiedClassName(
+            $fqsen->getFullyQualifiedClassName()
         )->hasClassConstantWithName($fqsen->getNameWithAlternateId());
     }
 
@@ -975,8 +978,8 @@ class CodeBase
     public function getClassConstantByFQSEN(
         FullyQualifiedClassConstantName $fqsen
     ) : ClassConstant {
-        return $this->getClassMapByFQSEN(
-            $fqsen
+        return $this->getClassMapByFullyQualifiedClassName(
+            $fqsen->getFullyQualifiedClassName()
         )->getClassConstantByName($fqsen->getNameWithAlternateId());
     }
 
@@ -1050,8 +1053,8 @@ class CodeBase
      */
     public function addProperty(Property $property)
     {
-        return $this->getClassMapByFQSEN(
-            $property->getFQSEN()
+        return $this->getClassMapByFullyQualifiedClassName(
+            $property->getClassFQSEN()
         )->addProperty($property);
     }
 
@@ -1062,8 +1065,8 @@ class CodeBase
     public function hasPropertyWithFQSEN(
         FullyQualifiedPropertyName $fqsen
     ) : bool {
-        return $this->getClassMapByFQSEN(
-            $fqsen
+        return $this->getClassMapByFullyQualifiedClassName(
+            $fqsen->getFullyQualifiedClassName()
         )->hasPropertyWithName($fqsen->getNameWithAlternateId());
     }
 
@@ -1077,8 +1080,8 @@ class CodeBase
     public function getPropertyByFQSEN(
         FullyQualifiedPropertyName $fqsen
     ) : Property {
-        return $this->getClassMapByFQSEN(
-            $fqsen
+        return $this->getClassMapByFullyQualifiedClassName(
+            $fqsen->getFullyQualifiedClassName()
         )->getPropertyByName($fqsen->getNameWithAlternateId());
     }
 

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -1124,11 +1124,12 @@ class CodeBase
     private function getClassMapByFullyQualifiedClassName(
         FullyQualifiedClassName $fqsen
     ) : ClassMap {
-        if (!$this->class_fqsen_class_map_map->offsetExists($fqsen)) {
-            $this->class_fqsen_class_map_map->offsetSet($fqsen, new ClassMap);
+        $class_fqsen_class_map_map = $this->class_fqsen_class_map_map;
+        if ($class_fqsen_class_map_map->offsetExists($fqsen)) {
+            return $class_fqsen_class_map_map->offsetGet($fqsen);
         }
-
-        return $this->class_fqsen_class_map_map->offsetGet($fqsen);
+        $class_fqsen_class_map_map->offsetSet($fqsen, new ClassMap);
+        return $class_fqsen_class_map_map->offsetGet($fqsen);
     }
 
     /**

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -1181,8 +1181,8 @@ class CodeBase
         // Don't need to track this any more
         unset($this->internal_function_fqsen_set[$canonical_fqsen]);
 
-        if (!$function_signature_map->offsetExists($name)) {
-            $signature = $function_signature_map->offsetGet($name);
+        if (isset($function_signature_map[$name])) {
+            $signature = $function_signature_map[$name];
 
             // Add each method returned for the signature
             foreach (FunctionFactory::functionListFromSignature(

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -429,7 +429,7 @@ class CodeBase
         $name_method_map = $this->name_method_map;
         $this->name_method_map = [];
         foreach ($name_method_map as $name => $method_map) {
-            $this->name_method_map->offsetSet($name, $method_map->deepCopy());
+            $this->name_method_map[$name] = $method_map->deepCopy();
         }
     }
 

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -429,7 +429,7 @@ class CodeBase
         $name_method_map = $this->name_method_map;
         $this->name_method_map = [];
         foreach ($name_method_map as $name => $method_map) {
-            $this->name_method_map[$name] = $method_map->deepCopy();
+            $this->name_method_map->offsetSet($name, $method_map->deepCopy());
         }
     }
 
@@ -1122,10 +1122,10 @@ class CodeBase
         FullyQualifiedClassName $fqsen
     ) : ClassMap {
         if (!$this->class_fqsen_class_map_map->offsetExists($fqsen)) {
-            $this->class_fqsen_class_map_map[$fqsen] = new ClassMap;
+            $this->class_fqsen_class_map_map->offsetSet($fqsen, new ClassMap);
         }
 
-        return $this->class_fqsen_class_map_map[$fqsen];
+        return $this->class_fqsen_class_map_map->offsetGet($fqsen);
     }
 
     /**
@@ -1160,7 +1160,7 @@ class CodeBase
             }
             // If we already created the alternates, do nothing.
             // TODO: This assumes we call hasFunctionWithFQSEN before adding.
-            if (isset($this->fqsen_func_map[$canonical_fqsen])) {
+            if ($this->fqsen_func_map->offsetExists($canonical_fqsen)) {
                 return false;
             }
         }
@@ -1181,8 +1181,8 @@ class CodeBase
         // Don't need to track this any more
         unset($this->internal_function_fqsen_set[$canonical_fqsen]);
 
-        if (!empty($function_signature_map[$name])) {
-            $signature = $function_signature_map[$name];
+        if (!$function_signature_map->offsetExists($name)) {
+            $signature = $function_signature_map->offsetGet($name);
 
             // Add each method returned for the signature
             foreach (FunctionFactory::functionListFromSignature(

--- a/src/Phan/CodeBase/ClassMap.php
+++ b/src/Phan/CodeBase/ClassMap.php
@@ -98,7 +98,7 @@ class ClassMap
      */
     public function addMethod(Method $method)
     {
-        $this->method_map[strtolower(
+        $this->method_map[\strtolower(
             $method->getFQSEN()->getNameWithAlternateId()
         )] = $method;
     }
@@ -108,7 +108,7 @@ class ClassMap
      */
     public function hasMethodWithName(string $name) : bool
     {
-        return !empty($this->method_map[strtolower($name)]);
+        return isset($this->method_map[\strtolower($name)]);
     }
 
     /**
@@ -116,7 +116,7 @@ class ClassMap
      */
     public function getMethodByName(string $name) : Method
     {
-        return $this->method_map[strtolower($name)];
+        return $this->method_map[\strtolower($name)];
     }
 
     /**

--- a/src/Phan/Debug.php
+++ b/src/Phan/Debug.php
@@ -131,7 +131,7 @@ class Debug
 
         $string .= "\n";
 
-        foreach ($node->children ?? [] as $name => $child_node) {
+        foreach ($node->children as $name => $child_node) {
             $string .= self::nodeToString(
                 $child_node,
                 $name,

--- a/src/Phan/Debug/DebugUnionType.php
+++ b/src/Phan/Debug/DebugUnionType.php
@@ -17,25 +17,25 @@ class DebugUnionType extends UnionType
     /**
      * Add a type name to the list of types
      *
-     * @return void
+     * @return UnionType
      * @override
      */
-    public function addType(Type $type)
+    public function withType(Type $type) : UnionType
     {
         \printf("%s: Adding type %s to %s", \spl_object_hash($this), (string)$type, (string)$this);
         \debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
-        parent::addType($type);
+        return parent::withType($type);
     }
 
     /**
      * Add the given types to this type
      *
-     * @return void
+     * @return UnionType
      */
-    public function addUnionType(UnionType $union_type)
+    public function withUnionType(UnionType $union_type) : UnionType
     {
         \printf("%s: Adding union type %s to %s", \spl_object_hash($this), (string)$union_type, (string)$this);
         \debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
-        parent::addUnionType($union_type);
+        return parent::withUnionType($union_type);
     }
 }

--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -94,11 +94,11 @@ class Context extends FileRef
         if (count($name_parts) > 1) {
             // We're looking for a namespace if there's more than one part
             // Namespaces are case insensitive.
-            $namespace_map_key = strtolower($name_parts[0]);
+            $namespace_map_key = \strtolower($name_parts[0]);
             $flags = \ast\flags\USE_NORMAL;
         } else {
             if ($flags !== \ast\flags\USE_CONST) {
-                $namespace_map_key = strtolower($name_parts[0]);
+                $namespace_map_key = \strtolower($name_parts[0]);
             } else {
                 // Constants are case sensitive, and stored in a case sensitive manner.
                 $namespace_map_key = $name;
@@ -119,14 +119,14 @@ class Context extends FileRef
 
         // Look for the mapping on the part before a
         // slash
-        $name_parts = explode('\\', $name, 2);
+        $name_parts = \explode('\\', $name, 2);
         if (count($name_parts) > 1) {
-            $name = strtolower($name_parts[0]);
+            $name = \strtolower($name_parts[0]);
             $suffix = $name_parts[1];
             // In php, namespaces, functions, and classes are case insensitive.
             // However, constants are almost always case insensitive.
             if ($flags !== \ast\flags\USE_CONST) {
-                $suffix = strtolower($suffix);
+                $suffix = \strtolower($suffix);
             }
             // The name we're looking for is a namespace(USE_NORMAL).
             // The suffix has type $flags
@@ -135,7 +135,7 @@ class Context extends FileRef
             $suffix = '';
             $map_flags = $flags;
             if ($flags !== \ast\flags\USE_CONST) {
-                $name = strtolower($name);
+                $name = \strtolower($name);
             }
         }
 
@@ -184,7 +184,7 @@ class Context extends FileRef
         FullyQualifiedGlobalStructuralElement $target
     ) : Context {
         if ($flags !== \ast\flags\USE_CONST) {
-            $alias = strtolower($alias);
+            $alias = \strtolower($alias);
         } else {
             $last_part_index = \strrpos($alias, '\\');
             if ($last_part_index !== false) {

--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -50,12 +50,16 @@ class Context extends FileRef
     private $scope;
 
     /**
+     * @var array<int,UnionType>
+     * caches union types for a given node
+     */
+    private $union_type_cache  = [];
+
+    /**
      * Create a new context
      */
     public function __construct()
     {
-        $this->namespace = '';
-        $this->namespace_map = [];
         $this->scope = new GlobalScope;
     }
 

--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -575,6 +575,26 @@ class Context extends FileRef
     }
 
     /**
+     * @param int $node_id
+     * @return ?array{0:UnionType,1:Clazz[]} $result
+     */
+    public function getCachedClassListOfNode(int $node_id)
+    {
+        return $this->union_type_cache[-$node_id] ?? null;
+    }
+
+    /**
+     * TODO: This may be unsafe? Clear the cache after a function goes out of scope.
+     * @param array{0:UnionType,1:Clazz[]} $result
+     * @return void
+     */
+    public function setCachedClassListOfNode(int $node_id, array $result)
+    {
+        // TODO: Rename
+        $this->union_type_cache[-$node_id] = $result;
+    }
+
+    /**
      * @return void
      */
     public function clearCachedUnionTypes()

--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -241,6 +241,8 @@ class Context extends FileRef
     public function setScope(Scope $scope)
     {
         $this->scope = $scope;
+        // TODO: Less aggressive? ConditionVisitor creates a lot of scopes
+        $this->union_type_cache = [];
     }
 
     /**
@@ -552,5 +554,31 @@ class Context extends FileRef
         }
 
         return $has_suppress_issue;
+    }
+
+    /**
+     * @param int $node_id
+     * @return ?UnionType
+     */
+    public function getUnionTypeOfNodeIfCached(int $node_id)
+    {
+        return $this->union_type_cache[$node_id] ?? null;
+    }
+
+    /**
+     * TODO: This may be unsafe? Clear the cache after a function goes out of scope.
+     * @return void
+     */
+    public function setCachedUnionTypeOfNode(int $node_id, UnionType $type)
+    {
+        $this->union_type_cache[$node_id] = $type;
+    }
+
+    /**
+     * @return void
+     */
+    public function clearCachedUnionTypes()
+    {
+        $this->union_type_cache = [];
     }
 }

--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -50,10 +50,10 @@ class Context extends FileRef
     private $scope;
 
     /**
-     * @var array<int,UnionType>
+     * @var array<mixed,mixed>
      * caches union types for a given node
      */
-    private $union_type_cache  = [];
+    private $cache  = [];
 
     /**
      * Create a new context
@@ -242,7 +242,7 @@ class Context extends FileRef
     {
         $this->scope = $scope;
         // TODO: Less aggressive? ConditionVisitor creates a lot of scopes
-        $this->union_type_cache = [];
+        $this->cache = [];
     }
 
     /**
@@ -557,21 +557,56 @@ class Context extends FileRef
     }
 
     /**
-     * @param int $node_id
+     * $this->cache is reused for multiple types of caches
+     * We xor the node ids with the following bits so that the values don't overlap.
+     * (The node id is based on \spl_object_id(), which is the object ID number.
+     *
+     * (This caching scheme makes a reasonable assumption
+     * that there are less than 1 billion Node objects on 32-bit systems,
+     * (It'd run out of memory with more than 4 bytes needed per Node)
+     * and less than (1 << 62) objects on 64-bit systems.)
+     *
+     * It also assumes that nodes won't be freed while this Context still exists
+     *
+     * 0x00(node_id) is used for getUnionTypeOfNodeIfCached(int $node_id, false)
+     * 0x10(node_id) is used for getUnionTypeOfNodeIfCached(int $node_id, true)
+     * 0x01(node_id) is used for getCachedClassListOfNode(int $node_id)
+     */
+    const HIGH_BIT_1 = (1 << (PHP_INT_SIZE * 8) - 1);
+    const HIGH_BIT_2 = (1 << (PHP_INT_SIZE * 8) - 2);
+
+    /**
+     * @param int $node_id \spl_object_id($node)
+     * @param bool $should_catch_issue_exception the value passed to UnionTypeVisitor
      * @return ?UnionType
      */
-    public function getUnionTypeOfNodeIfCached(int $node_id)
+    public function getUnionTypeOfNodeIfCached(int $node_id, bool $should_catch_issue_exception)
     {
-        return $this->union_type_cache[$node_id] ?? null;
+        if ($should_catch_issue_exception) {
+            return $this->cache[$node_id] ?? null;
+        }
+        return $this->cache[$node_id ^ self::HIGH_BIT_1] ?? null;
     }
 
     /**
      * TODO: This may be unsafe? Clear the cache after a function goes out of scope.
+     *
+     * A UnionType is only cached if there is no exception.
+     *
+     * @param int $node_id \spl_object_id($node)
+     * @param UnionType $type the type to cache.
+     * @param bool $should_catch_issue_exception the value passed to UnionTypeVisitor
      * @return void
      */
-    public function setCachedUnionTypeOfNode(int $node_id, UnionType $type)
+    public function setCachedUnionTypeOfNode(int $node_id, UnionType $type, bool $should_catch_issue_exception)
     {
-        $this->union_type_cache[$node_id] = $type;
+        if (!$should_catch_issue_exception) {
+            $this->cache[$node_id ^ self::HIGH_BIT_1] = $type;
+            // If we weren't suppressing exceptions and setCachedUnionTypeOfNode was called,
+            // that would mean that there were no exceptions to catch.
+            // So, that means the UnionType for should_catch_issue_exception = true will be the same
+        }
+        $this->cache[$node_id] = $type;
     }
 
     /**
@@ -580,18 +615,18 @@ class Context extends FileRef
      */
     public function getCachedClassListOfNode(int $node_id)
     {
-        return $this->union_type_cache[-$node_id] ?? null;
+        return $this->cache[$node_id ^ self::HIGH_BIT_2] ?? null;
     }
 
     /**
      * TODO: This may be unsafe? Clear the cache after a function goes out of scope.
+     * @param int $node_id \spl_object_id($node)
      * @param array{0:UnionType,1:Clazz[]} $result
      * @return void
      */
     public function setCachedClassListOfNode(int $node_id, array $result)
     {
-        // TODO: Rename
-        $this->union_type_cache[-$node_id] = $result;
+        $this->cache[$node_id ^ self::HIGH_BIT_2] = $result;
     }
 
     /**
@@ -599,6 +634,6 @@ class Context extends FileRef
      */
     public function clearCachedUnionTypes()
     {
-        $this->union_type_cache = [];
+        $this->cache = [];
     }
 }

--- a/src/Phan/Language/Element/AddressableElement.php
+++ b/src/Phan/Language/Element/AddressableElement.php
@@ -230,6 +230,8 @@ abstract class AddressableElement extends TypedElement implements AddressableEle
         return \count($this->reference_list);
     }
 
+    private $is_hydrated = false;
+
     /**
      * This method must be called before analysis
      * begins.
@@ -239,9 +241,10 @@ abstract class AddressableElement extends TypedElement implements AddressableEle
      */
     final public function hydrate(CodeBase $code_base)
     {
-        if (!$this->isFirstExecution(__METHOD__)) {
+        if ($this->is_hydrated) {  // Same as isFirstExecution(), inlined due to being called frequently.
             return;
         }
+        $this->is_hydrated = true;
 
         $this->hydrateOnce($code_base);
     }

--- a/src/Phan/Language/Element/AddressableElement.php
+++ b/src/Phan/Language/Element/AddressableElement.php
@@ -230,6 +230,7 @@ abstract class AddressableElement extends TypedElement implements AddressableEle
         return \count($this->reference_list);
     }
 
+    /** @var bool */
     private $is_hydrated = false;
 
     /**
@@ -247,6 +248,21 @@ abstract class AddressableElement extends TypedElement implements AddressableEle
         $this->is_hydrated = true;
 
         $this->hydrateOnce($code_base);
+    }
+
+    /**
+     * This method must be called before analysis begins.
+     * This is identical to hydrate(), but returns true only if this is the first time the element was hydrated.
+     */
+    final public function hydrateIndicatingFirstTime(CodeBase $code_base) : bool
+    {
+        if ($this->is_hydrated) {  // Same as isFirstExecution(), inlined due to being called frequently.
+            return false;
+        }
+        $this->is_hydrated = true;
+
+        $this->hydrateOnce($code_base);
+        return true;
     }
 
     protected function hydrateOnce(CodeBase $unused_code_base)

--- a/src/Phan/Language/Element/ClassConstant.php
+++ b/src/Phan/Language/Element/ClassConstant.php
@@ -60,7 +60,7 @@ class ClassConstant extends ClassElement implements ConstantInterface
     public function getUnionType() : UnionType
     {
         if (null !== ($union_type = $this->getFutureUnionType())) {
-            $this->getUnionType()->addUnionType($union_type);
+            $this->setUnionType($this->getUnionType()->withUnionType($union_type));
         }
 
         return parent::getUnionType();

--- a/src/Phan/Language/Element/ClassElement.php
+++ b/src/Phan/Language/Element/ClassElement.php
@@ -7,9 +7,37 @@ use Phan\Language\Context;
 use Phan\Language\FQSEN;
 use Phan\Language\FQSEN\FullyQualifiedClassElement;
 use Phan\Language\FQSEN\FullyQualifiedClassName;
+use Phan\Language\UnionType;
 
 abstract class ClassElement extends AddressableElement
 {
+    /** @var FullyQualifiedClassName */
+    private $class_fqsen;
+
+    public function __construct(
+        Context $context,
+        string $name,
+        UnionType $type,
+        int $flags,
+        FullyQualifiedClassElement $fqsen
+    ) {
+        parent::__construct($context, $name, $type, $flags, $fqsen);
+        $this->class_fqsen = $fqsen->getFullyQualifiedClassName();
+    }
+
+    /**
+     * @param FullyQualifiedClassElement $fqsen
+     * @return void
+     * @override
+     * @suppress PhanParamSignatureMismatch deliberately more specific
+     */
+    public function setFQSEN(FQSEN $fqsen)
+    {
+        \assert($fqsen instanceof FullyQualifiedClassElement);
+        parent::setFQSEN($fqsen);
+        $this->class_fqsen = $fqsen->getFullyQualifiedClassName();
+    }
+
     /**
      * @var FullyQualifiedClassElement|null
      * The FQSEN of this element where it is originally
@@ -87,14 +115,7 @@ abstract class ClassElement extends AddressableElement
      */
     public function getClassFQSEN() : FullyQualifiedClassName
     {
-        $fqsen = $this->getFQSEN();
-        if ($fqsen instanceof FullyQualifiedClassElement) {
-            return $fqsen->getFullyQualifiedClassName();
-        }
-
-        throw new \Exception(
-            "Cannot get defining class for non-class element $this"
-        );
+        return $this->class_fqsen;
     }
 
     /**
@@ -111,7 +132,7 @@ abstract class ClassElement extends AddressableElement
     public function getClass(
         CodeBase $code_base
     ) : Clazz {
-        $class_fqsen = $this->getClassFQSEN();
+        $class_fqsen = $this->class_fqsen;
 
         if (!$code_base->hasClassWithFQSEN($class_fqsen)) {
             throw new CodeBaseException(

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -358,7 +358,7 @@ class Clazz extends AddressableElement
                 $parent_type = Type::fromType(
                     $parent_type,
                     \array_map(function (UnionType $union_type) use ($template_type_map) : UnionType {
-                        return new UnionType(
+                        return UnionType::of(
                             \array_map(function (Type $type) use ($template_type_map) : Type {
                                 return $template_type_map[$type->getName()] ?? $type;
                             }, $union_type->getTypeSet())

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -371,8 +371,8 @@ class Clazz extends AddressableElement
         $this->parent_type = $parent_type;
 
         // Add the parent to the union type of this class
-        $this->setUnionType($this->getUnionType()->withUnionType(
-            $parent_type->asUnionType()
+        $this->setUnionType($this->getUnionType()->withType(
+            $parent_type
         ));
     }
 

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -196,7 +196,7 @@ class Clazz extends AddressableElement
 
         if ($class_name === "Traversable") {
             // Make sure that canCastToExpandedUnionType() works as expected for Traversable and its subclasses
-            $clazz->getUnionType()->addType(IterableType::instance(false));
+            $clazz->setUnionType($clazz->getUnionType()->withType(IterableType::instance(false)));
         }
 
         // Note: If there are multiple calls to Clazz->addProperty(),
@@ -371,9 +371,9 @@ class Clazz extends AddressableElement
         $this->parent_type = $parent_type;
 
         // Add the parent to the union type of this class
-        $this->getUnionType()->addUnionType(
+        $this->setUnionType($this->getUnionType()->withUnionType(
             $parent_type->asUnionType()
-        );
+        ));
     }
 
     /**
@@ -548,9 +548,9 @@ class Clazz extends AddressableElement
 
         // Add the interface to the union type of this
         // class
-        $this->getUnionType()->addUnionType(
+        $this->setUnionType($this->getUnionType()->withUnionType(
             UnionType::fromFullyQualifiedString((string)$fqsen)
-        );
+        ));
     }
 
     /**
@@ -1506,9 +1506,9 @@ class Clazz extends AddressableElement
         $this->trait_fqsen_list[] = $fqsen;
 
         // Add the trait to the union type of this class
-        $this->getUnionType()->addUnionType(
+        $this->setUnionType($this->getUnionType()->withUnionType(
             UnionType::fromFullyQualifiedString((string)$fqsen)
-        );
+        ));
     }
 
     /**

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -783,20 +783,23 @@ class Clazz extends AddressableElement
             return false;
         }
         // NOTE: This gets the **unexpanded** union type (Should be 1 class and no parent classes).
-        $type_of_class_of_property = $property->getDefiningClassFQSEN()->asUnionType();
+        $type_of_class_of_property = $property->getDefiningClassFQSEN()->asType();
+        $accessing_class_type = $context->getClassFQSEN()->asType();
+
+        if ($type_of_class_of_property === $accessing_class_type) {
+            // Check for common case: Same class
+            return true;
+        }
 
         // We are in a class scope, and the property is either private or protected.
         if ($property->isPrivate()) {
-            $accessing_class_type = $context->getClassFQSEN()->asUnionType();
-            return $accessing_class_type->canCastToUnionType(
+            return $accessing_class_type->canCastToType(
                 $type_of_class_of_property
             );
         } else {
-            // TODO: Remove, should be unnecessary
-            $accessing_class_type = $context->getClassFQSEN()->asUnionType();
             // If the definition of the property is protected, then the subclasses of the defining class can access it.
             return $accessing_class_type->asExpandedTypes($code_base)->canCastToUnionType(
-                $type_of_class_of_property
+                $type_of_class_of_property->asUnionType()
             );
         }
     }

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -941,7 +941,7 @@ class Clazz extends AddressableElement
             $property = new Property(
                 $context,
                 $name,
-                new UnionType(),
+                UnionType::empty(),
                 0,
                 $property_fqsen
             );

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -1039,6 +1039,17 @@ class Clazz extends AddressableElement
         CodeBase $code_base,
         string $name
     ) : bool {
+        if ($code_base->hasClassConstantWithFQSEN(
+            FullyQualifiedClassConstantName::make(
+                $this->getFQSEN(),
+                $name
+            )
+        )) {
+            return true;
+        }
+        if (!$this->hydrateIndicatingFirstTime($code_base)) {
+            return false;
+        }
         return $code_base->hasClassConstantWithFQSEN(
             FullyQualifiedClassConstantName::make(
                 $this->getFQSEN(),

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -1296,7 +1296,7 @@ class Clazz extends AddressableElement
     ) : bool {
         // All classes have a constructor even if it hasn't
         // been declared yet
-        if (!$is_direct_invocation && '__construct' === strtolower($name)) {
+        if (!$is_direct_invocation && '__construct' === \strtolower($name)) {
             return true;
         }
 
@@ -1516,7 +1516,7 @@ class Clazz extends AddressableElement
      */
     public function addTraitAdaptations(TraitAdaptations $trait_adaptations)
     {
-        $this->trait_adaptations_map[strtolower($trait_adaptations->getTraitFQSEN()->__toString())] = $trait_adaptations;
+        $this->trait_adaptations_map[\strtolower($trait_adaptations->getTraitFQSEN()->__toString())] = $trait_adaptations;
     }
 
     /**
@@ -1981,7 +1981,7 @@ class Clazz extends AddressableElement
         Clazz $class,
         $type_option
     ) {
-        $key = strtolower((string)$class->getFQSEN());
+        $key = \strtolower((string)$class->getFQSEN());
         if (!$this->isFirstExecution(
             __METHOD__ . ':' . $key
         )) {
@@ -2015,7 +2015,7 @@ class Clazz extends AddressableElement
         // Copy methods
         foreach ($class->getMethodMap($code_base) as $method) {
             if (!\is_null($trait_adaptations) && count($trait_adaptations->hidden_methods) > 0) {
-                $method_name_key = strtolower($method->getName());
+                $method_name_key = \strtolower($method->getName());
                 if (isset($trait_adaptations->hidden_methods[$method_name_key])) {
                     // TODO: Record that the method was hidden, and check later on that all method that were hidden were actually defined?
                     continue;

--- a/src/Phan/Language/Element/Comment.php
+++ b/src/Phan/Language/Element/Comment.php
@@ -963,6 +963,15 @@ class Comment
     }
 
     /**
+     * Sets A UnionType defined by a (at)return directive
+     * @return void
+     */
+    public function setReturnType(UnionType $return_union_type)
+    {
+        $this->return_union_type = $return_union_type;
+    }
+
+    /**
      * @return bool
      * True if this doc block contains a (at)return
      * directive specifying a type.

--- a/src/Phan/Language/Element/Comment.php
+++ b/src/Phan/Language/Element/Comment.php
@@ -279,7 +279,7 @@ class Comment
                 [],
                 [],
                 new None,
-                new UnionType(),
+                UnionType::empty(),
                 [],
                 [],
                 [],
@@ -291,7 +291,7 @@ class Comment
         $parameter_list = [];
         $template_type_list = [];
         $inherited_type = new None;
-        $return_union_type = new UnionType();
+        $return_union_type = UnionType::empty();
         $suppress_issue_list = [];
         $magic_property_list = [];
         $magic_method_list = [];
@@ -558,7 +558,7 @@ class Comment
         // Warn if there is neither a union type nor a variable
         if (\preg_match(self::param_comment_regex, $line, $match) && (isset($match[2]) || isset($match[17]))) {
             if (!isset($match[2])) {
-                return new CommentParameter('', new UnionType());
+                return new CommentParameter('', UnionType::empty());
             }
             $original_type = $match[2];
 
@@ -585,7 +585,7 @@ class Comment
                         Type::FROM_PHPDOC
                     );
             } else {
-                $union_type = new UnionType();
+                $union_type = UnionType::empty();
             }
             $is_output_parameter = \stripos($line, '@phan-output-reference') !== false;
 
@@ -612,7 +612,7 @@ class Comment
             }
         }
 
-        return new CommentParameter('', new UnionType());
+        return new CommentParameter('', UnionType::empty());
     }
 
     /**

--- a/src/Phan/Language/Element/Comment.php
+++ b/src/Phan/Language/Element/Comment.php
@@ -321,42 +321,43 @@ class Comment
             if (\strpos($line, '@') === false) {
                 continue;
             }
+            // https://secure.php.net/manual/en/regexp.reference.internal-options.php
+            // (?i) makes this case sensitive, (?-1) makes it case insensitive
+            if (\preg_match('/@((?i)param|var|return|returns|inherits|suppress|phan-[a-z0-9_-]*(?-i)|method|property|template|PhanClosureScope)\b/', $line, $matches)) {
+                $type = \strtolower($matches[1]);
 
-            if (\stripos($line, '@param') !== false) {
-                if (\preg_match('/@param\b/i', $line)) {
+                if ($type === 'param') {
                     $check_compatible('@param', Comment::FUNCTION_LIKE, $i, $line);
                     $parameter_list[] =
                         self::parameterFromCommentLine($code_base, $context, $line, false, $lineno, $i, $comment_lines_count);
-                }
-            } elseif (\stripos($line, '@var') !== false && \preg_match('/@var\b/i', $line)) {
-                $check_compatible('@var', Comment::HAS_VAR_ANNOTATION, $i, $line);
-                $comment_var = self::parameterFromCommentLine($code_base, $context, $line, true, $lineno, $i, $comment_lines_count);
-                if ($comment_var->getName() !== '' || !\in_array($comment_type, self::FUNCTION_LIKE)) {
-                    $variable_list[] = $comment_var;
-                }
-            } elseif (\strpos($line, '@template') !== false) {
-                // Make sure support for generic types is enabled
-                if (Config::getValue('generic_types_enabled')) {
-                    $check_compatible('@template', [Comment::ON_CLASS], $i, $line);
-                    if (($template_type =
-                        self::templateTypeFromCommentLine($line))
-                    ) {
-                        $template_type_list[] = $template_type;
+                } elseif ($type === 'var') {
+                    $check_compatible('@var', Comment::HAS_VAR_ANNOTATION, $i, $line);
+                    $comment_var = self::parameterFromCommentLine($code_base, $context, $line, true, $lineno, $i, $comment_lines_count);
+                    if ($comment_var->getName() !== '' || !\in_array($comment_type, self::FUNCTION_LIKE)) {
+                        $variable_list[] = $comment_var;
                     }
-                }
-            } elseif (\stripos($line, '@inherits') !== false) {
-                $check_compatible('@inherits', [Comment::ON_CLASS], $i, $line);
-                // Make sure support for generic types is enabled
-                if (Config::getValue('generic_types_enabled')) {
-                    $inherited_type =
-                        self::inheritsFromCommentLine($context, $line);
-                }
-            } elseif (\stripos($line, '@return') !== false) {
-                if (preg_match('/@return\b/i', $line)) {
+                } elseif ($type === 'template') {
+                    // Make sure support for generic types is enabled
+                    if (Config::getValue('generic_types_enabled')) {
+                        $check_compatible('@template', [Comment::ON_CLASS], $i, $line);
+                        if (($template_type =
+                            self::templateTypeFromCommentLine($line))
+                        ) {
+                            $template_type_list[] = $template_type;
+                        }
+                    }
+                } elseif ($type === 'inherits') {
+                    $check_compatible('@inherits', [Comment::ON_CLASS], $i, $line);
+                    // Make sure support for generic types is enabled
+                    if (Config::getValue('generic_types_enabled')) {
+                        $inherited_type =
+                            self::inheritsFromCommentLine($context, $line);
+                    }
+                } elseif ($type === 'return') {
                     $check_compatible('@return', Comment::FUNCTION_LIKE, $i, $line);
                     $return_union_type =
                         self::returnTypeFromCommentLine($context, $line);
-                } elseif (\stripos($line, '@returns') !== false) {
+                } elseif ($type === 'returns') {
                     Issue::maybeEmit(
                         $code_base,
                         $context,
@@ -365,57 +366,56 @@ class Comment
                         '@returns',
                         '@return'
                     );
-                }
-            } elseif (\stripos($line, '@suppress') !== false) {
-                $suppress_issue_type = self::suppressIssueFromCommentLine($line);
-                if ($suppress_issue_type !== '') {
-                    $suppress_issue_list[] = $suppress_issue_type;
-                }
-            } elseif (\strpos($line, '@property') !== false) {
-                $check_compatible('@property', [Comment::ON_CLASS], $i, $line);
-                // Make sure support for magic properties is enabled.
-                if (Config::getValue('read_magic_property_annotations')) {
-                    $magic_property = self::magicPropertyFromCommentLine($code_base, $context, $line, $lineno);
-                    if ($magic_property !== null) {
-                        $magic_property_list[] = $magic_property;
+                } elseif ($type === 'suppress') {
+                    $suppress_issue_type = self::suppressIssueFromCommentLine($line);
+                    if ($suppress_issue_type !== '') {
+                        $suppress_issue_list[] = $suppress_issue_type;
                     }
-                }
-            } elseif (\strpos($line, '@method') !== false) {
-                // Make sure support for magic methods is enabled.
-                if (Config::getValue('read_magic_method_annotations')) {
-                    $check_compatible('@method', [Comment::ON_CLASS], $i, $line);
-                    $magic_method = self::magicMethodFromCommentLine($code_base, $context, $line, $lineno, $i, $comment_lines_count);
-                    if ($magic_method !== null) {
-                        $magic_method_list[] = $magic_method;
+                } elseif ($type === 'property') {
+                    $check_compatible('@property', [Comment::ON_CLASS], $i, $line);
+                    // Make sure support for magic properties is enabled.
+                    if (Config::getValue('read_magic_property_annotations')) {
+                        $magic_property = self::magicPropertyFromCommentLine($code_base, $context, $line, $lineno);
+                        if ($magic_property !== null) {
+                            $magic_property_list[] = $magic_property;
+                        }
                     }
-                }
-            } elseif (\strpos($line, '@PhanClosureScope') !== false) {
-                // TODO: different type for closures
-                $check_compatible('@PhanClosureScope', Comment::FUNCTION_LIKE, $i, $line);
-                $closure_scope = self::getPhanClosureScopeFromCommentLine($context, $line);
-            } elseif (\stripos($line, '@phan-') !== false) {
-                if (\stripos($line, '@phan-forbid-undeclared-magic-properties') !== false) {
-                    $check_compatible('@phan-forbid-undeclared-magic-properties', [Comment::ON_CLASS], $i, $line);
-                    $comment_flags |= Flags::CLASS_FORBID_UNDECLARED_MAGIC_PROPERTIES;
-                } elseif (\stripos($line, '@phan-forbid-undeclared-magic-methods') !== false) {
-                    $check_compatible('@phan-forbid-undeclared-magic-methods', [Comment::ON_CLASS], $i, $line);
-                    $comment_flags |= Flags::CLASS_FORBID_UNDECLARED_MAGIC_METHODS;
-                } elseif (\stripos($line, '@phan-closure-scope') !== false && \preg_match('/@phan-closure-scope\b/', $line)) {
-                    $check_compatible('@phan-closure-scope', Comment::FUNCTION_LIKE, $i, $line);
+                } elseif ($type === 'method') {
+                    // Make sure support for magic methods is enabled.
+                    if (Config::getValue('read_magic_method_annotations')) {
+                        $check_compatible('@method', [Comment::ON_CLASS], $i, $line);
+                        $magic_method = self::magicMethodFromCommentLine($code_base, $context, $line, $lineno, $i, $comment_lines_count);
+                        if ($magic_method !== null) {
+                            $magic_method_list[] = $magic_method;
+                        }
+                    }
+                } elseif ($type === 'phanclosurescope' || $type === 'phan-closure_scope') {
+                    // TODO: different type for closures
+                    $check_compatible('@PhanClosureScope', Comment::FUNCTION_LIKE, $i, $line);
                     $closure_scope = self::getPhanClosureScopeFromCommentLine($context, $line);
-                } elseif (\stripos($line, '@phan-override') !== false) {
-                    $check_compatible('@override', [Comment::ON_METHOD, Comment::ON_CONST], $i, $line);
-                    $comment_flags |= Flags::IS_OVERRIDE_INTENDED;
-                } elseif (\stripos($line, '@phan-') !== false) {
-                    \preg_match('/@phan-\S*/', $line, $match);
-                    Issue::maybeEmit(
-                        $code_base,
-                        $context,
-                        Issue::MisspelledAnnotation,
-                        self::guessActualLineLocation($context, $lineno, $i, $comment_lines_count, $line),
-                        $match[0],
-                        '@phan-forbid-undeclared-magic-methods @phan-forbid-undeclared-magic-properties @phan-closure-scope @phan-override'
-                    );
+                } elseif (\strpos($type, 'phan-') === 0) {
+                    if ($type === 'phan-forbid-undeclared-magic-properties') {
+                        $check_compatible('@phan-forbid-undeclared-magic-properties', [Comment::ON_CLASS], $i, $line);
+                        $comment_flags |= Flags::CLASS_FORBID_UNDECLARED_MAGIC_PROPERTIES;
+                    } elseif ($type === 'phan-forbid-undeclared-magic-methods') {
+                        $check_compatible('@phan-forbid-undeclared-magic-methods', [Comment::ON_CLASS], $i, $line);
+                        $comment_flags |= Flags::CLASS_FORBID_UNDECLARED_MAGIC_METHODS;
+                    } elseif ($type === 'phan-closure-scope') {
+                        $check_compatible('@phan-closure-scope', Comment::FUNCTION_LIKE, $i, $line);
+                        $closure_scope = self::getPhanClosureScopeFromCommentLine($context, $line);
+                    } elseif ($type === 'phan-override') {
+                        $check_compatible('@override', [Comment::ON_METHOD, Comment::ON_CONST], $i, $line);
+                        $comment_flags |= Flags::IS_OVERRIDE_INTENDED;
+                    } else {
+                        Issue::maybeEmit(
+                            $code_base,
+                            $context,
+                            Issue::MisspelledAnnotation,
+                            self::guessActualLineLocation($context, $lineno, $i, $comment_lines_count, $line),
+                            '@' . $matches[1],
+                            '@phan-forbid-undeclared-magic-methods @phan-forbid-undeclared-magic-properties @phan-closure-scope @phan-override'
+                        );
+                    }
                 }
             }
 

--- a/src/Phan/Language/Element/Comment/Parameter.php
+++ b/src/Phan/Language/Element/Comment/Parameter.php
@@ -94,7 +94,7 @@ class Parameter
             $flags
         );
         if ($this->has_default_value) {
-            $param->setDefaultValueType(clone($union_type));
+            $param->setDefaultValueType($union_type);
             // TODO: could setDefaultValue in a future PR. Would have to run \ast\parse_code on the default value, catch ParseError if necessary.
             // If given '= "Default"', then extract the default from '<?php ("Default");'
             // Then get the type from UnionTypeVisitor, for defaults such as SomeClass::CONST.

--- a/src/Phan/Language/Element/Comment/Parameter.php
+++ b/src/Phan/Language/Element/Comment/Parameter.php
@@ -87,7 +87,7 @@ class Parameter
             $flags |= \ast\flags\PARAM_VARIADIC;
         }
         $union_type = $this->getUnionType();
-        $param = new \Phan\Language\Element\Parameter(
+        $param = \Phan\Language\Element\Parameter::create(
             $context,
             $this->getName(),
             $union_type,

--- a/src/Phan/Language/Element/ElementFutureUnionType.php
+++ b/src/Phan/Language/Element/ElementFutureUnionType.php
@@ -58,7 +58,7 @@ trait ElementFutureUnionType
         // Don't set 'null' as the type if that's the default
         // given that its the default default.
         if ($union_type->isType(NullType::instance(false))) {
-            $union_type = new UnionType();
+            $union_type = UnionType::empty();
         }
 
         return $union_type;

--- a/src/Phan/Language/Element/ElementFutureUnionType.php
+++ b/src/Phan/Language/Element/ElementFutureUnionType.php
@@ -56,7 +56,7 @@ trait ElementFutureUnionType
         $union_type = $future_union_type->get();
 
         // Don't set 'null' as the type if that's the default
-        // given that its the default default.
+        // given that its the default.
         if ($union_type->isType(NullType::instance(false))) {
             $union_type = UnionType::empty();
         }

--- a/src/Phan/Language/Element/Func.php
+++ b/src/Phan/Language/Element/Func.php
@@ -148,7 +148,7 @@ class Func extends AddressableElement implements FunctionInterface
         $func = new Func(
             $context,
             (string)$node->children['name'],
-            new UnionType(),
+            UnionType::empty(),
             $node->flags ?? 0,
             $fqsen
         );

--- a/src/Phan/Language/Element/Func.php
+++ b/src/Phan/Language/Element/Func.php
@@ -244,7 +244,7 @@ class Func extends AddressableElement implements FunctionInterface
             );
             $func->setRealReturnType($union_type);
 
-            $func->getUnionType()->addUnionType($union_type);
+            $func->setUnionType($func->getUnionType()->withUnionType($union_type));
         }
 
         if ($comment->hasReturnUnionType()) {
@@ -256,7 +256,7 @@ class Func extends AddressableElement implements FunctionInterface
                 "Function referencing self in $context"
             );
 
-            $func->getUnionType()->addUnionType($union_type);
+            $func->setUnionType($func->getUnionType()->withUnionType($union_type));
             $func->setPHPDocReturnType($union_type);
         }
 

--- a/src/Phan/Language/Element/FunctionFactory.php
+++ b/src/Phan/Language/Element/FunctionFactory.php
@@ -45,7 +45,7 @@ class FunctionFactory
         $function = new Func(
             $context,
             $fqsen->getNamespacedName(),
-            new UnionType(),
+            UnionType::empty(),
             0,
             $fqsen
         );
@@ -118,7 +118,7 @@ class FunctionFactory
         $method = new Method(
             $context,
             $reflection_method->name,
-            new UnionType(),
+            UnionType::empty(),
             $reflection_method->getModifiers(),
             $method_fqsen
         );

--- a/src/Phan/Language/Element/FunctionFactory.php
+++ b/src/Phan/Language/Element/FunctionFactory.php
@@ -221,7 +221,7 @@ class FunctionFactory
                     $parameter_name = \str_replace('=', '', $parameter_name);
                 }
 
-                $parameter = new Parameter(
+                $parameter = Parameter::create(
                     $function->getContext(),
                     $parameter_name,
                     $parameter_type,

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -453,8 +453,7 @@ trait FunctionTrait
     public function setRealReturnType(UnionType $union_type)
     {
         // TODO: was `self` properly resolved already? What about in subclasses?
-        // Clone it, since caller has a mutable version of this.
-        $this->real_return_type = clone($union_type);
+        $this->real_return_type = $union_type;
     }
 
     /**
@@ -469,8 +468,7 @@ trait FunctionTrait
             // throw new \Error(sprintf("Failed to get real return type in %s method %s", (string)$this->getClassFQSEN(), (string)$this));
         }
         // Clone the union type, to be certain it will remain immutable.
-        $union_type = clone($this->real_return_type);
-        return $union_type;
+        return $this->real_return_type;
     }
 
     /**

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -464,7 +464,7 @@ trait FunctionTrait
     {
         if (!$this->real_return_type) {
             // Incomplete patch for https://github.com/phan/phan/issues/670
-            return new UnionType();
+            return UnionType::empty();
             // throw new \Error(sprintf("Failed to get real return type in %s method %s", (string)$this->getClassFQSEN(), (string)$this));
         }
         // Clone the union type, to be certain it will remain immutable.

--- a/src/Phan/Language/Element/GlobalConstant.php
+++ b/src/Phan/Language/Element/GlobalConstant.php
@@ -21,7 +21,7 @@ class GlobalConstant extends AddressableElement implements ConstantInterface
     public function getUnionType() : UnionType
     {
         if (null !== ($union_type = $this->getFutureUnionType())) {
-            $this->getUnionType()->addUnionType($union_type);
+            $this->setUnionType($this->getUnionType()->withUnionType($union_type));
         }
 
         return parent::getUnionType();

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -443,7 +443,7 @@ class Method extends ClassElement implements FunctionInterface
 
         // Add the syntax-level return type to the method's union type
         // if it exists
-        $return_union_type = new UnionType;
+        $return_union_type = UnionType::empty();
         if ($node->children['returnType'] !== null) {
             $return_union_type = UnionType::fromNode(
                 $context,

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -450,7 +450,7 @@ class Method extends ClassElement implements FunctionInterface
                 $code_base,
                 $node->children['returnType']
             );
-            $method->getUnionType()->addUnionType($return_union_type);
+            $method->setUnionType($method->getUnionType()->withUnionType($return_union_type));
         }
         $method->setRealReturnType($return_union_type);
 
@@ -467,13 +467,14 @@ class Method extends ClassElement implements FunctionInterface
                     //       or $this in the type because I'm guessing
                     //       it doesn't really matter. Apologies if it
                     //       ends up being an issue.
-                    $comment_return_union_type->addUnionType(
+                    $comment_return_union_type = $comment_return_union_type->withUnionType(
                         $context->getClassFQSEN()->asUnionType()
                     );
+                    // $comment->setReturnType($comment_return_union_type);
                 }
             }
 
-            $method->getUnionType()->addUnionType($comment_return_union_type);
+            $method->setUnionType($method->getUnionType()->withUnionType($comment_return_union_type));
             $method->setPHPDocReturnType($comment_return_union_type);
         }
 
@@ -494,8 +495,7 @@ class Method extends ClassElement implements FunctionInterface
         // If the type is 'static', add this context's class
         // to the return type
         if ($union_type->hasStaticType()) {
-            $union_type = clone($union_type);
-            $union_type->addType(
+            $union_type = $union_type->withType(
                 $this->getFQSEN()->getFullyQualifiedClassName()->asType()
             );
         }
@@ -503,10 +503,9 @@ class Method extends ClassElement implements FunctionInterface
         // If the type is a generic array of 'static', add
         // a generic array of this context's class to the return type
         if ($union_type->genericArrayElementTypes()->hasStaticType()) {
-            $union_type = clone($union_type);
             // TODO: Base this on the static array type...
             $key_type_enum = GenericArrayType::keyTypeFromUnionTypeKeys($union_type);
-            $union_type->addType(
+            $union_type = $union_type->withType(
                 $this->getFQSEN()->getFullyQualifiedClassName()->asType()->asGenericArrayType($key_type_enum)
             );
         }

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -467,8 +467,8 @@ class Method extends ClassElement implements FunctionInterface
                     //       or $this in the type because I'm guessing
                     //       it doesn't really matter. Apologies if it
                     //       ends up being an issue.
-                    $comment_return_union_type = $comment_return_union_type->withUnionType(
-                        $context->getClassFQSEN()->asUnionType()
+                    $comment_return_union_type = $comment_return_union_type->withType(
+                        $context->getClassFQSEN()->asType()
                     );
                     // $comment->setReturnType($comment_return_union_type);
                 }

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -363,7 +363,7 @@ class Method extends ClassElement implements FunctionInterface
         $method = new Method(
             $context,
             (string)$node->children['name'],
-            new UnionType(),
+            UnionType::empty(),
             $node->flags ?? 0,
             $fqsen
         );

--- a/src/Phan/Language/Element/Parameter.php
+++ b/src/Phan/Language/Element/Parameter.php
@@ -83,14 +83,6 @@ class Parameter extends Variable
     }
 
     /**
-     * @return static - non-variadic clone which can be modified.
-     */
-    public function cloneAsNonVariadic()
-    {
-        return clone($this);  // See override in VariadicParameter;
-    }
-
-    /**
      * @return bool
      * True if this parameter has a type for its
      * default value
@@ -223,6 +215,11 @@ class Parameter extends Variable
             UnionType::fromReflectionType($reflection_parameter->getType()),
             $flags
         );
+        if ($reflection_parameter->isOptional()) {
+            $parameter->setDefaultValueType(
+                NullType::instance(false)->asUnionType()
+            );
+        }
         return $parameter;
     }
 
@@ -243,7 +240,7 @@ class Parameter extends Variable
         );
 
         // Create the skeleton parameter from what we know so far
-        $parameter = new Parameter(
+        $parameter = Parameter::create(
             $context,
             (string)$node->children['name'],
             $union_type,
@@ -364,11 +361,7 @@ class Parameter extends Variable
      */
     public function getNonVariadicUnionType() : UnionType
     {
-        $union_type = parent::getUnionType();
-        if ($this->isCloneOfVariadic()) {
-            return $union_type->nonArrayTypes();  // clones converted inner types to a generic array T[]. Convert it back to T.
-        }
-        return $union_type;
+        return self::getUnionType();
     }
 
     /**
@@ -391,7 +384,7 @@ class Parameter extends Variable
      */
     public function addUnionType(UnionType $union_type)
     {
-        parent::setUnionType(parent::getUnionType()->withUnionType($union_type));
+        parent::setUnionType(self::getUnionType()->withUnionType($union_type));
     }
 
     /**
@@ -404,7 +397,7 @@ class Parameter extends Variable
      */
     public function addType(Type $type)
     {
-        parent::setUnionType(parent::getUnionType()->withType($type));
+        parent::setUnionType(self::getUnionType()->withType($type));
     }
 
     /**

--- a/src/Phan/Language/Element/Parameter.php
+++ b/src/Phan/Language/Element/Parameter.php
@@ -279,15 +279,14 @@ class Parameter extends Variable
                     if ($default_node instanceof Node
                         && $default_node->kind === \ast\AST_ARRAY
                     ) {
-                        $union_type = new UnionType([
-                            ArrayType::instance(false),
-                        ]);
+                        $union_type = ArrayType::instance(false)->asUnionType();
                     } else {
                         // If we're in the parsing phase and we
                         // depend on a constant that isn't yet
                         // defined, give up and set it to
                         // bool|float|int|string to avoid having
                         // to handle a future type.
+                        // TODO: This can also be Null or an Array
                         $union_type = new UnionType([
                             BoolType::instance(false),
                             FloatType::instance(false),

--- a/src/Phan/Language/Element/Parameter.php
+++ b/src/Phan/Language/Element/Parameter.php
@@ -441,7 +441,7 @@ class Parameter extends Variable
      * (We avoid bugs by adding new types to a variadic parameter if this is cloned.)
      * However, error messages still need to convert variadic parameters to a string.
      */
-    protected function isCloneOfVariadic() : bool
+    public function isCloneOfVariadic() : bool
     {
         return Flags::bitVectorHasState($this->getPhanFlags(), Flags::IS_CLONE_OF_VARIADIC);
     }
@@ -456,7 +456,7 @@ class Parameter extends Variable
      */
     public function addUnionType(UnionType $union_type)
     {
-        parent::getUnionType()->addUnionType($union_type);
+        parent::setUnionType(parent::getUnionType()->withUnionType($union_type));
     }
 
     /**
@@ -469,7 +469,7 @@ class Parameter extends Variable
      */
     public function addType(Type $type)
     {
-        parent::getUnionType()->addType($type);
+        parent::setUnionType(parent::getUnionType()->withType($type));
     }
 
     /**

--- a/src/Phan/Language/Element/Parameter.php
+++ b/src/Phan/Language/Element/Parameter.php
@@ -68,20 +68,6 @@ class Parameter extends Variable
     }
 
     /**
-     * After a clone is called on this object, clone our
-     * deep objects.
-     *
-     * @return null
-     */
-    public function __clone()
-    {
-        parent::__clone();
-        $this->default_value_type = $this->default_value_type
-            ? clone($this->default_value_type)
-            : $this->default_value_type;
-    }
-
-    /**
      * @return static - non-variadic clone which can be modified.
      */
     public function cloneAsNonVariadic()

--- a/src/Phan/Language/Element/Parameter.php
+++ b/src/Phan/Language/Element/Parameter.php
@@ -24,6 +24,8 @@ class Parameter extends Variable
     const REFERENCE_READ_WRITE = 2;
     const REFERENCE_WRITE_ONLY = 3;
 
+    // __construct inherited from Variable
+
     /**
      * @var UnionType|null
      * The type of the default value if any
@@ -35,37 +37,6 @@ class Parameter extends Variable
      * The value of the default, if one is set
      */
     private $default_value = null;
-
-    /**
-     * @param FileRef $file_ref
-     * The file and lines in which the unaddressable element lives
-     *
-     * @param string $name
-     * The name of the typed structural element
-     *
-     * @param UnionType $type
-     * A '|' delimited set of types satisfyped by this
-     * typed structural element.
-     *
-     * @param int $flags
-     * The flags property contains node specific flags. It is
-     * always defined, but for most nodes it is always zero.
-     * ast\kind_uses_flags() can be used to determine whether
-     * a certain kind has a meaningful flags value.
-     */
-    protected function __construct(
-        FileRef $file_ref,
-        string $name,
-        UnionType $type,
-        int $flags
-    ) {
-        parent::__construct(
-            $file_ref,
-            $name,
-            $type,
-            $flags
-        );
-    }
 
     /**
      * @return static
@@ -160,7 +131,7 @@ class Parameter extends Variable
     ) : array {
         $parameter_list = [];
         $is_optional_seen = false;
-        foreach ($node->children ?? [] as $child_node) {
+        foreach ($node->children as $child_node) {
             $parameter =
                 Parameter::fromNode($context, $code_base, $child_node);
 

--- a/src/Phan/Language/Element/Property.php
+++ b/src/Phan/Language/Element/Property.php
@@ -79,7 +79,7 @@ class Property extends ClassElement
         try {
             $union_type = $this->getUnionType();
         } catch (\Exception $exception) {
-            $union_type = new UnionType();
+            $union_type = UnionType::empty();
         }
 
         $string .= "$union_type \${$this->getName()}";

--- a/src/Phan/Language/Element/Property.php
+++ b/src/Phan/Language/Element/Property.php
@@ -95,7 +95,7 @@ class Property extends ClassElement
     public function getUnionType() : UnionType
     {
         if (null !== ($union_type = $this->getFutureUnionType())) {
-            $this->getUnionType()->addUnionType($union_type);
+            $this->setUnionType($this->getUnionType()->withUnionType($union_type));
         }
 
         return parent::getUnionType();

--- a/src/Phan/Language/Element/Property.php
+++ b/src/Phan/Language/Element/Property.php
@@ -95,7 +95,7 @@ class Property extends ClassElement
     public function getUnionType() : UnionType
     {
         if (null !== ($union_type = $this->getFutureUnionType())) {
-            $this->setUnionType($this->getUnionType()->withUnionType($union_type));
+            $this->setUnionType(parent::getUnionType()->withUnionType($union_type));
         }
 
         return parent::getUnionType();

--- a/src/Phan/Language/Element/TypedElement.php
+++ b/src/Phan/Language/Element/TypedElement.php
@@ -96,10 +96,6 @@ abstract class TypedElement implements TypedElementInterface
         $this->context = $this->context
             ? clone($this->context)
             : $this->context;
-
-        $this->type = $this->type
-            ? clone($this->type)
-            : $this->type;
     }
 
     /**
@@ -128,7 +124,7 @@ abstract class TypedElement implements TypedElementInterface
      */
     public function setUnionType(UnionType $type)
     {
-        $this->type = clone($type);
+        $this->type = $type;
     }
 
     /**

--- a/src/Phan/Language/Element/TypedElement.php
+++ b/src/Phan/Language/Element/TypedElement.php
@@ -120,6 +120,8 @@ abstract class TypedElement implements TypedElementInterface
      * @param UnionType $type
      * Set the type of this element
      *
+     * TODO: A helper addUnionType(), accounting for variadic
+     *
      * @return void
      */
     public function setUnionType(UnionType $type)

--- a/src/Phan/Language/Element/UnaddressableTypedElement.php
+++ b/src/Phan/Language/Element/UnaddressableTypedElement.php
@@ -84,19 +84,6 @@ abstract class UnaddressableTypedElement
     }
 
     /**
-     * After a clone is called on this object, clone our
-     * type and fqsen so that they survive copies intact
-     *
-     * @return null
-     */
-    public function __clone()
-    {
-        $this->type = $this->type
-            ? clone($this->type)
-            : $this->type;
-    }
-
-    /**
      * @return string
      * The (not fully-qualified) name of this element.
      */
@@ -122,7 +109,7 @@ abstract class UnaddressableTypedElement
      */
     public function setUnionType(UnionType $type)
     {
-        $this->type = clone($type);
+        $this->type = $type;
     }
 
     /**

--- a/src/Phan/Language/Element/Variable.php
+++ b/src/Phan/Language/Element/Variable.php
@@ -146,7 +146,7 @@ class Variable extends UnaddressableTypedElement
         // Get the type of the assignment
         $union_type = $should_check_type
             ? UnionType::fromNode($context, $code_base, $node)
-            : new UnionType();
+            : UnionType::empty();
 
         $variable = new Variable(
             $context

--- a/src/Phan/Language/Element/VariadicParameter.php
+++ b/src/Phan/Language/Element/VariadicParameter.php
@@ -1,0 +1,127 @@
+<?php declare(strict_types=1);
+namespace Phan\Language\Element;
+
+use Phan\Language\UnionType;
+use Phan\Language\Type\GenericArrayType;
+
+class VariadicParameter extends Parameter {
+    // __construct inherited from Parameter
+
+    /**
+     * @return static - non-variadic clone which can be modified.
+     * @override
+     */
+    public function cloneAsNonVariadic()
+    {
+        $result = clone($this);
+        if (!$result->isCloneOfVariadic()) {
+            $result->convertToNonVariadic();
+            $result->setPhanFlags(Flags::bitVectorWithState(
+                $result->getPhanFlags(),
+                Flags::IS_CLONE_OF_VARIADIC,
+                true
+            ));
+        }
+        return $result;
+    }
+
+    /**
+     * @return bool - True when this is a non-variadic clone of a variadic parameter.
+     * (We avoid bugs by adding new types to a variadic parameter if this is cloned.)
+     * However, error messages still need to convert variadic parameters to a string.
+     * @override
+     */
+    public function isCloneOfVariadic() : bool
+    {
+        return Flags::bitVectorHasState($this->getPhanFlags(), Flags::IS_CLONE_OF_VARIADIC);
+    }
+
+    /**
+     * @return bool
+     * True if this parameter is variadic, i.e. can
+     * take an unlimited list of parameters and express
+     * them as an array.
+     * @override
+     */
+    public function isVariadic() : bool
+    {
+        return true;
+    }
+
+    /**
+     * @return bool
+     * True if this is an optional parameter (true because this is variadic)
+     * @override
+     */
+    public function isOptional() : bool
+    {
+        return true;
+    }
+
+    /**
+     * @return bool
+     * True if this is a required parameter (false because this is variadic)
+     * @override
+     */
+    public function isRequired() : bool
+    {
+        return false;
+    }
+
+    /**
+     * Returns the Parameter in the form expected by a caller.
+     *
+     * If this parameter is variadic (e.g. `DateTime ...$args`), then this
+     * would return a parameter with the type of the elements (e.g. `DateTime`)
+     *
+     * If this parameter is not variadic, returns $this.
+     *
+     * @return static
+     * @override
+     */
+    public function asNonVariadic()
+    {
+        // TODO: Is it possible to cache this while maintaining
+        //       correctness? PostOrderAnalysisVisitor clones the
+        //       value to avoid it being reused.
+        //
+        // Also, figure out if the cloning still working correctly
+        // after this PR for fixing variadic args. Create a single
+        // Parameter instance for analyzing callers of the
+        // corresponding method/function.
+        // e.g. $this->getUnionType() is of type T[]
+        //      $this->non_variadic->getUnionType() is of type T
+        return Parameter::create(
+            $this->getFileRef(),
+            $this->getName(),
+            $this->getNonVariadicUnionType(),
+            Flags::bitVectorWithState($this->getFlags(), \ast\flags\PARAM_VARIADIC, false)
+        );
+    }
+
+    /**
+     * If this parameter is variadic (e.g. `DateTime ...$args`),
+     * then this returns the corresponding array type(s) of $args.
+     * (e.g. `DateTime[]`)
+     *
+     * NOTE: For analyzing the code within a function,
+     * code should pass $param->cloneAsNonVariadic() instead.
+     * Modifying/analyzing the clone should work without any bugs.
+     *
+     * TODO(Issue #376) : We will probably want to be able to modify
+     * the underlying variable, e.g. by creating
+     * `class UnionTypeGenericArrayView extends UnionType`.
+     * Otherwise, type inference of `...$args` based on the function
+     * source will be less effective without phpdoc types.
+     *
+     * @override
+     */
+    public function getUnionType() : UnionType
+    {
+        if (!$this->isCloneOfVariadic()) {
+            // TODO: Figure out why asNonEmptyGenericArrayTypes() causes test failures
+            return parent::getUnionType()->asGenericArrayTypes(GenericArrayType::KEY_INT);
+        }
+        return parent::getUnionType();
+    }
+}

--- a/src/Phan/Language/Element/VariadicParameter.php
+++ b/src/Phan/Language/Element/VariadicParameter.php
@@ -91,7 +91,7 @@ class VariadicParameter extends Parameter {
         // corresponding method/function.
         // e.g. $this->getUnionType() is of type T[]
         //      $this->non_variadic->getUnionType() is of type T
-        return Parameter::create(
+        return new Parameter(
             $this->getFileRef(),
             $this->getName(),
             $this->getNonVariadicUnionType(),
@@ -100,9 +100,20 @@ class VariadicParameter extends Parameter {
     }
 
     /**
+     * If this Parameter is variadic, calling `getUnionType`
+     * will return an array type such as `DateTime[]`. This
+     * method will return the element type (such as `DateTime`)
+     * for variadic parameters.
+     */
+    public function getNonVariadicUnionType() : UnionType
+    {
+        return parent::getUnionType();
+    }
+
+    /**
      * If this parameter is variadic (e.g. `DateTime ...$args`),
      * then this returns the corresponding array type(s) of $args.
-     * (e.g. `DateTime[]`)
+     * (e.g. `array<int,DateTime>`)
      *
      * NOTE: For analyzing the code within a function,
      * code should pass $param->cloneAsNonVariadic() instead.

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -1,0 +1,874 @@
+<?php declare(strict_types=1);
+namespace Phan\Language;
+
+use ast\Node;
+use Phan\CodeBase;
+use Phan\Language\Type\ArrayType;
+
+/**
+ * NOTE: there may also be instances of UnionType that are empty, due to the constructor being public
+ */
+final class EmptyUnionType extends UnionType
+{
+    /**
+     * An optional list of types represented by this union
+     */
+    private function __construct()
+    {
+        parent::__construct([], true);
+    }
+
+    /**
+     * Use UnionType::empty() instead elsewhere in the codebase.
+     */
+    protected static function instance() : EmptyUnionType {
+        static $self = null;
+        return $self ?? ($self = new EmptyUnionType());
+    }
+
+    /**
+     * @return Type[]
+     * The list of simple types associated with this
+     * union type. Keys are consecutive.
+     * @override
+     */
+    public function getTypeSet() : array
+    {
+        return [];
+    }
+
+    /**
+     * Add a type name to the list of types
+     *
+     * @return UnionType
+     * @override
+     */
+    public function withType(Type $type)
+    {
+        return $type->asUnionType();
+    }
+
+    /**
+     * Returns a new union type
+     * which removes this type from the list of types,
+     * keeping the keys in a consecutive order.
+     *
+     * Each type in $this->type_set occurs exactly once.
+     *
+     * @return UnionType
+     * @override
+     */
+    public function withoutType(Type $type)
+    {
+        return $this;
+    }
+
+    /**
+     * @return bool
+     * True if this union type contains the given named
+     * type.
+     * @override
+     */
+    public function hasType(Type $type) : bool
+    {
+        return false;
+    }
+
+    /**
+     * Returns a union type which add the given types to this type
+     *
+     * @return UnionType
+     * @override
+     */
+    public function withUnionType(UnionType $union_type)
+    {
+        return $union_type;
+    }
+
+    /**
+     * @return bool
+     * True if this type has a type referencing the
+     * class context in which it exists such as 'self'
+     * or '$this'
+     * @override
+     */
+    public function hasSelfType() : bool
+    {
+        return false;
+    }
+
+    /**
+     * @return bool
+     * True if this union type has any types that are bool/false/true types
+     * @override
+     */
+    public function hasTypeInBoolFamily() : bool
+    {
+        return false;
+    }
+
+    /**
+     * @return UnionType[]
+     * A map from template type identifiers to the UnionType
+     * to replace it with
+     * @override
+     */
+    public function getTemplateParameterTypeList() : array
+    {
+        return [];
+    }
+
+    /**
+     * @param CodeBase $code_base
+     * The code base to look up classes against
+     *
+     * TODO: Defer resolving the template parameters until parse ends. Low priority.
+     *
+     * @return UnionType[]
+     * A map from template type identifiers to the UnionType
+     * to replace it with
+     */
+    public function getTemplateParameterTypeMap(
+        CodeBase $code_base
+    ) : array {
+        return [];
+    }
+
+
+    /**
+     * @param UnionType[] $template_parameter_type_map
+     * A map from template type identifiers to concrete types
+     *
+     * @return UnionType
+     * This UnionType with any template types contained herein
+     * mapped to concrete types defined in the given map.
+     */
+    public function withTemplateParameterTypeMap(
+        array $template_parameter_type_map
+    ) : UnionType {
+        return $this;
+    }
+
+    /**
+     * @return bool
+     * True if this union type has any types that are generic
+     * types
+     * @override
+     */
+    public function hasTemplateType() : bool
+    {
+        return false;
+    }
+
+    /**
+     * @return bool
+     * True if this type has a type referencing the
+     * class context 'static'.
+     * @override
+     */
+    public function hasStaticType() : bool
+    {
+        return false;
+    }
+
+    /**
+     * @return UnionType
+     * A new UnionType with any references to 'static' resolved
+     * in the given context.
+     */
+    public function withStaticResolvedInContext(
+        Context $context
+    ) : UnionType {
+        return $this;
+    }
+
+    /**
+     * @return bool
+     * True if and only if this UnionType contains
+     * the given type and no others.
+     * @override
+     */
+    public function isType(Type $type) : bool
+    {
+        return false;
+    }
+
+    /**
+     * @return bool
+     * True if this UnionType is exclusively native
+     * types
+     * @override
+     */
+    public function isNativeType() : bool
+    {
+        return false;
+    }
+
+    /**
+     * @return bool
+     * True iff this union contains the exact set of types
+     * represented in the given union type.
+     * @override
+     */
+    public function isEqualTo(UnionType $union_type) : bool
+    {
+        return $union_type->isEmpty();
+    }
+
+    /**
+     * @return bool
+     * True iff this union contains a type that's also in
+     * the other union type.
+     */
+    public function hasCommonType(UnionType $union_type) : bool
+    {
+        return false;
+    }
+
+    /**
+     * @return bool - True if not empty and at least one type is NullType or nullable.
+     */
+    public function containsNullable() : bool
+    {
+        return false;
+    }
+
+    /** @override */
+    public function nonNullableClone() : UnionType
+    {
+        return $this;
+    }
+
+    /** @override */
+    public function nullableClone() : UnionType
+    {
+        return $this;
+    }
+
+    /**
+     * @return bool - True if type set is not empty and at least one type is NullType or nullable or FalseType or BoolType.
+     * (I.e. the type is always falsey, or both sometimes falsey with a non-falsey type it can be narrowed down to)
+     * This does not include values such as `IntType`, since there is currently no `NonZeroIntType`.
+     * @override
+     */
+    public function containsFalsey() : bool
+    {
+        return false;
+    }
+
+    /** @override */
+    public function nonFalseyClone() : UnionType
+    {
+        return $this;
+    }
+
+    /**
+     * @return bool - True if type set is not empty and at least one type is NullType or nullable or FalseType or BoolType.
+     * (I.e. the type is always falsey, or both sometimes falsey with a non-falsey type it can be narrowed down to)
+     * This does not include values such as `IntType`, since there is currently no `NonZeroIntType`.
+     * @override
+     */
+    public function containsTruthy() : bool
+    {
+        return false;
+    }
+
+    /** @override */
+    public function nonTruthyClone() : UnionType
+    {
+        return $this;
+    }
+
+    /**
+     * @return bool - True if type set is not empty and at least one type is BoolType or FalseType
+     * @override
+     */
+    public function containsFalse() : bool
+    {
+        return false;
+    }
+
+    /**
+     * @return bool - True if type set is not empty and at least one type is BoolType or TrueType
+     * @override
+     */
+    public function containsTrue() : bool
+    {
+        return false;
+    }
+
+    public function nonFalseClone() : UnionType
+    {
+        return $this;
+    }
+
+    public function nonTrueClone() : UnionType
+    {
+        return $this;
+    }
+
+    /**
+     * @param UnionType $union_type
+     * A union type to compare against
+     *
+     * @param Context $context
+     * The context in which this type exists.
+     *
+     * @param CodeBase $code_base
+     * The code base in which both this and the given union
+     * types exist.
+     *
+     * @return bool
+     * True if each type within this union type can cast
+     * to the given union type.
+     */
+    // Currently unused and buggy, commenting this out.
+    /**
+    public function isExclusivelyNarrowedFormOrEquivalentTo(
+        UnionType $union_type,
+        Context $context,
+        CodeBase $code_base
+    ) : bool {
+
+        // Special rule: anything can cast to nothing
+        // and nothing can cast to anything
+        if ($union_type->isEmpty() || $this->isEmpty()) {
+            return true;
+        }
+
+        // Check to see if the types are equivalent
+        if ($this->isEqualTo($union_type)) {
+            return true;
+        }
+        // TODO: Allow casting MyClass<TemplateType> to MyClass (Without the template?
+
+        // Resolve 'static' for the given context to
+        // determine whats actually being referred
+        // to in concrete terms.
+        $other_resolved_type =
+            $union_type->withStaticResolvedInContext($context);
+        $other_resolved_type_set = $other_resolved_type->type_set;
+
+        // Convert this type to a set of resolved types to iterate over.
+        $this_resolved_type_set =
+            $this->withStaticResolvedInContext($context)->type_set;
+
+        // TODO: Need to resolve expanded union types (parents, interfaces) of classes *before* this is called.
+
+        // Test to see if every single type in this union
+        // type can cast to the given union type.
+        foreach ($this_resolved_type_set as $type) {
+            // First check if this contains the type as an optimization.
+            if ($other_resolved_type_set->contains($type)) {
+                continue;
+            }
+            $expanded_types = $type->asExpandedTypes($code_base);
+            if ($other_resolved_type->canCastToUnionType(
+                $expanded_types
+            )) {
+                continue;
+            }
+        }
+        return true;
+    }
+     */
+
+    /**
+     * @param Type[] $type_list
+     * A list of types
+     *
+     * @return bool
+     * True if this union type contains any of the given
+     * named types
+     */
+    public function hasAnyType(array $type_list) : bool
+    {
+        return false;
+    }
+
+    /**
+     * @return bool
+     * True if this type has any subtype of `iterable` type (e.g. Traversable, Array).
+     */
+    public function hasIterable() : bool
+    {
+        return false;
+    }
+
+    /**
+     * @return int
+     * The number of types in this union type
+     */
+    public function typeCount() : int
+    {
+        return 0;
+    }
+
+    /**
+     * @return bool
+     * True if this Union has no types
+     */
+    public function isEmpty() : bool
+    {
+        return true;
+    }
+
+    /**
+     * @param UnionType $target
+     * The type we'd like to see if this type can cast
+     * to
+     *
+     * @param CodeBase $code_base
+     * The code base used to expand types
+     *
+     * @return bool
+     * Test to see if this type can be cast to the
+     * given type after expanding both union types
+     * to include all ancestor types
+     *
+     * TODO: ensure that this is only called after the parse phase is over.
+     */
+    public function canCastToExpandedUnionType(
+        UnionType $target,
+        CodeBase $code_base
+    ) : bool {
+        return true;  // Empty can cast to anything.
+    }
+
+    /**
+     * @param UnionType $target
+     * A type to check to see if this can cast to it
+     *
+     * @return bool
+     * True if this type is allowed to cast to the given type
+     * i.e. int->float is allowed  while float->int is not.
+     */
+    public function canCastToUnionType(
+        UnionType $target
+    ) : bool {
+        return true;  // Empty can cast to anything. See parent implementation.
+    }
+
+    /**
+     * @return bool
+     * True if all types in this union are scalars
+     */
+    public function isScalar() : bool
+    {
+        return false;
+    }
+
+    /**
+     * @return bool
+     * True if this union has array-like types (is of type array, is
+     * a generic array, or implements ArrayAccess).
+     */
+    public function hasArrayLike() : bool
+    {
+        return false;
+    }
+
+    /**
+     * @return bool
+     * True if this union has array-like types (is of type array, is
+     * a generic array, or implements ArrayAccess).
+     */
+    public function hasGenericArray() : bool
+    {
+        return false;
+    }
+
+    /**
+     * @return bool
+     * True if this union contains the ArrayAccess type.
+     * (Call asExpandedTypes() first to check for subclasses of ArrayAccess)
+     */
+    public function hasArrayAccess() : bool
+    {
+        return false;
+    }
+
+    /**
+     * @return bool
+     * True if this union contains the Traversable type.
+     * (Call asExpandedTypes() first to check for subclasses of Traversable)
+     */
+    public function hasTraversable() : bool
+    {
+        return false;
+    }
+
+    /**
+     * @return bool
+     * True if this union type represents types that are
+     * array-like, and nothing else (e.g. can't be null).
+     * If any of the array-like types are nullable, this returns false.
+     */
+    public function isExclusivelyArrayLike() : bool
+    {
+        return false;
+    }
+
+    /**
+     * @return bool
+     * True if this union type represents types that are arrays
+     * or generic arrays, but nothing else.
+     * @suppress PhanUnreferencedPublicMethod
+     */
+    public function isExclusivelyArray() : bool
+    {
+        return false;
+    }
+
+    /**
+     * @return UnionType
+     * Get the subset of types which are not native
+     */
+    public function nonNativeTypes() : UnionType
+    {
+        return $this;
+    }
+
+    /**
+     * A memory efficient way to create a UnionType from a filter operation.
+     * If this the filter preserves everything, returns $this instead
+     */
+    public function makeFromFilter(\Closure $cb) : UnionType
+    {
+        return $this;  // filtering empty results in empty
+    }
+
+    /**
+     * @param Context $context
+     * The context in which we're resolving this union
+     * type.
+     *
+     * @return \Generator
+     *
+     * A list of class FQSENs representing the non-native types
+     * associated with this UnionType
+     *
+     * @throws CodeBaseException
+     * An exception is thrown if a non-native type does not have
+     * an associated class
+     *
+     * @throws IssueException
+     * An exception is thrown if static is used as a type outside of an object
+     * context
+     *
+     * TODO: Add a method to ContextNode to directly get FQSEN instead?
+     */
+    public function asClassFQSENList(
+        Context $context
+    ) {
+        if (false) yield;
+    }
+
+    /**
+     * @param CodeBase $code_base
+     * The code base in which to find classes
+     *
+     * @param Context $context
+     * The context in which we're resolving this union
+     * type.
+     *
+     * @return \Generator
+     *
+     * A list of classes representing the non-native types
+     * associated with this UnionType
+     *
+     * @throws CodeBaseException
+     * An exception is thrown if a non-native type does not have
+     * an associated class
+     *
+     * @throws IssueException
+     * An exception is thrown if static is used as a type outside of an object
+     * context
+     */
+    public function asClassList(
+        CodeBase $code_base,
+        Context $context
+    ) {
+        if (false) yield;  // This is a generator yielding 0 results.
+    }
+
+    /**
+     * Takes "a|b[]|c|d[]|e" and returns "a|c|e"
+     *
+     * @return UnionType
+     * A UnionType with generic array types filtered out
+     *
+     * @suppress PhanUnreferencedPublicMethod
+     */
+    public function nonGenericArrayTypes() : UnionType
+    {
+        return $this;
+    }
+
+    /**
+     * Takes "a|b[]|c|d[]|e" and returns "b[]|d[]"
+     *
+     * @return UnionType
+     * A UnionType with generic array types kept, other types filtered out.
+     *
+     * @see nonGenericArrayTypes
+     */
+    public function genericArrayTypes() : UnionType
+    {
+        return $this;
+    }
+
+    /**
+     * Takes "MyClass|int|array|?object" and returns "MyClass|?object"
+     *
+     * @return UnionType
+     * A UnionType with known object types kept, other types filtered out.
+     *
+     * @see nonGenericArrayTypes
+     */
+    public function objectTypes() : UnionType
+    {
+        return $this;
+    }
+
+    /**
+     * Returns true if objectTypes would be non-empty.
+     *
+     * @return bool
+     */
+    public function hasObjectTypes() : bool
+    {
+        return false;
+    }
+
+    /**
+     * Returns the types for which is_scalar($x) would be true.
+     * This means null/nullable is removed.
+     * Takes "MyClass|int|?bool|array|?object" and returns "int|bool"
+     * Takes "?MyClass" and returns an empty union type.
+     *
+     * @return UnionType
+     * A UnionType with known scalar types kept, other types filtered out.
+     *
+     * @see nonGenericArrayTypes
+     */
+    public function scalarTypes() : UnionType
+    {
+        return $this;
+    }
+
+    /**
+     * Returns the types for which is_callable($x) would be true.
+     * TODO: Check for __invoke()?
+     * Takes "Closure|false" and returns "Closure"
+     * Takes "?MyClass" and returns an empty union type.
+     *
+     * @return UnionType
+     * A UnionType with known callable types kept, other types filtered out.
+     *
+     * @see nonGenericArrayTypes
+     */
+    public function callableTypes() : UnionType
+    {
+        return $this;
+    }
+
+    /**
+     * Returns true if this has one or more callable types
+     * TODO: Check for __invoke()?
+     * Takes "Closure|false" and returns true
+     * Takes "?MyClass" and returns false
+     *
+     * @return bool
+     * A UnionType with known callable types kept, other types filtered out.
+     *
+     * @see $this->callableTypes()
+     *
+     * @suppress PhanUnreferencedPublicMethod
+     */
+    public function hasCallableType() : bool
+    {
+        return false;  // has no types
+    }
+
+    /**
+     * Returns true if every type in this type is callable.
+     * TODO: Check for __invoke()?
+     * Takes "callable" and returns true
+     * Takes "callable|false" and returns false
+     *
+     * @return bool
+     * A UnionType with known callable types kept, other types filtered out.
+     *
+     * @see nonGenericArrayTypes
+     */
+    public function isExclusivelyCallable() : bool
+    {
+        return true; // !$this->hasTypeMatchingCallback(empty)
+    }
+
+    /**
+     * Takes "a|b[]|c|d[]|e|array|ArrayAccess" and returns "a|c|e|ArrayAccess"
+     *
+     * @return UnionType
+     * A UnionType with generic types(as well as the non-generic type "array")
+     * filtered out.
+     *
+     * @see nonGenericArrayTypes
+     */
+    public function nonArrayTypes() : UnionType
+    {
+        return $this;
+    }
+
+    /**
+     * @return bool
+     * True if this is exclusively generic types
+     */
+    public function isGenericArray() : bool
+    {
+        return false;  // empty
+    }
+
+    /**
+     * @return bool
+     * True if any of the types in this UnionType made $matcher_callback return true
+     */
+    public function hasTypeMatchingCallback(\Closure $matcher_callback) : bool
+    {
+        return false;
+    }
+
+    /**
+     * @return Type|false
+     * Returns the first type in this UnionType made $matcher_callback return true
+     */
+    public function findTypeMatchingCallback(\Closure $matcher_callback)
+    {
+        return false;  // empty, no types
+    }
+
+    /**
+     * Takes "a|b[]|c|d[]|e" and returns "b|d"
+     *
+     * @return UnionType
+     * The subset of types in this
+     */
+    public function genericArrayElementTypes() : UnionType
+    {
+        return $this; // empty
+    }
+
+    /**
+     * Takes "b|d[]" and returns "b[]|d[][]"
+     *
+     * @param int $key_type
+     * Corresponds to the type of the array keys. Set this to a GenericArrayType::KEY_* constant.
+     *
+     * @return UnionType
+     * The subset of types in this
+     */
+    public function elementTypesToGenericArray(int $key_type) : UnionType
+    {
+        return $this;
+    }
+
+    /**
+     * @param \Closure $closure
+     * A closure mapping `Type` to `Type`
+     *
+     * @return UnionType
+     * A new UnionType with each type mapped through the
+     * given closure
+     */
+    public function asMappedUnionType(\Closure $closure) : UnionType
+    {
+        return $this;  // empty
+    }
+
+    /**
+     * @param int $key_type
+     * Corresponds to the type of the array keys. Set this to a GenericArrayType::KEY_* constant.
+     *
+     * @return UnionType
+     * Get a new type for each type in this union which is
+     * the generic array version of this type. For instance,
+     * 'int|float' will produce 'int[]|float[]'.
+     *
+     * If $this is an empty UnionType, this method will produce an empty UnionType
+     */
+    public function asGenericArrayTypes(int $key_type) : UnionType
+    {
+        return $this;  // empty
+    }
+
+    /**
+     * @return UnionType
+     * Get a new type for each type in this union which is
+     * the generic array version of this type. For instance,
+     * 'int|float' will produce 'int[]|float[]'.
+     *
+     * If $this is an empty UnionType, this method will produce 'array'
+     */
+    public function asNonEmptyGenericArrayTypes(int $key_type) : UnionType
+    {
+        return ArrayType::instance(false)->asUnionType();
+    }
+
+    /**
+     * @param CodeBase
+     * The code base to use in order to find super classes, etc.
+     *
+     * @param $recursion_depth
+     * This thing has a tendency to run-away on me. This tracks
+     * how bad I messed up by seeing how far the expanded types
+     * go
+     *
+     * @return UnionType
+     * Expands all class types to all inherited classes returning
+     * a superset of this type.
+     */
+    public function asExpandedTypes(
+        CodeBase $code_base,
+        int $recursion_depth = 0
+    ) : UnionType {
+        return $this;
+    }
+
+    /**
+     * As per the Serializable interface
+     *
+     * @return string
+     * A serialized representation of this type
+     *
+     * @see \Serializable
+     */
+    public function serialize() : string
+    {
+        return '';
+    }
+
+    /**
+     * @return string
+     * A human-readable string representation of this union
+     * type
+     */
+    public function __toString() : string
+    {
+        return '';
+    }
+
+    /**
+     * @return UnionType - A normalized version of this union type (May or may not be the same object, if no modifications were made)
+     *
+     * The following normalization rules apply
+     *
+     * 1. If one of the types is null or nullable, convert all types to nullable and remove "null" from the union type
+     * 2. If both "true" and "false" (possibly nullable) coexist, or either coexists with "bool" (possibly nullable),
+     *    then remove "true" and "false"
+     */
+    public function asNormalizedTypes() : UnionType
+    {
+        return $this;
+    }
+}

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -12,8 +12,9 @@ final class EmptyUnionType extends UnionType
 {
     /**
      * An optional list of types represented by this union
+     * @internal
      */
-    private function __construct()
+    public function __construct()
     {
         parent::__construct([], true);
     }

--- a/src/Phan/Language/FQSEN/FullyQualifiedClassElement.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedClassElement.php
@@ -62,20 +62,15 @@ abstract class FullyQualifiedClassElement extends AbstractFQSEN
     ) {
         $name = static::canonicalName($name);
 
-        $key = self::toString($fully_qualified_class_name, $name, $alternate_id)
-            . '|' . static::class;
+        $key = $fully_qualified_class_name . '::' . $name . ',' . $alternate_id .
+               '|' . static::class;
 
-        return self::memoizeStatic($key, function () use (
+        static $cache = [];
+        return $cache[$key] ?? ($cache[$key] = new static(
             $fully_qualified_class_name,
             $name,
             $alternate_id
-        ) {
-            return new static(
-                $fully_qualified_class_name,
-                $name,
-                $alternate_id
-            );
-        });
+        ));
     }
 
     /**

--- a/src/Phan/Language/FQSEN/FullyQualifiedClassElement.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedClassElement.php
@@ -63,7 +63,7 @@ abstract class FullyQualifiedClassElement extends AbstractFQSEN
         $name = static::canonicalName($name);
 
         $key = self::toString($fully_qualified_class_name, $name, $alternate_id)
-            . '|' . \get_called_class();
+            . '|' . static::class;
 
         return self::memoizeStatic($key, function () use (
             $fully_qualified_class_name,

--- a/src/Phan/Language/Scope.php
+++ b/src/Phan/Language/Scope.php
@@ -15,7 +15,7 @@ abstract class Scope
     /**
      * @var Scope|null
      */
-    private $parent_scope = null;
+    protected $parent_scope = null;
 
     /**
      * @var FQSEN|null
@@ -53,10 +53,7 @@ abstract class Scope
      */
     public function hasParentScope() : bool
     {
-        return (
-            !empty($this->parent_scope)
-            && $this->parent_scope !== null
-        );
+        return $this->parent_scope !== null;
     }
 
     /**
@@ -74,7 +71,7 @@ abstract class Scope
      */
     public function hasFQSEN() : bool
     {
-        return !empty($this->fqsen);
+        return $this->fqsen !== null;
     }
 
     /**
@@ -164,7 +161,7 @@ abstract class Scope
      */
     public function hasVariableWithName(string $name) : bool
     {
-        return (!empty($this->variable_map[$name]));
+        return \array_key_exists($name, $this->variable_map);
     }
 
     /**

--- a/src/Phan/Language/Scope/BranchScope.php
+++ b/src/Phan/Language/Scope/BranchScope.php
@@ -2,6 +2,9 @@
 namespace Phan\Language\Scope;
 
 use Phan\Language\Element\Variable;
+use Phan\Language\FQSEN\FullyQualifiedClassName;
+use Phan\Language\FQSEN\FullyQualifiedFunctionName;
+use Phan\Language\FQSEN\FullyQualifiedMethodName;
 use Phan\Language\Scope;
 
 class BranchScope extends Scope
@@ -15,8 +18,8 @@ class BranchScope extends Scope
     public function hasVariableWithName(string $name) : bool
     {
         return (
-            !empty($this->variable_map[$name])
-            || $this->getParentScope()->hasVariableWithName($name)
+            \array_key_exists($name, $this->variable_map)
+            || $this->parent_scope->hasVariableWithName($name)
         );
     }
 
@@ -27,7 +30,7 @@ class BranchScope extends Scope
     {
         return (
             $this->variable_map[$name]
-            ?? $this->getParentScope()->getVariableByName($name)
+            ?? $this->parent_scope->getVariableByName($name)
         );
     }
 
@@ -37,6 +40,42 @@ class BranchScope extends Scope
      */
     public function getVariableMap() : array
     {
-        return $this->variable_map + $this->getParentScope()->getVariableMap();
+        return $this->variable_map + $this->parent_scope->getVariableMap();
+    }
+
+    /**
+     * @return bool
+     * True if we're in a class scope
+     */
+    public function isInClassScope() : bool
+    {
+        return $this->parent_scope->isInClassScope();
+    }
+
+    /**
+     * @return FullyQualifiedClassName
+     * Crawl the scope hierarchy to get a class FQSEN.
+     */
+    public function getClassFQSEN() : FullyQualifiedClassName
+    {
+        return $this->parent_scope->getClassFQSEN();
+    }
+
+    /**
+     * @return FullyQualifiedMethodName|FullyQualifiedFunctionName
+     * Get the FQSEN for the closure, method or function we're in
+     */
+    public function getFunctionLikeFQSEN()
+    {
+        return $this->parent_scope->getFunctionLikeFQSEN();
+    }
+
+    /**
+     * @return bool
+     * True if we're in a class scope
+     */
+    public function isInFunctionLikeScope() : bool
+    {
+        return $this->parent_scope->isInFunctionLikeScope();
     }
 }

--- a/src/Phan/Language/Scope/FunctionLikeScope.php
+++ b/src/Phan/Language/Scope/FunctionLikeScope.php
@@ -1,12 +1,30 @@
 <?php declare(strict_types=1);
 namespace Phan\Language\Scope;
 
+use Phan\Language\FQSEN\FullyQualifiedClassName;
 use Phan\Language\FQSEN\FullyQualifiedFunctionName;
 use Phan\Language\FQSEN\FullyQualifiedMethodName;
 
 // TODO: Wrap this with a ClosureLikeScope
 class FunctionLikeScope extends ClosedScope
 {
+    /**
+     * @return bool
+     * True if we're in a class scope
+     */
+    public function isInClassScope() : bool
+    {
+        return $this->parent_scope->isInClassScope();
+    }
+
+    /**
+     * @return FullyQualifiedClassName
+     * Crawl the scope hierarchy to get a class FQSEN.
+     */
+    public function getClassFQSEN() : FullyQualifiedClassName
+    {
+        return $this->parent_scope->getClassFQSEN();
+    }
 
     /**
      * @return bool

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -635,7 +635,14 @@ class Type
     public static function fromFullyQualifiedString(
         string $fully_qualified_string
     ) : Type {
+        static $type_cache = [];
+        return $type_cache[$fully_qualified_string] ?? ($type_cache[$fully_qualified_string] = self::fromFullyQualifiedStringInner($fully_qualified_string));
+    }
 
+
+    public static function fromFullyQualifiedStringInner(
+        string $fully_qualified_string
+    ) : Type {
         \assert(
             !empty($fully_qualified_string),
             "Type cannot be empty"

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -1014,7 +1014,7 @@ class Type
     {
         // return new UnionType([$this]);
         // Memoize the set of types. The constructed UnionType object can be modified later, so it isn't memoized.
-        return $this->singleton_union_type ?? ($this->singleton_union_type = UnionType([$this], true));
+        return $this->singleton_union_type ?? ($this->singleton_union_type = new UnionType([$this], true));
     }
 
     /**

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -1353,7 +1353,7 @@ class Type
      */
     private static function isGenericArrayString(string $type_name) : bool
     {
-        if (strrpos($type_name, '[]') !== false) {
+        if (\strrpos($type_name, '[]') !== false) {
             return $type_name !== '[]';
         }
         return false;
@@ -1371,7 +1371,7 @@ class Type
             "Cannot call genericArrayElementType on non-generic array"
         );
 
-        if (($pos = strrpos($this->getName(), '[]')) !== false) {
+        if (($pos = \strrpos($this->getName(), '[]')) !== false) {
             \assert(
                 $this->getName() !== '[]' && $this->getName() !== 'array',
                 "Non-generic type requested to be non-generic"
@@ -1780,7 +1780,7 @@ class Type
     private function templateParameterTypeListAsString() : string
     {
         return '<' .
-            implode(',', array_map(function (UnionType $type) {
+            \implode(',', \array_map(function (UnionType $type) {
                 return (string)$type;
             }, $this->template_parameter_type_list)) . '>';
     }
@@ -1819,8 +1819,18 @@ class Type
      * 4: The shape components, if any. Null unless this is an array shape type string such as 'array{field:int}'
      *
      * NOTE: callers must check for the generic array symbol in the type name or for type names beginning with 'array{' (case insensitive)
+     *
+     * NOTE: callers must not mutate the result.
      */
     private static function typeStringComponents(
+        string $type_string
+    ) {
+        // This doesn't depend on any configs; the result can be safely cached.
+        static $cache = [];
+        return $cache[$type_string] ?? ($cache[$type_string] = self::typeStringComponentsInner($type_string));
+    }
+
+    private static function typeStringComponentsInner(
         string $type_string
     ) {
         // Check to see if we have template parameter types
@@ -1867,7 +1877,7 @@ class Type
             (string)\array_pop($fq_class_name_elements);
 
         $namespace = ($is_fully_qualified ? '\\' : '')
-            . implode('\\', \array_filter(
+            . \implode('\\', \array_filter(
                 $fq_class_name_elements
             ));
 

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -506,8 +506,21 @@ class Type
      */
     public static function fromObject($object) : Type
     {
+        static $type_map = null;
+        if ($type_map === null) {
+            $type_map = [
+                'integer' => IntType::instance(false),
+                'boolean' => BoolType::instance(false),
+                'double'   => FloatType::instance(false),
+                'string'  => StringType::instance(false),
+                'object'  => ObjectType::instance(false),
+                'NULL'    => NullType::instance(false),
+                'array'   => ArrayType::instance(false),
+                'resource' => ResourceType::instance(false),  // For inferring the type of constants STDIN, etc.
+            ];
+        }
         // gettype(2) doesn't return 'int', it returns 'integer', so use FROM_PHPDOC
-        return Type::fromInternalTypeName(\gettype($object), false, self::FROM_PHPDOC);
+        return $type_map[\gettype($object)];
     }
 
     /**

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -992,9 +992,9 @@ class Type
     }
 
     /**
-     * @var ?array<int,Type> - [$this]
+     * @var ?UnionType of [$this]
      */
-    protected $singleton_type_list;
+    protected $singleton_union_type;
 
     /**
      * @return UnionType
@@ -1004,10 +1004,7 @@ class Type
     {
         // return new UnionType([$this]);
         // Memoize the set of types. The constructed UnionType object can be modified later, so it isn't memoized.
-        return new UnionType(
-            ($this->singleton_type_list) ?? ($this->singleton_type_list = [$this]),
-            true
-        );
+        return $this->singleton_union_type ?? ($this->singleton_union_type = new UnionType([$this], true));
     }
 
     /**

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -643,6 +643,9 @@ class Type
     public static function fromFullyQualifiedStringInner(
         string $fully_qualified_string
     ) : Type {
+        if (empty($fully_qualified_string)) {
+            debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+        }
         \assert(
             !empty($fully_qualified_string),
             "Type cannot be empty"

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -1014,7 +1014,7 @@ class Type
     {
         // return new UnionType([$this]);
         // Memoize the set of types. The constructed UnionType object can be modified later, so it isn't memoized.
-        return $this->singleton_union_type ?? ($this->singleton_union_type = new UnionType([$this], true));
+        return $this->singleton_union_type ?? ($this->singleton_union_type = UnionType([$this], true));
     }
 
     /**

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -1491,23 +1491,23 @@ class Type
 
             $clazz = $code_base->getClassByFQSEN($class_fqsen);
 
-            $union_type->addUnionType(
+            $union_type = $union_type->withUnionType(
                 $clazz->getUnionType()
             );
 
             // Recurse up the tree to include all types
             $representation = (string)$this;
-            $recursive_union_type = new UnionType();
+            $recursive_union_type_builder = new UnionTypeBuilder();
             foreach ($union_type->getTypeSet() as $clazz_type) {
                 if ((string)$clazz_type != $representation) {
-                    $recursive_union_type->addUnionType(
+                    $recursive_union_type_builder->addUnionType(
                         $clazz_type->asExpandedTypes(
                             $code_base,
                             $recursion_depth + 1
                         )
                     );
                 } else {
-                    $recursive_union_type->addType($clazz_type);
+                    $recursive_union_type_builder->addType($clazz_type);
                 }
             }
 
@@ -1516,14 +1516,14 @@ class Type
             $fqsen_aliases = $code_base->getClassAliasesByFQSEN($class_fqsen);
             foreach ($fqsen_aliases as $alias_fqsen_record) {
                 $alias_fqsen = $alias_fqsen_record->alias_fqsen;
-                $recursive_union_type->addUnionType(
-                    $alias_fqsen->asUnionType()
+                $recursive_union_type_builder->addType(
+                    $alias_fqsen->asType()
                 );
             }
 
-            return $recursive_union_type;
+            return $recursive_union_type_builder->getUnionType();
         });
-        return clone($union_type);
+        return $union_type;
     }
 
     /**

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -709,7 +709,7 @@ class Type
             return UnionType::fromFullyQualifiedString($type_name);
         }, $template_parameter_type_name_list);
 
-        if (0 !== strpos($namespace, '\\')) {
+        if (0 !== \strpos($namespace, '\\')) {
             $namespace = '\\' . $namespace;
         }
 
@@ -1205,7 +1205,7 @@ class Type
      */
     public function isSelfType() : bool
     {
-        return self::isSelfTypeString((string)$this);
+        return $this->namespace === '\\' && self::isSelfTypeString($this->name);
     }
 
     /**

--- a/src/Phan/Language/Type/ArrayShapeType.php
+++ b/src/Phan/Language/Type/ArrayShapeType.php
@@ -3,6 +3,7 @@ namespace Phan\Language\Type;
 
 use Phan\Language\Type;
 use Phan\Language\UnionType;
+use Phan\Language\UnionTypeBuilder;
 use Phan\Language\FQSEN\FullyQualifiedClassName;
 use Phan\CodeBase;
 
@@ -175,11 +176,11 @@ final class ArrayShapeType extends ArrayType
             "Recursion has gotten out of hand"
         );
         // TODO: Use UnionType::merge from a future change?
-        $result = new UnionType();
+        $result = new UnionTypeBuilder();
         $key_type = GenericArrayType::getKeyTypeForArrayLiteral($this->field_types);
         foreach ($this->field_types as $type) {
             $result->addUnionType(GenericArrayType::fromElementType($type, $this->is_nullable, $key_type)->asExpandedTypes($code_base, $recursion_depth + 1));
         }
-        return $result;
+        return $result->getUnionType();
     }
 }

--- a/src/Phan/Language/Type/ClosureType.php
+++ b/src/Phan/Language/Type/ClosureType.php
@@ -42,20 +42,8 @@ final class ClosureType extends Type
     public function __clone()
     {
         assert($this->fqsen === null, 'should only clone null fqsen');
+        $this->singleton_union_type = null;
         // same as new static($this->namespace, $this->name, $this->template_parameter_type_list, $this->is_nullable);
-    }
-
-    /**
-     * @return UnionType
-     * A UnionType representing this and only this type
-     * @override so that cloning ClosureType won't break singleton_type_list
-     */
-    public function asUnionType() : UnionType
-    {
-        return new UnionType(
-            [$this],
-            true
-        );
     }
 
     public function hasKnownFQSEN() : bool

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -5,6 +5,7 @@ use Phan\AST\UnionTypeVisitor;
 use Phan\Language\Type;
 use Phan\Language\Context;
 use Phan\Language\UnionType;
+use Phan\Language\UnionTypeBuilder;
 use Phan\Language\FQSEN\FullyQualifiedClassName;
 use Phan\CodeBase;
 use Phan\Config;
@@ -281,23 +282,23 @@ final class GenericArrayType extends ArrayType
 
             $clazz = $code_base->getClassByFQSEN($class_fqsen);
 
-            $union_type->addUnionType(
+            $union_type = $union_type->withUnionType(
                 $clazz->getUnionType()->asGenericArrayTypes($this->key_type)
             );
 
             // Recurse up the tree to include all types
-            $recursive_union_type = new UnionType();
+            $recursive_union_type_builder = new UnionTypeBuilder();
             $representation = (string)$this;
             foreach ($union_type->getTypeSet() as $clazz_type) {
                 if ((string)$clazz_type != $representation) {
-                    $recursive_union_type->addUnionType(
+                    $recursive_union_type_builder->addUnionType(
                         $clazz_type->asExpandedTypes(
                             $code_base,
                             $recursion_depth + 1
                         )
                     );
                 } else {
-                    $recursive_union_type->addType($clazz_type);
+                    $recursive_union_type_builder->addType($clazz_type);
                 }
             }
 
@@ -306,11 +307,11 @@ final class GenericArrayType extends ArrayType
             $fqsen_aliases = $code_base->getClassAliasesByFQSEN($class_fqsen);
             foreach ($fqsen_aliases as $alias_fqsen_record) {
                 $alias_fqsen = $alias_fqsen_record->alias_fqsen;
-                $recursive_union_type->addUnionType(
-                    $alias_fqsen->asUnionType()->asGenericArrayTypes($this->key_type)
+                $recursive_union_type_builder->addType(
+                    $alias_fqsen->asType()->asGenericArrayType($this->key_type)
                 );
             }
-            return $recursive_union_type;
+            return $recursive_union_type_builder->getUnionType();
         });
         return clone($union_type);
     }

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -313,7 +313,7 @@ final class GenericArrayType extends ArrayType
             }
             return $recursive_union_type_builder->getUnionType();
         });
-        return clone($union_type);
+        return $union_type;
     }
 
     public static function keyTypeFromUnionTypeKeys(UnionType $union_type) : int

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -353,7 +353,7 @@ final class GenericArrayType extends ArrayType
                 if ($behavior === self::CONVERT_KEY_MIXED_TO_INT_OR_STRING_UNION_TYPE) {
                     return new UnionType([$int_type, $string_type], true);
                 }
-                return new UnionType();
+                return UnionType::empty();
         }
     }
 

--- a/src/Phan/Language/Type/GenericMultiArrayType.php
+++ b/src/Phan/Language/Type/GenericMultiArrayType.php
@@ -3,6 +3,7 @@ namespace Phan\Language\Type;
 
 use Phan\Language\Type;
 use Phan\Language\UnionType;
+use Phan\Language\UnionTypeBuilder;
 use Phan\Language\FQSEN\FullyQualifiedClassName;
 use Phan\CodeBase;
 
@@ -175,7 +176,7 @@ final class GenericMultiArrayType extends ArrayType
             "Recursion has gotten out of hand"
         );
         // TODO: Use UnionType::merge from a future change?
-        $result = new UnionType();
+        $result = new UnionTypeBuilder();
         foreach ($this->element_types as $type) {
             $result->addUnionType(
                 GenericArrayType::fromElementType(
@@ -185,6 +186,6 @@ final class GenericMultiArrayType extends ArrayType
                 )->asExpandedTypes($code_base, $recursion_depth + 1)
             );
         }
-        return $result;
+        return $result->getUnionType();
     }
 }

--- a/src/Phan/Language/Type/NativeType.php
+++ b/src/Phan/Language/Type/NativeType.php
@@ -24,21 +24,19 @@ abstract class NativeType extends Type
         if ($is_nullable) {
             static $nullable_instance = null;
 
-            if (empty($nullable_instance)) {
+            if ($nullable_instance === null) {
                 $nullable_instance = static::make('\\', static::NAME, [], true, Type::FROM_NODE);
             }
-            \assert($nullable_instance instanceof static);
 
             return $nullable_instance;
         }
 
         static $instance = null;
 
-        if (empty($instance)) {
+        if ($instance === null) {
             $instance = static::make('\\', static::NAME, [], false, Type::FROM_NODE);
         }
 
-        \assert($instance instanceof static);
         return $instance;
     }
 

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -27,6 +27,10 @@ use Phan\Language\Type\TemplateType;
 use Phan\Language\Type\TrueType;
 use ast\Node;
 
+if (!\function_exists('spl_object_id')) {
+    require_once __DIR__ . '/../../spl_object_id.php';
+}
+
 class UnionType implements \Serializable
 {
     /**

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -93,11 +93,11 @@ class UnionType implements \Serializable
         }
     }
 
-    /** @var UnionType */
+    /** @var EmptyUnionType */
     private static $empty_instance;
 
     /**
-     * @return UnionType
+     * @return EmptyUnionType (Real return type omitted for performance)
      */
     public static function empty() {
         return self::$empty_instance;
@@ -109,7 +109,7 @@ class UnionType implements \Serializable
      */
     public static function init() {
         if (is_null(self::$empty_instance)) {
-            self::$empty_instance = new UnionType();
+            self::$empty_instance = EmptyUnionType::instance();
         }
     }
 
@@ -596,10 +596,6 @@ class UnionType implements \Serializable
      */
     public function getTemplateParameterTypeList() : array
     {
-        if ($this->isEmpty()) {
-            return [];
-        }
-
         return \array_reduce(
             $this->type_set,
             function (array $map, Type $type) {
@@ -693,14 +689,12 @@ class UnionType implements \Serializable
      */
     public function hasStaticType() : bool
     {
-        static $static_types = null;
-        if ($static_types === null) {
-            $static_types = [
-                StaticType::instance(false),
-                StaticType::instance(true),
-            ];
+        foreach ($this->type_set as $type) {
+            if ($type instanceof StaticType) {
+                return true;
+            }
         }
-        return $this->hasAnyType($static_types);
+        return false;
     }
 
     /**
@@ -1269,10 +1263,6 @@ class UnionType implements \Serializable
      */
     public function hasArrayLike() : bool
     {
-        if ($this->isEmpty()) {
-            return false;
-        }
-
         return $this->hasTypeMatchingCallback(function (Type $type) : bool {
             return $type->isArrayLike();
         });
@@ -1285,10 +1275,6 @@ class UnionType implements \Serializable
      */
     public function hasGenericArray() : bool
     {
-        if ($this->isEmpty()) {
-            return false;
-        }
-
         return $this->hasTypeMatchingCallback(function (Type $type) : bool {
             return $type->isGenericArray();
         });
@@ -1301,10 +1287,6 @@ class UnionType implements \Serializable
      */
     public function hasArrayAccess() : bool
     {
-        if ($this->isEmpty()) {
-            return false;
-        }
-
         return $this->hasTypeMatchingCallback(function (Type $type) : bool {
             return $type->isArrayAccess();
         });
@@ -1317,10 +1299,6 @@ class UnionType implements \Serializable
      */
     public function hasTraversable() : bool
     {
-        if ($this->isEmpty()) {
-            return false;
-        }
-
         return $this->hasTypeMatchingCallback(function (Type $type) : bool {
             return $type->isTraversable();
         });
@@ -1414,7 +1392,10 @@ class UnionType implements \Serializable
     ) {
         // Iterate over each viable class type to see if any
         // have the constant we're looking for
-        foreach ($this->nonNativeTypes()->type_set as $class_type) {
+        foreach ($this->type_set as $class_type) {
+            if ($class_type->isNativeType()) {
+                continue;
+            }
             // Get the class FQSEN
             $class_fqsen = $class_type->asFQSEN();
 
@@ -1464,7 +1445,10 @@ class UnionType implements \Serializable
     ) {
         // Iterate over each viable class type to see if any
         // have the constant we're looking for
-        foreach ($this->nonNativeTypes()->type_set as $class_type) {
+        foreach ($this->type_set as $class_type) {
+            if ($class_type->isNativeType()) {
+                continue;
+            }
             // Get the class FQSEN
             $class_fqsen = $class_type->asClassFQSEN();
 

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -66,13 +66,13 @@ class UnionType implements \Serializable
     }
 
     /** @var UnionType */
-    private static $instance;
+    private static $empty_instance;
 
     /**
      * @return UnionType
      */
     public static function empty() {
-        return self::$instance;
+        return self::$empty_instance;
     }
 
     /**
@@ -80,8 +80,8 @@ class UnionType implements \Serializable
      * @internal
      */
     public static function init() {
-        if (is_null(self::$instance)) {
-            self::$instance = new UnionType();
+        if (is_null(self::$empty_instance)) {
+            self::$empty_instance = new UnionType();
         }
     }
 
@@ -99,7 +99,7 @@ class UnionType implements \Serializable
         string $fully_qualified_string
     ) : UnionType {
         if ($fully_qualified_string === '') {
-            return new UnionType();
+            return self::$empty_instance;
         }
 
         /** @var array<string,UnionType> annotation not read by phan */
@@ -156,7 +156,7 @@ class UnionType implements \Serializable
         int $source
     ) : UnionType {
         if (empty($type_string)) {
-            return new UnionType();
+            return self::$empty_instance;
         }
 
         // If our scope has a generic type identifier defined on it
@@ -309,7 +309,7 @@ class UnionType implements \Serializable
         if ($reflection_type !== null) {
             return Type::fromReflectionType($reflection_type)->asUnionType();
         }
-        return new UnionType();
+        return self::$empty_instance;
     }
 
     /**
@@ -419,7 +419,7 @@ class UnionType implements \Serializable
             $parameter_name_type_map = [];
 
             foreach ($name_type_name_map as $name => $type_name) {
-                $parameter_name_type_map[$name] = $get_for_global_context($type_name) ?? new UnionType();
+                $parameter_name_type_map[$name] = $get_for_global_context($type_name) ?? self::$empty_instance;
             }
 
             $configurations[] = [

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -219,6 +219,7 @@ class UnionType implements \Serializable
         if (\count($instances) === 1) {
             return \reset($instances)->asUnionType();
         }
+        // 2 or more
         return new UnionType($instances);
     }
 
@@ -495,6 +496,7 @@ class UnionType implements \Serializable
         if (\in_array($type, $type_set, true)) {
             return $this;
         }
+        // 2 or more types in type_set
         $type_set[] = $type;
         return new UnionType($type_set, true);
     }

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -69,7 +69,8 @@ class UnionType implements \Serializable
      * @param Type[] $type_list
      * @return UnionType
      */
-    public static function of(array $type_list) {
+    public static function of(array $type_list)
+    {
         $n = \count($type_list);
         if ($n === 0) {
             return self::$empty_instance;
@@ -77,6 +78,18 @@ class UnionType implements \Serializable
             return \reset($type_list)->asUnionType();
         } else {
             return new self($type_list);
+        }
+    }
+
+    private static function ofUniqueTypes(array $type_list)
+    {
+        $n = \count($type_list);
+        if ($n === 0) {
+            return self::$empty_instance;
+        } elseif ($n === 1) {
+            return \reset($type_list)->asUnionType();
+        } else {
+            return new self($type_list, true);
         }
     }
 
@@ -503,7 +516,7 @@ class UnionType implements \Serializable
             if ($type === $other_type) {
                 // Remove the only instance of $type from the copy.
                 unset($type_set[$key]);
-                return self::of($type_set);
+                return self::ofUniqueTypes($type_set);
             }
         }
         // We did not find $type in type_set. The resulting union type is unchanged.
@@ -2012,6 +2025,10 @@ class UnionType implements \Serializable
      */
     public static function merge(array $union_types) : UnionType
     {
+        $n = \count($union_types);
+        if ($n < 2) {
+            return \reset($union_types) ?: UnionType::$empty_instance;
+        }
         $new_type_set = [];
         foreach ($union_types as $type) {
             $type_set = $type->type_set;
@@ -2028,7 +2045,7 @@ class UnionType implements \Serializable
                 }
             }
         }
-        return new UnionType($new_type_set, true);
+        return UnionType::ofUniqueTypes($new_type_set);
     }
 
     /**

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -65,6 +65,26 @@ class UnionType implements \Serializable
         $this->type_set = ($is_unique || \count($type_list) <= 1) ? $type_list : self::getUniqueTypes($type_list);
     }
 
+    /** @var UnionType */
+    private static $instance;
+
+    /**
+     * @return UnionType
+     */
+    public static function empty() {
+        return self::$instance;
+    }
+
+    /**
+     * @return void
+     * @internal
+     */
+    public static function init() {
+        if (is_null(self::$instance)) {
+            self::$instance = new UnionType();
+        }
+    }
+
     // __clone of $this->type_set would be a no-op due to copy on write semantics.
     // And clone isn't necessary anymore now that type_set is immutable
 
@@ -2015,5 +2035,6 @@ class UnionType implements \Serializable
     public static function createBuilderFromTypeList(array $type_list) : UnionTypeBuilder {
         return new UnionTypeBuilder(\count($type_list) <= 1 ? $type_list : self::getUniqueTypes($type_list));
     }
-
 }
+
+UnionType::init();

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -8,6 +8,7 @@ use Phan\Exception\CodeBaseException;
 use Phan\Exception\IssueException;
 use Phan\Issue;
 use Phan\Language\Element\Clazz;
+use Phan\Language\FQSEN\FullyQualifiedClassName;
 use Phan\Language\FQSEN\FullyQualifiedFunctionName;
 use Phan\Language\FQSEN\FullyQualifiedMethodName;
 use Phan\Language\Type\ArrayShapeType;
@@ -199,28 +200,37 @@ class UnionType implements \Serializable
                 $type_string
             )->asUnionType();
         }
-        $types = \array_map(
-            function (string $type_name) use ($context, $source) : Type {
-                \assert($type_name !== '', "Type cannot be empty.");
-                return Type::fromStringInContext(
-                    $type_name,
-                    $context,
-                    $source
-                );
-            },
-            \array_filter(self::extractTypeParts($type_string), function (string $type_name) {
-                // Exclude empty type names
-                // Exclude namespaces without type names (e.g. `\`, `\NS\`)
-                return $type_name !== '' && \preg_match('@\\\\[\[\]]*$@', $type_name) === 0;
-            })
-        );
-
-        $instances = self::normalizeGenericMultiArrayTypes($types);
-        if (\count($instances) === 1) {
-            return \reset($instances)->asUnionType();
+        $types = [];
+        foreach (self::extractTypePartsForStringInContext($type_string) as $type_name) {
+            $types[] = Type::fromStringInContext(
+                $type_name,
+                $context,
+                $source
+            );
         }
-        // 2 or more
-        return new UnionType($instances);
+        return UnionType::of(self::normalizeGenericMultiArrayTypes($types));
+    }
+
+    /**
+     * @return array<int,string>
+     */
+    private static function extractTypePartsForStringInContext(string $type_string)
+    {
+        static $cache = [];
+        $parts = $cache[$type_string] ?? null;
+        if (\is_array($parts)) {
+            return $parts;
+        }
+        $parts = [];
+        foreach (self::extractTypeParts($type_string) as $type_name) {
+            // Exclude empty type names
+            // Exclude namespaces without type names (e.g. `\`, `\NS\`)
+            if ($type_name !== '' && \preg_match('@\\\\[\[\]]*$@', $type_name) === 0) {
+                $parts[] = $type_name;
+            }
+        }
+        $cache[$type_string] = $parts;
+        return $parts;
     }
 
     /**
@@ -228,7 +238,11 @@ class UnionType implements \Serializable
      */
     private static function extractTypeParts(string $type_string) : array
     {
-        $parts = \array_map('trim', \explode('|', $type_string));
+        $parts = [];
+        foreach (\explode('|', $type_string) as $part) {
+            $parts[] = \trim($part);
+        }
+
         if (\count($parts) <= 1) {
             return $parts;
         }
@@ -1450,7 +1464,7 @@ class UnionType implements \Serializable
                 continue;
             }
             // Get the class FQSEN
-            $class_fqsen = $class_type->asClassFQSEN();
+            $class_fqsen = FullyQualifiedClassName::fromType($class_type);
 
             if ($class_type->isStaticType()) {
                 if (!$context->isInClassScope()) {
@@ -1716,9 +1730,6 @@ class UnionType implements \Serializable
         // This is frequently called, and has been optimized
         $builder = new UnionTypeBuilder();
         $type_set = $this->type_set;
-        if (\count($type_set) === 0) {
-            return self::$empty_instance;
-        }
         foreach ($type_set as $type) {
             if ($type->isGenericArray()) {
                 $builder->addType($type->genericArrayElementType());

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -497,14 +497,17 @@ class UnionType implements \Serializable
      */
     public function withoutType(Type $type)
     {
+        // Copy the array $this->type_set
         $type_set = $this->type_set;
-        $i = \array_search($type, $type_set, true);
-        if ($i === false) {
-            return $this;
+        foreach ($type_set as $key => $other_type) {
+            if ($type === $other_type) {
+                // Remove the only instance of $type from the copy.
+                unset($type_set[$key]);
+                return self::of($type_set);
+            }
         }
-        $new_type_set = $this->type_set;
-        unset($new_type_set[$i]);
-        return self::of($new_type_set);
+        // We did not find $type in type_set. The resulting union type is unchanged.
+        return $this;
     }
 
     /**

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -111,11 +111,16 @@ class UnionType implements \Serializable
                 return Type::fromFullyQualifiedString($type_name);
             }, self::extractTypeParts($fully_qualified_string));
 
-            // TODO: Support brackets, template types within <>, etc.
-            $union_type = new UnionType(
-                self::getUniqueTypes(self::normalizeGenericMultiArrayTypes($types)),
-                true
-            );
+            $unique_types = self::getUniqueTypes(self::normalizeGenericMultiArrayTypes($types));
+            if (\count($unique_types) === 1) {
+                $union_type = \reset($unique_types)->asUnionType();
+            } else {
+                // TODO: Support brackets, template types within <>, etc.
+                $union_type = new UnionType(
+                    $unique_types,
+                    true
+                );
+            }
             $memoize_map[$fully_qualified_string] = $union_type;
         }
 
@@ -182,7 +187,11 @@ class UnionType implements \Serializable
             })
         );
 
-        return new UnionType(self::normalizeGenericMultiArrayTypes($types));
+        $instances = self::normalizeGenericMultiArrayTypes($types);
+        if (\count($instances) === 1) {
+            return \reset($instances)->asUnionType();
+        }
+        return new UnionType($instances);
     }
 
     /**

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -1878,11 +1878,9 @@ class UnionType implements \Serializable
      */
     public function unserialize($serialized)
     {
-        $this->type_set = self::getUniqueTypes(
-            \array_map(function (string $type_name) : Type {
-                return Type::fromFullyQualifiedString($type_name);
-            }, \explode('|', $serialized ?? ''))
-        );
+        // NOTE: Potentially need to handle "array{field:int|string}" in the future.
+        // TODO: Not going to work with template types
+        $this->type_set = UnionType::fromFullyQualifiedString($serialized)->getTypeSet();
     }
 
     /**

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -763,42 +763,36 @@ class UnionType implements \Serializable
 
     public function nonNullableClone() : UnionType
     {
-        $result = new UnionType();
-        $result_type_set = [];
+        $builder = new UnionTypeBuilder();
         $did_change = false;
         foreach ($this->type_set as $type) {
             if (!$type->getIsNullable()) {
-                $result_type_set[] = $type;
+                $builder->addType($type);
+                continue;
             }
             $did_change = true;
             if ($type === NullType::instance(false)) {
                 continue;
             }
 
-            $new_type = $type->withIsNullable(false);
-            if (!\in_array($new_type, $result_type_set, true)) {
-                $result_type_set[] = $new_type;
-            }
+            $builder->addType($type->withIsNullable(false));
         }
-        return $result;
+        return $did_change ? $builder->getUnionType() : $this;
     }
 
     public function nullableClone() : UnionType
     {
-        $result = new UnionTypeBuilder();
+        $builder = new UnionTypeBuilder();
         $did_change = false;
         foreach ($this->type_set as $type) {
             if ($type->getIsNullable()) {
-                $result->addType($type);
+                $builder->addType($type);
                 continue;
             }
             $did_change = true;
-            $result->addType($type->withIsNullable(true));
+            $builder->addType($type->withIsNullable(true));
         }
-        if (!$did_change) {
-            return $this;
-        }
-        return $result->getUnionType();
+        return $did_change ? $builder->getUnionType() : $this;
     }
 
     /**
@@ -834,10 +828,7 @@ class UnionType implements \Serializable
             // add non-nullable equivalents, and replace BoolType with non-nullable TrueType
             $builder->addType($type->asNonFalseyType());
         }
-        if (!$did_change) {
-            return $this;
-        }
-        return $builder->getUnionType();
+        return $did_change ? $builder->getUnionType() : $this;
     }
 
     /**
@@ -873,10 +864,7 @@ class UnionType implements \Serializable
             // add non-nullable equivalents, and replace BoolType with non-nullable TrueType
             $builder->addType($type->asNonTruthyType());
         }
-        if (!$did_change) {
-            return $this;
-        }
-        return $builder->getUnionType();
+        return $did_change ? $builder->getUnionType() : $this;
     }
 
     /**
@@ -923,10 +911,7 @@ class UnionType implements \Serializable
             // add non-nullable equivalents, and replace BoolType with non-nullable TrueType
             $builder->addType($type->asNonFalseType());
         }
-        if (!$did_change) {
-            return $this;
-        }
-        return $builder->getUnionType();
+        return $did_change ? $builder->getUnionType() : $this;
     }
 
     public function nonTrueClone() : UnionType
@@ -947,10 +932,7 @@ class UnionType implements \Serializable
             // add non-nullable equivalents, and replace BoolType with non-nullable TrueType
             $builder->addType($type->asNonTrueType());
         }
-        if (!$did_change) {
-            return $this;
-        }
-        return $builder->getUnionType();
+        return $did_change ? $builder->getUnionType() : $this;
     }
 
     /**

--- a/src/Phan/Language/UnionTypeBuilder.php
+++ b/src/Phan/Language/UnionTypeBuilder.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+
+namespace Phan\Language;
+
+final class UnionTypeBuilder {
+    /** @var array<int,Type> */
+    private $type_set;
+
+    /** @param array<int,Type> $type_set (must be unique) */
+    public function __construct(array $type_set = []) {
+        $this->type_set = $type_set;
+    }
+
+    /**
+     * @return void
+     */
+    public function addType(Type $type) {
+        if (\in_array($type, $this->type_set, true)) {
+            return;
+        }
+        $this->type_set[] = $type;
+    }
+
+    /**
+     * @return void
+     */
+    public function addUnionType(UnionType $union_type) {
+        $old_type_set = $this->type_set;
+        foreach ($union_type->getTypeSet() as $type) {
+            if (!\in_array($type, $old_type_set, true)) {
+                $this->type_set[] = $type;
+            }
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function removeType(Type $type) {
+        $i = \array_search($type, $this->type_set, true);
+        if ($i !== false) {
+            // equivalent to unset($new_type_set[$i]) but fills in the gap in array keys.
+            // TODO: How do other versions affect performance on large projects?
+            $replacement_type = \array_pop($this->type_set);
+            if ($replacement_type !== $type) {
+                $this->type_set[$i] = $replacement_type;
+            }
+        }
+    }
+
+    public function isEmpty() : bool {
+        return \count($this->type_set) === 0;
+    }
+
+    /**
+     * @return array<int,Type>
+     */
+    public function getTypeSet() : array {
+        return $this->type_set;
+    }
+
+    public function getUnionType() : UnionType {
+        return UnionType::of($this->type_set);
+    }
+}

--- a/src/Phan/Library/Composer/XdebugHandler.php
+++ b/src/Phan/Library/Composer/XdebugHandler.php
@@ -87,7 +87,8 @@ class XdebugHandler
         Automatically disabling xdebug, it's unnecessary unless you are debugging or developing phan itself, and makes phan slower.
         To run Phan with xdebug, set the environment variable PHAN_ALLOW_XDEBUG to 1.
         To disable this warning, set the environment variable PHAN_DISABLE_XDEBUG_WARN to 1.
-        To include function signatures of xdebug, see .phan/internal_stubs/xdebug.xdebug.phan_php
+        To include function signatures of xdebug, see .phan/internal_stubs/xdebug.phan_php
+
 EOT
                 );
             }

--- a/src/Phan/Library/Composer/XdebugHandler.php
+++ b/src/Phan/Library/Composer/XdebugHandler.php
@@ -82,6 +82,15 @@ class XdebugHandler
         $args = explode('|', strval(getenv(self::ENV_ALLOW)), 2);
 
         if ($this->needsRestart($args[0])) {
+            if (!getenv('PHAN_DISABLE_XDEBUG_WARN')) {
+                fwrite(STDERR, <<<EOT
+        Automatically disabling xdebug, it's unnecessary unless you are debugging or developing phan itself, and makes phan slower.
+        To run Phan with xdebug, set the environment variable PHAN_ALLOW_XDEBUG to 1.
+        To disable this warning, set the environment variable PHAN_DISABLE_XDEBUG_WARN to 1.
+        To include function signatures of xdebug, see .phan/internal_stubs/xdebug.xdebug.phan_php
+EOT
+                );
+            }
             if ($this->prepareRestart()) {
                 $command = $this->getCommand();
                 $this->restart($command);

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -448,13 +448,13 @@ class ParseVisitor extends ScopeVisitor
                     $this->context,
                     $child_node->children['default']
                 );
-                $union_type = new UnionType();
+                $union_type = UnionType::empty();
             }
 
             // Don't set 'null' as the type if that's the default
             // given that its the default default.
             if ($union_type->isType(NullType::instance(false))) {
-                $union_type = new UnionType();
+                $union_type = UnionType::empty();
             }
 
             $property_name = $child_node->children['name'];
@@ -569,7 +569,7 @@ class ParseVisitor extends ScopeVisitor
                     ->withLineNumberStart($line_number_start)
                     ->withLineNumberEnd($child_node->endLineno ?? $line_number_start),
                 $name,
-                new UnionType(),
+                UnionType::empty(),
                 $node->flags ?? 0,
                 $fqsen
             );
@@ -1123,7 +1123,7 @@ class ParseVisitor extends ScopeVisitor
             $this->context
                 ->withLineNumberStart($node->lineno ?? 0),
             $name,
-            new UnionType(),
+            UnionType::empty(),
             $flags,
             $fqsen
         );

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -1211,4 +1211,22 @@ class ParseVisitor extends ScopeVisitor
         // Figure out if any of the aliases are wrong after analysis phase.
         $this->code_base->addClassAlias($original_fqsen, $alias_fqsen, $context, $node->lineno ?? 0);
     }
+
+    // common no-ops
+    /** @return Context */
+    public function visitArrayElem(Node $node) { return $this->context; }
+    /** @return Context */
+    public function visitVar(Node $node) { return $this->context; }
+    /** @return Context */
+    public function visitName(Node $node) { return $this->context; }
+    /** @return Context */
+    public function visitArgList(Node $node) { return $this->context; }
+    /** @return Context */
+    public function visitStmtList(Node $node) { return $this->context; }
+    /** @return Context */
+    public function visitProp(Node $node) { return $this->context; }
+    /** @return Context */
+    public function visitArray(Node $node) { return $this->context; }
+    /** @return Context */
+    public function visitBinaryOp(Node $node) { return $this->context; }
 }

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -836,6 +836,8 @@ class ParseVisitor extends ScopeVisitor
      * @return Context
      * A new or an unchanged context resulting from
      * parsing the node
+     *
+     * TODO: Defer analysis of the inside of methods until the class gets hydrated.
      */
     public function visitReturn(Node $node) : Context
     {
@@ -873,6 +875,8 @@ class ParseVisitor extends ScopeVisitor
      * @return Context
      * A new or an unchanged context resulting from
      * parsing the node
+     *
+     * TODO: Defer analysis of the inside of methods until the method/function gets hydrated.
      */
     public function visitYield(Node $node) : Context
     {

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -1031,8 +1031,8 @@ class ParseVisitor extends ScopeVisitor
             $line = $ftemp->current();
             \assert(\is_string($line));
             unset($ftemp);
-            if (strpos($line, '{') === false
-                || strpos($line, '}') === false
+            if (\strpos($line, '{') === false
+                || \strpos($line, '}') === false
             ) {
                 $this->emitIssue(
                     Issue::CompatibleExpressionPHP7,

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -419,7 +419,7 @@ class ParseVisitor extends ScopeVisitor
             Comment::ON_PROPERTY
         );
 
-        foreach ($node->children ?? [] as $i => $child_node) {
+        foreach ($node->children as $i => $child_node) {
             // Ignore children which are not property elements
             if (!$child_node
                 || $child_node->kind != \ast\AST_PROP_ELEM
@@ -547,7 +547,7 @@ class ParseVisitor extends ScopeVisitor
     {
         $class = $this->getContextClass();
 
-        foreach ($node->children ?? [] as $child_node) {
+        foreach ($node->children as $child_node) {
             \assert($child_node instanceof Node, 'expected class const element to be a Node');
             $name = $child_node->children['name'];
 
@@ -612,7 +612,7 @@ class ParseVisitor extends ScopeVisitor
      */
     public function visitConstDecl(Node $node) : Context
     {
-        foreach ($node->children ?? [] as $child_node) {
+        foreach ($node->children as $child_node) {
             \assert($child_node instanceof Node);
 
             $this->addConstant(
@@ -771,7 +771,7 @@ class ParseVisitor extends ScopeVisitor
         if (Config::get_backward_compatibility_checks()) {
             $this->analyzeBackwardCompatibility($node);
 
-            foreach ($node->children['args']->children ?? [] as $arg_node) {
+            foreach ($node->children['args']->children as $arg_node) {
                 if ($arg_node instanceof Node) {
                     $this->analyzeBackwardCompatibility($arg_node);
                 }

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -179,7 +179,7 @@ class ParseVisitor extends ScopeVisitor
         $extends_node = $node->children['extends'] ?? null;
         if ($extends_node instanceof Node) {
             $parent_class_name =
-                $extends_node->children['name'];
+                (string)$extends_node->children['name'];
 
             // Check to see if the name isn't fully qualified
             if ($extends_node->flags & \ast\flags\NAME_NOT_FQ) {
@@ -371,15 +371,15 @@ class ParseVisitor extends ScopeVisitor
                 }
             }
         } elseif ('__invoke' === $method_name) {
-            $class->getUnionType()->addType(
+            $class->setUnionType($class->getUnionType()->withType(
                 CallableType::instance(false)
-            );
+            ));
         } elseif ('__toString' === $method_name
             && !$this->context->getIsStrictTypes()
         ) {
-            $class->getUnionType()->addType(
+            $class->setUnionType($class->getUnionType()->withType(
                 StringType::instance(false)
-            );
+            ));
         }
 
 
@@ -510,9 +510,9 @@ class ParseVisitor extends ScopeVisitor
 
                 // Set the declared type to the doc-comment type and add
                 // |null if the default value is null
-                $property->getUnionType()->addUnionType(
+                $property->setUnionType($property->getUnionType()->withUnionType(
                     $variable->getUnionType()
-                );
+                ));
             }
 
             $property->setIsDeprecated($comment->isDeprecated());

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -54,12 +54,14 @@ class ParseVisitor extends ScopeVisitor
      * The global code base in which we store all
      * state
      */
+    /*
     public function __construct(
         CodeBase $code_base,
         Context $context
     ) {
         parent::__construct($code_base, $context);
     }
+     */
 
     /**
      * Visit a node with kind `\ast\AST_CLASS`
@@ -793,7 +795,7 @@ class ParseVisitor extends ScopeVisitor
         $call = $node->children['class'];
 
         if ($call->kind == \ast\AST_NAME) {
-            $func_name = strtolower($call->children['name']);
+            $func_name = \strtolower($call->children['name']);
             if ($func_name == 'parent') {
                 // Make sure it is not a crazy dynamic parent method call
                 if (!($node->children['method'] instanceof Node)) {

--- a/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
@@ -49,8 +49,7 @@ final class ArrayReturnTypeOverridePlugin extends PluginV2 implements
                 $array_type = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $args[0]);
                 $element_types = $array_type->genericArrayElementTypes();
                 if (!$element_types->isEmpty()) {
-                    $element_types->addType($false_type);
-                    return $element_types;
+                    return $element_types->withType($false_type);
                 }
             }
             return $mixed_type->asUnionType();
@@ -61,8 +60,7 @@ final class ArrayReturnTypeOverridePlugin extends PluginV2 implements
                 $key_type_enum = GenericArrayType::keyTypeFromUnionTypeKeys($array_type);
                 if ($key_type_enum !== GenericArrayType::KEY_MIXED) {
                     $key_type = GenericArrayType::unionTypeForKeyType($key_type_enum);
-                    $key_type->addType($false_type);
-                    return $key_type;
+                    return $key_type->withType($false_type);
                 }
             }
             static $types = null;
@@ -75,8 +73,7 @@ final class ArrayReturnTypeOverridePlugin extends PluginV2 implements
                 $key_type_enum = GenericArrayType::keyTypeFromUnionTypeKeys($array_type);
                 if ($key_type_enum !== GenericArrayType::KEY_MIXED) {
                     $key_type = GenericArrayType::unionTypeForKeyType($key_type_enum);
-                    $key_type->addType($false_type);
-                    return $key_type;
+                    return $key_type->withType($false_type);
                 }
             }
             static $types = null;
@@ -169,10 +166,10 @@ final class ArrayReturnTypeOverridePlugin extends PluginV2 implements
             $function_return_types = new UnionType();
             foreach ($function_like_list as $function_like) {
                 // TODO: Support analysis of map/reduce functions with dependent union types?
-                $function_return_types->addUnionType($function_like->getUnionType());
+                $function_return_types = $function_return_types->withUnionType($function_like->getUnionType());
             }
             if ($function_return_types->isEmpty()) {
-                $function_return_types->addType($mixed_type);
+                $function_return_types = $function_return_types->withType($mixed_type);
             }
             return $function_return_types;
         };
@@ -181,10 +178,10 @@ final class ArrayReturnTypeOverridePlugin extends PluginV2 implements
             $types = new UnionType();
             foreach ($args as $arg) {
                 $passed_array_type = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $arg);
-                $types->addUnionType($passed_array_type->genericArrayTypes());
+                $types = $types->withUnionType($passed_array_type->genericArrayTypes());
             }
             if ($types->isEmpty()) {
-                $types->addType($array_type);
+                $types = $types->withType($array_type);
             }
             return $types;
         };
@@ -238,9 +235,9 @@ final class ArrayReturnTypeOverridePlugin extends PluginV2 implements
                     $get_argument_type_for_array_map
                 );
                 if ($map_function->hasDependentReturnType()) {
-                    $possible_return_types->addUnionType($map_function->getDependentReturnType($code_base, $context, $arguments));
+                    $possible_return_types = $possible_return_types->withUnionType($map_function->getDependentReturnType($code_base, $context, $arguments));
                 } else {
-                    $possible_return_types->addUnionType($map_function->getUnionType());
+                    $possible_return_types = $possible_return_types->withUnionType($map_function->getUnionType());
                 }
             }
             if (Config::get_track_references()) {
@@ -271,9 +268,9 @@ final class ArrayReturnTypeOverridePlugin extends PluginV2 implements
             }
             $padded_array_type = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $args[0]);
             $result_types = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $args[2])->asGenericArrayTypes(GenericArrayType::KEY_INT);
-            $result_types->addUnionType($padded_array_type->genericArrayTypes());
+            $result_types = $result_types->withUnionType($padded_array_type->genericArrayTypes());
             if ($result_types->isEmpty()) {
-                $result_types->addType($array_type);
+                $result_types = $result_types->withType($array_type);
             }
             return $result_types;
         };

--- a/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
@@ -163,7 +163,7 @@ final class ArrayReturnTypeOverridePlugin extends PluginV2 implements
             if (\count($function_like_list) === 0) {
                 return $mixed_type->asUnionType();
             }
-            $function_return_types = new UnionType();
+            $function_return_types = UnionType::empty();
             foreach ($function_like_list as $function_like) {
                 // TODO: Support analysis of map/reduce functions with dependent union types?
                 $function_return_types = $function_return_types->withUnionType($function_like->getUnionType());
@@ -175,7 +175,7 @@ final class ArrayReturnTypeOverridePlugin extends PluginV2 implements
         };
 
         $merge_array_types_callback = static function (CodeBase $code_base, Context $context, Func $function, array $args) use ($array_type) : UnionType {
-            $types = new UnionType();
+            $types = UnionType::empty();
             foreach ($args as $arg) {
                 $passed_array_type = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $arg);
                 $types = $types->withUnionType($passed_array_type->genericArrayTypes());
@@ -200,7 +200,7 @@ final class ArrayReturnTypeOverridePlugin extends PluginV2 implements
                 return $array_type->asUnionType();
             }
             $arguments = \array_slice($args, 1);
-            $possible_return_types = new UnionType();
+            $possible_return_types = UnionType::empty();
             $cache_outer = [];
             $get_argument_type = function ($argument, int $i) use ($code_base, $context, &$cache_outer) : UnionType {
                 if (isset($cache_outer[$i])) {

--- a/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
@@ -43,6 +43,7 @@ final class ArrayReturnTypeOverridePlugin extends PluginV2 implements
         $array_type  = ArrayType::instance(false);
         $int_type    = IntType::instance(false);
         $string_type = StringType::instance(false);
+        $int_or_string_or_false = new UnionType([$int_type, $string_type, $false_type]);
 
         $get_element_type_of_first_arg = static function (CodeBase $code_base, Context $context, Func $function, array $args) use ($mixed_type, $false_type) : UnionType {
             if (\count($args) >= 1) {
@@ -54,7 +55,7 @@ final class ArrayReturnTypeOverridePlugin extends PluginV2 implements
             }
             return $mixed_type->asUnionType();
         };
-        $get_key_type_of_first_arg = static function (CodeBase $code_base, Context $context, Func $function, array $args) use ($int_type, $string_type, $false_type) : UnionType {
+        $get_key_type_of_first_arg = static function (CodeBase $code_base, Context $context, Func $function, array $args) use ($int_or_string_or_false, $false_type) : UnionType {
             if (\count($args) >= 1) {
                 $array_type = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $args[0]);
                 $key_type_enum = GenericArrayType::keyTypeFromUnionTypeKeys($array_type);
@@ -63,11 +64,9 @@ final class ArrayReturnTypeOverridePlugin extends PluginV2 implements
                     return $key_type->withType($false_type);
                 }
             }
-            static $types = null;
-            $types = $types ?? [$int_type, $string_type, $false_type];
-            return new UnionType($types, true);
+            return $int_or_string_or_false;
         };
-        $get_key_type_of_second_arg = static function (CodeBase $code_base, Context $context, Func $function, array $args) use ($int_type, $string_type, $false_type) : UnionType {
+        $get_key_type_of_second_arg = static function (CodeBase $code_base, Context $context, Func $function, array $args) use ($int_or_string_or_false, $false_type) : UnionType {
             if (\count($args) >= 2) {
                 $array_type = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $args[1]);
                 $key_type_enum = GenericArrayType::keyTypeFromUnionTypeKeys($array_type);
@@ -76,9 +75,7 @@ final class ArrayReturnTypeOverridePlugin extends PluginV2 implements
                     return $key_type->withType($false_type);
                 }
             }
-            static $types = null;
-            $types = $types ?? [$int_type, $string_type, $false_type];
-            return new UnionType($types, true);
+            return $int_or_string_or_false;
         };
         $get_first_array_arg = static function (CodeBase $code_base, Context $context, Func $function, array $args) use ($array_type) : UnionType {
             if (\count($args) >= 1) {

--- a/src/Phan/Plugin/Internal/ClosureReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ClosureReturnTypeOverridePlugin.php
@@ -58,7 +58,7 @@ final class ClosureReturnTypeOverridePlugin extends PluginV2 implements
             Func $function,
             array $args
         ) : UnionType {
-            $element_types = new UnionType();
+            $element_types = UnionType::empty();
             if (\count($args) < 1) {
                 return $element_types;
             }
@@ -86,7 +86,7 @@ final class ClosureReturnTypeOverridePlugin extends PluginV2 implements
             Func $function,
             array $args
         ) : UnionType {
-            $element_types = new UnionType();
+            $element_types = UnionType::empty();
             if (\count($args) < 2) {
                 return $element_types;
             }
@@ -96,7 +96,7 @@ final class ClosureReturnTypeOverridePlugin extends PluginV2 implements
                 return $element_types;
             }
             $arguments = self::extractArrayArgs($args[1]);
-            $element_types = new UnionType();
+            $element_types = UnionType::empty();
 
             foreach ($function_like_list as $function_like) {
                 if ($arguments !== null && $function_like->hasDependentReturnType()) {
@@ -128,7 +128,7 @@ final class ClosureReturnTypeOverridePlugin extends PluginV2 implements
             if (\count($function_like_list) === 0) {
                 return ClosureType::instance(false)->asUnionType();
             }
-            $closure_types = new UnionType();
+            $closure_types = UnionType::empty();
             foreach ($function_like_list as $function_like) {
                 $closure_types = $closure_types->withType(ClosureType::instanceWithClosureFQSEN($function_like->getFQSEN()));
             }

--- a/src/Phan/Plugin/Internal/ClosureReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ClosureReturnTypeOverridePlugin.php
@@ -68,9 +68,9 @@ final class ClosureReturnTypeOverridePlugin extends PluginV2 implements
             }
             foreach ($function_like_list as $function_like) {
                 if ($function_like->hasDependentReturnType()) {
-                    $element_types->addUnionType($function_like->getDependentReturnType($code_base, $context, \array_slice($args, 1)));
+                    $element_types = $element_types->withUnionType($function_like->getDependentReturnType($code_base, $context, \array_slice($args, 1)));
                 } else {
-                    $element_types->addUnionType($function_like->getUnionType());
+                    $element_types = $element_types->withUnionType($function_like->getUnionType());
                 }
             }
             if (Config::get_track_references()) {
@@ -100,9 +100,9 @@ final class ClosureReturnTypeOverridePlugin extends PluginV2 implements
 
             foreach ($function_like_list as $function_like) {
                 if ($arguments !== null && $function_like->hasDependentReturnType()) {
-                    $element_types->addUnionType($function_like->getDependentReturnType($code_base, $context, $arguments));
+                    $element_types = $element_types->withUnionType($function_like->getDependentReturnType($code_base, $context, $arguments));
                 } else {
-                    $element_types->addUnionType($function_like->getUnionType());
+                    $element_types = $element_types->withUnionType($function_like->getUnionType());
                 }
             }
             if (Config::get_track_references()) {
@@ -130,7 +130,7 @@ final class ClosureReturnTypeOverridePlugin extends PluginV2 implements
             }
             $closure_types = new UnionType();
             foreach ($function_like_list as $function_like) {
-                $closure_types->addType(ClosureType::instanceWithClosureFQSEN($function_like->getFQSEN()));
+                $closure_types = $closure_types->withType(ClosureType::instanceWithClosureFQSEN($function_like->getFQSEN()));
             }
             return $closure_types;
         };

--- a/src/Phan/Prep.php
+++ b/src/Phan/Prep.php
@@ -62,7 +62,7 @@ class Prep
         $visit_node($node, $file_path);
 
         // Scan all children recursively
-        foreach ($node->children ?? [] as $child_node) {
+        foreach ($node->children as $child_node) {
             if (!($child_node instanceof Node)) {
                 continue;
             }

--- a/src/requirements.php
+++ b/src/requirements.php
@@ -19,16 +19,6 @@ assert(
 if (extension_loaded('xdebug')) {
     require_once __DIR__ . '/Phan/Library/Composer/XdebugHandler.php';
     require_once __DIR__ . '/Phan/Library/Composer/IniHelper.php';
-    if (!getenv('PHAN_DISABLE_XDEBUG_WARN')) {
-        fwrite(STDERR, <<<EOT
-Automatically disabling xdebug, it's unnecessary unless you are debugging or developing phan itself, and makes phan slower.
-To run Phan with xdebug, set the environment variable PHAN_ALLOW_XDEBUG to 1.
-To disable this warning, set the environment variable PHAN_DISABLE_XDEBUG_WARN to 1.
-To include function signatures of xdebug, see .phan/internal_stubs/xdebug.xdebug.phan_php
-
-EOT
-        );
-    }
     // This code is taken from composer's automatic restart without xdebug.
     // Restart if xdebug is loading, unless the environment variable PHAN_ALLOW_XDEBUG is set.
     (new \Phan\Library\Composer\XdebugHandler())->check();

--- a/tests/Phan/BaseTest.php
+++ b/tests/Phan/BaseTest.php
@@ -17,5 +17,8 @@ abstract class BaseTest extends TestCase
             'canonical_object_map',
             'internal_fn_cache',
         ],
+        'Phan\Language\UnionType' => [
+            'empty_instance',
+        ],
     ];
 }

--- a/tests/Phan/Language/TypeTest.php
+++ b/tests/Phan/Language/TypeTest.php
@@ -282,7 +282,7 @@ class TypeTest extends BaseTest
         $expected_flattened_type = UnionType::fromStringInContext($normalized_union_type_string, new Context(), Type::FROM_PHPDOC);
         $this->assertInstanceOf(ArrayShapeType::class, $actual_type, "Failed to create expected class for $type_string");
         assert($actual_type instanceof ArrayShapeType);
-        $actual_flattened_type = new UnionType($actual_type->asGenericArrayTypeInstances());
+        $actual_flattened_type = UnionType::of($actual_type->asGenericArrayTypeInstances());
         $this->assertTrue($expected_flattened_type->isEqualTo($actual_flattened_type), "expected $actual_flattened_type to equal $expected_flattened_type");
     }
 

--- a/tests/Phan/Language/UnionTypeTest.php
+++ b/tests/Phan/Language/UnionTypeTest.php
@@ -51,6 +51,9 @@ class UnionTypeTest extends BaseTest
             'canonical_object_map',
             'internal_fn_cache',
         ],
+        'Phan\Language\UnionType' => [
+            'empty_instance',
+        ],
         // Back this up because it takes 306 ms.
         'Phan\Tests\Language\UnionTypeTest' => [
             'code_base',

--- a/tests/files/expected/0405_array_union_type_bug.php.expected
+++ b/tests/files/expected/0405_array_union_type_bug.php.expected
@@ -1,0 +1,1 @@
+%s:12 PhanUndeclaredConstant Reference to undeclared constant \CC::TYPE_MISSING

--- a/tests/files/expected/0406_dependency_cycles.php.expected
+++ b/tests/files/expected/0406_dependency_cycles.php.expected
@@ -1,0 +1,1 @@
+%s:11 PhanUndeclaredClassConstant Reference to constant class from undeclared class \Missing406

--- a/tests/files/expected/0407_property_refer_to_inherited_const.php.expected
+++ b/tests/files/expected/0407_property_refer_to_inherited_const.php.expected
@@ -1,0 +1,2 @@
+%s:34 PhanTypeMismatchArgument Argument 1 (e) is \BaseException407|\Exception|\Exception407|\Throwable but \expect_int() takes int defined at %s:25
+%s:41 PhanTypeMismatchArgument Argument 1 (e) is \BaseException407|\Exception|\Throwable but \expect_int() takes int defined at %s:25

--- a/tests/files/src/0405_array_union_type_bug.php
+++ b/tests/files/src/0405_array_union_type_bug.php
@@ -1,0 +1,15 @@
+<?php
+
+class Common{
+        const TYPE_INT = 'i';
+}
+
+class CC extends Common {
+    protected static $mappings = [
+        'key' => ['name' => 'name', 'type' => self::TYPE_INT],
+    ];
+    protected static $other_mappings = [
+        'key' => ['name' => 'name', 'type' => self::TYPE_MISSING],
+    ];
+}
+

--- a/tests/files/src/0406_dependency_cycles.php
+++ b/tests/files/src/0406_dependency_cycles.php
@@ -1,0 +1,19 @@
+<?php
+
+class B406 extends C406 {
+    public function d() : A406 {
+        return new A406;
+    }
+}
+
+class C406 {
+    public $p = A406::class;
+    public $q = Missing406::class;
+    public static function e() {}
+}
+
+class A406 extends B406 {
+    private function f() {
+        self::e();
+    }
+}

--- a/tests/files/src/0407_property_refer_to_inherited_const.php
+++ b/tests/files/src/0407_property_refer_to_inherited_const.php
@@ -1,0 +1,44 @@
+<?php
+
+class Exception407 extends BaseException407 {
+    protected static $otherProp = self::MY_PROP;
+    protected static $property = [
+        self::MY_PROP => 'value',
+    ];
+    const MY_PROP = 42;
+}
+
+class OtherClass407 {
+    protected $a = Exception407::MY_PROP;
+}
+
+class BaseException407 extends Exception {
+}
+
+class ThirdOtherClass407 {
+    protected $a = Exception407::MY_PROP;
+}
+
+function expect_exception(Exception $e) {
+}
+
+function expect_int(int $e) {
+}
+
+function foo() {
+    try {
+        $x = new Exception407();
+        throw $x;
+    } catch(Exception407 $e) {
+        expect_exception($e);  // should not warn
+        expect_int($e);  // should warn
+    }
+    try {
+        $x = new Exception407();
+        throw $x;
+    } catch(BaseException407 $e) {
+        expect_exception($e);
+        expect_int($e);  // Should warn. Just there to see what types phan infers.
+    }
+}
+


### PR DESCRIPTION
The overall effect is that Phan analysis is much faster

- Self-analysis time dropped from 4.5 seconds to 3.5 seconds.
- Unit tests continue to pass

Being able to reuse UnionType instances reduces memory usage somewhat and makes functions accepting UnionType easier to reason about.

- Instead of addType() and removeType(), withType() : UnionType and withoutType() : UnionType were added.
- However, the additional caching of computed UnionType instances increases the memory. So the overall memory usage for self-analysis drops very little from a maximum of 229MB to a maximum of 226MB.
- The UnionTypeBuilder class was introduced in case a large number of union types needed to be merged.

The other benefit of making UnionType instances immutable is that you don't have to clone() them just in case they're modified by a helper method.

---

Caching:

- UnionTypeVisitor::unionTypeFromNode and ContextNode::getClassList were some of the performance bottlenecks identified by xdebug's profiler.
- Previously, when Phan analyzed an expression such as `$a = expr()`, we would previously calculate the type of expr() twice: Once when analyzing the assignment, and another time during the generic BlockAnalysisVisitor visiting all nodes. This was inefficient. However, the Context now contains a cache which has the resulting UnionType for expr().
- UnionTypeVisitor::unionTypeFromNode has a parameter should_catch_issue_exception that needs to be accounted for when caching. If we don't, we might fail to throw an IssueException which would cause Phan to fail to emit an issue

Performance:

- Make $type->asUnionType() return the same UnionType every time.
- Add EmptyUnionType singleton, an immutable subclass of UnionType for an empty type list.
  Many functions of union type can be changed to return false/true/$this in that subclass.
- Inline more __invoke() calls.
- Fully qualify frequently used function calls. (PHP interpreter won't have to check for NS\explode() before explode())
- An idea to test in the future is to change frequently used visitor classes (e.g. BlockAnalysisVisitor, ContextVisitor from visit(Node $node) to visit(Context $context, Node $node), and use $this->{visitMethod}($child_context, $child_node) instead.
- Split VariadicParameter into a separate subclass of Parameter. This makes the majority of Parameter method calls more efficient by not needing the checks for variadic cases.
- Remove __construct where it's identical to the ancestor __construct, in frequently used classes. (PHP interpreter still has to pass arguments, check parameter types against argument types)