### PR TITLE
Fix bugs in language server: Stop reading input after forking

### DIFF
--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -467,7 +467,7 @@ class ContextNode
      */
     public function getClassList(bool $ignore_missing_classes = false, int $expected_type_categories = self::CLASS_LIST_ACCEPT_ANY, string $custom_issue_type = null) : array
     {
-        [$union_type, $class_list] = $this->getClassListInner($ignore_missing_classes);
+        list($union_type, $class_list) = $this->getClassListInner($ignore_missing_classes);
         if ($union_type->isEmpty()) {
             return [];
         }

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -2494,9 +2494,11 @@ Node\SourceFileNode
     {
         $nameParts = $name->nameParts;
         // TODO: Handle error case
-        return \implode('', \array_map(function (Token $token) : string {
-            return \trim(self::tokenToString($token));
-        }, $nameParts));
+        $result = '';
+        foreach ($nameParts as $part) {
+            $result .= \trim(self::tokenToString($part));
+        }
+        return $result;
     }
 
     const _NODES_WITH_NULL_DOC_COMMENT = [

--- a/src/Phan/Daemon/Request.php
+++ b/src/Phan/Daemon/Request.php
@@ -218,7 +218,7 @@ class Request
             Daemon::debugf("Already sent response");
             return;
         }
-        fwrite($response_connection, json_encode($response) . "\n");
+        fwrite($response_connection, json_encode($response, JSON_UNESCAPED_SLASHES|JSON_UNESCAPED_UNICODE) . "\n");
         // disable further receptions and transmissions
         // Note: This is likely a giant hack,
         // and pcntl and sockets may break in the future if used together. (multiple processes owning a single resource).
@@ -232,7 +232,7 @@ class Request
         if (isset($this->response_connection)) {
             $this->sendJSONResponse([
                 'status' => self::STATUS_ERROR_UNKNOWN,
-                'message' => 'failed to send a response - Possibly encountered an exception. See daemon output.',
+                'message' => 'failed to send a response - Possibly encountered an exception. See daemon output.' . json_encode(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS)),
             ]);
         }
     }
@@ -311,7 +311,7 @@ class Request
         $request = json_decode($request_bytes, true);
 
         if (!\is_array($request)) {
-            Daemon::debugf("Received invalid request, expected JSON: %s", json_encode($request_bytes));
+            Daemon::debugf("Received invalid request, expected JSON: %s", json_encode($request_bytes, JSON_UNESCAPED_SLASHES));
             self::sendJSONResponseOverSocket($response_connection, [
                 'status'  => self::STATUS_INVALID_REQUEST,
                 'message' => 'malformed JSON',

--- a/src/Phan/LanguageServer/LanguageServer.php
+++ b/src/Phan/LanguageServer/LanguageServer.php
@@ -111,12 +111,19 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
      */
     protected $file_mapping;
 
+    private $is_accepting_new_requests = true;
+
     public function __construct(ProtocolReader $reader, ProtocolWriter $writer, CodeBase $code_base, Closure $file_path_lister)
     {
         parent::__construct($this, '/');
         $this->protocolReader = $reader;
         $this->file_mapping = new FileMapping();
         $reader->on('close', function () {
+            if (!$this->is_accepting_new_requests) {
+                // This is the forked process, which forced the ProtocolReader to close. Don't exit().
+                // Instead, carry on and analyze the input files.
+                return;
+            }
             $this->shutdown();
             $this->exit();
         });
@@ -271,7 +278,9 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
             Logger::logInfo("Connected to $address to receive requests");
             Loop\run();
             Logger::logInfo("Finished connecting to $address to receive requests");
-            return $ls->most_recent_request;
+            $most_recent_request = $ls->most_recent_request;
+            $ls->most_recent_request = null;
+            return $most_recent_request;
         } elseif (!empty($options['tcp-server'])) {
             // Run a TCP Server
             $address = $options['tcp-server'];
@@ -307,7 +316,9 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
                         Logger::logInfo("Worker started accepting requests on $address");
                         Loop\run();
                         Logger::logInfo("Worker finished accepting requests on $address");
-                        return $ls->most_recent_request;
+                        $most_recent_request = $ls->most_recent_request;
+                        $ls->most_recent_request = null;
+                        return $most_recent_request;;
                     }
                 } else {*/
                     // To avoid edge cases, we only accept one connection.
@@ -317,10 +328,12 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
                         new ProtocolStreamReader($socket),
                         new ProtocolStreamWriter($socket)
                     );
-                    Logger::logInfo("Started listening on stdin");
+                    Logger::logInfo("Started listening on tcp");
                     Loop\run();
-                    Logger::logInfo("Finished listening on stdin");
-                    return $ls->most_recent_request;
+                    Logger::logInfo("Finished listening on tcp");
+                    $most_recent_request = $ls->most_recent_request;
+                    $ls->most_recent_request = null;
+                    return $most_recent_request;;
                 /* } */
             }
         } else {
@@ -334,7 +347,9 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
             Logger::logInfo("Started listening on stdin");
             Loop\run();
             Logger::logInfo("Finished listening on stdin");
-            return $ls->most_recent_request;
+            $most_recent_request = $ls->most_recent_request;
+            $ls->most_recent_request = null;
+            return $most_recent_request;;
         }
     }
 
