### PR TITLE
Improve Phan's Language Server Protocol implementation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,24 @@
 Phan NEWS
+
+?? ??? 2018, Phan 0.10.6 (dev)
+------------------------
+
+Language Server
++ Make Phan Language Server analyze new files added to a project (Issue #920)
++ Analyze all of the PHP files that are currently opened in the IDE
+  according to the language server client,
+  instead of just the most recently edited file (Issue #1147)
+  (E.g. analyze other files open in tabs or split windows)
++ When closing or deleting a file, clear the issues that were emitted
+  for that file.
++ If analysis requests (opening files, editing files, etc)
+  are arriving faster than Phan can analyze and generate responses,
+  then buffer the file changes (until end of input)
+  and then begin to generate analysis results.
+
+  Hopefully, this should reduce the necessity for limiting Phan to
+  analyzing only on save.
+
 14 Feb 2018, Phan 0.10.5
 ------------------------
 

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -21,7 +21,7 @@ class CLI
     /**
      * This should be updated to x.y.z-dev after every release, and x.y.z before a release.
      */
-    const PHAN_VERSION = '0.10.5';
+    const PHAN_VERSION = '0.10.6-dev';
 
     /**
      * @var OutputInterface

--- a/src/Phan/LanguageServer/FileMapping.php
+++ b/src/Phan/LanguageServer/FileMapping.php
@@ -11,10 +11,16 @@ namespace Phan\LanguageServer;
 class FileMapping
 {
     /**
-     * @var string[] maps the absolute paths on disks to the currently edited versions of those files.
+     * @var array<string,string> maps the absolute paths on disks to the currently edited versions of those files.
      * TODO: Won't work with more than one client.
      */
     private $overrides = [];
+
+    /**
+     * @var array<string,string> maps the absolute path on disk to the URI sent by the language server.
+     * This may or may not help avoid creating duplicate requests for a given path.
+     */
+    private $uri_for_path = [];
 
     public function __construct()
     {
@@ -32,7 +38,12 @@ class FileMapping
      */
     public function addOverrideURI(string $uri, $new_contents)
     {
-        $this->addOverride(Utils::uriToPath($uri), $new_contents);
+        $path = Utils::uriToPath($uri);
+        if ($new_contents === null) {
+            $this->removeOverride($path);
+        }
+        $this->uri_for_path[$path] = $uri;
+        $this->addOverride($path, $new_contents);
     }
 
     /**
@@ -58,11 +69,16 @@ class FileMapping
         $this->removeOverride($path);
     }
 
+    public function getURIForPath(string $path) : string {
+        return $this->uri_for_path[$path] ?? Utils::pathToUri($path);
+    }
+
     /**
      * @return void
      */
     public function removeOverride(string $path)
     {
+        unset($this->uri_for_path[$path]);
         unset($this->overrides[$path]);
     }
 }

--- a/src/Phan/LanguageServer/ProtocolStreamReader.php
+++ b/src/Phan/LanguageServer/ProtocolStreamReader.php
@@ -27,13 +27,15 @@ class ProtocolStreamReader extends Emitter implements ProtocolReader
      */
     private $is_accepting_new_requests = true;
     /** @var int */
-    private $parsingMode = self::PARSE_HEADERS;
+    private $parsing_mode = self::PARSE_HEADERS;
     /** @var string */
     private $buffer = '';
     /** @var string[] */
     private $headers = [];
     /** @var int */
-    private $contentLength;
+    private $content_length;
+    /** @var bool */
+    private $did_emit_close = false;
 
     /**
      * @param resource $input
@@ -50,59 +52,72 @@ class ProtocolStreamReader extends Emitter implements ProtocolReader
             if (feof($this->input)) {
                 // If stream_select reported a status change for this stream,
                 // but the stream is EOF, it means it was closed.
-                $this->emit('close');
+                $this->emitClose();
                 return;
             }
             if (!$this->is_accepting_new_requests) {
                 // If we fork, don't read any bytes in the input buffer from the worker process.
-                $this->emit('close');
+                $this->emitClose();
                 return;
             }
-            $c = '';
-            while (($c = fgetc($this->input)) !== false && $c !== '') {
-                $this->buffer .= $c;
-                switch ($this->parsingMode) {
-                    case self::PARSE_HEADERS:
-                        if ($this->buffer === "\r\n") {
-                            $this->parsingMode = self::PARSE_BODY;
-                            $this->contentLength = (int)$this->headers['Content-Length'];
-                            $this->buffer = '';
-                        } elseif (substr($this->buffer, -2) === "\r\n") {
-                            $parts = explode(':', $this->buffer);
-                            $this->headers[$parts[0]] = trim($parts[1]);
-                            $this->buffer = '';
-                        }
-                        break;
-                    case self::PARSE_BODY:
-                        if (strlen($this->buffer) === $this->contentLength) {
-                            if (!$this->is_accepting_new_requests) {
-                                // If we fork, don't read any bytes in the input buffer from the worker process.
-                                $this->emit('close');
-                                return;
-                            }
-                            Logger::logRequest($this->headers, $this->buffer);
-                            // MessageBody::parse can throw an Error, maybe log an error?
-                            try {
-                                $msg = new Message(MessageBody::parse($this->buffer), $this->headers);
-                            } catch (\Exception $e) {
-                                $msg = null;
-                            }
-                            if ($msg) {
-                                $this->emit('message', [$msg]);
-                                if (!$this->is_accepting_new_requests) {
-                                    // If we fork, don't read any bytes in the input buffer from the worker process.
-                                    $this->emit('close');
-                                    return;
-                                }
-                            }
-                            $this->parsingMode = self::PARSE_HEADERS;
-                            $this->headers = [];
-                            $this->buffer = '';
-                        }
-                        break;
-                }
+            $emitted_messages = $this->readMessages();
+            if ($emitted_messages > 0) {
+                $this->emit('readMessageGroup');
             }
         });
+    }
+
+    /**
+     * @return int
+     */
+    private function readMessages() : int {
+        $c = '';
+        $emitted_messages = 0;
+        while (($c = fgetc($this->input)) !== false && $c !== '') {
+            $this->buffer .= $c;
+            switch ($this->parsing_mode) {
+                case self::PARSE_HEADERS:
+                    if ($this->buffer === "\r\n") {
+                        $this->parsing_mode = self::PARSE_BODY;
+                        $this->content_length = (int)$this->headers['Content-Length'];
+                        $this->buffer = '';
+                    } elseif (substr($this->buffer, -2) === "\r\n") {
+                        $parts = explode(':', $this->buffer);
+                        $this->headers[$parts[0]] = trim($parts[1]);
+                        $this->buffer = '';
+                    }
+                    break;
+                case self::PARSE_BODY:
+                    if (strlen($this->buffer) === $this->content_length) {
+                        if (!$this->is_accepting_new_requests) {
+                            // If we fork, don't read any bytes in the input buffer from the worker process.
+                            $this->emitClose();
+                            return $emitted_messages;
+                        }
+                        Logger::logRequest($this->headers, $this->buffer);
+                        // MessageBody::parse can throw an Error, maybe log an error?
+                        try {
+                            $msg = new Message(MessageBody::parse($this->buffer), $this->headers);
+                        } catch (\Exception $e) {
+                            $msg = null;
+                        }
+                        if ($msg) {
+                            $emitted_messages++;
+                            $this->emit('message', [$msg]);
+                            if (!$this->is_accepting_new_requests) {
+                                // If we fork, don't read any bytes in the input buffer from the worker process.
+                                $this->emitClose();
+                                return $emitted_messages;
+                            }
+                        }
+                        $this->parsing_mode = self::PARSE_HEADERS;
+                        $this->headers = [];
+                        $this->buffer = '';
+                    }
+                    break;
+            }
+        }
+        return $emitted_messages;
     }
 
     /**
@@ -111,5 +126,17 @@ class ProtocolStreamReader extends Emitter implements ProtocolReader
     public function stopAcceptingNewRequests()
     {
         $this->is_accepting_new_requests = false;
+    }
+
+    /**
+     * @return void
+     */
+    private function emitClose()
+    {
+        if ($this->did_emit_close) {
+            return;
+        }
+        $this->did_emit_close = true;
+        $this->emit('close');
     }
 }

--- a/src/Phan/LanguageServer/Server/Workspace.php
+++ b/src/Phan/LanguageServer/Server/Workspace.php
@@ -8,6 +8,7 @@ use Phan\LanguageServer\LanguageClient;
 use Phan\LanguageServer\LanguageServer;
 use Phan\LanguageServer\Protocol\FileChangeType;
 use Phan\LanguageServer\Protocol\FileEvent;
+use Phan\LanguageServer\Utils;
 
 /**
  * Provides method handlers for all workspace/* methods
@@ -61,14 +62,14 @@ class Workspace
         // Trigger diagnostics. TODO: Is that necessary?
         foreach ($changes as $change) {
             if ($change->type === FileChangeType::DELETED) {
-                $this->client->textDocument->publishDiagnostics($change->uri, []);
+                $this->client->textDocument->publishDiagnostics(Utils::pathToUri(Utils::uriToPath($change->uri)), []);
             }
         }
         // TODO: more than one file
         foreach ($changes as $change) {
             if ($change->type === FileChangeType::CHANGED) {
                 $uri = $change->uri;
-                $this->server->analyzeURI($uri);
+                $this->server->analyzeURIAsync($uri);
             }
         }
     }

--- a/src/phan.php
+++ b/src/phan.php
@@ -35,7 +35,10 @@ $cli = new CLI();
 $is_issue_found =
     Phan::analyzeFileList(
         $code_base,
-        function () use ($cli) {
+        function (bool $recomputeFileList = false) use ($cli) {
+            if ($recomputeFileList) {
+                $cli->recomputeFileList();
+            }
             return $cli->getFileList();
         }  // Daemon mode will reload the file list.
     );


### PR DESCRIPTION
+ Make Phan Language Server analyze new files added to a project (Fixes #920)
+ Analyze all of the PHP files that are currently opened in the IDE
  according to the language server client,
  instead of just the most recently edited file (Fixes #1147)
  (E.g. analyze other files open in tabs or split windows)
+ When closing or deleting a file, clear the issues that were emitted
  for that file.
+ If analysis requests (opening files, editing files, etc)
  are arriving faster than Phan can analyze and generate responses,
  then buffer the file changes (until end of input)
  and then begin to generate analysis results.

  Hopefully, this should reduce the necessity for limiting Phan to
  analyzing only on save.