### PR TITLE
Remove dead code; run phpcbf

### DIFF
--- a/src/Phan/AST/ASTSimplifier.php
+++ b/src/Phan/AST/ASTSimplifier.php
@@ -113,22 +113,6 @@ class ASTSimplifier
     }
 
     /**
-     * Get a modifiable Node that is a clone of the statement or statement list.
-     * The resulting Node has kind AST_STMT_LIST
-     */
-    private static function cloneStatementList(Node $stmt_list = null) : Node
-    {
-        if (\is_null($stmt_list)) {
-            return self::buildStatementList(0);
-        }
-        if ($stmt_list->kind === \ast\AST_STMT_LIST) {
-            return clone($stmt_list);
-        }
-        // $parent->children['stmts'] is a statement, not a statement list.
-        return self::buildStatementList($stmt_list->lineno ?? 0, $stmt_list);
-    }
-
-    /**
      * @param \ast\Node[] $statements
      * @return \ast\Node[][]|bool[] - [New/old list, bool $modified] An equivalent list after simplifying (or the original list)
      */

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -1622,11 +1622,6 @@ Node\SourceFileNode
         return new ast\Node(ast\AST_NAME, $ast_kind, ['name' => $imploded_parts], $line);
     }
 
-    private static function astMagicConst(int $flags, int $line)
-    {
-        return new ast\Node(ast\AST_MAGIC_CONST, $flags, [], $line);
-    }
-
     /** @param ?PhpParser\Node\DelimitedList\ParameterDeclarationList $parser_params */
     private static function phpParserParamsToAstParams($parser_params, int $line) : ast\Node
     {

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -1695,7 +1695,6 @@ Node\SourceFileNode
                 $node instanceof PhpParser\Node\Expression\ParenthesizedExpression ||
                 $node instanceof PhpParser\Node\ArrayElement ||
                 $node instanceof PhpParser\Node\Statement\ReturnStatement) {
-
                 $doc_comment = $node->getDocCommentText();
                 if ($doc_comment) {
                     return $doc_comment;
@@ -2580,7 +2579,6 @@ Node\SourceFileNode
         if (is_string($doc_comment) ||
             ($kind === ast\AST_PROP_ELEM && $flags !== \ast\flags\MODIFIER_STATIC) ||
             ($kind === ast\AST_CONST_ELEM && self::$php_version_id_parsing >= 70100)) {
-
             $children['docComment'] = $doc_comment;
             return new ast\Node($kind, $flags, $children, $lineno);
         }

--- a/src/Phan/AST/TolerantASTConverter/ast_shim.php
+++ b/src/Phan/AST/TolerantASTConverter/ast_shim.php
@@ -7,7 +7,9 @@
  * @author Nikita Popov <nikic@php.net>
  *
  * With modifications to be a functional replacement for the data
- * structures and global constants of ext-ast. (for class ast\Node and ast\Node\Decl)
+ * structures and global constants of ext-ast. (for class ast\Node)
+ *
+ * This supports AST version 50
  *
  * However, this file does not define any global functions such as
  * ast\parse_code() and ast\parse_file(). (to avoid confusion)
@@ -248,25 +250,5 @@ if (!class_exists('\ast\Node')) {
             $this->children = $children;
             $this->lineno = $lineno;
         }
-    }
-}
-
-namespace ast\Node;
-
-if (!class_exists('\ast\Node\Decl')) {
-    /**
-     * AST Node type for function and class declarations.
-     * @suppress PhanRedefineClassInternal
-     */
-    class Decl extends \ast\Node
-    {
-        /** @var int End line number of the declaration */
-        public $endLineno;
-
-        /** @var string Name of the function or class (not including the namespace prefix) */
-        public $name;
-
-        /** @var string|null Doc comment preceeding the declaration. null if no doc comment was used. */
-        public $docComment;
     }
 }

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -106,7 +106,8 @@ class ParameterTypesAnalyzer
     /**
      * Precondition: $target_php_version < 70200
      */
