### PR TITLE
Fixes #1534: Use array shapes for analyzing array destructuring.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,11 @@ Phan NEWS
 02 Mar 2018, Phan 0.12.2
 ------------------------
 
+New Features(Analysis)
+
++ Emit `PhanTypeInvalidDimOffsetArrayDestructuring` when an unknown offset value is used in an array destructuring assignment (#1534)
+  (E.g. `foreach ($expr as ['key' => $value])`, `list($k) = [2]`, etc.)
+
 Plugins
 + Add a new plugin capability `PostAnalyzeNodeCapability` (preferred) and `LegacyPostAnalyzeNodeCapability`.
   These capabilities give plugins for post-order analysis access to a list of parent nodes,

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -492,6 +492,9 @@ class ConditionVisitor extends KindVisitorImplementation
             // If we already have possible scalar types, then keep those
             // (E.g. T|false becomes bool, T becomes int|float|bool|string|null)
             $newType = $variable->getUnionType()->scalarTypes();
+            if ($newType->containsNullable()) {
+                $newType = $newType->nonNullableClone();
+            }
             if ($newType->isEmpty()) {
                 // If there are no inferred types, or the only type we saw was 'null',
                 // assume there this can be any possible scalar.

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -64,6 +64,7 @@ class Issue
     const TypeInvalidRightOperand   = 'PhanTypeInvalidRightOperand';
     const TypeInvalidInstanceof     = 'PhanTypeInvalidInstanceof';
     const TypeInvalidDimOffset      = 'PhanTypeInvalidDimOffset';
+    const TypeInvalidDimOffsetArrayDestructuring = 'PhanTypeInvalidDimOffsetArrayDestructuring';
     const TypeMagicVoidWithReturn   = 'PhanTypeMagicVoidWithReturn';
     const TypeMismatchArgument      = 'PhanTypeMismatchArgument';
     const TypeMismatchArgumentInternal = 'PhanTypeMismatchArgumentInternal';
@@ -1105,6 +1106,14 @@ class Issue
                 "Invalid offset {SCALAR} of array type {TYPE}",
                 self::REMEDIATION_B,
                 10046
+            ),
+            new Issue(
+                self::TypeInvalidDimOffsetArrayDestructuring,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                "Invalid offset {SCALAR} of array type {TYPE} in an array destructuring assignment",
+                self::REMEDIATION_B,
+                10047
             ),
             // Issue::CATEGORY_VARIABLE
             new Issue(

--- a/tests/files/expected/0253_keys_in_lists.php.expected
+++ b/tests/files/expected/0253_keys_in_lists.php.expected
@@ -1,8 +1,12 @@
-%s:16 PhanTypeMismatchArgument Argument 1 (p1) is int|string but \f253_1() takes bool defined at %s:2
-%s:17 PhanTypeMismatchArgument Argument 1 (p1) is int|string but \f253_1() takes bool defined at %s:2
-%s:20 PhanTypeMismatchArgument Argument 1 (p1) is int|string but \f253_1() takes bool defined at %s:2
-%s:21 PhanTypeMismatchArgument Argument 1 (p1) is int|string but \f253_1() takes bool defined at %s:2
+%s:16 PhanTypeMismatchArgument Argument 1 (p1) is int but \f253_1() takes bool defined at %s:2
+%s:17 PhanTypeMismatchArgument Argument 1 (p1) is string but \f253_1() takes bool defined at %s:2
+%s:20 PhanTypeMismatchArgument Argument 1 (p1) is int but \f253_1() takes bool defined at %s:2
+%s:21 PhanTypeMismatchArgument Argument 1 (p1) is string but \f253_1() takes bool defined at %s:2
 %s:26 PhanTypeMismatchArgument Argument 1 (p1) is int but \f253_1() takes bool defined at %s:2
 %s:27 PhanTypeMismatchArgument Argument 1 (p1) is int but \f253_1() takes bool defined at %s:2
 %s:30 PhanTypeMismatchArgument Argument 1 (p1) is int but \f253_1() takes bool defined at %s:2
 %s:31 PhanTypeMismatchArgument Argument 1 (p1) is int but \f253_1() takes bool defined at %s:2
+%s:39 PhanTypeMismatchArgument Argument 1 (p1) is string but \f253_1() takes bool defined at %s:2
+%s:42 PhanTypeInvalidDimOffsetArrayDestructuring Invalid offset 1 of array type array{k1:int,k2:string} in an array destructuring assignment
+%s:42 PhanTypeMismatchArrayDestructuringKey Attempting an array destructing assignment with a key of type int but the only key types of the right hand side are of type string
+%s:46 PhanTypeInvalidDimOffsetArrayDestructuring Invalid offset "kMissing" of array type array{k1:int,k2:string} in an array destructuring assignment

--- a/tests/files/expected/0253_keys_in_lists.php.expected70
+++ b/tests/files/expected/0253_keys_in_lists.php.expected70
@@ -1,2 +1,6 @@
-%s:14 PhanTypeMismatchArgument Argument 1 (p1) is int|string but \f253_1() takes bool defined at %s:2
-%s:15 PhanTypeMismatchArgument Argument 1 (p1) is int|string but \f253_1() takes bool defined at %s:2
+%s:15 PhanTypeMismatchArgument Argument 1 (p1) is int but \f253_1() takes bool defined at %s:3
+%s:16 PhanTypeMismatchArgument Argument 1 (p1) is string but \f253_1() takes bool defined at %s:3
+%s:18 PhanTypeInvalidDimOffsetArrayDestructuring Invalid offset 2 of array type array{0:int,1:string} in an array destructuring assignment
+%s:27 PhanTypeInvalidDimOffsetArrayDestructuring Invalid offset 0 of array type array{42:int,k2:string} in an array destructuring assignment
+%s:36 PhanTypeInvalidDimOffsetArrayDestructuring Invalid offset 0 of array type array{x:string} in an array destructuring assignment
+%s:36 PhanTypeMismatchArrayDestructuringKey Attempting an array destructing assignment with a key of type int but the only key types of the right hand side are of type string

--- a/tests/files/expected/0313_undefined_array_push.php.expected
+++ b/tests/files/expected/0313_undefined_array_push.php.expected
@@ -2,5 +2,6 @@
 %s:9 PhanUndeclaredVariableDim Variable $myvAR was undeclared, but array fields are being added to it.
 %s:11 PhanUndeclaredProperty Reference to undeclared property \Foo313->prop
 %s:12 PhanUndeclaredStaticProperty Static property 'undef_static_prop' on \Foo313 is undeclared
+%s:13 PhanTypeInvalidDimOffsetArrayDestructuring Invalid offset 1 of array type array{0:int} in an array destructuring assignment
 %s:13 PhanUndeclaredProperty Reference to undeclared property \Foo313->otherProp
 %s:13 PhanUndeclaredVariableDim Variable $myUndefListVar was undeclared, but array fields are being added to it.

--- a/tests/files/expected/0402_array_destructuring.php.expected
+++ b/tests/files/expected/0402_array_destructuring.php.expected
@@ -1,3 +1,7 @@
+%s:4 PhanTypeInvalidDimOffsetArrayDestructuring Invalid offset 0 of array type array{key:int} in an array destructuring assignment
 %s:4 PhanTypeMismatchArrayDestructuringKey Attempting an array destructing assignment with a key of type int but the only key types of the right hand side are of type string
+%s:5 PhanTypeInvalidDimOffsetArrayDestructuring Invalid offset "key" of array type array{0:int} in an array destructuring assignment
 %s:5 PhanTypeMismatchArrayDestructuringKey Attempting an array destructing assignment with a key of type string but the only key types of the right hand side are of type int
+%s:6 PhanTypeInvalidDimOffsetArrayDestructuring Invalid offset 0 of array type array{key:int} in an array destructuring assignment
 %s:6 PhanTypeMismatchArrayDestructuringKey Attempting an array destructing assignment with a key of type int but the only key types of the right hand side are of type string
+%s:7 PhanTypeInvalidDimOffsetArrayDestructuring Invalid offset 2 of array type array{0:int} in an array destructuring assignment

--- a/tests/files/expected/0402_array_destructuring.php.expected70
+++ b/tests/files/expected/0402_array_destructuring.php.expected70
@@ -1,1 +1,2 @@
+%s:4 PhanTypeInvalidDimOffsetArrayDestructuring Invalid offset 0 of array type array{key:int} in an array destructuring assignment
 %s:4 PhanTypeMismatchArrayDestructuringKey Attempting an array destructing assignment with a key of type int but the only key types of the right hand side are of type string

--- a/tests/files/src/0253_keys_in_lists.php
+++ b/tests/files/src/0253_keys_in_lists.php
@@ -1,11 +1,11 @@
 <?php
 function f253_1(bool $p1) : void {}
 
-// Unfortunately, we only see $v1 as a mixed array
-// and as such, can't map individual keys to the
+// we see $v1 as a nested array shape,
+// so we can map individual keys to the
 // types at those offsets. The types for `$v2`,
 // `$v3`, `$v4`, `$v5`, `$v6`, `$v7`, `$v8`,
-// and `$v9` will be unknown.
+// and `$v9` will be known.
 $v1 = [
     ['k1' => 1, 'k2' => 'string'],
     ['k1' => 2, 'k2' => 'string'],
@@ -30,11 +30,19 @@ f253_1($v12);
 f253_1($v13);
 f253_1($v14);
 
-// Unfortunately, we only see $v15 as a mixed array
-// and as such, can't map individual keys to the
+// We see $v15 as an array shape
+// and can map individual keys to the
 // types at those offsets. The types for `$v16` and
-// `$v17` will be unknown.
+// `$v17` will be known.
 $v15 = ['k1' => 'string', 'k2' => false];
 ['k1' => $v16, 'k2' => $v17] = $v15;
-f253_1($v16);
+f253_1($v16);  // should warn
 f253_1($v17);
+
+foreach ($v1 as [1 => $v18]) {
+    var_export($v18);
+}
+
+foreach ($v1 as ['kMissing' => $v19]) {
+    var_export($v18);
+}

--- a/tests/files/src/0253_keys_in_lists.php70
+++ b/tests/files/src/0253_keys_in_lists.php70
@@ -1,11 +1,12 @@
 <?php
-function f253_1(bool $p1) : void {}
+error_reporting(E_ALL);
+function f253_1(bool $p1) {}
 
-// Unfortunately, we only see $v1 as a mixed array
-// and as such, can't map individual keys to the
+// we see $v1 as a nested array shape,
+// so we can map individual keys to the
 // types at those offsets. The types for `$v2`,
 // `$v3`, `$v4`, `$v5`, `$v6`, `$v7`, `$v8`,
-// and `$v9` will be unknown.
+// and `$v9` will be known.
 $v1 = [
     [1, 'string'],
     [2, 'string2'],
@@ -13,4 +14,25 @@ $v1 = [
 foreach ($v1 as list($a, $b)) {
     f253_1($a);
     f253_1($b);
+}
+foreach ($v1 as list($a, $b, $c)) {
+    var_export($c);
+}
+
+$v2 = [
+    [42 => 1, 'k2' => 'string'],
+    [42 => 2, 'k2' => 'string2'],
+];
+
+foreach ($v2 as list($x)) {
+    var_export($x);
+}
+
+$v3 = [
+    ['x' => 'string'],
+    ['x' => 'string2'],
+];
+
+foreach ($v3 as list($x)) {
+    var_export($x);
 }

--- a/tests/files/src/0402_array_destructuring.php
+++ b/tests/files/src/0402_array_destructuring.php
@@ -4,3 +4,4 @@
 [$c] = ['key' => 42];  // should warn
 ['key' => $d] = [42];  // should warn
 [0 => $e] = ['key' => 42];  // should warn
+[,,$b] = [42];


### PR DESCRIPTION
Make `foreach($expr as list($v1, $v2))` work with array shapes
Make `list('key' => $v1) = array_shape_expression()` work.