### PR TITLE
Improve phan's analysis of array shape types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,7 @@ samples
 all_output.*
 *.swo
 *.swp
+*.zip
 /tags
 .phan/config.local.php
+nohup.out

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,11 @@ New Features(CLI, Configs)
   (Normally, the polyfill wouldn't include that information, to closely imitate `php-ast`'s behavior)
 
 New Features(Analysis)
++ Infer the type of `[]` as `array{}` (the empty array), not `array`.
++ Emit `PhanTypeArrayUnsetSuspicious` when trying to unset the offset of something that isn't an array or array-like.
++ Add limited support for analyzing `unset` on variables and the first dimension of arrays.
+  Unsetting variables does not yet work in branches.
++ Don't emit `PhanTypeInvalidDimOffset` in `isset`/`empty`/`unset`
 + Add new issue types `PhanWriteOnlyPublicProperty`, `PhanWriteOnlyProtectedProperty`, and `PhanWriteOnlyPrivateProperty`,
   which will be emitted on properties that are written to but never read from.
   (Requires that dead code detection be enabled)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ and does not attempt to track values.
 The easiest way to use Phan is via Composer.
 
 ```
-composer require --dev phan/phan
+composer require phan/phan
 ```
 
 With Phan installed, you'll want to [create a `.phan/config.php` file](https://github.com/phan/phan/wiki/Getting-Started#creating-a-config-file) in
@@ -251,7 +251,7 @@ Usage: ./phan [options] [files...]
     that Phan infers from composer.json's "autoload" settings
   [--init-analyze-file] can be used as a relative path alongside files
     that Phan infers from composer.json's "bin" settings
-  [--init-no-composer] can be used to tell Phan that the project 
+  [--init-no-composer] can be used to tell Phan that the project
     is not a composer project.
     Phan will not check for composer.json or vendor/,
     and will not include those paths in the generated config.
@@ -302,6 +302,10 @@ Usage: ./phan [options] [files...]
 
  --disable-plugins
   Don't run any plugins. Slightly faster.
+
+ --plugin <pluginName|path/to/Plugin.php>
+  Add an additional plugin to run. This flag can be repeated.
+  (Either pass the name of the plugin or a relative/absolute path to the plugin)
 
  --use-fallback-parser
   If a file to be analyzed is syntactically invalid

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -2233,6 +2233,9 @@ final class TolerantASTConverter
         return $ast_visibility;
     }
 
+    /**
+     * @suppress PhanTypeMismatchArgument casting to a more specific node
+     */
     private static function phpParserPropertyToAstNode(PhpParser\Node\PropertyDeclaration $n, int $start_line) : ast\Node
     {
         $prop_elems = [];
@@ -2249,6 +2252,9 @@ final class TolerantASTConverter
         return new ast\Node(ast\AST_PROP_DECL, $flags, $prop_elems, $prop_elems[0]->lineno ?? (self::getStartLine($n) ?: $start_line));
     }
 
+    /**
+     * @suppress PhanTypeMismatchArgument casting to something more specific
+     */
     private static function phpParserClassConstToAstNode(PhpParser\Node\ClassConstDeclaration $n, int $start_line) : ast\Node
     {
         $const_elems = [];

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -1341,6 +1341,10 @@ final class TolerantASTConverter
             'Microsoft\PhpParser\Node\Expression\UnsetIntrinsicExpression' => function (PhpParser\Node\Expression\UnsetIntrinsicExpression $n, int $start_line) {
                 $stmts = [];
                 foreach ($n->expressions->children as $var) {
+                    if ($var instanceof Token) {
+                        // Skip over ',' and invalid tokens
+                        continue;
+                    }
                     $stmts[] = new ast\Node(ast\AST_UNSET, 0, ['var' => self::phpParserNodeToAstNode($var)], self::getEndLine($var) ?: $start_line);
                 }
                 return \count($stmts) === 1 ? $stmts[0] : $stmts;

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1301,7 +1301,7 @@ class UnionTypeVisitor extends AnalysisVisitor
                 }
                 continue;
             }
-            $element_type = $type->arrayShapeFieldTypes()[$dim_value] ?? null;
+            $element_type = $type->getFieldTypes()[$dim_value] ?? null;
             if ($element_type !== null) {
                 // $element_type may be non-null but $element_type->isEmpty() may be true.
                 // So, we use null to indicate failure below

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -771,8 +771,7 @@ class UnionTypeVisitor extends AnalysisVisitor
 
         // TODO: Also return types such as array<int, mixed>?
         // TODO: Fix or suppress false positives PhanTypeArraySuspicious caused by loops...
-        // return ArrayShapeType::empty(false)->asUnionType();
-        return ArrayType::instance(false)->asUnionType();
+        return ArrayShapeType::empty(false)->asUnionType();
     }
 
 

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -113,7 +113,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             $this->context,
             $node,
             $right_type
