### PR TITLE
Improve analysis of array shape type casts and return statements

### DIFF
--- a/.phan/plugins/PrintfCheckerPlugin.php
+++ b/.phan/plugins/PrintfCheckerPlugin.php
@@ -323,7 +323,7 @@ class PrintfCheckerPlugin extends PluginV2 implements AnalyzeFunctionCallCapabil
          * The list of placeholders for between braces can be found
          * in \Phan\Issue::uncolored_format_string_for_template.
          *
-         * @param string[] $issue_message_args
+         * @param array<int,string|float|int> $issue_message_args
          * The arguments for this issue format.
          * If this array is empty, $issue_message_args is kept in place
          *

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@ Phan NEWS
 ?? ??? 2018, Phan 0.12.6 (dev)
 ------------------------
 
-New Features(CLI, Configs)
+New features(Analysis)
 + Warn about properties that are read but not written to when dead code detection is enabled
   (Similar to existing warnings about properties that are written to but never read)
   New issue types: `PhanReadOnlyPrivateProperty`, `PhanReadOnlyProtectedProperty`, `PhanReadOnlyPublicProperty`
@@ -11,8 +11,14 @@ New Features(CLI, Configs)
   New issue types: `PhanNoopStringLiteral`, `PhanNoopEncapsulatedStringLiteral`, `PhanNoopNumericLiteral`.
 
   Note: This will not warn about Phan's [inline type checks via string literals](https://github.com/phan/phan/wiki/Annotating-Your-Source-Code#inline-type-checks-via-string-literals)
++ When returning an array literal (with known keys) directly,
+  make Phan infer the array literal's array shape type instead of a combination of generic array types.
++ Make type casting rules stricter when checking if an array shape can cast to a given generic array type.
+  (E.g. `array{a:string,b:int}` can no longer cast to `array<string,int>`, but can cast to `array<string,int>|array<string,string>`).
+
+  E.g. Phan will now warn about `/** @return array<string,int> */ function example() { $result = ['a' => 'x', 'b' => 2]; return $result; }`
 + Warn about invalid expressions/variables encapsulated within double-quoted strings or within heredoc strings.
