### PR TITLE
Fix edge cases causing Phan to fail to inherit constants/properties/methods

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -57,6 +57,7 @@ New Features(Analysis)
 + More precise analysis of the return types of `var_export()`, `print_r()`, and `json_decode()` (#1326, #1327)
 + Improve type narrowing from `iterable` to `\Traversable`/`array` (#1427)
   This change affects `is_array()`/`is_object()` checks and their negations.
++ Fix more edge cases which may cause Phan to fail to infer that properties, constants, or methods are inherited. (#311, #1426, #454)
 
 Plugins
 + Fix bugs in NonBoolBranchPlugin and NonBoolInLogicalArithPlugin (#1413, #1410)
@@ -74,6 +75,7 @@ Bug fixes
 + Warn when attempting to call an instance method on an expression with type string (#1314).
 + Fix a bug in `tool/make_stubs` when generating stubs of global functions.
 + Fix some bugs that occurred when Phan resolved inherited class constants in class elements such as properties. (#537 and #454)
++ Emit an issue when a function/method's parameter defaults refer to an undeclared class constant/global constant.
 
 20 Jan 2018, Phan 0.10.3
 ------------------------

--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -241,6 +241,8 @@ class Analysis
             if ($function_or_method->isPHPInternal()) {
                 return;
             }
+            // Phan always has to call this, to add default values to types of parameters.
+            $function_or_method->ensureScopeInitialized($code_base);
 
             // If there is an array limiting the set of files, skip this file if it's not in the list,
             if (\is_array($file_filter) && !isset($file_filter[$function_or_method->getContext()->getFile()])) {

--- a/src/Phan/Analysis/Analyzable.php
+++ b/src/Phan/Analysis/Analyzable.php
@@ -5,6 +5,7 @@ use Phan\BlockAnalysisVisitor;
 use Phan\CodeBase;
 use Phan\Config;
 use Phan\Language\Context;
+use Phan\Language\Element\FunctionInterface;
 use ast\Node;
 
 /**
@@ -59,7 +60,7 @@ trait Analyzable
      * @return Node
      * The AST node associated with this object
      */
-    public function getNode() : Node
+    public function getNode()
     {
         return $this->node;
     }

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -2129,7 +2129,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
      */
     private function updateParameterTypeByArgument(
         FunctionInterface $method,
-        Variable $parameter,
+        Parameter $parameter,
         $argument,
         UnionType $argument_type,
         array &$parameter_list,

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -117,16 +117,18 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
     public function visitMethod(Node $node) : Context
     {
         $method_name = (string)$node->children['name'];
+        $code_base = $this->code_base;
+        $context = $this->context;
 
         \assert(
-            $this->context->isInClassScope(),
+            $context->isInClassScope(),
             "Must be in class context to see a method"
         );
 
         $clazz = $this->getContextClass();
 
         if (!$clazz->hasMethodWithName(
-            $this->code_base,
+            $code_base,
             $method_name
         )) {
             throw new CodeBaseException(
@@ -136,19 +138,14 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
         }
 
         $method = $clazz->getMethodByName(
-            $this->code_base,
+            $code_base,
             $method_name
         );
+        $method->ensureScopeInitialized($code_base);
 
         // Parse the comment above the method to get
         // extra meta information about the method.
-        $comment = Comment::fromStringInContext(
-            $node->children['docComment'] ?? '',
-            $this->code_base,
-            $this->context,
-            $node->lineno ?? 0,
-            Comment::ON_METHOD
-        );
+        $comment = $method->getComment();
 
         $context = $this->context->withScope(
             $method->getInternalScope()
@@ -156,10 +153,12 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
 
         // For any @var references in the method declaration,
         // add them as variables to the method's scope
-        foreach ($comment->getVariableList() as $parameter) {
-            $context->addScopeVariable(
-                $parameter->asVariable($this->context)
-            );
+        if ($comment !== null) {
+            foreach ($comment->getVariableList() as $parameter) {
+                $context->addScopeVariable(
+                    $parameter->asVariable($this->context)
+                );
+            }
         }
 
         // Add $this to the scope of non-static methods
@@ -188,6 +187,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
             }
         }
 
+        // TODO: Why is the check for yield in PreOrderAnalysisVisitor?
         if ($method->getHasYield()) {
             $this->setReturnTypeOfGenerator($method, $node);
         }
@@ -208,11 +208,13 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
     public function visitFuncDecl(Node $node) : Context
     {
         $function_name = (string)$node->children['name'];
+        $code_base = $this->code_base;
+        $original_context = $this->context;
 
         try {
             $canonical_function = (new ContextNode(
-                $this->code_base,
-                $this->context,
+                $code_base,
+                $original_context,
                 $node
             ))->getFunction($function_name, true);
         } catch (CodeBaseException $exception) {
@@ -225,9 +227,9 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
         // Hunt for the alternate associated with the file we're
         // looking at currently in this context.
         $function = null;
-        foreach ($canonical_function->alternateGenerator($this->code_base) as $alternate_function) {
+        foreach ($canonical_function->alternateGenerator($code_base) as $alternate_function) {
             if ($alternate_function->getFileRef()->getProjectRelativePath()
-                === $this->context->getProjectRelativePath()
+                === $original_context->getProjectRelativePath()
             ) {
                 $function = $alternate_function;
                 break;
@@ -243,28 +245,25 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
         }
 
         \assert($function instanceof Func);
+        $function->ensureScopeInitialized($code_base);
 
-        $context = $this->context->withScope(
+        $context = $original_context->withScope(
             $function->getInternalScope()
         );
 
         // Parse the comment above the function to get
         // extra meta information about the method.
         // TODO: Investigate caching information from Comment::fromStringInContext?
-        $comment = Comment::fromStringInContext(
-            $node->children['docComment'] ?? '',
-            $this->code_base,
-            $this->context,
-            $node->lineno ?? 0,
-            Comment::ON_FUNCTION
-        );
+        $comment = $function->getComment();
 
         // For any @var references in the method declaration,
         // add them as variables to the method's scope
-        foreach ($comment->getVariableList() as $parameter) {
-            $context->addScopeVariable(
-                $parameter->asVariable($this->context)
-            );
+        if ($comment !== null) {
+            foreach ($comment->getVariableList() as $parameter) {
+                $context->addScopeVariable(
+                    $parameter->asVariable($this->context)
+                );
+            }
         }
 
         if ($function->getRecursionDepth() === 0) {
@@ -363,20 +362,21 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
      */
     public function visitClosure(Node $node) : Context
     {
+        $code_base = $this->code_base;
+        $context = $this->context;
         $closure_fqsen = FullyQualifiedFunctionName::fromClosureInContext(
-            $this->context->withLineNumberStart($node->lineno ?? 0),
+            $context->withLineNumberStart($node->lineno ?? 0),
             $node
         );
-        $func = $this->code_base->getFunctionByFQSEN($closure_fqsen);
-
-        $context = $this->context;
+        $func = $code_base->getFunctionByFQSEN($closure_fqsen);
+        $func->ensureScopeInitialized($code_base);
 
         // If we have a 'this' variable in our current scope,
         // pass it down into the closure
-        self::addThisVariableToInternalScope($this->code_base, $context, $func);
+        self::addThisVariableToInternalScope($code_base, $context, $func);
 
         // Make the closure reachable by FQSEN from anywhere
-        $this->code_base->addFunction($func);
+        $code_base->addFunction($func);
 
         if (!empty($node->children['uses'])
             && $node->children['uses']->kind == \ast\AST_CLOSURE_USES
@@ -392,7 +392,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
                 }
 
                 $variable_name = (new ContextNode(
-                    $this->code_base,
+                    $code_base,
                     $context,
                     $use->children['name']
                 ))->getVariableName();

--- a/src/Phan/Language/Element/ElementFutureUnionType.php
+++ b/src/Phan/Language/Element/ElementFutureUnionType.php
@@ -36,6 +36,18 @@ trait ElementFutureUnionType
     }
 
     /**
+     * @return bool
+     * Returns true if this element has an unresolved union type.
+     *
+     * @internal - Mostly useful for Phan internals
+     *             (e.g. a property with an unresolved future union type can't have a template type)
+     */
+    public function hasUnresolvedFutureUnionType() : bool
+    {
+        return $this->future_union_type !== null;
+    }
+
+    /**
      * @return UnionType|null
      * Get the UnionType from a future union type defined
      * on this object or null if there is no future

--- a/src/Phan/Language/Element/Func.php
+++ b/src/Phan/Language/Element/Func.php
@@ -177,7 +177,6 @@ class Func extends AddressableElement implements FunctionInterface
             }
         }
 
-
         // @var array<int,Parameter>
         // The list of parameters specified on the
         // function
@@ -194,7 +193,7 @@ class Func extends AddressableElement implements FunctionInterface
             );
         }
 
-        if (!$context->isPHPInternal()) {
+        if (!$func->isPHPInternal()) {
             // If the function is Analyzable, set the node so that
             // we can come back to it whenever we like and
             // rescan it
@@ -260,8 +259,9 @@ class Func extends AddressableElement implements FunctionInterface
             $func->setPHPDocReturnType($union_type);
         }
 
-        // Add params to local scope for user functions
-        FunctionTrait::addParamsToScopeOfFunctionOrMethod($context, $code_base, $node, $func, $comment);
+        // Defer adding params to the local scope for user functions. (FunctionTrait::addParamsToScopeOfFunctionOrMethod)
+        // See PreOrderAnalysisVisitor->visitFuncDecl and visitClosure
+        $func->setComment($comment);
 
         return $func;
     }

--- a/src/Phan/Language/Element/FunctionInterface.php
+++ b/src/Phan/Language/Element/FunctionInterface.php
@@ -307,4 +307,26 @@ interface FunctionInterface extends AddressableElementInterface
      * @return void
      */
     public function setFunctionCallAnalyzer(\Closure $closure);
+
+    /**
+     * Initialize the inner scope of this method with variables created from the parameters.
+     *
+     * Deferred until the parse phase because getting the UnionType of parameter defaults requires having all class constants be known.
+     *
+     * @return void
+     */
+    public function ensureScopeInitialized(CodeBase $code_base);
+
+    /** @return Node */
+    public function getNode();
+
+    /**
+     * @return ?Comment - Not set for internal functions/methods
+     */
+    public function getComment();
+
+    /**
+     * @param Comment $comment
+     */
+    public function setComment(Comment $comment);
 }

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -395,7 +395,7 @@ class Method extends ClassElement implements FunctionInterface
             );
         }
 
-        if (!$context->isPHPInternal()) {
+        if (!$method->isPHPInternal()) {
             // If the method is Analyzable, set the node so that
             // we can come back to it whenever we like and
             // rescan it
@@ -478,8 +478,9 @@ class Method extends ClassElement implements FunctionInterface
             $method->setPHPDocReturnType($comment_return_union_type);
         }
 
-        // Add params to local scope for user functions
-        FunctionTrait::addParamsToScopeOfFunctionOrMethod($context, $code_base, $node, $method, $comment);
+        // Defer adding params to the local scope for user functions. (FunctionTrait::addParamsToScopeOfFunctionOrMethod)
+        // See PostOrderAnalysisVisitor->analyzeCallToMethod
+        $method->setComment($comment);
 
         return $method;
     }

--- a/src/Phan/Language/Element/Variable.php
+++ b/src/Phan/Language/Element/Variable.php
@@ -55,22 +55,6 @@ class Variable extends UnaddressableTypedElement
     ];
 
     /**
-     * @param FileRef $file_ref
-     * The file and lines in which the unaddressable element lives
-     *
-     * @param string $name
-     * The name of the typed structural element
-     *
-     * @param UnionType $type
-     * A '|' delimited set of types satisfyped by this
-     * typed structural element.
-     *
-     * @param int $flags
-     * The flags property contains node specific flags. It is
-     * always defined, but for most nodes it is always zero.
-     * ast\kind_uses_flags() can be used to determine whether
-     * a certain kind has a meaningful flags value.
-     */
     public function __construct(
         FileRef $file_ref,
         string $name,
@@ -84,6 +68,7 @@ class Variable extends UnaddressableTypedElement
             $flags
         );
     }
+     */
 
     /**
      * @return bool

--- a/src/Phan/Language/FutureUnionType.php
+++ b/src/Phan/Language/FutureUnionType.php
@@ -57,4 +57,20 @@ class FutureUnionType
             false
         );
     }
+
+    /**
+     * @internal (May rethink exposing the codebase in the future)
+     */
+    public function getCodebase() : CodeBase
+    {
+        return $this->code_base;
+    }
+
+    /**
+     * @internal (May rethink exposing the codebase in the future)
+     */
+    public function getContext() : Context
+    {
+        return $this->context;
+    }
 }

--- a/src/Phan/LanguageServer/LanguageServer.php
+++ b/src/Phan/LanguageServer/LanguageServer.php
@@ -333,7 +333,8 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
                     Logger::logInfo("Finished listening on tcp");
                     $most_recent_request = $ls->most_recent_request;
                     $ls->most_recent_request = null;
-                    return $most_recent_request;;
+                    return $most_recent_request;
+                ;
                 /* } */
             }
         } else {
@@ -349,7 +350,8 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
             Logger::logInfo("Finished listening on stdin");
             $most_recent_request = $ls->most_recent_request;
             $ls->most_recent_request = null;
-            return $most_recent_request;;
+            return $most_recent_request;
+            ;
         }
     }
 

--- a/src/Phan/LanguageServer/ProtocolStreamReader.php
+++ b/src/Phan/LanguageServer/ProtocolStreamReader.php
@@ -108,7 +108,8 @@ class ProtocolStreamReader extends Emitter implements ProtocolReader
     /**
      * @return void
      */
-    public function stopAcceptingNewRequests() {
+    public function stopAcceptingNewRequests()
+    {
         $this->is_accepting_new_requests = false;
     }
 }

--- a/src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php
@@ -87,7 +87,11 @@ final class DependentReturnTypeOverridePlugin extends PluginV2 implements
             Context $context,
             Func $function,
             array $args
-        ) use ($json_decode_array_types, $json_decode_object_types, $json_decode_array_or_object_types) {
+        ) use (
+            $json_decode_array_types,
+            $json_decode_object_types,
+            $json_decode_array_or_object_types
+) {
             //  mixed json_decode ( string $json [, bool $assoc = FALSE [, int $depth = 512 [, int $options = 0 ]]] )
             //  $options can include JSON_OBJECT_AS_ARRAY in a bitmask
             // TODO: reject `...` operator? (Low priority)

--- a/tests/Phan/LanguageServer/MockProtocolStream.php
+++ b/tests/Phan/LanguageServer/MockProtocolStream.php
@@ -35,7 +35,8 @@ class MockProtocolStream extends Emitter implements ProtocolReader, ProtocolWrit
     /**
      * @return void
      */
-    public function stopAcceptingNewRequests() {
+    public function stopAcceptingNewRequests()
+    {
         $this->did_stop_accepting_new_requests = true;
     }
 }

--- a/tests/files/expected/0415_class_property_hydration_fail.php.expected
+++ b/tests/files/expected/0415_class_property_hydration_fail.php.expected
@@ -1,0 +1,1 @@
+%s:18 PhanUndeclaredConstant Reference to undeclared constant \D415::MISSING_CONSTNAME

--- a/tests/files/expected/0416_method_hydration_test.php.expected
+++ b/tests/files/expected/0416_method_hydration_test.php.expected
@@ -1,0 +1,1 @@
+%s:30 PhanUndeclaredConstant Reference to undeclared constant \D416::MISSING_CONSTNAME

--- a/tests/files/src/0415_class_property_hydration_fail.php
+++ b/tests/files/src/0415_class_property_hydration_fail.php
@@ -1,0 +1,19 @@
+<?php
+
+// Regression test for Phan failing to hydrate classes if properties used inherited constants
+
+class A415 {
+    const CONSTNAME = 2;
+}
+
+class C415 extends B415 {
+    public $otherProperty = D415::CONSTNAME;
+}
+
+class D415 extends C415 {
+}
+
+class B415 extends A415 {
+    public $property = D415::CONSTNAME;
+    public $badProperty = D415::MISSING_CONSTNAME;
+}

--- a/tests/files/src/0416_method_hydration_test.php
+++ b/tests/files/src/0416_method_hydration_test.php
@@ -1,0 +1,33 @@
+<?php
+
+// Ensure that phan can properly hydrate classes if method parameter defaults use inherited constants.
+
+class A416 {
+    const CONSTNAME = 2;
+}
+
+class C416 extends B416 {
+    public function test($param = D416::CONSTNAME) {
+        return $param;
+    }
+    /** @var int $param */
+    public function test2($param = D416::CONSTNAME) {
+        return $param;
+    }
+}
+
+class D416 extends C416 {
+}
+
+class B416 extends A416 {
+    /** @var int $param */
+    public function test3($param = D416::CONSTNAME) {
+        return $param;
+    }
+    public function test4($param = D416::CONSTNAME) {
+        return $param;
+    }
+    public function test5($param = D416::MISSING_CONSTNAME) {
+        return $param;
+    }
+}


### PR DESCRIPTION
Two common edge cases have been fixed in the following ways:

1. Allow Phan to hydrate the values of class constants without hydrating
   the methods and properties. Also, consistently use FutureUnionType when first creating class constants.
   (Except for nodes that are obvious literals)
2. Be consistent about using FutureUnionType to infer the type of
   method parameter defaults.

   Parameter defaults may refer to class constants and global constants
   that won't exist before the parse phase is completely finished.

This PR required moving some parts of the code from the parse phase to the
method/analysis phases. Those parts include:

- For Phan-style generic PHP classes,
  Check if __construct() in the method analysis phase or later
  (The code needed to resolve parameter defaults)
- Defer adding variables to the inner scope of
  functions/methods/closures until **after** the parse phase.
  They are now resolved when Phan starts to analyze that method.

  In order to get the default types of those variables,
  Phan needed to know the types of parameter defaults,

This PR also fixes a bug/completes a TODO.
Now, Phan will warn about an undeclared constant in a parameter default.

For Issue #311, #1426, and #454