### PR TITLE
Fix more issues about array shapes, add TODO

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@ New Features(Analysis)
 
 Bug Fixes
 + Fix an "Undefined variable" error when checking for php 7.1/7.0 incompatibilities in return types. (#1511)
+  Fix other crashes.
 
 25 Feb 2018, Phan 0.12.0
 ------------------------

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1775,11 +1775,12 @@ class UnionTypeVisitor extends AnalysisVisitor
                         $static_type = $union_type->findTypeMatchingCallback(function (Type $type) : bool {
                             return (
                                 $type->isGenericArray()
-                                && $type->genericArrayElementType()->isStaticType()
+                                && $type->genericArrayElementUnionType()->hasStaticType()
                             );
                         });
 
                         // Remove it from the list
+                        // TODO: Limit this to fields of ArrayShapeType that actually have static type
                         $union_type = $union_type->withoutType($static_type);
                     }
 

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -52,6 +52,7 @@ class ParameterTypesAnalyzer
             foreach ($union_type->getTypeSet() as $outer_type) {
                 $type = $outer_type;
 
+                // TODO: Add unit test of `array{key:MissingClazz}`
                 while ($type instanceof GenericArrayType) {
                     $type = $type->genericArrayElementType();
                 }

--- a/src/Phan/Analysis/PropertyTypesAnalyzer.php
+++ b/src/Phan/Analysis/PropertyTypesAnalyzer.php
@@ -34,6 +34,7 @@ class PropertyTypesAnalyzer
             // Look at each type in the parameter's Union Type
             foreach ($union_type->getTypeSet() as $outer_type) {
                 $type = $outer_type;
+                // TODO: Expand this to ArrayShapeType
                 while ($type instanceof GenericArrayType) {
                     $type = $type->genericArrayElementType();
                 }

--- a/src/Phan/Analysis/ReturnTypesAnalyzer.php
+++ b/src/Phan/Analysis/ReturnTypesAnalyzer.php
@@ -34,6 +34,7 @@ class ReturnTypesAnalyzer
         // Look at each type in the function's return union type
         foreach ($return_type->getTypeSet() as $outer_type) {
             $type = $outer_type;
+            // TODO: Expand this to ArrayShapeType, add unit test of `@return array{key:MissingClazz}`
             while ($type instanceof GenericArrayType) {
                 $type = $type->genericArrayElementType();
             }

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -1381,6 +1381,16 @@ class Type
     }
 
     /**
+     * @return UnionType
+     * A variation of this type that is not generic.
+     * i.e. 'int[]' becomes 'int'.
+     */
+    public function genericArrayElementUnionType() : UnionType
+    {
+        throw new \Error("genericArrayElementUnionType should not be called on Type base class");
+    }
+
+    /**
      * @param int $key_type
      * Corresponds to the type of the array keys. Set this to a GenericArrayType::KEY_* constant.
      *

--- a/src/Phan/Language/Type/ArrayShapeType.php
+++ b/src/Phan/Language/Type/ArrayShapeType.php
@@ -100,6 +100,12 @@ final class ArrayShapeType extends ArrayType
         return $this->generic_array_element_union_type ?? ($this->generic_array_element_union_type = UnionType::merge($this->field_types));
     }
 
+    public function genericArrayElementType() : Type
+    {
+        // FIXME Deprecate genericArrayElementType
+        return MixedType::instance(false);
+    }
+
     /**
      * @return bool
      * True if this Type can be cast to the given Type
@@ -114,7 +120,7 @@ final class ArrayShapeType extends ArrayType
                     // However, the scalar_array_key_cast config would make any cast of array keys a valid cast.
                     return false;
                 }
-                return $this->genericArrayElementUnionType()->canCastToUnionType($type->genericArrayElementType()->asUnionType());
+                return $this->genericArrayElementUnionType()->canCastToUnionType($type->genericArrayElementUnionType());
             } elseif ($type instanceof ArrayShapeType) {
                 foreach ($type->field_types as $key => $field_type) {
                     $this_field_type = $this->field_types[$key] ?? null;

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -145,7 +145,7 @@ final class GenericArrayType extends ArrayType
                 // However, the scalar_array_key_cast config would make any cast of array keys a valid cast.
                 return false;
             }
-            return $this->genericArrayElementType()->asUnionType()->canCastToUnionType($type->genericArrayElementUnionType());
+            return $this->genericArrayElementUnionType()->canCastToUnionType($type->genericArrayElementUnionType());
         }
 
         if ($type->isArrayLike()) {
@@ -219,6 +219,16 @@ final class GenericArrayType extends ArrayType
     public function genericArrayElementType() : Type
     {
         return $this->element_type;
+    }
+
+    /**
+     * @return UnionType
+     * A variation of this type that is not generic.
+     * i.e. 'int[]' becomes 'int'.
+     */
+    public function genericArrayElementUnionType() : UnionType
+    {
+        return $this->element_type->asUnionType();
     }
 
     public function __toString() : string

--- a/src/Phan/Language/Type/GenericMultiArrayType.php
+++ b/src/Phan/Language/Type/GenericMultiArrayType.php
@@ -110,6 +110,8 @@ final class GenericMultiArrayType extends ArrayType
             return false;
         }
 
+        // TODO: More precise about checking if can cast to ArrayShapeType
+
         if ($type->isArrayLike()) {
             return true;
         }

--- a/tests/Phan/Language/UnionTypeTest.php
+++ b/tests/Phan/Language/UnionTypeTest.php
@@ -148,6 +148,10 @@ class UnionTypeTest extends BaseTest
             $type->genericArrayElementType()->__toString(),
             "int[]"
         );
+        $this->assertEquals(
+            $type->genericArrayElementUnionType()->__toString(),
+            "int[]"
+        );
     }
 
     public function testGenericArrayTypeFromString()


### PR DESCRIPTION
ArrayShapeType returns true for isGenericArrayType(), so it needs to
implement $this->genericArrayElementType()

A future release will phase genericArrayElementType() out.