### PR TITLE
Add unused variable/param detection to self-test

### DIFF
--- a/.phan/plugins/PrintfCheckerPlugin.php
+++ b/.phan/plugins/PrintfCheckerPlugin.php
@@ -57,7 +57,7 @@ class PrintfCheckerPlugin extends PluginV2 implements AnalyzeFunctionCallCapabil
     /**
      * People who have translations may subclass this plugin and return a mapping from other locales to those locales translations of $fmt_str.
      * @return string[] mapping locale to the translation (e.g. ['fr_FR' => 'Bonjour'] for $fmt_str == 'Hello')
-     * @suppress PhanPluginUnusedVariable
+     * @suppress PhanPluginUnusedProtectedMethodArgument
      */
     protected static function gettextForAllLocales(string $fmt_str)
     {

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ cache:
   directories:
     - $HOME/.composer/cache
     - $HOME/.cache/phan-ast/build
+    - $HOME/.phan-ci
 
 # We invoke php multiple times via CLI in several tests, so enable the opcache file cache.
 before_install:

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -1077,7 +1077,7 @@ class ContextNode
                         $this->node->lineno ?? 0,
                         [
                             (string)$property->getFQSEN(),
-                            $property->getElementNamespace($this->code_base),
+                            $property->getElementNamespace(),
                             $property->getFileRef()->getFile(),
                             $property->getFileRef()->getLineNumberStart(),
                             $this->context->getNamespace(),
@@ -1350,7 +1350,7 @@ class ContextNode
                     $node->lineno ?? 0,
                     [
                         (string)$constant->getFQSEN(),
-                        $constant->getElementNamespace($code_base),
+                        $constant->getElementNamespace(),
                         $constant->getFileRef()->getFile(),
                         $constant->getFileRef()->getLineNumberStart(),
                         $context->getNamespace()

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -1013,7 +1013,7 @@ final class TolerantASTConverter
             'Microsoft\PhpParser\Node\ClassConstDeclaration' => function (PhpParser\Node\ClassConstDeclaration $n, int $start_line) : ast\Node {
                 return self::phpParserClassConstToAstNode($n, $start_line);
             },
-            'Microsoft\PhpParser\Node\MissingMemberDeclaration' => function (PhpParser\Node\MissingMemberDeclaration $n, int $start_line) {
+            'Microsoft\PhpParser\Node\MissingMemberDeclaration' => function (PhpParser\Node\MissingMemberDeclaration $unused_n, int $unused_start_line) {
                 // This node type is generated for something that isn't a function/constant/property. e.g. "public example();"
                 return null;
             },

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1899,6 +1899,7 @@ class UnionTypeVisitor extends AnalysisVisitor
     /**
      * `print($str)` always returns 1.
      * See https://secure.php.net/manual/en/function.print.php#refsect1-function.print-returnvalues
+     * @suppress PhanPluginUnusedPublicMethodArgument
      */
     public function visitPrint(Node $node) : UnionType
     {
@@ -2202,6 +2203,7 @@ class UnionTypeVisitor extends AnalysisVisitor
      * @param string|Node $node the node to fetch CallableType instances for.
      * @param bool $log_error whether or not to log errors while searching
      * @return array<int,FunctionInterface>
+     * @suppress PhanPluginUnusedPublicMethodArgument (TODO: Implement $log_error)
      */
     public static function functionLikeListFromNodeAndContext(CodeBase $code_base, Context $context, $node, bool $log_error) : array
     {

--- a/src/Phan/Analysis/ArgumentType.php
+++ b/src/Phan/Analysis/ArgumentType.php
@@ -196,7 +196,7 @@ class ArgumentType
                 Issue::AccessMethodInternal,
                 $context->getLineNumberStart(),
                 (string)$method->getFQSEN(),
-                $method->getElementNamespace($code_base) ?: '\\',
+                $method->getElementNamespace() ?: '\\',
                 $method->getFileRef()->getFile(),
                 $method->getFileRef()->getLineNumberStart(),
                 ($context->getNamespace()) ?: '\\'

--- a/src/Phan/Analysis/AssignOperatorFlagVisitor.php
+++ b/src/Phan/Analysis/AssignOperatorFlagVisitor.php
@@ -204,6 +204,8 @@ class AssignOperatorFlagVisitor extends FlagVisitorImplementation
      *
      * @return UnionType
      * The resulting type(s) of the binary operation
+     *
+     * @suppress PhanPluginUnusedPublicMethodArgument
      */
     public function visitBinaryConcat(Node $node) : UnionType
     {

--- a/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
+++ b/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
@@ -187,7 +187,8 @@ class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
      *
      * @return UnionType
      * The resulting type(s) of the binary operation
-     * @suppress PhanPluginUnusedMethodArgument
+     *
+     * @suppress PhanPluginUnusedPublicMethodArgument
      */
     public function visitBinaryConcat(Node $node) : UnionType
     {

--- a/src/Phan/Analysis/BlockExitStatusChecker.php
+++ b/src/Phan/Analysis/BlockExitStatusChecker.php
@@ -24,6 +24,8 @@ use Phan\AST\Visitor\KindVisitorImplementation;
  *
  * TODO: Change to AnalysisVisitor if this ever emits issues.
  * TODO: Analyze switch (if there is a default) in another PR (And handle fallthrough)
+ *
+ * @phan-file-suppress PhanPluginUnusedPublicFinalMethodArgument
  */
 final class BlockExitStatusChecker extends KindVisitorImplementation
 {

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -19,9 +19,13 @@ use Phan\Language\UnionType;
 use Phan\Language\UnionTypeBuilder;
 use ast\Node;
 
-// TODO: Make $x != null remove FalseType and NullType from $x
-// TODO: Make $x > 0, $x < 0, $x >= 50, etc.  remove FalseType and NullType from $x
-// TODO: if (a || b || c || d) might get really slow, due to creating both ConditionVisitor and NegatedConditionVisitor
+/**
+ * TODO: Make $x != null remove FalseType and NullType from $x
+ * TODO: Make $x > 0, $x < 0, $x >= 50, etc.  remove FalseType and NullType from $x
+ * TODO: if (a || b || c || d) might get really slow, due to creating both ConditionVisitor and NegatedConditionVisitor
+ *
+ * @phan-file-suppress PhanPluginUnusedClosureArgument
+ */
 class ConditionVisitor extends KindVisitorImplementation
 {
     use ConditionVisitorUtil;

--- a/src/Phan/Analysis/ContextMergeVisitor.php
+++ b/src/Phan/Analysis/ContextMergeVisitor.php
@@ -45,14 +45,14 @@ class ContextMergeVisitor extends KindVisitorImplementation
      * Default visitor for node kinds that do not have
      * an overriding method
      *
-     * @param Node $node
+     * @param Node $unused_node
      * A node to parse
      *
      * @return Context
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visit(Node $node) : Context
+    public function visit(Node $unused_node) : Context
     {
         // TODO: if ($this->context->isInGlobalScope()) {
         //            copy local to global
@@ -269,6 +269,7 @@ class ContextMergeVisitor extends KindVisitorImplementation
 
         // Get the intersection of all types for all versions of
         // the variable from every side of the branch
+        /** @suppress PhanPluginUnusedVariable plugin doesn't handle loops well */
         $union_type =
             function (string $variable_name) use ($scope_list) {
                 $previous_type = null;

--- a/src/Phan/Analysis/NegatedConditionVisitor.php
+++ b/src/Phan/Analysis/NegatedConditionVisitor.php
@@ -292,9 +292,9 @@ class NegatedConditionVisitor extends KindVisitorImplementation
         if (self::isArgumentListWithVarAsFirstArgument($args)) {
             $function_name = \strtolower(\ltrim($raw_function_name, '\\'));
             if (\count($args) !== 1) {
-                if (\strcasecmp($function_name, 'is_a') === 0) {
+                /*if (\strcasecmp($function_name, 'is_a') === 0) {
                     return $this->analyzeNegationOfVariableIsA($args, $context);
-                }
+                }*/
                 return $context;
             }
             static $map;
@@ -323,11 +323,13 @@ class NegatedConditionVisitor extends KindVisitorImplementation
 
     // TODO: negate instanceof
 
+    /*
     private function analyzeNegationOfVariableIsA(array $args, Context $context) : Context
     {
         // TODO: implement
         return $context;
     }
+     */
 
     /**
      * @return array<string,\Closure> (ConditionVisitor $cv, Node $var_node, Context $context) -> Context

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -190,6 +190,7 @@ class ParameterTypesAnalyzer
 
     /**
      * @return void
+     * @suppress PhanPluginUnusedVariable
      */
     private static function checkCommentParametersAreInOrder(CodeBase $code_base, FunctionInterface $method)
     {

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -166,10 +166,11 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
      * @return Context
      * A new or an unchanged context resulting from
      * parsing the node
+     * @suppress PhanPluginUnusedPublicMethodArgument
      */
     public function visitWhile(Node $node) : Context
     {
-        return $this->visitIfElem($node);
+        return $this->context;
     }
 
     /**
@@ -179,10 +180,11 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
      * @return Context
      * A new or an unchanged context resulting from
      * parsing the node
+     * @suppress PhanPluginUnusedPublicMethodArgument
      */
     public function visitSwitch(Node $node) : Context
     {
-        return $this->visitIfElem($node);
+        return $this->context;
     }
 
     /**
@@ -192,10 +194,11 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
      * @return Context
      * A new or an unchanged context resulting from
      * parsing the node
+     * @suppress PhanPluginUnusedPublicMethodArgument
      */
     public function visitSwitchCase(Node $node) : Context
     {
-        return $this->visitIfElem($node);
+        return $this->context;
     }
 
     /**
@@ -205,10 +208,11 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
      * @return Context
      * A new or an unchanged context resulting from
      * parsing the node
+     * @suppress PhanPluginUnusedPublicMethodArgument
      */
     public function visitExprList(Node $node) : Context
     {
-        return $this->visitIfElem($node);
+        return $this->context;
     }
 
     /**

--- a/src/Phan/Analysis/ScopeVisitor.php
+++ b/src/Phan/Analysis/ScopeVisitor.php
@@ -39,7 +39,7 @@ abstract class ScopeVisitor extends AnalysisVisitor
      * @return Context
      * A new or an unchanged context resulting from
      * parsing the node
-     * @suppress PhanPluginUnusedMethodArgument
+     * @suppress PhanPluginUnusedPublicMethodArgument
      */
     public function visit(Node $node) : Context
     {

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -95,6 +95,9 @@ class BlockAnalysisVisitor extends AnalysisVisitor
         return $context;
     }
 
+    /**
+     * @suppress PhanPluginUnusedPublicMethodArgument
+     */
     public function visitUseElem(Node $node) : Context
     {
         // Could invoke plugins, but not right now
@@ -147,6 +150,9 @@ class BlockAnalysisVisitor extends AnalysisVisitor
         return $this->postOrderAnalyze($context, $node);
     }
 
+    /**
+     * @suppress PhanPluginUnusedPublicMethodArgument
+     */
     public function visitName(Node $node) : Context
     {
         // Could invoke plugins, but not right now
@@ -618,6 +624,52 @@ class BlockAnalysisVisitor extends AnalysisVisitor
 
         // Return the initial context as we exit
         return $this->context;
+    }
+
+    /**
+     * @param Node $node
+     * An AST node we'd like to analyze the statements for
+     *
+     * @return Context
+     * The updated context after visiting the node
+     */
+    public function visitSwitchList(Node $node) : Context
+    {
+        // Make a copy of the internal context so that we don't
+        // leak any changes within the closed context to the
+        // outer scope
+        $context = clone($this->context->withLineNumberStart(
+            $node->lineno ?? 0
+        ));
+
+        $context = $this->preOrderAnalyze($context, $node);
+        $child_context_list = [];
+
+        // TODO: Improve inferences in switch statements?
+        // TODO: Behave differently if switch lists don't cover every case (e.g. if there is no default)
+        foreach ($node->children as $child_node) {
+            // Step into each child node and get an
+            // updated context for the node
+            $child_context = $this->analyzeAndGetUpdatedContext($context, $node, $child_node);
+
+            // We can improve analysis of `case` blocks by using
+            // a BlockExitStatusChecker to avoid propogating invalid inferences.
+            if (!BlockExitStatusChecker::willUnconditionallyThrowOrReturn($child_node->children['stmts'])) {
+                $child_context_list[] = $child_context;
+            }
+        }
+
+        if (count($child_context_list) > 0) {
+            // For case statements, we need to merge the contexts
+            // of all child context into a single scope based
+            // on any possible branching structure
+            $context = (new ContextMergeVisitor(
+                $context,
+                $child_context_list
+            ))->__invoke($node);
+        }
+
+        return $this->postOrderAnalyze($context, $node);
     }
 
     /**
@@ -1225,7 +1277,6 @@ class BlockAnalysisVisitor extends AnalysisVisitor
 
         $context = $this->context;
         $class = $context->getClassInScope($this->code_base);
-        $is_static = (\end($this->parent_node_list)->flags & \ast\flags\MODIFIER_STATIC) !== 0;
 
         $context = $this->context->withScope(new PropertyScope(
             $context->getScope(),

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -336,9 +336,12 @@ class CLI
                     Config::setValue('plugins', []);
                     break;
                 case 'plugin':
+                    if (!is_array($value)) {
+                        $value = [$value];
+                    }
                     Config::setValue(
                         'plugins',
-                        array_unique(array_merge(Config::getValue('plugins'), [$value]))
+                        array_unique(array_merge(Config::getValue('plugins'), $value))
                     );
                     break;
                 case 'use-fallback-parser':
@@ -453,7 +456,8 @@ class CLI
             }
         }
 
-        while ($key = array_pop($pruneargv)) {
+        while (count($pruneargv) > 0) {
+            $key = array_pop($pruneargv);
             unset($argv[$key]);
         }
 

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -320,7 +320,7 @@ class CodeBase
                 continue;
             }
             try {
-                $const_obj = GlobalConstant::fromGlobalConstantName($this, $const_name);
+                $const_obj = GlobalConstant::fromGlobalConstantName($const_name);
                 $this->addGlobalConstant($const_obj);
             } catch (\InvalidArgumentException $e) {
                 // Workaround for windows bug in #1011
@@ -376,7 +376,6 @@ class CodeBase
                 // Force loading these even if automatic loading failed.
                 // (Shouldn't happen, the function list is fetched from reflection by callers.
                 $function_alternate_generator = FunctionFactory::functionListFromReflectionFunction(
-                    $this,
                     $function_fqsen,
                     new \ReflectionFunction($function_fqsen->getNamespacedName())
                 );
@@ -608,9 +607,9 @@ class CodeBase
         if ($this->undo_tracker) {
             $this->undo_tracker->recordUndo(function (CodeBase $inner) use ($file, $key) {
                 Daemon::debugf("Undoing addParsedNamespaceMap file = %s namespace = %s\n", $file, $key);
-                unset($this->parsed_namespace_maps[$file][$key]);
+                unset($inner->parsed_namespace_maps[$file][$key]);
                 // Hack: addParsedNamespaceMap is called at least once per each file, so unset file-level suppressions at the same time in daemon mode
-                unset($this->file_level_suppression_set[$file]);
+                unset($inner->file_level_suppression_set[$file]);
             });
         }
     }
@@ -1345,7 +1344,6 @@ class CodeBase
 
             // Add each method returned for the signature
             foreach (FunctionFactory::functionListFromSignature(
-                $this,
                 $canonical_fqsen,
                 $signature
             ) as $function) {
@@ -1362,7 +1360,6 @@ class CodeBase
         } elseif ($found) {
             // Phan doesn't have extended information for the signature for this function, but the function exists.
             foreach (FunctionFactory::functionListFromReflectionFunction(
-                $this,
                 $canonical_fqsen,
                 new \ReflectionFunction($name)
             ) as $function) {
@@ -1402,6 +1399,7 @@ class CodeBase
 
     /**
      * @return void
+     * @suppress PhanPluginUnusedPublicMethodArgument
      */
     public function flushDependenciesForFile(string $file_path)
     {
@@ -1412,6 +1410,7 @@ class CodeBase
      * @return string[]
      * The list of files that depend on the code in the given
      * file path
+     * @suppress PhanPluginUnusedPublicMethodArgument
      */
     public function dependencyListForFile(string $file_path) : array
     {

--- a/src/Phan/Config/Initializer.php
+++ b/src/Phan/Config/Initializer.php
@@ -76,6 +76,7 @@ class Initializer
 
     /**
      * @return array<string,string[]> maps a config name to a list of comment lines about that config
+     * @suppress PhanPluginUnusedVariable used in loop
      */
     private static function computeCommentNameDocumentationMap() : array
     {

--- a/src/Phan/Daemon.php
+++ b/src/Phan/Daemon.php
@@ -223,6 +223,8 @@ class Daemon
      *
      * @param string $format - printf style format string
      * @param mixed ...$args - printf args
+     *
+     * @suppress PhanPluginUnusedPublicMethodArgument (Currently commented out)
      */
     public static function debugf(string $format, ...$args)
     {

--- a/src/Phan/Language/Element/AddressableElement.php
+++ b/src/Phan/Language/Element/AddressableElement.php
@@ -117,7 +117,7 @@ abstract class AddressableElement extends TypedElement implements AddressableEle
     }
 
     /**
-     * @param CodeBase $code_base (@phan-unused-param, may be used by subclasses)
+     * @param CodeBase $code_base (@phan-unused-param, this is used by subclasses)
      * The code base in which this element exists.
      *
      * @return bool
@@ -142,7 +142,7 @@ abstract class AddressableElement extends TypedElement implements AddressableEle
     }
 
     /**
-     * @param CodeBase $code_base
+     * @param CodeBase $code_base (@phan-unused-param, this is used by subclasses)
      * The code base in which this element exists.
      *
      * @return bool
@@ -153,7 +153,7 @@ abstract class AddressableElement extends TypedElement implements AddressableEle
         Context $context
     ) : bool {
         // Figure out which namespace this element is within
-        $element_namespace = $this->getElementNamespace($code_base);
+        $element_namespace = $this->getElementNamespace();
 
         // Get our current namespace from the context
         $context_namespace = $context->getNamespace();
@@ -246,7 +246,7 @@ abstract class AddressableElement extends TypedElement implements AddressableEle
         // Do nothing unless overridden
     }
 
-    public function getElementNamespace(CodeBase $unused_code_base) : string
+    public function getElementNamespace() : string
     {
         $element_fqsen = $this->getFQSEN();
         \assert($element_fqsen instanceof FullyQualifiedGlobalStructuralElement);

--- a/src/Phan/Language/Element/ClassElement.php
+++ b/src/Phan/Language/Element/ClassElement.php
@@ -192,7 +192,10 @@ abstract class ClassElement extends AddressableElement
         );
     }
 
-    public function getElementNamespace(CodeBase $code_base) : string
+    /**
+     * @suppress PhanPluginUnusedMethodArgument
+     */
+    public function getElementNamespace() : string
     {
         // Get the namespace that the class is within
         return $this->getClassFQSEN()->getNamespace() ?: '\\';

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -296,7 +296,6 @@ class Clazz extends AddressableElement
             $method_list =
                 FunctionFactory::methodListFromReflectionClassAndMethod(
                     $method_context,
-                    $code_base,
                     $class,
                     $reflection_method
                 );
@@ -2369,8 +2368,8 @@ class Clazz extends AddressableElement
             $stub .= "\n\n    // methods\n";
 
             $is_interface = $this->isInterface();
-            $stub .= implode("\n", array_map(function (Method $method) use ($code_base, $is_interface) {
-                return $method->toStub($code_base, $is_interface);
+            $stub .= implode("\n", array_map(function (Method $method) use ($is_interface) {
+                return $method->toStub($is_interface);
             }, $method_map));
         }
 

--- a/src/Phan/Language/Element/Comment.php
+++ b/src/Phan/Language/Element/Comment.php
@@ -1018,7 +1018,7 @@ class Comment
         // a Closure would be bound with bind() or bindTo(), so using a custom tag.
         //
         // TODO: Also add a version which forbids using $this in the closure?
-        if (preg_match('/@(PhanClosureScope|phan-closure-scope)\s+(' . UnionType::union_type_regex . ')/', $line, $match)) {
+        if (preg_match('/@(PhanClosureScope|phan-closure-scope)\s+(' . Type::type_regex . ')/', $line, $match)) {
             $closure_scope_union_type_string = $match[2];
         }
 

--- a/src/Phan/Language/Element/FunctionFactory.php
+++ b/src/Phan/Language/Element/FunctionFactory.php
@@ -1,7 +1,6 @@
 <?php declare(strict_types=1);
 namespace Phan\Language\Element;
 
-use Phan\CodeBase;
 use Phan\Language\Context;
 use Phan\Language\FQSEN\FullyQualifiedFunctionName;
 use Phan\Language\FQSEN\FullyQualifiedMethodName;
@@ -17,7 +16,6 @@ class FunctionFactory
      * reflection info and internal functions data
      */
     public static function functionListFromReflectionFunction(
-        CodeBase $code_base,
         FullyQualifiedFunctionName $fqsen,
         \ReflectionFunction $reflection_function
     ) : array {
@@ -45,7 +43,7 @@ class FunctionFactory
         $function->setRealReturnType(UnionType::fromReflectionType($reflection_function->getReturnType()));
         $function->setRealParameterList(Parameter::listFromReflectionParameterList($reflection_function->getParameters()));
 
-        return self::functionListFromFunction($function, $code_base);
+        return self::functionListFromFunction($function);
     }
 
     /**
@@ -54,7 +52,6 @@ class FunctionFactory
      * reflection info and internal method data
      */
     public static function functionListFromSignature(
-        CodeBase $code_base,
         FullyQualifiedFunctionName $fqsen,
         array $signature
     ) : array {
@@ -76,7 +73,7 @@ class FunctionFactory
             []  // will be filled in by functionListFromFunction
         );
 
-        return self::functionListFromFunction($func, $code_base);
+        return self::functionListFromFunction($func);
     }
 
     /**
@@ -84,7 +81,6 @@ class FunctionFactory
      */
     public static function methodListFromReflectionClassAndMethod(
         Context $context,
-        CodeBase $code_base,
         \ReflectionClass $class,
         \ReflectionMethod $reflection_method
     ) : array {
@@ -128,7 +124,7 @@ class FunctionFactory
             $method->setRealParameterList(Parameter::listFromReflectionParameterList($reflection_method->getParameters()));
         }
 
-        return self::functionListFromFunction($method, $code_base);
+        return self::functionListFromFunction($method);
     }
 
     /**
@@ -136,15 +132,11 @@ class FunctionFactory
      * Get a list of methods hydrated with type information
      * for the given partial method
      *
-     * @param CodeBase $code_base
-     * The global code base holding all state
-     *
      * @return array<int,FunctionInterface>
      * A list of typed functions/methods based on the given method
      */
     public static function functionListFromFunction(
-        FunctionInterface $function,
-        CodeBase $code_base
+        FunctionInterface $function
     ) : array {
         // See if we have any type information for this
         // internal function

--- a/src/Phan/Language/Element/FunctionInterface.php
+++ b/src/Phan/Language/Element/FunctionInterface.php
@@ -216,7 +216,7 @@ interface FunctionInterface extends AddressableElementInterface
      */
     public function analyzeWithNewParams(Context $context, CodeBase $code_base, array $parameter_list) : Context;
 
-    public function getElementNamespace(CodeBase $code_base) : string;
+    public function getElementNamespace() : string;
 
     /**
      * @return UnionType

--- a/src/Phan/Language/Element/GlobalConstant.php
+++ b/src/Phan/Language/Element/GlobalConstant.php
@@ -1,7 +1,6 @@
 <?php declare(strict_types=1);
 namespace Phan\Language\Element;
 
-use Phan\CodeBase;
 use Phan\Language\Context;
 use Phan\Language\FQSEN\FullyQualifiedGlobalConstantName;
 use Phan\Language\Type;
@@ -38,7 +37,6 @@ class GlobalConstant extends AddressableElement implements ConstantInterface
     }
 
     /**
-     * @param CodeBase $code_base
      * @param string $name
      * The name of a builtin constant to build a new GlobalConstant structural
      * element from.
@@ -48,16 +46,12 @@ class GlobalConstant extends AddressableElement implements ConstantInterface
      * builtin constant.
      */
     public static function fromGlobalConstantName(
-        CodeBase $code_base,
         string $name
     ) : GlobalConstant {
-        if ($name === 'strict_types') {
-            debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
-        }
-        if (!defined($name)) {
+        if (!\defined($name)) {
             throw new \InvalidArgumentException(sprintf("This should not happen, defined(%s) is false, but the constant was returned by get_defined_constants()", var_export($name, true)));
         }
-        $value = constant($name);
+        $value = \constant($name);
         $constant_fqsen = FullyQualifiedGlobalConstantName::fromFullyQualifiedString(
             '\\' . $name
         );

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -630,7 +630,7 @@ class Method extends ClassElement implements FunctionInterface
         return $string;
     }
 
-    public function toStub(CodeBase $code_base, bool $class_is_interface = false) : string
+    public function toStub(bool $class_is_interface = false) : string
     {
         $string = '    ';
         // It's an error to have visibility or abstract in an interface's stub (e.g. JsonSerializable)

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -6,6 +6,8 @@ use Phan\Language\Type\ArrayType;
 
 /**
  * NOTE: there may also be instances of UnionType that are empty, due to the constructor being public
+ *
+ * @phan-file-suppress PhanPluginUnusedPublicFinalMethodArgument the results don't depend on passed in parameters
  */
 final class EmptyUnionType extends UnionType
 {

--- a/src/Phan/Language/FQSEN/AbstractFQSEN.php
+++ b/src/Phan/Language/FQSEN/AbstractFQSEN.php
@@ -104,9 +104,9 @@ abstract class AbstractFQSEN implements FQSEN, Serializable
         throw new \Error("serializing an FQSEN (" . (string)$this . ") is forbidden\n");
     }
 
-    public function unserialize($serialized)
+    public function unserialize($unused_serialized)
     {
         // We compare and look up FQSENs by their identity
-        throw new \Error("unserializing an FQSEN (" . (string)$this . ") is forbidden\n");
+        throw new \Error("unserializing an FQSEN ($unused_serialized) is forbidden\n");
     }
 }

--- a/src/Phan/Language/Type/ArrayType.php
+++ b/src/Phan/Language/Type/ArrayType.php
@@ -114,7 +114,7 @@ class ArrayType extends IterableType
     /**
      * Overridden in subclasses
      *
-     * @param int $key_type
+     * @param int $key_type @phan-unused-param (TODO: Use?)
      * Corresponds to the type of the array keys. Set this to a GenericArrayType::KEY_* constant.
      *
      * @return Type

--- a/src/Phan/Language/Type/MixedType.php
+++ b/src/Phan/Language/Type/MixedType.php
@@ -35,6 +35,9 @@ final class MixedType extends NativeType
         return $union_type->hasType($this);
     }
 
+    /**
+     * @suppress PhanPluginUnusedPublicFinalMethodArgument (TODO: maybe use it in the future?)
+     */
     public function asGenericArrayType(int $key_type) : Type
     {
         return ArrayType::instance(false);

--- a/src/Phan/Language/Type/NativeType.php
+++ b/src/Phan/Language/Type/NativeType.php
@@ -172,10 +172,10 @@ abstract class NativeType extends Type
     }
 
     /**
-     * @param CodeBase
+     * @param CodeBase $code_base @phan-unused-param
      * The code base to use in order to find super classes, etc.
      *
-     * @param $recursion_depth
+     * @param int $recursion_depth @phan-unused-param
      * This thing has a tendency to run-away on me. This tracks
      * how bad I messed up by seeing how far the expanded types
      * go

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -279,6 +279,7 @@ class UnionType implements \Serializable
      * @param string[] $parts (already trimmed)
      * @return string[]
      * @see Type::extractTemplateParameterTypeNameList (Similar method)
+     * @suppress PhanPluginUnusedVariable $prev_parts is used in loop
      */
     private static function mergeTypeParts(array $parts) : array
     {

--- a/src/Phan/LanguageServer/Server/Workspace.php
+++ b/src/Phan/LanguageServer/Server/Workspace.php
@@ -80,6 +80,8 @@ class Workspace
      * no-op for now. Stop the JSON RPC2 framework from warning about this method being undefined.
      * TODO: Define this so that Phan can respond to changes in client configuration.
      * @suppress PhanUnreferencedPublicMethod called by client via AdvancedJsonRpc
+     *
+     * @param $settings @phan-unused-param
      */
     public function didChangeConfiguration($settings)
     {

--- a/src/Phan/Output/Collector/ParallelChildCollector.php
+++ b/src/Phan/Output/Collector/ParallelChildCollector.php
@@ -13,7 +13,7 @@ use Phan\Output\IssueCollectorInterface;
 class ParallelChildCollector implements IssueCollectorInterface
 {
     /**
-     * @var Resource
+     * @var resource
      */
     private $message_queue_resource;
 
@@ -89,8 +89,10 @@ class ParallelChildCollector implements IssueCollectorInterface
      * Remove all collected issues (from the parse phase) for the given file paths.
      * Called from daemon mode.
      *
-     * @param string[] $files - the relative paths to those files
+     * @param string[] $files @phan-unused-param - the relative paths to those files
      * @return void
+     *
+     * @override
      */
     public function removeIssuesForFiles(array $files)
     {

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -39,6 +39,8 @@ use ast\Node;
  * possibly new context as modified by the given node.
  *
  * @property-read CodeBase $code_base
+ *
+ * @phan-file-suppress PhanPluginUnusedPublicMethodArgument implementing faster no-op methods for common visit*
  */
 class ParseVisitor extends ScopeVisitor
 {
@@ -330,7 +332,7 @@ class ParseVisitor extends ScopeVisitor
 
         if ($context->isPHPInternal()) {
             // only for stubs
-            foreach (FunctionFactory::functionListFromFunction($method, $code_base) as $method_variant) {
+            foreach (FunctionFactory::functionListFromFunction($method) as $method_variant) {
                 \assert($method_variant instanceof Method);
                 $class->addMethod($code_base, $method_variant, new None);
             }
@@ -657,7 +659,7 @@ class ParseVisitor extends ScopeVisitor
 
         if ($context->isPHPInternal()) {
             // only for stubs
-            foreach (FunctionFactory::functionListFromFunction($func, $code_base) as $func_variant) {
+            foreach (FunctionFactory::functionListFromFunction($func) as $func_variant) {
                 \assert($func_variant instanceof Func);
                 $code_base->addFunction($func_variant);
             }

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -626,10 +626,11 @@ final class ConfigPluginSet extends PluginV2 implements
                      * Create an instance of $plugin_analysis_class and run the visit*() method corresponding to $node->kind.
                      *
                      * @suppress PhanParamTooMany
-                     * @suppress PhanUndeclaredProperty
+                     * @suppress PhanTypeInstantiateInterface
                      * @suppress PhanDeprecatedInterface (TODO: Fix bugs in PhanClosureScope)
+                     * @phan-closure-scope PostAnalyzeNodeCapability
                      */
-                    $closure = (static function (CodeBase $code_base, Context $context, Node $node, array $parent_node_list = []) {
+                    $closure = (static function (CodeBase $code_base, Context $context, Node $node, array $unused_parent_node_list = []) {
                         $visitor = new static($code_base, $context);
                         $fn_name = Element::VISIT_LOOKUP_TABLE[$node->kind];
                         $visitor->{$fn_name}($node);

--- a/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
@@ -22,6 +22,8 @@ use Phan\PluginV2;
  * NOTE: This is automatically loaded by phan. Do not include it in a config.
  *
  * TODO: Refactor this.
+ *
+ * @phan-file-suppress PhanPluginUnusedClosureArgument
  */
 final class ArrayReturnTypeOverridePlugin extends PluginV2 implements
     ReturnTypeOverrideCapability

--- a/src/Phan/Plugin/Internal/ClosureReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ClosureReturnTypeOverridePlugin.php
@@ -54,7 +54,7 @@ final class ClosureReturnTypeOverridePlugin extends PluginV2 implements
         $call_user_func_callback = static function (
             CodeBase $code_base,
             Context $context,
-            Func $function,
+            Func $unused_function,
             array $args
         ) : UnionType {
             $element_types = UnionType::empty();
@@ -82,7 +82,7 @@ final class ClosureReturnTypeOverridePlugin extends PluginV2 implements
         $call_user_func_array_callback = static function (
             CodeBase $code_base,
             Context $context,
-            Func $function,
+            Func $unused_function,
             array $args
         ) : UnionType {
             $element_types = UnionType::empty();
@@ -177,7 +177,7 @@ final class ClosureReturnTypeOverridePlugin extends PluginV2 implements
         $call_user_func_callback = static function (
             CodeBase $code_base,
             Context $context,
-            Func $function,
+            Func $unused_function,
             array $args
         ) {
             if (\count($args) < 1) {
@@ -197,7 +197,7 @@ final class ClosureReturnTypeOverridePlugin extends PluginV2 implements
         $call_user_func_array_callback = static function (
             CodeBase $code_base,
             Context $context,
-            Func $function,
+            Func $unused_function,
             array $args
         ) {
             if (\count($args) < 2) {

--- a/src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php
@@ -37,6 +37,7 @@ final class DependentReturnTypeOverridePlugin extends PluginV2 implements
         $make_dependent_type_method = static function (int $expected_bool_pos, $type_if_true, $type_if_false, $type_if_unknown) : \Closure {
             /**
              * @return UnionType
+             * @suppress PhanPluginUnusedClosureArgument
              */
             return static function (
                 CodeBase $code_base,
@@ -74,7 +75,10 @@ final class DependentReturnTypeOverridePlugin extends PluginV2 implements
         $string_if_2_true           = $make_dependent_type_method(1, $string_union_type, $void_union_type, $nullable_string_union_type);
         $string_if_2_true_else_true = $make_dependent_type_method(1, $string_union_type, $true_union_type, $string_or_true_union_type);
 
-        /** @return UnionType */
+        /**
+         * @return UnionType
+         * @suppress PhanPluginUnusedClosureArgument
+         */
         $json_decode_return_type_handler = static function (
             CodeBase $code_base,
             Context $context,

--- a/src/Phan/Plugin/Internal/StringFunctionPlugin.php
+++ b/src/Phan/Plugin/Internal/StringFunctionPlugin.php
@@ -62,7 +62,7 @@ final class StringFunctionPlugin extends PluginV2 implements
     /**
      * @return array<string,\Closure>
      */
-    private static function getAnalyzeFunctionCallClosuresStatic(CodeBase $code_base) : array
+    private static function getAnalyzeFunctionCallClosuresStatic() : array
     {
         $make_order_warner = static function (int $expected_const_pos, int $expected_variable_pos) : \Closure {
             $expected_arg_count = 1 + (int)max($expected_const_pos, $expected_variable_pos);
@@ -196,13 +196,14 @@ final class StringFunctionPlugin extends PluginV2 implements
     /**
      * @return array<string,\Closure>
      * @override
+     * @suppress PhanPluginUnusedPublicFinalMethodArgument
      */
     public function getAnalyzeFunctionCallClosures(CodeBase $code_base) : array
     {
         // Unit tests invoke this repeatedly. Cache it.
         static $analyzers = null;
         if ($analyzers === null) {
-            $analyzers = self::getAnalyzeFunctionCallClosuresStatic($code_base);
+            $analyzers = self::getAnalyzeFunctionCallClosuresStatic();
         }
         return $analyzers;
     }

--- a/tests/run_test
+++ b/tests/run_test
@@ -15,7 +15,14 @@ case "$TEST_SUITE" in
 		exit $?
 		;;
 	__FakeSelfFallbackTest)
+		PLUGIN_PATH=$HOME/.phan-ci/UnusedVariablePlugin-c20aea3e.php
+
+		ARGS=""
+		if [ -e "$PLUGIN_PATH" ]; then
+			ARGS="--plugin $PLUGIN_PATH"
+		fi
 		./phan --plugin PHPUnitNotDeadCodePlugin \
+			$ARGS \
 			--dead-code-detection \
 			--polyfill-parse-all-element-doc-comments \
 			--force-polyfill-parser \

--- a/tests/travis_setup.sh
+++ b/tests/travis_setup.sh
@@ -35,6 +35,13 @@ else
   echo "Using cached extension."
 fi
 
+PLUGIN_PATH=$HOME/.phan-ci/UnusedVariablePlugin-c20aea3e.php
+
+if [[ ! -e "$PLUGIN_PATH" ]]; then
+    rm -r "$HOME/.phan-ci"
+    curl --create-dirs -fsS https://raw.githubusercontent.com/phan/PhanUnusedVariable/c20aea3e468654481c8bfb1d9c4938ff5fe107ba/src/UnusedVariablePlugin.php -o "$PLUGIN_PATH" || rm "$PLUGIN_PATH"
+fi
+
 echo "extension=$EXPECTED_AST_FILE" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 
 php -r 'function_exists("ast\parse_code") || (print("Failed to enable php-ast\n") && exit(1));'

--- a/tool/make_stubs
+++ b/tool/make_stubs
@@ -25,6 +25,9 @@ class StubsGenerator {
 
     public static function printHelpAndExit(string $message = '', int $exit_code = 1)
     {
+        if ($message) {
+            echo "$message\n";
+        }
         global $argv;
         $prog_name = $argv[0];
         echo <<<EOT


### PR DESCRIPTION
Download the plugin in travis and cache it.
Pin a given version of the plugin to make the builds reproducible.

Fix/suppress unused variable/param errors in Phan's own codebase.