### PR TITLE
Fixes #1511: Undefined variable: real_parameter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,13 @@
 Phan NEWS
 
-?? ??? 2018, Phan 0.12.1(dev)
+?? ??? 2018, Phan 0.12.1 (dev)
+------------------------
 
 New Features(Analysis)
 + Emit `PhanTypeInvalidDimOffset` when an unknown offset is fetched from an array shape type. (#1478)
+
+Bug Fixes
++ Fix an "Undefined variable" error when checking for php 7.1/7.0 incompatibilities in return types. (#1511)
 
 25 Feb 2018, Phan 0.12.0
 ------------------------
@@ -22,7 +26,7 @@ New Features(CLI, Configs)
 
   NOTE: This setting does not let a PHP 7.0 installation parse PHP 7.1 nullable syntax or PHP 7.1 array destructuring syntax.
 
-  If you are unable to upgrade the PHP version used for analysis to php 7.1, the polyfill parser settings may help 
+  If you are unable to upgrade the PHP version used for analysis to php 7.1, the polyfill parser settings may help
   (See `--force-polyfill-parser` or `--use-fallback-parser`. Those have a few known bugs in edge cases.)
 + Add `--init` CLI flag and CLI options to affect the generated config. (#145)
   (Options: `--init-level=1..5`, `--init-analyze-dir=path/to/src`, `--init-analyze-file=path/to/file.php`, `--init-no-composer`, `--init-overwrite`)

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -154,7 +154,7 @@ class ParameterTypesAnalyzer
                         $code_base,
                         $method->getContext(),
                         Issue::CompatibleNullableTypePHP70,
-                        $real_parameter->getFileRef()->getLineNumberStart(),
+                        $method->getFileRef()->getLineNumberStart(),
                         (string)$type
                     );
                 }
@@ -182,7 +182,7 @@ class ParameterTypesAnalyzer
                     $code_base,
                     $method->getContext(),
                     Issue::CompatibleObjectTypePHP71,
-                    $real_parameter->getFileRef()->getLineNumberStart(),
+                    $method->getFileRef()->getLineNumberStart(),
                     (string)$type
                 );
             }

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -22,7 +22,7 @@ class CLI
     /**
      * This should be updated to x.y.z-dev after every release, and x.y.z before a release.
      */
-    const PHAN_VERSION = '0.12.0';
+    const PHAN_VERSION = '0.12.1-dev';
 
     /**
      * @var OutputInterface

--- a/tests/php70_test/expected/002_object_hint.php.expected
+++ b/tests/php70_test/expected/002_object_hint.php.expected
@@ -1,1 +1,2 @@
 src/002_object_hint.php:3 PhanCompatibleNullableTypePHP71 Type 'object' refers to any object starting in PHP 7.2. In PHP 7.1 and earlier, it refers to a class/interface with the name 'object'
+src/002_object_hint.php:18 PhanCompatibleNullableTypePHP71 Type 'object' refers to any object starting in PHP 7.2. In PHP 7.1 and earlier, it refers to a class/interface with the name 'object'

--- a/tests/php70_test/expected/005_nullable.php.expected
+++ b/tests/php70_test/expected/005_nullable.php.expected
@@ -1,3 +1,4 @@
 src/005_nullable.php:3 PhanCompatibleNullableTypePHP70 Nullable type '?int' is not compatible with PHP 7.0
 src/005_nullable.php:5 PhanCompatibleNullableTypePHP70 Nullable type '?int' is not compatible with PHP 7.0
 src/005_nullable.php:9 PhanCompatibleNullableTypePHP70 Nullable type '?int' is not compatible with PHP 7.0
+src/005_nullable.php:17 PhanCompatibleNullableTypePHP70 Nullable type '?int' is not compatible with PHP 7.0

--- a/tests/php70_test/src/002_object_hint.php
+++ b/tests/php70_test/src/002_object_hint.php
@@ -14,3 +14,8 @@ function test_object_phpdoc_param($obj) {
 
 test_object_phpdoc_param(new stdClass());
 test_object_real_param(new stdClass());
+
+function test_object_real_return() : object {
+    return new stdClass();
+}
+test_object_real_return();

--- a/tests/php70_test/src/005_nullable.php
+++ b/tests/php70_test/src/005_nullable.php
@@ -13,3 +13,8 @@ nullableArg(null, 5);
 nullableOptionalArg(2);
 nullableArg2(2);
 echo nullableReturn(2);
+
+function nullableReturn2() : ?int {
+    return 2;
+}
+nullableReturn2();


### PR DESCRIPTION
The foreach may be over an empty list of parameters.
This was the wrong place to get the line number from.
Long term, the return type should have its line number tracked