### PR TITLE
Fixes #1101: Improve phan's analysis of loose equality slightly.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@ New Features(Analysis)
 + Add limited support for analyzing `unset` on variables and the first dimension of arrays.
   Unsetting variables does not yet work in branches.
 + Don't emit `PhanTypeInvalidDimOffset` in `isset`/`empty`/`unset`
++ Improve Phan's analysis of loose equality (#1101)
 + Add new issue types `PhanWriteOnlyPublicProperty`, `PhanWriteOnlyProtectedProperty`, and `PhanWriteOnlyPrivateProperty`,
   which will be emitted on properties that are written to but never read from.
   (Requires that dead code detection be enabled)

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -18,6 +18,7 @@ use Phan\Language\Type\StringType;
 use Phan\Language\UnionType;
 use Phan\Language\UnionTypeBuilder;
 use ast\Node;
+use ast\flags;
 
 /**
  * TODO: Make $x != null remove FalseType and NullType from $x
@@ -35,7 +36,7 @@ class ConditionVisitor extends KindVisitorImplementation
      * The context in which the node we're going to be looking
      * at exits.
      */
-    private $context;
+    protected $context;
 
     /**
      * @param CodeBase $code_base
@@ -163,53 +164,22 @@ class ConditionVisitor extends KindVisitorImplementation
     public function visitBinaryOp(Node $node) : Context
     {
         $flags = $node->flags;
-        if ($flags === \ast\flags\BINARY_BOOL_AND) {
+        if ($flags === flags\BINARY_BOOL_AND) {
             return $this->analyzeShortCircuitingAnd($node->children['left'], $node->children['right']);
-        } elseif ($flags === \ast\flags\BINARY_BOOL_OR) {
+        } elseif ($flags === flags\BINARY_BOOL_OR) {
             return $this->analyzeShortCircuitingOr($node->children['left'], $node->children['right']);
-        } elseif ($flags === \ast\flags\BINARY_IS_IDENTICAL) {
+        } elseif ($flags === flags\BINARY_IS_IDENTICAL || $flags === flags\BINARY_IS_EQUAL) {
+            // TODO: Could be more precise, and preserve 0, [], etc. for `$x == null`
             $this->checkVariablesDefined($node);
-            return $this->analyzeIsIdentical($node->children['left'], $node->children['right']);
-        } elseif ($flags === \ast\flags\BINARY_IS_NOT_IDENTICAL || $flags === \ast\flags\BINARY_IS_NOT_EQUAL) {
+            return $this->analyzeAndUpdateToBeIdentical($node->children['left'], $node->children['right']);
+        } elseif ($flags === flags\BINARY_IS_NOT_IDENTICAL) {
             $this->checkVariablesDefined($node);
             // TODO: Add a different function for IS_NOT_EQUAL, e.g. analysis of != null should be different from !== null (First would remove FalseType)
-            return $this->analyzeIsNotIdentical($node->children['left'], $node->children['right']);
+            return $this->analyzeAndUpdateToBeNotIdentical($node->children['left'], $node->children['right']);
+        } elseif ($flags === flags\BINARY_IS_NOT_EQUAL) {
+            return $this->analyzeAndUpdateToBeNotEqual($node->children['left'], $node->children['right']);
         } else {
             $this->checkVariablesDefined($node);
-        }
-        return $this->context;
-    }
-
-    /**
-     * @param Node|int|float|string $left
-     * @param Node|int|float|string $right
-     * @return Context - Constant after inferring type from an expression such as `if ($x === 'literal')`
-     */
-    private function analyzeIsIdentical($left, $right) : Context
-    {
-        if (($left instanceof Node) && $left->kind === \ast\AST_VAR) {
-            // e.g. if ($x === null)
-            return $this->updateVariableToBeIdentical($left, $right, $this->context);
-        } elseif (($right instanceof Node) && $right->kind === \ast\AST_VAR) {
-            // e.g. if (null === $x)
-            return $this->updateVariableToBeIdentical($right, $left, $this->context);
-        }
-        return $this->context;
-    }
-
-    /**
-     * @param Node|int|float|string $left
-     * @param Node|int|float|string $right
-     * @return Context - Constant after inferring type from an expression such as `if ($x !== false)`
-     */
-    private function analyzeIsNotIdentical($left, $right) : Context
-    {
-        if (($left instanceof Node) && $left->kind === \ast\AST_VAR) {
-            // e.g. if ($x !== null)
-            return $this->updateVariableToBeNotIdentical($left, $right, $this->context);
-        } elseif (($right instanceof Node) && $right->kind === \ast\AST_VAR) {
-            // e.g. if (null !== $x)
-            return $this->updateVariableToBeNotIdentical($right, $left, $this->context);
         }
         return $this->context;
     }
