### PR TITLE
Fixes #1436: Track types if phan ignores undeclared global variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
 # Group the remaining tests into groups.
 env:
   - TEST_SUITES="PhanTest UtilTest RasmusTest LanguageTest"
-  - TEST_SUITES="__FakeSelfTest __FakeRewritingTest __FakePluginTest __FakeFallbackTest __FakeToolTest"
+  - TEST_SUITES="__FakeSelfTest __FakeRewritingTest __FakePluginTest __FakeFallbackTest __FakeToolTest __FakeConfigOverrideTest"
 
 sudo: false
 dist: trusty

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,8 @@ Maintenance:
 Bug fixes
 + Fix a bug in `tool/make_stubs` when generating stubs of namespaced global functions.
 + Fix a refactoring bug that caused methods and properties to fail to be inherited (#1456)
++ If `ignore_undeclared_variables_in_global_scope` is true, then analyze `assert()`
+  and conditionals in the global scope as if the variable was defined after the check.
 
 11 Feb 2018, Phan 0.10.4
 ------------------------

--- a/src/Phan/Analysis/ConditionVisitorUtil.php
+++ b/src/Phan/Analysis/ConditionVisitorUtil.php
@@ -311,9 +311,7 @@ trait ConditionVisitorUtil
             if (Variable::isHardcodedVariableInScopeWithName($var_name, $context->isInGlobalScope())) {
                 return null;
             }
-            if (!Config::getValue('ignore_undeclared_variables_in_global_scope')
-                || !$context->isInGlobalScope()
-            ) {
+            if (!($context->isInGlobalScope() && Config::getValue('ignore_undeclared_variables_in_global_scope'))) {
                 throw new IssueException(
                     Issue::fromType(Issue::UndeclaredVariable)(
                         $context->getFile(),
@@ -322,7 +320,14 @@ trait ConditionVisitorUtil
                     )
                 );
             }
-            return null;
+            $variable = new Variable(
+                $context,
+                $var_name,
+                UnionType::empty(),
+                $var_node->flags
+            );
+            $context->addScopeVariable($variable);
+            return $variable;
         }
         return $context->getScope()->getVariableByName(
             $var_name

--- a/tests/misc/config_override_test/.phan/config.php
+++ b/tests/misc/config_override_test/.phan/config.php
@@ -1,0 +1,57 @@
+<?php
+
+use \Phan\Issue;
+
+/**
+ * This configuration will be read and overlayed on top of the
+ * default configuration. Command line arguments will be applied
+ * after this file is read.
+ *
+ * @see src/Phan/Config.php
+ * See Config for all configurable options.
+ *
+ * This is a config file which tests all built in plugins,
+ * in addition to testing backwards compatibility checks and dead code detection.
+ */
+return [
+
+    // If true, missing properties will be created when
+    // they are first seen. If false, we'll report an
+    // error message.
+    "allow_missing_properties" => false,
+
+    // Allow null to be cast as any type and for any
+    // type to be cast to null.
+    "null_casts_as_any_type" => false,
+
+    // If enabled, scalars (int, float, bool, string, null)
+    // are treated as if they can cast to each other.
+    'scalar_implicit_cast' => false,
+
+    // If true, seemingly undeclared variables in the global
+    // scope will be ignored. This is useful for projects
+    // with complicated cross-file globals that you have no
+    // hope of fixing.
+    'ignore_undeclared_variables_in_global_scope' => false,
+
+    // Backwards Compatibility Checking
+    // Check for $$var[] and $foo->$bar['baz'] and Foo::$bar['baz']() and $this->$bar['baz']
+    'backward_compatibility_checks' => false,
+
+    "quick_mode" => false,
+
+    "simplify_ast" => false,
+
+    'generic_types_enabled' => true,
+
+    'minimum_severity' => Issue::SEVERITY_LOW,
+
+    'directory_list' => ['src'],
+
+    'ignore_undeclared_variables_in_global_scope' => true,
+
+    // A list of plugin files to execute
+    'plugins' => [
+        'NonBoolBranchPlugin',
+    ],
+];

--- a/tests/misc/config_override_test/expected/000_ignore_undeclared_global_variables.php.expected
+++ b/tests/misc/config_override_test/expected/000_ignore_undeclared_global_variables.php.expected
@@ -1,0 +1,3 @@
+src/000_ignore_undeclared_global_variables.php:16: [W999] PhanPluginNonBoolBranch: Non bool value of type string evaluated in if clause
+src/000_ignore_undeclared_global_variables.php:19: [W10004] PhanTypeMismatchArgumentInternal: Argument 1 (numerator) is string but \intdiv() takes int
+src/000_ignore_undeclared_global_variables.php:21: [W999] PhanPluginNonBoolBranch: Non bool value of type string evaluated in if clause

--- a/tests/misc/config_override_test/src/000_ignore_undeclared_global_variables.php
+++ b/tests/misc/config_override_test/src/000_ignore_undeclared_global_variables.php
@@ -1,0 +1,22 @@
+<?php
+
+class A
+{
+    /** @var string */
+    public $b = 'value';
+
+    /** @var bool */
+    public $boolVal = true;
+}
+
+assert($a instanceof A);
+
+echo strlen($a->b);
+if ($a->boolVal) {}
+if ($a->b) {}
+
+if ($myVar instanceof A) {
+    echo intdiv($myVar->b, 2);
+    if ($myVar->boolVal) {}
+    if ($myVar->b) {}
+}

--- a/tests/misc/config_override_test/test.sh
+++ b/tests/misc/config_override_test/test.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# This test suite tests rare config options and configuration modes.
+EXPECTED_PATH=expected/all_output.expected
+ACTUAL_PATH=all_output.actual
+if [ ! -d expected  ]; then
+	echo "Error: must run this script from tests/misc/fallback_test folder" 1>&2
+	exit 1
+fi
+for path in $(echo expected/*.php.expected | LC_ALL=C sort); do cat $path; done > $EXPECTED_PATH
+if [[ $? != 0 ]]; then
+	echo "Failed to concatenate test cases" 1>&2
+	exit 1
+fi
+echo "Running phan in '$PWD' ..."
+rm $ACTUAL_PATH -f || exit 1
+../../../phan --output-mode pylint | tee $ACTUAL_PATH
+# diff returns a non-zero exit code if files differ or are missing
+echo
+echo "Comparing the output:"
+diff $EXPECTED_PATH $ACTUAL_PATH
+EXIT_CODE=$?
+if [ "$EXIT_CODE" == 0 ]; then
+	echo "Files $EXPECTED_PATH and output $ACTUAL_PATH are identical"
+fi
+exit $EXIT_CODE

--- a/tests/run_all_tests
+++ b/tests/run_all_tests
@@ -7,7 +7,7 @@ fi
 
 TEST_SUITES="PhanTest"
 TEST_SUITES+=" UtilTest RasmusTest LanguageTest"
-TEST_SUITES+=" __FakeSelfTest __FakeRewritingTest __FakePluginTest __FakeFallbackTest __FakeToolTest"
+TEST_SUITES+=" __FakeSelfTest __FakeRewritingTest __FakePluginTest __FakeFallbackTest __FakeToolTest __FakeConfigOverrideTest"
 
 FAILURES=""
 for TEST_SUITE in $TEST_SUITES; do

--- a/tests/run_test
+++ b/tests/run_test
@@ -34,6 +34,11 @@ case "$TEST_SUITE" in
 		./test.sh
 		exit $?
 		;;
+	__FakeConfigOverrideTest)
+		cd tests/misc/config_override_test
+		./test.sh
+		exit $?
+		;;
 	__*)
 		echo "Unknown test '$TEST_SUITE' (Tests beginning with __ are not phpunit tests)" 1>&2
 		exit 1


### PR DESCRIPTION
In conditionals such as `assert()` and `if()`

Add a separate group of integration tests for rare config options.