### PR TITLE
Fixes #1325 : Create full TextDocumentSyncOptions

### DIFF
--- a/.phan/plugins/NonBoolBranchPlugin.php
+++ b/.phan/plugins/NonBoolBranchPlugin.php
@@ -65,7 +65,6 @@ class NonBoolBranchVisitor extends PluginAwareAnalysisVisitor
         }
         return $this->context;
     }
-
 }
 
 return new NonBoolBranchPlugin;

--- a/.phan/plugins/NonBoolInLogicalArithPlugin.php
+++ b/.phan/plugins/NonBoolInLogicalArithPlugin.php
@@ -61,7 +61,7 @@ class NonBoolInLogicalArithVisitor extends PluginAwareAnalysisVisitor
             $right_type = UnionType::fromNode($this->context, $this->code_base, $right_node);
 
             // if left or right type is NOT boolean, emit issue
-            if (!$left_type->isExclusivelyBoolTypes())  {
+            if (!$left_type->isExclusivelyBoolTypes()) {
                 if ($left_node instanceof Node) {
                     $this->context = $this->context->withLineNumberStart($left_node->lineno);
                 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,10 +11,10 @@ platform: x86
 environment:
   matrix:
     - PHP_EXT_VERSION: '7.1'
-      PHP_VERSION: '7.1.13'
+      PHP_VERSION: '7.1.14'
       VC_VERSION: 14
     - PHP_EXT_VERSION: '7.2'
-      PHP_VERSION: '7.2.1'
+      PHP_VERSION: '7.2.2'
       VC_VERSION: 15
 
 branches:

--- a/src/Phan/AST/ASTSimplifier.php
+++ b/src/Phan/AST/ASTSimplifier.php
@@ -196,15 +196,15 @@ class ASTSimplifier
             return true;
         }
         switch ($node->kind) {
-        case \ast\AST_CONST:
-        case \ast\AST_MAGIC_CONST:
-        case \ast\AST_NAME:
-            return true;
-        case \ast\AST_BINARY_OP:
-        case \ast\AST_CLASS_CONST:
-            return self::isExpressionWithoutSideEffects($node->children['class']);
-        default:
-            return false;
+            case \ast\AST_CONST:
+            case \ast\AST_MAGIC_CONST:
+            case \ast\AST_NAME:
+                return true;
+            case \ast\AST_BINARY_OP:
+            case \ast\AST_CLASS_CONST:
+                return self::isExpressionWithoutSideEffects($node->children['class']);
+            default:
+                return false;
         }
     }
 

--- a/src/Phan/Analysis/ContextMergeVisitor.php
+++ b/src/Phan/Analysis/ContextMergeVisitor.php
@@ -239,14 +239,14 @@ class ContextMergeVisitor extends KindVisitorImplementation
      * A generic helper method to merge multiple Contexts. (e.g. for use outside of BlockAnalysisVisitor)
      * If you wish to include the base context, add it to $child_context_list in the constructor of ContextMergeVisitor.
      */
-    public function combineChildContextList() : Context {
+    public function combineChildContextList() : Context
+    {
         $child_context_list = $this->child_context_list;
         \assert(\count($child_context_list) >= 2);
         $scope_list = \array_map(function (Context $context) {
             return $context->getScope();
         }, $child_context_list);
         return $this->combineScopeList($scope_list);
-
     }
 
     /**

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -2426,7 +2426,8 @@ class Clazz extends AddressableElement
     /**
      * @return void
      */
-    public function setDidFinishParsing(bool $did_finish_parsing) {
+    public function setDidFinishParsing(bool $did_finish_parsing)
+    {
         $this->did_finish_parsing = $did_finish_parsing;
     }
 

--- a/src/Phan/Language/Element/VariadicParameter.php
+++ b/src/Phan/Language/Element/VariadicParameter.php
@@ -4,7 +4,8 @@ namespace Phan\Language\Element;
 use Phan\Language\UnionType;
 use Phan\Language\Type\GenericArrayType;
 
-class VariadicParameter extends Parameter {
+class VariadicParameter extends Parameter
+{
     // __construct inherited from Parameter
 
     /**

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -22,7 +22,8 @@ final class EmptyUnionType extends UnionType
     /**
      * Use UnionType::empty() instead elsewhere in the codebase.
      */
-    protected static function instance() : EmptyUnionType {
+    protected static function instance() : EmptyUnionType
+    {
         static $self = null;
         return $self ?? ($self = new EmptyUnionType());
     }
@@ -562,7 +563,9 @@ final class EmptyUnionType extends UnionType
     public function asClassFQSENList(
         Context $context
     ) {
-        if (false) yield;
+        if (false) {
+            yield;
+        }
     }
 
     /**
@@ -590,7 +593,9 @@ final class EmptyUnionType extends UnionType
         CodeBase $code_base,
         Context $context
     ) {
-        if (false) yield;  // This is a generator yielding 0 results.
+        if (false) {
+            yield;  // This is a generator yielding 0 results.
+        }
     }
 
     /**

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -104,7 +104,8 @@ class UnionType implements \Serializable
     /**
      * @return EmptyUnionType (Real return type omitted for performance)
      */
-    public static function empty() {
+    public static function empty()
+    {
         return self::$empty_instance;
     }
 
@@ -112,7 +113,8 @@ class UnionType implements \Serializable
      * @return void
      * @internal
      */
-    public static function init() {
+    public static function init()
+    {
         if (is_null(self::$empty_instance)) {
             self::$empty_instance = EmptyUnionType::instance();
         }
@@ -2099,7 +2101,8 @@ class UnionType implements \Serializable
         $builder->addType($bool_type);
     }
 
-    public static function createBuilderFromTypeList(array $type_list) : UnionTypeBuilder {
+    public static function createBuilderFromTypeList(array $type_list) : UnionTypeBuilder
+    {
         return new UnionTypeBuilder(\count($type_list) <= 1 ? $type_list : self::getUniqueTypes($type_list));
     }
 }

--- a/src/Phan/Language/UnionTypeBuilder.php
+++ b/src/Phan/Language/UnionTypeBuilder.php
@@ -2,19 +2,22 @@
 
 namespace Phan\Language;
 
-final class UnionTypeBuilder {
+final class UnionTypeBuilder
+{
     /** @var array<int,Type> */
     private $type_set;
 
     /** @param array<int,Type> $type_set (must be unique) */
-    public function __construct(array $type_set = []) {
+    public function __construct(array $type_set = [])
+    {
         $this->type_set = $type_set;
     }
 
     /**
      * @return void
      */
-    public function addType(Type $type) {
+    public function addType(Type $type)
+    {
         if (\in_array($type, $this->type_set, true)) {
             return;
         }
@@ -24,7 +27,8 @@ final class UnionTypeBuilder {
     /**
      * @return void
      */
-    public function addUnionType(UnionType $union_type) {
+    public function addUnionType(UnionType $union_type)
+    {
         $old_type_set = $this->type_set;
         foreach ($union_type->getTypeSet() as $type) {
             if (!\in_array($type, $old_type_set, true)) {
@@ -36,7 +40,8 @@ final class UnionTypeBuilder {
     /**
      * @return void
      */
-    public function removeType(Type $type) {
+    public function removeType(Type $type)
+    {
         $i = \array_search($type, $this->type_set, true);
         if ($i !== false) {
             // equivalent to unset($new_type_set[$i]) but fills in the gap in array keys.
@@ -48,18 +53,21 @@ final class UnionTypeBuilder {
         }
     }
 
-    public function isEmpty() : bool {
+    public function isEmpty() : bool
+    {
         return \count($this->type_set) === 0;
     }
 
     /**
      * @return array<int,Type>
      */
-    public function getTypeSet() : array {
+    public function getTypeSet() : array
+    {
         return $this->type_set;
     }
 
-    public function getUnionType() : UnionType {
+    public function getUnionType() : UnionType
+    {
         return UnionType::of($this->type_set);
     }
 }

--- a/src/Phan/LanguageServer/LanguageServer.php
+++ b/src/Phan/LanguageServer/LanguageServer.php
@@ -15,9 +15,11 @@ use Phan\LanguageServer\Protocol\InitializeResult;
 use Phan\LanguageServer\Protocol\Message;
 use Phan\LanguageServer\Protocol\Position;
 use Phan\LanguageServer\Protocol\Range;
+use Phan\LanguageServer\Protocol\SaveOptions;
 use Phan\LanguageServer\Protocol\ServerCapabilities;
 use Phan\LanguageServer\Protocol\TextDocumentIdentifier;
 use Phan\LanguageServer\Protocol\TextDocumentSyncKind;
+use Phan\LanguageServer\Protocol\TextDocumentSyncOptions;
 use Phan\LanguageServer\Server\TextDocument;
 use Phan\LanguageServer\ProtocolReader;
 use Phan\LanguageServer\ProtocolWriter;
@@ -515,10 +517,13 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
                 );
             }
 
+
             $serverCapabilities = new ServerCapabilities();
+
             // FULL: Ask the client to return always return full documents (because we need to rebuild the AST from scratch)
             // NONE: Don't sync until the user explitly saves a document.
-            $serverCapabilities->textDocumentSync = Config::getValue('language_server_analyze_only_on_save') ? TextDocumentSyncKind::NONE : TextDocumentSyncKind::FULL;
+            $serverCapabilities->textDocumentSync = $this->makeTextDocumentSyncOptions();
+
             // TODO: Support "Find all symbols"?
             //$serverCapabilities->documentSymbolProvider = true;
             // TODO: Support "Find all symbols in workspace"?
@@ -544,6 +549,17 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
 
             return new InitializeResult($serverCapabilities);
         });
+    }
+
+    private function makeTextDocumentSyncOptions() : TextDocumentSyncOptions {
+        $textDocumentSyncOptions = new TextDocumentSyncOptions();
+        $textDocumentSyncOptions->openClose = true;
+        $textDocumentSyncOptions->change = Config::getValue('language_server_analyze_only_on_save') ? TextDocumentSyncKind::NONE : TextDocumentSyncKind::FULL;
+
+        $saveOptions = new SaveOptions();
+        $saveOptions->includeText = true;
+        $textDocumentSyncOptions->save = $saveOptions;
+        return $textDocumentSyncOptions;
     }
 
     public function initialized()

--- a/src/Phan/LanguageServer/LanguageServer.php
+++ b/src/Phan/LanguageServer/LanguageServer.php
@@ -551,7 +551,8 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
         });
     }
 
-    private function makeTextDocumentSyncOptions() : TextDocumentSyncOptions {
+    private function makeTextDocumentSyncOptions() : TextDocumentSyncOptions
+    {
         $textDocumentSyncOptions = new TextDocumentSyncOptions();
         $textDocumentSyncOptions->openClose = true;
         $textDocumentSyncOptions->change = Config::getValue('language_server_analyze_only_on_save') ? TextDocumentSyncKind::NONE : TextDocumentSyncKind::FULL;

--- a/src/Phan/LanguageServer/Protocol/SaveOptions.php
+++ b/src/Phan/LanguageServer/Protocol/SaveOptions.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Phan\LanguageServer\Protocol;
+
+/**
+ * TODO: Contribute to php-language-server?
+ * Based on SaveOptions description in
+ * https://microsoft.github.io/language-server-protocol/specification
+ */
+class SaveOptions
+{
+    /**
+     * @var bool|null
+     * The client is supposed to include the content on save.
+     */
+    public $includeText;
+}

--- a/src/Phan/LanguageServer/Protocol/ServerCapabilities.php
+++ b/src/Phan/LanguageServer/Protocol/ServerCapabilities.php
@@ -11,7 +11,7 @@ class ServerCapabilities
     /**
      * Defines how text documents are synced.
      *
-     * @var int|null
+     * @var TextDocumentSyncOptions|int|null
      */
     public $textDocumentSync;
 

--- a/src/Phan/LanguageServer/Protocol/TextDocumentSyncOptions.php
+++ b/src/Phan/LanguageServer/Protocol/TextDocumentSyncOptions.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Phan\LanguageServer\Protocol;
+
+/**
+ * TODO: Contribute to php-language-server?
+ * Based on TextDocumentSyncOptions description in
+ * https://microsoft.github.io/language-server-protocol/specification
+ */
+class TextDocumentSyncOptions
+{
+    /**
+     * @var bool|null
+     * Open and close notifications are sent to the server.
+     */
+    public $openClose;
+    /**
+     * @var int|null
+     * Change notifications are sent to the server. See TextDocumentSyncKind.None, TextDocumentSyncKind.Full
+     * and TextDocumentSyncKindIncremental.
+     */
+    public $change;
+
+    /**
+     * @var bool|null
+     * Will save notifications get sent to the server.
+     */
+    public $willSave;
+
+    /**
+     * @var bool|null
+     * Will save wait until requests get sent to the server.
+     */
+    public $willSaveWaitUntil;
+
+    /**
+     * @var SaveOptions|null
+     * Save notifications are sent to the server.
+     */
+    public $save;
+}

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -1218,19 +1218,43 @@ class ParseVisitor extends ScopeVisitor
 
     // common no-ops
     /** @return Context */
-    public function visitArrayElem(Node $node) { return $this->context; }
+    public function visitArrayElem(Node $node)
+    {
+        return $this->context;
+    }
     /** @return Context */
-    public function visitVar(Node $node) { return $this->context; }
+    public function visitVar(Node $node)
+    {
+        return $this->context;
+    }
     /** @return Context */
-    public function visitName(Node $node) { return $this->context; }
+    public function visitName(Node $node)
+    {
+        return $this->context;
+    }
     /** @return Context */
-    public function visitArgList(Node $node) { return $this->context; }
+    public function visitArgList(Node $node)
+    {
+        return $this->context;
+    }
     /** @return Context */
-    public function visitStmtList(Node $node) { return $this->context; }
+    public function visitStmtList(Node $node)
+    {
+        return $this->context;
+    }
     /** @return Context */
-    public function visitProp(Node $node) { return $this->context; }
+    public function visitProp(Node $node)
+    {
+        return $this->context;
+    }
     /** @return Context */
-    public function visitArray(Node $node) { return $this->context; }
+    public function visitArray(Node $node)
+    {
+        return $this->context;
+    }
     /** @return Context */
-    public function visitBinaryOp(Node $node) { return $this->context; }
+    public function visitBinaryOp(Node $node)
+    {
+        return $this->context;
+    }
 }


### PR DESCRIPTION
The save notification wasn't getting sent with TextDocumentSyncKind::NONE.

(TextDocumentSyncOptions might not be supported in older language server
protocol clients. But vscode-php-phan is bundled with the latest client
library, so it should work)