### PR TITLE
Fixes #1542: Warn about non-stringable types passed to echo/print

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,9 @@ New Features(Analysis)
   which will be emitted on properties that are written to but never read from.
   (Requires that dead code detection be enabled)
 + Improve Phan's analysis of switch statements and fix bugs. (#1561)
++ Add `PhanTypeSuspiciousEcho` to warn about suspicious types being passed to echo/print statements.
+  This now warns about booleans, arrays, resources, null, non-stringable classes, combinations of those types, etc.
+  (`var_export` or JSON encoding usually makes more sense for a boolean/null)
 
 Maintenance
 + Add `--disable-usage-on-error` option to `phan_client` (#1540)

--- a/src/Phan/Analysis/ArgumentType.php
+++ b/src/Phan/Analysis/ArgumentType.php
@@ -525,7 +525,7 @@ class ArgumentType
         if ($method->isPHPInternal()) {
             // If we are not in strict mode and we accept a string parameter
             // and the argument we are passing has a __toString method then it is ok
-            if (!$context->getIsStrictTypes() && \is_object($parameter_type) && $parameter_type->hasType(StringType::instance(false))) {
+            if (!$context->getIsStrictTypes() && $parameter_type->hasType(StringType::instance(false))) {
                 try {
                     foreach ($argument_type_expanded->asClassList($code_base, $context) as $clazz) {
                         if ($clazz->hasMethodWithName($code_base, "__toString")) {

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -94,6 +94,7 @@ class Issue
     const TypeMissingReturn         = 'PhanTypeMissingReturn';
     const TypeNonVarPassByRef       = 'PhanTypeNonVarPassByRef';
     const TypeParentConstructorCalled = 'PhanTypeParentConstructorCalled';
+    const TypeSuspiciousEcho        = 'PhanTypeSuspiciousEcho';
     const TypeVoidAssignment        = 'PhanTypeVoidAssignment';
     const TypeInvalidCallableArraySize = 'PhanTypeInvalidCallableArraySize';
     const TypeInvalidCallableArrayKey = 'PhanTypeInvalidCallableArrayKey';
@@ -1135,6 +1136,14 @@ class Issue
                 "Invalid offset {SCALAR} of array type {TYPE} in an array destructuring assignment",
                 self::REMEDIATION_B,
                 10047
+            ),
+            new Issue(
+                self::TypeSuspiciousEcho,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                "Suspicious argument {TYPE} for an echo/print statement",
+                self::REMEDIATION_B,
+                10049
             ),
             // Issue::CATEGORY_VARIABLE
             new Issue(

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -463,6 +463,16 @@ final class EmptyUnionType extends UnionType
 
     /**
      * @return bool
+     * True if any types in this union are a printable scalar, or this is the empty union type
+     * @internal
+     */
+    public function hasPrintableScalar() : bool
+    {
+        return true;
+    }
+
+    /**
+     * @return bool
      * True if this union has array-like types (is of type array, is
      * a generic array, or implements ArrayAccess).
      */

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -1289,6 +1289,16 @@ class Type
 
     /**
      * @return bool
+     * True if this type is a printable scalar.
+     * @internal
+     */
+    public function isPrintableScalar() : bool
+    {
+        return false;  // Overridden in subclass ScalarType
+    }
+
+    /**
+     * @return bool
      * True if this type is a callable or a Closure.
      */
     public function isCallable() : bool
@@ -1663,7 +1673,7 @@ class Type
             ],
         ];
 
-        return $matrix[(string)$this][(string)$type] ?? false;
+        return $matrix[$this->__toString()][$type->__toString()] ?? false;
     }
 
     /**

--- a/src/Phan/Language/Type/BoolType.php
+++ b/src/Phan/Language/Type/BoolType.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 namespace Phan\Language\Type;
 
+use Phan\Config;
 use Phan\Language\Type;
 
 final class BoolType extends ScalarType
@@ -58,6 +59,12 @@ final class BoolType extends ScalarType
     public function getNormalizationFlags() : int
     {
         return $this->is_nullable ? (self::_bit_nullable | self::_bit_true | self::_bit_false) : (self::_bit_true | self::_bit_false);
+    }
+
+    public function isPrintableScalar() : bool
+    {
+        // This would be '' or '1', which is probably not intended
+        return Config::getValue('scalar_implicit_cast');
     }
 }
 

--- a/src/Phan/Language/Type/FalseType.php
+++ b/src/Phan/Language/Type/FalseType.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 namespace Phan\Language\Type;
 
+use Phan\Config;
 use Phan\Language\Type;
 
 final class FalseType extends ScalarType
@@ -55,5 +56,11 @@ final class FalseType extends ScalarType
     public function getNormalizationFlags() : int
     {
         return $this->is_nullable ? (self::_bit_nullable | self::_bit_false) : self::_bit_false;
+    }
+
+    public function isPrintableScalar() : bool
+    {
+        // This would be '', which is probably not intended
+        return Config::getValue('scalar_implicit_cast');
     }
 }

--- a/src/Phan/Language/Type/IterableType.php
+++ b/src/Phan/Language/Type/IterableType.php
@@ -13,6 +13,11 @@ class IterableType extends NativeType
         return true;
     }
 
+    public function isPrintableScalar() : bool
+    {
+        return false;  // Overridden in subclass IterableType
+    }
+
     public function isPossiblyObject() : bool
     {
         return true;  // can be Traversable, which is an object

--- a/src/Phan/Language/Type/MixedType.php
+++ b/src/Phan/Language/Type/MixedType.php
@@ -42,4 +42,9 @@ final class MixedType extends NativeType
     {
         return ArrayType::instance(false);
     }
+
+    public function isPrintableScalar() : bool
+    {
+        return true;  // It's possible.
+    }
 }

--- a/src/Phan/Language/Type/NullType.php
+++ b/src/Phan/Language/Type/NullType.php
@@ -115,4 +115,10 @@ final class NullType extends ScalarType
     {
         return true;  // Null is always falsey.
     }
+
+    public function isPrintableScalar() : bool
+    {
+        // This would be '', which is probably not intended. allow null in union types for `echo` if there are **other** valid types.
+        return Config::get_null_casts_as_any_type();
+    }
 }

--- a/src/Phan/Language/Type/ResourceType.php
+++ b/src/Phan/Language/Type/ResourceType.php
@@ -5,4 +5,9 @@ final class ResourceType extends NativeType
 {
     /** @phan-override */
     const NAME = 'resource';
+
+    public function isPrintableScalar() : bool
+    {
+        return false;
+    }
 }

--- a/src/Phan/Language/Type/ScalarType.php
+++ b/src/Phan/Language/Type/ScalarType.php
@@ -14,6 +14,11 @@ abstract class ScalarType extends NativeType
         return true;
     }
 
+    public function isPrintableScalar() : bool
+    {
+        return true;  // Overridden in subclass IterableType and ResourceType
+    }
+
     public function isSelfType() : bool
     {
         return false;

--- a/src/Phan/Language/Type/TrueType.php
+++ b/src/Phan/Language/Type/TrueType.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 namespace Phan\Language\Type;
 
+use Phan\Config;
 use Phan\Language\Type;
 
 // Not sure if it made sense to extend BoolType, so not doing that.
@@ -46,5 +47,11 @@ final class TrueType extends ScalarType
     public function getNormalizationFlags() : int
     {
         return $this->is_nullable ? (self::_bit_nullable | self::_bit_true) : self::_bit_true;
+    }
+
+    public function isPrintableScalar() : bool
+    {
+        // This would be '1', which is probably not intended
+        return Config::getValue('scalar_implicit_cast');
     }
 }

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -1273,6 +1273,22 @@ class UnionType implements \Serializable
 
     /**
      * @return bool
+     * True if any types in this union are a printable scalar, or this is the empty union type
+     * @internal
+     */
+    public function hasPrintableScalar() : bool
+    {
+        if ($this->isEmpty()) {
+            return true;
+        }
+
+        return $this->hasTypeMatchingCallback(function (Type $type) : bool {
+            return $type->isPrintableScalar();
+        });
+    }
+
+    /**
+     * @return bool
      * True if this union has array-like types (is of type array, is
      * a generic array, or implements ArrayAccess).
      */

--- a/tests/files/expected/0028_if_condition_assignment.php.expected
+++ b/tests/files/expected/0028_if_condition_assignment.php.expected
@@ -1,0 +1,1 @@
+%s:3 PhanTypeSuspiciousEcho Suspicious argument true for an echo/print statement

--- a/tests/files/expected/0192_constants.php.expected
+++ b/tests/files/expected/0192_constants.php.expected
@@ -1,3 +1,4 @@
 %s:8 PhanUndeclaredConstant Reference to undeclared constant \this
 %s:13 PhanTypeMismatchReturn Returning type int but g() is declared to return \C
 %s:18 PhanTypeMismatchReturn Returning type int but h() is declared to return \C
+%s:22 PhanTypeSuspiciousEcho Suspicious argument \C for an echo/print statement

--- a/tests/files/expected/0335_property_types_mixed.php.expected
+++ b/tests/files/expected/0335_property_types_mixed.php.expected
@@ -1,1 +1,2 @@
 %s:10 PhanTypeMismatchArgumentInternal Argument 2 (haystack) is int but \in_array() takes array
+%s:14 PhanTypeSuspiciousEcho Suspicious argument bool for an echo/print statement

--- a/tests/files/expected/0453_suspicious_echo.php.expected
+++ b/tests/files/expected/0453_suspicious_echo.php.expected
@@ -1,0 +1,12 @@
+%s:3 PhanTypeSuspiciousEcho Suspicious argument null for an echo/print statement
+%s:4 PhanTypeSuspiciousEcho Suspicious argument resource for an echo/print statement
+%s:5 PhanTypeSuspiciousEcho Suspicious argument false for an echo/print statement
+%s:6 PhanTypeSuspiciousEcho Suspicious argument true for an echo/print statement
+%s:10 PhanTypeSuspiciousEcho Suspicious argument null for an echo/print statement
+%s:11 PhanTypeSuspiciousEcho Suspicious argument resource for an echo/print statement
+%s:12 PhanTypeSuspiciousEcho Suspicious argument false for an echo/print statement
+%s:13 PhanTypeSuspiciousEcho Suspicious argument true for an echo/print statement
+%s:15 PhanTypeSuspiciousEcho Suspicious argument \stdClass for an echo/print statement
+%s:25 PhanTypeSuspiciousEcho Suspicious argument \NonStringableClass for an echo/print statement
+%s:28 PhanTypeSuspiciousEcho Suspicious argument array{key:string}|false for an echo/print statement
+%s:34 PhanTypeSuspiciousEcho Suspicious argument void for an echo/print statement

--- a/tests/files/src/0071_callable.php
+++ b/tests/files/src/0071_callable.php
@@ -3,7 +3,7 @@ class Test {
     static function fn() { echo "Hello"; }
 }
 $a = ['Test','fn'];
-echo is_callable($a);
+var_export(is_callable($a));
 $a();
 
 function f(Closure $c) {}

--- a/tests/files/src/0190_dom_properties.php
+++ b/tests/files/src/0190_dom_properties.php
@@ -5,8 +5,8 @@ $attribute = new DOMAttr('name');
 $attribute = new DOMAttr('name', 'value');
 echo $attribute->name;
 $attributeOwnerElement = $attribute->ownerElement;
-echo $attribute->schemaTypeInfo;
-echo $attribute->specified;
+var_export($attribute->schemaTypeInfo);
+var_export($attribute->specified);
 $attribute->value = 'value';
 
 $document = new DOMDocument();
@@ -39,7 +39,7 @@ $documentTypeNotations = $documentType->notations;
 echo $documentType->internalSubset;
 
 $element = new DOMElement('name');
-echo $element->schemaTypeInfo;
+var_export($element->schemaTypeInfo);  // https://secure.php.net/manual/en/class.domelement.php#domelement.props.schematypeinfo
 echo $element->tagName;
 
 $entity = new DOMEntity();

--- a/tests/files/src/0453_suspicious_echo.php
+++ b/tests/files/src/0453_suspicious_echo.php
@@ -1,0 +1,34 @@
+<?php
+// Suspicious echos:
+echo null,
+     STDOUT,
+     false,
+     true;
+echo 2.5;  // fine.
+echo 'x';  // fine.
+echo 2;  // fine.
+print(null);
+print(STDERR);
+print(false);
+print(true);
+print(2.5);
+echo new stdClass();
+
+class NonStringableClass {
+}
+class StringableClass {
+    public function __toString() {
+        return self::class;
+    }
+}
+echo new StringableClass();
+echo new NonStringableClass();
+
+$v = ((rand(0,1) > 0) ? ['key' => 'value'] : false);
+echo $v;
+
+/** @return void */
+function returns_void() {
+
+}
+echo returns_void();


### PR DESCRIPTION
Previously, Phan would just warn about arrays being passed to echo.
This now warns about booleans, arrays, resources, null,
non-stringable classes, combinations of those types, etc.
(var_export or JSON encode usually makes more sense for a boolean/null)