### PR TITLE
Use array{key?:type} syntax instead of array{key:type=}

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@ New Features(CLI, Configs)
 
 New Features(Analysis)
 + Infer the type of `[]` as `array{}` (the empty array), not `array`. (#1382)
-+ Allow phpdoc `@param` array shapes to contain optional fields. (E.g. `array{requiredKey:int,optionalKey:string=}`) (#1382)
++ Allow phpdoc `@param` array shapes to contain optional fields. (E.g. `array{requiredKey:int,optionalKey?:string}`) (#1382)
   An array shape is now allowed to cast to another array shape, as long as the required fields are compatible with the target type,
   and any optional fields from the target type are absent in the source type or compatible.
 + Emit `PhanTypeArrayUnsetSuspicious` when trying to unset the offset of something that isn't an array or array-like.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Phan is able to perform the following kinds of analysis.
 * Supports generic arrays such as `int[]`, `UserObject[]`, `array<int,UserObject>`, etc..
 * Supports array shapes such as `array{key:string,otherKey:?stdClass}`, etc. (internally and in PHPDoc tags) as of Phan >= 0.12.0.
 * The upcoming 0.12.3 release will support indicating that fields of an array shape are optional
-  via `array{requiredKey:string,optionalKey:string=}` (useful for `@param`)
+  via `array{requiredKey:string,optionalKey?:string}` (useful for `@param`)
 * Supports phpdoc [type annotations](https://github.com/phan/phan/wiki/Annotating-Your-Source-Code).
 * Supports inheriting phpdoc type annotations.
 * Supports checking that phpdoc type annotations are a narrowed form (E.g. subclasses/subtypes) of the real type signatures

--- a/src/Phan/Language/AnnotatedUnionType.php
+++ b/src/Phan/Language/AnnotatedUnionType.php
@@ -21,7 +21,10 @@ class AnnotatedUnionType extends UnionType
      */
     public function withIsPossiblyUndefined(bool $is_possibly_undefined) : UnionType
     {
-        if ($is_possibly_undefined === $this->is_possibly_undefined) {
+        if (!$is_possibly_undefined) {
+            return UnionType::ofUniqueTypes($this->getTypeSet());
+        }
+        if (!$this->is_possibly_undefined) {
             return $this;
         }
         $result = clone($this);
@@ -41,5 +44,38 @@ class AnnotatedUnionType extends UnionType
             return $result . '=';
         }
         return $result;
+    }
+
+    /**
+     * Add a type name to the list of types
+     *
+     * @return UnionType
+     * @override
+     */
+    public function withType(Type $type)
+    {
+        return parent::withType($type)->withIsPossiblyUndefined(false);
+    }
+
+    /**
+     * Add a type name to the list of types
+     *
+     * @return UnionType
+     * @override
+     */
+    public function withoutType(Type $type)
+    {
+        return parent::withoutType($type)->withIsPossiblyUndefined(false);
+    }
+
+    /**
+     * Returns a union type which add the given types to this type
+     *
+     * @return UnionType
+     * @override
+     */
+    public function withUnionType(UnionType $union_type)
+    {
+        return parent::withUnionType($union_type)->withIsPossiblyUndefined(false);
     }
 }

--- a/src/Phan/Language/Internal/FunctionSignatureMap.php
+++ b/src/Phan/Language/Internal/FunctionSignatureMap.php
@@ -54,8 +54,8 @@ PHAN;
  *
  *   \Phan\Language\UnionType->withFlattenedArrayShapeTypeInstances() may be of help to programatically convert these to array<string,T1>|array<string,T2>
  *
- * - This started using array shapes with optional fields for union types (array{key:int=}).
- *   The `=` after the union type indicates that the field is optional.
+ * - This started using array shapes with optional fields for union types (array{key?:int}).
+ *   A `?` after the array shape field's key indicates that the field is optional.
  */
 return [
 '__halt_compiler' => [''],
@@ -6710,7 +6710,7 @@ return [
 'parse_ini_file' => ['array|false', 'filename'=>'string', 'process_sections='=>'bool', 'scanner_mode='=>'int'],
 'parse_ini_string' => ['array|false', 'ini_string'=>'string', 'process_sections='=>'bool', 'scanner_mode='=>'int'],
 'parse_str' => ['void', 'encoded_string'=>'string', '&w_result='=>'array'],
-'parse_url' => ['array{scheme:string=,host:string=,port:int=,user:string=,pass:string=,path:string=,query:string=,fragment:string=}|string|int|null', 'url'=>'string', 'url_component='=>'int'],
+'parse_url' => ['array{scheme?:string,host?:string,port?:int,user?:string,pass?:string,path?:string,query?:string,fragment?:string}|string|int|null', 'url'=>'string', 'url_component='=>'int'],
 'ParseError::__clone' => ['void'],
 'ParseError::__construct' => ['void', 'message='=>'string', 'code='=>'int', 'previous='=>'?Throwable|?ParseError'],
 'ParseError::__toString' => ['string'],
@@ -10222,7 +10222,7 @@ return [
 'unlink' => ['bool', 'filename'=>'string', 'context='=>'resource'],
 'unpack' => ['array', 'format'=>'string', 'data'=>'string', 'offset='=>'int'],
 'unregister_tick_function' => ['void', 'function_name'=>'string'],
-'unserialize' => ['mixed', 'variable_representation'=>'string', 'allowed_classes='=>'array{allowed_classes:string[]|bool=}'],
+'unserialize' => ['mixed', 'variable_representation'=>'string', 'allowed_classes='=>'array{allowed_classes?:string[]|bool}'],
 'unset' => ['void', 'var='=>'mixed', '...='=>'mixed'],
 'untaint' => ['bool', '&rw_string'=>'string', '&...rw_strings='=>'string'],
 'uopz_allow_exit' => ['void', 'allow'=>'bool'],

--- a/src/Phan/Language/Type/ArrayShapeType.php
+++ b/src/Phan/Language/Type/ArrayShapeType.php
@@ -239,13 +239,15 @@ final class ArrayShapeType extends ArrayType
     {
         $parts = [];
         foreach ($this->field_types as $key => $value) {
-            $parts[] = "$key:$value";
+            $value_repr = $value->__toString();
+            if (\substr($value_repr, -1) === '=') {
+                // convert {key:type=} to {key?:type} in representation.
+                $parts[] = $key . '?:' . \substr($value_repr, 0, -1);
+            } else {
+                $parts[] = "$key:$value_repr";
+            }
         }
-        $string = 'array{' . \implode(',', $parts) . '}';
-        if ($this->is_nullable) {
-            $string = '?' . $string;
-        }
-        return $string;
+        return ($this->is_nullable ? '?' : '') . 'array{' . \implode(',', $parts) . '}';
     }
 
     /**

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -85,7 +85,7 @@ class UnionType implements \Serializable
         }
     }
 
-    private static function ofUniqueTypes(array $type_list)
+    protected static function ofUniqueTypes(array $type_list)
     {
         $n = \count($type_list);
         if ($n === 0) {

--- a/tests/Phan/Language/UnionTypeTest.php
+++ b/tests/Phan/Language/UnionTypeTest.php
@@ -448,7 +448,7 @@ class UnionTypeTest extends BaseTest
         $types = $union_type->getTypeSet();
         $type = reset($types);
 
-        $this->assertSame('array{key:int|string=}', (string)$type);
+        $this->assertSame('array{key?:int|string}', (string)$type);
         \assert($type instanceof ArrayShapeType);
         $this->assertSame('array<string,int>|array<string,string>', (string)$union_type->withFlattenedArrayShapeTypeInstances());
         $field_union_type = $type->getFieldTypes()['key'];

--- a/tests/files/expected/0444_optional_array_shape.php.expected
+++ b/tests/files/expected/0444_optional_array_shape.php.expected
@@ -1,10 +1,10 @@
-%s:7 PhanTypeMismatchArgumentInternal Argument 1 (string) is array{strKey:string=,intKey:int=} but \strlen() takes string
+%s:7 PhanTypeMismatchArgumentInternal Argument 1 (string) is array{strKey?:string,intKey?:int} but \strlen() takes string
 %s:9 PhanTypeMismatchArgumentInternal Argument 1 (var) is int but \count() takes \Countable|array
 %s:12 PhanTypeMismatchArgumentInternal Argument 1 (var) is string but \count() takes \Countable|array
-%s:17 PhanTypeMismatchArgument Argument 1 (options) is array{strKey:int} but \acceptsOptionArray() takes array{strKey:string=,intKey:int=} defined at %s:6
-%s:19 PhanTypeMismatchArgument Argument 1 (options) is array{strKey:null} but \acceptsOptionArray() takes array{strKey:string=,intKey:int=} defined at %s:6
-%s:21 PhanTypeMismatchArgument Argument 1 (options) is array{intKey:string} but \acceptsOptionArray() takes array{strKey:string=,intKey:int=} defined at %s:6
-%s:22 PhanTypeMismatchArgument Argument 1 (options) is array{intKey:null} but \acceptsOptionArray() takes array{strKey:string=,intKey:int=} defined at %s:6
-%s:23 PhanTypeMismatchArgument Argument 1 (options) is array{intKey:string,strKey:string} but \acceptsOptionArray() takes array{strKey:string=,intKey:int=} defined at %s:6
+%s:17 PhanTypeMismatchArgument Argument 1 (options) is array{strKey:int} but \acceptsOptionArray() takes array{strKey?:string,intKey?:int} defined at %s:6
+%s:19 PhanTypeMismatchArgument Argument 1 (options) is array{strKey:null} but \acceptsOptionArray() takes array{strKey?:string,intKey?:int} defined at %s:6
+%s:21 PhanTypeMismatchArgument Argument 1 (options) is array{intKey:string} but \acceptsOptionArray() takes array{strKey?:string,intKey?:int} defined at %s:6
+%s:22 PhanTypeMismatchArgument Argument 1 (options) is array{intKey:null} but \acceptsOptionArray() takes array{strKey?:string,intKey?:int} defined at %s:6
+%s:23 PhanTypeMismatchArgument Argument 1 (options) is array{intKey:string,strKey:string} but \acceptsOptionArray() takes array{strKey?:string,intKey?:int} defined at %s:6
 %s:30 PhanTypeMismatchArgumentInternal Argument 1 (var) is ?string but \count() takes \Countable|array
-%s:37 PhanTypeMismatchArgument Argument 1 (options) is array{nullableStrKey:int} but \acceptsOptionArrayB() takes array{nullableStrKey:?string=} defined at %s:28
+%s:37 PhanTypeMismatchArgument Argument 1 (options) is array{nullableStrKey:int} but \acceptsOptionArrayB() takes array{nullableStrKey?:?string} defined at %s:28

--- a/tests/files/expected/0445_unserialize_allowed_classes.php.expected
+++ b/tests/files/expected/0445_unserialize_allowed_classes.php.expected
@@ -1,1 +1,1 @@
-%s:5 PhanTypeMismatchArgumentInternal Argument 2 (allowed_classes) is array{allowed_classes:array{0:array{0:string}}} but \unserialize() takes array{allowed_classes:bool|string[]=}
+%s:5 PhanTypeMismatchArgumentInternal Argument 2 (allowed_classes) is array{allowed_classes:array{0:array{0:string}}} but \unserialize() takes array{allowed_classes?:bool|string[]}

--- a/tests/files/expected/0447_parse_url.php.expected
+++ b/tests/files/expected/0447_parse_url.php.expected
@@ -1,3 +1,3 @@
 %s:5 PhanTypeMismatchArgumentInternal Argument 1 (string) is int but \strlen() takes string
 %s:6 PhanTypeMismatchArgumentInternal Argument 1 (var) is string but \count() takes \Countable|array
-%s:7 PhanTypeInvalidDimOffset Invalid offset "Host" of array type array{scheme:string=,host:string=,port:int=,user:string=,pass:string=,path:string=,query:string=,fragment:string=}|int|null|string
+%s:7 PhanTypeInvalidDimOffset Invalid offset "Host" of array type array{scheme?:string,host?:string,port?:int,user?:string,pass?:string,path?:string,query?:string,fragment?:string}|int|null|string


### PR DESCRIPTION
The latter syntax is still allowed, but may be deprecated in the future.

For #1328 

Fixes #1566 as well.