-        ))($node->children['var']);
+        ))->__invoke($node->children['var']);
 
         if ($node->children['expr'] instanceof Node
             && $node->children['expr']->kind == \ast\AST_CLOSURE
@@ -144,6 +144,90 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
     public function visitAssignRef(Node $node) : Context
     {
         return $this->visitAssign($node);
+    }
+
+    /**
+     * @param Node $node
+     * A node to parse
+     *
+     * @return Context
+     * A new or an unchanged context resulting from
+     * parsing the node
+     */
+    public function visitUnset(Node $node) : Context
+    {
+        $context = $this->context;
+        // Get the type of the thing being unset
+        $var_node = $node->children['var'];
+        if (!is_object($var_node)) {
+            var_export($node);
+        }
+
+        $kind = $var_node->kind;
+        if ($kind === \ast\AST_VAR) {
+            $var_name = $var_node->children['name'];
+            if (\is_string($var_name)) {
+                // TODO: Make this work in branches
+                $context->unsetScopeVariable($var_name);
+            }
+            // I think DollarDollarPlugin already warns, so don't warn here.
+        } elseif ($kind === \ast\AST_DIM) {
+            $this->analyzeUnsetDim($var_node);
+        }
+        return $context;
+    }
+
+    /**
+     * @param Node $node a node of type AST_DIM in unset()
+     * @return void
+     * @see UnionTypeVisitor::resolveArrayShapeElementTypes()
+     * @see UnionTypeVisitor::visitDim()
+     */
+    private function analyzeUnsetDim(Node $node)
+    {
+        $expr_node = $node->children['expr'];
+        if (!($expr_node instanceof Node)) {
+            // php -l would warn
+            return;
+        }
+
+        // For now, just handle a single level of dimensions for unset($x['field']);
+        if ($expr_node->kind === \ast\AST_VAR) {
+            $var_name = $expr_node->children['name'];
+            if (!\is_string($var_name)) {
+                return;
+            }
+
+            $context = $this->context;
+            $scope = $context->getScope();
+            if (!$scope->hasVariableWithName($var_name)) {
+                // TODO: Warn about potentially pointless unset in function scopes?
+                return;
+            }
+            // TODO: Could warn about invalid offsets for isset
+            $variable = $scope->getVariableByName($var_name);
+            $union_type = $variable->getUnionType();
+            if ($union_type->isEmpty()) {
+                return;
+            }
+            if (!$union_type->asExpandedTypes($this->code_base)->hasArrayLike()) {
+                $this->emitIssue(
+                    Issue::TypeArrayUnsetSuspicious,
+                    $node->lineno ?? 0,
+                    (string)$union_type
+                );
+            }
+            if (!$union_type->hasTopLevelArrayShapeTypeInstances()) {
+                return;
+            }
+            $dim_node = $node->children['dim'];
+            $dim_value = $dim_node instanceof Node ? (new ContextNode($this->code_base, $this->context, $dim_node))->getEquivalentPHPScalarValue() : $dim_node;
+            // TODO: detect and warn about null
+            if (!\is_scalar($dim_value)) {
+                return;
+            }
+            $variable->setUnionType($variable->getUnionType()->withoutArrayShapeField($dim_value));
+        }
     }
 
     /**

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -1567,6 +1567,12 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 // will analyze $x['key'] = expr in AssignmentVisitor
                 return $context;
             }
+        } elseif ($parent_kind === \ast\AST_ARRAY_ELEM) {
+            if ($this->shouldSkipNestedDim()) {
+                return $context;
+            }
+        } elseif ($parent_kind === \ast\AST_ISSET || $parent_kind === \ast\AST_UNSET || $parent_kind === \ast\AST_EMPTY) {
+            return $context;
         }
         // Check the array type to trigger TypeArraySuspicious
         try {
@@ -1609,7 +1615,15 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                     return true;
                 }
                 return false;
+            } elseif ($kind === \ast\AST_ARRAY_ELEM) {
+                $prev_parent_node = \prev($parent_node_list);  // this becomes AST_ARRAY
+                continue;
+            } elseif ($kind === \ast\AST_ARRAY) {
+                continue;
+            } elseif ($kind === \ast\AST_UNSET) {
+                return true;  // This is removing the offset
             }
+
             return false;
         }
     }

--- a/src/Phan/Analysis/ScopeVisitor.php
+++ b/src/Phan/Analysis/ScopeVisitor.php
@@ -182,6 +182,10 @@ abstract class ScopeVisitor extends AnalysisVisitor
             } else {
                 $alias = $child_node->children['alias'];
             }
+            if (!\is_string($alias)) {
+                // Should be impossible
+                continue;
+            }
 
             // if AST_USE does not have any flags set, then its AST_USE_ELEM
             // children will (this will be for AST_GROUP_USE)

--- a/src/Phan/CodeBase/UndoTracker.php
+++ b/src/Phan/CodeBase/UndoTracker.php
@@ -131,7 +131,6 @@ class UndoTracker
     {
         $file = $this->current_parsed_file;
         if (!\is_string($file)) {
-            debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
             throw new \Error("Called recordUndo in CodeBaseMutable, but not parsing a file");
         }
         if (!isset($this->undoOperationsForPath[$file])) {

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -57,6 +57,7 @@ class Issue
     const NonClassMethodCall        = 'PhanNonClassMethodCall';
     const TypeArrayOperator         = 'PhanTypeArrayOperator';
     const TypeArraySuspicious       = 'PhanTypeArraySuspicious';
+    const TypeArrayUnsetSuspicious  = 'PhanTypeArrayUnsetSuspicious';
     const TypeArraySuspiciousNullable = 'PhanTypeArraySuspiciousNullable';
     const TypeSuspiciousIndirectVariable = 'PhanTypeSuspiciousIndirectVariable';
     const TypeComparisonFromArray   = 'PhanTypeComparisonFromArray';
@@ -862,6 +863,14 @@ class Issue
                 "Suspicious array access to {TYPE}",
                 self::REMEDIATION_B,
                 10009
+            ),
+            new Issue(
+                self::TypeArrayUnsetSuspicious,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                "Suspicious attempt to unset an offset of a value of type {TYPE}",
+                self::REMEDIATION_B,
+                10048
             ),
             new Issue(
                 self::TypeComparisonToArray,

--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -342,6 +342,23 @@ class Context extends FileRef
     }
 
     /**
+     * Unset a variable in this context's scope. Note that
+     * this does not create a new context. You're actually
+     * removing the variable from the context. Use with
+     * caution.
+     *
+     * @param string $variable_name
+     * The name of a variable to remove from the context.
+     *
+     * @return void
+     */
+    public function unsetScopeVariable(
+        string $variable_name
+    ) {
+        $this->getScope()->unsetVariable($variable_name);
+    }
+
+    /**
      * @return bool
      * True if this context is currently within a class
      * scope, else false.

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -699,6 +699,7 @@ trait FunctionTrait
             if ($default_is_null) {
                 // The parameter constructor or above check for wasEmpty already took care of null default case
             } else {
+                $default_type = $default_type->withFlattenedArrayShapeTypeInstances();
                 if ($wasEmpty) {
                     $parameter->addUnionType($default_type);
                 } else {

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -920,4 +920,12 @@ final class EmptyUnionType extends UnionType
     {
         return true;
     }
+
+    /**
+     * @param int|string $field_key
+     */
+    public function withoutArrayShapeField($field_key) : UnionType
+    {
+        return $this;
+    }
 }

