### PR TITLE
Fixes #1525: Convert array shapes to generic arrays before recursive …

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@ Bug Fixes
 + Don't warn when adding new keys to an array when assigning multiple dimensions at once (#1518)
 + Reduce false positives when a property's type gets inferred as an array shape(#1520)
 + Reduce false positives when adding fields to an array in the global scope.
++ Reduce false positives by converting array shapes to generic arrays before recursively analyzing method/function invocations (#1525)
 
 28 Feb 2018, Phan 0.12.1
 ------------------------

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -2233,13 +2233,15 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         // on the argument's type. We'll use this to
         // retest the method with the passed in types
         // TODO: if $argument_type is non-empty and !isType(NullType), instead use setUnionType?
+
+        // For https://github.com/phan/phan/issues/1525 : Collapse array shapes into generic arrays before recursively analyzing a method.
         if (!$parameter->isCloneOfVariadic()) {
             $parameter->addUnionType(
-                $argument_type
+                $argument_type->withFlattenedArrayShapeTypeInstances()
             );
         } else {
             $parameter->addUnionType(
-                $argument_type->asGenericArrayTypes(GenericArrayType::KEY_INT)
+                $argument_type->withFlattenedArrayShapeTypeInstances()->asGenericArrayTypes(GenericArrayType::KEY_INT)
             );
         }
 

--- a/tests/files/expected/0174_is_a_generic.php.expected
+++ b/tests/files/expected/0174_is_a_generic.php.expected
@@ -1,5 +1,5 @@
 %s:7 PhanTypeMismatchArgument Argument 1 (var) is array but \f() takes resource defined at %s:3
-%s:7 PhanTypeMismatchArgument Argument 1 (var) is array{0:string,1:string,2:string} but \f() takes resource defined at %s:3
+%s:7 PhanTypeMismatchArgument Argument 1 (var) is array<int,string> but \f() takes resource defined at %s:3
 %s:9 PhanTypeMismatchArgument Argument 1 (var) is bool but \f() takes resource defined at %s:3
-%s:12 PhanTypeMismatchReturn Returning type array{0:string,1:string,2:string}|bool but g() is declared to return resource
+%s:12 PhanTypeMismatchReturn Returning type array<int,string>|bool but g() is declared to return resource
 %s:12 PhanTypeMismatchReturn Returning type array|bool but g() is declared to return resource

--- a/tests/rasmus_files/expected/0037_properties2.php.expected
+++ b/tests/rasmus_files/expected/0037_properties2.php.expected
@@ -1,3 +1,3 @@
-%s:13 PhanTypeMismatchProperty Assigning array{0:int,1:int,2:int} to property but \B::text is string
+%s:13 PhanTypeMismatchProperty Assigning array<int,int> to property but \B::text is string
 %s:20 PhanAccessPropertyProtected Cannot access protected property \B::$text
 %s:30 PhanTypeMismatchProperty Assigning array to property but \B::text is string


### PR DESCRIPTION
…analysis

There's a lot more false positives and it's difficult to see which
caller is the cause.

This imitates Phan's behavior from before array shapes were added to the
type system.