### PR TITLE
Infer details of first array dimension from isset on arrays

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,27 @@ New Features(Analysis)
 + Allow phpdoc `@param` array shapes to contain optional fields. (E.g. `array{requiredKey:int,optionalKey?:string}`) (#1382)
   An array shape is now allowed to cast to another array shape, as long as the required fields are compatible with the target type,
   and any optional fields from the target type are absent in the source type or compatible.
++ In issue messages, represent closures by their signatures instead of as `\closure_{hexdigits}`
++ Emit `PhanTypeArrayUnsetSuspicious` when trying to unset the offset of something that isn't an array or array-like.
++ Add limited support for analyzing `unset` on variables and the first dimension of arrays.
+  Unsetting variables does not yet work in branches.
++ Don't emit `PhanTypeInvalidDimOffset` in `isset`/`empty`/`unset`
++ Improve Phan's analysis of loose equality (#1101)
++ Add new issue types `PhanWriteOnlyPublicProperty`, `PhanWriteOnlyProtectedProperty`, and `PhanWriteOnlyPrivateProperty`,
+  which will be emitted on properties that are written to but never read from.
+  (Requires that dead code detection be enabled)
++ Improve Phan's analysis of switch statements and fix bugs. (#1561)
++ Add `PhanTypeSuspiciousEcho` to warn about suspicious types being passed to echo/print statements.
+  This now warns about booleans, arrays, resources, null, non-stringable classes, combinations of those types, etc.
+  (`var_export` or JSON encoding usually makes more sense for a boolean/null)
++ Make Phan infer that top level array keys for expressions such as `if (isset($x['keyName']))` exist and are non-null. (#1514)
++ Make Phan infer that top level array keys for expressions such as `if (array_key_exists('keyName', $x))` exist. (#1514)
++ Make Phan aware of types after negated of `isset`/`array_key_exists` checks for array shapes (E.g. `if (!array_key_exists('keyName', $x)) { var_export($x['keyName']); }`)
+  Note: This will likely fail to warn if the variable is already a mix of generic arrays and array shapes.
++ Make Phan check that types in `@throws` annotations are valid; don't warn about classes in `@throws` being unreferenced. (#1555)
+  New issue types: `PhanUndeclaredTypeThrowsType`, `PhanTypeInvalidThrowsNonObject`, `PhanTypeInvalidThrowsNonThrowable`, `PhanTypeInvalidThrowsIsTrait`, `PhanTypeInvalidThrowsIsInterface`
+
+New types:
 + Add `Closure` and `callable` with annotated param types and return to Phan's type system(#1578, #1581).
   This is not a part of the phpdoc2 standard or any other standard.
   These can be used in any phpdoc tags that Phan is aware of,
@@ -43,21 +64,6 @@ New Features(Analysis)
   - Placeholder variable names can be part of these types,
     similarly to `@method` (`Closure($unknown,int $count=0):T`
     is equivalent to `Closure(mixed,int):T`
-+ In issue messages, represent closures by their signatures instead of as `\closure_{hexdigits}`
-+ Emit `PhanTypeArrayUnsetSuspicious` when trying to unset the offset of something that isn't an array or array-like.
-+ Add limited support for analyzing `unset` on variables and the first dimension of arrays.
-  Unsetting variables does not yet work in branches.
-+ Don't emit `PhanTypeInvalidDimOffset` in `isset`/`empty`/`unset`
-+ Improve Phan's analysis of loose equality (#1101)
-+ Add new issue types `PhanWriteOnlyPublicProperty`, `PhanWriteOnlyProtectedProperty`, and `PhanWriteOnlyPrivateProperty`,
-  which will be emitted on properties that are written to but never read from.
-  (Requires that dead code detection be enabled)
-+ Improve Phan's analysis of switch statements and fix bugs. (#1561)
-+ Add `PhanTypeSuspiciousEcho` to warn about suspicious types being passed to echo/print statements.
-  This now warns about booleans, arrays, resources, null, non-stringable classes, combinations of those types, etc.
-  (`var_export` or JSON encoding usually makes more sense for a boolean/null)
-+ Make Phan check that types in `@throws` annotations are valid; don't warn about classes in `@throws` being unreferenced. (#1555)
-  New issue types: `PhanUndeclaredTypeThrowsType`, `PhanTypeInvalidThrowsNonObject`, `PhanTypeInvalidThrowsNonThrowable`, `PhanTypeInvalidThrowsIsTrait`, `PhanTypeInvalidThrowsIsInterface`
 
 Maintenance
 + Add `--disable-usage-on-error` option to `phan_client` (#1540)

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -942,11 +942,11 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             $true_context = (new ConditionVisitor(
                 $this->code_base,
                 $base_context
-            ))($cond_node);
+            ))->__invoke($cond_node);
             $false_context = (new NegatedConditionVisitor(
                 $this->code_base,
                 $base_context
-            ))($cond_node);
+            ))->__invoke($cond_node);
         } else {
             $true_context = $context;
             $false_context = $this->context;

--- a/src/Phan/Language/AnnotatedUnionType.php
+++ b/src/Phan/Language/AnnotatedUnionType.php
@@ -78,4 +78,24 @@ class AnnotatedUnionType extends UnionType
     {
         return parent::withUnionType($union_type)->withIsPossiblyUndefined(false);
     }
+
+    /**
+     * @return bool - True if not empty, not possibly undefined, and at least one type is NullType or nullable.
+     * @override
+     */
+    public function containsNullableOrUndefined() : bool
+    {
+        return $this->is_possibly_undefined || $this->containsNullable();
+    }
+
+    /**
+     * @override
+     */
+    public function generateUniqueId() : string {
+        $id = parent::generateUniqueId();
+        if ($this->is_possibly_undefined) {
+            return $id . '=';
+        }
+        return $id;
+    }
 }

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -238,6 +238,14 @@ final class EmptyUnionType extends UnionType
         return false;
     }
 
