### PR TITLE
Fixes #1518 : Don't warn when creating nested dimensions

### DIFF
--- a/.phan/plugins/DemoPlugin.php
+++ b/.phan/plugins/DemoPlugin.php
@@ -10,15 +10,15 @@ use Phan\PluginV2\AnalyzeClassCapability;
 use Phan\PluginV2\AnalyzeFunctionCapability;
 use Phan\PluginV2\AnalyzeMethodCapability;
 use Phan\PluginV2\AnalyzePropertyCapability;
-use Phan\PluginV2\AnalyzeNodeCapability;
-use Phan\PluginV2\PluginAwareAnalysisVisitor;
+use Phan\PluginV2\PluginAwarePostAnalysisVisitor;
+use Phan\PluginV2\PostAnalyzeNodeCapability;
 use ast\Node;
 
 /**
  * This file demonstrates plugins for Phan.
  * This Plugin hooks into five events;
  *
- * - getAnalyzeNodeVisitorClassName
+ * - getPostAnalyzeNodeVisitorClassName
  *   This method returns a class that is called on every AST node from every
  *   file being analyzed
  *
@@ -57,14 +57,15 @@ class DemoPlugin extends PluginV2 implements
     AnalyzeClassCapability,
     AnalyzeFunctionCapability,
     AnalyzeMethodCapability,
-    AnalyzeNodeCapability,
+    PostAnalyzeNodeCapability,
     AnalyzePropertyCapability
 {
 
     /**
      * @return string - The name of the visitor that will be called (formerly analyzeNode)
+     * @override
      */
-    public static function getAnalyzeNodeVisitorClassName() : string
+    public static function getPostAnalyzeNodeVisitorClassName() : string
     {
         return DemoNodeVisitor::class;
     }
@@ -192,8 +193,13 @@ class DemoPlugin extends PluginV2 implements
  * Visitors such as this are useful for defining lots of different
  * checks on a node based on its kind.
  */
