### PR TITLE
Support optional fields in array shapes.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,10 @@ New Features(CLI, Configs)
   (Normally, the polyfill wouldn't include that information, to closely imitate `php-ast`'s behavior)
 
 New Features(Analysis)
-+ Infer the type of `[]` as `array{}` (the empty array), not `array`.
++ Infer the type of `[]` as `array{}` (the empty array), not `array`. (#1382)
++ Allow phpdoc `@param` array shapes to contain optional fields. (E.g. `array{requiredKey:int,optionalKey:string=}`) (#1382)
+  An array shape is now allowed to cast to another array shape, as long as the required fields are compatible with the target type,
+  and any optional fields from the target type are absent in the source type or compatible.
 + Emit `PhanTypeArrayUnsetSuspicious` when trying to unset the offset of something that isn't an array or array-like.
 + Add limited support for analyzing `unset` on variables and the first dimension of arrays.
   Unsetting variables does not yet work in branches.
@@ -23,8 +26,10 @@ Maintenance
 + Print directory which phan daemon is going to await analysis requests for (#1544)
 
 Bug Fixes
++ Allow phpdoc `@param` array shapes to contain union types (#1382)
 + Remove leading `./` from Phan's relative paths for files (#1548, #1538)
 + Reduce false positives in dead code detection for constants/properties/methods.
++ Don't warn when base classes access protected properties of their subclasses.
 
 02 Mar 2018, Phan 0.12.2
 ------------------------

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Phan is able to perform the following kinds of analysis.
 * Supports [Union Types](https://github.com/phan/phan/wiki/About-Union-Types).
 * Supports generic arrays such as `int[]`, `UserObject[]`, `array<int,UserObject>`, etc..
 * Supports array shapes such as `array{key:string,otherKey:?stdClass}`, etc. (internally and in PHPDoc tags) as of Phan >= 0.12.0.
+* The upcoming 0.12.3 release will support indicating that fields of an array shape are optional
+  via `array{requiredKey:string,optionalKey:string=}` (useful for `@param`)
 * Supports phpdoc [type annotations](https://github.com/phan/phan/wiki/Annotating-Your-Source-Code).
 * Supports inheriting phpdoc type annotations.
 * Supports checking that phpdoc type annotations are a narrowed form (E.g. subclasses/subtypes) of the real type signatures

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -556,7 +556,7 @@ final class TolerantASTConverter
                 $return_type_line = self::getEndLine($n->returnType) ?: $start_line;
                 $return_type = self::phpParserTypeToAstNode($n->returnType, $return_type_line);
                 if ($n->questionToken !== null) {
-                    $return_type = new ast\Node(ast\AST_NULLABLE_TYPE, 0, ['type' => $ast_return_type], $return_type_line);
+                    $return_type = new ast\Node(ast\AST_NULLABLE_TYPE, 0, ['type' => $return_type], $return_type_line);
                 }
                 return self::astDeclClosure(
                     $n->byRefToken !== null,

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -130,7 +130,8 @@ class ConditionVisitor extends KindVisitorImplementation
      *
      * TODO: Add to NegatedConditionVisitor
      */
-    private function checkArrayAccessDefined(Node $node) {
+    private function checkArrayAccessDefined(Node $node)
+    {
         $code_base = $this->code_base;
         $context = $this->context;
 

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -28,7 +28,7 @@ class Config
      * New features increment minor versions, and bug fixes increment patch versions.
      * @suppress PhanUnreferencedPublicClassConstant
      */
-    const PHAN_PLUGIN_VERSION = '2.2.0';
+    const PHAN_PLUGIN_VERSION = '2.3.0';
 
     /**
      * @var string|null

--- a/src/Phan/Config/Initializer.php
+++ b/src/Phan/Config/Initializer.php
@@ -18,7 +18,7 @@ use Composer\Semver\Constraint\ConstraintInterface;
 class Initializer
 {
     /**
-     * @param array<string,mixed> $opts
+     * @param array{init-overwrite:mixed=,init-no-composer:mixed=,init-level:string=} $opts
      * Returns a process exit code for `phan --init`
      */
     public static function initPhanConfig(array $opts) : int
@@ -225,7 +225,7 @@ EOT;
     /**
      * @param array<string,mixed> $composer_settings (can be empty for --init-no-composer)
      * @param ?string $vendor_path (can be null for --init-no-composer)
-     * @param array<string,mixed> $opts parsed from getopt
+     * @param array{init-overwrite:mixed=,init-no-composer:mixed=,init-level:string=} $opts parsed from getopt
      * @return ?InitializedSettings
      */
     private static function createPhanSettingsForComposerSettings(array $composer_settings, $vendor_path, array $opts)

--- a/src/Phan/Language/AnnotatedUnionType.php
+++ b/src/Phan/Language/AnnotatedUnionType.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+namespace Phan\Language;
+
+/**
+ * This is used to represent a union type that has various annotations.
+ * Currently, the only annotation is is_possibly_undefined, which is used in optional fields of array shapes.
+ * (It might eventually be used for variables that are defined in some branches but not others)
+ *
+ * NOTE: Instances should be immutable after UnionType returns them.
+ * They are not unique for combination of types and options.
+ *
+ * The internal representation may change in the future.
+ */
+class AnnotatedUnionType extends UnionType
+{
+    /** @var bool */
+    protected $is_possibly_undefined = false;
+
+    /**
+     * @override
+     */
+    public function withIsPossiblyUndefined(bool $is_possibly_undefined) : UnionType
+    {
+        if ($is_possibly_undefined === $this->is_possibly_undefined) {
+            return $this;
+        }
+        $result = clone($this);
+        $result->is_possibly_undefined = $is_possibly_undefined;
+        return $result;
+    }
+
+    public function getIsPossiblyUndefined() : bool
+    {
+        return $this->is_possibly_undefined;
+    }
+
+    public function __toString() : string
+    {
+        $result = parent::__toString();
+        if ($this->is_possibly_undefined) {
+            return $result . '=';
+        }
+        return $result;
+    }
+}

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -822,10 +822,20 @@ class Clazz extends AddressableElement
                 $type_of_class_of_property
             );
         } else {
-            // If the definition of the property is protected, then the subclasses of the defining class can access it.
-            return $accessing_class_type->asExpandedTypes($code_base)->canCastToUnionType(
-                $type_of_class_of_property->asUnionType()
-            );
+            // If the definition of the property is protected,
+            // then the subclasses of the defining class can access it.
+            foreach ($accessing_class_type->asExpandedTypes($code_base)->getTypeSet() as $type) {
+                if ($type->canCastToType($type_of_class_of_property)) {
+                    return true;
+                }
+            }
+            // and base classes of the defining class can access it
+            foreach ($type_of_class_of_property->asExpandedTypes($code_base)->getTypeSet() as $type) {
+                if ($type->canCastToType($accessing_class_type)) {
+                    return true;
+                }
+            }
+            return false;
         }
     }
 

--- a/src/Phan/Language/Internal/FunctionSignatureMap.php
+++ b/src/Phan/Language/Internal/FunctionSignatureMap.php
@@ -45,8 +45,18 @@ PHAN;
  * 2. '&w_name' indicates that a parameter is expected to be passed in, and the value will be ignored, and may be overwritten.
  *
  * This file contains the signatures for the most recent minor release of PHP supported by phan (php 7.2)
+ *
+ * Changes:
+ *
+ * In Phan 0.12.3,
+ *
+ * - This started using array shapes for union types (array{...}).
+ *
+ *   \Phan\Language\UnionType->withFlattenedArrayShapeTypeInstances() may be of help to programatically convert these to array<string,T1>|array<string,T2>
+ *
+ * - This started using array shapes with optional fields for union types (array{key:int=}).
+ *   The `=` after the union type indicates that the field is optional.
  */
-
 return [
 '__halt_compiler' => [''],
 'abs' => ['int', 'number'=>'int'],
@@ -276,6 +286,7 @@ return [
 'ast\get_metadata' => ['array<int,ast\Metadata>'],
 'ast\get_supported_versions' => ['array<int,int>', 'exclude_deprecated='=>'bool'],
 'ast\kind_uses_flags' => ['bool', 'kind'=>'int'],
+'ast\Node::__construct' => ['void', 'kind='=>'int', 'flags='=> 'int', 'children='=>'ast\Node\Decl[]|ast\Node[]|array[]|int[]|string[]|float[]|bool[]|null[]', 'start_line='=>'int'],
 'ast\parse_code' => ['ast\Node', 'code'=>'string', 'version'=>'int', 'filename='=>'string'],
 'ast\parse_file' => ['ast\Node', 'filename'=>'string', 'version'=>'int'],
 'atan' => ['float', 'number'=>'float'],
@@ -6699,7 +6710,7 @@ return [
 'parse_ini_file' => ['array|false', 'filename'=>'string', 'process_sections='=>'bool', 'scanner_mode='=>'int'],
 'parse_ini_string' => ['array|false', 'ini_string'=>'string', 'process_sections='=>'bool', 'scanner_mode='=>'int'],
 'parse_str' => ['void', 'encoded_string'=>'string', '&w_result='=>'array'],
-'parse_url' => ['mixed', 'url'=>'string', 'url_component='=>'int'],
+'parse_url' => ['array{scheme:string=,host:string=,port:int=,user:string=,pass:string=,path:string=,query:string=,fragment:string=}|string|int|null', 'url'=>'string', 'url_component='=>'int'],
 'ParseError::__clone' => ['void'],
 'ParseError::__construct' => ['void', 'message='=>'string', 'code='=>'int', 'previous='=>'?Throwable|?ParseError'],
 'ParseError::__toString' => ['string'],
@@ -10211,7 +10222,7 @@ return [
 'unlink' => ['bool', 'filename'=>'string', 'context='=>'resource'],
 'unpack' => ['array', 'format'=>'string', 'data'=>'string', 'offset='=>'int'],
 'unregister_tick_function' => ['void', 'function_name'=>'string'],
-'unserialize' => ['mixed', 'variable_representation'=>'string', 'allowed_classes='=>'array'],
+'unserialize' => ['mixed', 'variable_representation'=>'string', 'allowed_classes='=>'array{allowed_classes:string[]|bool=}'],
 'unset' => ['void', 'var='=>'mixed', '...='=>'mixed'],
 'untaint' => ['bool', '&rw_string'=>'string', '&...rw_strings='=>'string'],
 'uopz_allow_exit' => ['void', 'allow'=>'bool'],

--- a/src/Phan/Language/Internal/PropertyMap.php
+++ b/src/Phan/Language/Internal/PropertyMap.php
@@ -397,6 +397,7 @@ return [
         'file' => 'string',
         'line' => 'int'
     ],
+    // TODO: Could use array shape types to document ast\Node->children in more detail.
     'ast\node' => [
         'kind' => 'int',
         'flags' => 'int',

--- a/src/Phan/Language/Type/NativeType.php
+++ b/src/Phan/Language/Type/NativeType.php
@@ -192,6 +192,4 @@ abstract class NativeType extends Type
     }
 }
 \class_exists(ArrayType::class);
-\class_exists(ArrayShapeType::class);
-\class_exists(GenericArrayType::class);
 \class_exists(ScalarType::class);

--- a/tests/Phan/Language/EmptyUnionTypeTest.php
+++ b/tests/Phan/Language/EmptyUnionTypeTest.php
@@ -25,6 +25,13 @@ use TypeError;
 
 class EmptyUnionTypeTest extends BaseTest
 {
+    const SKIPPED_METHOD_NAMES = [
+        'unserialize',  // throws
+        '__construct',
+        // UnionType implementation can't be optimized
+        'withIsPossiblyUndefined',
+        'getIsPossiblyUndefined',
+    ];
 
     public function testMethods()
     {
@@ -35,7 +42,7 @@ class EmptyUnionTypeTest extends BaseTest
                 continue;
             }
             $method_name = $method->getName();
-            if (\in_array($method_name, ['unserialize', '__construct'], true)) {
+            if (\in_array($method_name, self::SKIPPED_METHOD_NAMES, true)) {
                 continue;
             }
             $failures .= $this->checkHasSameImplementationForEmpty($method);
@@ -112,6 +119,8 @@ class EmptyUnionTypeTest extends BaseTest
         $type = $param->getType();
         $type_name = (string)$type;
         switch ($type_name) {
+            case 'bool':
+                return [false, true];
             case 'array':
                 return [[]];
             case 'int':

--- a/tests/Phan/Language/TypeTest.php
+++ b/tests/Phan/Language/TypeTest.php
@@ -295,6 +295,14 @@ class TypeTest extends BaseTest
                 'array{field:int}'
             ],
             [
+                'array<string,int>',
+                'array{field:int=}'
+            ],
+            [
+                'array<string,int>|array<string,string>',
+                'array{field:int|string}'
+            ],
+            [
                 'array<int,int>|array<int,string>',
                 'array{0:int,1:string}'
             ],

--- a/tests/files/expected/0443_base_access_protected_subclass.php.expected
+++ b/tests/files/expected/0443_base_access_protected_subclass.php.expected
@@ -1,0 +1,2 @@
+%s:7 PhanAccessPropertyPrivate Cannot access private property \Subclass::$privateProp
+%s:9 PhanAccessMethodPrivate Cannot access private method \Subclass::privateMethod defined at %s:20

--- a/tests/files/expected/0444_optional_array_shape.php.expected
+++ b/tests/files/expected/0444_optional_array_shape.php.expected
@@ -1,0 +1,10 @@
+%s:7 PhanTypeMismatchArgumentInternal Argument 1 (string) is array{strKey:string=,intKey:int=} but \strlen() takes string
+%s:9 PhanTypeMismatchArgumentInternal Argument 1 (var) is int but \count() takes \Countable|array
+%s:12 PhanTypeMismatchArgumentInternal Argument 1 (var) is string but \count() takes \Countable|array
+%s:17 PhanTypeMismatchArgument Argument 1 (options) is array{strKey:int} but \acceptsOptionArray() takes array{strKey:string=,intKey:int=} defined at %s:6
+%s:19 PhanTypeMismatchArgument Argument 1 (options) is array{strKey:null} but \acceptsOptionArray() takes array{strKey:string=,intKey:int=} defined at %s:6
+%s:21 PhanTypeMismatchArgument Argument 1 (options) is array{intKey:string} but \acceptsOptionArray() takes array{strKey:string=,intKey:int=} defined at %s:6
+%s:22 PhanTypeMismatchArgument Argument 1 (options) is array{intKey:null} but \acceptsOptionArray() takes array{strKey:string=,intKey:int=} defined at %s:6
+%s:23 PhanTypeMismatchArgument Argument 1 (options) is array{intKey:string,strKey:string} but \acceptsOptionArray() takes array{strKey:string=,intKey:int=} defined at %s:6
+%s:30 PhanTypeMismatchArgumentInternal Argument 1 (var) is ?string but \count() takes \Countable|array
+%s:37 PhanTypeMismatchArgument Argument 1 (options) is array{nullableStrKey:int} but \acceptsOptionArrayB() takes array{nullableStrKey:?string=} defined at %s:28

--- a/tests/files/expected/0445_unserialize_allowed_classes.php.expected
+++ b/tests/files/expected/0445_unserialize_allowed_classes.php.expected
@@ -1,0 +1,1 @@
+%s:5 PhanTypeMismatchArgumentInternal Argument 2 (allowed_classes) is array{allowed_classes:array{0:array{0:string}}} but \unserialize() takes array{allowed_classes:bool|string[]=}

--- a/tests/files/expected/0446_new_node.php.expected
+++ b/tests/files/expected/0446_new_node.php.expected
@@ -1,0 +1,2 @@
+%s:4 PhanTypeMismatchArgumentInternal Argument 1 (kind) is string but \ast\Node::__construct() takes int
+%s:4 PhanTypeMismatchArgumentInternal Argument 3 (children) is array{0:\stdClass} but \ast\Node::__construct() takes \ast\Node[]|\ast\Node\Decl[]|array[]|bool[]|float[]|int[]|null[]|string[]

--- a/tests/files/expected/0447_parse_url.php.expected
+++ b/tests/files/expected/0447_parse_url.php.expected
@@ -1,0 +1,3 @@
+%s:5 PhanTypeMismatchArgumentInternal Argument 1 (string) is int but \strlen() takes string
+%s:6 PhanTypeMismatchArgumentInternal Argument 1 (var) is string but \count() takes \Countable|array
+%s:7 PhanTypeInvalidDimOffset Invalid offset "Host" of array type array{scheme:string=,host:string=,port:int=,user:string=,pass:string=,path:string=,query:string=,fragment:string=}|int|null|string

--- a/tests/files/src/0443_base_access_protected_subclass.php
+++ b/tests/files/src/0443_base_access_protected_subclass.php
@@ -1,0 +1,24 @@
+<?php
+
+class Base {
+    public static function main() {
+        $c = new Subclass();
+        var_export($c->protectedProp);
+        var_export($c->privateProp);
+        var_export($c->protectedMethod());
+        var_export($c->privateMethod());
+    }
+}
+
+class Subclass extends Base {
+    protected $protectedProp = 2;
+    private $privateProp = 2;
+
+    protected function protectedMethod() {
+        return 4;
+    }
+    private function privateMethod() {
+        return 5;
+    }
+}
+Base::main();

--- a/tests/files/src/0444_optional_array_shape.php
+++ b/tests/files/src/0444_optional_array_shape.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @param array{strKey:string=,intKey:int=} $options
+ */
+function acceptsOptionArray(array $options) {
+    echo strlen($options);  // should warn
+    if (isset($options['intKey'])) {
+        echo count($options['intKey']);
+    }
+    if (isset($options['strKey'])) {
+        echo count($options['strKey']);
+    }
+}
+
+acceptsOptionArray([]);
+acceptsOptionArray(['strKey' => 2]);  // should warn
+acceptsOptionArray(['strKey' => 'value']);
+acceptsOptionArray(['strKey' => null]);  // should warn
+acceptsOptionArray(['intKey' => 2]);
+acceptsOptionArray(['intKey' => 'value']);
+acceptsOptionArray(['intKey' => null]);
+acceptsOptionArray(['intKey' => 'value', 'strKey' => 'value']);
+
+/**
+ * @param array{nullableStrKey:?string=} $options
+ */
+function acceptsOptionArrayB(array $options = []) {
+    if (isset($options['nullableStrKey'])) {
+        echo count($options['nullableStrKey']);
+    }
+}
+
+acceptsOptionArrayB([]);
+acceptsOptionArrayB(['nullableStrKey' => 'value']);
+acceptsOptionArrayB(['nullableStrKey' => null]);  // should not warn
+acceptsOptionArrayB(['nullableStrKey' => 2]);  // should not warn
+
+// Mixed, so we don't know
+acceptsOptionArray($GLOBALS);

--- a/tests/files/src/0445_unserialize_allowed_classes.php
+++ b/tests/files/src/0445_unserialize_allowed_classes.php
@@ -1,0 +1,6 @@
+<?php
+
+$serialized = serialize(new stdClass());
+unserialize($serialized, []);
+unserialize($serialized, ['allowed_classes' => [['stdClass']]]);
+unserialize($serialized, ['allowed_classes' => ['stdClass']]);

--- a/tests/files/src/0446_new_node.php
+++ b/tests/files/src/0446_new_node.php
@@ -1,0 +1,8 @@
+<?php
+var_export(new ast\Node());
+var_export(new ast\Node(
+    'key',
+    2,
+    [new stdClass()],
+    4
+));

--- a/tests/files/src/0447_parse_url.php
+++ b/tests/files/src/0447_parse_url.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+$x = parse_url('http://example.com:8080/path?key=value');
+var_export($x);
+echo strlen($x['port']);
+echo count($x['host']);
+echo $x['Host'];

--- a/tests/misc/fallback_ast_src/php71_or_newer/closure_returning_nullable.php
+++ b/tests/misc/fallback_ast_src/php71_or_newer/closure_returning_nullable.php
@@ -1,0 +1,5 @@
+<?php
+
+return function() : ?string {
+    return 'key';
+};


### PR DESCRIPTION
Use array shapes for Phan's internal signatures of unserialize() and parse_url()
(Impractical to look up array shapes for everything right now)

Also, bump the version to 2.3.0, the upcoming release will have
`Post*Capability`.