### PR TITLE
WIP : Add array shapes to the type system, fix bugs in array shapes

### DIFF
--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -1743,7 +1743,7 @@ class ContextNode
                 $elements[$key_node] = $value_node;  // Check for float?
             } else {
                 $key = $this->getEquivalentPHPValueForNode($key_node, $flags);
-                if (is_scalar($key)) {
+                if (\is_scalar($key)) {
                     $elements[$key] = $value_node;
                 } else {
                     if (($flags & self::RESOLVE_KEYS_USE_FALLBACK_PLACEHOLDER) !== 0) {
@@ -1769,7 +1769,7 @@ class ContextNode
      *         If this could be resolved and we're certain of the value, this gets a raw PHP value for $node.
      *         Otherwise, this returns $node.
      */
-    private function getEquivalentPHPValueForNode($node, int $flags)
+    public function getEquivalentPHPValueForNode($node, int $flags)
     {
         if (!($node instanceof Node)) {
             return $node;

--- a/src/Phan/Analysis/ArgumentType.php
+++ b/src/Phan/Analysis/ArgumentType.php
@@ -700,6 +700,7 @@ class ArgumentType
         $arglist = $node->children['args'];
         $argcount = \count($arglist->children);
 
+        // TODO: We can replace many of these with Plugin\Internal\ArrayReturnTypePlugin
         switch ($method->getName()) {
             case 'join':
             case 'implode':
@@ -826,7 +827,7 @@ class ArgumentType
                         $arglist->children[$i],
                         $context,
                         $code_base,
-                        CallableType::instance(false)->asUnionType(),
+                        ArrayType::instance(false)->asUnionType(),
                         function (UnionType $node_type) use ($context, $method, $i) {
                         // "arg#".($i+1)." is %s but {$method->getFQSEN()}() takes array"
                             return Issue::fromType(Issue::ParamTypeMismatch)(

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -590,6 +590,8 @@ class AssignmentVisitor extends AnalysisVisitor
         if ($new_types->hasType(MixedType::instance(false))) {
             $new_types = $new_types->withoutType(MixedType::instance(false));
         }
+        $new_types = $new_types->withFlattenedArrayShapeTypeInstances();
+
         // TODO: Add an option to check individual types, not just the whole union type?
         //       If that is implemented, verify that generic arrays will properly cast to regular arrays (public $x = [];)
         $property->setUnionType($property_types->withUnionType($new_types));

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -876,4 +876,21 @@ final class EmptyUnionType extends UnionType
     {
         return $this;
     }
+
+    public function hasTopLevelArrayShapeTypeInstances() : bool
+    {
+        return false;
+    }
+
+    /** @override */
+    public function hasArrayShapeTypeInstances() : bool
+    {
+        return false;
+    }
+
+    /** @override */
+    public function withFlattenedArrayShapeTypeInstances() : UnionType
+    {
+        return $this;
+    }
 }

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -1386,18 +1386,11 @@ class Type
      * this type. For instance, 'int' will produce 'int[]'.
      *
      * As a special case to reduce false positives, 'array' (with no known types) will produce 'array'
+     *
+     * Overridden in subclasses
      */
     public function asGenericArrayType(int $key_type) : Type
     {
-        if (!($this instanceof GenericArrayType)
-            && (
-                $this->name === 'array'
-                || $this->name === 'mixed'
-            )
-        ) {
-            return ArrayType::instance(false);
-        }
-
         return GenericArrayType::fromElementType($this, false, $key_type);
     }
 

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -1000,13 +1000,13 @@ class Type
      * @param array<string|int,string> $shape_components Maps field keys (integers or strings) to the corresponding type representations
      * @param Context $context
      * @param int $source
-     * @return array<string|int,Type> The types for the representations of types, in the given $context
+     * @return array<string|int,UnionType> The types for the representations of types, in the given $context
      */
     private static function shapeComponentStringsToTypes(array $shape_components, Context $context, int $source) : array
     {
         return array_map(
-            function (string $component_string) use ($context, $source) : Type {
-                return Type::fromStringInContext($component_string, $context, $source);
+            function (string $component_string) use ($context, $source) : UnionType {
+                return UnionType::fromStringInContext($component_string, $context, $source);
             },
             $shape_components
         );
@@ -1330,7 +1330,7 @@ class Type
      */
     public function isGenericArray() : bool
     {
-        return false;  // Overridden in GenericArrayType
+        return false;  // Overridden in GenericArrayType and ArrayShapeType
     }
 
     /**
@@ -1374,27 +1374,7 @@ class Type
      */
     public function genericArrayElementType() : Type
     {
-        \assert(
-            $this->isGenericArray(),
-            "Cannot call genericArrayElementType on non-generic array"
-        );
-
-        if (($pos = \strrpos($this->getName(), '[]')) !== false) {
-            \assert(
-                $this->getName() !== '[]' && $this->getName() !== 'array',
-                "Non-generic type requested to be non-generic"
-            );
-
-            return Type::make(
-                $this->getNamespace(),
-                \substr($this->getName(), 0, $pos),
-                $this->template_parameter_type_list,
-                $this->getIsNullable(),
-                self::FROM_TYPE
-            );
-        }
-
-        return $this;
+        throw new \Error("genericArrayElementType should not be called on Type base class");
     }
 
     /**
@@ -1969,5 +1949,18 @@ class Type
     public function getNormalizationFlags() : int
     {
         return $this->is_nullable ? self::_bit_nullable : 0;
+    }
+
+    public function hasArrayShapeTypeInstances() : bool
+    {
+        return false;
+    }
+
+    /**
+     * @return Type[]
+     */
+    public function withFlattenedArrayShapeTypeInstances() : array
+    {
+        return [$this];
     }
 }

--- a/src/Phan/Language/Type/ArrayShapeType.php
+++ b/src/Phan/Language/Type/ArrayShapeType.php
@@ -5,11 +5,10 @@ use Phan\Language\Type;
 use Phan\Language\UnionType;
 use Phan\Language\UnionTypeBuilder;
 use Phan\CodeBase;
+use Phan\Config;
 
 /**
- * Callers should split this up into multiple GenericArrayType instances
- *
- * This is generated from phpdoc array<int, T1|T2> where callers expect a subclass of Type.
+ * This is generated from phpdoc such as array{field:int}
  */
 final class ArrayShapeType extends ArrayType
 {
@@ -17,13 +16,28 @@ final class ArrayShapeType extends ArrayType
     const NAME = 'array';
 
     /**
-     * @var array<string|int,Type>
+     * @var array<string|int,UnionType>
      * Maps 0 or more field names to the corresponding types
      */
     private $field_types = [];
 
     /**
-     * @param array<string|int,Type> $types
+     * @var ?array<int,ArrayType>
+     */
+    private $as_generic_array_type_instances = null;
+
+    /**
+     * @var ?int
+     */
+    private $key_type = null;
+
+    /**
+     * @var ?UnionType
+     */
+    private $generic_array_element_union_type = null;
+
+    /**
+     * @param array<string|int,UnionType> $types
      * Maps 0 or more field names to the corresponding types
      *
      * @param bool $is_nullable
@@ -33,9 +47,8 @@ final class ArrayShapeType extends ArrayType
     {
         // Could de-duplicate, but callers should be able to do that as well when converting to UnionType.
         // E.g. array<int|int> is int[].
-        parent::__construct('\\', self::NAME, [], false);
+        parent::__construct('\\', self::NAME, [], $is_nullable);
         $this->field_types = $types;
-        $this->is_nullable = $is_nullable;
     }
 
     /**
@@ -59,33 +72,32 @@ final class ArrayShapeType extends ArrayType
         );
     }
 
-    /**
-     * @return array<int,ArrayType>
-     */
-    public function asGenericArrayTypeInstances() : array
+    /** @override */
+    public function hasArrayShapeTypeInstances() : bool
     {
-        if (\count($this->field_types) === 0) {
-            // There are 0 fields, so we know nothing about the field types (And there's no way to indicate an empty array yet)
-            return [ArrayType::instance($this->is_nullable)];
-        }
-
-        $key_type = GenericArrayType::getKeyTypeForArrayLiteral($this->field_types);
-
-        return \array_map(function (Type $type) use ($key_type) {
-            return GenericArrayType::fromElementType($type, $this->is_nullable, $key_type);
-        }, UnionType::normalizeGenericMultiArrayTypes($this->field_types));
+        return false;
     }
 
-    /**
-     * @param array<string|int,Type> $field_types
-     * @param bool $is_nullable
-     * @return ArrayShapeType
-     */
-    public static function fromFieldTypes(
-        array $field_types,
-        bool $is_nullable
-    ) : ArrayShapeType {
-        return new self($field_types, $is_nullable);
+    /** @return array<int,type> */
+    private function computeGenericArrayTypeInstances() : array
+    {
+        $union_type_builder = new uniontypebuilder();
+        foreach ($this->field_types as $key => $field_union_type) {
+            foreach ($field_union_type->getTypeSet() as $type) {
+                $union_type_builder->addType(GenericArrayType::fromElementType($type, $this->is_nullable, \is_string($key) ? GenericArrayType::KEY_STRING : GenericArrayType::KEY_INT));
+            }
+        }
+        return $union_type_builder->getTypeSet();
+    }
+
+    public function getKeyType() : int
+    {
+        return $this->key_type ?? ($this->key_type = GenericArrayType::getKeyTypeForArrayLiteral($this->field_types));
+    }
+
+    public function genericArrayElementUnionType() : UnionType
+    {
+        return $this->generic_array_element_union_type ?? ($this->generic_array_element_union_type = UnionType::merge($this->field_types));
     }
 
     /**
@@ -96,12 +108,24 @@ final class ArrayShapeType extends ArrayType
     protected function canCastToNonNullableType(Type $type) : bool
     {
         if ($type instanceof GenericArrayType) {
-            foreach ($this->arrayShapeFieldTypes() as $inner_type) {
-                if ($type->canCastToType($type->genericArrayElementType())) {
-                    return true;
+            if (($this->getKeyType() & ($type->getKeyType() ?: GenericArrayType::KEY_MIXED)) === 0 && !Config::getValue('scalar_array_key_cast')) {
+                // Attempting to cast an int key to a string key (or vice versa) is normally invalid.
+                // However, the scalar_array_key_cast config would make any cast of array keys a valid cast.
+                return false;
+            }
+            return $this->genericArrayElementUnionType()->canCastToUnionType($type->genericArrayElementType()->asUnionType());
+        } elseif ($type instanceof ArrayShapeType) {
+            foreach ($type->field_types as $key => $field_type) {
+                $this_field_type = $this->field_types[$key] ?? null;
+                // Can't cast {a:int} to {a:int, other:string} if other is missing?
+                if ($this_field_type === null) {
+                    return false;
+                }
+                if (!$this_field_type->canCastToUnionType($field_type)) {
+                    return false;
                 }
             }
-            return false;
+            return true;
         }
 
         if ($type->isArrayLike()) {
@@ -113,10 +137,57 @@ final class ArrayShapeType extends ArrayType
             $d = \substr($d, 1);
         }
         if ($d === 'callable') {
+            if (\array_keys($this->field_types) !== [0, 1]) {
+                return false;
+            }
+            // TODO: Check types of offsets 0 and 1
             return true;
         }
 
         return parent::canCastToNonNullableType($type);
+    }
+
+    /**
+     * @param array<string|int,UnionType> $field_types
+     * @param bool $is_nullable
+     * @return ArrayShapeType
+     * TODO: deduplicate
+     */
+    public static function fromFieldTypes(
+        array $field_types,
+        bool $is_nullable
+    ) : ArrayShapeType {
+        // TODO: Investigate if caching makes this any more efficient?
+        static $cache = [];
+
+        $key_parts = [];
+        if ($is_nullable) {
+            $key_parts[] = '?';
+        }
+        foreach ($field_types as $key => $field_union_type) {
+            $key_parts[$key] = $field_union_type->generateUniqueId();
+        }
+        $key = \json_encode($key_parts);
+
+        return $cache[$key] ?? ($cache[$key] = new self($field_types, $is_nullable));
+    }
+
+    /**
+     * @param bool $is_nullable
+     * @return ArrayShapeType
+     * TODO: deduplicate
+     */
+    public static function empty(
+        bool $is_nullable = false
+    ) : ArrayShapeType {
+        // TODO: Investigate if caching makes this any more efficient?
+        static $nullable_shape = null;
+        static $nonnullable_shape = null;
+
+        if ($is_nullable) {
+            return $nullable_shape ?? ($nullable_shape = self::fromFieldTypes([], true));
+        }
+        return $nonnullable_shape ?? ($nonnullable_shape = self::fromFieldTypes([], false));
     }
 
     public function isGenericArray() : bool
@@ -125,7 +196,7 @@ final class ArrayShapeType extends ArrayType
     }
 
     /**
-     * @return array<string|int,Type>
+     * @return array<string|int,UnionType>
      * An array of mapping field keys of this type to field types
      */
     public function arrayShapeFieldTypes() : array
@@ -177,9 +248,27 @@ final class ArrayShapeType extends ArrayType
         // TODO: Use UnionType::merge from a future change?
         $result = new UnionTypeBuilder();
         $key_type = GenericArrayType::getKeyTypeForArrayLiteral($this->field_types);
-        foreach ($this->field_types as $type) {
-            $result->addUnionType(GenericArrayType::fromElementType($type, $this->is_nullable, $key_type)->asExpandedTypes($code_base, $recursion_depth + 1));
+        $result_fields = [];
+        foreach ($this->field_types as $key => $union_type) {
+            $result_fields[$key] = $union_type->asExpandedTypes($code_base, $recursion_depth + 1);
         }
-        return $result->getUnionType();
+        return ArrayShapeType::fromFieldTypes($result_fields, $this->is_nullable)->asUnionType();
+    }
+
+    /**
+     * @return GenericArrayType[]
+     * @override
+     */
+    public function withFlattenedArrayShapeTypeInstances() : array
+    {
+        if (\is_array($this->as_generic_array_type_instances)) {
+            return $this->as_generic_array_type_instances;
+        }
+        if (\count($this->field_types) === 0) {
+            // there are 0 fields, so we know nothing about the field types (and there's no way to indicate an empty array yet)
+            return $this->as_generic_array_type_instances = [arraytype::instance($this->is_nullable)];
+        }
+
+        return $this->as_generic_array_type_instances = $this->computegenericarraytypeinstances();
     }
 }

--- a/src/Phan/Language/Type/ArrayType.php
+++ b/src/Phan/Language/Type/ArrayType.php
@@ -2,6 +2,8 @@
 namespace Phan\Language\Type;
 
 use Phan\Language\Type;
+use Phan\Language\UnionType;
+use Phan\Language\UnionTypeBuilder;
 
 class ArrayType extends IterableType
 {
@@ -22,6 +24,108 @@ class ArrayType extends IterableType
     public function isPossiblyObject() : bool
     {
         return false;  // Overrides IterableType returning true
+    }
+
+    /**
+     * @return UnionType with ArrayType subclass(es)
+     */
+    public static function combineArrayTypesMerging(UnionType $union_type) : UnionType
+    {
+        $result = new UnionTypeBuilder();
+        $array_shape_types = [];
+        foreach ($union_type->getTypeSet() as $type) {
+            if ($type->isGenericArray()) {
+                if ($type instanceof ArrayShapeType) {
+                    $array_shape_types[] = $type;
+                } else {
+                    $result->addType($type);
+                }
+            } elseif ($type instanceof ArrayType) {
+                return $type->asUnionType();
+            }
+        }
+        if ($result->isEmpty()) {
+            return ArrayShapeType::union($array_shape_types)->asUnionType();
+        }
+        foreach ($array_shape_types as $type) {
+            foreach ($type->withFlattenedArrayShapeTypeInstances() as $type_part) {
+                $result->addType($type_part);
+            }
+        }
+        return $result->getUnionType();
+    }
+
+    /**
+     * E.g. array{0:int} + array{0:string,1:float} becomes array{0:int,1:float}
+     *
+     * @param UnionType $left the left hand side (e.g. of a `+` operator). Keys from these array shapes take precedence.
+     * @param UnionType $right the right hand side (e.g. of a `+` operator).
+     * @return UnionType with ArrayType subclass(es)
+     */
+    public static function combineArrayTypesOverriding(UnionType $left, UnionType $right) : UnionType
+    {
+        $result = new UnionTypeBuilder();
+        $left_array_shape_types = [];
+        foreach ($left->getTypeSet() as $type) {
+            if ($type->isGenericArray()) {
+                if ($type instanceof ArrayShapeType) {
+                    $left_array_shape_types[] = $type;
+                } else {
+                    $result->addType($type);
+                }
+            } elseif ($type instanceof ArrayType) {
+                return $type->asUnionType();
+            }
+        }
+        $right_array_shape_types = [];
+        foreach ($right->getTypeSet() as $type) {
+            if ($type->isGenericArray()) {
+                if ($type instanceof ArrayShapeType) {
+                    $right_array_shape_types[] = $type;
+                } else {
+                    $result->addType($type);
+                }
+            } elseif ($type instanceof ArrayType) {
+                return $type->asUnionType();
+            }
+        }
+        if ($result->isEmpty()) {
+            if (\count($left_array_shape_types) === 0) {
+                return ArrayShapeType::union($right_array_shape_types)->asUnionType();
+            }
+            if (\count($right_array_shape_types) === 0) {
+                return ArrayShapeType::union($left_array_shape_types)->asUnionType();
+            }
+            // fields from the left take precedence (e.g. [0, false] + ['string'] becomes [0, false])
+            return ArrayShapeType::combineWithPrecedence(
+                ArrayShapeType::union($left_array_shape_types),
+                ArrayShapeType::union($right_array_shape_types)
+            )->asUnionType();
+        }
+        foreach (\array_merge($left_array_shape_types, $right_array_shape_types) as $type) {
+            foreach ($type->withFlattenedArrayShapeTypeInstances() as $type_part) {
+                $result->addType($type_part);
+            }
+        }
+        return $result->getUnionType();
+    }
+
+    /**
+     * Overridden in subclasses
+     *
+     * @param int $key_type
+     * Corresponds to the type of the array keys. Set this to a GenericArrayType::KEY_* constant.
+     *
+     * @return Type
+     * Get a new type which is the generic array version of
+     * this type. For instance, 'int[]' will produce 'int[][]'.
+     *
+     * As a special case to reduce false positives, 'array' (with no known types) will produce 'array'
+     */
+    public function asGenericArrayType(int $key_type) : Type
+    {
+        // TODO: Allow one more level of nesting? E.g. array->array[], but array[]->array[]
+        return ArrayType::instance(false);
     }
 }
 // Trigger the autoloader for GenericArrayType so that it won't be called

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -459,4 +459,9 @@ final class GenericArrayType extends ArrayType
         }
         return $results;
     }
+
+    public function asGenericArrayType(int $key_type) : Type
+    {
+        return GenericArrayType::fromElementType($this, false, $key_type);
+    }
 }

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -424,7 +424,7 @@ final class GenericArrayType extends ArrayType
                 } elseif ($key_node !== null) {
                     if (\is_string($key_node)) {
                         $key_type_enum |= GenericArrayType::KEY_STRING;
-                    } elseif (\is_int($key_node) || \is_float($key_node)) {
+                    } elseif (\is_scalar($key_node)) {
                         $key_type_enum |= GenericArrayType::KEY_INT;
                     }
                 } else {

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -121,7 +121,6 @@ final class GenericArrayType extends ArrayType
         );
     }
 
-
     /**
      * @return bool
      * True if this Type can be cast to the given Type
@@ -140,6 +139,13 @@ final class GenericArrayType extends ArrayType
                 return Config::getValue('scalar_array_key_cast');
             }
             return true;
+        } elseif ($type instanceof ArrayShapeType) {
+            if ((($this->key_type ?: self::KEY_MIXED) & $type->getKeyType()) === 0 && !Config::getValue('scalar_array_key_cast')) {
+                // Attempting to cast an int key to a string key (or vice versa) is normally invalid.
+                // However, the scalar_array_key_cast config would make any cast of array keys a valid cast.
+                return false;
+            }
+            return $this->genericArrayElementType()->asUnionType()->canCastToUnionType($type->genericArrayElementUnionType());
         }
 
         if ($type->isArrayLike()) {
@@ -324,6 +330,9 @@ final class GenericArrayType extends ArrayType
                 $key_types |= $type->key_type;
                 continue;
                 // TODO: support array shape as well?
+            } elseif ($type instanceof ArrayShapeType) {
+                $key_types |= $type->getKeyType();
+                continue;
             }
         }
         // int|string corresponds to KEY_MIXED (KEY_INT|KEY_STRING)
@@ -429,5 +438,25 @@ final class GenericArrayType extends ArrayType
             return $key_type_enum ?: GenericArrayType::KEY_MIXED;
         }
         return GenericArrayType::KEY_MIXED;
+    }
+
+    public function hasArrayShapeTypeInstances() : bool
+    {
+        return $this->element_type->hasArrayShapeTypeInstances();
+    }
+
+    /** @return array<int,Type> */
+    public function withFlattenedArrayShapeTypeInstances() : array
+    {
+        // TODO: Any point in caching this?
+        $type_instances = $this->element_type->withFlattenedArrayShapeTypeInstances();
+        if (\count($type_instances) === 0 && $type_instances[0] === $this->element_type) {
+            return [$this];
+        }
+        $results = [];
+        foreach ($type_instances as $type) {
+            $results[] = GenericArrayType::fromElementType($type, $this->is_nullable, $this->key_type);
+        }
+        return $results;
     }
 }

--- a/src/Phan/Language/Type/MixedType.php
+++ b/src/Phan/Language/Type/MixedType.php
@@ -34,4 +34,9 @@ final class MixedType extends NativeType
         // But we don't want `@param mixed $x` to take precedence over `int $x` in the signature.
         return $union_type->hasType($this);
     }
+
+    public function asGenericArrayType(int $key_type) : Type
+    {
+        return ArrayType::instance(false);
+    }
 }

--- a/src/Phan/Language/Type/NativeType.php
+++ b/src/Phan/Language/Type/NativeType.php
@@ -192,3 +192,6 @@ abstract class NativeType extends Type
     }
 }
 \class_exists(ArrayType::class);
