### PR TITLE
 Warn about unextractable type/name annotations in more places

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -42,6 +42,9 @@ New Features(Analysis)
 + Start analyzing negated `instanceof` conditionals such as `assert(!($x instanceof MyClass))`.
 + Infer that the reference parameter's resulting type for `preg_match` is a `string[]`, not `array` (when possible)
   (And that the type is `array{0:string,1:int}` when `PREG_OFFSET_CAPTURE` is passed as a flag)
++ Warn in more places when Phan can't extract union types or element identifiers from a doc comment.
+  New issue types: `UnextractableAnnotationElementName`, `UnextractableAnnotationSuffix`.
+  (E.g. warn about `@param int description` (ideally has param name) and `@return int?` (Phan doesn't parse the `?`, should be `@return ?int`))
 
 Bug Fixes
 + Don't emit false positive `PhanTypeArraySuspiciousNullable`, etc. for complex isset/empty/unset expressions. (#642)

--- a/src/Phan/AST/ASTSimplifier.php
+++ b/src/Phan/AST/ASTSimplifier.php
@@ -169,7 +169,7 @@ class ASTSimplifier
      * If this returns true, the expression has no side effects, and can safely be reordered.
      * (E.g. returns true for `MY_CONST` or `false` in `if (MY_CONST === ($x = y))`
      *
-     * @param Node|string|float|int
+     * @param Node|string|float|int $node
      */
     private static function isExpressionWithoutSideEffects($node) : bool
     {

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -330,7 +330,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
 
     /**
      * Check if a given variable is undeclared.
-     * @param Node - Node with kind AST_VAR
+     * @param Node $node Node with kind AST_VAR
      * @return void
      */
     private function checkForUndeclaredVariable(Node $node)

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -476,7 +476,7 @@ class CodeBase
     }
 
     /**
-     * @param array{clone:CodeBase,callbacks:?(Closure():void)[]}
+     * @param array{clone:CodeBase,callbacks:?(Closure():void)[]} $restore_point
      * @return void
      */
     public function restoreFromRestorePoint(array $restore_point)
@@ -512,7 +512,7 @@ class CodeBase
      * For use by daemon mode when running without pcntl
      * Returns a serialized representation of everything in this CodeBase.
      * @internal
-     * @return array{clone:CodeBase,callbacks:?Closure():void)[]}
+     * @return array{clone:CodeBase,callbacks:(?Closure():void)[]}
      */
     public function createRestorePoint() : array
     {
@@ -1322,7 +1322,7 @@ class CodeBase
     }
 
     /**
-     * @param FullyQualifiedFunctionName
+     * @param FullyQualifiedFunctionName $fqsen
      * The FQSEN of a function we'd like to look up
      *
      * @return bool

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -287,6 +287,8 @@ class Issue
     const MisspelledAnnotation             = 'PhanMisspelledAnnotation';
     const UnextractableAnnotation          = 'PhanUnextractableAnnotation';
     const UnextractableAnnotationPart      = 'PhanUnextractableAnnotationPart';
+    const UnextractableAnnotationSuffix    = 'PhanUnextractableAnnotationSuffix';
+    const UnextractableAnnotationElementName = 'PhanUnextractableAnnotationElementName';
     const CommentParamWithoutRealParam     = 'PhanCommentParamWithoutRealParam';
     const CommentParamOnEmptyParamList     = 'PhanCommentParamOnEmptyParamList';
     const CommentOverrideOnNonOverrideMethod = 'PhanCommentOverrideOnNonOverrideMethod';
@@ -2406,7 +2408,7 @@ class Issue
                 self::UnextractableAnnotation,
                 self::CATEGORY_COMMENT,
                 self::SEVERITY_LOW,
-                "Saw unextractable annotation for comment {COMMENT}",
+                "Saw unextractable annotation for comment '{COMMENT}'",
                 self::REMEDIATION_B,
                 16002
             ),
@@ -2414,9 +2416,25 @@ class Issue
                 self::UnextractableAnnotationPart,
                 self::CATEGORY_COMMENT,
                 self::SEVERITY_LOW,
-                "Saw unextractable annotation for a fragment of comment {COMMENT}: {COMMENT}",
+                "Saw unextractable annotation for a fragment of comment '{COMMENT}': '{COMMENT}'",
                 self::REMEDIATION_B,
                 16003
+            ),
+            new Issue(
+                self::UnextractableAnnotationSuffix,
+                self::CATEGORY_COMMENT,
+                self::SEVERITY_LOW,
+                "Saw a token Phan may have failed to parse after '{COMMENT}': after {TYPE}, saw '{COMMENT}'",
+                self::REMEDIATION_B,
+                16009
+            ),
+            new Issue(
+                self::UnextractableAnnotationElementName,
+                self::CATEGORY_COMMENT,
+                self::SEVERITY_LOW,
+                "Saw possibly unextractable annotation for a fragment of comment '{COMMENT}': after {TYPE}, did not see an element name (will guess based on comment order)",
+                self::REMEDIATION_B,
+                16010
             ),
             new Issue(
                 self::CommentParamWithoutRealParam,

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -1758,7 +1758,7 @@ class Clazz extends AddressableElement
      * The entire code base from which we'll find ancestor
      * details
      *
-     * @param array<int,FullyQualifiedClassName>
+     * @param array<int,FullyQualifiedClassName> $fqsen_list
      * A list of class FQSENs to turn into a list of
      * Clazz objects
      *

--- a/src/Phan/Language/Element/Comment.php
+++ b/src/Phan/Language/Element/Comment.php
@@ -440,7 +440,7 @@ class Comment
                     }
                 } elseif ($type === 'return') {
                     $check_compatible('@return', Comment::FUNCTION_LIKE, $i, $line);
-                    $type = self::returnTypeFromCommentLine($context, $line)->withUnionType($return_union_type);
+                    $type = self::returnTypeFromCommentLine($code_base, $context, $line, $lineno, $i, $comment_lines_count)->withUnionType($return_union_type);
                     if (!$type->isEmpty()) {
                         $return_union_type = $type;
                     }
@@ -455,7 +455,7 @@ class Comment
                     );
                 } elseif ($type === 'throws') {
                     $check_compatible('@throws', Comment::FUNCTION_LIKE, $i, $line);
-                    $throw_union_type = $throw_union_type->withUnionType(self::returnTypeFromCommentLine($context, $line));
+                    $throw_union_type = $throw_union_type->withUnionType(self::returnTypeFromCommentLine($code_base, $context, $line, $lineno, $i, $comment_lines_count));
                 } elseif ($type === 'throw') {
                     Issue::maybeEmit(
                         $code_base,
@@ -469,6 +469,14 @@ class Comment
                     $suppress_issue_type = self::suppressIssueFromCommentLine($line);
                     if ($suppress_issue_type !== '') {
                         $suppress_issue_list[] = $suppress_issue_type;
+                    } else {
+                        Issue::maybeEmit(
+                            $code_base,
+                            $context,
+                            Issue::UnextractableAnnotation,
+                            self::guessActualLineLocation($context, $lineno, $i, $comment_lines_count, $line),
+                            trim($line)
+                        );
                     }
                 } elseif ($type === 'property') {
                     $check_compatible('@property', [Comment::ON_CLASS], $i, $line);
@@ -491,7 +499,7 @@ class Comment
                 } elseif ($type === 'phanclosurescope' || $type === 'phan-closure_scope') {
                     // TODO: different type for closures
                     $check_compatible('@PhanClosureScope', Comment::FUNCTION_LIKE, $i, $line);
-                    $closure_scope = self::getPhanClosureScopeFromCommentLine($context, $line);
+                    $closure_scope = self::getPhanClosureScopeFromCommentLine($code_base, $context, $line, $lineno, $i, $comment_lines_count);
                 } elseif (\strpos($type, 'phan-') === 0) {
                     if ($type === 'phan-forbid-undeclared-magic-properties') {
                         $check_compatible('@phan-forbid-undeclared-magic-properties', [Comment::ON_CLASS], $i, $line);
@@ -501,14 +509,14 @@ class Comment
                         $comment_flags |= Flags::CLASS_FORBID_UNDECLARED_MAGIC_METHODS;
                     } elseif ($type === 'phan-closure-scope') {
                         $check_compatible('@phan-closure-scope', Comment::FUNCTION_LIKE, $i, $line);
-                        $closure_scope = self::getPhanClosureScopeFromCommentLine($context, $line);
+                        $closure_scope = self::getPhanClosureScopeFromCommentLine($code_base, $context, $line, $lineno, $i, $comment_lines_count);
                     } elseif ($type === 'phan-param') {
                         $check_compatible('@phan-param', Comment::FUNCTION_LIKE, $i, $line);
                         $phan_overrides['param'][] =
                             self::parameterFromCommentLine($code_base, $context, $line, false, $lineno, $i, $comment_lines_count);
                     } elseif ($type === 'phan-return') {
                         $check_compatible('@phan-return', Comment::FUNCTION_LIKE, $i, $line);
-                        $phan_overrides['return'] = self::returnTypeFromCommentLine($context, $line);
+                        $phan_overrides['return'] = self::returnTypeFromCommentLine($code_base, $context, $line, $lineno, $i, $comment_lines_count);
                     } elseif ($type === 'phan-override') {
                         $check_compatible('@override', [Comment::ON_METHOD, Comment::ON_CONST], $i, $line);
                         $comment_flags |= Flags::IS_OVERRIDE_INTENDED;
@@ -602,7 +610,7 @@ class Comment
     private static function emitInvalidCommentForDeclarationType(
         CodeBase $code_base,
         Context $context,
-        string $annotationType,
+        string $annotation_type,
         int $comment_type,
         int $lineno
     ) {
@@ -611,7 +619,7 @@ class Comment
             $context,
             Issue::InvalidCommentForDeclarationType,
             $lineno,
-            $annotationType,
+            $annotation_type,
             self::NAME_FOR_TYPE[$comment_type]
         );
     }
@@ -628,15 +636,41 @@ class Comment
      *
      * @return UnionType
      * The declared return type
+     * @suppress PhanParamSuspiciousOrder strstr
      */
     private static function returnTypeFromCommentLine(
+        CodeBase $code_base,
         Context $context,
-        string $line
+        string $line,
+        int $lineno,
+        int $i,
+        int $comment_lines_count
     ) {
         $return_union_type_string = '';
 
         if (\preg_match(self::return_comment_regex, $line, $match)) {
             $return_union_type_string = $match[2];
+            $raw_match = $match[0];
+            $char_at_end_offset = $line[\strpos($line, $raw_match) + \strlen($raw_match)] ?? ' ';
+            if (strstr(' \t', $char_at_end_offset) === false) {
+                Issue::maybeEmit(
+                    $code_base,
+                    $context,
+                    Issue::UnextractableAnnotationSuffix,
+                    self::guessActualLineLocation($context, $lineno, $i, $comment_lines_count, $line),
+                    \trim($line),
+                    $return_union_type_string,
+                    $char_at_end_offset
+                );
+            }
+        } else {
+            Issue::maybeEmit(
+                $code_base,
+                $context,
+                Issue::UnextractableAnnotation,
+                self::guessActualLineLocation($context, $lineno, $i, $comment_lines_count, $line),
+                trim($line)
+            );
         }
         // Not emitting any issues about failing to extract, e.g. `@return - Description of what this returns` is a valid comment.
         $return_union_type_string = self::rewritePHPDocType($return_union_type_string);
@@ -703,6 +737,9 @@ class Comment
             if (!isset($match[2])) {
                 return new CommentParameter('', UnionType::empty());
             }
+            if (!$is_var && !isset($match[21])) {
+                self::checkParamWithoutVarName($code_base, $context, $line, $match[0], $match[2], $lineno, $i, $comment_lines_count);
+            }
             $original_type = $match[2];
 
             $is_variadic = ($match[20] ?? '') === '...';
@@ -739,23 +776,65 @@ class Comment
                 false,  // has_default_value
                 $is_output_parameter
             );
-        } else {
-            // Don't warn about @param $x Description of $x goes here
-            // TODO: extract doc comment of @param &$x?
-            // TODO: Use the right for the name of the comment parameter?
-            //       (don't see a benefit, would create a type if it was (at)var on a function-like)
-            if (!\preg_match('/@(param|var)\s+(\.\.\.)?\s*(\\$\S+)/', $line)) {
-                Issue::maybeEmit(
-                    $code_base,
-                    $context,
-                    Issue::UnextractableAnnotation,
-                    self::guessActualLineLocation($context, $lineno, $i, $comment_lines_count, $line),
-                    \trim($line)
-                );
-            }
+        }
+
+        // Don't warn about @param $x Description of $x goes here
+        // TODO: extract doc comment of @param &$x?
+        // TODO: Use the right for the name of the comment parameter?
+        //       (don't see a benefit, would create a type if it was (at)var on a function-like)
+        if (!\preg_match('/@(param|var)\s+(\.\.\.)?\s*(\\$\S+)/', $line)) {
+            Issue::maybeEmit(
+                $code_base,
+                $context,
+                Issue::UnextractableAnnotation,
+                self::guessActualLineLocation($context, $lineno, $i, $comment_lines_count, $line),
+                \trim($line)
+            );
         }
 
         return new CommentParameter('', UnionType::empty());
+    }
+
+    /**
+     * This should be uncommon: $line is a parameter for which a parameter name could not be parsed
+     * @suppress PhanParamSuspiciousOrder
+     */
+    private static function checkParamWithoutVarName(
+        CodeBase $code_base,
+        Context $context,
+        string $line,
+        string $raw_match,
+        string $union_type_string,
+        int $lineno,
+        int $i,
+        int $comment_lines_count
+    ) {
+
+        $match_offset = \strpos($line, $raw_match);
+        $end_offset = $match_offset + strlen($raw_match);
+
+        $char_at_end_offset = $line[$end_offset] ?? ' ';
+        $issue_line = self::guessActualLineLocation($context, $lineno, $i, $comment_lines_count, $line);
+        if (strstr(" \t\n", $char_at_end_offset) === false) {
+            Issue::maybeEmit(
+                $code_base,
+                $context,
+                Issue::UnextractableAnnotationSuffix,
+                $issue_line,
+                \trim($line),
+                $union_type_string,
+                $char_at_end_offset
+            );
+        }
+
+        Issue::maybeEmit(
+            $code_base,
+            $context,
+            Issue::UnextractableAnnotationElementName,
+            $issue_line,
+            \trim($line),
+            $union_type_string
+        );
     }
 
     /**
@@ -1037,8 +1116,12 @@ class Comment
      * (Phan expects a ClassScope to have exactly one type)
      */
     private static function getPhanClosureScopeFromCommentLine(
+        CodeBase $code_base,
         Context $context,
-        string $line
+        string $line,
+        int $lineno,
+        int $comment_line_offset,
+        int $comment_lines_count
     ) : Option {
         $closure_scope_union_type_string = '';
 
@@ -1058,6 +1141,13 @@ class Comment
                 Type::FROM_PHPDOC
             ));
         }
