### PR TITLE
Fixes #1461: Signatures of variadics may end up incorrect.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ vendor
 .phan/data
 composer.phar
 /build
+/report
 samples
 all_output.*
 *.swo

--- a/src/Phan/Analysis/ArgumentType.php
+++ b/src/Phan/Analysis/ArgumentType.php
@@ -501,7 +501,7 @@ class ArgumentType
             // See if the argument can be cast to the
             // parameter
             if ($argument_type_expanded->canCastToUnionType(
-                $alternate_parameter->getUnionType()
+                $alternate_parameter->getNonVariadicUnionType()
             )) {
                 return;
             }
@@ -515,7 +515,7 @@ class ArgumentType
             return;
         }
 
-        $parameter_type = $alternate_parameter->getUnionType();
+        $parameter_type = $alternate_parameter->getNonVariadicUnionType();
 
         if ($parameter_type->hasTemplateType()) {
             // Don't worry about template types

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -996,6 +996,7 @@ class ParameterTypesAnalyzer
             if ($normalized_phpdoc_param_union_type) {
                 $param_to_modify = $method->getParameterList()[$i] ?? null;
                 if ($param_to_modify) {
+                    // TODO: Maybe have two different sets of methods for setUnionType and setCallerUnionType, this is easy to mix up for variadics.
                     $param_to_modify->setUnionType($normalized_phpdoc_param_union_type);
                 }
             } else {

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -754,18 +754,18 @@ class Clazz extends AddressableElement
                 $class_fqsen,
                 $method_name
             );
+            $real_parameter_list = \array_map(function (\Phan\Language\Element\Comment\Parameter $parameter) use ($context) : Parameter {
+                return $parameter->asRealParameter($context);
+            }, $comment_method->getParameterList());
             $method = new Method(
                 $context,
                 $method_name,
                 $comment_method->getUnionType(),
                 $flags,
-                $method_fqsen
+                $method_fqsen,
+                $real_parameter_list
             );
-            $real_parameter_list = \array_map(function (\Phan\Language\Element\Comment\Parameter $parameter) use ($context) : Parameter {
-                return $parameter->asRealParameter($context);
-            }, $comment_method->getParameterList());
 
-            $method->setParameterList($real_parameter_list);
             $method->setRealParameterList($real_parameter_list);
             $method->setNumberOfRequiredParameters($comment_method->getNumberOfRequiredParameters());
             $method->setNumberOfOptionalParameters($comment_method->getNumberOfOptionalParameters());
@@ -1263,17 +1263,7 @@ class Clazz extends AddressableElement
             $method->setIsOverride($is_override);
 
             // Clone the parameter list, so that modifying the parameters on the first call won't modify the others.
-            // TODO: Make the parameter list immutable and have immutable types (e.g. getPhpdocParameterList(), setPhpdocParameterList()
-            // and use a clone of all of the parameters for analysis (quick_mode=false has different values).
-            // TODO: If they're immutable, they can be shared without cloning with less worry.
-            $method->setParameterList(
-                \array_map(
-                    function (Parameter $parameter) : Parameter {
-                        return clone($parameter);
-                    },
-                    $method->getParameterList()
-                )
-            );
+            $method->cloneParameterList();
 
             // If we have a parent type defined, map the method's
             // return type and parameter types through it

--- a/src/Phan/Language/Element/FunctionFactory.php
+++ b/src/Phan/Language/Element/FunctionFactory.php
@@ -47,7 +47,8 @@ class FunctionFactory
             $fqsen->getNamespacedName(),
             UnionType::empty(),
             0,
-            $fqsen
+            $fqsen,
+            null
         );
 
         $function->setNumberOfRequiredParameters(
@@ -89,7 +90,8 @@ class FunctionFactory
             $fqsen->getNamespacedName(),
             $return_type,
             0,
-            $fqsen
+            $fqsen,
+            []  // will be filled in by functionListFromFunction
         );
 
         return self::functionListFromFunction($func, $code_base);
@@ -120,7 +122,8 @@ class FunctionFactory
             $reflection_method->name,
             UnionType::empty(),
             $reflection_method->getModifiers(),
-            $method_fqsen
+            $method_fqsen,
+            null
         );
 
         $method->setNumberOfRequiredParameters(

--- a/src/Phan/Language/Element/FunctionInterface.php
+++ b/src/Phan/Language/Element/FunctionInterface.php
@@ -147,14 +147,6 @@ interface FunctionInterface extends AddressableElementInterface
     public function getParameterForCaller(int $i);
 
     /**
-     * @param array<int,Parameter> $parameter_list
-     * A list of parameters to set on this method
-     *
-     * @return void
-     */
-    public function setParameterList(array $parameter_list);
-
-    /**
      * @param Parameter $parameter
      * A parameter to append to the parameter list
      *
@@ -336,4 +328,12 @@ interface FunctionInterface extends AddressableElementInterface
      * Always false for global functions(Func).
      */
     public function isFromPHPDoc() : bool;
+
+    /**
+     * Clone the parameter list, so that modifying the parameters on the first call won't modify the others.
+     * TODO: If they're immutable, they can be shared without cloning with less worry.
+     * @internal
+     * @return void
+     */
+    public function cloneParameterList();
 }

--- a/src/Phan/Language/Element/VariadicParameter.php
+++ b/src/Phan/Language/Element/VariadicParameter.php
@@ -108,6 +108,7 @@ class VariadicParameter extends Parameter
      */
     public function getNonVariadicUnionType() : UnionType
     {
+        // if ($this->isCloneOfVariadic()) { throw new \Error("Calling getNonVariadicUnionType on clone?\n"); }
         return parent::getUnionType();
     }
 

--- a/src/Phan/Language/Scope.php
+++ b/src/Phan/Language/Scope.php
@@ -199,6 +199,12 @@ abstract class Scope
      */
     public function addVariable(Variable $variable)
     {
+        // uncomment to debug issues with variadics
+        /*
+        if ($variable->isVariadic() && !$variable->isCloneOfVariadic()) {
+            throw new \Error("Bad variable {$variable->getName()}\n");
+        }
+         */
         $this->variable_map[$variable->getName()] = $variable;
     }
 


### PR DESCRIPTION
Also, restore the function's internal scope in `finally`,
in case of an uncaught IssueException/NodeException.

Also, pass in a clone of the Parameter instead of the original parameter
to the function scope.

- This seems to have happened when the variadic was reassigned inside of
  the function/method. I wasn't able to create a minimal test case.

  Calling setUnionType would set the type inside the variadic.