+\class_exists(ArrayShapeType::class);
+\class_exists(GenericArrayType::class);
+\class_exists(ScalarType::class);

--- a/src/Phan/Language/Type/ScalarType.php
+++ b/src/Phan/Language/Type/ScalarType.php
@@ -109,3 +109,4 @@ abstract class ScalarType extends NativeType
         return $this;
     }
 }
+\class_exists(IntType::class);

--- a/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
@@ -75,7 +75,7 @@ final class ArrayReturnTypeOverridePlugin extends PluginV2 implements
             if (\count($args) >= 1) {
                 $element_types = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $args[0])->genericArrayTypes();
                 if (!$element_types->isEmpty()) {
-                    return $element_types;
+                    return $element_types->withFlattenedArrayShapeTypeInstances();
                 }
             }
             return $array_type->asUnionType();
@@ -84,7 +84,7 @@ final class ArrayReturnTypeOverridePlugin extends PluginV2 implements
             if (\count($args) >= 2) {
                 $element_types = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $args[1])->genericArrayTypes();
                 if (!$element_types->isEmpty()) {
-                    return $element_types;
+                    return $element_types->withFlattenedArrayShapeTypeInstances();
                 }
             }
             return $array_type->asUnionType();
@@ -140,7 +140,8 @@ final class ArrayReturnTypeOverridePlugin extends PluginV2 implements
                         // ARRAY_FILTER_USE_BOTH - pass both value and key as arguments to callback instead of the value
                     }
                     // TODO: Analyze if it and the flags are compatible with the arguments to the closure provided.