@@ -315,7 +285,7 @@ class ConditionVisitor extends KindVisitorImplementation
     public function visitUnaryOp(Node $node) : Context
     {
         $expr_node = $node->children['expr'];
-        if ($node->flags !== \ast\flags\UNARY_BOOL_NOT) {
+        if ($node->flags !== flags\UNARY_BOOL_NOT) {
             if ($expr_node instanceof Node) {
                 $this->checkVariablesDefined($expr_node);
             }

--- a/tests/files/expected/0254_array_bool_comparison.php.expected
+++ b/tests/files/expected/0254_array_bool_comparison.php.expected
@@ -1,4 +1,4 @@
 %s:5 PhanTypeComparisonFromArray array to string comparison
 %s:6 PhanTypeComparisonToArray string to array comparison
-%s:12 PhanTypeComparisonFromArray array to string comparison
-%s:13 PhanTypeComparisonToArray string to array comparison
+%s:15 PhanTypeComparisonFromArray array to string comparison
+%s:16 PhanTypeComparisonToArray string to array comparison

--- a/tests/files/expected/0449_loose_equality.php.expected
+++ b/tests/files/expected/0449_loose_equality.php.expected
@@ -1,0 +1,3 @@
+%s:14 PhanTypeMismatchArgumentInternal Argument 1 (string) is array{}|string[] but \strlen() takes string
+%s:16 PhanTypeMismatchArgumentInternal Argument 1 (string) is string[] but \strlen() takes string
+%s:20 PhanTypeMismatchArgumentInternal Argument 1 (string) is string[] but \strlen() takes string

--- a/tests/files/src/0254_array_bool_comparison.php
+++ b/tests/files/src/0254_array_bool_comparison.php
@@ -1,14 +1,17 @@
 <?php
-function f1(array $p) {
+function f1(array $p, array $p2) {
     if($p && true);
     if(true && $p);
     if($p == "string");
-    if("string" == $p);
+    if("string" == $p2);
 }
-/** @param string[] $p */
-function f2($p) {
+/**
+ * @param string[] $p
+ * @param string[] $p2
+ */
+function f2($p, $p2) {
     if($p && true);
     if(true && $p);
     if($p == "string");
-    if("string" == $p);
+    if("string" == $p2);
 }

--- a/tests/files/src/0449_loose_equality.php
+++ b/tests/files/src/0449_loose_equality.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @param string[]|null $x
+ * @param string[]|null $y
+ * @param string[]|null $z
+ */
+function foo($x = null, $y = null, $z = null) {
+    if ($x == null) {
+        $x = [];
+    }
+    // Expected postcondition: $x is string[] (and possibly array)
+    echo count($x);
+    echo strlen($x);
+    if ($y != "") {
+        echo strlen($y);  // inferred type should be string[]
+    }
+    if ($z == false) {
+    } else {
+        echo strlen($z);
+    }
+    // This check isn't comprehensive, e.g. Phan isn't aware that `!= []` implies not null.
+}


### PR DESCRIPTION
`==` behaves similarly to the `===` operator right now, except for
null/true/false. Same for `!=`.
This check doesn't handle many of the possible equality edge cases