+    /**
+     * @return bool - True if not empty, not possibly undefined, and at least one type is NullType or nullable.
+     */
+    public function containsNullableOrUndefined() : bool
+    {
+        return false;
+    }
+
     /** @override */
     public function nonNullableClone() : UnionType
     {

--- a/src/Phan/Language/Internal/FunctionSignatureMap.php
+++ b/src/Phan/Language/Internal/FunctionSignatureMap.php
@@ -66,6 +66,7 @@ PHAN;
  *   For some signatures, e.g. set_error_handler, this results in repetition, because callable(T1=) can't cast to callable(T1).
  */
 return [
+'_' => ['string', 'message'=>'string'],
 '__halt_compiler' => [''],
 'abs' => ['int', 'number'=>'int'],
 'abs\'1' => ['float', 'number'=>'float'],

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -264,7 +264,7 @@ final class GenericArrayType extends ArrayType
             "Recursion has gotten out of hand"
         );
 
-        $union_type = $this->memoize(__METHOD__, function () use ($code_base, $recursion_depth) {
+        return $this->memoize(__METHOD__, function () use ($code_base, $recursion_depth) {
             $union_type = $this->asUnionType();
 
             $class_fqsen = $this->genericArrayElementType()->asFQSEN();
@@ -312,7 +312,6 @@ final class GenericArrayType extends ArrayType
             }
             return $recursive_union_type_builder->getUnionType();
         });
-        return $union_type;
     }
 
     public static function keyTypeFromUnionTypeKeys(UnionType $union_type) : int

--- a/src/Phan/Language/Type/NullType.php
+++ b/src/Phan/Language/Type/NullType.php
@@ -106,6 +106,11 @@ final class NullType extends ScalarType
         return $this->name;
     }
 
+    public function getIsNullable() : bool
+    {
+        return true;
+    }
+
     public function getIsPossiblyFalsey() : bool
     {
         return true;  // Null is always falsey.

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -834,6 +834,14 @@ class UnionType implements \Serializable
         return false;
     }
 
