### PR TITLE
Fix a false positive in array shapes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 Phan NEWS
 
+?? Mar 2018, Phan 0.12.2 (dev)
+------------------------
+
+Bug Fixes
++ Reduce false positives in `PhanTypeInvalidDimOffset`
+
 28 Feb 2018, Phan 0.12.1
 ------------------------
 

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -769,8 +769,11 @@ class AssignmentVisitor extends AnalysisVisitor
             if ($this->dim_depth > 0) {
                 $old_variable_union_type = $variable->getUnionType();
                 $right_type = $this->typeCheckDimAssignment($old_variable_union_type, $node);
+                if ($old_variable_union_type->isEmpty()) {
+                    $old_variable_union_type = ArrayType::instance(false)->asUnionType();
+                }
                 // TODO: Make the behavior more precise for $x['a']['b'] = ...; when $x is an array shape.
-                if ($this->dim_depth > 1 || ($old_variable_union_type->hasTopLevelNonArrayShapeTypeInstances() || $right_type->hasTopLevelNonArrayShapeTypeInstances() || $old_variable_union_type->isEmpty() || $right_type->isEmpty())) {
+                if ($this->dim_depth > 1 || ($old_variable_union_type->hasTopLevelNonArrayShapeTypeInstances() || $right_type->hasTopLevelNonArrayShapeTypeInstances() || $right_type->isEmpty())) {
                     $variable->setUnionType($old_variable_union_type->withUnionType(
                         $right_type
                     ));

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -22,7 +22,7 @@ class CLI
     /**
      * This should be updated to x.y.z-dev after every release, and x.y.z before a release.
      */
-    const PHAN_VERSION = '0.12.1';
+    const PHAN_VERSION = '0.12.2-dev';
 
     /**
      * @var OutputInterface

--- a/tests/files/expected/0435_false_positive_shape_offset.php.expected
+++ b/tests/files/expected/0435_false_positive_shape_offset.php.expected
@@ -1,0 +1,1 @@
+%s:5 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is string but \intdiv() takes int                  

--- a/tests/files/src/0435_false_positive_shape_offset.php
+++ b/tests/files/src/0435_false_positive_shape_offset.php
@@ -1,0 +1,7 @@
+<?php
+
+function exampleShape436($x) {
+    $x['key'] = 'value';
+    echo intdiv($x['key'], 2);  // should warn
+    return $x['other']; // Should not warn.
+}


### PR DESCRIPTION
(When the union type was previously empty, a false positive was emitted due to an overly specific type being inferred)