### PR TITLE
Emit `PhanTypeArraySuspiciousNullable`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -45,6 +45,10 @@ New Features(CLI, Configs)
   class Example { }
   ```
 
++ Add `PhanTypeMismatchDimFetchNullable`, which is emitted if the non-null
+  version of the dimension type would be a valid index. (#1472)
++ Emit `PhanTypeArraySuspiciousNullable` when accessing fields of a nullable array (now including `?(T[])`, etc.). (#1472)
+  (Stop emitting PhanTypeArraySuspicious for `?array`)
 
 New Features(Analysis)
 + Add `PhanNoopBinaryOperator` and `PhanNoopUnaryOperator` checks (#1404)

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -52,6 +52,7 @@ class Issue
     const NonClassMethodCall        = 'PhanNonClassMethodCall';
     const TypeArrayOperator         = 'PhanTypeArrayOperator';
     const TypeArraySuspicious       = 'PhanTypeArraySuspicious';
+    const TypeArraySuspiciousNullable = 'PhanTypeArraySuspiciousNullable';
     const TypeSuspiciousIndirectVariable = 'PhanTypeSuspiciousIndirectVariable';
     const TypeComparisonFromArray   = 'PhanTypeComparisonFromArray';
     const TypeComparisonToArray     = 'PhanTypeComparisonToArray';
@@ -1080,6 +1081,14 @@ class Issue
                 'Attempting an array destructing assignment with a key of type {TYPE} but the only key types of the right hand side are of type {TYPE}',
                 self::REMEDIATION_B,
                 10043
+            ),
+            new Issue(
+                self::TypeArraySuspiciousNullable,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                "Suspicious array access to nullable {TYPE}",
+                self::REMEDIATION_B,
+                10045
             ),
             // Issue::CATEGORY_VARIABLE
             new Issue(

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -1770,10 +1770,7 @@ class UnionType implements \Serializable
             $builder->addType($mixed_type);
             $builder->addType($null_type);
         } elseif (\in_array($mixed_type, $type_set, true)
-            || (
-                Config::get_null_casts_as_any_type()
-                && \in_array($array_type_nullable, $type_set, true)
-            )
+            || \in_array($array_type_nullable, $type_set, true)
         ) {
             // Same for mixed
             $builder->addType($mixed_type);

--- a/tests/files/expected/0287_suspicious_nullable_array.php.expected
+++ b/tests/files/expected/0287_suspicious_nullable_array.php.expected
@@ -1,1 +1,1 @@
-%s:3 PhanTypeArraySuspicious Suspicious array access to ?array
+%s:3 PhanTypeArraySuspiciousNullable Suspicious array access to nullable ?array

--- a/tests/files/expected/0429_nullable_offsets.php.expected
+++ b/tests/files/expected/0429_nullable_offsets.php.expected
@@ -1,3 +1,5 @@
+%s:10 PhanTypeArraySuspiciousNullable Suspicious array access to nullable ?string[]
+%s:11 PhanTypeArraySuspiciousNullable Suspicious array access to nullable ?string[]
 %s:11 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is string but \intdiv() takes int
 %s:12 PhanTypeMismatchDimFetch When fetching an array index from a value of type array<int,string>, found an array index of type string, but expected the index to be of type int
 %s:14 PhanTypeMismatchDimFetch When fetching an array index from a value of type array<int,string>, found an array index of type string, but expected the index to be of type int

--- a/tests/multi_files/expected/704.php.expected
+++ b/tests/multi_files/expected/704.php.expected
@@ -1,1 +1,1 @@
-
+%s:3 PhanTypeArraySuspiciousNullable Suspicious array access to nullable ?array


### PR DESCRIPTION
Emit this new issue type when accessing fields of nullable arrays.
Start emitting it for generic arrays and array shapes as well.

Stop emitting `PhanTypeArraySuspicious` for the union type `?array`