+    /**
+     * @return bool - True if not empty, not possibly undefined, and at least one type is NullType or nullable.
+     */
+    public function containsNullableOrUndefined() : bool
+    {
+        return $this->containsNullable();
+    }
+
     public function nonNullableClone() : UnionType
     {
         $builder = new UnionTypeBuilder();

--- a/tests/files/expected/0444_optional_array_shape.php.expected
+++ b/tests/files/expected/0444_optional_array_shape.php.expected
@@ -6,5 +6,5 @@
 %s:21 PhanTypeMismatchArgument Argument 1 (options) is array{intKey:string} but \acceptsOptionArray() takes array{strKey?:string,intKey?:int} defined at %s:6
 %s:22 PhanTypeMismatchArgument Argument 1 (options) is array{intKey:null} but \acceptsOptionArray() takes array{strKey?:string,intKey?:int} defined at %s:6
 %s:23 PhanTypeMismatchArgument Argument 1 (options) is array{intKey:string,strKey:string} but \acceptsOptionArray() takes array{strKey?:string,intKey?:int} defined at %s:6
-%s:30 PhanTypeMismatchArgumentInternal Argument 1 (var) is ?string but \count() takes \Countable|array
+%s:30 PhanTypeMismatchArgumentInternal Argument 1 (var) is string but \count() takes \Countable|array
 %s:37 PhanTypeMismatchArgument Argument 1 (options) is array{nullableStrKey:int} but \acceptsOptionArrayB() takes array{nullableStrKey?:?string} defined at %s:28

--- a/tests/files/expected/0458_isset_array.php.expected
+++ b/tests/files/expected/0458_isset_array.php.expected
@@ -1,0 +1,7 @@
+%s:9 PhanTypeMismatchArgumentInternal Argument 1 (string) is array{otherKey:mixed,key:string} but \strlen() takes string
+%s:11 PhanTypeMismatchArgumentInternal Argument 1 (string) is array{key:string} but \strlen() takes string
+%s:15 PhanTypeMismatchArgumentInternal Argument 1 (var) is string but \count() takes \Countable|array
+%s:27 PhanTypeMismatchArgumentInternal Argument 1 (string) is array{key:mixed,0:?string,1:int} but \strlen() takes string
+%s:29 PhanTypeMismatchArgumentInternal Argument 1 (string) is array{0:?string,1:int} but \strlen() takes string
+%s:40 PhanTypeMismatchArgumentInternal Argument 1 (string) is array{0:string,1:int} but \strlen() takes string
+%s:42 PhanTypeMismatchArgumentInternal Argument 1 (string) is array{0?:null,1:int} but \strlen() takes string

--- a/tests/files/expected/0459_array_key_exists_array.php.expected
+++ b/tests/files/expected/0459_array_key_exists_array.php.expected
@@ -1,0 +1,7 @@
+%s:9 PhanTypeMismatchArgumentInternal Argument 1 (string) is array{otherKey:mixed,key:string} but \strlen() takes string
+%s:11 PhanTypeMismatchArgumentInternal Argument 1 (string) is array{key:string} but \strlen() takes string
+%s:14 PhanTypeMismatchArgumentInternal Argument 2 (search) is string but \array_key_exists() takes array
+%s:15 PhanTypeMismatchArgumentInternal Argument 1 (var) is string but \count() takes \Countable|array
+%s:28 PhanTypeMismatchArgumentInternal Argument 1 (string) is array{key:string,otherKey:int} but \strlen() takes string
+%s:30 PhanTypeMismatchArgumentInternal Argument 1 (string) is array{key:string} but \strlen() takes string
+%s:31 PhanTypeInvalidDimOffset Invalid offset "otherKey" of array type array{key:string}

--- a/tests/files/src/0458_isset_array.php
+++ b/tests/files/src/0458_isset_array.php
@@ -1,0 +1,46 @@
+<?php
+call_user_func(
+    /**
+     * @param array{key:string} $data
+     * @param string $str
+     */
+    function($data, $str) {
+        if (isset($data['otherKey'])) {
+            echo strlen($data);
+        } else {
+            echo strlen($data);
+        }
+        // This is still a string.
+        if (isset($str[5])) {
+            echo count($str);
+        }
+    },
+    [],
+    'stringVar'
+);
+call_user_func(
+    /**
+     * @param array{0:?string,1:int} $data
+     */
+    function($data, $str) {
+        if (isset($data['key'])) {
+            echo strlen($data);
+        } else {
+            echo strlen($data);
+        }
+    }
+);
+
+call_user_func(
+    /**
+     * @param array{0:?string,1:int} $data
+     */
+    function($data) {
+        if (isset($data[0])) {
+            echo strlen($data);
+        } else {
+            echo strlen($data);
+        }
+    },
+    ['x', 2]
+);

--- a/tests/files/src/0459_array_key_exists_array.php
+++ b/tests/files/src/0459_array_key_exists_array.php
@@ -1,0 +1,35 @@
+<?php
+call_user_func(
+    /**
+     * @param array{key:string} $data
+     * @param string $str
+     */
+    function($data, $str) {
+        if (array_key_exists('otherKey', $data)) {
+            echo strlen($data);
+        } else {
+            echo strlen($data);
+        }
+        // This is still a string.
+        if (array_key_exists(5, $str)) {  // The call should warn
+            echo count($str);
+        }
+    },
+    ['key' => 'value']
+);
+
+call_user_func(
+    /**
+     * @param array{key:string,otherKey:int} $data
+     * @param string $str
+     */
+    function($data, $str) {
+        if (array_key_exists('otherKey', $data)) {
+            echo strlen($data);
+        } else {
+            echo strlen($data);
+            var_export($data['otherKey']);
+        }
+    },
+    ['key' => 'string']
+);


### PR DESCRIPTION
Future PRs may add inferences about nested array dimensions

If the original type of the variable was `array{field:?T}`,
then the inferred type of the field after the isset check should be `T`,
not `mixed`

Unrelated: Add gettext() alias _() to internal type signatures

Fixes #1514 (Follow up issues will be filed for nested array dimensions)

Memoize expanded types of array shapes for performance (Should not affect analysis)