### PR TITLE
Fixes #1583 (already fixed for single dimension)

### DIFF
--- a/src/Phan/AST/PhanAnnotationAdder.php
+++ b/src/Phan/AST/PhanAnnotationAdder.php
@@ -1,0 +1,217 @@
+<?php declare(strict_types=1);
+namespace Phan\AST;
+
+use ast;
+use ast\Node;
+use ast\flags;
+
+/**
+ * This adds annotations for Phan analysis to a given node,
+ * modifying the flags of a node in place.
+ * This adds custom children ($node->children['phan_nf']) to node types that have a variable number of children or expected values for flags
+ *
+ * and returns the new Node.
+ * The original \ast\Node objects are not modified.
+ *
+ * This adds to $node->children - Many of these types can have null
+ *
+ * Current annotations:
+ *
+ * 1. Mark $x in isset($x['key']['nested']) as being acceptable to have null offsets.
+ *    Same for $x in $x ?? null, empty($x['offset']), and so on.
+ */
+class PhanAnnotationAdder
+{
+    const PHAN_NODE_FLAGS = 'phan_nf';
+
+    const FLAG_IGNORE_NULLABLE = 1 << 29;
+    const FLAG_IGNORE_UNDEF = 1 << 30;
+
+    const FLAG_IGNORE_NULLABLE_AND_UNDEF = self::FLAG_IGNORE_UNDEF | self::FLAG_IGNORE_NULLABLE;
+
+    public function __construct()
+    {
+    }
+
+    /** @var array<int,Closure(Node):void> */
+    private static $closures_for_kind;
+
+    public static function init()
+    {
+        if (\is_array(self::$closures_for_kind)) {
+            return;
+        }
+        self::initInner();
+    }
+
+    const FLAGS_NODE_TYPE_SET = [
+        ast\AST_VAR => true,
+        ast\AST_DIM => true,
+        ast\AST_ASSIGN => true,
+        ast\AST_ASSIGN_REF => true,
+    ];
+
+    /**
+     * @param array $children
+     * @param int $bit_set
+     */
+    private static function markArrayElements($children, $bit_set)
+    {
+        foreach ($children as $node) {
+            if ($node instanceof Node) {
+                $node->flags |= $bit_set;
+            }
+        }
+    }
+
+    /**
+     * @param Node $node
+     * @param int $bit_set
+     */
+    private static function markNode($node, $bit_set)
+    {
+        $kind = $node->kind;
+        if (\array_key_exists($kind, self::FLAGS_NODE_TYPE_SET)) {
+            $node->flags |= $bit_set;
+        } elseif ($kind === ast\AST_ARRAY) {
+            // flags and children are single-purpose right now
+            self::markArrayElements($node->children, $bit_set);
+        } else {
+            $node->children[self::PHAN_NODE_FLAGS] = $bit_set;
+        }
+    }
+
+    private static function initInner()
+    {
+        /**
+         * @param Node $node
+         * @return void
+         */
+        $binary_op_handler = function ($node) {
+            if ($node->flags === flags\BINARY_COALESCE) {
+                $inner_node = $node->children['left'];
+                if ($inner_node instanceof Node) {
+                    self::markNode($inner_node, self::FLAG_IGNORE_NULLABLE_AND_UNDEF);
+                }
+            }
+        };
+        /**
+         * @param Node $node
+         * @return void
+         */
+        $dim_handler = function ($node) {
+            if ($node->flags & self::FLAG_IGNORE_NULLABLE_AND_UNDEF) {
+                $inner_node = $node->children['expr'];
+                if ($inner_node instanceof Node) {
+                    self::markNode($inner_node, self::FLAG_IGNORE_NULLABLE_AND_UNDEF);
+                }
+            }
+        };
+
+        /**
+         * @param Node $node
+         * @return void
+         */
+        $ignore_nullable_and_undef_handler = function ($node) {
+            $inner_node = $node->children['var'];
+            if ($inner_node instanceof Node) {
+                self::markNode($inner_node, self::FLAG_IGNORE_NULLABLE_AND_UNDEF);
+            }
+        };
+
+        /**
+         * @param Node $node
+         * @return void
+         */
+        $ignore_nullable_and_undef_expr_handler = function ($node) {
+            $inner_node = $node->children['expr'];
+            if ($inner_node instanceof Node) {
+                self::markNode($inner_node, self::FLAG_IGNORE_NULLABLE_AND_UNDEF);
+            }
+        };
+        /**
+         * @param Node $node
+         * @return void
+         */
+        $ast_array_elem_handler = function ($node) {
+            // Handle [$a1, $a2] = $array; - Don't warn about $node
+            $bit = $node->flags & self::FLAG_IGNORE_UNDEF;
+            if ($bit) {
+                $inner_node = $node->children['value'];
+                if (($inner_node instanceof Node)) {
+                    self::markNode($inner_node, $bit);
+                }
+            }
+        };
+
+        self::$closures_for_kind = [
+            ast\AST_BINARY_OP => $binary_op_handler,
+            ast\AST_DIM => $dim_handler,
+            ast\AST_EMPTY => $ignore_nullable_and_undef_expr_handler,
+            ast\AST_ISSET => $ignore_nullable_and_undef_handler,
+            ast\AST_UNSET => $ignore_nullable_and_undef_handler,
+            ast\AST_ASSIGN => $ignore_nullable_and_undef_handler,
+            ast\AST_ASSIGN_REF => $ignore_nullable_and_undef_handler,
+            // Skip over AST_ARRAY
+            ast\AST_ARRAY_ELEM => $ast_array_elem_handler,
+        ];
+    }
+
+    /**
+     * @param Node|array|bool|int|float $node
+     * @return void
+     */
+    public static function applyFull($node)
+    {
+        if ($node instanceof Node) {
+            $closure = self::$closures_for_kind[$node->kind] ?? null;
+            if ($closure !== null) {
+                $closure($node);
+            }
+            foreach ($node->children as $inner) {
+                self::applyFull($inner);
+            }
+        } elseif (\is_array($node)) {
+            foreach ($node as $inner) {
+                self::applyFull($inner);
+            }
+        }
+    }
+
+    /**
+     * @return void
+     */
+    private static function applyToScopeInner($node)
+    {
+        if ($node instanceof Node) {
+            $kind = $node->kind;
+            if ($kind === ast\AST_CLASS || $kind === ast\AST_FUNC_DECL || $kind === ast\AST_CLOSURE) {
+                return;
+            }
+
+            $closure = self::$closures_for_kind[$kind] ?? null;
+            if ($closure !== null) {
+                $closure($node);
+            }
+            foreach ($node->children as $inner) {
+                self::applyToScopeInner($inner);
+            }
+        } elseif (\is_array($node)) {
+            foreach ($node as $inner) {
+                self::applyToScopeInner($inner);
+            }
+        }
+    }
+
+    /**
+     * @param Node $node a node beginning a scope such as AST_FUNC, AST_STMT_LIST, AST_METHOD, etc. (Assumes these nodes don't have any annotations.
+     * @return void
+     */
+    public static function applyToScope(Node $node)
+    {
+        foreach ($node->children as $inner) {
+            self::applyToScopeInner($inner);
+        }
+    }
+}
+PhanAnnotationAdder::init();

