### PR TITLE
Cache the compiled php-ast in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,11 @@ dist: trusty
 cache:
   directories:
     - $HOME/.composer/cache
+    - $HOME/.cache/phan-ast/build
 
 # We invoke php multiple times via CLI in several tests, so enable the opcache file cache.
 before_install:
-  - ./tests/setup.sh
+  - ./tests/travis_setup.sh
   - mkdir /tmp/opcache || true; echo -e 'opcache.enable_cli=1\nopcache.file_cache=/tmp/opcache' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - composer validate
 

--- a/tests/travis_setup.sh
+++ b/tests/travis_setup.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
-set -xeu
-
-if [[ "x$TRAVIS" == "x" ]]; then
+if [[ "x${TRAVIS:-}" == "x" ]]; then
     echo "This should only be run in travis"
     exit 1
 fi
 
+set -xeu
+
 # Ensure the build directory exist
-PHP_VERSION_ID=$(php -r "echo PHP_VERSION_ID;")
-PHAN_BUILD_DIR="$HOME/.cache/phan-ast-build"
+PHP_VERSION_ID=$(php -r "echo PHP_VERSION_ID . '_' . PHP_DEBUG . '_' . PHP_ZTS;")
+PHAN_BUILD_DIR="$HOME/.cache/phan-ast"
 EXPECTED_AST_FILE="$PHAN_BUILD_DIR/build/php-ast-$PHP_VERSION_ID.so"
 
 [[ -d "$PHAN_BUILD_DIR" ]] || mkdir -p "$PHAN_BUILD_DIR"
@@ -22,6 +22,7 @@ if [[ ! -e "$EXPECTED_AST_FILE" ]]; then
 
   git clone --depth 1 https://github.com/nikic/php-ast.git php-ast
 
+  export CFLAGS="-O3"
   pushd php-ast
   # Install the ast extension
   phpize


### PR DESCRIPTION
It takes 5 seconds to build this.
This assumes that the travis hosts use the same libraries.