-  New issue type: `TypeSuspicioousStringExpression` (May also emit `TypeConversionFromArray`)
+  New issue type: `TypeSuspiciousStringExpression` (May also emit `TypeConversionFromArray`)
 
 Bug Fixes
 + Consistently warn about unreferenced declared properties (i.e. properties that are not magic or dynamically added).

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -1772,6 +1772,22 @@ class Type
     }
 
     /**
+     * @param Type[] $target_type_set 1 or more types
+     * @return bool
+     * True if this Type can be cast to the given Type cleanly.
+     * This is overridden by ArrayShapeType to allow array{a:string,b:stdClass} to cast to string[]|stdClass[]
+     */
+    public function canCastToAnyTypeInSet(array $target_type_set) : bool
+    {
+        foreach ($target_type_set as $target_type) {
+            if ($this->canCastToType($target_type)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * @return bool
      * True if this Type can be cast to the given Type
      * cleanly

--- a/src/Phan/Language/Type/MixedType.php
+++ b/src/Phan/Language/Type/MixedType.php
@@ -18,6 +18,17 @@ final class MixedType extends NativeType
         return true;
     }
 
+    /**
+     * @param Type[] $target_type_set 1 or more types
+     * @return bool
+     * @override
+     * @suppress PhanPluginUnusedPublicFinalMethodArgument (mixed can cast to any type, probably won't get called)
+     */
+    public function canCastToAnyTypeInSet(array $target_type_set) : bool
+    {
+        return true;
+    }
+
     // mixed or ?mixed can cast to/from anything.
     // For purposes of analysis, there's no difference between mixed and nullable mixed.
     protected function canCastToNonNullableType(Type $unused_type) : bool

--- a/tests/Phan/MultiFileTest.php
+++ b/tests/Phan/MultiFileTest.php
@@ -6,7 +6,10 @@ class MultiFileTest extends AbstractPhanFileTest
 
     /**
      * @suppress PhanUndeclaredConstant
+     * @suppress PhanParamSignatureMismatch
+     *
      * The constant MULTI_FILE_DIR is defined in `phpunit.xml`.
+     * @return array<int,array{0:array<int,string>,1:string}>
      */
     public function getTestFiles()
     {

--- a/tests/files/expected/0245_nullable_dim.php.expected
+++ b/tests/files/expected/0245_nullable_dim.php.expected
@@ -1,1 +1,1 @@
-%s:4 PhanTypeMismatchReturn Returning type array<int,string> but f() is declared to return ?int[]
+%s:4 PhanTypeMismatchReturn Returning type array{0:string} but f() is declared to return ?int[]

--- a/tests/files/expected/0285_nullable_generic_array.php.expected
+++ b/tests/files/expected/0285_nullable_generic_array.php.expected
@@ -1,3 +1,3 @@
-%s:25 PhanTypeMismatchReturn Returning type array<int,string> but f285_6() is declared to return ?int[]
+%s:25 PhanTypeMismatchReturn Returning type array{0:string} but f285_6() is declared to return ?int[]
 %s:28 PhanUnextractableAnnotation Saw unextractable annotation for comment '/** @return ??int[] */'
 %s:33 PhanUnextractableAnnotation Saw unextractable annotation for comment '/** @return ??int[] */'

--- a/tests/files/expected/0339_bad_arrayreturn.php.expected
+++ b/tests/files/expected/0339_bad_arrayreturn.php.expected
@@ -1,2 +1,1 @@
-%s:6 PhanTypeMismatchReturn Returning type array<int,array{0:int}> but testarrayreturn() is declared to return int[]
-%s:6 PhanTypeMismatchReturn Returning type array<int,string> but testarrayreturn() is declared to return int[]
+%s:6 PhanTypeMismatchReturn Returning type array{0:int,1:string,2:array{0:int}} but testarrayreturn() is declared to return int[]

--- a/tests/files/expected/0386_multi_union_type.php.expected
+++ b/tests/files/expected/0386_multi_union_type.php.expected
@@ -1,1 +1,1 @@
-%s:8 PhanTypeMismatchReturn Returning type array<int,\stdClass> but testPipeInTemplate386() is declared to return array<int,bool>|array<int,null>
+%s:8 PhanTypeMismatchReturn Returning type array{0:\stdClass} but testPipeInTemplate386() is declared to return array<int,bool>|array<int,null>

--- a/tests/files/expected/0472_array_shape_return_check.php.expected
+++ b/tests/files/expected/0472_array_shape_return_check.php.expected
@@ -1,0 +1,8 @@
+%s:12 PhanTypeMismatchReturn Returning type array{key:int,other:string} but test_return472() is declared to return array{key:string}
+%s:15 PhanTypeMismatchReturn Returning type array{key:\stdClass} but test_return472() is declared to return array{key:string}
+%s:18 PhanTypeMismatchReturn Returning type array{key:null} but test_return472() is declared to return array{key:string}
+%s:21 PhanTypeMismatchReturn Returning type array{} but test_return472() is declared to return array{key:string}
+%s:32 PhanTypeMismatchReturn Returning type array{key:string,other:int} but test_return_generic_array_472() is declared to return array<string,bool>|array<string,string>
+%s:36 PhanTypeMismatchReturn Returning type array{key:string,other:null} but test_return_generic_array_472() is declared to return array<string,bool>|array<string,string>
+%s:43 PhanTypeMismatchReturn Returning type array<string,\stdClass> but test_return_generic_array_472() is declared to return array<string,bool>|array<string,string>
+%s:44 PhanTypeMismatchReturn Returning type array<string,null> but test_return_generic_array_472() is declared to return array<string,bool>|array<string,string>

--- a/tests/files/expected/0801_trait_analyze_method_body.php.expected
+++ b/tests/files/expected/0801_trait_analyze_method_body.php.expected
@@ -1,2 +1,2 @@
 %s:4 PhanTypeMismatchReturn Returning type string but f2() is declared to return int
-%s:10 PhanTypeMismatchReturn Returning type array but f() is declared to return \U301
+%s:10 PhanTypeMismatchReturn Returning type array{} but f() is declared to return \U301

--- a/tests/files/src/0472_array_shape_return_check.php
+++ b/tests/files/src/0472_array_shape_return_check.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @param string $unknown
+ * @return array{key:string}
+ */
+function test_return472(string $unknown) : array {
+    switch (rand() % 5) {
+        case 0:
+            return ['key' => 'x', 'other' => 2];  // valid
+        case 1:
+            return ['key' => 2, 'other' => 'x'];  // invalid
+        case 2:
+            return rand() % 2
+                ? ['key' => new stdClass()]  // invalid
+                : ['key' => 'a'];  // invalid
+        case 3:
+            return rand() % 2 ? ['key' => 'a'] : ['key' => null];  // invalid
+        case 4:
+        default:
+            return [];
+    }
+}
+
+/**
+ * @param string $unknown
+ * @return array<string,string|bool>
+ */
+function test_return_generic_array_472(string $unknown) : array {
+    switch (rand() % 5) {
+        case 0:
+            return ['key' => 'x', 'other' => 2];  // invalid due to int[]
+        case 1:
+            return ['key' => 'x', 'other' => false];  // valid
+        case 2:
+            return ['key' => 'x', 'other' => null];  // invalid
+        case 3:
+            return ['key' => 'x', 3 => 'y'];  // invalid
+        case 4:
+        default:
+            return [
+                'key' => 'x',
+                'other' => new stdClass(),  // invalid
+                $unknown => null,  // invalid
+            ];
+    }
+}

--- a/tests/rasmus_files/expected/0003_return_type.php.expected
+++ b/tests/rasmus_files/expected/0003_return_type.php.expected
@@ -1,2 +1,2 @@
-%s:4 PhanTypeMismatchReturn Returning type array<int,int> but test() is declared to return int
+%s:4 PhanTypeMismatchReturn Returning type array{0:int,1:int,2:int} but test() is declared to return int
 %s:13 PhanTypeMismatchReturn Returning type float but test3() is declared to return int

--- a/tests/rasmus_files/expected/0034_generics.php.expected
+++ b/tests/rasmus_files/expected/0034_generics.php.expected
@@ -1,1 +1,1 @@
-%s:13 PhanTypeMismatchReturn Returning type array<int,string> but test2() is declared to return \DateTime[]
+%s:13 PhanTypeMismatchReturn Returning type array{0:string} but test2() is declared to return \DateTime[]

--- a/tests/run_all_tests
+++ b/tests/run_all_tests
@@ -39,7 +39,7 @@ FAILURES=""
 if [[ "$PHAN_TEST_PARALLEL" == 1 ]]; then
 	# Note: Must install GNU parallel for this to work.
 	if ! echo "$TEST_SUITES" | tr ' ' '\n' | parallel --jobs 4 --no-notice --joblog tests/.run_all_tests.joblog --arg-sep ' ' tests/run_test --print-test-suite; then
-		FAILURES=" $(awk '$7 >= 1 && $10 { print $10}' < tests/.run_all_tests.joblog | tr '\n' ' ')"
+		FAILURES=" $(awk '$7 >= 1 && $11 { print $11}' < tests/.run_all_tests.joblog | tr '\n' ' ')"
 	fi
 else
 	for TEST_SUITE in $TEST_SUITES; do


### PR DESCRIPTION
When returning an array literal (with known keys) directly,
make Phan infer the array literal's array shape types instead of a
combination of generic array types.

Stricter type casting rules for checking if an array shape can cast to a
given generic array type
(E.g. `array{0:string,1:int}` can no longer cast to `array<int,int>`)

Make return type error lines more accurate when analyzing ternary
operators or arrays with one or more unknown keys.

Update unit tests to reflect the new behavior.