-    private static function analyzeRealSignatureCompatibility(CodeBase $code_base, FunctionInterface $method, int $target_php_version) {
+    private static function analyzeRealSignatureCompatibility(CodeBase $code_base, FunctionInterface $method, int $target_php_version)
+    {
         $php70_checks = $target_php_version < 70100;
 
         foreach ($method->getRealParameterList() as $real_parameter) {

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -631,7 +631,8 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
         return $this->context;
     }
 
-    private function analyzeArrayAssignBackwardsCompatibility(Node $node) {
+    private function analyzeArrayAssignBackwardsCompatibility(Node $node)
+    {
         if ($node->flags !== \ast\flags\ARRAY_SYNTAX_LIST) {
             $this->emitIssue(
                 Issue::CompatibleShortArrayAssignPHP70,

--- a/src/Phan/Analysis/ReferenceCountsAnalyzer.php
+++ b/src/Phan/Analysis/ReferenceCountsAnalyzer.php
@@ -285,6 +285,11 @@ class ReferenceCountsAnalyzer
                         // then also treat it as a reference to the duplicate.
                         return;
                     }
+                    if ($element_alt->isPHPInternal()) {
+                        // For efficiency, Phan doesn't track references to internal classes.
+                        // Phan already emitted a warning about duplicating an internal class.
+                        return;
+                    }
                 }
                 // Make issue types granular so that these can be fixed in smaller steps.
                 // E.g. composer libraries may have unreferenced but used public methods, properties, and class constants.

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -517,10 +517,10 @@ class CodeBase
             // Create callbacks to back up class constants and properties.
             // Methods were already backed up.
             foreach ($class_map->getClassConstantMap() as $const) {
-                $callbacks[] = $const->createRestoreCallback();;
+                $callbacks[] = $const->createRestoreCallback();
             }
             foreach ($class_map->getPropertyMap() as $property) {
-                $callbacks[] = $property->createRestoreCallback();;
+                $callbacks[] = $property->createRestoreCallback();
             }
         }
 

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -449,15 +449,6 @@ class CodeBase
         }
     }
 
-    private static function deepCopyMapMapValues(Map $map_map) : Map
-    {
-        $clone_of_clones = new Map();
-        foreach ($map_map as $key => $map) {
-            $clone_of_clones[$key] = $map->deepCopyValues();
-        }
-        return $clone_of_clones;
-    }
-
     /**
      * @param array{clone:CodeBase,callbacks:?Closure[]}
      * @return void

--- a/src/Phan/Daemon/ExitException.php
+++ b/src/Phan/Daemon/ExitException.php
@@ -1,5 +1,6 @@
 <?php declare(strict_types=1);
 namespace Phan\Daemon;
 
-class ExitException extends \Exception {
+class ExitException extends \Exception
+{
 }

--- a/src/Phan/Exception/NotFoundException.php
+++ b/src/Phan/Exception/NotFoundException.php
@@ -1,6 +1,0 @@
-<?php declare(strict_types=1);
-namespace Phan\Exception;
-
-class NotFoundException extends \Exception
-{
-}

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -2675,7 +2675,7 @@ class Clazz extends AddressableElement
         $is_hydrated = $this->is_hydrated;
         $original_union_type = $this->getUnionType();
 
-        return function() use($original_union_type, $is_hydrated, $are_constants_hydrated) {
+        return function () use ($original_union_type, $is_hydrated, $are_constants_hydrated) {
             $this->memoizeFlushAll();
             $this->are_constants_hydrated = $are_constants_hydrated;
             $this->is_hydrated = $is_hydrated;

--- a/src/Phan/Language/Element/ConstantTrait.php
+++ b/src/Phan/Language/Element/ConstantTrait.php
@@ -57,7 +57,7 @@ trait ConstantTrait
         }
         // If this refers to a class constant in another file,
         // the resolved union type might change if that file changes.
-        return function() use ($future_union_type) {
+        return function () use ($future_union_type) {
             $this->future_union_type = $future_union_type;
             // Probably don't need to call setUnionType(mixed) again...
         };

--- a/src/Phan/Language/Element/FunctionInterface.php
+++ b/src/Phan/Language/Element/FunctionInterface.php
@@ -336,5 +336,4 @@ interface FunctionInterface extends AddressableElementInterface
      * Always false for global functions(Func).
      */
     public function isFromPHPDoc() : bool;
-
 }

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -922,7 +922,7 @@ trait FunctionTrait
         $return_type_callback = $this->return_type_callback;
         $function_call_analyzer_callback = $this->function_call_analyzer_callback;
 