-                    return $generic_passed_array_type;
+                    // TODO: withFlattenedArrayShapeTypeInstances() for other values
+                    return $generic_passed_array_type->withFlattenedArrayShapeTypeInstances();
                 }
             }
             return $array_type->asUnionType();
@@ -169,7 +170,7 @@ final class ArrayReturnTypeOverridePlugin extends PluginV2 implements
             $types = UnionType::empty();
             foreach ($args as $arg) {
                 $passed_array_type = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $arg);
-                $types = $types->withUnionType($passed_array_type->genericArrayTypes());
+                $types = $types->withUnionType($passed_array_type->genericArrayTypes()->withFlattenedArrayShapeTypeInstances());
             }
             if ($types->isEmpty()) {
                 $types = $types->withType($array_type);

--- a/tests/Phan/Language/TypeTest.php
+++ b/tests/Phan/Language/TypeTest.php
@@ -279,7 +279,7 @@ class TypeTest extends BaseTest
         $expected_flattened_type = UnionType::fromStringInContext($normalized_union_type_string, new Context(), Type::FROM_PHPDOC);
         $this->assertInstanceOf(ArrayShapeType::class, $actual_type, "Failed to create expected class for $type_string");
         assert($actual_type instanceof ArrayShapeType);
-        $actual_flattened_type = UnionType::of($actual_type->asGenericArrayTypeInstances());
+        $actual_flattened_type = UnionType::of($actual_type->withFlattenedArrayShapeTypeInstances());
         $this->assertTrue($expected_flattened_type->isEqualTo($actual_flattened_type), "expected $actual_flattened_type to equal $expected_flattened_type");
     }
 
