### PR TITLE
Fixes #1633: Warn about read-only properties for dead code detection

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,10 @@ New Features(CLI, Configs)
 + Warn about invalid expressions/variables encapsulated within double-quoted strings or within heredoc strings.
   New issue type: `TypeSuspicioousStringExpression` (May also emit `TypeConversionFromArray`)
 
+Bug Fixes
++ Consistently warn about unreferenced declared properties (i.e. properties that are not magic or dynamically added).
+  Previously, Phan would just never warn if the class had a `__get()` method (as a heuristic).
+
 03 Apr 2018, Phan 0.12.5
 ------------------------
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@ Phan NEWS
 ------------------------
 
 New Features(CLI, Configs)
++ Warn about properties that are read but not written to when dead code detection is enabled
+  (Similar to existing warnings about properties that are written to but never read)
+  New issue types: `PhanReadOnlyPrivateProperty`, `PhanReadOnlyProtectedProperty`, `PhanReadOnlyPublicProperty`
 + Warn about string and numeric literals that are no-ops. (E.g. `<?php 'notEchoedStr'; "notEchoed $x"; ?>`)
   New issue types: `PhanNoopStringLiteral`, `PhanNoopEncapsulatedStringLiteral`, `PhanNoopNumericLiteral`.
 

--- a/composer.lock
+++ b/composer.lock
@@ -70,16 +70,16 @@
         },
         {
             "name": "composer/xdebug-handler",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "1852e549ad0d6f2910f89c27fec833dda1b25b4a"
+                "reference": "c919dc6c62e221fc6406f861ea13433c0aa24f08"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/1852e549ad0d6f2910f89c27fec833dda1b25b4a",
-                "reference": "1852e549ad0d6f2910f89c27fec833dda1b25b4a",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/c919dc6c62e221fc6406f861ea13433c0aa24f08",
+                "reference": "c919dc6c62e221fc6406f861ea13433c0aa24f08",
                 "shasum": ""
             },
             "require": {
@@ -110,7 +110,7 @@
                 "Xdebug",
                 "performance"
             ],
-            "time": "2018-03-08T13:09:50+00:00"
+            "time": "2018-04-11T15:42:36+00:00"
         },
         {
             "name": "felixfbecker/advanced-json-rpc",
@@ -497,7 +497,7 @@
         },
         {
             "name": "symfony/console",
-            "version": "v3.4.7",
+            "version": "v3.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
@@ -566,7 +566,7 @@
         },
         {
             "name": "symfony/debug",
-            "version": "v3.4.7",
+            "version": "v3.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
@@ -934,23 +934,23 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.7.5",
+            "version": "1.7.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401"
+                "reference": "33a7e3c4fda54e912ff6338c48823bd5c0f0b712"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/dfd6be44111a7c41c2e884a336cc4f461b3b2401",
-                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/33a7e3c4fda54e912ff6338c48823bd5c0f0b712",
+                "reference": "33a7e3c4fda54e912ff6338c48823bd5c0f0b712",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
                 "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
-                "sebastian/comparator": "^1.1|^2.0",
+                "sebastian/comparator": "^1.1|^2.0|^3.0",
                 "sebastian/recursion-context": "^1.0|^2.0|^3.0"
             },
             "require-dev": {
@@ -993,20 +993,20 @@
                 "spy",
                 "stub"
             ],