--- a/src/Phan/AST/PhanAnnotationAdder.php
+++ b/src/Phan/AST/PhanAnnotationAdder.php
@@ -13,12 +13,15 @@ use ast\flags;
  * and returns the new Node.
  * The original \ast\Node objects are not modified.
  *
- * This adds to $node->children - Many of these types can have null
+ * This adds to $node->children - Many different AST node kinds can be used in places Phan needs to know about
+ * (for being potentially null/undefined)
  *
  * Current annotations:
  *
  * 1. Mark $x in isset($x['key']['nested']) as being acceptable to have null offsets.
  *    Same for $x in $x ?? null, empty($x['offset']), and so on.
+ * 2. Mark $x and $x['key'] in "$x['key'] = $y" as being acceptable to be null or undefined.
+ *    and so on (e.g. ['key' => $x[0]] = $y)
  */
 class PhanAnnotationAdder
 {

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1069,8 +1069,6 @@ class UnionTypeVisitor extends AnalysisVisitor
 
     /** @internal - Duplicated for performance. Use PhanAnnotationAdder instead */
     const FLAG_IGNORE_NULLABLE = 1 << 29;
-    /** @internal - Duplicated for performance. Use PhanAnnotationAdder instead */
-    const FLAG_IGNORE_UNDEF = 1 << 30;
 
     /**
      * Visit a node with kind `\ast\AST_DIM`

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1067,6 +1067,11 @@ class UnionTypeVisitor extends AnalysisVisitor
         return BoolType::instance(false)->asUnionType();
     }
 
+    /** @internal - Duplicated for performance. Use PhanAnnotationAdder instead */
+    const FLAG_IGNORE_NULLABLE = 1 << 29;
+    /** @internal - Duplicated for performance. Use PhanAnnotationAdder instead */
+    const FLAG_IGNORE_UNDEF = 1 << 30;
+
     /**
      * Visit a node with kind `\ast\AST_DIM`
      *
@@ -1126,13 +1131,13 @@ class UnionTypeVisitor extends AnalysisVisitor
         );
 
         // Figure out what the types of accessed array
-        // elements would be
+        // elements would be.
         $generic_types =
             $union_type->genericArrayElementTypes();
 
         // If we have generics, we're all set
         if (!$generic_types->isEmpty()) {
-            if ($this->isSuspiciousNullable($union_type)) {
+            if ($this->isSuspiciousNullable($union_type) && !($node->flags & self::FLAG_IGNORE_NULLABLE)) {
                 $this->emitIssue(
                     Issue::TypeArraySuspiciousNullable,
                     $node->lineno ?? 0,

--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -3,6 +3,7 @@ namespace Phan;
 
 use Phan\AST\ASTSimplifier;
 use Phan\AST\Parser;
+use Phan\AST\PhanAnnotationAdder;
 use Phan\AST\TolerantASTConverter\ParseException;
 use Phan\AST\Visitor\Element;
 use Phan\Analysis\DuplicateFunctionAnalyzer;
@@ -135,7 +136,6 @@ class Analysis
                 );
             }
         }
-
 
         $context = self::parseNodeInContext(
             $code_base,
@@ -520,6 +520,7 @@ class Analysis
                 );
             }
         }
+        PhanAnnotationAdder::applyFull($node);
 
         $context = (new BlockAnalysisVisitor($code_base, $context))($node);
         $context->warnAboutUnusedUseElements($code_base);

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -356,6 +356,7 @@ class ConditionVisitor extends KindVisitorImplementation
 
     private function checkComplexIsset(Node $var_node) : Context
     {
+        // TODO: isset($obj->prop['offset']) should imply $obj is not null (removeNullFromVariable)
         $context = $this->context;
         if ($var_node->kind === \ast\AST_DIM) {
             $expr_node = $var_node;
@@ -392,7 +393,6 @@ class ConditionVisitor extends KindVisitorImplementation
                     $this->context = $context;
                 }
             }
-            $this->checkVariablesDefined($var_node);
         }
         return $context;
     }

--- a/tests/Phan/BaseTest.php
+++ b/tests/Phan/BaseTest.php
@@ -13,6 +13,9 @@ abstract class BaseTest extends TestCase
     // Needed to prevent phpunit from backing up these private static variables.
     // See https://phpunit.de/manual/current/en/fixtures.html#fixtures.global-state
     protected $backupStaticAttributesBlacklist = [
+        'Phan\AST\PhanAnnotationAdder' => [
+            'closures_for_kind',
+        ],
         'Phan\Language\Type' => [
             'canonical_object_map',
             'internal_fn_cache',

--- a/tests/Phan/Language/UnionTypeTest.php
+++ b/tests/Phan/Language/UnionTypeTest.php
@@ -45,6 +45,9 @@ class UnionTypeTest extends BaseTest
     // Based on BaseTest
     // TODO: Investigate instantiating CodeBase in a cheaper way (lazily?)
     protected $backupStaticAttributesBlacklist = [
+        'Phan\AST\PhanAnnotationAdder' => [
+            'closures_for_kind',
+        ],
         'Phan\Language\Type' => [
             'canonical_object_map',
             'internal_fn_cache',

--- a/tests/files/expected/0464_false_positive_nullable.php.expected
+++ b/tests/files/expected/0464_false_positive_nullable.php.expected
@@ -1,0 +1,3 @@
+%s:3 PhanTypeMismatchArgumentInternal Argument 1 (input) is ?array but \array_values() takes array
+%s:17 PhanTypeArraySuspiciousNullable Suspicious array access to nullable ?array
+%s:18 PhanTypeArraySuspiciousNullable Suspicious array access to nullable ?array

--- a/tests/files/src/0464_false_positive_nullable.php
+++ b/tests/files/src/0464_false_positive_nullable.php
@@ -1,0 +1,28 @@
+<?php
+function test464(string $key, array $arr = null, array $arr2 = null) {
+    var_export(array_values($arr));
+    if (isset($arr[$key])) {
+        var_export(array_values($arr));
+    }
+    if (isset($arr2[$key][0])) {
+        var_export(array_values($arr2));
+    }
+}
+
+// TODO: Avoid false positives via https://github.com/phan/phan/issues/642#issuecomment-376386284
+function testCoalesce464(string $key, string $key2, array $arr = null, array $arr2 = null) {
+    echo $arr[$key] ?? null;
+    echo $arr2[$key][$key2] ?? null;
+    echo $arr2['x']['y'] ?? null;
+    echo $arr2['other'];  // This should warn, the coalescing checks shouldn't
+    echo $arr2['other2']['inner'];  // This should warn, the coalescing checks shouldn't
+    // And isset/coalescing checks shouldn't warn
+    var_export(!isset($arr2['other2']['inner2b']));
+    var_export(empty($arr2['other3']['inner3']));
+    var_export(isset($arr2['other4']));
+    var_export(isset($arr2['other4']));
+
+    // TODO: Warn when an isset check might not make sense
+    // $bool = rand() % 2 > 0;
+    // var_export(isset($bool['key']));
+}


### PR DESCRIPTION
Fixes #642

This uses a similar approach to BlockExitStatusChecker and uses flags for
everything where an exact flag match isn't required
(Everything here except AST_BINARY_OP with flags AST_COALESCE)

A large number of method/function bodies aren't analyzed by Phan.
Don't add annotations flags for those nodes.