--- a/src/Phan/Language/Scope.php
+++ b/src/Phan/Language/Scope.php
@@ -196,6 +196,36 @@ abstract class Scope
     }
 
     /**
+     * @param string $variable_name
+     * The name of a variable to unset in the local scope
+     *
+     * @return Scope
+     *
+     * TODO: Make this work properly and merge properly when the variable is in a branch
+     *
+     * @suppress PhanUnreferencedPublicMethod unused, but adding to be consistent with `withVariable`
+     */
+    public function withUnsetVariable(string $variable_name) : Scope
+    {
+        $scope = clone($this);
+        $scope->unsetVariable($variable_name);
+        return $scope;
+    }
+
+    /**
+     * @param string $variable_name
+     * The name of a variable to unset in the local scope
+     *
+     * @return void
+     *
+     * TODO: Make this work properly and merge properly when the variable is in a branch (BranchScope)
+     */
+    public function unsetVariable(string $variable_name)
+    {
+        unset($this->variable_map[$variable_name]);
+    }
+
+    /**
      * @return void
      */
     public function addVariable(Variable $variable)

--- a/src/Phan/Language/Scope/BranchScope.php
+++ b/src/Phan/Language/Scope/BranchScope.php
@@ -14,6 +14,8 @@ class BranchScope extends Scope
      * @return bool
      * True if a variable with the given name is defined
      * within this scope
+     *
+     * TODO: Allow unsetting a variable within a scope, and properly merge that
      */
     public function hasVariableWithName(string $name) : bool
     {

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -658,9 +658,6 @@ class Type
     public static function fromFullyQualifiedStringInner(
         string $fully_qualified_string
     ) : Type {
-        if (empty($fully_qualified_string)) {
-            debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
-        }
         \assert(
             !empty($fully_qualified_string),
             "Type cannot be empty"

--- a/src/Phan/Language/Type/ArrayShapeType.php
+++ b/src/Phan/Language/Type/ArrayShapeType.php
@@ -133,13 +133,13 @@ final class ArrayShapeType extends ArrayType
                     }
                 }
                 return true;
-            } else {
-                // array{key:T} can cast to array.
-                return true;
             }
+            // array{key:T} can cast to array.
+            return true;
         }
 
-        if ($type->isArrayLike()) {
+        if (\get_class($type) === IterableType::class) {
+            // can cast to Iterable but not Traversable
             return true;
         }
 

--- a/src/Phan/Language/Type/ArrayShapeType.php
+++ b/src/Phan/Language/Type/ArrayShapeType.php
@@ -52,6 +52,28 @@ final class ArrayShapeType extends ArrayType
     }
 
     /**
+     * @return array<string|int,UnionType>
+     * An array mapping field keys of this type to their union types.
+     */
+    public function getFieldTypes() : array
+    {
+        return $this->field_types;
+    }
+
+    /**
+     * @param int|string $field_key
+     */
+    public function withoutField($field_key) : ArrayShapeType
+    {
+        $field_types = $this->field_types;
+        if (!\array_key_exists($field_key, $field_types)) {
+            return $this;
+        }
+        unset($field_types[$field_key]);
+        return self::fromFieldTypes($field_types, $this->is_nullable);
+    }
+
+    /**
      * @param bool $is_nullable
      * Set to true if the type should be nullable, else pass
      * false
@@ -66,7 +88,7 @@ final class ArrayShapeType extends ArrayType
             return $this;
         }
 
-        return ArrayShapeType::fromFieldTypes(
+        return self::fromFieldTypes(
             $this->field_types,
             $is_nullable
         );
@@ -205,15 +227,6 @@ final class ArrayShapeType extends ArrayType
     public function isGenericArray() : bool
     {
         return true;
-    }
-
-    /**
-     * @return array<string|int,UnionType>
-     * An array of mapping field keys of this type to field types
-     */
-    public function arrayShapeFieldTypes() : array
-    {
-        return $this->field_types;
     }
 
     public function __toString() : string

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -2254,6 +2254,23 @@ class UnionType implements \Serializable
             return $type->shouldBeReplacedBySpecificTypes();
         });
     }
