### PR TITLE
Speed up non-quick mode: Use better heuristic

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,9 @@ Plugins
   (`parent_node_list` is set as an instance property on the visitor returned by PostAnalyzeNodeCapability
   if the instance property was declared)
 
+Maintenance:
++ Speed up analysis when quick mode isn't used.
+
 Bug Fixes
 + Reduce false positives in `PhanTypeInvalidDimOffset`
 + Don't warn when adding new keys to an array when assigning multiple dimensions at once (#1518)

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -876,7 +876,7 @@ class AssignmentVisitor extends AnalysisVisitor
                         return StringType::instance(false)->asUnionType();
                     }
                 }
-            } else if (!$assign_type->hasType($mixed_type)) {
+            } elseif (!$assign_type->hasType($mixed_type)) {
                 // Imitate the check in UnionTypeVisitor, don't warn for mixed, etc.
                 $this->emitIssue(
                     Issue::TypeArraySuspicious,

--- a/src/Phan/Language/Element/FunctionInterface.php
+++ b/src/Phan/Language/Element/FunctionInterface.php
@@ -336,4 +336,11 @@ interface FunctionInterface extends AddressableElementInterface
      * @return void
      */
     public function cloneParameterList();
+
+    /**
+     * @return bool - Does any parameter type possibly require recursive analysis if more specific types are provided?
+     *
+     * If this returns true, there is at least one parameter and at least one of those can be overridden with a more specific type.
+     */
+    public function needsRecursiveAnalysis() : bool;
 }

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -904,7 +904,8 @@ final class EmptyUnionType extends UnionType
         return false;
     }
 
-    public function generateUniqueId() : string {
+    public function generateUniqueId() : string
+    {
         return '';
     }
 
@@ -913,4 +914,8 @@ final class EmptyUnionType extends UnionType
         return false;
     }
 
+    public function shouldBeReplacedBySpecificTypes() : bool
+    {
+        return true;
+    }
 }

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -1963,6 +1963,15 @@ class Type
     }
 
     /**
+     * @internal - Used to check for quick mode
+     */
+    public function shouldBeReplacedBySpecificTypes()
+    {
+        // Could check for final classes such as stdClass here, but not much of a reason to.
+        return true;
+    }
+
+    /**
      * @return Type[]
      */
     public function withFlattenedArrayShapeTypeInstances() : array

--- a/src/Phan/Language/Type/ArrayShapeType.php
+++ b/src/Phan/Language/Type/ArrayShapeType.php
@@ -330,4 +330,12 @@ final class ArrayShapeType extends ArrayType
     {
         return self::fromFieldTypes($left->field_types + $right->field_types, false);
     }
+
+    /**
+     * @override
+     */
+    public function shouldBeReplacedBySpecificTypes() : bool
+    {
+        return false;
+    }
 }

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -474,4 +474,12 @@ final class GenericArrayType extends ArrayType
     {
         return GenericArrayType::fromElementType($this, false, $key_type);
     }
+
+    /**
+     * @override
+     */
+    public function shouldBeReplacedBySpecificTypes() : bool
+    {
+        return false;
+    }
 }

--- a/src/Phan/Language/Type/ScalarType.php
+++ b/src/Phan/Language/Type/ScalarType.php
@@ -108,5 +108,13 @@ abstract class ScalarType extends NativeType
         // Subclasses of ScalarType all have false values within their types.
         return $this;
     }
+
+    /**
+     * @override
+     */
+    public function shouldBeReplacedBySpecificTypes() : bool
+    {
+        return false;
+    }
 }
 \class_exists(IntType::class);

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -2248,6 +2248,16 @@ class UnionType implements \Serializable
         }
         return $result->getUnionType();
     }
+
+    public function shouldBeReplacedBySpecificTypes() : bool
+    {
+        if ($this->isEmpty()) {
+            return true;
+        }
+        return $this->hasTypeMatchingCallback(function (Type $type) : bool {
+            return $type->shouldBeReplacedBySpecificTypes();
+        });
+    }
 }
 
 UnionType::init();

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -545,7 +545,7 @@ final class ConfigPluginSet extends PluginV2 implements
                     }
                 }
                 $closure = (new \ReflectionMethod($plugin, 'analyzeNode'))->getClosure($plugin);
-                $closures_for_kind->recordForAllKinds(function(CodeBase $code_base, Context $context, Node $node, array $parent_node_list) use ($closure) {
+                $closures_for_kind->recordForAllKinds(function (CodeBase $code_base, Context $context, Node $node, array $parent_node_list) use ($closure) {
                     $closure($code_base, $context, $node, \end($parent_node_list) ?: null);
                 });
             } elseif ($plugin instanceof LegacyPostAnalyzeNodeCapability) {

--- a/src/Phan/PluginV2/PluginAwarePostAnalysisVisitor.php
+++ b/src/Phan/PluginV2/PluginAwarePostAnalysisVisitor.php
@@ -2,6 +2,7 @@
 namespace Phan\PluginV2;
 
 use Phan\Issue;
+
 // use ast\Node;
 
 /**

--- a/tests/Phan/Language/EmptyUnionTypeTest.php
+++ b/tests/Phan/Language/EmptyUnionTypeTest.php
@@ -26,7 +26,8 @@ use TypeError;
 class EmptyUnionTypeTest extends BaseTest
 {
 
-    public function testMethods() {
+    public function testMethods()
+    {
         $this->assertTrue(class_exists(UnionType::class));  // Force the autoloader to load UnionType before attempting to load EmptyUnionType
         $failures = '';
         foreach ((new ReflectionClass(EmptyUnionType::class))->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
@@ -46,7 +47,8 @@ class EmptyUnionTypeTest extends BaseTest
         $this->assertSame('', $failures);
     }
 
-    public function checkHasSameImplementationForEmpty(ReflectionMethod $method) {
+    public function checkHasSameImplementationForEmpty(ReflectionMethod $method)
+    {
         $method_name = $method->getName();
         if (!method_exists(UnionType::class, $method_name)) {
             return '';
@@ -80,7 +82,8 @@ class EmptyUnionTypeTest extends BaseTest
      *
      * @return array<int,array>
      */
-    public function generateArgLists(ReflectionMethod $method) : array {
+    public function generateArgLists(ReflectionMethod $method) : array
+    {
         $list_of_arg_list = [[]];
 
         foreach ($method->getParameters() as $param) {
@@ -105,7 +108,8 @@ class EmptyUnionTypeTest extends BaseTest
         return $list_of_arg_list;
     }
 
-    public function getPossibleArgValues(ReflectionParameter $param) : array {
+    public function getPossibleArgValues(ReflectionParameter $param) : array
+    {
         $type = $param->getType();
         $type_name = (string)$type;
         switch ($type_name) {
@@ -142,11 +146,14 @@ class EmptyUnionTypeTest extends BaseTest
                 ];
             case Closure::class:
                 return [
-                    function(...$args) { return false; },
-                    function(...$args) { return true; },
+                    function (...$args) {
+                        return false;
+                    },
+                    function (...$args) {
+                        return true;
+                    },
                 ];
         }
         throw new TypeError("Unable to handle param {$type_name} \${$param->getName()}");
     }
-
 }


### PR DESCRIPTION
Instead of checking if the argument list is empty,
check if the argument list exclusively has parameter types that shouldn't be
overridden.