### PR TITLE
Fixes #819: Make language server work on Windows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -61,6 +61,14 @@ New Features(Analysis)
 + Add `PhanTypeMismatchArrayDestructuringKey` checks for invalid array key types in list assignments (E.g. `list($x) = ['key' => 'value']` (#1383)
 
 Language Server
++ Support running Language Server and daemon mode on Windows (#819)
+  (the `pcntl` dependency is no longer mandatory for running Phan as a server)
+  The `--language-server-allow-missing-pcntl` option must be set by the client.
+
+  When this fallback is used, Phan **manually** saves and restores the
+  data structures that store information about the project being analyzed.
+
+  This fallback is new and experimental.
 + Make Phan Language Server analyze new files added to a project (Issue #920)
 + Analyze all of the PHP files that are currently opened in the IDE
   according to the language server client,

--- a/src/Phan/AST/TolerantASTConverter/String_.php
+++ b/src/Phan/AST/TolerantASTConverter/String_.php
@@ -69,7 +69,8 @@ final class String_
      *
      * @return string The parsed string
      */
-    public static function parse(string $str, bool $parseUnicodeEscape = true) : string {
+    public static function parse(string $str, bool $parseUnicodeEscape = true) : string
+    {
         $bLength = 0;
         if ('b' === $str[0] || 'B' === $str[0]) {
             $bLength = 1;
@@ -83,7 +84,9 @@ final class String_
             );
         } else {
             return self::parseEscapeSequences(
-                substr($str, $bLength + 1, -1), '"', $parseUnicodeEscape
+                substr($str, $bLength + 1, -1),
+                '"',
+                $parseUnicodeEscape
             );
         }
     }
@@ -99,7 +102,8 @@ final class String_
      *
      * @return string String with escape sequences parsed
      */
-    public static function parseEscapeSequences(string $str, $quote, bool $parseUnicodeEscape = true) : string {
+    public static function parseEscapeSequences(string $str, $quote, bool $parseUnicodeEscape = true) : string
+    {
         if (null !== $quote) {
             $str = \str_replace('\\' . $quote, $quote, $str);
         }
@@ -111,7 +115,7 @@ final class String_
 
         return \preg_replace_callback(
             '~\\\\([\\\\$nrtfve]|[xX][0-9a-fA-F]{1,2}|[0-7]{1,3}' . $extra . ')~',
-            function($matches) {
+            function ($matches) {
                 $str = $matches[1];
 
                 if (isset(self::REPLACEMENTS[$str])) {
@@ -135,7 +139,8 @@ final class String_
      *
      * @return string UTF-8 representation of code point
      */
-    private static function codePointToUtf8(int $num) : string {
+    private static function codePointToUtf8(int $num) : string
+    {
         if ($num <= 0x7F) {
             return chr($num);
         }
@@ -151,5 +156,4 @@ final class String_
         }
         throw new Error('Invalid UTF-8 codepoint escape sequence: Codepoint too large');
     }
-
 }

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -1012,6 +1012,10 @@ Node\SourceFileNode
             'Microsoft\PhpParser\Node\ClassConstDeclaration' => function (PhpParser\Node\ClassConstDeclaration $n, int $start_line) : ast\Node {
                 return self::phpParserClassConstToAstNode($n, $start_line);
             },
+            'Microsoft\PhpParser\Node\MissingMemberDeclaration' => function (PhpParser\Node\MissingMemberDeclaration $n, int $start_line) {
+                // This node type is generated for something that isn't a function/constant/property. e.g. "public example();"
+                return null;
+            },
             'Microsoft\PhpParser\Node\MethodDeclaration' => function (PhpParser\Node\MethodDeclaration $n, int $start_line) : ast\Node {
                 $statements = $n->compoundStatementOrSemicolon;
                 $return_type = self::phpParserTypeToAstNode($n->returnType, self::getEndLine($n->returnType) ?: $start_line);
@@ -1261,7 +1265,7 @@ Node\SourceFileNode
                         assert($select_or_alias_clause instanceof PhpParser\Node\TraitSelectOrAliasClause);
                         $adaptations_inner[] = self::phpParserNodeToAstNode($select_or_alias_clause);
                     }
-                    $adaptations = new ast\Node(ast\AST_TRAIT_ADAPTATIONS, 0, $adaptations_inner, $adaptations_inner[0]->lineno ?: $start_line);
+                    $adaptations = new ast\Node(ast\AST_TRAIT_ADAPTATIONS, 0, $adaptations_inner, $adaptations_inner[0]->lineno ?? $start_line);
                 } else {
                     $adaptations = null;
                 }
@@ -2230,7 +2234,7 @@ Node\SourceFileNode
         }
         $flags = self::phpParserVisibilityToAstVisibility($n->modifiers);
 
-        return new ast\Node(ast\AST_CLASS_CONST_DECL, $flags, $const_elems, $const_elems[0]->lineno ?: $start_line);
+        return new ast\Node(ast\AST_CLASS_CONST_DECL, $flags, $const_elems, $const_elems[0]->lineno ?? $start_line);
     }
 
     private static function phpParserConstToAstNode(PhpParser\Node\Statement\ConstDeclaration $n, int $start_line) : ast\Node
@@ -2245,7 +2249,7 @@ Node\SourceFileNode
             $const_elems[] = self::phpParserConstelemToAstConstelem($prop, $i === 0 ? $doc_comment : null);
         }
 
-        return new ast\Node(ast\AST_CONST_DECL, 0, $const_elems, $const_elems[0]->lineno ?: $start_line);
+        return new ast\Node(ast\AST_CONST_DECL, 0, $const_elems, $const_elems[0]->lineno ?? $start_line);
     }
 
     /**

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -813,7 +813,8 @@ class UnionTypeVisitor extends AnalysisVisitor
      * @param array<int,Node> $children
      * @param array<int|string,true> $key_set
      */
-    private function createArrayShapeType(array $children, array $key_set) : ArrayShapeType {
+    private function createArrayShapeType(array $children, array $key_set) : ArrayShapeType
+    {
         \reset($key_set);
         $field_types = [];
 

--- a/src/Phan/AST/Visitor/KindVisitorImplementation.php
+++ b/src/Phan/AST/Visitor/KindVisitorImplementation.php
@@ -26,7 +26,7 @@ abstract class KindVisitorImplementation implements KindVisitor
 
     public function handleMissingNodeKind(Node $node)
     {
-        Debug::printNode($node);
+        fprintf(STDERR, "Unexpected Node kind. Node:\n%s\n", Debug::nodeToString($node));
         assert(false, 'All node kinds must match');
     }
 

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -644,6 +644,9 @@ class Config
         // Valid values: null, 'info'. Used when developing or debugging a language server client of Phan.
         'language_server_debug_level' => null,
 
+        // Use the command line option instead
+        'language_server_use_pcntl_fallback' => false,
+
         // Can be set to false to disable the plugins Phan uses to infer more accurate return types of array_map, array_filter, etc.
         // Phan is slightly faster when these are disabled.
         'enable_internal_return_type_plugins' => true,

--- a/src/Phan/Daemon.php
+++ b/src/Phan/Daemon.php
@@ -2,6 +2,9 @@
 namespace Phan;
 
 use Phan\Daemon\Request;
+use Phan\Daemon\Transport\StreamResponder;
+use Phan\Daemon\ExitException;
+use Closure;
 
 /**
  * an analyzing daemon, to be used by IDEs.
@@ -19,7 +22,7 @@ class Daemon
      *
      * @param CodeBase $code_base (Must have undo tracker enabled)
      *
-     * @param \Closure $file_path_lister
+     * @param Closure $file_path_lister
      * Returns string[] - A list of files to scan. This may be different from the previous contents.
      *
      * @return Request|null - A writeable request, which has been fully read from.
@@ -27,8 +30,13 @@ class Daemon
      *
      * @suppress PhanPluginUnusedVariable https://github.com/mattriverm/PhanUnusedVariable/issues/30
      */
-    public static function run(CodeBase $code_base, \Closure $file_path_lister)
+    public static function run(CodeBase $code_base, Closure $file_path_lister)
     {
+        if (Config::getValue('language_server_use_pcntl_fallback')) {
+            self::runWithoutPcntl($code_base, $file_path_lister);
+            // Not reachable
+            exit(0);
+        }
         \assert($code_base->isUndoTrackingEnabled());
 
         // example requests over TCP
@@ -74,7 +82,12 @@ class Daemon
                     // If we didn't get a connection, and it wasn't due to a signal from a child process, then stop the daemon.
                     break;
                 }
-                $request = Request::accept($code_base, $file_path_lister, $conn);
+                $request = Request::accept(
+                    $code_base,
+                    $file_path_lister,
+                    new StreamResponder($conn, true),
+                    true
+                );
                 if ($request instanceof Request) {
                     return $request;  // We forked off a worker process successfully, and this is the worker process
                 }
@@ -84,6 +97,97 @@ class Daemon
             restore_error_handler();
         }
         return null;
+    }
+
+    /**
+     * @return void - A writeable request, which has been fully read from.
+     * Callers should close after they are finished writing.
+     *
+     * @suppress PhanPluginUnusedVariable https://github.com/mattriverm/PhanUnusedVariable/issues/30
+     */
+    private static function runWithoutPcntl(CodeBase $code_base, Closure $file_path_lister)
+    {
+        // This is a single threaded server, it only analyzes one TCP request at a time
+        $socket_server = self::createDaemonStreamSocketServer();
+        try {
+            while (true) {
+                $gotSignal = false;  // reset this.
+                // We get an error from stream_socket_accept. After the RuntimeException is thrown, pcntl_signal is called.
+                $previousErrorHandler = set_error_handler(function ($severity, $message, $file, $line) use (&$previousErrorHandler) {
+                    self::debugf("In new error handler '$message'");
+                    if (!preg_match('/stream_socket_accept/i', $message)) {
+                        return $previousErrorHandler($severity, $message, $file, $line);
+                    }
+                    throw new \RuntimeException("Got signal");
+                });
+
+                $conn = false;
+                try {
+                    $conn = stream_socket_accept($socket_server, -1);
+                } catch (\RuntimeException $e) {
+                    self::debugf("Got signal");
+                    pcntl_signal_dispatch();
+                    self::debugf("done processing signals");
+                    if ($gotSignal) {
+                        continue;  // Ignore notices from stream_socket_accept if it's due to being interrupted by a child process terminating.
+                    }
+                } finally {
+                    restore_error_handler();
+                }
+
+                if (!\is_resource($conn)) {
+                    // If we didn't get a connection, and it wasn't due to a signal from a child process, then stop the daemon.
+                    break;
+                }
+                // We **are** the only process. Imitate the worker proces
+                $request = Request::accept(
+                    $code_base,
+                    $file_path_lister,
+                    new StreamResponder($conn, true),
+                    false  // This is not a fork, do not call exit($status)
+                );
+                if ($request instanceof Request) {
+                    self::debugf("Calling analyzeDaemonRequestOnMainThread\n");
+                    // This did not fork, and will not fork (Unless --processes N was used)
+                    self::analyzeDaemonRequestOnMainThread($code_base, $request);
+                    // Force garbage collection in case it didn't respond
+                    $request = null;
+                    self::debugf("Finished call to analyzeDaemonRequestOnMainThread\n");
+                    // We did not terminate, we keep accepting
+                }
+            }
+            error_log("Stopped accepting connections");
+        } finally {
+            restore_error_handler();
+        }
+    }
+
+    /**
+     * @return void
+     */
+    private static function analyzeDaemonRequestOnMainThread(CodeBase $code_base, Request $request)
+    {
+        $restore_point = $code_base->createRestorePoint();
+
+        // Stop tracking undo operations, now that the parse phase is done.
+        // TODO: Save and reset $code_base in place
+        $analyze_file_path_list = $request->filterFilesToAnalyze($code_base->getParsedFilePathList());
+        $code_base->disableUndoTracking();
+        Phan::setPrinter($request->getPrinter());
+        if (count($analyze_file_path_list) === 0) {
+            // Nothing to do, don't start analysis
+            $request->respondWithNoFilesToAnalyze();  // respond and exit.
+            return;
+        }
+        $temporary_file_mapping = $request->getTemporaryFileMapping();
+
+        try {
+            Phan::finishAnalyzingRemainingStatements($code_base, $request, $analyze_file_path_list, $temporary_file_mapping);
+        } catch (ExitException $e) {
+            // This is normal and expected, do nothing
+        } finally {
+            $code_base->restoreFromRestorePoint($restore_point);
+        }
     }
 
     /**

--- a/src/Phan/Daemon/ExitException.php
+++ b/src/Phan/Daemon/ExitException.php
@@ -1,0 +1,5 @@
+<?php declare(strict_types=1);
+namespace Phan\Daemon;
+
+class ExitException extends \Exception {
+}

--- a/src/Phan/Daemon/Transport/CapturerResponder.php
+++ b/src/Phan/Daemon/Transport/CapturerResponder.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+namespace Phan\Daemon\Transport;
+
+/**
+ * Instead of sending the data over a stream,
+ * this just keeps the raw array
+ */
+class CapturerResponder implements Responder
+{
+    /** @var array the data for getRequestData() */
+    private $request_data;
+
+    /** @var ?array the data sent via sendAndClose */
+    private $response_data;
+
+    public function __construct(array $data)
+    {
+        $this->request_data = $data;
+    }
+
+    /**
+     * @return array the request data
+     */
+    public function getRequestData()
+    {
+        return $this->request_data;
+    }
+
+    /**
+     * @param array<string,mixed> $data
+     * @return void
+     * @throws RuntimeException if called twice
+     */
+    public function sendResponseAndClose(array $data)
+    {
+        if (is_array($this->response_data)) {
+            throw new \RuntimeException("Called sendResponseAndClose twice: data = " . json_encode($data, JSON_UNESCAPED_SLASHES|JSON_UNESCAPED_UNICODE));
+        }
+        $this->response_data = $data;
+    }
+
+    /**
+     * @return ?array
+     */
+    public function getResponseData()
+    {
+        return $this->response_data;
+    }
+}

--- a/src/Phan/Daemon/Transport/Responder.php
+++ b/src/Phan/Daemon/Transport/Responder.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+namespace Phan\Daemon\Transport;
+
+/**
+ * This is an interface abstracting the transport which the worker process uses to send a response.
+ *
+ * StreamResponder is used for pcntl when this process is the fork
+ * CapturerResponder is used when a single process is run
+ */
+interface Responder
+{
+
+    /**
+     * @return ?array the request data(E.g. returns null if JSON is malformed)
+     */
+    function getRequestData();
+
+    /**
+     * This must be called exactly once
+     * @return void
+     */
+    function sendResponseAndClose(array $data);
+}

--- a/src/Phan/Daemon/Transport/StreamResponder.php
+++ b/src/Phan/Daemon/Transport/StreamResponder.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types=1);
+namespace Phan\Daemon\Transport;
+
+use Phan\Daemon;
+
+/**
+ * Sends json encoded data over a socket stream.
+ */
+class StreamResponder implements Responder
+{
+    /** @var ?resource a stream */
+    private $connection;
+
+    /** @var ?array the request data */
+    private $request_data;
+
+    private $did_read_request_data = false;
+
+    /** @param resource $connection a stream */
+    public function __construct($connection, bool $expect_request)
+    {
+        \assert(is_resource($connection));
+        $this->connection = $connection;
+        if (!$expect_request) {
+            $this->did_read_request_data = true;
+            $this->request_data = [];
+        }
+    }
+
+    /**
+     * @return ?array the request data(E.g. returns null if JSON is malformed)
+     */
+    public function getRequestData()
+    {
+        if (!$this->did_read_request_data) {
+            $response_connection = $this->connection;
+            Daemon::debugf("Got a connection");  // debugging code
+            $request_bytes = '';
+            while (!feof($response_connection)) {
+                $request_bytes .= fgets($response_connection);
+            }
+            $request = json_decode($request_bytes, true);
+            if (!is_array($request)) {
+                Daemon::debugf("Received invalid request, expected JSON: %s", json_encode($request_bytes, JSON_UNESCAPED_SLASHES));
+                $request = null;
+            }
+            $this->did_read_request_data = true;
+            $this->request_data = $request;
+        }
+        return $this->request_data;
+    }
+
+    /**
+     * @return void
+     * @throws RuntimeException if called twice
+     */
+    public function sendResponseAndClose(array $data)
+    {
+        $connection = $this->connection;
+        if (!$this->did_read_request_data) {
+            throw new \RuntimeException("Called sendAndClose before calling getRequestData");
+        }
+        if ($connection === null) {
+            throw new \RuntimeException("Called sendAndClose twice: data = " . json_encode($data, JSON_UNESCAPED_SLASHES|JSON_UNESCAPED_UNICODE));
+        }
+        fwrite($connection, json_encode($data, JSON_UNESCAPED_SLASHES|JSON_UNESCAPED_UNICODE) . "\n");
+        // disable further receptions and transmissions
+        // Note: This is likely a giant hack,
+        // and pcntl and sockets may break in the future if used together. (multiple processes owning a single resource).
+        // Not sure how to do that safely.
+        stream_socket_shutdown($connection, STREAM_SHUT_RDWR);
+        fclose($connection);
+        $this->connection = null;
+    }
+}

--- a/src/Phan/Debug.php
+++ b/src/Phan/Debug.php
@@ -66,20 +66,26 @@ class Debug
     }
 
     /**
+     * @param Node|string|null $node
      * @return string
      * The name of the node
      */
     public static function nodeName($node) : string
     {
         if (\is_string($node)) {
-            return 'string';
+            return "string";
         }
 
         if (!$node) {
             return 'null';
         }
 
-        return \ast\get_kind_name($node->kind);
+        $kind = $node->kind;
+        if (\is_string($kind)) {
+            // For placeholders created by tolerant-php-parser-to-php-ast
+            return "string ($kind)";
+        }
+        return \ast\get_kind_name($kind);
     }
 
     /**
@@ -114,11 +120,12 @@ class Debug
         if (!\is_object($node)) {
             return $string . $node . "\n";
         }
+        $kind = $node->kind;
 
-        $string .= \ast\get_kind_name($node->kind);
+        $string .= self::nodeName($node);
 
         $string .= ' ['
-            . self::astFlagDescription($node->flags ?? 0, $node->kind)
+            . (is_int($kind) ? self::astFlagDescription($node->flags ?? 0, $kind) : 'unknown')
             . ']';
 
         if (isset($node->lineno)) {

--- a/src/Phan/Language/Element/AddressableElement.php
+++ b/src/Phan/Language/Element/AddressableElement.php
@@ -8,6 +8,7 @@ use Phan\Language\FQSEN;
 use Phan\Language\FQSEN\FullyQualifiedGlobalStructuralElement;
 use Phan\Language\FileRef;
 use Phan\Language\UnionType;
+use Closure;
 
 abstract class AddressableElement extends TypedElement implements AddressableElementInterface
 {
@@ -277,4 +278,10 @@ abstract class AddressableElement extends TypedElement implements AddressableEle
         // Figure out which namespace this element is within
         return $element_fqsen->getNamespace();
     }
+
+    /**
+     * @internal - Used by daemon mode to restore an element to the state it had before parsing.
+     * @return ?Closure
+     */
+    abstract public function createRestoreCallback();
 }

--- a/src/Phan/Language/Element/ConstantTrait.php
+++ b/src/Phan/Language/Element/ConstantTrait.php
@@ -2,6 +2,7 @@
 namespace Phan\Language\Element;
 
 use ast\Node;
+use Closure;
 
 trait ConstantTrait
 {
@@ -40,5 +41,25 @@ trait ConstantTrait
     public function getNodeForValue()
     {
         return $this->defining_node;
+    }
+
+    /**
+     * @internal - Used by daemon mode to restore an element to the state it had before parsing.
+     * @return ?Closure
+     */
+    public function createRestoreCallback()
+    {
+        $future_union_type = $this->future_union_type;
+        if ($future_union_type === null) {
+            // We already inferred the type for this class constant/global constant.
+            // Nothing to do.
+            return null;
+        }
+        // If this refers to a class constant in another file,
+        // the resolved union type might change if that file changes.
+        return function() use ($future_union_type) {
+            $this->future_union_type = $future_union_type;
+            // Probably don't need to call setUnionType(mixed) again...
+        };
     }
 }

--- a/src/Phan/Language/Element/ElementFutureUnionType.php
+++ b/src/Phan/Language/Element/ElementFutureUnionType.php
@@ -16,7 +16,7 @@ trait ElementFutureUnionType
      * constant who's type is not yet known during
      * parsing.
      */
-    private $future_union_type = null;
+    protected $future_union_type = null;
 
     /**
      * @param UnionType $type

--- a/src/Phan/Language/FQSEN/AbstractFQSEN.php
+++ b/src/Phan/Language/FQSEN/AbstractFQSEN.php
@@ -3,11 +3,14 @@ namespace Phan\Language\FQSEN;
 
 use Phan\Language\Context;
 use Phan\Language\FQSEN;
+use Serializable;
 
 /**
  * A Fully-Qualified Name
+ *
+ * Serialization and cloning are forbidden.
  */
-abstract class AbstractFQSEN implements FQSEN
+abstract class AbstractFQSEN implements FQSEN, Serializable
 {
 
     /**
@@ -88,4 +91,19 @@ abstract class AbstractFQSEN implements FQSEN
      * structural element name.
      */
     abstract public function __toString() : string;
+
+    public function __clone() {
+        // We compare and look up FQSENs by their identity
+        throw new \Error("cloning an FQSEN (" . (string)$this . ") is forbidden\n");
+    }
+
+    public function serialize() {
+        // We compare and look up FQSENs by their identity
+        throw new \Error("serializing an FQSEN (" . (string)$this . ") is forbidden\n");
+    }
+
+    public function unserialize($serialized) {
+        // We compare and look up FQSENs by their identity
+        throw new \Error("unserializing an FQSEN (" . (string)$this . ") is forbidden\n");
+    }
 }

--- a/src/Phan/Language/NamespaceMapEntry.php
+++ b/src/Phan/Language/NamespaceMapEntry.php
@@ -6,7 +6,7 @@ use Phan\Language\FQSEN\FullyQualifiedGlobalStructuralElement;
 /**
  * Tracks a `use Foo\Bar;` statement at the top of a class.
  */
-class NamespaceMapEntry
+class NamespaceMapEntry implements \Serializable
 {
     /**
      * @var FullyQualifiedGlobalStructuralElement
@@ -36,5 +36,30 @@ class NamespaceMapEntry
         $this->fqsen = $fqsen;
         $this->original_name = $original_name;
         $this->lineno = $lineno;
+    }
+
+    /**
+     * @return string
+     */
+    public function serialize() {
+        return serialize([
+            get_class($this->fqsen),
+            (string)$this->fqsen,
+            $this->original_name,
+            $this->lineno,
+            $this->is_used
+        ]);
+    }
+
+    /**
+     * @param string $representation
+     */
+    public function unserialize($representation) {
+        list($fqsen_class, $fqsen, $this->original_name, $this->lineno, $this->is_used) = unserialize($representation);
+        if (!is_string($fqsen_class) || !is_subclass_of($fqsen_class, FullyQualifiedGlobalStructuralElement::class)) {
+            // Should not happen
+            throw new \RuntimeException("Not a global fqsen: class " . var_export($fqsen_class));
+        }
+        $this->fqsen = $fqsen_class::fromFullyQualifiedString($fqsen);
     }
 }

--- a/src/Phan/Library/Map.php
+++ b/src/Phan/Library/Map.php
@@ -64,6 +64,19 @@ class Map extends \SplObjectStorage
     }
 
     /**
+     * @return Map
+     * A new map with each value cloned (keys remain uncloned)
+     */
+    public function deepCopyValues() : Map
+    {
+        $map = new Map;
+        foreach ($this as $key => $value) {
+            $map[$key] = clone($value);
+        }
+        return $map;
+    }
+
+    /**
      * @return Set
      * A new set with the unique values from this map.
      * Precondition: values of this map are objects.

--- a/src/Phan/PluginV2.php
+++ b/src/Phan/PluginV2.php
@@ -38,17 +38,17 @@ use Phan\PluginV2\IssueEmitter;
  *     Analyze (and modify) a property definition, after parsing and before analyzing.
  *     (implement \Phan\PluginV2\AnalyzePropertyCapability)
  *
- *  6. public function finalize(CodeBase $code_base)
- *     Analyze (and modify) a property definition, after parsing and before analyzing.
- *     (implement \Phan\PluginV2\AnalyzePropertyCapability)
+ *  7. public function finalize(CodeBase $code_base)
+ *     Called after the analysis phase is complete.
+ *     (implement \Phan\PluginV2\FinalizeProcessCapability)
  *
- *  7. public function getAnalyzeFunctionCallClosures(CodeBase $code_base) : \Closure[]
+ *  8. public function getAnalyzeFunctionCallClosures(CodeBase $code_base) : \Closure[]
  *     Maps FQSEN of function or method to a closure used to analyze the function in question.
  *     'MyClass::myMethod' can be used as the FQSEN of a static or instance method.
  *     See .phan/plugins/PregRegexCheckerPlugin.php as an example.
  *
  *      Closure Type: function(CodeBase $code_base, Context $context, Func|Method $function, array $args) : void {...}
- *  8. public function getReturnTypeOverrides(CodeBase $code_base) : array
+ *  9. public function getReturnTypeOverrides(CodeBase $code_base) : array
  *     Maps FQSEN of function or method to a closure used to override the returned UnionType.
  *     See \Phan\Plugin\Internal\ArrayReturnTypeOverridePlugin as an example (That is automatically loaded by phan)
  *
@@ -65,6 +65,10 @@ use Phan\PluginV2\IssueEmitter;
  *     Pre-analyzes $node
  *     (implement \Phan\PluginV2\LegacyPreAnalyzeNodeCapability)
  *     (Deprecated in favor of \Phan\PluginV2\PreAnalyzeNodeCapability, which is faster)
+ *
+ * TODO: Implement a way to notify plugins that a parsed file is no longer valid,
+ * if the replacement for pcntl is being used.
+ * (Most of the plugins bundled with Phan don't need this)
  */
 abstract class PluginV2
 {


### PR DESCRIPTION
The `--language-server-allow-missing-pcntl` option must be provided by
the language client for this to work.

This implements a fallback mode without the dependency on pcntl

- Originally, pcntl_fork was used to avoid the need to manually
  save and restore state of Phan's data structures for
  classes/properties/constants/files/issues.

  (Phan's codebase may change or add new properties)

- This PR makes Phan manually save and restore it's representation
  of the project,
  only when this CLI setting is used an pcntl is not available

  This is meant to be limited to the mutable parts.

Make FQSENs throw if we attempt to serialize/unserialize/clone them.
They have to be globally unique.

Fix a few bugs in the previously unused codebase cloning methods.

Fix an edge case in the tolerant php parser to php-ast converter