+
+    /**
+     * @param int|string $field_key
+     */
+    public function withoutArrayShapeField($field_key) : UnionType
+    {
+        $types = $this->type_set;
+        foreach ($types as $i => $type) {
+            if ($type instanceof ArrayShapeType) {
+                $types[$i] = $type->withoutField($field_key);
+            }
+        }
+        if ($types === $this->type_set) {
+            return $this;
+        }
+        return UnionType::of($types);
+    }
 }
 
 UnionType::init();

--- a/src/Phan/LanguageServer/Protocol/Message.php
+++ b/src/Phan/LanguageServer/Protocol/Message.php
@@ -16,7 +16,7 @@ class Message
     public $body;
 
     /**
-     * @var string[]
+     * @var array<string,string>
      */
     public $headers;
 
@@ -41,8 +41,8 @@ class Message
     }
 
     /**
-     * @param ?\AdvancedJsonRpc\Message $body
-     * @param string[] $headers
+     * @param ?MessageBody $body
+     * @param array<string,string> $headers
      */
     public function __construct(MessageBody $body = null, array $headers = [])
     {

--- a/tests/Phan/Language/EmptyUnionTypeTest.php
+++ b/tests/Phan/Language/EmptyUnionTypeTest.php
@@ -152,6 +152,11 @@ class EmptyUnionTypeTest extends BaseTest
                         return true;
                     },
                 ];
+            case '':
+                if ($param->getName() === 'field_key') {
+                    return ['', 'key', 0, 2, false, 2.5];
+                }
+                break;
         }
         throw new TypeError("Unable to handle param {$type_name} \${$param->getName()}");
     }

--- a/tests/Phan/Language/UnionTypeTest.php
+++ b/tests/Phan/Language/UnionTypeTest.php
@@ -123,7 +123,7 @@ class UnionTypeTest extends BaseTest
     {
         $this->assertUnionTypeStringEqual(
             '[]',
-            'array'
+            'array{}'
         );
     }
     public function testInternalObject()

--- a/tests/files/expected/0146_array_concat.php.expected
+++ b/tests/files/expected/0146_array_concat.php.expected
@@ -1,4 +1,4 @@
 %s:5 PhanTypeMismatchArgument Argument 1 (p) is array{0:int,1:int} but \f() takes int defined at %s:3
 %s:6 PhanTypeMismatchArgument Argument 1 (p) is array{0:int,1:int} but \f() takes int defined at %s:3
-%s:16 PhanTypeMismatchArgument Argument 1 (p) is array but \f() takes int defined at %s:3
+%s:16 PhanTypeMismatchArgument Argument 1 (p) is array{} but \f() takes int defined at %s:3
 %s:17 PhanTypeMismatchArgument Argument 1 (p) is array but \f() takes int defined at %s:3

--- a/tests/files/expected/0258_variadic_comment_parsing.php.expected
+++ b/tests/files/expected/0258_variadic_comment_parsing.php.expected
@@ -4,4 +4,4 @@
 %s:25 PhanMismatchVariadicComment int ...$x is variadic in comment, but not variadic in param ($x)
 %s:25 PhanMismatchVariadicParam array $y is not variadic in comment, but variadic in param (...$y)
 %s:32 PhanMismatchVariadicParam int $z is not variadic in comment, but variadic in param (...$z)
-%s:36 PhanTypeMismatchArgument Argument 3 (y) is array but \badvariadic258b() takes int defined at %s:16
+%s:36 PhanTypeMismatchArgument Argument 3 (y) is array{} but \badvariadic258b() takes int defined at %s:16

--- a/tests/files/expected/0307_suppress_on_property.php.expected
+++ b/tests/files/expected/0307_suppress_on_property.php.expected
@@ -1,1 +1,2 @@
-%s:7 PhanTypeMismatchProperty Assigning array to property but \Foo307::x is \ArrayAccess
+%s:7 PhanTypeMismatchProperty Assigning array{} to property but \Foo307::x is \ArrayAccess
+%s:18 PhanTypeMismatchProperty Assigning array{key:string} to property but \Foo307::z is \ArrayAccess

--- a/tests/files/expected/0354_string_index.php.expected
+++ b/tests/files/expected/0354_string_index.php.expected
@@ -4,10 +4,10 @@
 %s:13 PhanTypeMismatchArgumentInternal Argument 1 (var) is string but \count() takes \Countable|array
 %s:14 PhanTypeMismatchDimEmpty Assigning to an empty array index of a value of type string, but expected the index to exist and be of type int
 %s:16 PhanTypeMismatchDimAssignment When appending to a value of type string, found an array access index of type string, but expected the index to be of type int
-%s:22 PhanTypeMismatchDimFetch When fetching an array index from a value of type string, found an array index of type array, but expected the index to be of type int
+%s:22 PhanTypeMismatchDimFetch When fetching an array index from a value of type string, found an array index of type array{}, but expected the index to be of type int
 %s:23 PhanTypeMismatchDimFetch When fetching an array index from a value of type string, found an array index of type string, but expected the index to be of type int
 %s:24 PhanTypeMismatchDimFetch When fetching an array index from a value of type string, found an array index of type null, but expected the index to be of type int