@@ -307,7 +307,7 @@ class TypeTest extends BaseTest
                 'array{string:int}'
             ],
             [
-                'array<string,T<int>>',
+                'array<string,\T<int>>',
                 'array{field:T<int>}'
             ],
             [
@@ -319,11 +319,11 @@ class TypeTest extends BaseTest
                 'array{field:int[],field2:?int}'
             ],
             [
-                'array<string,array>',
+                'array<string,array{}>',
                 'array{field:array{}}'
             ],
             [
-                'array<string,array<string,int>>',
+                'array<string,array{innerField:int}>',
                 'array{field:array{innerField:int}}'
             ],
         ];

--- a/tests/Phan/Language/UnionTypeTest.php
+++ b/tests/Phan/Language/UnionTypeTest.php
@@ -106,8 +106,8 @@ class UnionTypeTest extends BaseTest
     public function testArrayUniform()
     {
         $this->assertUnionTypeStringEqual(
-            '[1, 2, 3]',
-            'array{0:int,1:int,2:int}'
+            '[false => "string"]',
+            'array{0:string}'
         );
     }
 

--- a/tests/Phan/Language/UnionTypeTest.php
+++ b/tests/Phan/Language/UnionTypeTest.php
@@ -107,7 +107,7 @@ class UnionTypeTest extends BaseTest
     {
         $this->assertUnionTypeStringEqual(
             '[1, 2, 3]',
-            'array<int,int>'
+            'array{0:int,1:int,2:int}'
         );
     }
 
@@ -115,7 +115,7 @@ class UnionTypeTest extends BaseTest
     {
         $this->assertUnionTypeStringEqual(
             '[1, "string"]',
-            'array<int,int>|array<int,string>'
+            'array{0:int,1:string}'
         );
     }
 

--- a/tests/files/expected/0006_property_types.php.expected
+++ b/tests/files/expected/0006_property_types.php.expected
@@ -1,2 +1,2 @@
-%s:6 PhanTypeMismatchProperty Assigning array<int,string> to property but \A::property is \bad
+%s:6 PhanTypeMismatchProperty Assigning array{0:string,1:string,2:string} to property but \A::property is \bad
 %s:6 PhanUndeclaredTypeProperty Property \A::property has undeclared type \bad

--- a/tests/files/expected/0071_callable.php.expected
+++ b/tests/files/expected/0071_callable.php.expected
@@ -1,1 +1,1 @@
-%s:10 PhanTypeMismatchArgument Argument 1 (c) is array<int,string> but \f() takes \Closure defined at %s:9
+%s:10 PhanTypeMismatchArgument Argument 1 (c) is array{0:string,1:string} but \f() takes \Closure defined at %s:9

