### PR TITLE
Analyze `@throws` annotations to check if classes are valid

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,8 @@ New Features(Analysis)
 + Add `PhanTypeSuspiciousEcho` to warn about suspicious types being passed to echo/print statements.
   This now warns about booleans, arrays, resources, null, non-stringable classes, combinations of those types, etc.
   (`var_export` or JSON encoding usually makes more sense for a boolean/null)
++ Make Phan check that types in `@throws` annotations are valid; don't warn about classes in `@throws` being unreferenced. (#1555)
+  New issue types: `PhanUndeclaredTypeThrowsType`, `PhanTypeInvalidThrowsNonObject`, `PhanTypeInvalidThrowsNonThrowable`, `PhanTypeInvalidThrowsIsTrait`, `PhanTypeInvalidThrowsIsInterface`
 
 Maintenance
 + Add `--disable-usage-on-error` option to `phan_client` (#1540)

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -6,6 +6,7 @@ use Phan\Config;
 use Phan\Exception\CodeBaseException;
 use Phan\Exception\IssueException;
 use Phan\Exception\NodeException;
+use Phan\Exception\TypeException;
 use Phan\Exception\UnanalyzableException;
 use Phan\Issue;
 use Phan\Language\Context;
@@ -37,6 +38,7 @@ use Phan\Library\FileCache;
 use Phan\Library\None;
 use ast\Node;
 use ast;
+use InvalidArgumentException;
 
 if (!\function_exists('spl_object_id')) {
     require_once __DIR__ . '/../../spl_object_id.php';
@@ -520,7 +522,7 @@ class ContextNode
      * @throws NodeException
      * An exception is thrown if we can't understand the node
      *
-     * @throws CodeBaseExtension
+     * @throws CodeBaseException
      * An exception is thrown if we can't find the given
      * method
      *
@@ -1166,7 +1168,7 @@ class ContextNode
      * An exception is thrown if we can't find the given
      * class
      *
-     * @throws CodeBaseExtension
+     * @throws CodeBaseException
      * An exception is thrown if we can't find the given
      * class
      *
@@ -1266,7 +1268,7 @@ class ContextNode
      * @throws NodeException
      * An exception is thrown if we can't understand the node
      *
-     * @throws CodeBaseExtension
+     * @throws CodeBaseException
      * An exception is thrown if we can't find the given
      * class
      */
@@ -1370,7 +1372,7 @@ class ContextNode
      * @throws NodeException
      * An exception is thrown if we can't understand the node
      *
-     * @throws CodeBaseExtension
+     * @throws CodeBaseException
      * An exception is thrown if we can't find the given
      * class
      *

--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -9,6 +9,7 @@ use Phan\Analysis\DuplicateFunctionAnalyzer;
 use Phan\Analysis\ParameterTypesAnalyzer;
 use Phan\Analysis\ReturnTypesAnalyzer;
 use Phan\Analysis\ReferenceCountsAnalyzer;
+use Phan\Analysis\ThrowsTypesAnalyzer;
 use Phan\Language\Context;
 use Phan\Language\Element\Func;
 use Phan\Language\Element\FunctionInterface;
@@ -270,6 +271,11 @@ class Analysis
             );
 
             ReturnTypesAnalyzer::analyzeReturnTypes(
+                $code_base,
+                $function_or_method
+            );
+
+            ThrowsTypesAnalyzer::analyzeThrowsTypes(
                 $code_base,
                 $function_or_method
             );

--- a/src/Phan/Analysis/ThrowsTypesAnalyzer.php
+++ b/src/Phan/Analysis/ThrowsTypesAnalyzer.php
@@ -1,0 +1,110 @@
+<?php declare(strict_types=1);
+namespace Phan\Analysis;
+
+use Phan\CodeBase;
+use Phan\Issue;
+use Phan\Language\Element\FunctionInterface;
+use Phan\Language\Element\Method;
+use Phan\Language\FQSEN\FullyQualifiedClassName;
+use Phan\Language\Type;
+use Phan\Language\Type\TemplateType;
+
+class ThrowsTypesAnalyzer
+{
+
+    /**
+     * Check method phpdoc (at)throws types to make sure they're valid
+     *
+     * @return void
+     */
+    public static function analyzeThrowsTypes(
+        CodeBase $code_base,
+        FunctionInterface $method
+    ) {
+        foreach ($method->getThrowsUnionType()->getTypeSet() as $type) {
+            self::analyzeSingleThrowType($code_base, $method, $type);
+        }
+    }
+
+    /**
+     * Check a throw type to make sure it's valid
+     *
+     * @return void
+     */
+    private static function analyzeSingleThrowType(
+        CodeBase $code_base,
+        FunctionInterface $method,
+        Type $type
+    ) {
+        if (!$type->isObject()) {
+            Issue::maybeEmit(
+                $code_base,
+                $method->getContext(),
+                Issue::TypeInvalidThrowsNonObject,
+                $method->getFileRef()->getLineNumberStart(),
+                $method->getName(),
+                (string)$type
+            );
+            return;
+        }
+        if ($type instanceof TemplateType) {
+            // TODO: Add unit tests of templates for return types and checks
+            if ($method instanceof Method && $method->isStatic()) {
+                Issue::maybeEmit(
+                    $code_base,
+                    $method->getContext(),
+                    Issue::TemplateTypeStaticMethod,
+                    $method->getFileRef()->getLineNumberStart(),
+                    (string)$method->getFQSEN()
+                );
+            }
+            return;
+        }
+        static $throwable;
+        if ($throwable === null) {
+            $throwable = Type::fromFullyQualifiedString('\\Throwable');
+        }
+        if ($type === $throwable) {
+            // allow (at)throws Throwable.
+            return;
+        }
+
+        $type_fqsen = $type->asFQSEN();
+        \assert($type_fqsen instanceof FullyQualifiedClassName, 'non-native types must be class names');
+        if (!$code_base->hasClassWithFQSEN($type_fqsen)) {
+            Issue::maybeEmit(
+                $code_base,
+                $method->getContext(),
+                Issue::UndeclaredTypeThrowsType,
+                $method->getFileRef()->getLineNumberStart(),
+                $method->getName(),
+                $type
+            );
+            return;
+        }
+        $exception_class = $code_base->getClassByFQSEN($type_fqsen);
+        if ($exception_class->isTrait() || $exception_class->isInterface()) {
+            Issue::maybeEmit(
+                $code_base,
+                $method->getContext(),
+                $exception_class->isTrait() ? Issue::TypeInvalidThrowsIsTrait : Issue::TypeInvalidThrowsIsInterface,
+                $method->getFileRef()->getLineNumberStart(),
+                $method->getName(),
+                $type
+            );
+            return;
+        }
+
+        if (!($type->asExpandedTypes($code_base)->hasType($throwable))) {
+            Issue::maybeEmit(
+                $code_base,
+                $method->getContext(),
+                Issue::TypeInvalidThrowsNonThrowable,
+                $method->getFileRef()->getLineNumberStart(),
+                $method->getName(),
+                $type
+            );
+            return;
+        }
+    }
+}

--- a/src/Phan/Daemon/Transport/CapturerResponder.php
+++ b/src/Phan/Daemon/Transport/CapturerResponder.php
@@ -30,7 +30,7 @@ class CapturerResponder implements Responder
     /**
      * @param array<string,mixed> $data
      * @return void
-     * @throws RuntimeException if called twice
+     * @throws \RuntimeException if called twice
      */
     public function sendResponseAndClose(array $data)
     {

--- a/src/Phan/Daemon/Transport/StreamResponder.php
+++ b/src/Phan/Daemon/Transport/StreamResponder.php
@@ -52,7 +52,7 @@ class StreamResponder implements Responder
 
     /**
      * @return void
-     * @throws RuntimeException if called twice
+     * @throws \RuntimeException if called twice
      */
     public function sendResponseAndClose(array $data)
     {

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -46,6 +46,7 @@ class Issue
     const UndeclaredTypeParameter   = 'PhanUndeclaredTypeParameter';
     const UndeclaredTypeReturnType  = 'PhanUndeclaredTypeReturnType';
     const UndeclaredTypeProperty    = 'PhanUndeclaredTypeProperty';
+    const UndeclaredTypeThrowsType  = 'PhanUndeclaredTypeThrowsType';
     const UndeclaredVariable        = 'PhanUndeclaredVariable';
     const UndeclaredVariableDim     = 'PhanUndeclaredVariableDim';
     const UndeclaredClassInCallable = 'PhanUndeclaredClassInCallable';
@@ -71,6 +72,10 @@ class Issue
     const TypeInvalidInstanceof     = 'PhanTypeInvalidInstanceof';
     const TypeInvalidDimOffset      = 'PhanTypeInvalidDimOffset';
     const TypeInvalidDimOffsetArrayDestructuring = 'PhanTypeInvalidDimOffsetArrayDestructuring';
+    const TypeInvalidThrowsNonObject = 'PhanTypeInvalidThrowsNonObject';
+    const TypeInvalidThrowsNonThrowable = 'PhanTypeInvalidThrowsNonThrowable';
+    const TypeInvalidThrowsIsTrait = 'PhanTypeInvalidThrowsIsTrait';
+    const TypeInvalidThrowsIsInterface = 'PhanTypeInvalidThrowsIsInterface';
     const TypeMagicVoidWithReturn   = 'PhanTypeMagicVoidWithReturn';
     const TypeMismatchArgument      = 'PhanTypeMismatchArgument';
     const TypeMismatchArgumentInternal = 'PhanTypeMismatchArgumentInternal';
@@ -686,6 +691,14 @@ class Issue
                 11028
             ),
             new Issue(
+                self::UndeclaredTypeThrowsType,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_NORMAL,
+                "@throws type of {METHOD} has undeclared type {TYPE}",
+                self::REMEDIATION_B,
+                11034
+            ),
+            new Issue(
                 self::UndeclaredClassAliasOriginal,
                 self::CATEGORY_UNDEFINED,
                 self::SEVERITY_CRITICAL,
@@ -1144,6 +1157,38 @@ class Issue
                 "Suspicious argument {TYPE} for an echo/print statement",
                 self::REMEDIATION_B,
                 10049
+            ),
+            new Issue(
+                self::TypeInvalidThrowsNonObject,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                "@throws annotation of {FUNCTIONLIKE} has invalid non-object type {TYPE}, expected a class",
+                self::REMEDIATION_B,
+                10050
+            ),
+            new Issue(
+                self::TypeInvalidThrowsIsTrait,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                "@throws annotation of {FUNCTIONLIKE} has invalid trait type {TYPE}, expected a class",
+                self::REMEDIATION_B,
+                10051
+            ),
+            new Issue(
+                self::TypeInvalidThrowsIsInterface,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                "@throws annotation of {FUNCTIONLIKE} has suspicious interface type {TYPE} for an @throws annotation, expected class (Zend PHP allows interfaces to be caught, so this might be intentional)",
+                self::REMEDIATION_B,
+                10052
+            ),
+            new Issue(
+                self::TypeInvalidThrowsNonThrowable,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                "@throws annotation of {FUNCTIONLIKE} has suspicious class type {TYPE}, which does not extend Error/Exception",
+                self::REMEDIATION_B,
+                10053
             ),
             // Issue::CATEGORY_VARIABLE
             new Issue(

--- a/src/Phan/Language/Element/FunctionInterface.php
+++ b/src/Phan/Language/Element/FunctionInterface.php
@@ -322,6 +322,8 @@ interface FunctionInterface extends AddressableElementInterface
      */
     public function setComment(Comment $comment);
 
+    public function getThrowsUnionType() : UnionType;
+
     /**
      * @return bool
      * True if this is a magic phpdoc method (declared via (at)method on class declaration phpdoc)

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -920,6 +920,15 @@ trait FunctionTrait
     }
 
     /**
+     * @suppress PhanUnreferencedPublicMethod Phan knows FunctionInterface's method is referenced, but can't associate that yet.
+     */
+    public function getThrowsUnionType() : UnionType
+    {
+        $comment = $this->comment;
+        return $comment ? $comment->getThrowsUnionType() : UnionType::empty();
+    }
+
+    /**
      * Initialize the inner scope of this method with variables created from the parameters.
      *
      * Deferred until the parse phase because getting the UnionType of parameter defaults requires having all class constants be known.

--- a/src/Phan/Language/Element/Variable.php
+++ b/src/Phan/Language/Element/Variable.php
@@ -5,6 +5,7 @@ use Phan\AST\ContextNode;
 use Phan\AST\UnionTypeVisitor;
 use Phan\CodeBase;
 use Phan\Config;
+use Phan\Exception\IssueException;
 use Phan\Language\Context;
 use Phan\Language\Type;
 use Phan\Language\UnionType;

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -2,6 +2,8 @@
 namespace Phan\Language;
 
 use Phan\CodeBase;
+use Phan\Exception\CodeBaseException;
+use Phan\Exception\IssueException;
 use Phan\Language\Type\ArrayType;
 
 /**

--- a/src/Phan/Language/FutureUnionType.php
+++ b/src/Phan/Language/FutureUnionType.php
@@ -3,6 +3,7 @@ namespace Phan\Language;
 
 use Phan\AST\UnionTypeVisitor;
 use Phan\CodeBase;
+use Phan\Exception\IssueException;
 use ast\Node;
 
 /**

--- a/tests/files/expected/0454_throws.php.expected
+++ b/tests/files/expected/0454_throws.php.expected
@@ -1,0 +1,11 @@
+%s:15 PhanTypeMissingReturn Method \MyNs\example1 is declared to return \MyNs\MissingType but has no return value
+%s:15 PhanUndeclaredTypeReturnType Return type of example1 is undeclared type \MyNs\MissingType
+%s:21 PhanUndeclaredTypeThrowsType @throws type of example3 has undeclared type \MyNs\MissingException
+%s:23 PhanMisspelledAnnotation Saw misspelled annotation @throw, should be one of @throws
+%s:30 PhanTypeInvalidThrowsNonThrowable @throws annotation of a has suspicious class type \stdClass, which does not extend Error/Exception
+%s:33 PhanTypeInvalidThrowsNonObject @throws annotation of b has invalid non-object type false, expected a class
+%s:39 PhanTypeInvalidThrowsNonThrowable @throws annotation of d has suspicious class type \MyNs\Test454, which does not extend Error/Exception
+%s:42 PhanTypeInvalidThrowsNonObject @throws annotation of e has invalid non-object type resource, expected a class
+%s:48 PhanTypeInvalidThrowsNonObject @throws annotation of f has invalid non-object type false, expected a class
+%s:57 PhanTypeInvalidThrowsIsInterface @throws annotation of throwInterface has suspicious interface type \ArrayAccess for an @throws annotation, expected class (Zend PHP allows interfaces to be caught, so this might be intentional)
+%s:60 PhanTypeInvalidThrowsIsTrait @throws annotation of throwTrait has invalid trait type \MyNs\MyTrait, expected a class

--- a/tests/files/src/0454_throws.php
+++ b/tests/files/src/0454_throws.php
@@ -1,0 +1,61 @@
+<?php
+namespace MyNs;
+
+use RuntimeException;
+use Throwable;
+
+function do_stuff() {
+    echo "stuff\n";
+}
+
+/**
+ * @throws RuntimeException
+ * @return MissingType
+ */
+function example1() { do_stuff(); }
+
+/** @throws \InvalidArgumentException */
+function example2() { do_stuff(); }
+
+/** @throws MissingException */
+function example3() { do_stuff(); }
+
+/** @throw RuntimeException (not phpdoc2) */
+function example4() { do_stuff(); }
+
+trait MyTrait {}
+
+class Test454 {
+    /** @throws \stdClass description */
+    public function a() { do_stuff(); }
+
+    /** @throws false */
+    public function b() { do_stuff(); }
+
+    /** @throws Throwable */
+    public function c() { do_stuff(); }
+
+    /** @throws Test454 */
+    public function d() { do_stuff(); }
+
+    /** @throws resource */
+    public function e() { do_stuff(); }
+
+    /**
+     * @throws RuntimeException description
+     * @throws RuntimeException|false
+     */
+    public function f() { do_stuff(); }
+
+    /** @throws \Error */
+    public function throwError() { do_stuff(); }
+
+    /** @throws \Exception */
+    public function throwException() { do_stuff(); }
+
+    /** @throws \ArrayAccess */
+    public function throwInterface() { do_stuff(); }
+
+    /** @throws MyTrait */
+    public function throwTrait() { do_stuff(); }
+}


### PR DESCRIPTION
Fixes #1555 as well, by looking up the classes

Fix invalid `@throws` annotations in phan itself
(Typos/missing namespace)