### PR TITLE
Add closures with annotated param types and return to Phan's type system

### DIFF
--- a/.phan/plugins/PregRegexCheckerPlugin.php
+++ b/.phan/plugins/PregRegexCheckerPlugin.php
@@ -26,6 +26,7 @@ class PregRegexCheckerPlugin extends PluginV2 implements AnalyzeFunctionCallCapa
         ~(ContextNode::RESOLVE_KEYS_SKIP_UNKNOWN_KEYS | ContextNode::RESOLVE_ARRAY_VALUES);
 
 
+    /** @return void */
     private function analyzePattern(CodeBase $code_base, Context $context, Func $function, string $pattern)
     {
         /**
@@ -50,6 +51,7 @@ class PregRegexCheckerPlugin extends PluginV2 implements AnalyzeFunctionCallCapa
             }
         });
         if ($err !== null) {
+            // TODO: scan for 'at offset %d$' and print the corresponding section of the regex. Note: Have to remove delimiters and unescape characters within the delimiters.
             $this->emitIssue(
                 $code_base,
                 $context,
@@ -62,7 +64,8 @@ class PregRegexCheckerPlugin extends PluginV2 implements AnalyzeFunctionCallCapa
     }
 
     /**
-     * @return \Closure[]
+     * @return array<string,\Closure>
+     * @phan-return array<string, Closure(CodeBase,Context,Func,array):void>
      */
     public function getAnalyzeFunctionCallClosures(CodeBase $code_base) : array
     {

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -28,6 +28,7 @@ use Phan\Language\FQSEN\FullyQualifiedMethodName;
 use Phan\Language\FQSEN\FullyQualifiedPropertyName;
 use Phan\Language\Type;
 use Phan\Language\Type\ClosureType;
+use Phan\Language\Type\ClosureDeclarationType;
 use Phan\Language\Type\IntType;
 use Phan\Language\Type\MixedType;
 use Phan\Language\Type\NullType;
@@ -690,24 +691,24 @@ class ContextNode
 
                 foreach ($union_type->getTypeSet() as $type) {
                     // TODO: Allow CallableType to have FQSENs as well, e.g. `$x = [MyClass::class, 'myMethod']` has an FQSEN in a sense.
-                    if (!($type instanceof ClosureType)) {
-                        continue;
-                    }
+                    if ($type instanceof ClosureType) {
+                        $closure_fqsen =
+                            FullyQualifiedFunctionName::fromFullyQualifiedString(
+                                (string)$type->asFQSEN()
+                            );
 
-                    $closure_fqsen =
-                        FullyQualifiedFunctionName::fromFullyQualifiedString(
-                            (string)$type->asFQSEN()
-                        );
-
-                    if ($this->code_base->hasFunctionWithFQSEN(
-                        $closure_fqsen
-                    )) {
-                        // Get the closure
-                        $function = $this->code_base->getFunctionByFQSEN(
+                        if ($this->code_base->hasFunctionWithFQSEN(
                             $closure_fqsen
-                        );
+                        )) {
+                            // Get the closure
+                            $function = $this->code_base->getFunctionByFQSEN(
+                                $closure_fqsen
+                            );
 
-                        yield $function;
+                            yield $function;
+                        }
+                    } elseif ($type instanceof ClosureDeclarationType) {
+                        yield $type;
                     }
                 }
             }

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1402,11 +1402,16 @@ class UnionTypeVisitor extends AnalysisVisitor
                 $node
             );
 
-        $type = ClosureType::instanceWithClosureFQSEN(
-            $closure_fqsen
-        )->asUnionType();
+        if ($this->code_base->hasFunctionWithFQSEN($closure_fqsen)) {
+            $func = $this->code_base->getFunctionByFQSEN($closure_fqsen);
+        } else {
+            $func = null;
+        }
 
-        return $type;
+        return ClosureType::instanceWithClosureFQSEN(
+            $closure_fqsen,
+            $func
+        )->asUnionType();
     }
 
     /**

--- a/src/Phan/Analysis/ArgumentType.php
+++ b/src/Phan/Analysis/ArgumentType.php
@@ -73,7 +73,7 @@ class ArgumentType
                         Issue::ParamTooFewInternal,
                         $node->lineno ?? 0,
                         $argcount,
-                        (string)$method->getFQSEN(),
+                        $method->getRepresentationForIssue(),
                         $method->getNumberOfRequiredParameters()
                     );
                 } else {
@@ -83,7 +83,7 @@ class ArgumentType
                         Issue::ParamTooFew,
                         $node->lineno ?? 0,
                         $argcount,
-                        (string)$method->getFQSEN(),
+                        $method->getRepresentationForIssue(),
                         $method->getNumberOfRequiredParameters(),
                         $method->getFileRef()->getFile(),
                         $method->getFileRef()->getLineNumberStart()
@@ -111,7 +111,7 @@ class ArgumentType
                         Issue::ParamTooManyInternal,
                         $node->lineno ?? 0,
                         $argcount,
-                        (string)$method->getFQSEN(),
+                        $method->getRepresentationForIssue(),
                         $max
                     );
                 } else {
@@ -121,7 +121,7 @@ class ArgumentType
                         Issue::ParamTooMany,
                         $node->lineno ?? 0,
                         $argcount,
-                        (string)$method->getFQSEN(),
+                        $method->getRepresentationForIssue(),
                         $max,
                         $method->getFileRef()->getFile(),
                         $method->getFileRef()->getLineNumberStart()
@@ -154,7 +154,7 @@ class ArgumentType
                     $context,
                     Issue::DeprecatedFunctionInternal,
                     $context->getLineNumberStart(),
-                    (string)$method->getFQSEN()
+                    $method->getRepresentationForIssue()
                 );
             }
         } else {
@@ -165,7 +165,7 @@ class ArgumentType
                     $context,
                     Issue::DeprecatedFunction,
                     $context->getLineNumberStart(),
-                    (string)$method->getFQSEN(),
+                    $method->getRepresentationForIssue(),
                     $method->getFileRef()->getFile(),
                     $method->getFileRef()->getLineNumberStart()
                 );
@@ -184,7 +184,7 @@ class ArgumentType
                 $context,
                 Issue::AccessMethodInternal,
                 $context->getLineNumberStart(),
-                (string)$method->getFQSEN(),
+                $method->getRepresentationForIssue(),
                 $method->getElementNamespace() ?: '\\',
                 $method->getFileRef()->getFile(),
                 $method->getFileRef()->getLineNumberStart(),
@@ -268,7 +268,7 @@ class ArgumentType
                     Issue::ParamTooFewCallable,
                     $context->getLineNumberStart(),
                     $argcount,
-                    (string)$method->getFQSEN(),
+                    $method->getRepresentationForIssue(),
                     $method->getNumberOfRequiredParameters(),
                     $method->getFileRef()->getFile(),
                     $method->getFileRef()->getLineNumberStart()
@@ -294,7 +294,7 @@ class ArgumentType
                     Issue::ParamTooManyCallable,
                     $context->getLineNumberStart(),
                     $argcount,
-                    (string)$method->getFQSEN(),
+                    $method->getRepresentationForIssue(),
                     $max,
                     $method->getFileRef()->getFile(),
                     $method->getFileRef()->getLineNumberStart()
@@ -420,7 +420,7 @@ class ArgumentType
                             Issue::TypeNonVarPassByRef,
                             $node->lineno ?? 0,
                             ($i+1),
-                            (string)$method->getFQSEN()
+                            $method->getRepresentationForIssue()
                         );
                     }
                 } else {
@@ -533,7 +533,7 @@ class ArgumentType
                 ($i+1),
                 $alternate_parameter->getName(),
                 $argument_type_expanded,
-                (string)$method->getFQSEN(),
+                $method->getRepresentationForIssue(),
                 (string)$parameter_type
             );
             return;
@@ -546,7 +546,7 @@ class ArgumentType
             ($i+1),
             $alternate_parameter->getName(),
             $argument_type_expanded,
-            (string)$method->getFQSEN(),
+            $method->getRepresentationForIssue(),
             (string)$parameter_type,
             $method->getFileRef()->getFile(),
             $method->getFileRef()->getLineNumberStart()

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -19,6 +19,7 @@ use Phan\Language\UnionType;
 use Phan\Language\UnionTypeBuilder;
 use ast\Node;
 use ast\flags;
+use Closure;
 
 /**
  * TODO: Make $x != null remove FalseType and NullType from $x
@@ -457,11 +458,12 @@ class ConditionVisitor extends KindVisitorImplementation
      *
      * This contains Phan's logic for inferring the resulting union types of variables, e.g. in \is_array($x).
      *
-     * @return array<string,\Closure> - The closures to call for a given global function
+     * @return array<string,Closure> - The closures to call for a given global function
+     * @phan-return array<string,Closure(Variable,array):void>
      */
     private static function initTypeModifyingClosuresForVisitCall() : array
     {
-        $make_basic_assertion_callback = static function (string $union_type_string) : \Closure {
+        $make_basic_assertion_callback = static function (string $union_type_string) : Closure {
             $type = UnionType::fromFullyQualifiedString(
                 $union_type_string
             );

--- a/src/Phan/Analysis/NegatedConditionVisitor.php
+++ b/src/Phan/Analysis/NegatedConditionVisitor.php
@@ -20,6 +20,7 @@ use Phan\Language\UnionType;
 use Phan\Language\UnionTypeBuilder;
 use ast\Node;
 use ast\flags;
+use Closure;
 
 // TODO: Make $x != null remove FalseType and NullType from $x
 // TODO: Make $x > 0, $x < 0, $x >= 50, etc.  remove FalseType and NullType from $x
@@ -302,7 +303,8 @@ class NegatedConditionVisitor extends KindVisitorImplementation
      */
 
     /**
-     * @return array<string,\Closure> (ConditionVisitor $cv, Node $var_node, Context $context) -> Context
+     * @return array<string,Closure> (NegatedConditionVisitor $cv, Node $var_node, Context $context) -> Context
+     * @phan-return array<string,Closure(NegatedConditionVisitor,Node,Context):Context>
      */
     private static function createNegationCallbackMap() : array
     {
@@ -311,7 +313,7 @@ class NegatedConditionVisitor extends KindVisitorImplementation
         };
 
         // Remove any Types from UnionType that are subclasses of $base_class_name
-        $make_basic_negated_assertion_callback = static function (string $base_class_name) : \Closure {
+        $make_basic_negated_assertion_callback = static function (string $base_class_name) : Closure {
             return static function (NegatedConditionVisitor $cv, Node $var_node, Context $context) use ($base_class_name) : Context {
                 return $cv->updateVariableWithConditionalFilter(
                     $var_node,

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -18,6 +18,7 @@ use Phan\Language\FQSEN\FullyQualifiedFunctionName;
 use Phan\Language\Scope\ClosureScope;
 use Phan\Language\Type;
 use Phan\Language\Type\GenericArrayType;
+use Phan\Language\Type\VoidType;
 use Phan\Language\UnionType;
 use ast\Node;
 
@@ -277,6 +278,9 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
         if ($function->getHasYield()) {
             $this->setReturnTypeOfGenerator($function, $node);
         }
+        if (!$function->getHasReturn() && $function->getUnionType()->isEmpty()) {
+            $function->setUnionType(VoidType::instance(false)->asUnionType());
+        }
 
         return $context;
     }
@@ -444,6 +448,9 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
                 // Pass the variable into a new scope
                 $func->getInternalScope()->addVariable($variable);
             }
+        }
+        if (!$func->getHasReturn() && $func->getUnionType()->isEmpty()) {
+            $func->setUnionType(VoidType::instance(false)->asUnionType());
         }
 
         if ($func->getHasYield()) {

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -213,7 +213,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
             foreach ($matches as $group) {
                 $annotation_name = $group[1];
                 $type_string = $group[2];
-                $var_name = $group[18];
+                $var_name = $group[20];
                 $type = UnionType::fromStringInContext($type_string, $context, Type::FROM_PHPDOC);
                 $this->createVarForInlineComment($code_base, $context, $var_name, $type, $annotation_name === 'phan-var-force');
             }

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -449,7 +449,7 @@ class CodeBase
     }
 
     /**
-     * @param array{clone:CodeBase,callbacks:?Closure[]}
+     * @param array{clone:CodeBase,callbacks:?(Closure():void)[]}
      * @return void
      */
     public function restoreFromRestorePoint(array $restore_point)
@@ -485,7 +485,7 @@ class CodeBase
      * For use by daemon mode when running without pcntl
      * Returns a serialized representation of everything in this CodeBase.
      * @internal
-     * @return array{clone:CodeBase,callbacks:?Closure[]}
+     * @return array{clone:CodeBase,callbacks:?Closure():void)[]}
      */
     public function createRestorePoint() : array
     {
@@ -493,7 +493,7 @@ class CodeBase
         $clone = clone($this);
         // make a deep copy of the NamespaceMapEntry objects within parsed_namespace_maps
         $clone->parsed_namespace_maps = unserialize(serialize($clone->parsed_namespace_maps));
-        // @var array<int,?Closure>
+        /** @var array<int,?Closure()> */
         $callbacks = [];
         // Create callbacks to restore classes
         foreach ($this->fqsen_class_map as $class) {

--- a/src/Phan/CodeBase/UndoTracker.php
+++ b/src/Phan/CodeBase/UndoTracker.php
@@ -27,7 +27,8 @@ class UndoTracker
     private $current_parsed_file;
 
     /**
-     * @var array<string,array<int,\Closure>> operations to undo for a current path
+     * @var array<string,array<int,Closure>> operations to undo for a current path
+     * @phan-var array<string,array<int,Closure(CodeBase)>>
      */
     private $undoOperationsForPath = [];
 

--- a/src/Phan/Language/Element/FunctionFactory.php
+++ b/src/Phan/Language/Element/FunctionFactory.php
@@ -114,7 +114,7 @@ class FunctionFactory
         );
 
         if ($method->getIsMagicCall() || $method->getIsMagicCallStatic()) {
-            $method->setNumberOfOptionalParameters(999);
+            $method->setNumberOfOptionalParameters(FunctionInterface::INFINITE_PARAMETERS);
             $method->setNumberOfRequiredParameters(0);
         }
         $method->setIsDeprecated($reflection_method->isDeprecated());

--- a/src/Phan/Language/Element/FunctionInterface.php
+++ b/src/Phan/Language/Element/FunctionInterface.php
@@ -3,6 +3,7 @@ namespace Phan\Language\Element;
 
 use Phan\CodeBase;
 use Phan\Language\Context;
+use Phan\Language\Type\ClosureDeclarationType;
 use Phan\Language\UnionType;
 use Phan\Language\FQSEN\FullyQualifiedFunctionName;
 use Phan\Language\FQSEN\FullyQualifiedMethodName;
@@ -15,6 +16,11 @@ use ast\Node;
  */
 interface FunctionInterface extends AddressableElementInterface
 {
+    /**
+     * An easy workaround to mark a functionlike as accepting an infinite number of optional parameters
+     * TODO: Distinguish between __call and __callStatic invoked manually and via magic (See uses of this constant)
+     */
+    const INFINITE_PARAMETERS = 999999;
 
     /**
      * @return FullyQualifiedMethodName|FullyQualifiedFunctionName
@@ -345,4 +351,10 @@ interface FunctionInterface extends AddressableElementInterface
      * If this returns true, there is at least one parameter and at least one of those can be overridden with a more specific type.
      */
     public function needsRecursiveAnalysis() : bool;
+
+    /**
+     * Returns a ClosureDeclarationType based on phpdoc+real types.
+     * The return value is used for type casting rule checking.
+     */
+    public function asClosureDeclarationType() : ClosureDeclarationType;
 }

--- a/src/Phan/Language/Element/FunctionInterface.php
+++ b/src/Phan/Language/Element/FunctionInterface.php
@@ -30,6 +30,13 @@ interface FunctionInterface extends AddressableElementInterface
     public function getFQSEN();
 
     /**
+     * @return string
+     * The fully-qualified structural element name of this
+     * structural element, or a string for ClosureDeclarationType which lacks a real FQSEN
+     */
+    public function getRepresentationForIssue() : string;
+
+    /**
      * @return void
      */
     public function setInternalScope(ClosedScope $internal_scope);
@@ -252,7 +259,7 @@ interface FunctionInterface extends AddressableElementInterface
      * @param ?UnionType the raw phpdoc union type
      * @return void
      */
-    public function setPHPDocReturnType($parameter_map);
+    public function setPHPDocReturnType($union_type);
 
     /**
      * @return ?UnionType the raw phpdoc union type
@@ -315,7 +322,7 @@ interface FunctionInterface extends AddressableElementInterface
      */
     public function ensureScopeInitialized(CodeBase $code_base);
 
-    /** @return Node */
+    /** @return Node|null */
     public function getNode();
 
     /**

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -5,6 +5,7 @@ use Phan\CodeBase;
 use Phan\Config;
 use Phan\Issue;
 use Phan\Language\Context;
+use Phan\Language\FileRef;
 use Phan\Language\FQSEN;
 use Phan\Language\Element\Comment;
 use Phan\Language\Type\ClosureDeclarationType;
@@ -52,6 +53,17 @@ trait FunctionTrait
      * structural element
      */
     public abstract function getFQSEN();
+
+    /**
+     * @return string
+     * The fully-qualified structural element name of this
+     * structural element
+     */
+    public function getRepresentationForIssue() : string
+    {
+        return $this->getFQSEN()->__toString();
+
+    }
 
     /**
      * @var int
@@ -848,6 +860,8 @@ trait FunctionTrait
     /** @return Context */
     public abstract function getContext() : Context;
 
+    public abstract function getFileRef() : FileRef;
+
     /**
      * Returns true if the return type depends on the argument, and a plugin makes Phan aware of that.
      */
@@ -1011,6 +1025,7 @@ trait FunctionTrait
     /**
      * Returns a ClosureDeclarationType based on phpdoc+real types.
      * The return value is used for type casting rule checking.
+     * @suppress PhanUnreferencedPublicMethod Phan knows FunctionInterface's method is referenced, but can't associate that yet.
      */
     public function asClosureDeclarationType() : ClosureDeclarationType
     {
@@ -1029,7 +1044,8 @@ trait FunctionTrait
         if ($return_type->isEmpty()) {
             $return_type = MixedType::instance(false)->asUnionType();
         }
-        return ClosureDeclarationType::instanceForTypes(
+        return new ClosureDeclarationType(
+            $this->getFileRef(),
             $params,
             $return_type,
             $this->returnsRef(),

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -408,7 +408,7 @@ class Method extends ClassElement implements FunctionInterface
         $method->setSuppressIssueList($comment->getSuppressIssueList());
 
         if ($method->getIsMagicCall() || $method->getIsMagicCallStatic()) {
-            $method->setNumberOfOptionalParameters(999);
+            $method->setNumberOfOptionalParameters(FunctionInterface::INFINITE_PARAMETERS);
             $method->setNumberOfRequiredParameters(0);
         }
 

--- a/src/Phan/Language/Element/Parameter.php
+++ b/src/Phan/Language/Element/Parameter.php
@@ -11,9 +11,11 @@ use Phan\Language\FutureUnionType;
 use Phan\Language\Type;
 use Phan\Language\Type\ArrayType;
 use Phan\Language\Type\BoolType;
+use Phan\Language\Type\ClosureDeclarationParameter;
 use Phan\Language\Type\FalseType;
 use Phan\Language\Type\FloatType;
 use Phan\Language\Type\IntType;
+use Phan\Language\Type\MixedType;
 use Phan\Language\Type\NullType;
 use Phan\Language\Type\StringType;
 use Phan\Language\Type\TrueType;
@@ -541,5 +543,19 @@ class Parameter extends Variable
         }
 
         return $string;
+    }
+
+    public function asClosureDeclarationParameter() : ClosureDeclarationParameter
+    {
+        $param_type = $this->getNonVariadicUnionType();
+        if ($param_type->isEmpty()) {
+            $param_type = MixedType::instance(false)->asUnionType();
+        }
+        return new ClosureDeclarationParameter(
+            $param_type,
+            $this->isVariadic(),
+            $this->isPassByReference(),
+            $this->isOptional()
+        );
     }
 }

--- a/src/Phan/Language/FQSEN/FullyQualifiedClassName.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedClassName.php
@@ -51,7 +51,7 @@ class FullyQualifiedClassName extends FullyQualifiedGlobalStructuralElement
     public function asType() : Type
     {
         return Type::fromFullyQualifiedString(
-            (string)$this
+            $this->__toString()
         );
     }
 

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -730,7 +730,8 @@ class Type
                     // TODO: Maybe catch that in UnionType parsing instead
                     $return_type = \substr($return_type, 1, -1);
                 }
-                return ClosureDeclarationType::instanceForTypes(
+                return new ClosureDeclarationType(
+                    new Context(),
                     self::closureParamComponentStringsToParams($shape_components, new Context(), Type::FROM_NODE),
                     UnionType::fromStringInContext($return_type, new Context(), Type::FROM_PHPDOC),
                     false,
@@ -892,7 +893,8 @@ class Type
                 if ($return_type[0] === '(' && \substr($return_type, -1) === ')') {
                     $return_type = \substr($return_type, 1, -1);
                 }
-                return ClosureDeclarationType::instanceForTypes(
+                return new ClosureDeclarationType(
+                    $context,
                     self::closureParamComponentStringsToParams($shape_components, $context, $source),
                     UnionType::fromStringInContext($return_type, $context, $source),
                     false,

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -9,7 +9,7 @@ use Phan\Language\Type\ArrayShapeType;
 use Phan\Language\Type\BoolType;
 use Phan\Language\Type\CallableType;
 use Phan\Language\Type\ClosureType;
-use Phan\Language\Type\ClosureTypeDeclaration;
+use Phan\Language\Type\ClosureDeclarationType;
 use Phan\Language\Type\FalseType;
 use Phan\Language\Type\FloatType;
 use Phan\Language\Type\GenericArrayType;
@@ -706,9 +706,10 @@ class Type
                 if (!$return_type) {
                     throw new \AssertionError("Expected at least one component");
                 }
-                return ClosureTypeDeclaration::instanceForTypes(
+                return ClosureDeclarationType::instanceForTypes(
                     self::shapeComponentStringsToTypes($shape_components, new Context(), Type::FROM_NODE),
                     UnionType::fromStringInContext($return_type, new Context(), Type::FROM_PHPDOC),
+                    false,
                     $is_nullable
                 );
             }
@@ -864,9 +865,10 @@ class Type
                 if (!$return_type) {
                     throw new \AssertionError("Expected a return type");
                 }
-                return ClosureTypeDeclaration::instanceForTypes(
+                return ClosureDeclarationType::instanceForTypes(
                     self::shapeComponentStringsToTypes($shape_components, $context, $source),
                     UnionType::fromStringInContext($return_type, $context, $source),
+                    false,
                     $is_nullable
                 );
             }
@@ -1995,7 +1997,6 @@ class Type
         if ($arg_list === '') {
             return [];
         }
-        $comment_params = [];
         // TODO: Would need to use a different approach if templates were ever supported
         //       e.g. The magic method parsing doesn't support commas?
         return explode(',', $arg_list);

--- a/src/Phan/Language/Type/ArrayShapeType.php
+++ b/src/Phan/Language/Type/ArrayShapeType.php
@@ -200,11 +200,11 @@ final class ArrayShapeType extends ArrayType
         static $cache = [];
 
         $key_parts = [];
-        if ($is_nullable) {
-            $key_parts[] = '?';
-        }
         foreach ($field_types as $key => $field_union_type) {
             $key_parts[$key] = $field_union_type->generateUniqueId();
+        }
+        if ($is_nullable) {
+            $key_parts[] = '?';
         }
         $key = \json_encode($key_parts);
 

--- a/src/Phan/Language/Type/ClosureDeclarationParameter.php
+++ b/src/Phan/Language/Type/ClosureDeclarationParameter.php
@@ -1,0 +1,113 @@
+<?php declare(strict_types=1);
+namespace Phan\Language\Type;
+
+use Phan\Language\UnionType;
+
+/**
+ * Not a type, but used by ClosureDeclarationType
+ */
+final class ClosureDeclarationParameter
+{
+    /** @var UnionType */
+    private $type;
+
+    /** @var bool */
+    private $is_variadic;
+
+    /** @var bool */
+    private $is_reference;
+
+    /** @var bool */
+    private $is_optional;
+
+    public function __construct(UnionType $type, bool $is_variadic, bool $is_reference, bool $is_optional)
+    {
+        $this->type = $type;
+        $this->is_variadic = $is_variadic;
+        $this->is_reference = $is_reference;
+        $this->is_optional = $is_optional || $is_variadic;
+    }
+
+    public function getNonVariadicUnionType() : UnionType
+    {
+        return $this->type;
+    }
+
+    public function isVariadic() : bool
+    {
+        return $this->is_variadic;
+    }
+
+    public function isPassByReference() : bool
+    {
+        return $this->is_reference;
+    }
+
+    public function isOptional() : bool
+    {
+        return $this->is_optional;
+    }
+
+    // for debugging
+    public function __toString() : string
+    {
+        $repr = $this->type->__toString();
+        if ($this->is_reference) {
+            $repr .= '&';
+        }
+        if ($this->is_variadic) {
+            $repr .= '...';
+        }
+        if ($this->is_optional && !$this->is_variadic) {
+            $repr .= '=';
+        }
+        return $repr;
+    }
+
+    public function toStub(string $paramName) : string
+    {
+        $repr = $this->type->__toString() . ' ';
+        if ($this->is_variadic) {
+            $repr .= '...';
+        }
+        if ($this->is_reference) {
+            $repr .= '&';
+        }
+        $repr .= '$' . $paramName;
+        if ($this->is_optional && !$this->is_variadic) {
+            $repr .= '=';
+        }
+        return $repr;
+    }
+
+    public function generateUniqueId() : string
+    {
+        $repr = (string)$this->type->generateUniqueId();
+        if ($this->is_variadic) {
+            $repr .= '...';
+        }
+        if ($this->is_reference) {
+            $repr .= '&';
+        }
+        if ($this->is_optional && !$this->is_variadic) {
+            $repr .= '=';
+        }
+        return $repr;
+    }
+
+    /**
+     * @see \Phan\Analysis\ParameterTypesAnalyzer::analyzeOverrideSignatureForOverriddenMethod() - Similar logic using LSP
+     */
+    public function canCastToParameterIgnoringVariadic(ClosureDeclarationParameter $other) : bool
+    {
+        if ($this->is_reference !== $other->is_reference) {
+            return false;
+        }
+        if (!$this->is_optional && $other->is_optional) {
+            // We should have already checked this
+            return false;
+        }
+        // TODO: stricter? (E.g. shouldn't allow int|string to cast to int)
+        return $this->type->canCastToUnionType($other->getNonVariadicUnionType());
+    }
+}

--- a/src/Phan/Language/Type/ClosureDeclarationType.php
+++ b/src/Phan/Language/Type/ClosureDeclarationType.php
@@ -1,6 +1,8 @@
 <?php declare(strict_types=1);
 namespace Phan\Language\Type;
 
+use Phan\CodeBase;
+use Phan\Language\Element\FunctionInterface;
 use Phan\Language\Type;
 use Phan\Language\UnionType;
 
@@ -18,21 +20,50 @@ final class ClosureDeclarationType extends Type
     /** @var bool */
     private $returns_reference;
 
+    // computed properties
+
+    /** @var int see FunctionTrait */
+    private $required_param_count;
+
+    /** @var int see FunctionTrait */
+    private $optional_param_count;
+
+    private $is_variadic;
+    // end computed properties
+
     /**
-     * @param array<int,ClosureDeclarationParameter> $param_types
+     * @param array<int,ClosureDeclarationParameter> $params
      * @param UnionType $return_type
      */
-    protected function __construct(array $param_types, UnionType $return_type, bool $returns_reference, bool $is_nullable)
+    protected function __construct(array $params, UnionType $return_type, bool $returns_reference, bool $is_nullable)
     {
         parent::__construct('\\', self::NAME, [], $is_nullable);
-        $this->params = $param_types;
+        $this->params = $params;
         $this->return_type = $return_type;
         $this->returns_reference = $returns_reference;
+
+        $required_param_count = 0;
+        $optional_param_count = \count($params);
+        ;
+        // TODO: Warn about required after optional
+        foreach ($params as $param) {
+            if (!$param->isOptional()) {
+                $required_param_count++;
+            } elseif ($param->isVariadic()) {
+                $this->is_variadic = true;
+                $optional_param_count = FunctionInterface::INFINITE_PARAMETERS;
+                break;
+            }
+        }
+        $this->required_param_count = $required_param_count;
+        $this->optional_param_count = $optional_param_count;
     }
 
     /**
      * @param array<int,ClosureDeclarationParameter> $params
      * @param UnionType $return_type
+     * @param bool $returns_reference is this referring to a closure with a reference return value?
+     * @param bool $is_nullable is this a nullable type?
      */
     public static function instanceForTypes(array $params, UnionType $return_type, bool $returns_reference, bool $is_nullable)
     {
@@ -59,12 +90,18 @@ final class ClosureDeclarationType extends Type
      */
     public function __toString() : string
     {
-        $parts = [];
-        foreach ($this->params as $value) {
-            $parts[] = $value->__toString();
-        }
-        $return_type_string = $this->return_type->__toString();
-        return ($this->is_nullable ? '?' : '') . 'Closure(' . \implode(',', $parts) . '):' . $return_type_string;
+        return $this->memoize(__FUNCTION__, function () {
+            $parts = [];
+            foreach ($this->params as $value) {
+                $parts[] = $value->__toString();
+            }
+            $return_type = $this->return_type;
+            $return_type_string = $return_type->__toString();
+            if ($return_type->typeCount() >= 2) {
+                $return_type_string = "($return_type_string)";
+            }
+            return ($this->is_nullable ? '?' : '') . 'Closure(' . \implode(',', $parts) . '):' . $return_type_string;
+        });
     }
 
     public function __clone()
@@ -74,10 +111,80 @@ final class ClosureDeclarationType extends Type
 
     /**
      * @return bool
-     * True if this type is a callable or a Closure.
+     * True if this type is a callable or a Closure or a ClosureDeclarationType
      */
     public function isCallable() : bool
     {
         return true;
+    }
+
+    /**
+     * @return bool
+     * True if this Type can be cast to the given Type
+     * cleanly
+     */
+    public function canCastToNonNullableType(Type $type) : bool
+    {
+        if ($type->isCallable()) {
+            if ($this->getIsNullable()) {
+                return false;
+            }
+            if ($type instanceof ClosureDeclarationType) {
+                return $this->canCastToNonNullableClosureDeclarationType($type);
+            }
+            return true;
+        }
+
+        return parent::canCastToNonNullableType($type);
+    }
+
+    /**
+     * @return ?ClosureDeclarationParameter
+     */
+    public function getClosureParameterForArgument(int $i)
+    {
+        $result = $this->params[$i] ?? null;
+        if (!$result) {
+            return $this->is_variadic ? end($this->params) : null;
+        }
+        return $result;
+    }
+
+    public function canCastToNonNullableClosureDeclarationType(ClosureDeclarationType $type) : bool
+    {
+        if ($this->required_param_count > $type->required_param_count) {
+            return false;
+        }
+        if ($this->optional_param_count < $type->optional_param_count) {
+            return false;
+        }
+        if ($this->returns_reference !== $type->returns_reference) {
+            return false;
+        }
+        // TODO: Allow nullable/null to cast to void?
+        if (!$this->return_type->canCastToUnionType($type->return_type)) {
+            return false;
+        }
+        foreach ($this->params as $i => $param) {
+            $other_param = $type->getClosureParameterForArgument($i) ?? null;
+            if (!$other_param) {
+                break;
+            }
+            if (!$param->canCastToParameterIgnoringVariadic($other_param)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @override (Don't include \Closure in the expanded types. It interferes with type casting checking)
+     */
+    public function asExpandedTypes(
+        CodeBase $unused_code_base,
+        int $unused_recursion_depth = 0
+    ) : UnionType {
+        return $this->asUnionType();
     }
 }

--- a/src/Phan/Language/Type/ClosureTypeDeclaration.php
+++ b/src/Phan/Language/Type/ClosureTypeDeclaration.php
@@ -1,0 +1,74 @@
+<?php declare(strict_types=1);
+namespace Phan\Language\Type;
+
+use Phan\Language\Type;
+use Phan\Language\UnionType;
+
+final class ClosureTypeDeclaration extends Type
+{
+    /** Not an override */
+    const NAME = 'Closure';
+
+    /** @var array<int,UnionType> */
+    private $param_types;
+
+    /** @var UnionType */
+    private $return_type;
+
+    /**
+     * @param array<int,UnionType> $param_types
+     * @param UnionType $return_type
+     */
+    protected function __construct(array $param_types, UnionType $return_type, bool $is_nullable)
+    {
+        parent::__construct('\\', self::NAME, [], $is_nullable);
+        $this->param_types = $param_types;
+        $this->return_type = $return_type;
+    }
+
+    /**
+     * @param array<int,UnionType> $param_types
+     * @param UnionType $return_type
+     */
+    public static function instanceForTypes(array $param_types, UnionType $return_type, bool $is_nullable)
+    {
+        static $cache = [];
+        $key_parts = [];
+        if ($is_nullable) {
+            $key_parts[] = '?';
+        }
+        foreach ($param_types as $type) {
+            $key_parts[] = $type->generateUniqueId();
+        }
+        $key_parts[] = $return_type->generateUniqueId();
+        $key = \implode(',', $key_parts);
+
+        return $cache[$key] ?? ($cache[$key] = new self($param_types, $return_type, $is_nullable));
+    }
+
+    public function __toString() : string
+    {
+        $parts = [];
+        // TODO: CommentParameter instead of Parameter
+        foreach ($this->param_types as $key => $value) {
+            $value_repr = $value->__toString();
+            $parts[] = $value_repr;
+        }
+        $return_type_string = $this->return_type->__toString();
+        return ($this->is_nullable ? '?' : '') . 'Closure(' . \implode(',', $parts) . '):' . $return_type_string;
+    }
+
+    public function __clone()
+    {
+        throw new \AssertionError('Should not clone ClosureTypeDeclaration');
+    }
+
+    /**
+     * @return bool
+     * True if this type is a callable or a Closure.
+     */
+    public function isCallable() : bool
+    {
+        return true;
+    }
+}

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -14,6 +14,7 @@ use Phan\Language\Element\Clazz;
 use Phan\Language\Element\Comment;
 use Phan\Language\Element\Func;
 use Phan\Language\Element\FunctionFactory;
+use Phan\Language\Element\FunctionInterface;
 use Phan\Language\Element\GlobalConstant;
 use Phan\Language\Element\Method;
 use Phan\Language\Element\Property;
@@ -742,7 +743,7 @@ class ParseVisitor extends ScopeVisitor
             ], true)) {
                 if ($this->context->isInFunctionLikeScope()) {
                     $this->context->getFunctionLikeInScope($this->code_base)
-                                  ->setNumberOfOptionalParameters(999999);
+                                  ->setNumberOfOptionalParameters(FunctionInterface::INFINITE_PARAMETERS);
                 }
             } elseif ($function_name === 'define') {
                 // TODO: infer constant type from literal, string concatenation operators, etc?

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -65,10 +65,16 @@ final class ConfigPluginSet extends PluginV2 implements
     /** @var array<int,Plugin>|null - Cached plugin set for this instance. Lazily generated. */
     private $pluginSet;
 
-    /** @var array<int,\Closure>|null - plugins to analyze nodes in pre order. */
+    /**
+     * @var array<int,Closure>|null - plugins to analyze nodes in pre order.
+     * @phan-var array<int,Closure(CodeBase,Context,Node):void>|null
+     */
     private $preAnalyzeNodePluginSet;
 
-    /** @var array<int,\Closure>|null - plugins to analyze nodes in post order. */
+    /**
+     * @var array<int,Closure> - plugins to analyze nodes in post order.
+     * @phan-var array<int,Closure(CodeBase,Context,Node,array<int,Node>):void>|null
+     */
     private $postAnalyzeNodePluginSet;
 
     /** @var array<int,AnalyzeClassCapability>|null - plugins to analyze class declarations. */
@@ -443,8 +449,9 @@ final class ConfigPluginSet extends PluginV2 implements
     }
 
     /**
-     * @return array<int,\Closure>
+     * @return array<int,Closure>
      *         Returned value maps ast\Node->kind to [function(CodeBase $code_base, Context $context, Node $node, array<int,Node> $parent_node_list = []): void]
+     * @phan-return array<int,Closure(CodeBase,Context,Node,array<int,Node>=):void>
      */
     private static function filterPreAnalysisPlugins(array $plugin_set) : array
     {

--- a/src/Phan/Plugin/Internal/CallableParamPlugin.php
+++ b/src/Phan/Plugin/Internal/CallableParamPlugin.php
@@ -10,6 +10,7 @@ use Phan\Language\Type\CallableType;
 use Phan\Language\Type;
 use Phan\PluginV2\AnalyzeFunctionCallCapability;
 use Phan\PluginV2;
+use Closure;
 
 /**
  * NOTE: This is automatically loaded by phan. Do not include it in a config.
@@ -23,8 +24,9 @@ final class CallableParamPlugin extends PluginV2 implements
 
     /**
      * @param array<int,int> $params
+     * @phan-return Closure(CodeBase,Context,FunctionInterface,array):void
      */
-    private static function generateClosure(array $params) : \Closure
+    private static function generateClosure(array $params) : Closure
     {
         $key = \json_encode($params);
         static $cache = [];
@@ -65,6 +67,7 @@ final class CallableParamPlugin extends PluginV2 implements
 
     /**
      * @return array<string,\Closure>
+     * @phan-return array<string,Closure(CodeBase,Context,FunctionInterface,array):void>
      */
     private function getAnalyzeFunctionCallClosuresStatic(CodeBase $code_base) : array
     {
@@ -115,7 +118,7 @@ final class CallableParamPlugin extends PluginV2 implements
     }
 
     /**
-     * @return array<string,\Closure>
+     * @phan-return array<string,Closure(CodeBase,Context,FunctionInterface,array):void>
      */
     public function getAnalyzeFunctionCallClosures(CodeBase $code_base) : array
     {

--- a/src/Phan/Plugin/Internal/ClosureReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ClosureReturnTypeOverridePlugin.php
@@ -17,6 +17,7 @@ use Phan\PluginV2;
 use Phan\PluginV2\AnalyzeFunctionCallCapability;
 use Phan\PluginV2\ReturnTypeOverrideCapability;
 use ast\Node;
+use Closure;
 
 /**
  * NOTE: This is automatically loaded by phan. Do not include it in a config.
@@ -129,7 +130,7 @@ final class ClosureReturnTypeOverridePlugin extends PluginV2 implements
             }
             $closure_types = UnionType::empty();
             foreach ($function_like_list as $function_like) {
-                $closure_types = $closure_types->withType(ClosureType::instanceWithClosureFQSEN($function_like->getFQSEN()));
+                $closure_types = $closure_types->withType(ClosureType::instanceWithClosureFQSEN($function_like->getFQSEN(), $function_like));
             }
             return $closure_types;
         };
@@ -252,7 +253,10 @@ final class ClosureReturnTypeOverridePlugin extends PluginV2 implements
         return $analyzers;
     }
 
-    public static function createNormalArgumentCache(CodeBase $code_base, Context $context) : \Closure
+    /**
+     * @phan-return Closure(mixed,int):UnionType
+     */
+    public static function createNormalArgumentCache(CodeBase $code_base, Context $context) : Closure
     {
         $cache = [];
         return function ($argument, int $i) use ($code_base, $context, &$cache) : UnionType {

--- a/src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php
@@ -11,6 +11,7 @@ use Phan\Language\Type\VoidType;
 use Phan\Language\UnionType;
 use Phan\PluginV2;
 use Phan\PluginV2\ReturnTypeOverrideCapability;
+use Closure;
 
 /**
  * NOTE: This is automatically loaded by phan. Do not include it in a config.
@@ -25,6 +26,7 @@ final class DependentReturnTypeOverridePlugin extends PluginV2 implements
 {
     /**
      * @return array<string,\Closure>
+     * @phan-return array<string, Closure(CodeBase,Context,Func,array):UnionType>
      */
     private static function getReturnTypeOverridesStatic(CodeBase $code_base) : array
     {
@@ -34,7 +36,10 @@ final class DependentReturnTypeOverridePlugin extends PluginV2 implements
         $void_union_type = VoidType::instance(false)->asUnionType();
         $nullable_string_union_type = StringType::instance(true)->asUnionType();
 
-        $make_dependent_type_method = static function (int $expected_bool_pos, $type_if_true, $type_if_false, $type_if_unknown) : \Closure {
+        /**
+         * @phan-return Closure(CodeBase,Context,Func,array):UnionType
+         */
+        $make_dependent_type_method = static function (int $expected_bool_pos, $type_if_true, $type_if_false, $type_if_unknown) : Closure {
             /**
              * @return UnionType
              * @suppress PhanPluginUnusedClosureArgument
@@ -44,12 +49,7 @@ final class DependentReturnTypeOverridePlugin extends PluginV2 implements
                 Context $context,
                 Func $function,
                 array $args
-            ) use (
-                $type_if_true,
-                $type_if_unknown,
-                $type_if_false,
-                $expected_bool_pos
-) {
+            ) use ($type_if_true, $type_if_unknown, $type_if_false, $expected_bool_pos) : UnionType {
                 if (\count($args) <= $expected_bool_pos) {
                     return $type_if_false;
                 }
@@ -84,11 +84,7 @@ final class DependentReturnTypeOverridePlugin extends PluginV2 implements
             Context $context,
             Func $function,
             array $args
-        ) use (
-            $json_decode_array_types,
-            $json_decode_object_types,
-            $json_decode_array_or_object_types
-) {
+        ) use ($json_decode_array_types, $json_decode_object_types, $json_decode_array_or_object_types) : UnionType {
             //  mixed json_decode ( string $json [, bool $assoc = FALSE [, int $depth = 512 [, int $options = 0 ]]] )
             //  $options can include JSON_OBJECT_AS_ARRAY in a bitmask
             // TODO: reject `...` operator? (Low priority)

--- a/src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php
@@ -49,7 +49,12 @@ final class DependentReturnTypeOverridePlugin extends PluginV2 implements
                 Context $context,
                 Func $function,
                 array $args
-            ) use ($type_if_true, $type_if_unknown, $type_if_false, $expected_bool_pos) : UnionType {
+            ) use (
+                $type_if_true,
+                $type_if_unknown,
+                $type_if_false,
+                $expected_bool_pos
+) : UnionType {
                 if (\count($args) <= $expected_bool_pos) {
                     return $type_if_false;
                 }
@@ -84,7 +89,11 @@ final class DependentReturnTypeOverridePlugin extends PluginV2 implements
             Context $context,
             Func $function,
             array $args
-        ) use ($json_decode_array_types, $json_decode_object_types, $json_decode_array_or_object_types) : UnionType {
+        ) use (
+            $json_decode_array_types,
+            $json_decode_object_types,
+            $json_decode_array_or_object_types
+) : UnionType {
             //  mixed json_decode ( string $json [, bool $assoc = FALSE [, int $depth = 512 [, int $options = 0 ]]] )
             //  $options can include JSON_OBJECT_AS_ARRAY in a bitmask
             // TODO: reject `...` operator? (Low priority)

--- a/src/Phan/Plugin/Internal/MiscParamPlugin.php
+++ b/src/Phan/Plugin/Internal/MiscParamPlugin.php
@@ -13,6 +13,7 @@ use Phan\Language\UnionType;
 use Phan\PluginV2\AnalyzeFunctionCallCapability;
 use Phan\PluginV2\StopParamAnalysisException;
 use Phan\PluginV2;
+use Closure;
 
 /**
  * NOTE: This is automatically loaded by phan. Do not include it in a config.
@@ -24,7 +25,8 @@ final class MiscParamPlugin extends PluginV2 implements
     AnalyzeFunctionCallCapability
 {
     /**
-     * @return array<string,\Closure>
+     * @return array<string,Closure>
+     * @phan-return array<string,Closure(CodeBase,Context,FunctionInterface,array):void>
      */
     private function getAnalyzeFunctionCallClosuresStatic(CodeBase $code_base) : array
     {
@@ -297,7 +299,8 @@ final class MiscParamPlugin extends PluginV2 implements
     }
 
     /**
-     * @return array<string,\Closure>
+     * @return array<string,Closure>
+     * @phan-return array<string,Closure(CodeBase,Context,FunctionInterface,array):void>
      */
     public function getAnalyzeFunctionCallClosures(CodeBase $code_base) : array
     {

--- a/src/Phan/Plugin/Internal/StringFunctionPlugin.php
+++ b/src/Phan/Plugin/Internal/StringFunctionPlugin.php
@@ -4,11 +4,12 @@ namespace Phan\Plugin\Internal;
 use Phan\CodeBase;
 use Phan\Issue;
 use Phan\Language\Context;
-use Phan\Language\Element\Func;
+use Phan\Language\Element\FunctionInterface;
 use Phan\PluginV2;
 use Phan\PluginV2\AnalyzeFunctionCallCapability;
 use ast;
 use ast\Node;
+use Closure;
 
 /**
  * NOTE: This is automatically loaded by phan. Do not include it in a config.
@@ -60,11 +61,12 @@ final class StringFunctionPlugin extends PluginV2 implements
     }
 
     /**
-     * @return array<string,\Closure>
+     * @return array<string,Closure>
+     * @phan-return array<string,Closure(CodeBase,Context,FunctionInterface,array):void>
      */
     private static function getAnalyzeFunctionCallClosuresStatic() : array
     {
-        $make_order_warner = static function (int $expected_const_pos, int $expected_variable_pos) : \Closure {
+        $make_order_warner = static function (int $expected_const_pos, int $expected_variable_pos) : Closure {
             $expected_arg_count = 1 + (int)max($expected_const_pos, $expected_variable_pos);
             /**
              * @return void
@@ -72,7 +74,7 @@ final class StringFunctionPlugin extends PluginV2 implements
             return static function (
                 CodeBase $code_base,
                 Context $context,
-                Func $function,
+                FunctionInterface $function,
                 array $args
             ) use (
                 $expected_const_pos,

--- a/src/Phan/PluginV2.php
+++ b/src/Phan/PluginV2.php
@@ -44,13 +44,13 @@ use Phan\PluginV2\IssueEmitter;
  *     Called after the analysis phase is complete.
  *     (implement \Phan\PluginV2\FinalizeProcessCapability)
  *
- *  8. public function getAnalyzeFunctionCallClosures(CodeBase $code_base) : \Closure[]
+ *  8. public function getAnalyzeFunctionCallClosures(CodeBase $code_base) : array<string, Closure(CodeBase,Context,Func|Method,array):void>
  *     Maps FQSEN of function or method to a closure used to analyze the function in question.
  *     'MyClass::myMethod' can be used as the FQSEN of a static or instance method.
  *     See .phan/plugins/PregRegexCheckerPlugin.php as an example.
  *
  *      Closure Type: function(CodeBase $code_base, Context $context, Func|Method $function, array $args) : void {...}
- *  9. public function getReturnTypeOverrides(CodeBase $code_base) : array
+ *  9. public function getReturnTypeOverrides(CodeBase $code_base) : array<string,Closure(CodeBase,Context,Func|Method,array):UnionType>
  *     Maps FQSEN of function or method to a closure used to override the returned UnionType.
  *     See \Phan\Plugin\Internal\ArrayReturnTypeOverridePlugin as an example (That is automatically loaded by phan)
  *

--- a/tests/Phan/Language/TypeTest.php
+++ b/tests/Phan/Language/TypeTest.php
@@ -9,6 +9,7 @@ use Phan\Language\Type\ArrayShapeType;
 use Phan\Language\Type\BoolType;
 use Phan\Language\Type\CallableType;
 use Phan\Language\Type\ClosureType;
+use Phan\Language\Type\ClosureTypeDeclaration;
 use Phan\Language\Type\FalseType;
 use Phan\Language\Type\FloatType;
 use Phan\Language\Type\GenericArrayType;
@@ -68,9 +69,12 @@ class TypeTest extends BaseTest
         $this->assertParsesAsType(VoidType::instance(false), 'void');
     }
 
-    private function assertSameType(Type $expected, Type $actual)
+    private function assertSameType(Type $expected, Type $actual, string $extra = '')
     {
         $message = \sprintf("Expected %s to be %s", (string)$actual, (string)$expected);
+        if ($extra) {
+            $message .= ": $extra";
+        }
         $this->assertEquals($expected, $actual, $message);
         $this->assertSame($expected, $actual, $message);
     }
@@ -244,6 +248,35 @@ class TypeTest extends BaseTest
         );
         $this->assertSameType($expectedStringArrayType, $stringArrayType);
         $this->assertSame('?float[]', (string)$stringArrayType);
+    }
+
+    public function testClosureAnnotation()
+    {
+        foreach (['Closure():void', 'Closure()'] as $union_type_string) {
+            $expectedClosureVoidType = ClosureTypeDeclaration::instanceForTypes(
+                [],
+                VoidType::instance(false)->asUnionType(),
+                false
+            );
+            $this->assertParsesAsType($expectedClosureVoidType, $union_type_string);
+            $closureVoidType = self::makePHPDocType($union_type_string);
+            $this->assertSame('Closure():void', (string)$closureVoidType, "failed parsing $union_type_string");
+        }
+    }
+
+    public function testClosureIntAnnotation()
+    {
+        foreach (['Closure(int):int', 'Closure(int $p1)'] as $union_type_string) {
+            // TODO: Finish implementing
+            $expectedClosureVoidType = ClosureTypeDeclaration::instanceForTypes(
+                [new ClosureTypeParameter(IntType::instance(false), false, false, false)],  // PARAM_REF, PARAM_VARIADIC, IS_OPTIONAL
+                VoidType::instance(false)->asUnionType(),
+                false
+            );
+            $this->assertParsesAsType($expectedClosureVoidType, $union_type_string);
+            $closureVoidType = self::makePHPDocType($union_type_string);
+            $this->assertSame('Closure():void', (string)$closureVoidType, "failed parsing $union_type_string");
+        }
     }
 
     /**

--- a/tests/Phan/Language/TypeTest.php
+++ b/tests/Phan/Language/TypeTest.php
@@ -266,14 +266,18 @@ class TypeTest extends BaseTest
 
     private function verifyClosureParam(ClosureDeclarationType $expected_closure_type, string $union_type_string, string $normalized_type_string)
     {
-        $this->assertParsesAsType($expected_closure_type, $union_type_string);
+        $this->assertTrue(\preg_match(self::delimited_type_regex_or_this, $union_type_string) > 0, "Failed to parse '$union_type_string'");
         $parsed_closure_type = self::makePHPDocType($union_type_string);
+        $this->assertInstanceOf(ClosureDeclarationType::class, $parsed_closure_type);
         $this->assertSame($normalized_type_string, (string)$parsed_closure_type, "failed parsing $union_type_string");
+        $this->assertTrue($expected_closure_type->canCastToType($parsed_closure_type), "failed casting $union_type_string");
+        $this->assertTrue($parsed_closure_type->canCastToType($expected_closure_type), "failed casting $union_type_string");
     }
 
     public function testClosureAnnotation()
     {
-        $expected_closure_void_type = ClosureDeclarationType::instanceForTypes(
+        $expected_closure_void_type = new ClosureDeclarationType(
+            new Context(),
             [],
             VoidType::instance(false)->asUnionType(),
             false,
@@ -287,7 +291,8 @@ class TypeTest extends BaseTest
 
     public function testClosureBasicAnnotation()
     {
-        $expected_closure_type = ClosureDeclarationType::instanceForTypes(
+        $expected_closure_type = new ClosureDeclarationType(
+            new Context(),
             [self::makeBasicClosureParam('int'), self::makeBasicClosureParam('mixed')],
             IntType::instance(false)->asUnionType(),
             false,
@@ -302,7 +307,8 @@ class TypeTest extends BaseTest
     {
         $nullable_scalar_param = self::makeBasicClosureParam('?int|?string');
 
-        $expected_closure_scalar_type = ClosureDeclarationType::instanceForTypes(
+        $expected_closure_scalar_type = new ClosureDeclarationType(
+            new Context(),
             [$nullable_scalar_param],
             UnionType::fromFullyQualifiedString('?int|?string'),
             false,
@@ -322,7 +328,8 @@ class TypeTest extends BaseTest
         $string_ref_annotation = new ClosureDeclarationParameter(UnionType::fromFullyQualifiedString('string'), false, true, false);
         $variadic_bool_annotation = new ClosureDeclarationParameter(UnionType::fromFullyQualifiedString('bool'), true, true, false);
 
-        $expected_closure_type = ClosureDeclarationType::instanceForTypes(
+        $expected_closure_type = new ClosureDeclarationType(
+            new Context(),
             [$string_ref_annotation, $variadic_bool_annotation],
             UnionType::fromFullyQualifiedString('void'),
             false,
@@ -339,7 +346,8 @@ class TypeTest extends BaseTest
         $optional_string_annotation = new ClosureDeclarationParameter(UnionType::fromFullyQualifiedString('?string'), false, false, true);
         $optional_int_annotation = new ClosureDeclarationParameter(UnionType::fromFullyQualifiedString('int'), false, false, true);
 
-        $expected_closure_type = ClosureDeclarationType::instanceForTypes(
+        $expected_closure_type = new ClosureDeclarationType(
+            new Context(),
             [$optional_string_annotation, $optional_int_annotation],
             UnionType::fromFullyQualifiedString('void'),
             false,

--- a/tests/Phan/Language/TypeTest.php
+++ b/tests/Phan/Language/TypeTest.php
@@ -9,7 +9,8 @@ use Phan\Language\Type\ArrayShapeType;
 use Phan\Language\Type\BoolType;
 use Phan\Language\Type\CallableType;
 use Phan\Language\Type\ClosureType;
-use Phan\Language\Type\ClosureTypeDeclaration;
+use Phan\Language\Type\ClosureDeclarationType;
+use Phan\Language\Type\ClosureDeclarationParameter;
 use Phan\Language\Type\FalseType;
 use Phan\Language\Type\FloatType;
 use Phan\Language\Type\GenericArrayType;
@@ -252,12 +253,13 @@ class TypeTest extends BaseTest
 
     public function testClosureAnnotation()
     {
+        $expectedClosureVoidType = ClosureDeclarationType::instanceForTypes(
+            [],
+            VoidType::instance(false)->asUnionType(),
+            false,
+            false
+        );
         foreach (['Closure():void', 'Closure()'] as $union_type_string) {
-            $expectedClosureVoidType = ClosureTypeDeclaration::instanceForTypes(
-                [],
-                VoidType::instance(false)->asUnionType(),
-                false
-            );
             $this->assertParsesAsType($expectedClosureVoidType, $union_type_string);
             $closureVoidType = self::makePHPDocType($union_type_string);
             $this->assertSame('Closure():void', (string)$closureVoidType, "failed parsing $union_type_string");
@@ -266,14 +268,16 @@ class TypeTest extends BaseTest
 
     public function testClosureIntAnnotation()
     {
-        foreach (['Closure(int):int', 'Closure(int $p1)'] as $union_type_string) {
+        $param = new ClosureDeclarationParameter(IntType::instance(false)->asUnionType(), false, false, false);
+        $expectedClosureIntType = ClosureDeclarationType::instanceForTypes(
+            [$param],  // PARAM_REF, PARAM_VARIADIC, IS_OPTIONAL
+            IntType::instance(false)->asUnionType(),
+            false,
+            false
+        );
+        foreach (['Closure(int):int', 'Closure(int $p1): int'] as $union_type_string) {
             // TODO: Finish implementing
-            $expectedClosureVoidType = ClosureTypeDeclaration::instanceForTypes(
-                [new ClosureTypeParameter(IntType::instance(false), false, false, false)],  // PARAM_REF, PARAM_VARIADIC, IS_OPTIONAL
-                VoidType::instance(false)->asUnionType(),
-                false
-            );
-            $this->assertParsesAsType($expectedClosureVoidType, $union_type_string);
+            $this->assertParsesAsType($expectedClosureIntType, $union_type_string);
             $closureVoidType = self::makePHPDocType($union_type_string);
             $this->assertSame('Closure():void', (string)$closureVoidType, "failed parsing $union_type_string");
         }

--- a/tests/Phan/Language/TypeTest.php
+++ b/tests/Phan/Language/TypeTest.php
@@ -43,9 +43,11 @@ class TypeTest extends BaseTest
         $this->assertParsesAsType(ArrayType::instance(false), '((array))');
     }
 
+    const delimited_type_regex_or_this = '@^' . Type::type_regex_or_this . '$@';
+
     public function assertParsesAsType(Type $expected_type, string $type_string)
     {
-        $this->assertTrue(\preg_match('@^' . Type::type_regex_or_this . '$@', $type_string) > 0, "Failed to parse '$type_string'");
+        $this->assertTrue(\preg_match(self::delimited_type_regex_or_this, $type_string) > 0, "Failed to parse '$type_string'");
         $this->assertSameType($expected_type, self::makePHPDocType($type_string));
     }
 
@@ -291,7 +293,7 @@ class TypeTest extends BaseTest
             false,
             false
         );
-        foreach (['Closure(int,mixed):int', 'Closure(int $p1,$other): int'] as $union_type_string) {
+        foreach (['Closure(int,mixed):int', '\Closure(int,mixed):int', 'Closure(int $p1,$other): int'] as $union_type_string) {
             $this->verifyClosureParam($expected_closure_type, $union_type_string, 'Closure(int,mixed):int');
         }
     }
@@ -306,8 +308,11 @@ class TypeTest extends BaseTest
             false,
             false
         );
-        foreach (['Closure(?int|?string $argName) : ?int|?string', 'Closure(?int|?string):?int|?string'] as $union_type_string) {
-            $this->verifyClosureParam($expected_closure_scalar_type, $union_type_string, 'Closure(?int|?string):?int|?string');
+        foreach ([
+            'Closure(?int|?string $argName) : (?int|?string)',
+            'Closure(?int|?string):(?int|?string)',
+        ] as $union_type_string) {
+            $this->verifyClosureParam($expected_closure_scalar_type, $union_type_string, 'Closure(?int|?string):(?int|?string)');
         }
     }
 

--- a/tests/files/expected/0070_closure_type.php.expected
+++ b/tests/files/expected/0070_closure_type.php.expected
@@ -1,3 +1,3 @@
 %s:3 PhanUndeclaredTypeParameter Parameter of undeclared type \A\Closure
-%s:4 PhanTypeMismatchArgument Argument 1 (c) is \Closure but \A\f() takes \A\Closure defined at %s:3
+%s:4 PhanTypeMismatchArgument Argument 1 (c) is Closure():void but \A\f() takes \A\Closure defined at %s:3
 %s:14 PhanTypeMismatchArgument Argument 1 (c) is callable but \C\f() takes \Closure defined at %s:13

--- a/tests/files/expected/0263_alias_outside_phpdoc.php.expected
+++ b/tests/files/expected/0263_alias_outside_phpdoc.php.expected
@@ -7,6 +7,6 @@
 %s:5 PhanTypeMismatchReturn Returning type false but foo263() is declared to return \boolean
 %s:7 PhanTypeMismatchArgument Argument 1 (a) is false but \foo263() takes \boolean defined at %s:4
 %s:7 PhanTypeMismatchArgument Argument 2 (b) is int but \foo263() takes \integer defined at %s:4
-%s:7 PhanTypeMismatchArgument Argument 3 (c) is \Closure but \foo263() takes \callback defined at %s:4
+%s:7 PhanTypeMismatchArgument Argument 3 (c) is Closure():void but \foo263() takes \callback defined at %s:4
 %s:7 PhanTypeMismatchArgument Argument 4 (d) is float but \foo263() takes \double defined at %s:4
 %s:7 PhanTypeMismatchArgument Argument 5 (e) is float but \foo263() takes \double defined at %s:4

--- a/tests/files/expected/0278_internal_elements.php.expected
+++ b/tests/files/expected/0278_internal_elements.php.expected
@@ -1,4 +1,7 @@
+%s:35 PhanTypeVoidAssignment Cannot assign void return value
+%s:61 PhanTypeVoidAssignment Cannot assign void return value
 %s:92 PhanAccessMethodInternal Cannot access internal method \NS278\A\f of namespace \NS278\A defined at %s:33 from namespace \NS278\B
+%s:92 PhanTypeVoidAssignment Cannot assign void return value
 %s:94 PhanAccessConstantInternal Cannot access internal constant \NS278\A\CONST_INTERNAL of namepace \NS278\A defined at %s:8 from namespace \NS278\B
 %s:96 PhanAccessMethodInternal Cannot access internal method \NS278\A\C1::__construct of namespace \NS278\A defined at %s:11 from namespace \NS278\B
 %s:97 PhanAccessPropertyInternal Cannot access internal property \NS278\A\C1::p of namespace \NS278\A defined at %s:13 from namespace \NS278\B

--- a/tests/files/expected/0278_internal_elements.php.expected70
+++ b/tests/files/expected/0278_internal_elements.php.expected70
@@ -1,4 +1,7 @@
+%s:35 PhanTypeVoidAssignment Cannot assign void return value
+%s:61 PhanTypeVoidAssignment Cannot assign void return value
 %s:92 PhanAccessMethodInternal Cannot access internal method \NS278\A\f of namespace \NS278\A defined at %s:33 from namespace \NS278\B
+%s:92 PhanTypeVoidAssignment Cannot assign void return value
 %s:96 PhanAccessMethodInternal Cannot access internal method \NS278\A\C1::__construct of namespace \NS278\A defined at %s:11 from namespace \NS278\B
 %s:97 PhanAccessPropertyInternal Cannot access internal property \NS278\A\C1::p of namespace \NS278\A defined at %s:13 from namespace \NS278\B
 %s:98 PhanAccessMethodInternal Cannot access internal method \NS278\A\C1::f of namespace \NS278\A defined at %s:14 from namespace \NS278\B

--- a/tests/files/expected/0364_extended_array_analyze.php.expected
+++ b/tests/files/expected/0364_extended_array_analyze.php.expected
@@ -30,6 +30,6 @@
 %s:38 PhanTypeMismatchArgument Argument 1 (x) is array<int,\stdClass> but \p364() takes \stdClass defined at %s:45
 %s:39 PhanTypeMismatchArgument Argument 1 (x) is array<int,string> but \p364() takes \stdClass defined at %s:45
 %s:40 PhanTypeMismatchArgument Argument 1 (x) is array<int,string> but \p364() takes \stdClass defined at %s:45
-%s:41 PhanParamTypeMismatch Argument 3 is \Closure but \array_uintersect_assoc() takes array
+%s:41 PhanParamTypeMismatch Argument 3 is Closure(mixed,mixed):(float|int) but \array_uintersect_assoc() takes array
 %s:41 PhanTypeMismatchArgument Argument 1 (x) is array<int,string> but \p364() takes \stdClass defined at %s:45
 %s:42 PhanTypeMismatchArgument Argument 1 (x) is array<int,string> but \p364() takes \stdClass defined at %s:45

--- a/tests/files/expected/0372_ternary_shorthand.php.expected
+++ b/tests/files/expected/0372_ternary_shorthand.php.expected
@@ -1,2 +1,4 @@
 %s:21 PhanTypeMismatchArgument Argument 1 (x) is string but \expect_int382() takes int defined at %s:17
+%s:21 PhanTypeSuspiciousEcho Suspicious argument void for an echo/print statement
 %s:22 PhanTypeMismatchArgument Argument 1 (x) is array{0:string}|string but \expect_int382() takes int defined at %s:17
+%s:22 PhanTypeSuspiciousEcho Suspicious argument void for an echo/print statement

--- a/tests/files/expected/0455_closure_type_cast.php.expected
+++ b/tests/files/expected/0455_closure_type_cast.php.expected
@@ -1,0 +1,16 @@
+%s:8 PhanTypeSuspiciousEcho Suspicious argument Closure(int):void for an echo/print statement
+%s:15 PhanTypeMismatchArgument Argument 1 (fn) is Closure(int,string):void but \expects_int_param() takes Closure(int):void defined at %s:6
+%s:17 PhanTypeMismatchArgument Argument 1 (fn) is Closure(int&):void but \expects_int_param() takes Closure(int):void defined at %s:6
+%s:28 PhanTypeMismatchArgument Argument 1 (fn) is Closure(int):void but \expects_optional_int_param() takes Closure(int=):void defined at %s:22
+%s:31 PhanTypeMismatchArgument Argument 1 (fn) is Closure(int,string):void but \expects_optional_int_param() takes Closure(int=):void defined at %s:22
+%s:32 PhanTypeMismatchArgument Argument 1 (fn) is Closure():void but \expects_optional_int_param() takes Closure(int=):void defined at %s:22
+%s:33 PhanTypeMismatchArgument Argument 1 (fn) is Closure(int&=):void but \expects_optional_int_param() takes Closure(int=):void defined at %s:22
+%s:48 PhanTypeMismatchArgument Argument 1 (fn) is Closure():array but \expects_int_return() takes Closure():int defined at %s:40
+%s:49 PhanTypeMismatchArgument Argument 1 (fn) is Closure(array):int but \expects_int_return() takes Closure():int defined at %s:40
+%s:58 PhanTypeMismatchArgument Argument 1 (fn) is Closure():void but \expects_int_param() takes Closure(int):void defined at %s:6
+%s:59 PhanTypeMismatchArgument Argument 1 (fn) is Closure():void but \expects_int_return() takes Closure():int defined at %s:40
+%s:67 PhanTypeMismatchArgument Argument 1 (fn) is Closure(mixed):void but \expects_void() takes Closure():void defined at %s:56
+%s:68 PhanTypeMismatchArgument Argument 1 (fn) is Closure():int but \expects_void() takes Closure():void defined at %s:56
+%s:69 PhanTypeMismatchArgument Argument 1 (fn) is Closure(int):void but \expects_void() takes Closure():void defined at %s:56
+%s:80 PhanTypeMismatchArgument Argument 1 (fn) is Closure(int...):void but \expects_void_variadic() takes Closure(string...):void defined at %s:74
+%s:82 PhanTypeMismatchArgument Argument 1 (fn) is Closure(string):void but \expects_void_variadic() takes Closure(string...):void defined at %s:74

--- a/tests/files/expected/0455_closure_type_cast.php.expected
+++ b/tests/files/expected/0455_closure_type_cast.php.expected
@@ -1,16 +1,24 @@
 %s:8 PhanTypeSuspiciousEcho Suspicious argument Closure(int):void for an echo/print statement
+%s:9 PhanTypeMismatchArgument Argument 1 (p0) is \stdClass but Closure(int):void() takes int defined at %s:6
+%s:10 PhanParamTooFew Call with 0 arg(s) to Closure(int):void() which requires 1 arg(s) defined at %s:6
 %s:15 PhanTypeMismatchArgument Argument 1 (fn) is Closure(int,string):void but \expects_int_param() takes Closure(int):void defined at %s:6
 %s:17 PhanTypeMismatchArgument Argument 1 (fn) is Closure(int&):void but \expects_int_param() takes Closure(int):void defined at %s:6
+%s:24 PhanTypeMismatchArgument Argument 1 (p0) is \stdClass but Closure(int=):void() takes int defined at %s:22
+%s:26 PhanTypeMismatchArgument Argument 1 (p0) is null but Closure(int=):void() takes int defined at %s:22
 %s:28 PhanTypeMismatchArgument Argument 1 (fn) is Closure(int):void but \expects_optional_int_param() takes Closure(int=):void defined at %s:22
 %s:31 PhanTypeMismatchArgument Argument 1 (fn) is Closure(int,string):void but \expects_optional_int_param() takes Closure(int=):void defined at %s:22
 %s:32 PhanTypeMismatchArgument Argument 1 (fn) is Closure():void but \expects_optional_int_param() takes Closure(int=):void defined at %s:22
 %s:33 PhanTypeMismatchArgument Argument 1 (fn) is Closure(int&=):void but \expects_optional_int_param() takes Closure(int=):void defined at %s:22
+%s:41 PhanParamTooMany Call with 1 arg(s) to Closure():int() which only takes 0 arg(s) defined at %s:40
+%s:42 PhanTypeMismatchReturn Returning type int but expects_int_return() is declared to return \stdClass
 %s:48 PhanTypeMismatchArgument Argument 1 (fn) is Closure():array but \expects_int_return() takes Closure():int defined at %s:40
 %s:49 PhanTypeMismatchArgument Argument 1 (fn) is Closure(array):int but \expects_int_return() takes Closure():int defined at %s:40
+%s:57 PhanTypeVoidAssignment Cannot assign void return value
 %s:58 PhanTypeMismatchArgument Argument 1 (fn) is Closure():void but \expects_int_param() takes Closure(int):void defined at %s:6
 %s:59 PhanTypeMismatchArgument Argument 1 (fn) is Closure():void but \expects_int_return() takes Closure():int defined at %s:40
 %s:67 PhanTypeMismatchArgument Argument 1 (fn) is Closure(mixed):void but \expects_void() takes Closure():void defined at %s:56
 %s:68 PhanTypeMismatchArgument Argument 1 (fn) is Closure():int but \expects_void() takes Closure():void defined at %s:56
 %s:69 PhanTypeMismatchArgument Argument 1 (fn) is Closure(int):void but \expects_void() takes Closure():void defined at %s:56
+%s:77 PhanTypeMismatchArgument Argument 1 (p0) is array{0:string} but Closure(string...):void() takes string defined at %s:74
 %s:80 PhanTypeMismatchArgument Argument 1 (fn) is Closure(int...):void but \expects_void_variadic() takes Closure(string...):void defined at %s:74
 %s:82 PhanTypeMismatchArgument Argument 1 (fn) is Closure(string):void but \expects_void_variadic() takes Closure(string...):void defined at %s:74

--- a/tests/files/expected/0456_closure_return.php.expected
+++ b/tests/files/expected/0456_closure_return.php.expected
@@ -1,0 +1,3 @@
+%s:11 PhanTypeMismatchReturn Returning type Closure(int):int but return_closure() is declared to return Closure(int):string
+%s:15 PhanTypeMismatchReturn Returning type Closure(string):int but return_closure() is declared to return Closure(int):string
+%s:17 PhanTypeMismatchReturn Returning type Closure():string but return_closure() is declared to return Closure(int):string

--- a/tests/files/expected/0456_closure_return.php.expected70
+++ b/tests/files/expected/0456_closure_return.php.expected70
@@ -1,0 +1,4 @@
+%s:11 PhanTypeMismatchReturn Returning type Closure(int):int but return_closure() is declared to return Closure(int):string
+%s:13 PhanUndeclaredStaticMethod Static call to undeclared method \Closure::fromCallable
+%s:15 PhanUndeclaredStaticMethod Static call to undeclared method \Closure::fromCallable
+%s:17 PhanTypeMismatchReturn Returning type Closure():string but return_closure() is declared to return Closure(int):string

--- a/tests/files/src/0455_closure_type_cast.php
+++ b/tests/files/src/0455_closure_type_cast.php
@@ -6,8 +6,8 @@
 function expects_int_param(Closure $fn) {
     $fn(1);
     echo $fn;
-    $fn(new stdClass());
-    $fn();
+    $fn(new stdClass());  // should warn
+    $fn();  // should warn
 }
 
 expects_int_param(function(int $x) { echo $x; });
@@ -23,8 +23,8 @@ function expects_optional_int_param(Closure $fn) {
     $fn(1);
     $fn(new stdClass());  // should warn
     $fn();
+    $fn(null);  // should warn
 }
-
 expects_optional_int_param(function(int $x) { echo $x; });  // should warn
 expects_optional_int_param(function(int $x = 2) { echo $x; });
 expects_optional_int_param(function(int $x = 2, int ...$rest) { echo $x, count($rest); });  // valid
@@ -38,8 +38,8 @@ expects_optional_int_param(function(int &$x = 0) { $x = 2; });  // should warn
  * @param Closure():int $fn
  */
 function expects_int_return(Closure $fn) : stdClass {
-    $fn(2);
-    return $fn();
+    $fn(2);  // should warn
+    return $fn();  // should warn, int can't cast to stdClass
 }
 
 expects_int_return(function(...$args) : int { return count($args); } ); // should not warn
@@ -54,7 +54,7 @@ expects_int_return(function(array $args) : int { return count($args); } ); // sh
  * @param Closure():void $fn
  */
 function expects_void(Closure $fn) {
-    $result = $fn();  // TODO: Make analyzer treat these like regular closures in another PR
+    $result = $fn();  // should warn
     expects_int_param($fn); // should warn
     expects_int_return($fn); // should warn
     if (rand() % 2 > 0) {
@@ -72,10 +72,10 @@ expects_void(function(int $extra) { echo "invoked $extra\n"; });  // invalid
  * @param Closure(string...):void $fn
  */
 function expects_void_variadic(Closure $fn) {
-    $fn('arg1', 'arg2');
-    $fn(['arg']);  // TODO: warn
+    $fn('arg1', 'arg2');  // valid. TODO: Warn for third arg being non-string
+    $fn();  // valid
+    $fn(['arg']);  // should warn
 }
-
 expects_void_variadic(function(string ...$args) { var_export($args); });
 expects_void_variadic(function(int ...$args) { var_export($args); });  // should warn
 expects_void_variadic(function(...$args) { var_export($args); });

--- a/tests/files/src/0455_closure_type_cast.php
+++ b/tests/files/src/0455_closure_type_cast.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * @param Closure(int):void $fn
+ */
+function expects_int_param(Closure $fn) {
+    $fn(1);
+    echo $fn;
+    $fn(new stdClass());
+    $fn();
+}
+
+expects_int_param(function(int $x) { echo $x; });
+expects_int_param(function(int $x, string $y='arg') { echo $x, $y; });
+expects_int_param(function(int $x, string $y) { echo $x, $y; });  // should warn
+expects_int_param(function(int $x = 2) { echo $x; return; });
+expects_int_param(function(int &$x) { $x = 2; });  // should warn
+
+/**
+ * @param Closure(int=):void $fn
+ */
+function expects_optional_int_param(Closure $fn) {
+    $fn(1);
+    $fn(new stdClass());  // should warn
+    $fn();
+}
+
+expects_optional_int_param(function(int $x) { echo $x; });  // should warn
+expects_optional_int_param(function(int $x = 2) { echo $x; });
+expects_optional_int_param(function(int $x = 2, int ...$rest) { echo $x, count($rest); });  // valid
+expects_optional_int_param(function(int $x, string $y) { echo $x, $y; });  // should warn
+expects_optional_int_param(function() { });  // should warn
+expects_optional_int_param(function(int &$x = 0) { $x = 2; });  // should warn
+
+
+/**
+ * Should warn
+ * @param Closure():int $fn
+ */
+function expects_int_return(Closure $fn) : stdClass {
+    $fn(2);
+    return $fn();
+}
+
+expects_int_return(function(...$args) : int { return count($args); } ); // should not warn
+expects_int_return(function(int $optional = 2) : int { return $optional; } ); // should not warn
+expects_int_return(function() : int { return 0; } ); // valid
+expects_int_return(function() : array { return []; } ); // should warn
+expects_int_return(function(array $args) : int { return count($args); } ); // should warn
+
+
+
+/**
+ * @param Closure():void $fn
+ */
+function expects_void(Closure $fn) {
+    $result = $fn();  // TODO: Make analyzer treat these like regular closures in another PR
+    expects_int_param($fn); // should warn
+    expects_int_return($fn); // should warn
+    if (rand() % 2 > 0) {
+        expects_void($fn);
+    }
+}
+
+expects_void(function() { echo "invoked\n"; });  // valid
+expects_void(function() : void { echo "invoked\n"; });  // valid
+expects_void(function($extra) : void { echo "invoked $extra\n"; });  // invalid
+expects_void(function() : int { echo "invoked\n"; return 2; });  // invalid
+expects_void(function(int $extra) { echo "invoked $extra\n"; });  // invalid
+
+/**
+ * @param Closure(string...):void $fn
+ */
+function expects_void_variadic(Closure $fn) {
+    $fn('arg1', 'arg2');
+    $fn(['arg']);  // TODO: warn
+}
+
+expects_void_variadic(function(string ...$args) { var_export($args); });
+expects_void_variadic(function(int ...$args) { var_export($args); });  // should warn
+expects_void_variadic(function(...$args) { var_export($args); });
+expects_void_variadic(function(string $arg) { var_export($arg); });  // should warn

--- a/tests/files/src/0456_closure_return.php
+++ b/tests/files/src/0456_closure_return.php
@@ -1,0 +1,19 @@
+<?php
+
+function fn_456(int $x) { return "($x)"; }
+
+/** @return \Closure(int):string */
+function return_closure() {
+    switch(rand(0,5)) {
+        case 0:
+            return function(int $x) : string {return "p$x"; };
+        case 1:
+            return function(int $x) : int {return $x * 2; };
+        case 2:
+            return Closure::fromCallable('fn_456');
+        case 3:
+            return Closure::fromCallable('strlen');
+        default:
+            return function() : string { return "Default"; };
+    }
+}

--- a/tests/plugin_test/expected/006_preg_regex.php.expected
+++ b/tests/plugin_test/expected/006_preg_regex.php.expected
@@ -6,6 +6,6 @@ src/006_preg_regex.php:16 PhanPluginInvalidPregRegex Call to \preg_split was pas
 src/006_preg_regex.php:17 PhanPluginInvalidPregRegex Call to \preg_match_all was passed an invalid regex '/\\w/i/': Unknown modifier '/'
 src/006_preg_regex.php:18 PhanPluginInvalidPregRegex Call to \preg_grep was passed an invalid regex '/\\w/i/': Unknown modifier '/'
 src/006_preg_regex.php:21 PhanPluginInvalidPregRegex Call to \preg_replace_callback_array was passed an invalid regex '0': Delimiter must not be alphanumeric or backslash
-src/006_preg_regex.php:21 PhanTypeMismatchArgumentInternal Argument 1 (pattern) is array{0:\Closure} but \preg_replace_callback_array() takes array<string,callable>
+src/006_preg_regex.php:21 PhanTypeMismatchArgumentInternal Argument 1 (pattern) is array{0:Closure(mixed):string} but \preg_replace_callback_array() takes array<string,callable>
 src/006_preg_regex.php:22 PhanPluginInvalidPregRegex Call to \preg_replace_callback_array was passed an invalid regex '0': Delimiter must not be alphanumeric or backslash
-src/006_preg_regex.php:22 PhanTypeMismatchArgumentInternal Argument 1 (pattern) is array{0:\Closure} but \preg_replace_callback_array() takes array<string,callable>
+src/006_preg_regex.php:22 PhanTypeMismatchArgumentInternal Argument 1 (pattern) is array{0:Closure(mixed):string} but \preg_replace_callback_array() takes array<string,callable>


### PR DESCRIPTION
Fixes #1578

Add closures with annotated param types and return to Phan's type system(#1578).
This is not a part of the phpdoc2 standard or any other standard.
These can be used in any phpdoc tags that Phan is aware of,
to indicate their expected types (`@param`, `@var`, `@return`, etc.)

Examples:

- `function(int $x) : ?int {return $x;}` has the type `Closure(int):?int`
- `function(array &$x) {$x[] = 2;}` has the type `Closure(array&):void`
- `function(int $i = 2, int ...$args) : void {}`
  has the type `Closure(int=,int...):void`

Note: Complex return types such as `int[]` or `int|false`
**must** be surrounded by brackets to avoid potential ambiguities.

- e.g. `Closure(int|array): (int[])`
- e.g. `Closure(): (int|false)`
- e.g. `Closure(): (array{key:string})` is not ambiguous,
  but the return type must be surrounded by brackets for now

Other notes:
- For now, the inner parameter list of `Closure(...)`
  cannot contain the characters `(` or `)`
  (or `,`, except to separate the arguments)
  Future changes are planned to allow those characters.
- Phan treats `Closure(T)` as an alias of `Closure(T):void`
- Placeholder variable names can be part of these types,
  similarly to `@method` (`Closure($unknown,int $count=0):T`
  is equivalent to `Closure(mixed,int):T`

Also, in issue messages, represent closures by their signatures
instead of as `\closure_{hexdigits}`