-%s:27 PhanTypeMismatchDimFetch When fetching an array index from a value of type array{offset:string}, found an array index of type array, but expected the index to be of type string
+%s:27 PhanTypeMismatchDimFetch When fetching an array index from a value of type array{offset:string}, found an array index of type array{}, but expected the index to be of type string
 %s:28 PhanTypeMismatchDimFetchNullable When fetching an array index from a value of type array{offset:string}, found an array index of type null, but expected the index to be of the non-nullable type string
 %s:29 PhanTypeInvalidDimOffset Invalid offset 0 of array type array{offset:string}
 %s:29 PhanTypeMismatchDimFetch When fetching an array index from a value of type array{offset:string}, found an array index of type int, but expected the index to be of type string

--- a/tests/files/expected/0363_namespaced_internal_function.php.expected
+++ b/tests/files/expected/0363_namespaced_internal_function.php.expected
@@ -1,3 +1,3 @@
 %s:5 PhanTypeMismatchArgumentInternal Argument 1 (code) is int but \ast\parse_code() takes string
-%s:5 PhanTypeMismatchArgumentInternal Argument 2 (version) is array but \ast\parse_code() takes int
+%s:5 PhanTypeMismatchArgumentInternal Argument 2 (version) is array{} but \ast\parse_code() takes int
 %s:5 PhanTypeMismatchReturn Returning type \ast\Node but test363() is declared to return int

--- a/tests/files/expected/0367_call_user_func.php.expected
+++ b/tests/files/expected/0367_call_user_func.php.expected
@@ -1,5 +1,5 @@
 %s:3 PhanTypeMismatchArgumentInternal Argument 1 (string) is int but \strlen() takes string
-%s:3 PhanTypeMismatchArgumentInternal Argument 2 (divisor) is array but \intdiv() takes int
+%s:3 PhanTypeMismatchArgumentInternal Argument 2 (divisor) is array{} but \intdiv() takes int
 %s:6 PhanTypeMismatchArgumentInternal Argument 1 (string) is int but \strlen() takes string
 %s:7 PhanTypeMismatchArgumentInternal Argument 1 (string) is int but \strlen() takes string
 %s:7 PhanTypeMismatchArgumentInternal Argument 2 (divisor) is \SimpleXMLElement|\Traversable|iterable but \intdiv() takes int

--- a/tests/files/expected/0369_callable_non_quick.php.expected
+++ b/tests/files/expected/0369_callable_non_quick.php.expected
@@ -1,4 +1,4 @@
 %s:8 PhanTypeMismatchArgumentInternal Argument 1 (var) is \A369 but \count() takes \Countable|array
 %s:12 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \A369 but \intdiv() takes int
 %s:15 PhanTypeMismatchArgumentInternal Argument 1 (string) is \stdClass but \strlen() takes string
-%s:16 PhanTypeMismatchArgumentInternal Argument 1 (string) is array but \strlen() takes string
+%s:16 PhanTypeMismatchArgumentInternal Argument 1 (string) is array{} but \strlen() takes string

--- a/tests/files/expected/0370_callable_edge_cases.php.expected
+++ b/tests/files/expected/0370_callable_edge_cases.php.expected
@@ -2,9 +2,9 @@
 %s:33 PhanUndeclaredClassInCallable Reference to undeclared class \parent in callable \parent::foo
 %s:34 PhanUndeclaredClassInCallable Reference to undeclared class \static in callable \static::foo
 %s:35 PhanUndeclaredClassInCallable Reference to undeclared class \self in callable \self::foo
-%s:37 PhanTypeMismatchArgument Argument 1 (x) is array but \C370::foo() takes int defined at %s:41
-%s:38 PhanTypeMismatchArgument Argument 1 (x) is array but \C370::foo() takes int defined at %s:41
-%s:39 PhanTypeMismatchArgument Argument 1 (x) is array but \C370::foo() takes int defined at %s:41
+%s:37 PhanTypeMismatchArgument Argument 1 (x) is array{} but \C370::foo() takes int defined at %s:41
+%s:38 PhanTypeMismatchArgument Argument 1 (x) is array{} but \C370::foo() takes int defined at %s:41
+%s:39 PhanTypeMismatchArgument Argument 1 (x) is array{} but \C370::foo() takes int defined at %s:41
 %s:47 PhanContextNotObjectInCallable Cannot access self when not in object context, but code is using callable self::foo
 %s:48 PhanContextNotObjectInCallable Cannot access static when not in object context, but code is using callable static::foo
 %s:49 PhanContextNotObjectInCallable Cannot access parent when not in object context, but code is using callable parent::foo

--- a/tests/files/expected/0377_static_callable.php.expected
+++ b/tests/files/expected/0377_static_callable.php.expected
@@ -1,6 +1,6 @@
 %s:11 PhanTypeMismatchArgument Argument 1 (x) is \stdClass but \TestStaticCallable377::triple() takes int defined at %s:24
 %s:12 PhanTypeMismatchArgument Argument 1 (x) is \stdClass but \TestStaticCallable377::triple() takes int defined at %s:24
-%s:17 PhanTypeMismatchArgument Argument 1 (x) is array but \TestStaticCallable377::triple() takes int defined at %s:24
-%s:18 PhanTypeMismatchArgument Argument 1 (x) is array but \TestStaticCallable377::triple() takes int defined at %s:24
+%s:17 PhanTypeMismatchArgument Argument 1 (x) is array{} but \TestStaticCallable377::triple() takes int defined at %s:24
+%s:18 PhanTypeMismatchArgument Argument 1 (x) is array{} but \TestStaticCallable377::triple() takes int defined at %s:24
 %s:20 PhanTypeMismatchArgument Argument 1 (x) is \stdClass but \TestStaticCallable377::triple() takes int defined at %s:24
 %s:21 PhanTypeMismatchArgument Argument 1 (x) is \stdClass but \TestStaticCallable377::triple() takes int defined at %s:24