--- a/tests/files/expected/0114_array_concatenation.php.expected
+++ b/tests/files/expected/0114_array_concatenation.php.expected
@@ -1,3 +1,3 @@
-%s:6 PhanTypeMismatchArgument Argument 1 (p) is array but \g() takes int defined at %s:5
-%s:7 PhanTypeMismatchArgument Argument 1 (p) is array<int,int> but \g() takes int defined at %s:5
+%s:6 PhanTypeMismatchArgument Argument 1 (p) is array{0:int,1:int} but \g() takes int defined at %s:5
+%s:7 PhanTypeMismatchArgument Argument 1 (p) is array{0:int,1:int} but \g() takes int defined at %s:5
 %s:12 PhanTypeInvalidLeftOperand Invalid operator: right operand is array and left is not

--- a/tests/files/expected/0146_array_concat.php.expected
+++ b/tests/files/expected/0146_array_concat.php.expected
@@ -1,4 +1,4 @@
-%s:5 PhanTypeMismatchArgument Argument 1 (p) is array but \f() takes int defined at %s:3
-%s:6 PhanTypeMismatchArgument Argument 1 (p) is array<int,int> but \f() takes int defined at %s:3
+%s:5 PhanTypeMismatchArgument Argument 1 (p) is array{0:int,1:int} but \f() takes int defined at %s:3
+%s:6 PhanTypeMismatchArgument Argument 1 (p) is array{0:int,1:int} but \f() takes int defined at %s:3
 %s:16 PhanTypeMismatchArgument Argument 1 (p) is array but \f() takes int defined at %s:3
 %s:17 PhanTypeMismatchArgument Argument 1 (p) is array but \f() takes int defined at %s:3

--- a/tests/files/expected/0174_is_a_generic.php.expected
+++ b/tests/files/expected/0174_is_a_generic.php.expected
@@ -1,5 +1,5 @@
 %s:7 PhanTypeMismatchArgument Argument 1 (var) is array but \f() takes resource defined at %s:3
-%s:7 PhanTypeMismatchArgument Argument 1 (var) is array<int,string> but \f() takes resource defined at %s:3
+%s:7 PhanTypeMismatchArgument Argument 1 (var) is array{0:string,1:string,2:string} but \f() takes resource defined at %s:3
 %s:9 PhanTypeMismatchArgument Argument 1 (var) is bool but \f() takes resource defined at %s:3
-%s:12 PhanTypeMismatchReturn Returning type array<int,string>|bool but g() is declared to return resource
+%s:12 PhanTypeMismatchReturn Returning type array{0:string,1:string,2:string}|bool but g() is declared to return resource
 %s:12 PhanTypeMismatchReturn Returning type array|bool but g() is declared to return resource

--- a/tests/files/expected/0217_variadic_call_types.php.expected
+++ b/tests/files/expected/0217_variadic_call_types.php.expected
@@ -1,7 +1,7 @@
-%s:26 PhanTypeMismatchArgument Argument 5 (params) is array<int,int> but \test_ints() takes int defined at %s:6
-%s:28 PhanTypeMismatchArgument Argument 1 (req) is array<int,string> but \test_ints() takes string defined at %s:6
+%s:26 PhanTypeMismatchArgument Argument 5 (params) is array{0:int} but \test_ints() takes int defined at %s:6
+%s:28 PhanTypeMismatchArgument Argument 1 (req) is array{0:string} but \test_ints() takes string defined at %s:6
 %s:29 PhanParamTooFew Call with 0 arg(s) to \test_ints() which requires 1 arg(s) defined at %s:6
 %s:30 PhanTypeMismatchArgument Argument 2 (params) is \DateTime|\DateTimeInterface but \test_ints() takes int defined at %s:6
-%s:31 PhanTypeMismatchArgument Argument 2 (params) is array<int,int> but \test_ints() takes int defined at %s:6
+%s:31 PhanTypeMismatchArgument Argument 2 (params) is array{0:int,1:int,2:int,3:int} but \test_ints() takes int defined at %s:6
 %s:35 PhanTypeMismatchArgument Argument 1 (date_time_list) is int but \test_vararg_within_function() takes \DateTime defined at %s:9
 %s:38 PhanTypeMismatchArgument Argument 1 (a) is array<int,int> but \accept_int() takes int defined at %s:17

--- a/tests/files/expected/0238_generic_array_scalar_cast.php.expected
+++ b/tests/files/expected/0238_generic_array_scalar_cast.php.expected
@@ -1,1 +1,1 @@
-%s:4 PhanTypeMismatchArgument Argument 1 (p) is array<int,int> but \f() takes string[] defined at %s:3
+%s:4 PhanTypeMismatchArgument Argument 1 (p) is array{0:int} but \f() takes string[] defined at %s:3

--- a/tests/files/expected/0260_variadic_bug.php.expected
+++ b/tests/files/expected/0260_variadic_bug.php.expected
@@ -1,3 +1,3 @@
-%s:42 PhanTypeMismatchArgument Argument 3 (arguments) is array<int,int> but \VariadicBug::foo() takes int|string defined at %s:16
-%s:44 PhanTypeMismatchArgument Argument 3 (arguments) is array<int,int> but \variadic_bug_260() takes int|string defined at %s:31
+%s:42 PhanTypeMismatchArgument Argument 3 (arguments) is array{0:int} but \VariadicBug::foo() takes int|string defined at %s:16
+%s:44 PhanTypeMismatchArgument Argument 3 (arguments) is array{0:int} but \variadic_bug_260() takes int|string defined at %s:31
 

--- a/tests/files/expected/0279_void_return.php.expected
+++ b/tests/files/expected/0279_void_return.php.expected
@@ -1,2 +1,3 @@
 %s:9 PhanTypeMismatchReturn Returning type void but f() is declared to return \DateTime
+%s:10 PhanTypeMismatchReturn Returning type int but f() is declared to return \DateTime
 %s:15 PhanTypeMismatchReturn Returning type void but g() is declared to return int

--- a/tests/files/expected/0292_strict_equality.php.expected
+++ b/tests/files/expected/0292_strict_equality.php.expected
@@ -1,5 +1,5 @@
 %s:10 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is string but \intdiv() takes int
-%s:13 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is array<int,string> but \intdiv() takes int
+%s:13 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is array{0:string} but \intdiv() takes int
 %s:16 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is float but \intdiv() takes int
 %s:22 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is null but \intdiv() takes int
 %s:25 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is false but \intdiv() takes int

--- a/tests/files/expected/0298_weird_variable_name.php.expected
+++ b/tests/files/expected/0298_weird_variable_name.php.expected
@@ -1,5 +1,5 @@
 %s:7 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is array<int,string> but \intdiv() takes int
 %s:10 PhanTypeSuspiciousIndirectVariable Indirect variable ${(expr)} has invalid inner expression type true, expected string/integer
 %s:11 PhanTypeSuspiciousIndirectVariable Indirect variable ${(expr)} has invalid inner expression type bool, expected string/integer