@@ -409,6 +424,9 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
         // FIXME update the parsed file lists before and after (e.g. add to analyzeURI). See Daemon\Request::accept()
         //    TODO: refactor accept() to make it easier to work with.
         // TODO: add unit tests
+
+        $this->protocolReader->stopAcceptingNewRequests();
+        $this->is_accepting_new_requests = false;
         Loop\stop();  // abort the loop (without closing streams?)
     }
 

--- a/src/Phan/LanguageServer/ProtocolReader.php
+++ b/src/Phan/LanguageServer/ProtocolReader.php
@@ -16,5 +16,8 @@ use Sabre\Event\EmitterInterface;
  */
 interface ProtocolReader extends EmitterInterface
 {
-
+    /**
+     * @return void
+     */
+    public function stopAcceptingNewRequests();
 }

--- a/src/Phan/LanguageServer/ProtocolStreamReader.php
+++ b/src/Phan/LanguageServer/ProtocolStreamReader.php
@@ -20,6 +20,12 @@ class ProtocolStreamReader extends Emitter implements ProtocolReader
 
     /** @var resource */
     private $input;
+    /**
+     * This is checked by ProtocolStreamReader so that it will stop reading from streams in the forked process.
+     * There could be buffered bytes in stdin/over TCP, those would be processed by TCP if it were not for this check.
+     * @var bool
+     */
+    private $is_accepting_new_requests = true;
     /** @var int */
     private $parsingMode = self::PARSE_HEADERS;
     /** @var string */
@@ -47,6 +53,11 @@ class ProtocolStreamReader extends Emitter implements ProtocolReader
                 $this->emit('close');
                 return;
             }
+            if (!$this->is_accepting_new_requests) {
+                // If we fork, don't read any bytes in the input buffer from the worker process.
+                $this->emit('close');
+                return;
+            }
             $c = '';
             while (($c = fgetc($this->input)) !== false && $c !== '') {
                 $this->buffer .= $c;
@@ -64,6 +75,11 @@ class ProtocolStreamReader extends Emitter implements ProtocolReader
                         break;
                     case self::PARSE_BODY:
                         if (strlen($this->buffer) === $this->contentLength) {
+                            if (!$this->is_accepting_new_requests) {
+                                // If we fork, don't read any bytes in the input buffer from the worker process.
+                                $this->emit('close');
+                                return;
+                            }
                             Logger::logRequest($this->headers, $this->buffer);
                             // MessageBody::parse can throw an Error, maybe log an error?
                             try {
@@ -73,6 +89,11 @@ class ProtocolStreamReader extends Emitter implements ProtocolReader
                             }
                             if ($msg) {
                                 $this->emit('message', [$msg]);
+                                if (!$this->is_accepting_new_requests) {
+                                    // If we fork, don't read any bytes in the input buffer from the worker process.
+                                    $this->emit('close');
+                                    return;
+                                }
                             }
                             $this->parsingMode = self::PARSE_HEADERS;
                             $this->headers = [];
@@ -82,5 +103,12 @@ class ProtocolStreamReader extends Emitter implements ProtocolReader
                 }
             }
         });
+    }
+
+    /**
+     * @return void
+     */
+    public function stopAcceptingNewRequests() {
+        $this->is_accepting_new_requests = false;
     }
 }

--- a/tests/Phan/LanguageServer/MockProtocolStream.php
+++ b/tests/Phan/LanguageServer/MockProtocolStream.php
@@ -28,4 +28,14 @@ class MockProtocolStream extends Emitter implements ProtocolReader, ProtocolWrit
         });
         return Promise\resolve(null);
     }
+
+    /** @var bool TODO: use in tests */
+    public $did_stop_accepting_new_requests = false;
+
+    /**
+     * @return void
+     */
+    public function stopAcceptingNewRequests() {
+        $this->did_stop_accepting_new_requests = true;
+    }
 }


### PR DESCRIPTION
And don't exit() from LanguageServer if the current process
is the forked process that is acting on behalf of
the main language server process.