### PR TITLE
Fix error with class hydration; add --language-server-analyze-only-on-save

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -59,6 +59,10 @@ Plugins
   To modify the type of elements(properties, method return types, parameters, variables, etc),
   `Element->setUnionType(plugin_modifier_function(Element->getUnionType()))` should be used.
 
+Language server:
++ Add a CLI option `--language-server-analyze-only-on-save` to prevent the client from sending change notifications. (#1325)
+  (Only notify the language server when the user saves a document)
+  This significantly reduces CPU usage, but clients won't get notifications about issues immediately.
 
 Bug fixes
 + Warn when attempting to call an instance method on an expression with type string (#1314).

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -10,8 +10,10 @@ use Phan\Analysis\ContextMergeVisitor;
 use Phan\Analysis\PostOrderAnalysisVisitor;
 use Phan\Analysis\PreOrderAnalysisVisitor;
 use Phan\Language\Context;
+use Phan\Language\FQSEN\FullyQualifiedPropertyName;
 use Phan\Language\Scope\BranchScope;
 use Phan\Language\Scope\GlobalScope;
+use Phan\Language\Scope\PropertyScope;
 use Phan\Plugin\ConfigPluginSet;
 use ast\Node;
 
@@ -1208,13 +1210,15 @@ class BlockAnalysisVisitor extends AnalysisVisitor
     {
         $prop_name = (string)$node->children['name'];
 
-        $class = $this->context->getClassInScope($this->code_base);
+        $context = $this->context;
+        $class = $context->getClassInScope($this->code_base);
         $is_static = ($this->parent_node->flags & \ast\flags\MODIFIER_STATIC) !== 0;
-        $property = $class->getPropertyByNameInContext($this->code_base, $prop_name, $this->context, $is_static);
+        $property = $class->getPropertyByNameInContext($this->code_base, $prop_name, $context, $is_static);
 
-        $context = $this->context->withScope(
-            $property->getInternalScope()
-        )->withLineNumberStart(
+        $context = $this->context->withScope(new PropertyScope(
+            $context->getScope(),
+            FullyQualifiedPropertyName::make($class->getFQSEN(), $prop_name)
+        ))->withLineNumberStart(
             $node->lineno ?? 0
         );
 

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -104,6 +104,7 @@ class CLI
                 'language-server-on-stdin',
                 'language-server-tcp-server:',
                 'language-server-tcp-connect:',
+                'language-server-analyze-only-on-save',
                 'language-server-verbose',
                 'extended-help',
             ]
@@ -322,6 +323,9 @@ class CLI
                     break;
                 case 'language-server-tcp-connect':
                     Config::setValue('language_server_config', ['tcp' => $value]);
+                    break;
+                case 'language-server-analyze-only-on-save':
+                    Config::setValue('language_server_analyze_only_on_save', true);
                     break;
                 case 'language-server-verbose':
                     Config::setValue('language_server_debug_level', 'info');
@@ -596,6 +600,10 @@ Usage: {$argv[0]} [options] [files...]
 
  --language-server-tcp-connect <addr>
   Start the language server and connect to the client listening on <addr> (e.g. 127.0.0.1:<port>)
+
+ --language-server-analyze-only-on-save
+  Prevent the client from sending change notifications (Only notify the language server when the user saves a document)
+  This significantly reduces CPU usage, but clients won't get notifications about issues immediately.
 
  -v, --version
   Print phan's version number

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -632,6 +632,9 @@ class Config
         // ['tcp' => string (address client is listening on)
         'language_server_config' => false,
 
+        // Valid values: false, true. Should only be set via CLI (--language-server-analyze-only-on-save)
+        'language_server_analyze_only_on_save' => false,
+
         // Valid values: null, 'info'. Used when developing or debugging a language server client of Phan.
         'language_server_debug_level' => null,
 

--- a/src/Phan/Language/Element/AddressableElement.php
+++ b/src/Phan/Language/Element/AddressableElement.php
@@ -231,7 +231,7 @@ abstract class AddressableElement extends TypedElement implements AddressableEle
     }
 
     /** @var bool */
-    private $is_hydrated = false;
+    protected $is_hydrated = false;
 
     /**
      * This method must be called before analysis
@@ -240,7 +240,7 @@ abstract class AddressableElement extends TypedElement implements AddressableEle
      * @return void
      * @override
      */
-    final public function hydrate(CodeBase $code_base)
+    public function hydrate(CodeBase $code_base)
     {
         if ($this->is_hydrated) {  // Same as isFirstExecution(), inlined due to being called frequently.
             return;
@@ -254,7 +254,7 @@ abstract class AddressableElement extends TypedElement implements AddressableEle
      * This method must be called before analysis begins.
      * This is identical to hydrate(), but returns true only if this is the first time the element was hydrated.
      */
-    final public function hydrateIndicatingFirstTime(CodeBase $code_base) : bool
+    public function hydrateIndicatingFirstTime(CodeBase $code_base) : bool
     {
         if ($this->is_hydrated) {  // Same as isFirstExecution(), inlined due to being called frequently.
             return false;

--- a/src/Phan/LanguageServer/LanguageServer.php
+++ b/src/Phan/LanguageServer/LanguageServer.php
@@ -516,9 +516,9 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
             }
 
             $serverCapabilities = new ServerCapabilities();
-            // Ask the client to return always return full documents (because we need to rebuild the AST from scratch)
-            // TODO: use the full documents
-            $serverCapabilities->textDocumentSync = TextDocumentSyncKind::FULL;
+            // FULL: Ask the client to return always return full documents (because we need to rebuild the AST from scratch)
+            // NONE: Don't sync until the user explitly saves a document.
+            $serverCapabilities->textDocumentSync = Config::getValue('language_server_analyze_only_on_save') ? TextDocumentSyncKind::NONE : TextDocumentSyncKind::FULL;
             // TODO: Support "Find all symbols"?
             //$serverCapabilities->documentSymbolProvider = true;
             // TODO: Support "Find all symbols in workspace"?

--- a/tests/files/expected/0410_hydration_bug.php.expected
+++ b/tests/files/expected/0410_hydration_bug.php.expected
@@ -1,0 +1,2 @@
+%s:5 PhanUndeclaredConstant Reference to undeclared constant \HydrateExample::INVALID
+%s:12 PhanUndeclaredConstant Reference to undeclared constant \HydrateExampleStep::INVALID

--- a/tests/files/src/0410_hydration_bug.php
+++ b/tests/files/src/0410_hydration_bug.php
@@ -1,0 +1,16 @@
+<?php
+class HydrateExample
+{
+    protected $messageTemplates = [
+        self::INVALID      => "Invalid",
+    ];
+}
+
+class HydrateExampleStep extends HydrateExample
+{
+    protected $messageTemplates = [
+        self::INVALID      => "Invalid",
+    ];
+
+    protected $baseValue = 'a value';
+}


### PR DESCRIPTION
Previously, there would be an uncaught CodeBaseException due to phan
failing to resolve a missing/inherited constant in the parse phase.

This defers hydration until after Phan finishes parsing a given class.
(This isn't ideal, and won't work as expected in some edge cases
when using inherited constants)

Fixes #1325: Allow language server to only be notified on file save
(and not on file edit). This greatly reduces CPU usage.