--- a/tests/files/expected/0377_static_callable.php.expected70
+++ b/tests/files/expected/0377_static_callable.php.expected70
@@ -1,4 +1,4 @@
 %s:11 PhanTypeMismatchArgument Argument 1 (x) is \stdClass but \TestStaticCallable377::triple() takes int defined at %s:24
-%s:17 PhanTypeMismatchArgument Argument 1 (x) is array but \TestStaticCallable377::triple() takes int defined at %s:24
-%s:18 PhanTypeMismatchArgument Argument 1 (x) is array but \TestStaticCallable377::triple() takes int defined at %s:24
+%s:17 PhanTypeMismatchArgument Argument 1 (x) is array{} but \TestStaticCallable377::triple() takes int defined at %s:24
+%s:18 PhanTypeMismatchArgument Argument 1 (x) is array{} but \TestStaticCallable377::triple() takes int defined at %s:24
 %s:20 PhanTypeMismatchArgument Argument 1 (x) is \stdClass but \TestStaticCallable377::triple() takes int defined at %s:24

--- a/tests/files/expected/0399_array_key.php.expected
+++ b/tests/files/expected/0399_array_key.php.expected
@@ -1,3 +1,3 @@
 %s:8 PhanTypeMismatchDimFetch When fetching an array index from a value of type array<string,string>, found an array index of type int, but expected the index to be of type string
-%s:9 PhanTypeMismatchDimFetch When fetching an array index from a value of type array<string,string>, found an array index of type array, but expected the index to be of type string
+%s:9 PhanTypeMismatchDimFetch When fetching an array index from a value of type array<string,string>, found an array index of type array{}, but expected the index to be of type string
 %s:10 PhanTypeMismatchDimFetch When fetching an array index from a value of type array<int,string>, found an array index of type string, but expected the index to be of type int

--- a/tests/files/expected/0433_infer_array_type.php.expected
+++ b/tests/files/expected/0433_infer_array_type.php.expected
@@ -1,2 +1,2 @@
 %s:6 PhanTypeMismatchArgumentInternal Argument 1 (var) is string but \count() takes \Countable|array
-%s:7 PhanTypeMismatchArgumentInternal Argument 1 (string) is array but \strlen() takes string
+%s:7 PhanTypeMismatchArgumentInternal Argument 1 (string) is array{} but \strlen() takes string

--- a/tests/files/expected/0439_multi.php.expected
+++ b/tests/files/expected/0439_multi.php.expected
@@ -1,0 +1,1 @@
+%s:4 PhanTypeInvalidDimOffset Invalid offset "otherOffset" of array type array{offset:string,first:int}

--- a/tests/files/expected/0439_multi.php.expected70
+++ b/tests/files/expected/0439_multi.php.expected70
@@ -1,0 +1,1 @@
+%s:3 PhanSyntaxError syntax error, unexpected '='

--- a/tests/files/expected/0440_no_warn_set_check.php.expected
+++ b/tests/files/expected/0440_no_warn_set_check.php.expected
@@ -1,0 +1,1 @@
+%s:7 PhanTypeMismatchReturn Returning type array{} but test() is declared to return string

--- a/tests/files/expected/0441_unset_basic.php.expected
+++ b/tests/files/expected/0441_unset_basic.php.expected
@@ -1,0 +1,2 @@
+%s:7 PhanUndeclaredVariable Variable $myVar is undeclared
+%s:11 PhanTypeMismatchArgumentInternal Argument 1 (string) is array{b:array<int,string>} but \strlen() takes string

--- a/tests/files/expected/0442_unset_suspicious.php.expected
+++ b/tests/files/expected/0442_unset_suspicious.php.expected
@@ -1,0 +1,3 @@
+%s:4 PhanTypeArrayUnsetSuspicious Suspicious attempt to unset an offset of a value of type string
+%s:7 PhanTypeArrayUnsetSuspicious Suspicious attempt to unset an offset of a value of type false
+%s:10 PhanTypeArrayUnsetSuspicious Suspicious attempt to unset an offset of a value of type \stdClass

--- a/tests/files/src/0307_suppress_on_property.php
+++ b/tests/files/src/0307_suppress_on_property.php
@@ -11,4 +11,9 @@ class Foo307 {
      * @suppress PhanTypeMismatchProperty
      */
     public $y = [];
+
+    /**
+     * @var ArrayAccess
+     */
+    public $z = ['key' => 'value'];
 }

--- a/tests/files/src/0439_multi.php
+++ b/tests/files/src/0439_multi.php
@@ -1,0 +1,4 @@
+<?php
+$x = ['first' => 2];
+[$a, $x['offset']] = [2, 'value'];
+echo $x['otherOffset'];

--- a/tests/files/src/0440_no_warn_set_check.php
+++ b/tests/files/src/0440_no_warn_set_check.php
@@ -1,0 +1,9 @@
+<?php
+
+function test(array $data = []) : string {
+    if (!isset($data['key'])) {
+        $data['key'] = [];
+    }
+    return $data['key'];
+}
+test();

--- a/tests/files/src/0441_unset_basic.php
+++ b/tests/files/src/0441_unset_basic.php
@@ -1,0 +1,12 @@
+<?php
+call_user_func(function() {
+    global $argv;
+
+    $myVar = 'someVal';
+    unset($myVar);
+    echo $myVar;  // should warn
+
+    $x = ['a' => 2, 'b' => $argv];
+    unset($x['a']);
+    echo strlen($x);
+});