-%s:12 PhanTypeSuspiciousIndirectVariable Indirect variable ${(expr)} has invalid inner expression type array<int,int>, expected string/integer
-%s:13 PhanTypeSuspiciousIndirectVariable Indirect variable ${(expr)} has invalid inner expression type array<int,int>, expected string/integer
+%s:12 PhanTypeSuspiciousIndirectVariable Indirect variable ${(expr)} has invalid inner expression type array{0:int}, expected string/integer
+%s:13 PhanTypeSuspiciousIndirectVariable Indirect variable ${(expr)} has invalid inner expression type array{0:int}, expected string/integer

--- a/tests/files/expected/0298_weird_variable_name.php.expected
+++ b/tests/files/expected/0298_weird_variable_name.php.expected
@@ -1,4 +1,4 @@
-%s:7 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is array<int,string> but \intdiv() takes int
+%s:7 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is array{0:string} but \intdiv() takes int
 %s:10 PhanTypeSuspiciousIndirectVariable Indirect variable ${(expr)} has invalid inner expression type true, expected string/integer
 %s:11 PhanTypeSuspiciousIndirectVariable Indirect variable ${(expr)} has invalid inner expression type bool, expected string/integer
 %s:12 PhanTypeSuspiciousIndirectVariable Indirect variable ${(expr)} has invalid inner expression type array{0:int}, expected string/integer

--- a/tests/files/expected/0339_bad_arrayreturn.php.expected
+++ b/tests/files/expected/0339_bad_arrayreturn.php.expected
@@ -1,2 +1,2 @@
-%s:6 PhanTypeMismatchReturn Returning type array<int,array<int,int>> but testarrayreturn() is declared to return int[]
-%s:6 PhanTypeMismatchReturn Returning type array<int,string> but testarrayreturn() is declared to return int[]
+%s:6 PhanTypeMismatchReturn Returning type array<int,array{0:int}> but testarrayreturn() is declared to return int[]\n
+%s:6 PhanTypeMismatchReturn Returning type array<int,string> but testarrayreturn() is declared to return int[]\n

--- a/tests/files/expected/0339_bad_arrayreturn.php.expected
+++ b/tests/files/expected/0339_bad_arrayreturn.php.expected
@@ -1,2 +1,2 @@
-%s:6 PhanTypeMismatchReturn Returning type array<int,array{0:int}> but testarrayreturn() is declared to return int[]\n
-%s:6 PhanTypeMismatchReturn Returning type array<int,string> but testarrayreturn() is declared to return int[]\n
+%s:6 PhanTypeMismatchReturn Returning type array<int,array{0:int}> but testarrayreturn() is declared to return int[]
+%s:6 PhanTypeMismatchReturn Returning type array<int,string> but testarrayreturn() is declared to return int[]

--- a/tests/files/expected/0354_string_index.php.expected
+++ b/tests/files/expected/0354_string_index.php.expected
@@ -8,6 +8,6 @@
 %s:22 PhanTypeMismatchDimFetch When fetching an array index from a value of type string, found an array index of type array, but expected the index to be of type int
 %s:23 PhanTypeMismatchDimFetch When fetching an array index from a value of type string, found an array index of type string, but expected the index to be of type int
 %s:24 PhanTypeMismatchDimFetch When fetching an array index from a value of type string, found an array index of type null, but expected the index to be of type int
-%s:27 PhanTypeMismatchDimFetch When fetching an array index from a value of type array<string,string>, found an array index of type array, but expected the index to be of type string
-%s:28 PhanTypeMismatchDimFetch When fetching an array index from a value of type array<string,string>, found an array index of type null, but expected the index to be of type string
-%s:29 PhanTypeMismatchDimFetch When fetching an array index from a value of type array<string,string>, found an array index of type int, but expected the index to be of type string
+%s:27 PhanTypeMismatchDimFetch When fetching an array index from a value of type array{offset:string}, found an array index of type array, but expected the index to be of type string
+%s:28 PhanTypeMismatchDimFetch When fetching an array index from a value of type array{offset:string}, found an array index of type null, but expected the index to be of type string
+%s:29 PhanTypeMismatchDimFetch When fetching an array index from a value of type array{offset:string}, found an array index of type int, but expected the index to be of type string

--- a/tests/files/expected/0364_extended_array_analyze.php.expected
+++ b/tests/files/expected/0364_extended_array_analyze.php.expected
@@ -9,7 +9,7 @@
 %s:17 PhanTypeMismatchArgument Argument 1 (x) is false|float but \p364() takes \stdClass defined at %s:45
 %s:18 PhanTypeMismatchArgument Argument 1 (x) is array<string,int> but \p364() takes \stdClass defined at %s:45
 %s:19 PhanTypeMismatchArgument Argument 1 (x) is array<string,\stdClass> but \p364() takes \stdClass defined at %s:45
-%s:20 PhanTypeMismatchArgument Argument 1 (x) is array<string,array<int,int>> but \p364() takes \stdClass defined at %s:45
+%s:20 PhanTypeMismatchArgument Argument 1 (x) is array<string,array{0:int}> but \p364() takes \stdClass defined at %s:45
 %s:21 PhanTypeMismatchArgument Argument 1 (x) is array<int,string> but \p364() takes \stdClass defined at %s:45
 %s:22 PhanTypeMismatchArgument Argument 1 (x) is int[] but \p364() takes \stdClass defined at %s:45
 %s:23 PhanTypeMismatchArgument Argument 1 (x) is array<int,float> but \p364() takes \stdClass defined at %s:45
@@ -21,7 +21,7 @@
 %s:29 PhanTypeMismatchArgument Argument 1 (x) is array<int,float> but \p364() takes \stdClass defined at %s:45
 %s:30 PhanTypeMismatchArgument Argument 1 (x) is array<int,int>|array<int,string> but \p364() takes \stdClass defined at %s:45
 %s:31 PhanTypeMismatchArgument Argument 1 (x) is array<int,int>|array<int,string> but \p364() takes \stdClass defined at %s:45
-%s:32 PhanTypeMismatchArgument Argument 1 (x) is array<int,int>|array<int,string> but \p364() takes \stdClass defined at %s:45
+%s:32 PhanTypeMismatchArgument Argument 1 (x) is array<int,string>|array{0:int,1:int} but \p364() takes \stdClass defined at %s:45
 %s:33 PhanTypeMismatchArgument Argument 1 (x) is array<int,int>|array<int,string> but \p364() takes \stdClass defined at %s:45
 %s:34 PhanTypeMismatchArgument Argument 1 (x) is array<int,int>|array<int,string> but \p364() takes \stdClass defined at %s:45
 %s:35 PhanTypeMismatchArgument Argument 1 (x) is array<int,\stdClass> but \p364() takes \stdClass defined at %s:45
@@ -30,5 +30,6 @@
 %s:38 PhanTypeMismatchArgument Argument 1 (x) is array<int,\stdClass> but \p364() takes \stdClass defined at %s:45
 %s:39 PhanTypeMismatchArgument Argument 1 (x) is array<int,string> but \p364() takes \stdClass defined at %s:45
 %s:40 PhanTypeMismatchArgument Argument 1 (x) is array<int,string> but \p364() takes \stdClass defined at %s:45
