### PR TITLE
Improve type narrowing for iterable -> Traversable/array

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -55,6 +55,8 @@ New Features(Analysis)
   for params and return types that were previously untyped.
   (Imported from docs.php.net's SVN repo)
 + More precise analysis of the return types of `var_export()`, `print_r()`, and `json_decode()` (#1326, #1327)
++ Improve type narrowing from `iterable` to `\Traversable`/`array` (#1427)
+  This change affects `is_array()`/`is_object()` checks and their negations.
 
 Plugins
 + Fix bugs in NonBoolBranchPlugin and NonBoolInLogicalArithPlugin (#1413, #1410)

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -1293,6 +1293,16 @@ class Type
 
     /**
      * @return bool
+     * True if this type is possibly an object (or the phpdoc `object`)
+     * This is the same as isObject(), except that it returns true for the exact class of IterableType.
+     */
+    public function isPossiblyObject() : bool
+    {
+        return true;  // Overridden in various subclasses
+    }
+
+    /**
+     * @return bool
      * True if this type is iterable.
      */
     public function isIterable() : bool

--- a/src/Phan/Language/Type/ArrayType.php
+++ b/src/Phan/Language/Type/ArrayType.php
@@ -18,6 +18,11 @@ class ArrayType extends IterableType
         // There's no EmptyArrayType, so return $this
         return $this;
     }
+
+    public function isPossiblyObject() : bool
+    {
+        return false;  // Overrides IterableType returning true
+    }
 }
 // Trigger the autoloader for GenericArrayType so that it won't be called
 // before ArrayType.

--- a/src/Phan/Language/Type/IterableType.php
+++ b/src/Phan/Language/Type/IterableType.php
@@ -13,6 +13,11 @@ class IterableType extends NativeType
         return true;
     }
 
+    public function isPossiblyObject() : bool
+    {
+        return true;  // can be Traversable, which is an object
+    }
+
     /**
      * @return bool
      * True if this type is array-like (is of type array, is

--- a/src/Phan/Language/Type/NativeType.php
+++ b/src/Phan/Language/Type/NativeType.php
@@ -65,6 +65,11 @@ abstract class NativeType extends Type
         return false;
     }
 
+    public function isPossiblyObject() : bool
+    {
+        return false;
+    }
+
     /**
      * @return bool
      * True if this Type can be cast to the given Type

--- a/src/Phan/Language/Type/ObjectType.php
+++ b/src/Phan/Language/Type/ObjectType.php
@@ -27,4 +27,14 @@ final class ObjectType extends NativeType
     {
         return true;  // Overridden in various subclasses
     }
+
+    /**
+     * @return bool
+     * True if this type is an object (or the phpdoc `object`)
+     * @override
+     */
+    public function isPossiblyObject() : bool
+    {
+        return true;
+    }
 }

--- a/src/Phan/Language/Type/StaticType.php
+++ b/src/Phan/Language/Type/StaticType.php
@@ -57,11 +57,6 @@ final class StaticType extends Type
         return true;
     }
 
-    public function isObject() : bool
-    {
-        return true;
-    }
-
     public function __toString() : string
     {
         $string = $this->name;

--- a/src/Phan/Language/Type/TemplateType.php
+++ b/src/Phan/Language/Type/TemplateType.php
@@ -61,4 +61,9 @@ final class TemplateType extends Type
         // Not sure if this will be called.
         return true;
     }
+
+    public function isPossiblyObject() : bool
+    {
+        return true;
+    }
 }

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -1576,6 +1576,20 @@ class UnionType implements \Serializable
     }
 
     /**
+     * Returns true if at least one type could possibly be an object.
+     * E.g. returns true for iterator.
+     * NOTE: this returns false for `mixed`
+     *
+     * @return bool
+     */
+    public function hasPossiblyObjectTypes() : bool
+    {
+        return $this->hasTypeMatchingCallback((function (Type $type) : bool {
+            return $type->isPossiblyObject();
+        }));
+    }
+
+    /**
      * Returns the types for which is_scalar($x) would be true.
      * This means null/nullable is removed.
      * Takes "MyClass|int|?bool|array|?object" and returns "int|bool"

--- a/tests/files/expected/0413_traversable.php.expected
+++ b/tests/files/expected/0413_traversable.php.expected
@@ -1,0 +1,5 @@
+%s:5 PhanTypeMismatchArgumentInternal Argument 1 (string) is array but \strlen() takes string
+%s:9 PhanTypeMismatchReturn Returning type \Traversable but to_array() is declared to return array
+%s:18 PhanUndeclaredMethod Call to undeclared method \Traversable::nnnext
+%s:19 PhanTypeMismatchReturn Returning type \Traversable but check_iterable() is declared to return array
+%s:21 PhanTypeMismatchArgumentInternal Argument 1 (string) is array but \strlen() takes string

--- a/tests/files/src/0413_traversable.php
+++ b/tests/files/src/0413_traversable.php
@@ -1,0 +1,24 @@
+<?php
+
+function to_array(iterable $input): array {
+    if (is_array($input)) {
+        echo strlen($input);  // wrong
+        return $input;
+    } else {
+        if (rand() % 2 > 0) {
+            return $input;  // wrong
+        } else {
+            return iterator_to_array($input, true);
+        }
+    }
+}
+
+function check_iterable(iterable $input) : array {
+    if (is_object($input)) {
+        var_export($input->nnnext());  // does not exist
+        return $input;  // wrong
+    } else {
+        echo strlen($input);  // wrong
+        return $input;
+    }
+}


### PR DESCRIPTION
This change affects `is_array()`/`is_object()` checks and their
negations.

Fixes #1427
Fixes #1428