### PR TITLE
Add option to disable usage messages of phan_client

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@ Phan NEWS
 ?? ??? 2018, Phan 0.12.3 (dev)
 ------------------------
 
+Maintenance
++ Add `--disable-usage-on-error` option to `phan_client` (#1540)
+
 Bug Fixes
 + Remove leading `./` from Phan's relative paths for files (#1548, #1538)
 

--- a/composer.lock
+++ b/composer.lock
@@ -393,16 +393,16 @@
         },
         {
             "name": "sabre/event",
-            "version": "5.0.2",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sabre-io/event.git",
-                "reference": "3cb619803d5e3e38ed7c309250da5589676aedc8"
+                "reference": "f5cf802d240df1257866d8813282b98aee3bc548"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sabre-io/event/zipball/3cb619803d5e3e38ed7c309250da5589676aedc8",
-                "reference": "3cb619803d5e3e38ed7c309250da5589676aedc8",
+                "url": "https://api.github.com/repos/sabre-io/event/zipball/f5cf802d240df1257866d8813282b98aee3bc548",
+                "reference": "f5cf802d240df1257866d8813282b98aee3bc548",
                 "shasum": ""
             },
             "require": {
@@ -449,20 +449,20 @@
                 "reactor",
                 "signal"
             ],
-            "time": "2017-06-10T09:11:18+00:00"
+            "time": "2018-03-05T13:55:47+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v3.4.4",
+            "version": "v3.4.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "26b6f419edda16c19775211987651cb27baea7f1"
+                "reference": "067339e9b8ec30d5f19f5950208893ff026b94f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/26b6f419edda16c19775211987651cb27baea7f1",
-                "reference": "26b6f419edda16c19775211987651cb27baea7f1",
+                "url": "https://api.github.com/repos/symfony/console/zipball/067339e9b8ec30d5f19f5950208893ff026b94f7",
+                "reference": "067339e9b8ec30d5f19f5950208893ff026b94f7",
                 "shasum": ""
             },
             "require": {
@@ -518,20 +518,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2018-01-29T09:03:43+00:00"
+            "time": "2018-02-26T15:46:28+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v3.4.4",
+            "version": "v3.4.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "53f6af2805daf52a43b393b93d2f24925d35c937"
+                "reference": "9b1071f86e79e1999b3d3675d2e0e7684268b9bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/53f6af2805daf52a43b393b93d2f24925d35c937",
-                "reference": "53f6af2805daf52a43b393b93d2f24925d35c937",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/9b1071f86e79e1999b3d3675d2e0e7684268b9bc",
+                "reference": "9b1071f86e79e1999b3d3675d2e0e7684268b9bc",
                 "shasum": ""
             },
             "require": {
@@ -574,7 +574,7 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2018-01-18T22:16:57+00:00"
+            "time": "2018-02-28T21:49:22+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -1202,16 +1202,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.5.6",
+            "version": "6.5.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "3330ef26ade05359d006041316ed0fa9e8e3cefe"
+                "reference": "6bd77b57707c236833d2b57b968e403df060c9d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3330ef26ade05359d006041316ed0fa9e8e3cefe",
-                "reference": "3330ef26ade05359d006041316ed0fa9e8e3cefe",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6bd77b57707c236833d2b57b968e403df060c9d9",
+                "reference": "6bd77b57707c236833d2b57b968e403df060c9d9",
                 "shasum": ""
             },
             "require": {
@@ -1282,7 +1282,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-02-01T05:57:37+00:00"
+            "time": "2018-02-26T07:01:09+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",

--- a/phan_client
+++ b/phan_client
@@ -272,6 +272,9 @@ class PhanPHPLinterOpts
     /** @var bool */
     public $use_fallback_parser;
 
+    /** @var bool */
+    private $print_usage_on_error = true;
+
     /**
      * @param string $msg - optional message
      * @param int $exit_code - process exit code.
@@ -279,15 +282,16 @@ class PhanPHPLinterOpts
      */
     public function usage($msg = '', $exit_code = 0)
     {
-        global $argv;
-        if (!empty($msg)) {
-            echo "$msg\n";
-        }
+        if (!$msg || $this->print_usage_on_error) {
+            global $argv;
+            if (!empty($msg)) {
+                echo "$msg\n";
+            }
 
-        // TODO: Add an option to autostart the daemon if user also has global configuration to allow it for a given project folder. ($HOME/.phanconfig)
-        // TODO: Allow changing (adding/removing) issue suppression types for the analysis phase (would not affect the parse phase)
+            // TODO: Add an option to autostart the daemon if user also has global configuration to allow it for a given project folder. ($HOME/.phanconfig)
+            // TODO: Allow changing (adding/removing) issue suppression types for the analysis phase (would not affect the parse phase)
 
-        echo <<<EOB
+            echo <<<EOB
 Usage: {$argv[0]} [options] -l file.php [ -l file2.php]
  --daemonize-socket </path/to/file.sock>
   Unix socket which a Phan daemon is listening for requests on.
@@ -312,6 +316,10 @@ Usage: {$argv[0]} [options] -l file.php [ -l file2.php]
   A simpler way to specify a file mapping when checking a single files.
   Pass this after the only occurrence of --syntax-check.
 
+ -d, --disable-usage-on-error
+  If this option is set, don't print full usage messages for missing/inaccessible files or inaccessible daemons.
+  (Continue printing usage messages for invalid combinations of options.)
+
  -v, --verbose
   Whether to emit debugging output of this client.
 
@@ -319,6 +327,7 @@ Usage: {$argv[0]} [options] -l file.php [ -l file2.php]
   This help information
 
 EOB;
+        }
         exit($exit_code);
     }
 
@@ -332,11 +341,12 @@ EOB;
 
         // Parse command line args
         $optind = 0;
-        $shortopts = "s:p:l:t:f:v";
+        $shortopts = "s:p:l:t:f:vhd";
         $longopts = [
             'help',
             'daemonize-socket:',
             'daemonize-tcp-port:',
+            'disable-usage-on-error',
             'syntax-check:',
             'temporary-file-map:',
             'use-fallback-parser',
@@ -360,6 +370,7 @@ EOB;
             PhanPHPLinter::$verbose = true;
             $this->verbose = true;
         }
+        $print_usage_on_error = true;
 
         foreach ((\is_array($opts) ? $opts : []) as $key => $value) {
             switch ($key) {
@@ -425,6 +436,7 @@ EOB;
                 case 'syntax-check':
                     $path = $value;
                     if (!file_exists($path)) {
+                        $this->print_usage_on_error = $print_usage_on_error;
                         $this->usage(sprintf("Error: asked to analyze file %s which does not exist", json_encode($path)), 1);
                         exit(1);
                     }
@@ -433,6 +445,10 @@ EOB;
                 case 'h':
                 case 'help':
                     $this->usage();
+                    break;
+                case 'd':
+                case 'disable-usage-on-error':
+                    $print_usage_on_error = false;
                     break;
                 case 'v':
                 case 'verbose':
@@ -443,6 +459,7 @@ EOB;
             }
         }
         if (count($this->file_list) === 0) {
+            // Invalid invocation, always print this message
             $this->usage("This requires at least one file to analyze (with -l path/to/file", 1);
         }
         if (\is_array($this->temporary_file_map)) {
@@ -455,6 +472,9 @@ EOB;
         if ($this->url === null) {
             $this->url = 'tcp://127.0.0.1:4846';
         }
+		// In the majority of cases, apply this **after** checking sanity of CLI options
+		// (without actually starting the analysis).
+        $this->print_usage_on_error = $print_usage_on_error;
     }
 
     /**

--- a/plugins/vim/phansnippet.vim
+++ b/plugins/vim/phansnippet.vim
@@ -13,6 +13,7 @@ au! BufWritePost  *.php,*.html    call PHPsynCHK()
 
 function! PHPsynCHK()
   let winnum =winnr() " get current window number
+  " or 'silent make --disable-usage-on-error -l %' in Phan 0.12.3+
   silent make -l %
   cw " open the error window if it contains an error. Don't limit the number of lines.
   " return to the window with cursor set on the line of the first error (if any)


### PR DESCRIPTION
(on a subset of error types, e.g. missing files or
being unable to access the daemon.)

- This is useful for the vim snippet, etc.

and upgrade composer.lock dependencies.

Fixes #1540