### PR TITLE
Add `@phan-var` and `@phan-file-suppress` annotations

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -185,7 +185,6 @@ return [
     // Add any issue types (such as 'PhanUndeclaredMethod')
     // here to inhibit them from being reported
     'suppress_issue_types' => [
-        'PhanPluginMixedKeyNoKey',  // FunctionSignatureMap.php has many of these, intentionally.
         'PhanUnreferencedClosure',  // False positives seen with closures in arrays, TODO: move closure checks closer to what is done by unused variable plugin
         // 'PhanUndeclaredMethod',
     ],

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,45 @@ Phan NEWS
 New Features(CLI, Configs)
 + Add `--init` CLI flag and CLI options to affect the generated config. (#145)
   (Options: `--init-level=1..5`, `--init-analyze-dir=path/to/src`, `--init-analyze-file=path/to/file.php`, `--init-no-composer`, `--init-overwrite`)
++ Add a non-standard way to explicitly set var types inline.  (#890)
+  `; '@phan-var T $varName'; expression_using($varName);` and
+  `; '@phan-var-force T $varName'; expression_using($varName);`
+
+  If Phan sees a string literal containing `@phan-var` in the top level of a statement list, it will immediately set the type of `$varName` to `T` without any type checks.
+  (`@phan-var-force T $x` will do the same thing, and will create the variable if it didn't already exist).
+
+  Note: Due to limitations of the `php-ast` parser, Phan isn't able to use inline doc comments, so this is the solution that was used instead.
+
+  Example Usage:
+
+  ```php
+  $values = mixed_expression();
+
+  // Note: This annotation must go **after** setting the variable.
+  // This has to be a string literal; phan cannot parse inline doc comments.
+  '@phan-var array<int,MyClass> $values';
+
+  foreach ($x as $instance) {
+	  function_expecting_myclass($x);
+  }
+  ```
++ Add a way to suppress issues for the entire file (including within methods, etc.) (#1190)
+  The `@phan-file-suppress` annotation can also be added to phpdoc for classes, etc.
+  This feature is recommended for use at the top of the file or on the first class in the file.
+  It may or may not affect statements above the suppression.
+  This feature may fail to catch certain issues emitted during the parse phase.
+
+  ```php
+  <?php
+  // Add a suppression for remaining statements in this file.
+  '@phan-file-suppress PhanUnreferencedUseNormal (description)';
+  use MyNS\MyClass;
+  // ...
+
+  /** @SomeUnreadableAnnotation {MyClass} */
+  class Example { }
+  ```
+
 
 New Features(Analysis)
 + Add `PhanNoopBinaryOperator` and `PhanNoopUnaryOperator` checks (#1404)

--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -68,7 +68,7 @@ class Context extends FileRef
      * @var array<mixed,mixed>
      * caches union types for a given node
      */
-    private $cache  = [];
+    private $cache = [];
 
     /**
      * Create a new context
@@ -578,6 +578,9 @@ class Context extends FileRef
         CodeBase $code_base,
         string $issue_name
     ) : bool {
+        if ($code_base->hasFileLevelSuppression($this->getFile(), $issue_name)) {
+            return true;
+        }
         if (!$this->isInElementScope()) {
             return false;
         }

--- a/src/Phan/Language/Internal/FunctionSignatureMap.php
+++ b/src/Phan/Language/Internal/FunctionSignatureMap.php
@@ -1,6 +1,10 @@
 <?php // @codingStandardsIgnoreFile (phpcs runs out of memory)
 namespace Phan\Language\Internal;
 
+<<<PHAN
+@phan-file-suppress PhanPluginMixedKeyNoKey (read by Phan when analyzing this file)
+PHAN;
+
 /**
  * Format
  *

--- a/tests/files/expected/0425_inline_var.php.expected
+++ b/tests/files/expected/0425_inline_var.php.expected
@@ -1,0 +1,1 @@
+%s:7 PhanTypeMismatchArgumentInternal Argument 1 (string) is int but \strlen() takes string

--- a/tests/files/expected/0426_inline_var_force.php.expected
+++ b/tests/files/expected/0426_inline_var_force.php.expected
@@ -1,0 +1,4 @@
+%s:6 PhanUndeclaredVariable Variable $prev is undeclared
+%s:10 PhanUndeclaredVariable Variable $prev is undeclared
+%s:22 PhanUnextractableAnnotation Saw unextractable annotation for comment @phan-example-annotation array<int,string> description :
+%s:22 PhanUnextractableAnnotation Saw unextractable annotation for comment @phan-param a value

--- a/tests/files/expected/0427_file_suppress.php.expected
+++ b/tests/files/expected/0427_file_suppress.php.expected
@@ -1,0 +1,2 @@
+%s:10 PhanUnreferencedUseConstant Possibly zero references to use statement for constant MAGIC_FUNCTION (\ast\flags\MAGIC_FUNCTION)
+%s:14 PhanTypeMissingReturn Method \test is declared to return string but has no return value

--- a/tests/files/expected/0428_file_suppress_on_class.php.expected
+++ b/tests/files/expected/0428_file_suppress_on_class.php.expected
@@ -1,0 +1,1 @@
+%s:11 PhanParamTooManyInternal Call with 5 arg(s) to \ast\parse_code() which only takes 3 arg(s)

--- a/tests/files/src/0425_inline_var.php
+++ b/tests/files/src/0425_inline_var.php
@@ -1,0 +1,9 @@
+<?php
+
+/** @param mixed $x */
+function test($x) : int {
+    '@phan-var int $x';
+
+    echo strlen($x);
+    return $x;
+}

--- a/tests/files/src/0426_inline_var_force.php
+++ b/tests/files/src/0426_inline_var_force.php
@@ -1,0 +1,39 @@
+<?php
+
+function example(int ...$values) {
+    $data = ['key' => 'value'];
+    $first = true;
+    $sum = 0;
+    '@phan-var int $prev';
+    foreach ($values as $value) {
+        if (!$first) {
+            $sum += $prev * $value;
+        } else {
+            $first = false;
+            $prev = $value;
+        }
+    }
+    return $sum;
+}
+
+function example2(int ...$values) {
+    $data = ['key' => 'value'];
+    $first = true;
+    $sum = 0;
+    <<<'PHAN'
+start text
+  @phan-example-annotation array<int,string> description :
+other text
+PHAN;
+    '@phan-param a value';
+    '@phan-var-force int $prev';
+    foreach ($values as $value) {
+        if (!$first) {
+            $sum += $prev * $value;
+        } else {
+            $first = false;
+            $prev = $value;
+        }
+    }
+    return $sum;
+}

--- a/tests/files/src/0427_file_suppress.php
+++ b/tests/files/src/0427_file_suppress.php
@@ -1,0 +1,17 @@
+<?php
+
+<<<'PHAN'
+@phan-file-suppress PhanUnreferencedUseFunction
+@phan-file-suppress PhanUndeclaredVariable
+PHAN;
+
+// This is unused, but thanks to the file-level suppression, it doesn't work.
+use function ast\parse_code;
+use const ast\flags\MAGIC_FUNCTION;
+
+echo $someVar;
+
+function test() : string {
+    // PhanUndeclaredVariable has a **file-level** suppression, so this doesn't warn. But we see other warnings.
+    echo $globalVar;
+}

--- a/tests/files/src/0428_file_suppress_on_class.php
+++ b/tests/files/src/0428_file_suppress_on_class.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @phan-file-suppress PhanParamTooFewInternal
+ */
+class MyClass {
+    public function test(string $source) {
+        // This is invalid, but we suppressed it globally
+        \ast\parse_code();
+        // However, passing too many has not been globally suppressed
+        \ast\parse_code($source, 50, 'filename.php', 'extra', 'extra');
+    }
+}
+
+// The phan-file-suppress annotation affects everything below it in the file.
+\ast\parse_code('');


### PR DESCRIPTION
... and `@phan-var-force T $varName`

Fixes #1190 (Adds a way to suppress issues for the entire file)
Fixes #890 (Adds a way to explicitly set variable types inline)

NOTE: Phan does not support inline phpdoc. Those are only available as string literals.
Note: `@phan-var` and `@phan-file-suppress` are also supported
on other elements that have phpdoc (classes, properties, functions, etc)

Example:

```php
$varName = mixed_expression();

'@phan-var MyClass[] $varName';
expression_using($varName);
```

```php
<?php
// Add a suppression for remaining statements in this file.
'@phan-file-suppress PhanUnreferencedUseNormal (description)';
use MyNS\MyClass;
// ...

/** @SomeUnreadableAnnotation MyClass */
class Example { }
```