### PR TITLE
 Add a config setting to perform strict checks of return statements

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -213,6 +213,7 @@ return [
         'PhanPossiblyFalseTypeArgumentInternal',
         'PhanPossiblyNullTypeArgument',
         'PhanPossiblyNullTypeArgumentInternal',
+        'PhanPossiblyNullTypeReturn',
         // 'PhanUndeclaredMethod',
     ],
 

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -56,6 +56,12 @@ return [
     // (For self-analysis, Phan has a large number of suppressions and file-level suppressions, due to \ast\Node being difficult to type check)
     'strict_param_checking' => true,
 
+    // If enabled, Phan will warn if **any** type in the argument's type
+    // cannot be cast to a type in the parameter's expected type.
+    // Setting this to true will introduce a large number of false positives (and some bugs).
+    // (For self-analysis, Phan has a large number of suppressions and file-level suppressions, due to \ast\Node being difficult to type check)
+    'strict_return_checking' => true,
+
     // If enabled, scalars (int, float, bool, string, null)
     // are treated as if they can cast to each other.
     // This does not affect checks of array keys. See scalar_array_key_cast.

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,11 +4,19 @@ Phan NEWS
 ------------------------
 
 New Features(CLI, Configs)
-+ Add a `strict_param_checking` config setting.
++ Add a `strict_param_checking` config setting. (And a `--strict-param-checking` CLI flag)
   If this is set to true, then Phan will warn if at least one of the types
   in an argument's union type can't cast to the expected parameter type.
-  New issue types: `PartialTypeMismatchArgument`, `PossiblyNullTypeArgument`, and `PossiblyFalseTypeArgument`
+  New issue types: `PhanPartialTypeMismatchArgument`, `PhanPossiblyNullTypeArgument`, and `PhanPossiblyFalseTypeArgument`
   (along with equivalents for internal functions and methods)
+
+  Setting this to true will likely introduce large numbers of warnings.
+  Those issue types would need to be suppressed entirely,
+  or with `@phan-file-suppress`, or with `@suppress`.
++ Add a `strict_return_checking` config setting. (And a `--strict-return-checking` CLI flag)
+  If this is set to true, then Phan will warn if at least one of the types
+  in a return statement's union type can't cast to the expected return type type.
+  New issue types: `PhanPartialTypeMismatchReturn`, `PhanPossiblyNullTypeReturn`, and `PhanPossiblyFalseTypeReturn`
 
   Setting this to true will likely introduce large numbers of warnings.
   Those issue types would need to be suppressed entirely,
@@ -19,8 +27,10 @@ New Features(Analysis)
   (Check if an earlier catch statement caught an ancestor of a given catch statement)
 + Support phpdoc3's `scalar` type in phpdoc. (#1589)
   That type is equivalent to `bool|float|int|string`.
-+ Improve inferences about ternary conditionals.
++ Improve analysis of return statements with ternary conditionals (e.g. `return $a ?: $b`).
 + Start analyzing negated `instanceof` conditionals such as `assert(!($x instanceof MyClass))`.
++ Infer that the reference parameter's resulting type for `preg_match` is a `string[]`, not `array` (when possible)
+  (And that the type is `array{0:string,1:int}` when `PREG_OFFSET_CAPTURE` is passed as a flag)
 
 Bug Fixes
 + Don't emit false positive `PhanTypeArraySuspiciousNullable`, etc. for complex isset/empty/unset expressions. (#642)
@@ -28,6 +38,7 @@ Bug Fixes
 + Appending an unknown type to an array shape should update Phan's inferred keys(int) and values(mixed) of an array. (#1560)
 + Make line numbers for arguments more accurate
 + Infer that the result of `|` or `&` on two strings is a string.
++ Fix a crash caused by empty FQSENs for classlike names or function names (#1616)
 
 24 Mar 2018, Phan 0.12.3
 ------------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,7 @@ Bug Fixes
 + Analyze conditionals wrapped by `@(cond)` (e.g. `if (@array_key_exists('key', $array)) {...}`) (#1591)
 + Appending an unknown type to an array shape should update Phan's inferred keys(int) and values(mixed) of an array. (#1560)
 + Make line numbers for arguments more accurate
++ Infer that the result of `|` or `&` on two strings is a string.
 
 24 Mar 2018, Phan 0.12.3
 ------------------------

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -1089,20 +1089,33 @@ $v8->f();
 
 ## PhanPartialTypeMismatchArgument
 
+This issue (and similar issues) may be emitted when `strict_param_checking` is true, when analyzing a user-defined function.
+(when some types of the argument's union type match, but not others.)
+
 ```
 Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE}() takes {TYPE} ({TYPE} is incompatible) defined at {FILE}:{LINE}
 ```
 
 ## PhanPartialTypeMismatchArgumentInternal
 
+This issue may be emitted when `strict_param_checking` is true, when analyzing an internal function.
+
 ```
 Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE}() takes {TYPE} ({TYPE} is incompatible)
 ```
 
+## PhanPartialTypeMismatchReturn
+
+This issue (and similar issues) may be emitted when `strict_return_checking` is true
+(when some types of the return statement's union type match, but not others.)
+
+```
+Returning type {TYPE} but {FUNCTIONLIKE}() is declared to return {TYPE} ({TYPE} is incompatible)
+```
+
 ## PhanPossiblyFalseTypeArgument
 
-This issue (and other `PhanPossibly*` issues) may be emitted when `strict_param_checking` is true
-(when some types of the argument match, but not others.)
+This issue may be emitted when `strict_param_checking` is true
 
 ```
 Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE}() takes {TYPE} ({TYPE} is incompatible) defined at {FILE}:{LINE}
@@ -1110,11 +1123,23 @@ Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE}() takes {TYPE} ({TYPE
 
 ## PhanPossiblyFalseTypeArgumentInternal
 
+This issue may be emitted when `strict_param_checking` is true
+
 ```
 Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE}() takes {TYPE} ({TYPE} is incompatible)
 ```
 
+## PhanPossiblyFalseTypeReturn
+
+This issue may be emitted when `strict_return_checking` is true
+
+```
+Returning type {TYPE} but {FUNCTIONLIKE}() is declared to return {TYPE} ({TYPE} is incompatible)
+```
+
 ## PhanPossiblyNullTypeArgument
+
+This issue may be emitted when `strict_param_checking` is true
 
 ```
 Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE}() takes {TYPE} ({TYPE} is incompatible) defined at {FILE}:{LINE}
@@ -1122,8 +1147,18 @@ Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE}() takes {TYPE} ({TYPE
 
 ## PhanPossiblyNullTypeArgumentInternal
 
+This issue may be emitted when `strict_param_checking` is true
+
 ```
 Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE}() takes {TYPE} ({TYPE} is incompatible)
+```
+
+## PhanPossiblyNullTypeReturn
+
+This issue may be emitted when `strict_return_checking` is true
+
+```
+Returning type {TYPE} but {FUNCTIONLIKE}() is declared to return {TYPE} ({TYPE} is incompatible)
 ```
 
 ## PhanTypeArrayOperator
@@ -2060,4 +2095,3 @@ Emitted for syntax errors.
 
 This emits warnings for unparseable PHP files (detected by `php-ast`).
 Note: This is not the same thing as running `php -l` on a file - PhanSyntaxError checks for syntax errors, but not sematics such as where certain expressions can occur (Which `php -l` would check for).
-

--- a/internal/internalsignatures.php
+++ b/internal/internalsignatures.php
@@ -727,7 +727,7 @@ class IncompatibleXMLSignatureDetector extends IncompatibleSignatureDetectorBase
                 $param_name .= '=';
             }
 
-            $result[$param_name] = static::toTypeString($part->type);
+            $result[$param_name] = self::toTypeString($part->type);
         }
         return $result;
     }

--- a/internal/internalsignatures.php
+++ b/internal/internalsignatures.php
@@ -707,7 +707,7 @@ class IncompatibleXMLSignatureDetector extends IncompatibleSignatureDetectorBase
     }
 
     /**
-     * @return array<int,string>
+     * @return array<string,string>
      */
     private function extractMethodParams(SimpleXMLElement $param)
     {

--- a/internal/update_wiki_issue_types.php
+++ b/internal/update_wiki_issue_types.php
@@ -153,9 +153,13 @@ EOT;
                 $writer->append($placeholder);
             }
         }
