### PR TITLE
Fix premature hydration of ancestor classes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@ Maintenance:
 
 Bug fixes
 + Fix a bug in `tool/make_stubs` when generating stubs of namespaced global functions.
++ Fix a refactoring bug that caused methods and properties to fail to be inherited (#1456)
 
 11 Feb 2018, Phan 0.10.4
 ------------------------

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -1346,7 +1346,7 @@ class ContextNode
     public function getClassConst() : ClassConstant
     {
         \assert(
-            $this->node instanceof ast\Node,
+            $this->node instanceof Node,
             '$this->node must be a node'
         );
 

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -646,6 +646,7 @@ class CodeBase
         $this->fqsen_class_map_internal[$fqsen] = $class;
         unset($this->fqsen_class_map_reflection[$fqsen]);
     }
+
     /**
      * @param FullyQualifiedClassName $fqsen
      * The FQSEN of a class to get
@@ -672,6 +673,19 @@ class CodeBase
         }
 
         return $clazz;
+    }
+
+    /**
+     * @param FullyQualifiedClassName $fqsen
+     * The FQSEN of a class to get
+     *
+     * @return Clazz
+     * A class with the given FQSEN
+     */
+    public function getClassByFQSENWithoutHydrating(
+        FullyQualifiedClassName $fqsen
+    ) : Clazz {
+        return $this->fqsen_class_map[$fqsen];
     }
 
     /**

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -449,6 +449,34 @@ class Clazz extends AddressableElement
         );
     }
 
+    /**
+     * @return Clazz
+     * The parent class of this class if defined
+     *
+     * @throws \Exception
+     * An exception is thrown if this class has no parent
+     */
+    private function getParentClassWithoutHydrating(CodeBase $code_base) : Clazz
+    {
+        $parent_type_option = $this->getParentTypeOption();
+
+        if (!$parent_type_option->isDefined()) {
+            throw new \Exception("Class $this has no parent");
+        }
+
+        $parent_fqsen = $parent_type_option->get()->asFQSEN();
+        \assert($parent_fqsen instanceof FullyQualifiedClassName);
+
+        // invoking hasClassWithFQSEN also has the side effect of lazily loading the parent class definition.
+        if (!$code_base->hasClassWithFQSEN($parent_fqsen)) {
+            throw new \Exception("Failed to load parent Class $parent_fqsen of Class $this");
+        }
+
+        return $code_base->getClassByFQSENWithoutHydrating(
+            $parent_fqsen
+        );
+    }
+
     public function isSubclassOf(CodeBase $code_base, Clazz $other) : bool
     {
         if (!$this->hasParentType()) {
@@ -1824,7 +1852,7 @@ class Clazz extends AddressableElement
                 continue;
             }
 
-            $ancestor = $code_base->getClassByFQSEN($fqsen);
+            $ancestor = $code_base->getClassByFQSENWithoutHydrating($fqsen);
             $this->importConstantsFromAncestorClass(
                 $code_base,
                 $ancestor
@@ -1836,7 +1864,7 @@ class Clazz extends AddressableElement
                 continue;
             }
 
-            $ancestor = $code_base->getClassByFQSEN($fqsen);
+            $ancestor = $code_base->getClassByFQSENWithoutHydrating($fqsen);
             $this->importConstantsFromAncestorClass(
                 $code_base,
                 $ancestor
@@ -1935,7 +1963,7 @@ class Clazz extends AddressableElement
         }
 
         // Get the parent class
-        $parent = $this->getParentClass($code_base);
+        $parent = $this->getParentClassWithoutHydrating($code_base);
 
         // import constants from that class
         $this->importConstantsFromAncestorClass($code_base, $parent);
@@ -2086,7 +2114,7 @@ class Clazz extends AddressableElement
         $class->addReference($this->getContext());
 
         // Make sure that the class imports its parents' constants first
-        // (And **only** the constants and
+        // (And **only** the constants)
         $class->hydrateConstants($code_base);
 
         // Copy constants
@@ -2411,7 +2439,7 @@ class Clazz extends AddressableElement
     {
         foreach ($this->getAncestorFQSENList() as $fqsen) {
             if ($code_base->hasClassWithFQSEN($fqsen)) {
-                $code_base->getClassByFQSEN(
+                $code_base->getClassByFQSENWithoutHydrating(
                     $fqsen
                 )->hydrateConstants($code_base);
             }
@@ -2445,7 +2473,7 @@ class Clazz extends AddressableElement
         $original_declared_class_constants = $this->getConstantMap($code_base);
 
         // Load parent methods, properties, constants
-        $this->importAncestorClasses($code_base);
+        $this->importConstantsFromAncestorClasses($code_base);
 
         self::analyzeClassConstantOverrides($code_base, $original_declared_class_constants);
     }
@@ -2463,11 +2491,13 @@ class Clazz extends AddressableElement
 
         foreach ($this->getAncestorFQSENList() as $fqsen) {
             if ($code_base->hasClassWithFQSEN($fqsen)) {
-                $code_base->getClassByFQSEN(
+                $code_base->getClassByFQSENWithoutHydrating(
                     $fqsen
                 )->hydrate($code_base);
             }
         }
+
+        $this->importAncestorClasses($code_base);
 
         // Make sure there are no abstract methods on non-abstract classes
         AbstractMethodAnalyzer::analyzeAbstractMethodsAreImplemented(

--- a/tests/files/expected/0419_email.php.expected
+++ b/tests/files/expected/0419_email.php.expected
@@ -1,0 +1,2 @@
+%s:29 PhanParamTooMany Call with 2 arg(s) to \VerificationEmail419::__construct() which only takes 1 arg(s) defined at %s:4
+%s:30 PhanTypeMismatchReturn Returning type string but _getMethod() is declared to return int

--- a/tests/files/src/0419_email.php
+++ b/tests/files/src/0419_email.php
@@ -1,0 +1,32 @@
+<?php
+
+abstract class VerificationBase419 {
+    public function __construct($method) {
+    }
+
+    const EMAIL = 'email';
+
+    abstract protected function _getMethod();
+
+    protected function _shouldVerify($uid){
+    }
+}
+class VerificationEmail419 extends VerificationBase419 {
+    /**
+     * @var string
+     */
+    protected $_emailConstant = self::EMAIL;
+
+    /**
+     * @var string
+     */
+    protected $_method;
+
+    /**
+     * @return int
+     */
+    protected function _getMethod() {
+        new VerificationEmail419('method', 'extra');
+        return $this->_method;
+    }
+}


### PR DESCRIPTION
When importing ancestor classes,
Phan should hydrate only the constants of the ancestor classes.

- getClassByFQSEN() may cause full hydration.
  Use a different helper method instead.

Fixes #1456

This bug was probably introduced by #1440
This may help with #1455