-            "time": "2018-02-19T10:16:54+00:00"
+            "time": "2018-04-18T13:57:24+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "5.3.0",
+            "version": "5.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "661f34d0bd3f1a7225ef491a70a020ad23a057a1"
+                "reference": "c89677919c5dd6d3b3852f230a663118762218ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/661f34d0bd3f1a7225ef491a70a020ad23a057a1",
-                "reference": "661f34d0bd3f1a7225ef491a70a020ad23a057a1",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c89677919c5dd6d3b3852f230a663118762218ac",
+                "reference": "c89677919c5dd6d3b3852f230a663118762218ac",
                 "shasum": ""
             },
             "require": {
@@ -1056,7 +1056,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-12-06T09:29:45+00:00"
+            "time": "2018-04-06T15:36:58+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1246,16 +1246,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.5.7",
+            "version": "6.5.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "6bd77b57707c236833d2b57b968e403df060c9d9"
+                "reference": "4f21a3c6b97c42952fd5c2837bb354ec0199b97b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6bd77b57707c236833d2b57b968e403df060c9d9",
-                "reference": "6bd77b57707c236833d2b57b968e403df060c9d9",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/4f21a3c6b97c42952fd5c2837bb354ec0199b97b",
+                "reference": "4f21a3c6b97c42952fd5c2837bb354ec0199b97b",
                 "shasum": ""
             },
             "require": {
@@ -1326,7 +1326,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-02-26T07:01:09+00:00"
+            "time": "2018-04-10T11:38:34+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -501,6 +501,29 @@ $a = 42;
 $a;
 ```
 
+## PhanReadOnlyPrivateProperty
+
+These issues are emitted when the analyzed file list contains at least one read operation
+for a given declared property, but no write operations on that property.
+
+There may be false positives if dynamic property accesses are performed, or if the code is a library that is used elsewhere.
+
+```
+Possibly zero write references to private property {PROPERTY}
+```
+
+## PhanReadOnlyProtectedProperty
+
+```
+Possibly zero write references to protected property {PROPERTY}
+```
+
+## PhanReadOnlyPublicProperty
+
+```
+Possibly zero write references to public property {PROPERTY}
+```
+
 ## PhanUnreachableCatch
 
 ```

--- a/src/Phan/Analysis/ConditionVisitorUtil.php
+++ b/src/Phan/Analysis/ConditionVisitorUtil.php
@@ -26,6 +26,9 @@ trait ConditionVisitorUtil
      * @var Context
      * The context in which the node we're going to be looking
      * at exits.
+     *
+     * @suppress PhanReadOnlyProtectedProperty the subclasses using the trait inherit $context from base contexts.
+     *  Phan can't analyze that.
      */
     protected $context;
 

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -218,6 +218,9 @@ class Issue
     const UnreferencedPublicProperty    = 'PhanUnreferencedPublicProperty';
     const UnreferencedProtectedProperty = 'PhanUnreferencedProtectedProperty';
     const UnreferencedPrivateProperty   = 'PhanUnreferencedPrivateProperty';
+    const ReadOnlyPublicProperty        = 'PhanReadOnlyPublicProperty';
+    const ReadOnlyProtectedProperty     = 'PhanReadOnlyProtectedProperty';
+    const ReadOnlyPrivateProperty       = 'PhanReadOnlyPrivateProperty';
     const WriteOnlyPublicProperty       = 'PhanWriteOnlyPublicProperty';
     const WriteOnlyProtectedProperty    = 'PhanWriteOnlyProtectedProperty';
     const WriteOnlyPrivateProperty      = 'PhanWriteOnlyPrivateProperty';
@@ -1956,6 +1959,30 @@ class Issue
                 "Possibly zero references to private property {PROPERTY}",
                 self::REMEDIATION_B,
                 6016
+            ),
+            new Issue(
+                self::ReadOnlyPublicProperty,
+                self::CATEGORY_NOOP,
+                self::SEVERITY_NORMAL,
+                "Possibly zero write references to public property {PROPERTY}",
+                self::REMEDIATION_B,
+                6032
+            ),
+            new Issue(
+                self::ReadOnlyProtectedProperty,
+                self::CATEGORY_NOOP,
+                self::SEVERITY_NORMAL,
+                "Possibly zero write references to protected property {PROPERTY}",
+                self::REMEDIATION_B,
+                6033
+            ),
+            new Issue(
+                self::ReadOnlyPrivateProperty,
+                self::CATEGORY_NOOP,
+                self::SEVERITY_NORMAL,
+                "Possibly zero write references to private property {PROPERTY}",
+                self::REMEDIATION_B,
+                6034
             ),
             new Issue(
                 self::WriteOnlyPublicProperty,

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -703,6 +703,7 @@ class Clazz extends AddressableElement
                 $flags,
                 $property_fqsen
             );
+            $property->setIsFromPHPDoc(true);
 
             $this->addProperty($code_base, $property, new None);
         }
@@ -922,6 +923,7 @@ class Clazz extends AddressableElement
         }
 
         // Check to see if we can use a __get magic method
+        // TODO: What about __set?
         if (!$is_static && $this->hasMethodWithName($code_base, '__get')) {
             $method = $this->getMethodByName($code_base, '__get');
 
@@ -952,6 +954,7 @@ class Clazz extends AddressableElement
                 0,
                 $property_fqsen
             );
+            $property->setIsDynamicProperty(true);
 
             $this->addProperty($code_base, $property, new None);
 
@@ -993,6 +996,7 @@ class Clazz extends AddressableElement
                 0,
                 $property_fqsen
             );
+            $property->setIsDynamicProperty(true);
 
             $this->addProperty($code_base, $property, new None);
 
@@ -1527,6 +1531,7 @@ class Clazz extends AddressableElement
      * @return bool
      * True if this class has a magic '__get' or '__set'
      * method