-        return function() use($parameter_list, $parameter_list_hash, $union_type, $return_type_callback, $function_call_analyzer_callback) {
+        return function () use ($parameter_list, $parameter_list_hash, $union_type, $return_type_callback, $function_call_analyzer_callback) {
             $this->memoizeFlushAll();
             $this->parameter_list_hash = $parameter_list_hash;
             $this->parameter_list = $parameter_list;

--- a/src/Phan/Language/Element/Parameter.php
+++ b/src/Phan/Language/Element/Parameter.php
@@ -40,11 +40,6 @@ class Parameter extends Variable
     private $default_value_future_type = null;
 
     /**
-     * @var Context|null used to resolve default_value_future_type
-     */
-    private $default_value_context = null;
-
-    /**
      * @var mixed
      * The value of the default, if one is set
      */

--- a/src/Phan/Language/Element/Property.php
+++ b/src/Phan/Language/Element/Property.php
@@ -149,7 +149,7 @@ class Property extends ClassElement
         }
         // If this refers to a class constant in another file,
         // the resolved union type might change if that file changes.
-        return function() use ($future_union_type) {
+        return function () use ($future_union_type) {
             $this->future_union_type = $future_union_type;
             // Probably don't need to call setUnionType(mixed) again...
         };

--- a/src/Phan/Language/Element/UnaddressableTypedElement.php
+++ b/src/Phan/Language/Element/UnaddressableTypedElement.php
@@ -260,20 +260,6 @@ abstract class UnaddressableTypedElement
     }
 
     /**
-     * @return void
-     */
-    private function setIsPHPInternal(bool $is_internal)
-    {
-        $this->setPhanFlags(
-            Flags::bitVectorWithState(
-                $this->getPhanFlags(),
-                Flags::IS_PHP_INTERNAL,
-                $is_internal
-            )
-        );
-    }
-
-    /**
      * This method must be called before analysis
      * begins.
      *

--- a/src/Phan/Language/FQSEN/AbstractFQSEN.php
+++ b/src/Phan/Language/FQSEN/AbstractFQSEN.php
@@ -92,17 +92,20 @@ abstract class AbstractFQSEN implements FQSEN, Serializable
      */
     abstract public function __toString() : string;
 
-    public function __clone() {
+    public function __clone()
+    {
         // We compare and look up FQSENs by their identity
         throw new \Error("cloning an FQSEN (" . (string)$this . ") is forbidden\n");
     }
 
-    public function serialize() {
+    public function serialize()
+    {
         // We compare and look up FQSENs by their identity
         throw new \Error("serializing an FQSEN (" . (string)$this . ") is forbidden\n");
     }
 
-    public function unserialize($serialized) {
+    public function unserialize($serialized)
+    {
         // We compare and look up FQSENs by their identity
         throw new \Error("unserializing an FQSEN (" . (string)$this . ") is forbidden\n");
     }

--- a/src/Phan/Language/NamespaceMapEntry.php
+++ b/src/Phan/Language/NamespaceMapEntry.php
@@ -41,7 +41,8 @@ class NamespaceMapEntry implements \Serializable
     /**
      * @return string
      */
-    public function serialize() {
+    public function serialize()
+    {
         return serialize([
             get_class($this->fqsen),
             (string)$this->fqsen,
@@ -54,7 +55,8 @@ class NamespaceMapEntry implements \Serializable
     /**
      * @param string $representation
      */
-    public function unserialize($representation) {
+    public function unserialize($representation)
+    {
         list($fqsen_class, $fqsen, $this->original_name, $this->lineno, $this->is_used) = unserialize($representation);
         if (!is_string($fqsen_class) || !is_subclass_of($fqsen_class, FullyQualifiedGlobalStructuralElement::class)) {
             // Should not happen

--- a/src/Phan/LanguageServer/LanguageServer.php
+++ b/src/Phan/LanguageServer/LanguageServer.php
@@ -558,7 +558,8 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
      * @param array{issues:array} $response_data
      * @return void
      */
-    private function handleJSONResponseFromWorker(array $uris_to_analyze, array $response_data) {
+    private function handleJSONResponseFromWorker(array $uris_to_analyze, array $response_data)
+    {
         if (!\array_key_exists('issues', $response_data)) {
             Logger::logInfo("Failed to fetch 'issues' from JSON:" . json_encode($response_data));
             return;

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -584,12 +584,4 @@ final class ConfigPluginSet extends PluginV2 implements
         }
         return $result;
     }
-
-    /**
-     * @return array<int,Plugin>
-     */
-    private function getPlugins() : array
-    {
-        return $this->pluginSet;
-    }
 }

--- a/src/Phan/Plugin/Internal/StringFunctionPlugin.php
+++ b/src/Phan/Plugin/Internal/StringFunctionPlugin.php
@@ -21,25 +21,6 @@ use ast\Node;
 final class StringFunctionPlugin extends PluginV2 implements
     AnalyzeFunctionCallCapability
 {
-
-    /**
-     * @param Node|int|string $arg_array_node
-     * @return ?array
-     */
-    private static function extractArrayArgs($arg_array_node)
-    {
-        if (($arg_array_node instanceof Node) && $arg_array_node->kind === \ast\AST_ARRAY) {
-            $arguments = [];
-            // TODO: Sanity check keys.
-            foreach ($arg_array_node->children as $child) {
-                $arguments[] = $child->children['value'];
-            }
-            return $arguments;
-        } else {
-            return null;
-        }
-    }
-
     /**
      * @param Node|string|float|int|null $arg
      * @return bool true if the expression is simple to look up.


### PR DESCRIPTION
Don't warn about elements that are duplicates of internal elements being unused.
There was already a warning about them being duplicates (assume they're polyfills, e.g. Phan's spl_object_id declaration)

Finish cleaning up the polyfill parser's support for AST versions of less than 50.