### PR TITLE
Fixes #1560: appending an unknown type to an array should modify array shape or generic array

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@ New Features(Analysis)
 
 Bug Fixes
 + Analyze conditionals wrapped by `@(cond)` (e.g. `if (@array_key_exists('key', $array)) {...}`) (#1591)
++ Appending an unknown type to an array shape should update Phan's inferred keys(int) and values(mixed) of an array. (#1560)
 
 24 Mar 2018, Phan 0.12.3
 ------------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@ New Features(Analysis)
   That type is equivalent to `bool|float|int|string`.
 
 Bug Fixes
++ Don't emit false positive `PhanTypeArraySuspiciousNullable`, etc. for complex isset/empty/unset expressions. (#642)
 + Analyze conditionals wrapped by `@(cond)` (e.g. `if (@array_key_exists('key', $array)) {...}`) (#1591)
 + Appending an unknown type to an array shape should update Phan's inferred keys(int) and values(mixed) of an array. (#1560)
 

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -540,8 +540,16 @@ class AssignmentVisitor extends AnalysisVisitor
             } else {
                 $key_type_enum = GenericArrayType::KEY_INT;
             }
-            $right_type =
-                $this->right_type->asGenericArrayTypes($key_type_enum);
+            $right_inner_type = $this->right_type;
+            if ($right_inner_type->isEmpty()) {
+                if ($key_type_enum === GenericArrayType::KEY_MIXED) {
+                    $right_type = ArrayType::instance(false)->asUnionType();
+                } else {
+                    $right_type = GenericArrayType::fromElementType(MixedType::instance(false), false, $key_type_enum)->asUnionType();
+                }
+            } else {
+                $right_type = $right_inner_type->asGenericArrayTypes($key_type_enum);
+            }
         }
 
         // Recurse into whatever we're []'ing

--- a/src/Phan/Language/Type/ArrayShapeType.php
+++ b/src/Phan/Language/Type/ArrayShapeType.php
@@ -61,6 +61,11 @@ final class ArrayShapeType extends ArrayType
         return $this->field_types;
     }
 
+    public function isNotEmptyArrayShape() : bool
+    {
+        return \count($this->field_types) !== 0;
+    }
+
     /**
      * @param int|string $field_key
      */

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -320,11 +320,11 @@ final class GenericArrayType extends ArrayType
         foreach ($union_type->getTypeSet() as $type) {
             if ($type instanceof GenericArrayType) {
                 $key_types |= $type->key_type;
-                continue;
                 // TODO: support array shape as well?
             } elseif ($type instanceof ArrayShapeType) {
-                $key_types |= $type->getKeyType();
-                continue;
+                if ($type->isNotEmptyArrayShape()) {
+                    $key_types |= $type->getKeyType();
+                }
             }
         }
         // int|string corresponds to KEY_MIXED (KEY_INT|KEY_STRING)

--- a/tests/files/expected/0465_append_changes_shape.php.expected
+++ b/tests/files/expected/0465_append_changes_shape.php.expected
@@ -1,0 +1,2 @@
+%s:3 PhanUndeclaredVariable Variable $this is undeclared
+%s:5 PhanTypeMismatchDimFetch When fetching an array index from a value of type array<int,mixed>|array{}, found an array index of type string, but expected the index to be of type int

--- a/tests/files/expected/0466_append_modifies_array_shape.php.expected
+++ b/tests/files/expected/0466_append_modifies_array_shape.php.expected
@@ -1,0 +1,4 @@
+%s:4 PhanUndeclaredVariable Variable $this is undeclared
+%s:7 PhanTypeMismatchDimFetch When fetching an array index from a value of type array<int,mixed>|array{}, found an array index of type string, but expected the index to be of type int
+%s:8 PhanTypeMismatchDimFetch When fetching an array index from a value of type array<int,mixed>|array{}, found an array index of type string, but expected the index to be of type int
+%s:9 PhanTypeMismatchArgumentInternal Argument 1 (string) is array<int,mixed>|array{} but \strlen() takes string

--- a/tests/files/src/0465_append_changes_shape.php
+++ b/tests/files/src/0465_append_changes_shape.php
@@ -1,0 +1,5 @@
+<?php
+$x = [];
+$x[] = $this->undefVar;  // Expected PhanUndeclaredVariable
+echo $x[0];
+echo $x['key'];

--- a/tests/files/src/0466_append_modifies_array_shape.php
+++ b/tests/files/src/0466_append_modifies_array_shape.php
@@ -1,0 +1,10 @@
+<?php
+call_user_func(function() {
+    $x = [];
+    $x[] = $this->undefVar;  // Expected PhanUndeclaredVariable
+    echo $x[0];
+    $s = 'key';
+    echo $x[$s];
+    echo $x['key2'];
+    echo strlen($x);
+});


### PR DESCRIPTION
Phan should infer that int is a possibly key type, and mixed is a possible value type