+     * @suppress PhanUnreferencedPublicMethod
      */
     public function hasGetOrSetMethod(CodeBase $code_base)
     {

--- a/src/Phan/Language/Element/Flags.php
+++ b/src/Phan/Language/Element/Flags.php
@@ -32,7 +32,10 @@ class Flags
     const IS_PARAM_USING_NULLABLE_SYNTAX = (1 << 17);
 
     // For dead code detection
-    const WAS_PROPERTY_READ = (1 << 17);
+    const WAS_PROPERTY_READ = (1 << 18);
+    const WAS_PROPERTY_WRITTEN = (1 << 19);
+
+    const IS_DYNAMIC_PROPERTY = (1 << 20);
 
     /**
      * Either enable or disable the given flag on

--- a/src/Phan/Language/Element/Property.php
+++ b/src/Phan/Language/Element/Property.php
@@ -194,6 +194,24 @@ class Property extends ClassElement
     }
 
     /**
+     * Returns true if at least one of the references to this property was **writing** the property
+     *
+     * Precondition: Config::get_track_references() === true
+     */
+    public function hasWriteReference() : bool
+    {
+        return $this->getPhanFlagsHasState(Flags::WAS_PROPERTY_WRITTEN);
+    }
+
+    /**
+     * @return void
+     */
+    public function setHasWriteReference()
+    {
+        $this->enablePhanFlagBits(Flags::WAS_PROPERTY_WRITTEN);
+    }
+
+    /**
      * Copy addressable references from an element of the same subclass
      * @override
      * @return void
@@ -211,5 +229,48 @@ class Property extends ClassElement
         if ($element->hasReadReference()) {
             $this->setHasReadReference();
         }
+        if ($element->hasWriteReference()) {
+            $this->setHasWriteReference();
+        }
+    }
+
+    /**
+     * @return bool
+     * True if this is a magic phpdoc property (declared via (at)property (-read,-write,) on class declaration phpdoc)
+     */
+    public function isFromPHPDoc() : bool
+    {
+        return $this->getPhanFlagsHasState(Flags::IS_FROM_PHPDOC);
+    }
+
+    /**
+     * @param bool $from_phpdoc - True if this is a magic phpdoc property (declared via (at)property (-read,-write,) on class declaration phpdoc)
+     * @return void
+     */
+    public function setIsFromPHPDoc(bool $from_phpdoc)
+    {
+        $this->setPhanFlags(
+            Flags::bitVectorWithState(
+                $this->getPhanFlags(),
+                Flags::IS_FROM_PHPDOC,
+                $from_phpdoc
+            )
+        );
+    }
+
+    public function isDynamicProperty() : bool
+    {
+        return $this->getPhanFlagsHasState(Flags::IS_DYNAMIC_PROPERTY);
+    }
+
+    public function setIsDynamicProperty(bool $is_dynamic)
+    {
+        $this->setPhanFlags(
+            Flags::bitVectorWithState(
+                $this->getPhanFlags(),
+                Flags::IS_DYNAMIC_PROPERTY,
+                $is_dynamic
+            )
+        );
     }
 }

--- a/src/Phan/LanguageServer/Protocol/TextDocumentContentChangeEvent.php
+++ b/src/Phan/LanguageServer/Protocol/TextDocumentContentChangeEvent.php
@@ -31,6 +31,7 @@ class TextDocumentContentChangeEvent
      * The new text of the document.
      *
      * @var string
+     * @suppress PhanReadOnlyPublicProperty (we don't have tests setting this, yet)
      */
     public $text;
 }

--- a/src/Phan/LanguageServer/Protocol/TextDocumentItem.php
+++ b/src/Phan/LanguageServer/Protocol/TextDocumentItem.php
@@ -14,6 +14,7 @@ class TextDocumentItem
      * The text document's URI.
      *
      * @var string
+     * @suppress PhanReadOnlyPublicProperty
      */
     public $uri;
 
@@ -38,6 +39,7 @@ class TextDocumentItem
      * The content of the opened text document.
      *
      * @var string
+     * @suppress PhanReadOnlyPublicProperty
      */
     public $text;
 }

--- a/src/Phan/LanguageServer/Protocol/VersionedTextDocumentIdentifier.php
+++ b/src/Phan/LanguageServer/Protocol/VersionedTextDocumentIdentifier.php
@@ -12,6 +12,7 @@ class VersionedTextDocumentIdentifier extends TextDocumentIdentifier
      * The version number of this document.
      *
      * @var int
+     * @suppress PhanReadOnlyPublicProperty
      */
     public $version;
 }