--- a/tests/files/src/0442_unset_suspicious.php
+++ b/tests/files/src/0442_unset_suspicious.php
@@ -1,0 +1,15 @@
+<?php
+call_user_func(function() {
+    $x = 'myString';
+    unset($x[0]);
+
+    $y = false;
+    unset($y['key']);
+
+    $obj = new stdClass;
+    unset($obj['key']);
+
+    // NOTE: We don't analyze shapes of ArrayObject yet.
+    $obj = new ArrayObject(['key' => 'value']);
+    unset($obj['key']);
+});

--- a/tests/misc/fallback_ast_src/multi_unset.php
+++ b/tests/misc/fallback_ast_src/multi_unset.php
@@ -1,0 +1,2 @@
+<?php
+unset($x, $y);

--- a/tests/misc/fallback_test/expected/000_missing_semicolon_check.php.expected
+++ b/tests/misc/fallback_test/expected/000_missing_semicolon_check.php.expected
@@ -1,3 +1,3 @@
 src/000_missing_semicolon_check.php:5 PhanSyntaxError syntax error, unexpected 'return' (T_RETURN)
-src/000_missing_semicolon_check.php:5 PhanTypeMismatchArgumentInternal Argument 1 (string) is array but \strlen() takes string
+src/000_missing_semicolon_check.php:5 PhanTypeMismatchArgumentInternal Argument 1 (string) is array{} but \strlen() takes string
 src/000_missing_semicolon_check.php:5 PhanTypeMismatchReturn Returning type int but test_missing_semicolon() is declared to return string

--- a/tests/php72_files/expected/0001_objecthint.php.expected
+++ b/tests/php72_files/expected/0001_objecthint.php.expected
@@ -1,6 +1,6 @@
 %s:9 PhanTypeMismatchReturn Returning type null but object_test() is declared to return object
 %s:13 PhanTypeMismatchArgument Argument 1 (x) is null but \object_test() takes object defined at %s:3
-%s:14 PhanTypeMismatchArgument Argument 1 (x) is array but \object_test() takes object defined at %s:3
-%s:14 PhanTypeMismatchArgument Argument 2 (y) is array but \object_test() takes ?object defined at %s:3
+%s:14 PhanTypeMismatchArgument Argument 1 (x) is array{} but \object_test() takes object defined at %s:3
+%s:14 PhanTypeMismatchArgument Argument 2 (y) is array{} but \object_test() takes ?object defined at %s:3
 %s:26 PhanTypeMismatchReturn Returning type string but nullableobject_test() is declared to return ?object
 %s:29 PhanUndeclaredClassMethod Call to method __construct from undeclared class \object

--- a/tests/plugin_test/expected/004_unused_suppression_plugin.php.expected
+++ b/tests/plugin_test/expected/004_unused_suppression_plugin.php.expected
@@ -1,4 +1,4 @@
 src/004_unused_suppression_plugin.php:6 UnusedSuppression Element \SuppressionTest suppresses issue PhanPluginNotARealIssue but does not use it
 src/004_unused_suppression_plugin.php:11 UnusedSuppression Element \SuppressionTest::foo suppresses issue PhanParamTooMany but does not use it
 src/004_unused_suppression_plugin.php:23 UnusedSuppression Element \suppression_test_fn suppresses issue PhanParamTooFew but does not use it
-src/004_unused_suppression_plugin.php:27 PhanTypeMismatchArgument Argument 1 (x) is array but \SuppressionTest::bar() takes int defined at src/004_unused_suppression_plugin.php:15
+src/004_unused_suppression_plugin.php:27 PhanTypeMismatchArgument Argument 1 (x) is array{} but \SuppressionTest::bar() takes int defined at src/004_unused_suppression_plugin.php:15

--- a/tests/plugin_test/expected/007_printf.php.expected
+++ b/tests/plugin_test/expected/007_printf.php.expected
@@ -8,7 +8,7 @@ src/007_printf.php:8 PhanPluginPrintfNoSpecifiers None of the formatting argumen
 src/007_printf.php:9 PhanPluginPrintfNoSpecifiers None of the formatting arguments passed alongside format string "Not using args\n" are used
 src/007_printf.php:10 PhanPluginPrintfNoSpecifiers None of the formatting arguments passed alongside format string "Not using args\n" are used
 src/007_printf.php:11 PhanPluginPrintfNoSpecifiers None of the formatting arguments passed alongside format string "Not using args\n" are used
-src/007_printf.php:13 PhanTypeMismatchArgumentInternal Argument 1 (format) is array but \printf() takes string
+src/007_printf.php:13 PhanTypeMismatchArgumentInternal Argument 1 (format) is array{} but \printf() takes string
 src/007_printf.php:14 PhanPluginPrintfNoSpecifiers None of the formatting arguments passed alongside format string "3" are used
 src/007_printf.php:14 PhanTypeMismatchArgumentInternal Argument 1 (format) is int but \printf() takes string
 src/007_printf.php:16 PhanPluginPrintfNoArguments No format string arguments are given for "Hello world\n", consider using fwrite instead