+        Issue::maybeEmit(
+            $code_base,
+            $context,
+            Issue::UnextractableAnnotation,
+            self::guessActualLineLocation($context, $lineno, $comment_line_offset, $comment_lines_count, $line),
+            trim($line)
+        );
         return new None();
     }
 

--- a/src/Phan/Language/Element/FunctionInterface.php
+++ b/src/Phan/Language/Element/FunctionInterface.php
@@ -244,7 +244,7 @@ interface FunctionInterface extends AddressableElementInterface
     public function getRealParameterList();
 
     /**
-     * @param array<string,UnionType> maps a subset of param names to the unmodified phpdoc parameter types.
+     * @param array<string,UnionType> $parameter_map maps a subset of param names to the unmodified phpdoc parameter types.
      * Will differ from real parameter types (ideally narrower)
      * @return void
      */
@@ -256,7 +256,7 @@ interface FunctionInterface extends AddressableElementInterface
     public function getPHPDocParameterTypeMap();
 
     /**
-     * @param ?UnionType the raw phpdoc union type
+     * @param ?UnionType $union_type the raw phpdoc union type
      * @return void
      */
     public function setPHPDocReturnType($union_type);

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -510,7 +510,7 @@ trait FunctionTrait
     }
 
     /**
-     * @param UnionType
+     * @param UnionType $union_type
      * The real (non-phpdoc) return type of this method in its given context.
      *
      * @return void
@@ -762,7 +762,7 @@ trait FunctionTrait
     }
 
     /**
-     * @param array<string,UnionType> maps a subset of param names to the unmodified phpdoc parameter types. May differ from real parameter types
+     * @param array<string,UnionType> $parameter_map maps a subset of param names to the unmodified phpdoc parameter types. May differ from real parameter types
      * @return void
      * @suppress PhanUnreferencedPublicMethod Phan knows FunctionInterface's method is referenced, but can't associate that yet.
      */

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -867,10 +867,10 @@ final class EmptyUnionType extends UnionType
     }
 
     /**
-     * @param CodeBase
+     * @param CodeBase $code_base
      * The code base to use in order to find super classes, etc.
      *
-     * @param $recursion_depth
+     * @param int $recursion_depth
      * This thing has a tendency to run-away on me. This tracks
      * how bad I messed up by seeing how far the expanded types
      * go

--- a/src/Phan/Language/Scope.php
+++ b/src/Phan/Language/Scope.php
@@ -186,7 +186,7 @@ abstract class Scope
      * @param Variable $variable
      * A variable to add to the local scope
      *
-     * @return Scope;
+     * @return Scope
      */
     public function withVariable(Variable $variable) : Scope
     {

--- a/src/Phan/Language/Scope/GlobalScope.php
+++ b/src/Phan/Language/Scope/GlobalScope.php
@@ -63,7 +63,7 @@ class GlobalScope extends Scope
      * @param Variable $variable
      * A variable to add to the local scope
      *
-     * @return Scope;
+     * @return Scope
      */
     public function withVariable(Variable $variable) : Scope
     {

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -1659,7 +1659,7 @@ class Type
     }
 
     /**
-     * @param CodeBase
+     * @param CodeBase $code_base
      * The code base to use in order to find super classes, etc.
      *
      * @param $recursion_depth

--- a/src/Phan/Language/Type/ArrayShapeType.php
+++ b/src/Phan/Language/Type/ArrayShapeType.php
@@ -107,7 +107,10 @@ final class ArrayShapeType extends ArrayType
         return true;
     }
 
-    /** @return array<int,ArrayType> */
+    /**
+     * @return array<int,ArrayType>
+     * @suppress PhanPartialTypeMismatchReturn
+     */
     private function computeGenericArrayTypeInstances() : array
     {
         $field_types = $this->field_types;
@@ -263,10 +266,10 @@ final class ArrayShapeType extends ArrayType
     }
 
     /**
-     * @param CodeBase
+     * @param CodeBase $code_base
      * The code base to use in order to find super classes, etc.
      *
-     * @param $recursion_depth
+     * @param int $recursion_depth
      * This thing has a tendency to run-away on me. This tracks
      * how bad I messed up by seeing how far the expanded types
      * go

--- a/src/Phan/Language/Type/FunctionLikeDeclarationType.php
+++ b/src/Phan/Language/Type/FunctionLikeDeclarationType.php
@@ -531,7 +531,7 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
     }
 
     /**
-     * @param ?UnionType the raw phpdoc union type
+     * @param ?UnionType $union_type the raw phpdoc union type
      */
     public function setPHPDocReturnType($union_type)
     {

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -239,7 +239,7 @@ final class GenericArrayType extends ArrayType
     }
 
     /**
-     * @param CodeBase
+     * @param CodeBase $code_base
      * The code base to use in order to find super classes, etc.
      *
      * @param $recursion_depth

--- a/src/Phan/Language/Type/GenericMultiArrayType.php
+++ b/src/Phan/Language/Type/GenericMultiArrayType.php
@@ -156,7 +156,7 @@ final class GenericMultiArrayType extends ArrayType implements MultiType
     }
 
     /**
-     * @param CodeBase
+     * @param CodeBase $code_base
      * The code base to use in order to find super classes, etc.
      *
      * @param $recursion_depth

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -2028,7 +2028,7 @@ class UnionType implements \Serializable
         );
     }
     /**
-     * @param CodeBase
+     * @param CodeBase $code_base
      * The code base to use in order to find super classes, etc.
      *
      * @param $recursion_depth

--- a/tests/files/expected/0030_comment_params.php.expected
+++ b/tests/files/expected/0030_comment_params.php.expected
@@ -1,0 +1,1 @@
+%s:10 PhanUnextractableAnnotationElementName Saw possibly unextractable annotation for a fragment of comment '* @param bool g more malformed stuff.': after bool, did not see an element name (will guess based on comment order)

--- a/tests/files/expected/0055_named_params.php.expected
+++ b/tests/files/expected/0055_named_params.php.expected
@@ -1,5 +1,6 @@
 %s:7 PhanTypeMismatchArgument Argument 2 (b) is string but \f() takes float defined at %s:5
 %s:14 PhanTypeMismatchArgument Argument 2 (b) is string but \g() takes \Traversable|float|int defined at %s:12
+%s:17 PhanUnextractableAnnotationElementName Saw possibly unextractable annotation for a fragment of comment '* @param int': after int, did not see an element name (will guess based on comment order)
+%s:18 PhanUnextractableAnnotationElementName Saw possibly unextractable annotation for a fragment of comment '* @param string': after string, did not see an element name (will guess based on comment order)
 %s:21 PhanTypeMismatchArgument Argument 1 (a) is string but \h() takes int defined at %s:20
 %s:21 PhanTypeMismatchArgument Argument 2 (b) is int but \h() takes string defined at %s:20
-

--- a/tests/files/expected/0150_call_is_hard.php.expected
+++ b/tests/files/expected/0150_call_is_hard.php.expected
@@ -1,0 +1,2 @@
+%s:5 PhanUnextractableAnnotationElementName Saw possibly unextractable annotation for a fragment of comment '* @param string': after string, did not see an element name (will guess based on comment order)
+%s:6 PhanUnextractableAnnotationElementName Saw possibly unextractable annotation for a fragment of comment '* @param array': after array, did not see an element name (will guess based on comment order)

--- a/tests/files/expected/0203_generic_errors.php.expected
+++ b/tests/files/expected/0203_generic_errors.php.expected
@@ -2,6 +2,12 @@
 %s:16 PhanTemplateTypeStaticMethod static method \C::f may not use template types
 %s:21 PhanTemplateTypeStaticMethod static method \C::g may not use template types
 %s:21 PhanTypeMissingReturn Method \C::g is declared to return T but has no return value
+%s:24 PhanUnextractableAnnotationElementName Saw possibly unextractable annotation for a fragment of comment '* @param int': after int, did not see an element name (will guess based on comment order)
+%s:25 PhanUnextractableAnnotationElementName Saw possibly unextractable annotation for a fragment of comment '* @param X': after X, did not see an element name (will guess based on comment order)
 %s:27 PhanGenericConstructorTypes Missing template parameters T on constructor for generic class \C
 %s:27 PhanUndeclaredTypeParameter Parameter of undeclared type \X
 %s:30 PhanParamTooFew Call with 0 arg(s) to \C::__construct() which requires 2 arg(s) defined at %s:27
+%s:36 PhanUnextractableAnnotationElementName Saw possibly unextractable annotation for a fragment of comment '* @param int': after int, did not see an element name (will guess based on comment order)
+%s:37 PhanUnextractableAnnotationElementName Saw possibly unextractable annotation for a fragment of comment '* @param T': after T, did not see an element name (will guess based on comment order)
+%s:45 PhanUnextractableAnnotationElementName Saw possibly unextractable annotation for a fragment of comment '* @param T': after T, did not see an element name (will guess based on comment order)
+%s:46 PhanUnextractableAnnotationElementName Saw possibly unextractable annotation for a fragment of comment '* @param int': after int, did not see an element name (will guess based on comment order)

--- a/tests/files/expected/0264_closure_override_context.php.expected
+++ b/tests/files/expected/0264_closure_override_context.php.expected
@@ -1,4 +1,5 @@
 %s:17 PhanTypeMissingReturn Method \NS264\TestFramework::mockA is declared to return string but has no return value
+%s:22 PhanUnextractableAnnotation Saw unextractable annotation for comment '* @phan-closure-scope'
 %s:44 PhanUndeclaredProperty Reference to undeclared property \NS264\BoundClass264->d
 %s:50 PhanTypeInvalidClosureScope Invalid @phan-closure-scope: expected a class name, got string
 %s:51 PhanUndeclaredProperty Reference to undeclared property \NS264\TestFramework->b

--- a/tests/files/expected/0284_non_empty_array_default.php.expected
+++ b/tests/files/expected/0284_non_empty_array_default.php.expected
@@ -1,0 +1,1 @@
+%s:2 PhanUnextractableAnnotationElementName Saw possibly unextractable annotation for a fragment of comment '/** @param int[] */': after int[], did not see an element name (will guess based on comment order)

--- a/tests/files/expected/0285_nullable_generic_array.php.expected
+++ b/tests/files/expected/0285_nullable_generic_array.php.expected
@@ -1,1 +1,3 @@
 %s:25 PhanTypeMismatchReturn Returning type array<int,string> but f285_6() is declared to return ?int[]
+%s:28 PhanUnextractableAnnotation Saw unextractable annotation for comment '/** @return ??int[] */'
+%s:33 PhanUnextractableAnnotation Saw unextractable annotation for comment '/** @return ??int[] */'

--- a/tests/files/expected/0301_comment_checks.php.expected
+++ b/tests/files/expected/0301_comment_checks.php.expected
@@ -2,16 +2,16 @@
 %s:5 PhanInvalidCommentForDeclarationType The phpdoc comment for @param cannot occur on a class
 %s:6 PhanInvalidCommentForDeclarationType The phpdoc comment for @return cannot occur on a class
 %s:7 PhanMisspelledAnnotation Saw misspelled annotation @phan-forbid-this-is-a-typo, should be one of @phan-forbid-undeclared-magic-methods @phan-forbid-undeclared-magic-properties @phan-closure-scope @phan-override
-%s:12 PhanUnextractableAnnotationPart Saw unextractable annotation for a fragment of comment * @method foo(string$invalidType $param1): string$invalidType $param1
-%s:13 PhanUnextractableAnnotation Saw unextractable annotation for comment * @method unmatched(
-%s:17 PhanUnextractableAnnotation Saw unextractable annotation for comment * @property int (Can't parse the variable name, so silently ignore)
+%s:12 PhanUnextractableAnnotationPart Saw unextractable annotation for a fragment of comment '* @method foo(string$invalidType $param1)': 'string$invalidType $param1'
+%s:13 PhanUnextractableAnnotation Saw unextractable annotation for comment '* @method unmatched('
+%s:17 PhanUnextractableAnnotation Saw unextractable annotation for comment '* @property int (Can't parse the variable name, so silently ignore)'
 %s:19 PhanInvalidCommentForDeclarationType The phpdoc comment for @param cannot occur on a property
 %s:20 PhanInvalidCommentForDeclarationType The phpdoc comment for @return cannot occur on a property
 %s:26 PhanInvalidCommentForDeclarationType The phpdoc comment for @phan-forbid-undeclared-magic-properties cannot occur on a method
 %s:27 PhanInvalidCommentForDeclarationType The phpdoc comment for @property cannot occur on a method
 %s:28 PhanInvalidCommentForDeclarationType The phpdoc comment for @method cannot occur on a method
-%s:28 PhanUnextractableAnnotation Saw unextractable annotation for comment * @method int $wrongPlaceForMethod
-%s:35 PhanUnextractableAnnotation Saw unextractable annotation for comment * @param
-%s:36 PhanUnextractableAnnotation Saw unextractable annotation for comment * @param <>$x $x (not parseable)
-%s:42 PhanUnextractableAnnotation Saw unextractable annotation for comment * @param <
-%s:43 PhanUnextractableAnnotation Saw unextractable annotation for comment * @param > */
+%s:28 PhanUnextractableAnnotation Saw unextractable annotation for comment '* @method int $wrongPlaceForMethod'
+%s:35 PhanUnextractableAnnotation Saw unextractable annotation for comment '* @param'
+%s:36 PhanUnextractableAnnotation Saw unextractable annotation for comment '* @param <>$x $x (not parseable)'
+%s:42 PhanUnextractableAnnotation Saw unextractable annotation for comment '* @param <'
+%s:43 PhanUnextractableAnnotation Saw unextractable annotation for comment '* @param > */'

--- a/tests/files/expected/0378_parsing_args.php.expected
+++ b/tests/files/expected/0378_parsing_args.php.expected
@@ -1,2 +1,4 @@
+%s:4 PhanUnextractableAnnotationElementName Saw possibly unextractable annotation for a fragment of comment '* @param float[]string $blah this should be parsed as (at)param float[] - The following token `string` is nonsense.': after float[], did not see an element name (will guess based on comment order)
+%s:4 PhanUnextractableAnnotationSuffix Saw a token Phan may have failed to parse after '* @param float[]string $blah this should be parsed as (at)param float[] - The following token `string` is nonsense.': after float[], saw 's'
 %s:10 PhanTypeMismatchArgument Argument 1 (x) is \stdClass but \test378() takes float[] defined at %s:7
 %s:10 PhanTypeMismatchArgument Argument 2 (y) is \stdClass but \test378() takes int[] defined at %s:7

--- a/tests/files/expected/0426_inline_var_force.php.expected
+++ b/tests/files/expected/0426_inline_var_force.php.expected
@@ -1,4 +1,4 @@
 %s:6 PhanUndeclaredVariable Variable $prev is undeclared
 %s:10 PhanUndeclaredVariable Variable $prev is undeclared
-%s:22 PhanUnextractableAnnotation Saw unextractable annotation for comment @phan-example-annotation array<int,string> description :
-%s:22 PhanUnextractableAnnotation Saw unextractable annotation for comment @phan-param a value
+%s:22 PhanUnextractableAnnotation Saw unextractable annotation for comment '@phan-example-annotation array<int,string> description :'
+%s:22 PhanUnextractableAnnotation Saw unextractable annotation for comment '@phan-param a value'


### PR DESCRIPTION
And fix instances of these issues for self-analysis.

See NEWS.md for more details