+%s:41 PhanParamTypeMismatch Argument 3 is \Closure but \array_uintersect_assoc() takes array
 %s:41 PhanTypeMismatchArgument Argument 1 (x) is array<int,string> but \p364() takes \stdClass defined at %s:45
 %s:42 PhanTypeMismatchArgument Argument 1 (x) is array<int,string> but \p364() takes \stdClass defined at %s:45

--- a/tests/files/expected/0372_ternary_shorthand.php.expected
+++ b/tests/files/expected/0372_ternary_shorthand.php.expected
@@ -1,2 +1,2 @@
 %s:21 PhanTypeMismatchArgument Argument 1 (x) is string but \expect_int382() takes int defined at %s:17
-%s:22 PhanTypeMismatchArgument Argument 1 (x) is array<int,string>|string but \expect_int382() takes int defined at %s:17
+%s:22 PhanTypeMismatchArgument Argument 1 (x) is array{0:string}|string but \expect_int382() takes int defined at %s:17

--- a/tests/files/expected/0377_static_callable.php.expected
+++ b/tests/files/expected/0377_static_callable.php.expected
@@ -1,4 +1,6 @@
 %s:11 PhanTypeMismatchArgument Argument 1 (x) is \stdClass but \TestStaticCallable377::triple() takes int defined at %s:24
 %s:12 PhanTypeMismatchArgument Argument 1 (x) is \stdClass but \TestStaticCallable377::triple() takes int defined at %s:24
+%s:17 PhanTypeMismatchArgument Argument 1 (x) is array but \TestStaticCallable377::triple() takes int defined at %s:24
+%s:18 PhanTypeMismatchArgument Argument 1 (x) is array but \TestStaticCallable377::triple() takes int defined at %s:24
 %s:20 PhanTypeMismatchArgument Argument 1 (x) is \stdClass but \TestStaticCallable377::triple() takes int defined at %s:24
 %s:21 PhanTypeMismatchArgument Argument 1 (x) is \stdClass but \TestStaticCallable377::triple() takes int defined at %s:24

--- a/tests/files/expected/0379_array_template.php.expected
+++ b/tests/files/expected/0379_array_template.php.expected
@@ -1,2 +1,2 @@
 %s:18 PhanTypeMismatchReturn Returning type array<int,string> but keys2() is declared to return array<string,string>
-%s:25 PhanTypeMismatchArgument Argument 1 (x) is array<int,float> but \MyNS\TemplateArray379::keys() takes array<int,string> defined at %s:9
+%s:25 PhanTypeMismatchArgument Argument 1 (x) is array{0:float} but \MyNS\TemplateArray379::keys() takes array<int,string> defined at %s:9

--- a/tests/files/expected/0384_array_bug.php.expected
+++ b/tests/files/expected/0384_array_bug.php.expected
@@ -1,1 +1,1 @@
-%s:5 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is array but \intdiv() takes int
+%s:5 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is array{0:mixed} but \intdiv() takes int

--- a/tests/files/expected/0394_invalid_calling_method.php.expected
+++ b/tests/files/expected/0394_invalid_calling_method.php.expected
@@ -1,2 +1,2 @@
 %s:9 PhanNonClassMethodCall Call to method callMethod on non-class type string
-%s:11 PhanNonClassMethodCall Call to method callMethod on non-class type array<int,string>
+%s:11 PhanNonClassMethodCall Call to method callMethod on non-class type array{0:string}

--- a/tests/files/expected/0395_array_shape.php.expected
+++ b/tests/files/expected/0395_array_shape.php.expected
@@ -1,1 +1,1 @@
-%s:11 PhanTypeMismatchArgument Argument 1 (options) is array<string,int> but \test_options() takes array<string,string> defined at %s:6
+%s:11 PhanTypeMismatchArgument Argument 1 (options) is array{field:int} but \test_options() takes array{field:string} defined at %s:6

--- a/tests/files/expected/0425_array_shape.php.expected
+++ b/tests/files/expected/0425_array_shape.php.expected
@@ -1,0 +1,3 @@
+%s:10 PhanTypeMismatchArgument Argument 1 (params) is array{case:string} but \test() takes array{Case:string} defined at %s:7
+%s:12 PhanTypeMismatchArgument Argument 1 (params) is array{Case:null} but \test() takes array{Case:string} defined at %s:7
+%s:15 PhanTypeMismatchArgument Argument 1 (params) is array{Case:null} but \test() takes array{Case:string} defined at %s:7

--- a/tests/files/expected/0426_array_shape_partial.php.expected
+++ b/tests/files/expected/0426_array_shape_partial.php.expected
@@ -1,0 +1,4 @@
+%s:10 PhanTypeMismatchArgument Argument 1 (params) is array{firstProp:string} but \test426() takes array{firstProp:string,secondProp:?int} defined at %s:7
+%s:11 PhanTypeMismatchArgument Argument 1 (params) is array{secondProp:int} but \test426() takes array{firstProp:string,secondProp:?int} defined at %s:7
+%s:12 PhanTypeMismatchArgument Argument 1 (params) is array{secondProp:false} but \test426() takes array{firstProp:string,secondProp:?int} defined at %s:7
+%s:15 PhanTypeMismatchArgument Argument 1 (params) is array{firstProp:string,secondProp:false} but \test426() takes array{firstProp:string,secondProp:?int} defined at %s:7

--- a/tests/files/src/0425_array_shape.php
+++ b/tests/files/src/0425_array_shape.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @param array{Case:string} $params
+ * @return void
+ */
+function test(array $params) {
+    var_export($params);
+}
+test(['case' => 'x']);
+test(['Case' => 'x']);
+test(['Case' => null]);
+test(['Case' => 'x', 'other' => false]);
+$global425 = ['Case' => null];
+test($global425);

--- a/tests/files/src/0426_array_shape_partial.php
+++ b/tests/files/src/0426_array_shape_partial.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @param array{firstProp:string,secondProp:?int} $params
+ * @return void
+ */
+function test426(array $params) {
+    echo strlen($params['firstProp']);
+}
+test426(['firstProp' => 'value']);
+test426(['secondProp' => 2]);
+test426(['secondProp' => false]);
+test426(['firstProp' => 'value', 'secondProp' => 22]);
+test426(['firstProp' => 'value', 'secondProp' => null]);
+test426(['firstProp' => 'value', 'secondProp' => false]);

--- a/tests/misc/fallback_test/expected/002_missing_property_check.php.expected
+++ b/tests/misc/fallback_test/expected/002_missing_property_check.php.expected
@@ -1,2 +1,2 @@
 src/002_missing_property_check.php:5 PhanSyntaxError syntax error, unexpected ';', expecting identifier (T_STRING) or variable (T_VARIABLE) or '{' or '$'
-src/002_missing_property_check.php:6 PhanTypeMismatchReturn Returning type array<int,string> but missing_property() is declared to return int
+src/002_missing_property_check.php:6 PhanTypeMismatchReturn Returning type array{0:string} but missing_property() is declared to return int

