### PR TITLE
Fixes #1457: Check union type of foreach() before analysis

### DIFF
--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -326,35 +326,6 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitForeach(Node $node) : Context
-    {
-        $expression_type = UnionType::fromNode(
-            $this->context,
-            $this->code_base,
-            $node->children['expr']
-        );
-
-        // Check the expression type to make sure its
-        // something we can iterate over
-        if ($expression_type->isScalar()) {
-            $this->emitIssue(
-                Issue::TypeMismatchForeach,
-                $node->lineno ?? 0,
-                (string)$expression_type
-            );
-        }
-
-        return $this->context;
-    }
-
-    /**
-     * @param Node $node
-     * A node to parse
-     *
-     * @return Context
-     * A new or an unchanged context resulting from
-     * parsing the node
-     */
     public function visitStatic(Node $node) : Context
     {
         $variable = Variable::fromNodeInContext(

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -502,11 +502,21 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
      */
     public function visitForeach(Node $node) : Context
     {
-        $expression_union_type = UnionType::fromNode(
-            $this->context,
+        $expression_union_type = UnionTypeVisitor::unionTypeFromNode(
             $this->code_base,
+            $this->context,
             $node->children['expr']
         );
+
+        // Check the expression type to make sure its
+        // something we can iterate over
+        if ($expression_union_type->isScalar()) {
+            $this->emitIssue(
+                Issue::TypeMismatchForeach,
+                $node->lineno ?? 0,
+                (string)$expression_union_type
+            );
+        }
 
         // Filter out the non-generic types of the
         // expression

--- a/tests/files/src/0420_loop.php
+++ b/tests/files/src/0420_loop.php
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * @return bool
+ */
+function foreach420(stdClass $params) {
+    foreach ($params->results as $reviewItem) {
+        // NOTE: PHP would have already resolved $params->results - This should not cause a warning above.
+        $params = [ ];
+    }
+    return true;
+}


### PR DESCRIPTION
Move the check from PostOrderAnalysisVisitor to
PreOrderAnalysisVisitor.