### PR TITLE
Split out PhanTypeMismatchDimFetchNullable

### DIFF
--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -69,6 +69,7 @@ class Issue
     const TypeMismatchDimAssignment = 'PhanTypeMismatchDimAssignment';
     const TypeMismatchDimEmpty      = 'PhanTypeMismatchDimEmpty';
     const TypeMismatchDimFetch      = 'PhanTypeMismatchDimFetch';
+    const TypeMismatchDimFetchNullable = 'PhanTypeMismatchDimFetchNullable';
     const TypeMismatchUnpackKey     = 'PhanTypeMismatchUnpackKey';
     const TypeMismatchUnpackValue   = 'PhanTypeMismatchUnpackValue';
     const TypeMismatchArrayDestructuringKey = 'PhanTypeMismatchArrayDestructuringKey';
@@ -983,6 +984,14 @@ class Issue
                 'When fetching an array index from a value of type {TYPE}, found an array index of type {TYPE}, but expected the index to be of type {TYPE}',
                 self::REMEDIATION_B,
                 10032
+            ),
+            new Issue(
+                self::TypeMismatchDimFetchNullable,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                'When fetching an array index from a value of type {TYPE}, found an array index of type {TYPE}, but expected the index to be of the non-nullable type {TYPE}',
+                self::REMEDIATION_B,
+                10044
             ),
             new Issue(
                 self::TypeInvalidCallableArraySize,

--- a/tests/files/expected/0354_string_index.php.expected
+++ b/tests/files/expected/0354_string_index.php.expected
@@ -9,5 +9,5 @@
 %s:23 PhanTypeMismatchDimFetch When fetching an array index from a value of type string, found an array index of type string, but expected the index to be of type int
 %s:24 PhanTypeMismatchDimFetch When fetching an array index from a value of type string, found an array index of type null, but expected the index to be of type int
 %s:27 PhanTypeMismatchDimFetch When fetching an array index from a value of type array{offset:string}, found an array index of type array, but expected the index to be of type string
-%s:28 PhanTypeMismatchDimFetch When fetching an array index from a value of type array{offset:string}, found an array index of type null, but expected the index to be of type string
+%s:28 PhanTypeMismatchDimFetchNullable When fetching an array index from a value of type array{offset:string}, found an array index of type null, but expected the index to be of the non-nullable type string
 %s:29 PhanTypeMismatchDimFetch When fetching an array index from a value of type array{offset:string}, found an array index of type int, but expected the index to be of type string

--- a/tests/files/expected/0429_nullable_offsets.php.expected
+++ b/tests/files/expected/0429_nullable_offsets.php.expected
@@ -1,0 +1,6 @@
+%s:11 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is string but \intdiv() takes int
+%s:12 PhanTypeMismatchDimFetch When fetching an array index from a value of type array<int,string>, found an array index of type string, but expected the index to be of type int
+%s:14 PhanTypeMismatchDimFetch When fetching an array index from a value of type array<int,string>, found an array index of type string, but expected the index to be of type int
+%s:16 PhanTypeMismatchDimFetchNullable When fetching an array index from a value of type array<int,string>, found an array index of type ?int, but expected the index to be of the non-nullable type int
+%s:17 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is string but \intdiv() takes int
+%s:17 PhanTypeMismatchDimFetchNullable When fetching an array index from a value of type array<int,string>, found an array index of type ?int, but expected the index to be of the non-nullable type int

--- a/tests/files/src/0429_nullable_offsets.php
+++ b/tests/files/src/0429_nullable_offsets.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @param ?string[] $data
+ * @param array<int,string> $data_int_key
+ * @param array<int,string> $nullable_data_int_key
+ * @param ?int $index
+ */
+function example429($data, $data_int_key, $nullable_data_int_key, $index) {
+    echo strlen($data['opt']);
+    echo intdiv($data['opt'], 2);
+    echo strlen($data_int_key['opt']);
+    echo strlen($data_int_key[2]);
+    echo strlen($nullable_data_int_key['opt']);
+    echo strlen($nullable_data_int_key[2]);
+    echo strlen($nullable_data_int_key[$index]);
+    echo intdiv($nullable_data_int_key[$index], 2);
+}


### PR DESCRIPTION
Fixes #1472

If the non-nullable version of the index would be permissible,
then emit PhanTypeMismatchDimFetchNullable instead
of PhanTypeMismatchDimFetch.

Also, make UnionTypeVisitor return the
generic array element types even if the provided offset was invalid.