--- a/tests/plugin_test/expected/006_preg_regex.php.expected
+++ b/tests/plugin_test/expected/006_preg_regex.php.expected
@@ -6,5 +6,6 @@ src/006_preg_regex.php:16 PhanPluginInvalidPregRegex Call to \preg_split was pas
 src/006_preg_regex.php:17 PhanPluginInvalidPregRegex Call to \preg_match_all was passed an invalid regex '/\\w/i/': Unknown modifier '/'
 src/006_preg_regex.php:18 PhanPluginInvalidPregRegex Call to \preg_grep was passed an invalid regex '/\\w/i/': Unknown modifier '/'
 src/006_preg_regex.php:21 PhanPluginInvalidPregRegex Call to \preg_replace_callback_array was passed an invalid regex '0': Delimiter must not be alphanumeric or backslash
-src/006_preg_regex.php:21 PhanTypeMismatchArgumentInternal Argument 1 (pattern) is array<int,\Closure> but \preg_replace_callback_array() takes array<string,callable>
+src/006_preg_regex.php:21 PhanTypeMismatchArgumentInternal Argument 1 (pattern) is array{0:\Closure} but \preg_replace_callback_array() takes array<string,callable>
 src/006_preg_regex.php:22 PhanPluginInvalidPregRegex Call to \preg_replace_callback_array was passed an invalid regex '0': Delimiter must not be alphanumeric or backslash
+src/006_preg_regex.php:22 PhanTypeMismatchArgumentInternal Argument 1 (pattern) is array{0:\Closure} but \preg_replace_callback_array() takes array<string,callable>

--- a/tests/rasmus_files/expected/0011_internal_arg.php.expected
+++ b/tests/rasmus_files/expected/0011_internal_arg.php.expected
@@ -1,1 +1,1 @@
-%s:2 PhanTypeMismatchArgumentInternal Argument 2 (start) is array<int,int> but \substr() takes int
+%s:2 PhanTypeMismatchArgumentInternal Argument 2 (start) is array{0:int,1:int,2:int} but \substr() takes int

--- a/tests/rasmus_files/expected/0013_alternate_signature.php.expected
+++ b/tests/rasmus_files/expected/0013_alternate_signature.php.expected
@@ -1,2 +1,2 @@
 %s:4 PhanParamTooFewInternal Call with 1 arg(s) to \strtr() which requires 3 arg(s)
-%s:4 PhanTypeMismatchArgumentInternal Argument 1 (str) is array<string,string> but \strtr() takes string
+%s:4 PhanTypeMismatchArgumentInternal Argument 1 (str) is array{def:string} but \strtr() takes string

--- a/tests/rasmus_files/expected/0023_doc_comment.php.expected
+++ b/tests/rasmus_files/expected/0023_doc_comment.php.expected
@@ -1,3 +1,3 @@
 %s:7 PhanTypeMismatchReturn Returning type int|string but test() is declared to return array
-%s:10 PhanTypeMismatchArgument Argument 1 (arg) is array<int,int> but \test() takes int|string defined at %s:6
+%s:10 PhanTypeMismatchArgument Argument 1 (arg) is array{0:int,1:int,2:int} but \test() takes int|string defined at %s:6
 

--- a/tests/rasmus_files/expected/0031_prop.php.expected
+++ b/tests/rasmus_files/expected/0031_prop.php.expected
@@ -1,1 +1,1 @@
-%s:9 PhanTypeMismatchArgument Argument 1 (arg) is array<int,int> but \A::test() takes string defined at %s:4
+%s:9 PhanTypeMismatchArgument Argument 1 (arg) is array{0:int,1:int,2:int} but \A::test() takes string defined at %s:4

--- a/tests/rasmus_files/expected/0032_ns_alias.php.expected
+++ b/tests/rasmus_files/expected/0032_ns_alias.php.expected
@@ -1,1 +1,1 @@
-%s:14 PhanTypeMismatchArgument Argument 1 (arg) is array<int,int> but \NS1\SubA\A::test() takes string defined at %s:5
+%s:14 PhanTypeMismatchArgument Argument 1 (arg) is array{0:int,1:int,2:int} but \NS1\SubA\A::test() takes string defined at %s:5

--- a/tests/rasmus_files/expected/0033_ns_function.php.expected
+++ b/tests/rasmus_files/expected/0033_ns_function.php.expected
@@ -1,1 +1,1 @@
-%s:7 PhanTypeMismatchArgument Argument 1 (arg) is array<int,int> but \NS1\test() takes string defined at %s:3
+%s:7 PhanTypeMismatchArgument Argument 1 (arg) is array{0:int,1:int,2:int} but \NS1\test() takes string defined at %s:3

--- a/tests/rasmus_files/expected/0035_class_const.php.expected
+++ b/tests/rasmus_files/expected/0035_class_const.php.expected
@@ -1,1 +1,1 @@
-%s:6 PhanTypeMismatchArgument Argument 1 (arg) is array<int,int> but \test() takes int defined at %s:5
+%s:6 PhanTypeMismatchArgument Argument 1 (arg) is array{0:int,1:int,2:int} but \test() takes int defined at %s:5

--- a/tests/rasmus_files/expected/0037_properties2.php.expected
+++ b/tests/rasmus_files/expected/0037_properties2.php.expected
@@ -1,3 +1,3 @@
-%s:13 PhanTypeMismatchProperty Assigning array<int,int> to property but \B::text is string
+%s:13 PhanTypeMismatchProperty Assigning array{0:int,1:int,2:int} to property but \B::text is string
 %s:20 PhanAccessPropertyProtected Cannot access protected property \B::$text
 %s:30 PhanTypeMismatchProperty Assigning array to property but \B::text is string


### PR DESCRIPTION
For #1382

- Start making Phan infer array shape types instead of generic arrays
  in the type system.
- Start warning when a key is not found.
- TODO: Warning about missing keys introduces a lot of false positives,
  especially in loops.
  Being aware of types from loops (E.g. by analyzing loops twice)
  may help.
  Alternately, try to check if the variable definitions are defined
  outside a loop but are used inside a loop?
  Haven't decided how to fix these false positives.
- Fix bugs in ArrayShapeType, which previously wasn't part of the type
  system.
- Support array concatenation
- Convert array shapes to generic arrays in array_filter, array_merge,
  etc.
- Update expectations in unit tests.
  Followup work would be to create the same tests again, but ensuring
  that Phan would test generic arrays instead of more specific array
  shapes.



---

TODO:

- [x] Add more unit tests
- [ ] Improve scalar casting rules. E.g. `array{a:int}` should not be able to cast to `array{a:int, other:int}`.
  A followup PR may add optional fields to array shapes
- [x] Test this on large projects for crashes and unexpected results
- [ ] Reduce false positives in loops (Another PR provided ways to suppress issues for an entire file (phan-file-suppress) or to set a variable's type inline (phan-var in top level string literal)) 
- [ ] Look into inferring `[]` as `array{}` in future PRs. This was disabled due to high false positives in loops