--- a/tests/plugin_test/expected/009_vprintf.php.expected
+++ b/tests/plugin_test/expected/009_vprintf.php.expected
@@ -6,7 +6,7 @@ src/009_vprintf.php:9 PhanPluginPrintfNotPercent Format string "%d dollars 100% 
 src/009_vprintf.php:10 PhanPluginPrintfNoSpecifiers None of the formatting arguments passed alongside format string "Not using args" are used
 src/009_vprintf.php:11 PhanPluginPrintfNoSpecifiers None of the formatting arguments passed alongside format string "Not using args" are used
 src/009_vprintf.php:12 PhanPluginPrintfUnusedArgument Format string "Not using %d\n args\n" does not use provided argument #2
-src/009_vprintf.php:14 PhanTypeMismatchArgumentInternal Argument 1 (format) is array but \vprintf() takes string
+src/009_vprintf.php:14 PhanTypeMismatchArgumentInternal Argument 1 (format) is array{} but \vprintf() takes string
 src/009_vprintf.php:14 PhanTypeMismatchArgumentInternal Argument 2 (args) is int but \vprintf() takes array
 src/009_vprintf.php:16 PhanPluginPrintfNoArguments No format string arguments are given for "Hello world\n", consider using fwrite instead
 src/009_vprintf.php:18 PhanTypeMismatchArgumentInternal Argument 3 (args) is string but \vfprintf() takes array

--- a/tests/plugin_test/expected/010_printf_types.php.expected
+++ b/tests/plugin_test/expected/010_printf_types.php.expected
@@ -4,8 +4,8 @@ src/010_printf_types.php:9 PhanPluginPrintfIncompatibleArgumentType Format strin
 src/010_printf_types.php:9 PhanTypeMismatchArgumentInternal Argument 2 (args) is ?int but \printf() takes float|int|string
 src/010_printf_types.php:10 PhanPluginPrintfIncompatibleArgumentType Format string "Hello, %s" refers to argument #1 as %s, so type string is expected, but printf was passed incompatible type false
 src/010_printf_types.php:10 PhanTypeMismatchArgumentInternal Argument 2 (args) is false but \printf() takes float|int|string
-src/010_printf_types.php:11 PhanPluginPrintfIncompatibleArgumentType Format string "Hello, %s" refers to argument #1 as %s, so type string is expected, but printf was passed incompatible type array
-src/010_printf_types.php:11 PhanTypeMismatchArgumentInternal Argument 2 (args) is array but \printf() takes float|int|string
+src/010_printf_types.php:11 PhanPluginPrintfIncompatibleArgumentType Format string "Hello, %s" refers to argument #1 as %s, so type string is expected, but printf was passed incompatible type array{}
+src/010_printf_types.php:11 PhanTypeMismatchArgumentInternal Argument 2 (args) is array{} but \printf() takes float|int|string
 src/010_printf_types.php:12 PhanPluginPrintfIncompatibleArgumentTypeWeak Format string "Hello, %f %s" refers to argument #2 as %s, so type string is expected. However, printf was passed the type int (which is weaker than string)
 src/010_printf_types.php:12 PhanPluginPrintfIncompatibleArgumentType Format string "Hello, %f %s" refers to argument #1 as %f, so type float is expected, but printf was passed incompatible type string
 src/010_printf_types.php:13 PhanPluginPrintfIncompatibleArgumentType Format string "Hello, %1$d %1$f" refers to argument #1 as %1$d,%1$f, so type float|int is expected, but printf was passed incompatible type string

--- a/tests/rasmus_files/expected/0005_arg_types.php.expected
+++ b/tests/rasmus_files/expected/0005_arg_types.php.expected
@@ -1,3 +1,2 @@
 %s:7 PhanTypeMismatchArgument Argument 4 (arg4) is int but \test() takes array defined at %s:2
 %s:8 PhanTypeMismatchArgument Argument 2 (arg2) is float but \test() takes int defined at %s:2
-

--- a/tests/rasmus_files/expected/0036_properties.php.expected
+++ b/tests/rasmus_files/expected/0036_properties.php.expected
@@ -1,6 +1,6 @@
 %s:8 PhanTypeMismatchProperty Assigning int to property but \A::text is string
 %s:8 PhanTypeMismatchProperty Assigning string to property but \A::num is int
 %s:11 PhanUndeclaredProperty Reference to undeclared property \A->str
-%s:12 PhanTypeMismatchProperty Assigning array to property but \A::text is int|string
+%s:12 PhanTypeMismatchProperty Assigning array{} to property but \A::text is int|string
 %s:18 PhanAccessPropertyProtected Cannot access protected property \A::$foo
 %s:19 PhanUndeclaredProperty Reference to undeclared property \A->bar

--- a/tests/rasmus_files/expected/0037_properties2.php.expected
+++ b/tests/rasmus_files/expected/0037_properties2.php.expected
@@ -1,3 +1,3 @@
 %s:13 PhanTypeMismatchProperty Assigning array<int,int> to property but \B::text is string
 %s:20 PhanAccessPropertyProtected Cannot access protected property \B::$text
-%s:30 PhanTypeMismatchProperty Assigning array to property but \B::text is string
+%s:30 PhanTypeMismatchProperty Assigning array{} to property but \B::text is string


### PR DESCRIPTION
Allow phan to infer the empty array shape type from an empty array literal.

Make unset() affect the first level array shape types, as well as variables (unset on variables currently doesn't work as expected in branch scopes)

Emit `PhanTypeArrayUnsetSuspicious` when trying to unset the array offset of something that isn't an array or ArrayAccess.

Don't emit `PhanTypeInvalidDimOffset` in `isset`/`empty`/`unset`