+
+        // Get the new file contents, and normalize the whitespace at the end of the file.
+        $contents = rtrim($writer->getContents()) . "\n";
+
         $wiki_filename_new = $wiki_filename . '.new';
         fwrite(STDERR, str_repeat('-', 80) . "\nSaving to '$wiki_filename_new'\n");
-        file_put_contents($wiki_filename_new, $writer->getContents());
+        file_put_contents($wiki_filename_new, $contents);
     }
 }
 WikiIssueTypeUpdater::main();

--- a/src/Phan/AST/ASTSimplifier.php
+++ b/src/Phan/AST/ASTSimplifier.php
@@ -114,6 +114,7 @@ class ASTSimplifier
     /**
      * @param array<int,?Node|?float|?int|?string|?float|?bool> $statements
      * @return array{0:array<int,\ast\Node>,1:bool} - [New/old list, bool $modified] An equivalent list after simplifying (or the original list)
+     * @suppress PhanPartialTypeMismatchReturn
      */
     private function normalizeStatementList(array $statements) : array
     {
@@ -280,6 +281,7 @@ class ASTSimplifier
     private function applyAssignInLeftSideOfBinaryOpReduction(Node $node) : array
     {
         $inner_assign_statement = $node->children[0]->children['cond']->children['left'];
+        \assert($inner_assign_statement instanceof Node);  // already checked
         $inner_assign_var = $inner_assign_statement->children['var'];
 
         \assert($inner_assign_var->kind === \ast\AST_VAR);
@@ -304,6 +306,7 @@ class ASTSimplifier
         $inner_assign_statement = $node->children[0]->children['cond']->children['right'];
         $inner_assign_var = $inner_assign_statement->children['var'];
 
+        \assert($inner_assign_statement instanceof Node);
         \assert($inner_assign_var->kind === \ast\AST_VAR);
 
         $new_node_elem = clone($node->children[0]);
@@ -404,6 +407,7 @@ class ASTSimplifier
     private function applyIfAssignReduction(Node $node) : array
     {
         $outer_assign_statement = $node->children[0]->children['cond'];
+        \assert($outer_assign_statement instanceof Node);
         $new_node_elem = clone($node->children[0]);
         $new_node_elem->children['cond'] = $new_node_elem->children['cond']->children['var'];
         $new_node_elem->flags = 0;

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -1793,7 +1793,7 @@ class ContextNode
      * @see $this->getEquivalentPHPValue
      *
      * @param Node|float|int|string $node
-     * @return Node|Node[]|string[]|int[]|float[]|string|float|int|bool|null -
+     * @return Node|string[]|int[]|float[]|string|float|int|bool|null -
      *         If this could be resolved and we're certain of the value, this gets a raw PHP value for $node.
      *         Otherwise, this returns $node.
      */
@@ -1915,7 +1915,9 @@ class ContextNode
      *
      * This does not create new object instances.
      *
-     * @return Node|string[]|int[]|float[]|string|float|int|bool|null - If this could be resolved and we're certain of the value, this gets an equivalent definition. Otherwise, this returns $node.
+     * @return Node|string[]|int[]|float[]|string|float|int|bool|null -
+     *   If this could be resolved and we're certain of the value, this gets an equivalent definition.
+     *   Otherwise, this returns $node.
      * @throws InvalidArgumentException if the object could not be determined - Callers must catch this.
      */
     public function getEquivalentPHPValue(int $flags = self::RESOLVE_DEFAULT)
@@ -1934,6 +1936,7 @@ class ContextNode
      *         Otherwise, this returns $node. If this would be an array, this returns $node.
      *
      * @throws InvalidArgumentException if the object could not be determined - Callers must catch this.
+     * @suppress PhanPartialTypeMismatchReturn the flags prevent this from returning an array
      */
     public function getEquivalentPHPScalarValue()
     {

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -68,6 +68,8 @@ if (!class_exists('\ast\Node')) {
  * SOFTWARE.
  *
  * @phan-file-suppress PhanPartialTypeMismatchArgument
+ * @phan-file-suppress PhanPossiblyNullTypeReturn
+ * @phan-file-suppress PhanPartialTypeMismatchReturn
  */
 final class TolerantASTConverter
 {
@@ -181,6 +183,7 @@ final class TolerantASTConverter
      * @param int $ast_version
      * @param string $file_contents
      * @return ast\Node
+     * @suppress PhanPartialTypeMismatchReturn this should always be passed a statement list
      */
     public function phpParserToPhpast(PhpParser\Node $parser_node, int $ast_version, string $file_contents)
     {

--- a/src/Phan/Analysis/ArgumentType.php
+++ b/src/Phan/Analysis/ArgumentType.php
@@ -588,8 +588,8 @@ class ArgumentType
                     // If we are not in strict mode and we accept a string parameter
                     // and the argument we are passing has a __toString method then it is ok
                     if (!$context->getIsStrictTypes() && $parameter_type->hasType(StringType::instance(false))) {
-                        if (self::hasToString($code_base, $context, $individual_type_expanded)) {
-                            continue;
+                        if ($individual_type_expanded->hasClassWithToStringMethod($code_base, $context)) {
+                            continue;  // don't warn about $type
                         }
                     }
                 }
@@ -650,23 +650,6 @@ class ArgumentType
             }
         }
         return $is_internal ? Issue::PartialTypeMismatchArgumentInternal : Issue::PartialTypeMismatchArgument;
-    }
-
-    private static function hasToString(
-        CodeBase $code_base,
-        Context $context,
-        UnionType $individual_type_expanded
-    ) : bool {
-        try {
-            foreach ($individual_type_expanded->asClassList($code_base, $context) as $clazz) {
-                if ($clazz->hasMethodWithName($code_base, "__toString")) {
-                    return true;
-                }
-            }
-        } catch (CodeBaseException $e) {
-            // Swallow "Cannot find class", go on to emit issue
-        }
-        return false;
     }
 
     /**

--- a/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
+++ b/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
@@ -103,6 +103,23 @@ class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
         ]));
     }
 
+    /**
+     * Analyzes the `<=>` operator.
+     *
+     * @param Node $node @phan-unused-param
+     * A node to check types on
+     *
+     * @return UnionType
+     * The resulting type(s) of the binary operation
+     */
+    public function visitBinarySpaceship(Node $node) : UnionType
+    {
+        // TODO: Any sanity checks should go here.
+
+        // <=> returns -1, 0, or 1
+        return IntType::instance(false)->asUnionType();
+    }
+
     // Code can bitwise xor strings byte by byte in PHP
     public function visitBinaryBitwiseXor(Node $node) : UnionType
     {

--- a/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
+++ b/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
@@ -120,8 +120,32 @@ class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
         return IntType::instance(false)->asUnionType();
     }
 
-    // Code can bitwise xor strings byte by byte in PHP
+    /**
+     * Code can bitwise xor strings byte by byte in PHP
+     * @override
+     */
     public function visitBinaryBitwiseXor(Node $node) : UnionType
+    {
+        return $this->analyzeBinaryBitwiseCommon($node);
+    }
+
+    /**
+     * @override
+     */
+    public function visitBinaryBitwiseOr(Node $node) : UnionType
+    {
+        return $this->analyzeBinaryBitwiseCommon($node);
+    }
+
+    /**
+     * @override
+     */
+    public function visitBinaryBitwiseAnd(Node $node) : UnionType
+    {
+        return $this->analyzeBinaryBitwiseCommon($node);
+    }
+
+    private function analyzeBinaryBitwiseCommon(Node $node) : UnionType
     {
         $left = UnionTypeVisitor::unionTypeFromNode(
             $this->code_base,

--- a/src/Phan/Analysis/ContextMergeVisitor.php
+++ b/src/Phan/Analysis/ContextMergeVisitor.php
@@ -195,6 +195,8 @@ class ContextMergeVisitor extends KindVisitorImplementation
      * @return Context
      * A new or an unchanged context resulting from
      * parsing the node
+     *
+     * @suppress PhanPossiblyFalseTypeReturn child_context_list is not empty
      */
     public function visitIf(Node $node) : Context
     {

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -814,7 +814,6 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         // Figure out what is actually being returned
         // TODO: Properly check return values of array shapes
         foreach ($this->getReturnTypes($context, $node->children['expr']) as $expression_type) {
-
             // If there is no declared type, see if we can deduce
             // what it should be based on the return type
             if ($method_return_type->isEmpty()
@@ -835,7 +834,6 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
 
             // Check if the return type is compatible with the declared return type.
             if (!$method->isReturnTypeUndefined()) {
-
                 // We allow base classes to cast to subclasses, and subclasses to cast to baseclasses,
                 // but don't allow subclasses to cast to subclasses on a separate branch of the inheritance tree
                 if (!$this->checkCanCastToReturnType($code_base, $expression_type, $method_return_type)) {
@@ -930,6 +928,10 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             return;
         }
 
+        // If we have TypeMismatchReturn already, then also suppress the partial mismatch warnings as well.
+        if ($this->context->hasSuppressIssue($code_base, Issue::TypeMismatchReturn)) {
+            return;
+        }
         $this->emitIssue(
             self::getStrictIssueType($mismatch_type_set),
             $node->lineno ?? 0,

--- a/src/Phan/Analysis/ScopeVisitor.php
+++ b/src/Phan/Analysis/ScopeVisitor.php
@@ -162,6 +162,8 @@ abstract class ScopeVisitor extends AnalysisVisitor
      *
      * @return array<string,array{0:int,1:FullyQualifiedGlobalStructuralElement,2:int}>
      * A map from alias to target
+     *
+     * @suppress PhanPartialTypeMismatchReturn TODO: investigate
      */
     private function aliasTargetMapFromUseNode(
         Node $node,

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -128,6 +128,7 @@ class CLI
                 'require-config-exists',
                 'signature-compatibility',
                 'strict-param-checking',
+                'strict-return-checking',
                 'target-php-version',
                 'use-fallback-parser',
                 'version',
@@ -363,6 +364,9 @@ class CLI
                     break;
                 case 'strict-param-checking':
                     Config::setValue('strict_param_checking', true);
+                    break;
+                case 'strict-return-checking':
+                    Config::setValue('strict_return_checking', true);
                     break;
                 case 's':
                 case 'daemonize-socket':
@@ -719,6 +723,9 @@ Usage: {$argv[0]} [options] [files...]
 
  --strict-param-checking
   Enables the config option `strict_param_checking`.
+
+ --strict-return-checking
+  Enables the config option `strict_return_checking`.
 
  --use-fallback-parser
   If a file to be analyzed is syntactically invalid

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -567,6 +567,7 @@ class CLI
     /**
      * @return array<int,string>
      * Get the set of files to analyze
+     * @suppress PhanPartialTypeMismatchReturn other types get inferred from assignments
      */
     public function getFileList() : array
     {

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -59,6 +59,8 @@ use ReflectionClass;
  *
  * This supports undoing some operations in the parse phase,
  * for a background daemon analyzing single files. (Phan\CodeBase\UndoTracker)
+ *
+ * @phan-file-suppress PhanPartialTypeMismatchReturn the way generic objects is type hinted is inadequate, etc.
  */
 class CodeBase
 {

--- a/src/Phan/CodeBase/UndoTracker.php
+++ b/src/Phan/CodeBase/UndoTracker.php
@@ -143,6 +143,7 @@ class UndoTracker
     /**
      * @param CodeBase $code_base - code base owning this tracker
      * @param array<int,string> $new_file_list
+     * @param array<string,string> $file_mapping_contents
      * @return array<int,string> - Subset of $new_file_list which changed on disk and has to be parsed again. Automatically unparses the old versions of files which were modified.
      */
     public function updateFileList(CodeBase $code_base, array $new_file_list, array $file_mapping_contents)

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -56,6 +56,9 @@ class Config
     private static $strict_param_checking = false;
 
     /** @var bool */
+    private static $strict_return_checking = false;
+
+    /** @var bool */
     private static $track_references = false;
 
     /** @var bool */
@@ -224,8 +227,15 @@ class Config
 
         // If enabled, Phan will warn if **any** type in the argument's type
         // cannot be cast to a type in the parameter's expected type.
-        // Setting this to true will introduce a large number of false positives (and some bugs).
+        // Setting this to true will introduce a large number of false positives
+        // (and reveal some bugs).
         'strict_param_checking' => false,
+
+        // If enabled, Phan will warn if **any** type in the return value's type
+        // cannot be cast to a type in the declared return type.
+        // Setting this to true will introduce a large number of false positives
+        // (and reveal some bugs).
+        'strict_return_checking' => false,
 
         // If enabled, scalars (int, float, bool, string, null)
         // are treated as if they can cast to each other.
@@ -766,6 +776,11 @@ class Config
         return self::$strict_param_checking;
     }
 
+    public static function get_strict_return_checking() : bool
+    {
+        return self::$strict_param_checking;
+    }
+
     public static function get_null_casts_as_array() : bool
     {
         return self::$null_casts_as_array;
@@ -845,6 +860,9 @@ class Config
                 break;
             case 'strict_param_checking':
                 self::$strict_param_checking = $value;
+                break;
+            case 'strict_return_checking':
+                self::$strict_return_checking = $value;
                 break;
             case 'dead_code_detection':
             case 'force_tracking_references':

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -708,6 +708,7 @@ class Config
      * @return string
      * Get the root directory of the project that we're
      * scanning
+     * @suppress PhanPossiblyFalseTypeReturn getcwd() can technically be false, but we should have checked earlier
      */
     public static function getProjectRootDirectory() : string
     {

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -102,6 +102,9 @@ class Issue
     const TypeMismatchForeach       = 'PhanTypeMismatchForeach';
     const TypeMismatchProperty      = 'PhanTypeMismatchProperty';
     const TypeMismatchReturn        = 'PhanTypeMismatchReturn';
+    const PartialTypeMismatchReturn = 'PhanPartialTypeMismatchReturn';
+    const PossiblyNullTypeReturn  = 'PhanPossiblyNullTypeReturn';
+    const PossiblyFalseTypeReturn  = 'PhanPossiblyFalseTypeReturn';
     const TypeMismatchDeclaredReturn = 'PhanTypeMismatchDeclaredReturn';
     const TypeMismatchDeclaredReturnNullable = 'PhanTypeMismatchDeclaredReturnNullable';
     const TypeMismatchDeclaredParam = 'PhanTypeMismatchDeclaredParam';
@@ -889,6 +892,30 @@ class Issue
                 "Returning type {TYPE} but {FUNCTIONLIKE}() is declared to return {TYPE}",
                 self::REMEDIATION_B,
                 10005
+            ),
+            new Issue(
+                self::PartialTypeMismatchReturn,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                "Returning type {TYPE} but {FUNCTIONLIKE}() is declared to return {TYPE} ({TYPE} is incompatible)",
+                self::REMEDIATION_B,
+                10060
+            ),
+            new Issue(
+                self::PossiblyNullTypeReturn,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                "Returning type {TYPE} but {FUNCTIONLIKE}() is declared to return {TYPE} ({TYPE} is incompatible)",
+                self::REMEDIATION_B,
+                10061
+            ),
+            new Issue(
+                self::PossiblyFalseTypeReturn,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                "Returning type {TYPE} but {FUNCTIONLIKE}() is declared to return {TYPE} ({TYPE} is incompatible)",
+                self::REMEDIATION_B,
+                10062
             ),
             new Issue(
                 self::TypeMismatchDeclaredReturn,

--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -670,6 +670,7 @@ class Context extends FileRef
     /**
      * @param int $node_id
      * @return ?array{0:UnionType,1:Clazz[]} $result
+     * @suppress PhanPartialTypeMismatchReturn cache is mixed with other cache objects
      */
     public function getCachedClassListOfNode(int $node_id)
     {

--- a/src/Phan/Language/Element/AddressableElement.php
+++ b/src/Phan/Language/Element/AddressableElement.php
@@ -20,7 +20,7 @@ abstract class AddressableElement extends TypedElement implements AddressableEle
     protected $fqsen;
 
     /**
-     * @var FileRef[]
+     * @var array<string,FileRef>
      * A list of locations in which this typed structural
      * element is referenced from.
      * References from the same file and line are deduplicated to save memory.
@@ -201,6 +201,7 @@ abstract class AddressableElement extends TypedElement implements AddressableEle
     /**
      * @return array<string,FileRef>
      * A list of references to this typed structural element.
+     * @suppress PhanPartialTypeMismatchReturn TODO: investigate
      */
     public function getReferenceList() : array
     {

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -576,6 +576,7 @@ class Clazz extends AddressableElement
     /**
      * @return array<int,FullyQualifiedClassName>
      * Get the list of interfaces implemented by this class
+     * @suppress PhanPartialTypeMismatchReturn
      */
     public function getInterfaceFQSENList() : array
     {
@@ -1559,6 +1560,7 @@ class Clazz extends AddressableElement
     /**
      * @return array<int,FullyQualifiedClassName>
      * A list of FQSEN's for included traits
+     * @suppress PhanPartialTypeMismatchReturn TODO: investigate
      */
     public function getTraitFQSENList() : array
     {
@@ -2664,7 +2666,8 @@ class Clazz extends AddressableElement
     /**
      * @param array<string,UnionType> $template_parameter_type_map
      */
-    public function resolveParentTemplateType(array $template_parameter_type_map) : UnionType {
+    public function resolveParentTemplateType(array $template_parameter_type_map) : UnionType
+    {
         if (\count($template_parameter_type_map) === 0) {
             return UnionType::empty();
         }

--- a/src/Phan/Language/Element/Comment.php
+++ b/src/Phan/Language/Element/Comment.php
@@ -1144,6 +1144,8 @@ class Comment
      * @return Option<Type>
      * An optional Type defined by a (at)PhanClosureScope
      * directive specifying a single type.
+     *
+     * @suppress PhanPartialTypeMismatchReturn (Null)
      */
     public function getClosureScopeOption() : Option
     {
@@ -1164,6 +1166,7 @@ class Comment
      * @return array<string,CommentParameter> (maps the names of parameters to their values. Does not include parameters which didn't provide names)
      *
      * @suppress PhanUnreferencedPublicMethod
+     * @suppress PhanPartialTypeMismatchReturn (Null)
      */
     public function getParameterMap() : array
     {
@@ -1182,6 +1185,7 @@ class Comment
     /**
      * @return Option<Type>
      * An optional type declaring what a class extends.
+     * @suppress PhanPartialTypeMismatchReturn (Null)
      */
     public function getInheritedTypeOption() : Option
     {

--- a/src/Phan/Language/Element/Comment.php
+++ b/src/Phan/Language/Element/Comment.php
@@ -769,7 +769,6 @@ class Comment
     private static function templateTypeFromCommentLine(
         string $line
     ) {
-        $match = [];
         // TODO: Just use WORD_REGEX? Backslashes or nested templates wouldn't make sense.
         if (preg_match('/@template\s+(' . Type::simple_type_regex. ')/', $line, $match)) {
             $template_type_identifier = $match[1];

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -579,6 +579,8 @@ class Method extends ClassElement implements FunctionInterface
     /**
      * @return FullyQualifiedMethodName the FQSEN with the original definition (Even if this is private/protected and inherited from a trait). Used for dead code detection.
      *                                  Inheritance tests use getDefiningFQSEN() so that access checks won't break.
+     *
+     * @suppress PhanPartialTypeMismatchReturn TODO: Allow subclasses to make property types more specific
      */
     public function getRealDefiningFQSEN() : FullyQualifiedMethodName
     {

--- a/src/Phan/Language/Element/Property.php
+++ b/src/Phan/Language/Element/Property.php
@@ -72,6 +72,7 @@ class Property extends ClassElement
      *                                    Inheritance tests use getDefiningFQSEN() so that access checks won't break.
      *
      * @suppress PhanUnreferencedPublicMethod this is used, but the invocation could be one of multiple classes.
+     * @suppress PhanPartialTypeMismatchReturn TODO: Allow subclasses to make property types more specific
      */
     public function getRealDefiningFQSEN() : FullyQualifiedPropertyName
     {

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -993,4 +993,9 @@ final class EmptyUnionType extends UnionType
     {
         return false;
     }
+
+    public function hasClassWithToStringMethod(CodeBase $code_base, Context $context) : bool
+    {
+        return false;
+    }
 }

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -167,6 +167,17 @@ final class EmptyUnionType extends UnionType
 
     /**
      * @return bool
+     * True if this union type has any types that have generic
+     * types
+     * @override
+     */
+    public function hasTemplateParameterTypes() : bool
+    {
+        return false;
+    }
+
+    /**
+     * @return bool
      * True if this type has a type referencing the
      * class context 'static'.
      * @override

--- a/src/Phan/Language/Internal/PropertyMap.php
+++ b/src/Phan/Language/Internal/PropertyMap.php
@@ -16,6 +16,7 @@ $ast_node_shape_inner = \implode(',', [
     "right?:$ordinary_ast_node",
     "var?:ast\Node",
     "value?:$ordinary_ast_node",
+    "stmts?:?ast\Node",
 ]);
 
 $ast_node_children_types = 'array{' . $ast_node_shape_inner . '}|ast\Node[]|array[]|int[]|string[]|float[]|bool[]|null[]';

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -1708,10 +1708,10 @@ class Type
             }
 
             // Recurse up the tree to include all types
-            $representation = (string)$this;
+            $representation = $this->__toString();
             $recursive_union_type_builder = new UnionTypeBuilder();
             foreach ($union_type->getTypeSet() as $clazz_type) {
-                if ((string)$clazz_type != $representation) {
+                if ($clazz_type->__toString() !== $representation) {
                     $recursive_union_type_builder->addUnionType(
                         $clazz_type->asExpandedTypes(
                             $code_base,
@@ -1721,6 +1721,11 @@ class Type
                 } else {
                     $recursive_union_type_builder->addType($clazz_type);
                 }
+            }
+            if (!empty($this->template_parameter_type_list)) {
+                $recursive_union_type_builder->addUnionType(
+                    $clazz->resolveParentTemplateType($this->getTemplateParameterTypeMap($code_base))
+                );
             }
 
             // Add in aliases

--- a/src/Phan/Language/Type/FunctionLikeDeclarationType.php
+++ b/src/Phan/Language/Type/FunctionLikeDeclarationType.php
@@ -113,6 +113,7 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
 
     /**
      * @return ?ClosureDeclarationParameter
+     * @suppress PhanPossiblyFalseTypeReturn is_variadic implies at least one parameter exists.
      */
     public function getClosureParameterForArgument(int $i)
     {

--- a/src/Phan/Language/Type/NativeType.php
+++ b/src/Phan/Language/Type/NativeType.php
@@ -196,6 +196,11 @@ abstract class NativeType extends Type
     ) : UnionType {
         return $this->asUnionType();
     }
+
+    public function hasTemplateParameterTypes() : bool
+    {
+        return false;
+    }
 }
 \class_exists(ArrayType::class);
 \class_exists(ScalarType::class);

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -686,7 +686,7 @@ class UnionType implements \Serializable
             }
         }
 
-        return $has_template ? new UnionType($concrete_type_list) : $this;
+        return $has_template ? UnionType::of($concrete_type_list) : $this;
     }
 
     /**
@@ -698,6 +698,18 @@ class UnionType implements \Serializable
     {
         return $this->hasTypeMatchingCallback(function (Type $type) : bool {
             return ($type instanceof TemplateType);
+        });
+    }
+
+    /**
+     * @return bool
+     * True if this union type has any types that have generic
+     * types
+     */
+    public function hasTemplateParameterTypes() : bool
+    {
+        return $this->hasTypeMatchingCallback(function (Type $type) : bool {
+            return $type->hasTemplateParameterTypes();
         });
     }
 

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -2471,6 +2471,21 @@ class UnionType implements \Serializable
     {
         return false;
     }
+
+    // Assumes this was already expanded
+    public function hasClassWithToStringMethod(CodeBase $code_base, Context $context) : bool
+    {
+        try {
+            foreach ($this->asClassList($code_base, $context) as $clazz) {
+                if ($clazz->hasMethodWithName($code_base, "__toString")) {
+                    return true;
+                }
+            }
+        } catch (CodeBaseException $e) {
+            // Swallow "Cannot find class", go on to emit issue
+        }
+        return false;
+    }
 }
 
 UnionType::init();

--- a/src/Phan/Language/UnionTypeBuilder.php
+++ b/src/Phan/Language/UnionTypeBuilder.php
@@ -60,6 +60,7 @@ final class UnionTypeBuilder
 
     /**
      * @return array<int,Type>
+     * @suppress PhanPartialTypeMismatchReturn additional types were inferred
      */
     public function getTypeSet() : array
     {

--- a/src/Phan/LanguageServer/LanguageServer.php
+++ b/src/Phan/LanguageServer/LanguageServer.php
@@ -398,6 +398,10 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
         $file_path_list = ($this->file_path_lister)(true);
         $filtered_uris_to_analyze = [];
         foreach ($uris_to_analyze as $path_to_analyze => $uri) {
+            if (!is_string($uri)) {
+                Logger::logInfo("Uri for path '$path_to_analyze' is not a string, should not happen");
+                continue;
+            }
             $relative_path_to_analyze = FileRef::getProjectRelativePathForPath($path_to_analyze);
             if (!\in_array($uri, $file_path_list) && !\in_array($relative_path_to_analyze, $file_path_list)) {
                 Logger::logInfo("Path '$relative_path_to_analyze' (URI '$uri') not in parse list, skipping");

--- a/src/Phan/LanguageServer/Logger.php
+++ b/src/Phan/LanguageServer/Logger.php
@@ -12,7 +12,7 @@ use Phan\Config;
 class Logger
 {
     /** @var resource|false */
-    public static $file;
+    public static $file = false;
 
     public static function shouldLog() : bool
     {
@@ -52,10 +52,11 @@ class Logger
      */
     private static function getLogFile()
     {
-        if (self::$file === null) {
-            self::$file = STDERR;
+        $file = self::$file;
+        if (!$file) {
+            self::$file = $file = STDERR;
         }
-        return self::$file;
+        return $file;
     }
 
     /**

--- a/src/Phan/LanguageServer/Protocol/Position.php
+++ b/src/Phan/LanguageServer/Protocol/Position.php
@@ -67,6 +67,7 @@ class Position
     {
         $lines = explode("\n", $content);
         $slice = array_slice($lines, 0, $this->line);
-        return array_sum(array_map('strlen', $slice)) + count($slice) + $this->character;
+        // TODO: array_sum should infer sum of ints is typically an int
+        return ((int)array_sum(array_map('strlen', $slice))) + count($slice) + $this->character;
     }
 }

--- a/src/Phan/Library/Hasher/Consistent.php
+++ b/src/Phan/Library/Hasher/Consistent.php
@@ -43,6 +43,7 @@ class Consistent implements Hasher
     /**
      * Do a binary search in the consistent hashing ring to find the group.
      * @return int - an integer between 0 and $this->groupCount - 1, inclusive
+     * @suppress PhanPartialTypeMismatchReturn
      */
     public function getGroup(string $key) : int
     {

--- a/src/Phan/Library/Map.php
+++ b/src/Phan/Library/Map.php
@@ -46,7 +46,8 @@ class Map extends \SplObjectStorage
     {
         $map = new Map;
         foreach ($this as $key => $value) {
-            $map[$key_closure($key)] = $value_closure($value);
+            // TODO: Don't infer $map[$key] = ...; as making $map possibly an array
+            $map->offsetSet($key_closure($key), $value_closure($value));
         }
         return $map;
     }
@@ -72,7 +73,7 @@ class Map extends \SplObjectStorage
     {
         $map = new Map;
         foreach ($this as $key => $value) {
-            $map[$key] = clone($value);
+            $map->offsetSet($key, clone($value));
         }
         return $map;
     }

--- a/src/Phan/Ordering.php
+++ b/src/Phan/Ordering.php
@@ -37,6 +37,8 @@ class Ordering
      * @return array<int,array<int,string>>
      * A map from process_id to a list of files to be analyzed
      * on that process in stable ordering.
+     *
+     * @suppress PhanPartialTypeMismatchReturn TODO: investigate why array<int,null> is inferred as possible?
      */
     public function orderForProcessCount(
         int $process_count,

--- a/src/Phan/Plugin/ClosuresForKind.php
+++ b/src/Phan/Plugin/ClosuresForKind.php
@@ -60,6 +60,7 @@ class ClosuresForKind
     /**
      * @param \Closure $flattener
      * @return array<int,\Closure> (Maps a subset of node kinds to a closure to execute for that node kind.)
+     * @suppress PhanPartialTypeMismatchReturn TODO: investigate
      */
     public function getFlattenedClosures(\Closure $flattener)
     {

--- a/tests/Phan/AST/TolerantASTConverter/ConversionTest.php
+++ b/tests/Phan/AST/TolerantASTConverter/ConversionTest.php
@@ -16,6 +16,9 @@ use ast;
 
 class ConversionTest extends BaseTest
 {
+    /**
+     * @return array<int,string>
+     */
     protected function _scanSourceDirForPHP(string $source_dir) : array
     {
         $files = [];
@@ -68,7 +71,7 @@ class ConversionTest extends BaseTest
     /**
      * Asserts that valid files get parsed the same way by php-ast and the polyfill.
      *
-     * @return string[]|int[] [string $file_path, int $ast_version]
+     * @return array{0:string,1:int}[] array of [string $file_path, int $ast_version]
      * @suppress PhanPluginUnusedVariable
      */
     public function astValidFileExampleProvider()

--- a/tests/Phan/ASTRewriterTest.php
+++ b/tests/Phan/ASTRewriterTest.php
@@ -13,10 +13,7 @@ class ASTRewriterTest extends AbstractPhanFileTest
      */
     public function getTestFiles()
     {
-        /** @return string[] - Original file and expected file */
-        return array_map(function (array $values) : array {
-            return [$values[0], $values[1]];
-        }, $this->scanSourceFilesDir(AST_TEST_FILE_DIR, AST_EXPECTED_DIR));
+        return $this->scanSourceFilesDir(AST_TEST_FILE_DIR, AST_EXPECTED_DIR);
     }
 
     /**

--- a/tests/Phan/AbstractPhanFileTest.php
+++ b/tests/Phan/AbstractPhanFileTest.php
@@ -67,6 +67,7 @@ abstract class AbstractPhanFileTest extends BaseTest implements CodeBaseAwareTes
      */
     protected function scanSourceFilesDir(string $sourceDir, string $expectedDir)
     {
+        // TODO: Make Phan know that array_filter with a single argument implies elements aren't falsey
         $files = array_filter(
             array_filter(
                 scandir($sourceDir),

--- a/tests/files/expected/0299_binary_op.php.expected
+++ b/tests/files/expected/0299_binary_op.php.expected
@@ -1,5 +1,4 @@
 %s:7 PhanTypeMismatchArgument Argument 1 (x) is float|int but \expect_string_298() takes string defined at %s:3
-%s:8 PhanTypeMismatchArgument Argument 1 (x) is float|int but \expect_string_298() takes string defined at %s:3
 %s:10 PhanTypeMismatchArgument Argument 1 (x) is string but \expect_int_298() takes int defined at %s:4
 %s:11 PhanTypeMismatchArgument Argument 1 (x) is int but \expect_string_298() takes string defined at %s:3
 %s:12 PhanTypeMismatchArgument Argument 1 (x) is bool but \expect_string_298() takes string defined at %s:3
@@ -39,3 +38,4 @@
 %s:50 PhanTypeMismatchArgument Argument 1 (x) is int but \expect_string_298() takes string defined at %s:3
 %s:51 PhanTypeMismatchArgument Argument 1 (x) is int but \expect_string_298() takes string defined at %s:3
 %s:52 PhanTypeMismatchArgument Argument 1 (x) is int but \expect_string_298() takes string defined at %s:3
+%s:54 PhanTypeMismatchArgument Argument 1 (x) is string but \expect_int_298() takes int defined at %s:4

--- a/tests/files/expected/0328_references_preg_match_ignores_old_type.php.expected
+++ b/tests/files/expected/0328_references_preg_match_ignores_old_type.php.expected
@@ -1,2 +1,2 @@
 %s:6 PhanTypeNonVarPassByRef Only variables can be passed by reference at argument 3 of \preg_match()
-%s:8 PhanTypeMismatchArgumentInternal Argument 1 (string) is array but \strlen() takes string
+%s:8 PhanTypeMismatchArgumentInternal Argument 1 (string) is string[] but \strlen() takes string

--- a/tests/files/expected/0340_badternary_return.php.expected
+++ b/tests/files/expected/0340_badternary_return.php.expected
@@ -1,4 +1,4 @@
 %s:4 PhanTypeMismatchReturn Returning type string but foo340() is declared to return int
 %s:8 PhanTypeMismatchReturn Returning type array but foo340b() is declared to return int
-%s:8 PhanTypeMismatchReturn Returning type bool but foo340b() is declared to return int
+%s:8 PhanTypeMismatchReturn Returning type true but foo340b() is declared to return int
 %s:12 PhanTypeMismatchReturn Returning type string but foo() is declared to return int

--- a/tests/files/expected/0364_extended_array_analyze.php.expected
+++ b/tests/files/expected/0364_extended_array_analyze.php.expected
@@ -30,6 +30,6 @@
 %s:38 PhanTypeMismatchArgument Argument 1 (x) is array<int,\stdClass> but \p364() takes \stdClass defined at %s:45
 %s:39 PhanTypeMismatchArgument Argument 1 (x) is array<int,string> but \p364() takes \stdClass defined at %s:45
 %s:40 PhanTypeMismatchArgument Argument 1 (x) is array<int,string> but \p364() takes \stdClass defined at %s:45
-%s:41 PhanParamTypeMismatch Argument 3 is Closure(mixed,mixed):(float|int) but \array_uintersect_assoc() takes array
+%s:41 PhanParamTypeMismatch Argument 3 is Closure(mixed,mixed):int but \array_uintersect_assoc() takes array
 %s:41 PhanTypeMismatchArgument Argument 1 (x) is array<int,string> but \p364() takes \stdClass defined at %s:45
 %s:42 PhanTypeMismatchArgument Argument 1 (x) is array<int,string> but \p364() takes \stdClass defined at %s:45

--- a/tests/files/src/0299_binary_op.php
+++ b/tests/files/src/0299_binary_op.php
@@ -5,7 +5,7 @@ function expect_int_298(int $x) {}
 
 function test298() {
     expect_string_298("0" + "1");  // warn
-    expect_string_298("0" | "1");  // warn
+    expect_string_298("0" | "1");  // Don't warn - this binary ors the bytes of the two strings into a new string.
     expect_string_298("0" ^ "\x01");  // Becomes a string
     expect_int_298("0" ^ "\x01");  // warn, Becomes a string
     expect_string_298(1 ^ 2);  // warn
@@ -50,4 +50,6 @@ function test298() {
     expect_string_298($intVar -= 5);
     expect_string_298($intVar <<= 1);
     expect_string_298($intVar >>= 1);
+
+    expect_int_298("0" | "1");  // warn - this binary ors the bytes of the two strings into a new string.
 }

--- a/tests/misc/rewriting_test/expected/003_preg_match.php.expected
+++ b/tests/misc/rewriting_test/expected/003_preg_match.php.expected
@@ -1,1 +1,1 @@
-src/003_preg_match.php:13 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is array but \intdiv() takes int
+src/003_preg_match.php:13 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is string[] but \intdiv() takes int


### PR DESCRIPTION
Enable this setting for self-analysis.

Add suppressions to Phan itself to suppress places where there are partial type mismatches.
Add new features/bug fixes to Phan reduce the number of false positives seen during strict checks of return statements. 

See NEWS.md for more details.