-class DemoNodeVisitor extends PluginAwareAnalysisVisitor
+class DemoNodeVisitor extends PluginAwarePostAnalysisVisitor
 {
+    // Subclasses should declare protected $parent_node_list as an instance property if they need to know the list.
+
+    // @var array<int,Node> - Set after the constructor is called if an instance property with this name is declared
+    // protected $parent_node_list;
+
     // A plugin's visitors should NOT implement visit(), unless they need to.
 
     /**

--- a/.phan/plugins/DollarDollarPlugin.php
+++ b/.phan/plugins/DollarDollarPlugin.php
@@ -1,8 +1,8 @@
 <?php declare(strict_types=1);
 
 use Phan\PluginV2;
-use Phan\PluginV2\AnalyzeNodeCapability;
-use Phan\PluginV2\PluginAwareAnalysisVisitor;
+use Phan\PluginV2\PostAnalyzeNodeCapability;
+use Phan\PluginV2\PluginAwarePostAnalysisVisitor;
 use ast\Node;
 
 /**
@@ -12,7 +12,7 @@ use ast\Node;
  * This file demonstrates plugins for Phan. Plugins hook into various events.
  * DollarDollarPlugin hooks into one event:
  *
- * - getAnalyzeNodeVisitorClassName
+ * - getPostAnalyzeNodeVisitorClassName
  *   This method returns a visitor that is called on every AST node from every
  *   file being analyzed
  *
@@ -28,13 +28,13 @@ use ast\Node;
  * Note: When adding new plugins,
  * add them to the corresponding section of README.md
  */
-class DollarDollarPlugin extends PluginV2 implements AnalyzeNodeCapability
+class DollarDollarPlugin extends PluginV2 implements PostAnalyzeNodeCapability
 {
 
     /**
-     * @return string - name of PluginAwareAnalysisVisitor subclass
+     * @return string - name of PluginAwarePostAnalysisVisitor subclass
      */
-    public static function getAnalyzeNodeVisitorClassName() : string
+    public static function getPostAnalyzeNodeVisitorClassName() : string
     {
         return DollarDollarVisitor::class;
     }
@@ -47,7 +47,7 @@ class DollarDollarPlugin extends PluginV2 implements AnalyzeNodeCapability
  * Visitors such as this are useful for defining lots of different
  * checks on a node based on its kind.
  */
-class DollarDollarVisitor extends PluginAwareAnalysisVisitor
+class DollarDollarVisitor extends PluginAwarePostAnalysisVisitor
 {
 
     // A plugin's visitors should not override visit() unless they need to.

--- a/.phan/plugins/DuplicateArrayKeyPlugin.php
+++ b/.phan/plugins/DuplicateArrayKeyPlugin.php
@@ -5,8 +5,8 @@ use Phan\Exception\IssueException;
 use Phan\Exception\NodeException;
 use Phan\Issue;
 use Phan\PluginV2;
-use Phan\PluginV2\AnalyzeNodeCapability;
-use Phan\PluginV2\PluginAwareAnalysisVisitor;
+use Phan\PluginV2\PostAnalyzeNodeCapability;
+use Phan\PluginV2\PluginAwarePostAnalysisVisitor;
 use ast\Node;
 
 /**
@@ -14,13 +14,13 @@ use ast\Node;
  *
  * @see DollarDollarPlugin for generic plugin documentation.
  */
-class DuplicateArrayKeyPlugin extends PluginV2 implements AnalyzeNodeCapability
+class DuplicateArrayKeyPlugin extends PluginV2 implements PostAnalyzeNodeCapability
 {
     /**
-     * @return string - name of PluginAwareAnalysisVisitor subclass
+     * @return string - name of PluginAwarePostAnalysisVisitor subclass
      * @override
      */
-    public static function getAnalyzeNodeVisitorClassName() : string
+    public static function getPostAnalyzeNodeVisitorClassName() : string
     {
         return DuplicateArrayKeyVisitor::class;
     }
@@ -35,7 +35,7 @@ class DuplicateArrayKeyPlugin extends PluginV2 implements AnalyzeNodeCapability
  * Visitors such as this are useful for defining lots of different
  * checks on a node based on its kind.
  */
-class DuplicateArrayKeyVisitor extends PluginAwareAnalysisVisitor
+class DuplicateArrayKeyVisitor extends PluginAwarePostAnalysisVisitor
 {
     // Do not define the visit() method unless a plugin has code and needs to visit most/all node types.
 

--- a/.phan/plugins/InvalidVariableIssetPlugin.php
+++ b/.phan/plugins/InvalidVariableIssetPlugin.php
@@ -4,25 +4,25 @@
 use Phan\Language\Context;
 use Phan\Language\Element\Variable;
 use Phan\PluginV2;
-use Phan\PluginV2\AnalyzeNodeCapability;
-use Phan\PluginV2\PluginAwareAnalysisVisitor;
+use Phan\PluginV2\PostAnalyzeNodeCapability;
+use Phan\PluginV2\PluginAwarePostAnalysisVisitor;
 use ast\Node;
 
-class InvalidVariableIssetPlugin extends PluginV2 implements AnalyzeNodeCapability
+class InvalidVariableIssetPlugin extends PluginV2 implements PostAnalyzeNodeCapability
 {
 
     /**
-     * @return string - name of PluginAwareAnalysisVisitor subclass
+     * @return string - name of PluginAwarePostAnalysisVisitor subclass
      *
      * @override
      */
-    public static function getAnalyzeNodeVisitorClassName() : string
+    public static function getPostAnalyzeNodeVisitorClassName() : string
     {
         return InvalidVariableIssetVisitor::class;
     }
 }
 
-class InvalidVariableIssetVisitor extends PluginAwareAnalysisVisitor
+class InvalidVariableIssetVisitor extends PluginAwarePostAnalysisVisitor
 {
 
     /** define classes to parse */
@@ -50,9 +50,9 @@ class InvalidVariableIssetVisitor extends PluginAwareAnalysisVisitor
 
         // get variable name from argument
         while (!isset($variable->children['name'])) {
-            if (in_array($variable->kind, self::EXPRESSIONS)) {
+            if (in_array($variable->kind, self::EXPRESSIONS, true)) {
                 $variable = $variable->children['expr'];
-            } elseif (in_array($variable->kind, self::CLASSES)) {
+            } elseif (in_array($variable->kind, self::CLASSES, true)) {
                 $variable = $variable->children['class'];
             }
         }

--- a/.phan/plugins/NonBoolBranchPlugin.php
+++ b/.phan/plugins/NonBoolBranchPlugin.php
@@ -4,24 +4,24 @@
 use Phan\AST\UnionTypeVisitor;
 use Phan\Language\Context;
 use Phan\PluginV2;
-use Phan\PluginV2\AnalyzeNodeCapability;
-use Phan\PluginV2\PluginAwareAnalysisVisitor;
+use Phan\PluginV2\PostAnalyzeNodeCapability;
+use Phan\PluginV2\PluginAwarePostAnalysisVisitor;
 use ast\Node;
 
-class NonBoolBranchPlugin extends PluginV2 implements AnalyzeNodeCapability
+class NonBoolBranchPlugin extends PluginV2 implements PostAnalyzeNodeCapability
 {
     /**
-     * @return string - name of PluginAwareAnalysisVisitor subclass
+     * @return string - name of PluginAwarePostAnalysisVisitor subclass
      *
      * @override
      */
-    public static function getAnalyzeNodeVisitorClassName() : string
+    public static function getPostAnalyzeNodeVisitorClassName() : string
     {
         return NonBoolBranchVisitor::class;
     }
 }
 
-class NonBoolBranchVisitor extends PluginAwareAnalysisVisitor
+class NonBoolBranchVisitor extends PluginAwarePostAnalysisVisitor
 {
     // A plugin's visitors should not override visit() unless they need to.
 

--- a/.phan/plugins/NonBoolInLogicalArithPlugin.php
+++ b/.phan/plugins/NonBoolInLogicalArithPlugin.php
@@ -4,25 +4,25 @@
 use Phan\Language\Context;
 use Phan\Language\UnionType;
 use Phan\PluginV2;
-use Phan\PluginV2\AnalyzeNodeCapability;
-use Phan\PluginV2\PluginAwareAnalysisVisitor;
+use Phan\PluginV2\PostAnalyzeNodeCapability;
+use Phan\PluginV2\PluginAwarePostAnalysisVisitor;
 use ast\Node;
 
-class NonBoolInLogicalArithPlugin extends PluginV2 implements AnalyzeNodeCapability
+class NonBoolInLogicalArithPlugin extends PluginV2 implements PostAnalyzeNodeCapability
 {
 
     /**
-     * @return string - name of PluginAwareAnalysisVisitor subclass
+     * @return string - name of PluginAwarePostAnalysisVisitor subclass
      *
      * @override
      */
-    public static function getAnalyzeNodeVisitorClassName() : string
+    public static function getPostAnalyzeNodeVisitorClassName() : string
     {
         return NonBoolInLogicalArithVisitor::class;
     }
 }
 
-class NonBoolInLogicalArithVisitor extends PluginAwareAnalysisVisitor
+class NonBoolInLogicalArithVisitor extends PluginAwarePostAnalysisVisitor
 {
 
     /** define boolean operator list */

--- a/.phan/plugins/NumericalComparisonPlugin.php
+++ b/.phan/plugins/NumericalComparisonPlugin.php
@@ -4,25 +4,25 @@
 use Phan\Language\Context;
 use Phan\Language\UnionType;
 use Phan\PluginV2;
-use Phan\PluginV2\AnalyzeNodeCapability;
-use Phan\PluginV2\PluginAwareAnalysisVisitor;
+use Phan\PluginV2\PostAnalyzeNodeCapability;
+use Phan\PluginV2\PluginAwarePostAnalysisVisitor;
 use ast\Node;
 
-class NumericalComparisonPlugin extends PluginV2 implements AnalyzeNodeCapability
+class NumericalComparisonPlugin extends PluginV2 implements PostAnalyzeNodeCapability
 {
 
     /**
-     * @return string - name of PluginAwareAnalysisVisitor subclass
+     * @return string - name of PluginAwarePostAnalysisVisitor subclass
      *
      * @override
      */
-    public static function getAnalyzeNodeVisitorClassName() : string
+    public static function getPostAnalyzeNodeVisitorClassName() : string
     {
         return NumericalComparisonVisitor::class;
     }
 }
 
-class NumericalComparisonVisitor extends PluginAwareAnalysisVisitor
+class NumericalComparisonVisitor extends PluginAwarePostAnalysisVisitor
 {
     /** define equal operator list */
     const BINARY_EQUAL_OPERATORS = [

--- a/.phan/plugins/UnreachableCodePlugin.php
+++ b/.phan/plugins/UnreachableCodePlugin.php
@@ -2,8 +2,8 @@
 
 use Phan\Analysis\BlockExitStatusChecker;
 use Phan\PluginV2;
-use Phan\PluginV2\AnalyzeNodeCapability;
-use Phan\PluginV2\PluginAwareAnalysisVisitor;
+use Phan\PluginV2\PostAnalyzeNodeCapability;
+use Phan\PluginV2\PluginAwarePostAnalysisVisitor;
 use ast\Node;
 
 /**
@@ -12,7 +12,7 @@ use ast\Node;
  *
  * It hooks into one event:
  *
- * - getAnalyzeNodeVisitorClassName
+ * - getPostAnalyzeNodeVisitorClassName
  *   This method returns a class that is called on every AST node from every
  *   file being analyzed
  *
@@ -28,13 +28,13 @@ use ast\Node;
  * Note: When adding new plugins,
  * add them to the corresponding section of README.md
  */
-final class UnreachableCodePlugin extends PluginV2 implements AnalyzeNodeCapability
+final class UnreachableCodePlugin extends PluginV2 implements PostAnalyzeNodeCapability
 {
 
     /**
      * @return string - The name of the visitor that will be called (formerly analyzeNode)
      */
-    public static function getAnalyzeNodeVisitorClassName() : string
+    public static function getPostAnalyzeNodeVisitorClassName() : string
     {
         return UnreachableCodeVisitor::class;
     }
@@ -47,7 +47,7 @@ final class UnreachableCodePlugin extends PluginV2 implements AnalyzeNodeCapabil
  * Visitors such as this are useful for defining lots of different
  * checks on a node based on its kind.
  */
-final class UnreachableCodeVisitor extends PluginAwareAnalysisVisitor
+final class UnreachableCodeVisitor extends PluginAwarePostAnalysisVisitor
 {
     // A plugin's visitors should NOT implement visit(), unless they need to.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,8 +3,19 @@ Phan NEWS
 ?? Mar 2018, Phan 0.12.2 (dev)
 ------------------------
 
+Plugins
++ Add a new plugin capability `PostAnalyzeNodeCapability` (preferred) and `LegacyPostAnalyzeNodeCapability`.
+  These capabilities give plugins for post-order analysis access to a list of parent nodes,
+  instead of just the last parent node.
+  Plugin authors should use these instead of `AnalyzeNodeCapability` and `LegacyAnalyzeNodeCapability`.
+
+  (`parent_node_list` is set as an instance property on the visitor returned by PostAnalyzeNodeCapability
+  if the instance property was declared)
+
 Bug Fixes
 + Reduce false positives in `PhanTypeInvalidDimOffset`
++ Don't warn when adding new keys to an array when assigning multiple dimensions at once (#1518)
++ Reduce false positives when a property's type gets inferred as an array shape(#1520)
 
 28 Feb 2018, Phan 0.12.1
 ------------------------

--- a/src/Phan/Plugin.php
+++ b/src/Phan/Plugin.php
@@ -21,6 +21,7 @@ use ast\Node;
  * of themselves.
  *
  * @deprecated - Use PluginV2 instead
+ * This class will eventually be removed in favor of PluginV2.
  */
 abstract class Plugin extends PluginV2 implements
     AnalyzeClassCapability,

--- a/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
@@ -129,7 +129,7 @@ final class ArrayReturnTypeOverridePlugin extends PluginV2 implements
                                 $passed_array_element_types = $passed_array_type->genericArrayElementTypes();
                                 ArgumentType::analyzeParameter($code_base, $context, $filter_function, $passed_array_element_types, $context->getLineNumberStart(), 0);
                                 if (!Config::get_quick_mode()) {
-                                    $analyzer = new PostOrderAnalysisVisitor($code_base, $context, null);
+                                    $analyzer = new PostOrderAnalysisVisitor($code_base, $context, []);
                                     $analyzer->analyzeCallableWithArgumentTypes([$passed_array_element_types], $filter_function);
                                 }
                             }
@@ -243,7 +243,7 @@ final class ArrayReturnTypeOverridePlugin extends PluginV2 implements
                     $argument_types[] = $get_argument_type_for_array_map($node, $i);
                 }
                 foreach ($function_like_list as $map_function) {
-                    $analyzer = new PostOrderAnalysisVisitor($code_base, $context, null);
+                    $analyzer = new PostOrderAnalysisVisitor($code_base, $context, []);
                     $analyzer->analyzeCallableWithArgumentTypes($argument_types, $map_function);
                 }
             }

--- a/src/Phan/Plugin/Internal/ClosureReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ClosureReturnTypeOverridePlugin.php
@@ -296,7 +296,7 @@ final class ClosureReturnTypeOverridePlugin extends PluginV2 implements
         foreach ($arguments as $i => $argument) {
             $argument_types[] = $get_argument_type($argument, $i);
         }
-        $analyzer = new PostOrderAnalysisVisitor($code_base, $context, null);
+        $analyzer = new PostOrderAnalysisVisitor($code_base, $context, []);
         foreach ($function_like_list as $function_like) {
             $analyzer->analyzeCallableWithArgumentTypes($argument_types, $function_like);
         }

--- a/src/Phan/Plugin/PluginImplementation.php
+++ b/src/Phan/Plugin/PluginImplementation.php
@@ -120,7 +120,8 @@ class PluginImplementation extends Plugin
     // Internal methods, for use by ConfigPluginSet
 
     /**
-     * @return bool true if $method_name is defined by the subclass of PluginAwareAnalysisVisitor, and not by PluginAwareAnalysisVisitor or one of it's parents.
+     * @return bool true if $method_name is defined by the subclass of PluginAwareAnalysisVisitor or PluginAwarePostAnalysisVisitor,
+     * and not by PluginAware*AnalysisVisitor or one of its parents.
      */
     final public static function isDefinedInSubclass(string $method_name) : bool
     {

--- a/src/Phan/PluginV2.php
+++ b/src/Phan/PluginV2.php
@@ -26,9 +26,11 @@ use Phan\PluginV2\IssueEmitter;
  *     Analyze (and modify) a method definition, after parsing and before analyzing.
  *     (implement \Phan\PluginV2\AnalyzeMethodCapability)
  *
- *  4. public static function getAnalyzeNodeVisitorClassName() : string
- *     Returns the name of a class extending PluginAwareAnalysisVisitor, which will be used to analyze nodes in the analysis phase.
- *     (implement \Phan\PluginV2\AnalyzeNodeCapability)
+ *  4. public static function getPostAnalyzeNodeVisitorClassName() : string
+ *     Returns the name of a class extending PluginAwarePostAnalysisVisitor, which will be used to analyze nodes in the analysis phase.
+ *     If the PluginAwarePostAnalysisVisitor subclass has an instance property called parent_node_list,
+ *     Phan will automatically set that property to the list of parent nodes (The nodes deepest in the AST are at the end of the list)
+ *     (implement \Phan\PluginV2\PostAnalyzeNodeCapability)
  *
  *  5. public static function getPreAnalyzeNodeVisitorClassName() : string
  *     Returns the name of a class extending PluginAwarePreAnalysisVisitor, which will be used to pre-analyze nodes in the analysis phase.
@@ -59,12 +61,24 @@ use Phan\PluginV2\IssueEmitter;
  *  1. public static function analyzeNode(CodeBase $code_base, Context $context, Node $node, Node $parent_node = null)
  *     Analyzes $node
  *     (implement \Phan\PluginV2\LegacyAnalyzeNodeCapability)
- *     (Deprecated in favor of \Phan\PluginV2\AnalyzeNodeCapability, which is faster)
+ *     (Deprecated in favor of postAnalyzeNode and \Phan\PluginV2\AnalyzeNodeCapability, which are faster)
  *
  *  2. public static function preAnalyzeNode(CodeBase $code_base, Context $context, Node $node)
  *     Pre-analyzes $node
  *     (implement \Phan\PluginV2\LegacyPreAnalyzeNodeCapability)
  *     (Deprecated in favor of \Phan\PluginV2\PreAnalyzeNodeCapability, which is faster)
+ *
+ *  3. public static function postAnalyzeNode(CodeBase $code_base, Context $context, Node $node, array<int,Node> $parent_node_list = [])
+ *     Analyzes $node
+ *     (implement \Phan\PluginV2\LegacyPostAnalyzeNodeCapability)
+ *     (Deprecated in favor of \Phan\PluginV2\PostAnalyzeNodeCapability, which is much faster)
+ *
+ *  4. public static function getAnalyzeNodeVisitorClassName() : string
+ *     Returns the name of a class extending PluginAwareAnalysisVisitor, which will be used to analyze nodes in the analysis phase.
+ *     Phan will automatically add the instance property parent_node to instances of that PluginAwareAnalysisVisitor,
+ *     even if no such instance property was declared.
+ *     (implement \Phan\PluginV2\AnalyzeNodeCapability)
+ *     (Deprecated in favor of \Phan\PluginV2\PostAnalyzeNodeCapability, which is much faster)
  *
  * TODO: Implement a way to notify plugins that a parsed file is no longer valid,
  * if the replacement for pcntl is being used.

--- a/src/Phan/PluginV2/AnalyzeNodeCapability.php
+++ b/src/Phan/PluginV2/AnalyzeNodeCapability.php
@@ -1,6 +1,9 @@
 <?php declare(strict_types=1);
 namespace Phan\PluginV2;
 
+/**
+ * @deprecated - Use PostAnalyzeNodeCapability instead
+ */
 interface AnalyzeNodeCapability
 {
     /**

--- a/src/Phan/PluginV2/LegacyPostAnalyzeNodeCapability.php
+++ b/src/Phan/PluginV2/LegacyPostAnalyzeNodeCapability.php
@@ -9,7 +9,7 @@ use ast\Node;
 /**
  * @deprecated - New plugins should use PostAnalyzeNodeCapability
  */
-interface LegacyAnalyzeNodeCapability
+interface LegacyPostAnalyzeNodeCapability
 {
     /**
      * Analyze the given node in the given context after
@@ -26,17 +26,17 @@ interface LegacyAnalyzeNodeCapability
      * @param Node $node
      * The php-ast Node being analyzed.
      *
-     * @param ?Node $parent_node
+     * @param array<int,Node> $parent_node_list
      * The parent node of the given node (if any exist).
      *
      * @return void
      *
      * @deprecated
      */
-    public function analyzeNode(
+    public function postAnalyzeNode(
         CodeBase $code_base,
         Context $context,
         Node $node,
-        Node $parent_node = null
+        array $parent_node_list = []
     );
 }

--- a/src/Phan/PluginV2/PluginAwareBaseAnalysisVisitor.php
+++ b/src/Phan/PluginV2/PluginAwareBaseAnalysisVisitor.php
@@ -88,7 +88,8 @@ abstract class PluginAwareBaseAnalysisVisitor extends AnalysisVisitor
     }
 
     /**
-     * @return bool true if $method_name is defined by the subclass of PluginAwareAnalysisVisitor, and not by PluginAwareAnalysisVisitor or one of it's parents.
+     * @return bool true if $method_name is defined by the subclass of PluginAwareBaseAnalysisVisitor,
+     * and not by PluginAwareBaseAnalysisVisitor or one of its parents.
      */
     private static function isDefinedInSubclass(string $method_name) : bool
     {

--- a/src/Phan/PluginV2/PluginAwarePostAnalysisVisitor.php
+++ b/src/Phan/PluginV2/PluginAwarePostAnalysisVisitor.php
@@ -1,0 +1,74 @@
+<?php declare(strict_types=1);
+namespace Phan\PluginV2;
+
+use Phan\Issue;
+// use ast\Node;
+
+/**
+ * For plugins which define their own post-order analysis behaviors in the analysis phase.
+ * Called on a node after PluginAwarePreAnalysisVisitor implementations.
+ *
+ * - visit<VisitSuffix>(...) (Override these methods)
+ * - emitPluginIssue(CodeBase $code_base, Config $config, ...) (Call these methods)
+ * - emit(...)
+ * - Public methods from Phan\AST\AnalysisVisitor
+ *
+ * NOTE: Subclasses should not implement the visit() method unless they absolutely need to.
+ * (E.g. if the body would be empty, or if it could be replaced with a small number of more specific methods such as visitFuncDecl, visitVar, etc.)
+ *
+ * - Phan is able to figure out which methods a subclass implements, and only call the plugin's visitor for those types,
+ *   but only when the plugin's visitor does not override the fallback visit() method.
+ */
+abstract class PluginAwarePostAnalysisVisitor extends PluginAwareBaseAnalysisVisitor
+{
+    // Subclasses should declare protected $parent_node_list as an instance property if they need to know the list.
+
+    // @var array<int,Node> - Set after the constructor is called if an instance property with this name is declared
+    // protected $parent_node_list;
+
+    // Implementations should omit the constructor or call parent::__construct(CodeBase $code_base, Context $context)
+
+    /**
+     * @param string $issue_type
+     * A name for the type of issue such as 'PhanPluginMyIssue'
+     *
+     * @param string $issue_message_fmt
+     * The complete issue message format string to emit such as
+     * 'class with fqsen {CLASS} is broken in some fashion' (preferred)
+     * or 'class with fqsen %s is broken in some fashion'
+     * The list of placeholders for between braces can be found
+     * in \Phan\Issue::uncolored_format_string_for_template.
+     *
+     * @param array<int,string> $issue_message_args
+     * The arguments for this issue format.
+     * If this array is empty, $issue_message_args is kept in place
+     *
+     * @param int $severity
+     * A value from the set {Issue::SEVERITY_LOW,
+     * Issue::SEVERITY_NORMAL, Issue::SEVERITY_HIGH}.
+     *
+     * @param int $remediation_difficulty
+     * A guess at how hard the issue will be to fix from the
+     * set {Issue:REMEDIATION_A, Issue:REMEDIATION_B, ...
+     * Issue::REMEDIATION_F} with F being the hardest.
+     */
+    public function emit(
+        string $issue_type,
+        string $issue_message_fmt,
+        array $issue_message_args = [],
+        int $severity = Issue::SEVERITY_NORMAL,
+        int $remediation_difficulty = Issue::REMEDIATION_B,
+        int $issue_type_id = Issue::TYPE_ID_UNKNOWN
+    ) {
+        $this->emitPluginIssue(
+            $this->code_base,
+            $this->context,
+            $issue_type,
+            $issue_message_fmt,
+            $issue_message_args,
+            $severity,
+            $remediation_difficulty,
+            $issue_type_id
+        );
+    }
+}

--- a/src/Phan/PluginV2/PluginAwarePreAnalysisVisitor.php
+++ b/src/Phan/PluginV2/PluginAwarePreAnalysisVisitor.php
@@ -3,7 +3,7 @@ namespace Phan\PluginV2;
 
 /**
  * For plugins which define their own pre-order analysis behaviors in the analysis phase.
- * Called on a node before PluginAwareAnalysisVisitor implementations.
+ * Called on a node before PluginAwarePreAnalysisVisitor implementations.
  *
  * Public APIs for use by plugins:
  *

--- a/src/Phan/PluginV2/PostAnalyzeNodeCapability.php
+++ b/src/Phan/PluginV2/PostAnalyzeNodeCapability.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+namespace Phan\PluginV2;
+
+/**
+ * This is the same as AnalyzeNodeCapability.
+ *
+ * If $this->parent_node_list is an instance property, then that will automatically get set.
+ * $this->parent_node_list will have the elements closest to the current node at the end.
+ *
+ * - If that property is absent, it will not be set.
+ */
+interface PostAnalyzeNodeCapability
+{
+    /**
+     * Returns the name of the visitor class to be instantiated and invoked to analyze a node in the analysis phase.
+     * (To analyze a node. PostAnalyzeNodeCapability is run after PreAnalyzeNodeCapability)
+     * The class should be created by the plugin visitor, and must extend PluginAwarePostAnalysisVisitor.
+     *
+     * If state needs to be shared with a visitor and a plugin, a plugin author may use static variables of that plugin.
+     *
+     * @return string - The name of a class extending PluginAwarePostAnalysisVisitor
+     */
+    public static function getPostAnalyzeNodeVisitorClassName() : string;
+}

--- a/tests/files/expected/0437_array_multidim_assign.php.expected
+++ b/tests/files/expected/0437_array_multidim_assign.php.expected
@@ -1,0 +1,2 @@
+%s:6 PhanTypeMismatchArgumentInternal Argument 1 (string) is int but \strlen() takes string
+%s:7 PhanTypeMismatchArgumentInternal Argument 1 (string) is int but \strlen() takes string

--- a/tests/files/src/0437_array_multidim_assign.php
+++ b/tests/files/src/0437_array_multidim_assign.php
@@ -1,0 +1,8 @@
+<?php
+
+function test437() {
+    $x = ['a' => ['b' => 0]];
+    $x['a']['key2']['c'] = 2;
+    echo strlen($x['a']['b']);
+    echo strlen($x['a']['key2']['c']);
+}


### PR DESCRIPTION
Previously, this example would emit a false positive:

```
$x = [];
$x['a']['b'] = 0;     // No error here
$x['a']['c']['d'] = 0;  // previously threw PhanTypeInvalidDimOffset
```

In order to stop emitting this warning,
Phan had to start tracking the full list of parent nodes
instead of just the last parent node.