--- a/tests/Phan/BaseTest.php
+++ b/tests/Phan/BaseTest.php
@@ -10,8 +10,12 @@ use PHPUnit\Framework\TestCase;
  */
 abstract class BaseTest extends TestCase
 {
-    // Needed to prevent phpunit from backing up these private static variables.
-    // See https://phpunit.de/manual/current/en/fixtures.html#fixtures.global-state
+    /**
+     * Needed to prevent phpunit from backing up these private static variables.
+     * See https://phpunit.de/manual/current/en/fixtures.html#fixtures.global-state
+     *
+     * @suppress PhanReadOnlyProtectedProperty read by phpunit framework
+     */
     protected $backupStaticAttributesBlacklist = [
         'Phan\AST\PhanAnnotationAdder' => [
             'closures_for_kind',

--- a/tests/Phan/Language/UnionTypeTest.php
+++ b/tests/Phan/Language/UnionTypeTest.php
@@ -42,8 +42,11 @@ class UnionTypeTest extends BaseTest
     /** @var CodeBase|null */
     protected static $code_base = null;
 
-    // Based on BaseTest
-    // TODO: Investigate instantiating CodeBase in a cheaper way (lazily?)
+    /**
+     * Based on BaseTest
+     * TODO: Investigate instantiating CodeBase in a cheaper way (lazily?)
+     * @suppress PhanReadOnlyProtectedProperty read by phpunit framework
+     */
     protected $backupStaticAttributesBlacklist = [
         'Phan\AST\PhanAnnotationAdder' => [
             'closures_for_kind',

--- a/tests/plugin_test/expected/000_plugins.php.expected
+++ b/tests/plugin_test/expected/000_plugins.php.expected
@@ -19,3 +19,4 @@ src/000_plugins.php:77 PhanPluginAlwaysReturnMethod Method \ReturnChecks::missin
 src/000_plugins.php:127 PhanTypeMismatchArgumentInternal Argument 1 (string) is int but \strlen() takes string
 src/000_plugins.php:138 DemoPluginMethodName Method \TestDemoPlugin::function cannot be called `function`
 src/000_plugins.php:139 DemoPluginPropertyName Property \TestDemoPlugin::property should not be called `property`
+src/000_plugins.php:139 PhanReadOnlyPublicProperty Possibly zero write references to public property \TestDemoPlugin::property

--- a/tests/plugin_test/expected/001_dead_code.php.expected
+++ b/tests/plugin_test/expected/001_dead_code.php.expected
@@ -1,5 +1,7 @@
 src/001_dead_code.php:8 PhanUnreferencedFunction Possibly zero references to function \duplicateFnB
+src/001_dead_code.php:18 PhanReadOnlyPublicProperty Possibly zero write references to public property \DuplicateClass001::static_prop1
 src/001_dead_code.php:19 PhanUnreferencedPublicProperty Possibly zero references to public property \DuplicateClass001::static_prop2
+src/001_dead_code.php:21 PhanReadOnlyPublicProperty Possibly zero write references to public property \DuplicateClass001::instance_prop1
 src/001_dead_code.php:22 PhanUnreferencedPublicProperty Possibly zero references to public property \DuplicateClass001::instance_prop2
 src/001_dead_code.php:25 PhanUnreferencedPublicMethod Possibly zero references to public method \DuplicateClass001::f2
 src/001_dead_code.php:26 PhanUnreferencedPublicMethod Possibly zero references to public method \DuplicateClass001::f3

--- a/tests/plugin_test/expected/003_suppress_on_property.php.expected
+++ b/tests/plugin_test/expected/003_suppress_on_property.php.expected
@@ -1,2 +1,3 @@
+src/003_suppress_on_property.php:7 PhanReadOnlyPublicProperty Possibly zero write references to public property \A3::x
 src/003_suppress_on_property.php:10 PhanPluginMixedKeyNoKey Should not mix array entries of the form [key => value,] with entries of the form [value,].
 src/003_suppress_on_property.php:19 PhanPluginDuplicateArrayKey Duplicate/Equivalent array key value('key') detected in array - the earlier entry will be ignored.

--- a/tests/plugin_test/src/003_suppress_on_property.php
+++ b/tests/plugin_test/src/003_suppress_on_property.php
@@ -9,8 +9,8 @@ class A3 {
         'key' => 'otherValue',
         'key' => 'redundant',
     ];
-
     /**
+     * @suppress PhanReadOnlyPublicProperty
      * @suppress PhanPluginMixedKeyNoKey
      */
     public $y = [

--- a/tests/plugin_test/src/014_unreferenced_constant.php
+++ b/tests/plugin_test/src/014_unreferenced_constant.php
@@ -10,6 +10,7 @@ class A14 {
     public static $prop2 = 33;
     public static function foo() { echo "Called foo\n"; }
     public static function foo_unused() { echo "Called foo_unused\n"; }
+    public static $prop3 = 33;
 }
 class B14 extends A14 {
 }
@@ -19,4 +20,5 @@ $b = new B14();
 // Reference base class's elements from a subclass.
 $y = B14::myotherconst;
 B14::$prop++;
+A14::$prop3++;
 B14::foo();


### PR DESCRIPTION
(Those properties may be false positives in libraries,
if the caller or framework is responsible for instantiating the values)