### PR TITLE
Add partial support for iterable and Generator template types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ composer.phar
 /report
 samples
 all_output.*
+*.joblog
 *.swo
 *.swp
 *.zip

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,28 @@ New features(Analysis)
 + Warn about invalid expressions/variables encapsulated within double-quoted strings or within heredoc strings.
   New issue type: `TypeSuspiciousStringExpression` (May also emit `TypeConversionFromArray`)
 
++ Add incomplete support for template params in iterable types in phpdoc. (#824)
+  Phan supports `iterable<TValue>` and `iterable<TKey, TValue>` syntaxes. (Where TKey and TValue are union types)
+  Phan will check that generic arrays and array shapes can cast to iterable template types.
++ Add incomplete support for template params in Generator types in phpdoc. (#824)
+
+  1. `\Generator<TValue>`
+  2. `\Generator<TKey,TValue>`
+  3. `\Generator<TKey,TValue,TSend>` (TSend can be parsed, but is not analyzed yet)
+  4. `\Generator<TKey,TValue,TSend,TReturn>` (TReturn can be parsed, but is not analyzed yet)
+
+  New issue types: `PhanTypeMismatchGeneratorYieldValue`, `PhanTypeMismatchGeneratorYieldKey` (For comparing yield statements against the declared `TValue` and `TKey`)
+
+  Additionally, Phan will use `@return Generator|TValue[]` to analyze the yield statements
+  within a function/method body the same way as it would analyze `@return Generator<TValue>`.
+  (Analysis outside the method would not change)
+
++ Analyze `yield from` statements.
+
+  New issue types: `PhanTypeInvalidYieldFrom` (Emitted when the expression passed to `yield from` is not a Traversable or an array)
+
+  Warnings about the inferred keys/values of `yield from` being invalid reuse `PhanTypeMismatchGeneratorYieldValue` and `PhanTypeMismatchGeneratorYieldKey`
+
 Bug Fixes
 + Consistently warn about unreferenced declared properties (i.e. properties that are not magic or dynamically added).
   Previously, Phan would just never warn if the class had a `__get()` method (as a heuristic).

--- a/composer.lock
+++ b/composer.lock
@@ -497,16 +497,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v3.4.8",
+            "version": "v3.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "d4bb70fa24d540c309d88a9d6e43fb2d339b1fbf"
+                "reference": "5b1fdfa8eb93464bcc36c34da39cedffef822cdf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/d4bb70fa24d540c309d88a9d6e43fb2d339b1fbf",
-                "reference": "d4bb70fa24d540c309d88a9d6e43fb2d339b1fbf",
+                "url": "https://api.github.com/repos/symfony/console/zipball/5b1fdfa8eb93464bcc36c34da39cedffef822cdf",
+                "reference": "5b1fdfa8eb93464bcc36c34da39cedffef822cdf",
                 "shasum": ""
             },
             "require": {
@@ -527,7 +527,7 @@
                 "symfony/process": "~3.3|~4.0"
             },
             "suggest": {
-                "psr/log": "For using the console logger",
+                "psr/log-implementation": "For using the console logger",
                 "symfony/event-dispatcher": "",
                 "symfony/lock": "",
                 "symfony/process": ""
@@ -562,20 +562,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2018-04-03T05:22:50+00:00"
+            "time": "2018-04-30T01:22:56+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v3.4.8",
+            "version": "v3.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "9cf7c2271cfb89ef9727db1b740ca77be57bf9d7"
+                "reference": "1b95888cfd996484527cb41e8952d9a5eaf7454f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/9cf7c2271cfb89ef9727db1b740ca77be57bf9d7",
-                "reference": "9cf7c2271cfb89ef9727db1b740ca77be57bf9d7",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/1b95888cfd996484527cb41e8952d9a5eaf7454f",
+                "reference": "1b95888cfd996484527cb41e8952d9a5eaf7454f",
                 "shasum": ""
             },
             "require": {
@@ -618,20 +618,20 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2018-04-03T05:22:50+00:00"
+            "time": "2018-04-30T16:53:52+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.7.0",
+            "version": "v1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "78be803ce01e55d3491c1397cf1c64beb9c1b63b"
+                "reference": "3296adf6a6454a050679cde90f95350ad604b171"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/78be803ce01e55d3491c1397cf1c64beb9c1b63b",
-                "reference": "78be803ce01e55d3491c1397cf1c64beb9c1b63b",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/3296adf6a6454a050679cde90f95350ad604b171",
+                "reference": "3296adf6a6454a050679cde90f95350ad604b171",
                 "shasum": ""
             },
             "require": {
@@ -643,7 +643,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7-dev"
+                    "dev-master": "1.8-dev"
                 }
             },
             "autoload": {
@@ -677,7 +677,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-01-30T19:27:44+00:00"
+            "time": "2018-04-26T10:06:28+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -1420,6 +1420,12 @@ Invalid operator: left operand is array and right is not
 @throws annotation of {FUNCTIONLIKE} has suspicious class type {TYPE}, which does not extend Error/Exception
 ```
 
+## PhanTypeInvalidYieldFrom
+
+```
+Yield from statement was passed an invalid expression of type {TYPE} (expected Traversable/array)
+```
+
 ## PhanTypeMagicVoidWithReturn
 
 ```
@@ -1530,6 +1536,18 @@ This will be emitted for the code
 
 ```php
 foreach (null as $i) {}
+```
+
+## PhanTypeMismatchGeneratorYieldKey
+
+```
+Yield statement has a key with type {TYPE} but {FUNCTIONLIKE}() is declared to yield keys of type {TYPE} in {TYPE}
+```
+
+## PhanTypeMismatchGeneratorYieldValue
+
+```
+Yield statement has a value with type {TYPE} but {FUNCTIONLIKE}() is declared to yield values of type {TYPE} in {TYPE}
 ```
 
 ## PhanTypeMismatchProperty

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -674,6 +674,7 @@ class ContextNode
     /**
      * Yields a list of FunctionInterface objects for the 'expr' of an AST_CALL.
      * @return \Generator
+     * @phan-return \Generator<FunctionInterface>
      */
     public function getFunctionFromNode()
     {

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -2174,6 +2174,7 @@ class UnionTypeVisitor extends AnalysisVisitor
     }
 
     /**
+     * @phan-return \Generator<Clazz>
      * @return \Generator|Clazz[]
      * A list of classes associated with the given node
      *

--- a/src/Phan/Analysis/ReferenceCountsAnalyzer.php
+++ b/src/Phan/Analysis/ReferenceCountsAnalyzer.php
@@ -109,6 +109,7 @@ class ReferenceCountsAnalyzer
      * @param int $i
      *
      * @return \Generator|ClassElement[]
+     * @phan-return \Generator<ClassElement>
      */
     private static function getElementsFromClassMapForDeferredAnalysis(
         CodeBase $code_base,
@@ -174,6 +175,7 @@ class ReferenceCountsAnalyzer
      * @param int $i
      *
      * @return \Generator|ClassElement[]
+     * @phan-return \Generator<ClassElement>
      */
     private static function getElementsFromElementListForDeferredAnalysis(
         CodeBase $code_base,

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -127,6 +127,10 @@ class Issue
     const TypeExpectedObjectPropAccessButGotNull = 'PhanTypeExpectedObjectPropAccessButGotNull';
     const TypeExpectedObjectStaticPropAccess = 'PhanTypeExpectedObjectStaticPropAccess';
 
+    const TypeMismatchGeneratorYieldValue = 'PhanTypeMismatchGeneratorYieldValue';
+    const TypeMismatchGeneratorYieldKey = 'PhanTypeMismatchGeneratorYieldKey';
+    const TypeInvalidYieldFrom      = 'PhanTypeInvalidYieldFrom';
+
     // Issue::CATEGORY_ANALYSIS
     const Unanalyzable              = 'PhanUnanalyzable';
     const UnanalyzableInheritance   = 'PhanUnanalyzableInheritance';
@@ -872,6 +876,30 @@ class Issue
                 "Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE}() takes {TYPE}",
                 self::REMEDIATION_B,
                 10004
+            ),
+            new Issue(
+                self::TypeMismatchGeneratorYieldValue,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                "Yield statement has a value with type {TYPE} but {FUNCTIONLIKE}() is declared to yield values of type {TYPE} in {TYPE}",
+                self::REMEDIATION_B,
+                10067
+            ),
+            new Issue(
+                self::TypeMismatchGeneratorYieldKey,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                "Yield statement has a key with type {TYPE} but {FUNCTIONLIKE}() is declared to yield keys of type {TYPE} in {TYPE}",
+                self::REMEDIATION_B,
+                10068
+            ),
+            new Issue(
+                self::TypeInvalidYieldFrom,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                "Yield from statement was passed an invalid expression of type {TYPE} (expected Traversable/array)",
+                self::REMEDIATION_B,
+                10069
             ),
             new Issue(
                 self::PartialTypeMismatchArgument,

--- a/src/Phan/Language/Element/Func.php
+++ b/src/Phan/Language/Element/Func.php
@@ -282,6 +282,7 @@ class Func extends AddressableElement implements FunctionInterface
 
     /**
      * @return \Generator
+     * @phan-return \Generator<Func>
      * The set of all alternates to this function
      */
     public function alternateGenerator(CodeBase $code_base) : \Generator

--- a/src/Phan/Language/Element/FunctionInterface.php
+++ b/src/Phan/Language/Element/FunctionInterface.php
@@ -3,6 +3,7 @@ namespace Phan\Language\Element;
 
 use Phan\CodeBase;
 use Phan\Language\Context;
+use Phan\Language\Type;
 use Phan\Language\Type\FunctionLikeDeclarationType;
 use Phan\Language\UnionType;
 use Phan\Language\FQSEN\FullyQualifiedFunctionName;
@@ -369,4 +370,11 @@ interface FunctionInterface extends AddressableElementInterface
      * @return array<mixed,string> in the same format as FunctionSignatureMap.php
      */
     public function toFunctionSignatureArray() : array;
+
+    /**
+     * Precondition: This function is a generator type
+     * Converts Generator|T[] to Generator<T>
+     * Converts Generator|array<int,stdClass> to Generator<int,stdClass>, etc.
+     */
+    public function getReturnTypeAsGeneratorTemplateType() : Type;
 }

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -8,6 +8,7 @@ use Phan\Language\Context;
 use Phan\Language\Element\Comment;
 use Phan\Language\FileRef;
 use Phan\Language\FQSEN;
+use Phan\Language\Type;
 use Phan\Language\Type\ArrayType;
 use Phan\Language\Type\BoolType;
 use Phan\Language\Type\ClosureDeclarationParameter;
@@ -177,6 +178,11 @@ trait FunctionTrait
      * @var FunctionLikeDeclarationType|null (Lazily generated)
      */
     private $as_closure_declaration_type;
+
+    /**
+     * @var Type|null (Lazily generated)
+     */
+    private $as_generator_template_type;
 
     /**
      * @return int
@@ -1106,5 +1112,15 @@ trait FunctionTrait
             $stub[$name] = $type_string;
         }
         return $stub;
+    }
+
+    /**
+     * Precondition: This function is a generator type
+     * Converts Generator|T[] to Generator<T>
+     * Converts Generator|array<int,stdClass> to Generator<int,stdClass>, etc.
+     */
+    public function getReturnTypeAsGeneratorTemplateType() : Type
+    {
+        return $this->as_generator_template_type ?? ($this->as_generator_template_type = $this->getUnionType()->asGeneratorTemplateType());
     }
 }

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -498,6 +498,7 @@ class Method extends ClassElement implements FunctionInterface
 
     /**
      * @return \Generator
+     * @phan-return \Generator<Method>
      * The set of all alternates to this method
      */
     public function alternateGenerator(CodeBase $code_base) : \Generator

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -5,6 +5,7 @@ use Phan\CodeBase;
 use Phan\Exception\CodeBaseException;
 use Phan\Exception\IssueException;
 use Phan\Language\Type\ArrayType;
+use Phan\Language\FQSEN\FullyQualifiedClassName;
 
 /**
  * NOTE: there may also be instances of UnionType that are empty, due to the constructor being public
@@ -578,6 +579,8 @@ final class EmptyUnionType extends UnionType
      * type.
      *
      * @return \Generator
+     * @phan-return \Generator<FullyQualifiedClassName>
+     * @suppress PhanTypeMismatchGeneratorYieldValue (deliberate empty stub code)
      *
      * A list of class FQSENs representing the non-native types
      * associated with this UnionType
@@ -596,7 +599,7 @@ final class EmptyUnionType extends UnionType
         Context $context
     ) {
         if (false) {
-            yield null;
+            yield;
         }
     }
 
@@ -626,7 +629,7 @@ final class EmptyUnionType extends UnionType
         Context $context
     ) {
         if (false) {
-            yield null;  // This is a generator yielding 0 results. This works around a bug in tolerant-php-parser 0.0.9
+            yield;
         }
     }
 
@@ -997,5 +1000,10 @@ final class EmptyUnionType extends UnionType
     public function hasClassWithToStringMethod(CodeBase $code_base, Context $context) : bool
     {
         return false;
+    }
+
+    public function asGeneratorTemplateType() : Type
+    {
+        return Type::fromFullyQualifiedString('\Generator');
     }
 }

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -18,6 +18,7 @@ use Phan\Language\Type\FalseType;
 use Phan\Language\Type\FloatType;
 use Phan\Language\Type\FunctionLikeDeclarationType;
 use Phan\Language\Type\GenericArrayType;
+use Phan\Language\Type\GenericIterableType;
 use Phan\Language\Type\GenericMultiArrayType;
 use Phan\Language\Type\IntType;
 use Phan\Language\Type\IterableType;
@@ -37,6 +38,7 @@ use Phan\Library\Option;
 use Phan\Library\Some;
 use Phan\Library\Tuple5;
 
+use AssertionError;
 use InvalidArgumentException;
 
 /**
@@ -335,9 +337,7 @@ class Type
 
         // If this looks like a generic type string, explicitly
         // make it as such
-        if (self::isGenericArrayString($type_name)
-            && ($pos = \strrpos($type_name, '[]')) !== false
-        ) {
+        if (($pos = \strrpos($type_name, '[]')) > 0) {
             return GenericArrayType::fromElementType(Type::make(
                 $namespace,
                 \substr($type_name, 0, $pos),
@@ -347,28 +347,24 @@ class Type
             ), $is_nullable, GenericArrayType::KEY_MIXED);
         }
 
-        \assert(
-            !empty($namespace),
-            "Namespace cannot be empty"
-        );
+        if ($namespace === '') {
+            throw new AssertionError("Namespace cannot be empty");
+        }
 
-        \assert(
-            '\\' === $namespace[0],
-            "Namespace must be fully qualified"
-        );
+        if ('\\' !== $namespace[0]) {
+            throw new AssertionError("Namespace must be fully qualified");
+        }
 
-        \assert(
-            !empty($type_name),
-            "Type name cannot be empty"
-        );
+        if ($type_name === '') {
+            throw new AssertionError("Type name cannot be empty");
+        }
 
         if (\strpos($type_name, '|') !== false) {
-            throw new \AssertionError("Type name '$type_name' may not contain a pipe");
+            throw new AssertionError("Type name '$type_name' may not contain a pipe");
         }
 
         // Create a canonical representation of the
         // namespace and name
-        $namespace = $namespace ?: '\\';
         if ('\\' === $namespace && $source === Type::FROM_PHPDOC) {
             $type_name = self::canonicalNameFromName($type_name);
         }
@@ -387,8 +383,15 @@ class Type
 
         $value = self::$canonical_object_map[$key] ?? null;
         if (!$value) {
-            if ($type_name === 'Closure' && $namespace === '\\') {
+            if ($namespace === '\\' && $type_name === 'Closure') {
                 $value = new ClosureType(
+                    $namespace,
+                    $type_name,
+                    $template_parameter_type_list,
+                    $is_nullable
+                );
+            } elseif ($namespace === '\\' && $type_name === 'callable') {
+                $value = new CallableType(
                     $namespace,
                     $type_name,
                     $template_parameter_type_list,
@@ -646,7 +649,7 @@ class Type
         if (\substr($type_name, 0, 1) === '?') {
             return self::fromInternalTypeName(\substr($type_name, 1), true, $source);
         }
-        throw new \AssertionError("No internal type with name $type_name");
+        throw new AssertionError("No internal type with name $type_name");
     }
 
     /**
@@ -695,7 +698,6 @@ class Type
         static $type_cache = [];
         return $type_cache[$fully_qualified_string] ?? ($type_cache[$fully_qualified_string] = self::fromFullyQualifiedStringInner($fully_qualified_string));
     }
-
 
     public static function fromFullyQualifiedStringInner(
         string $fully_qualified_string
@@ -746,12 +748,16 @@ class Type
         }
 
         if (empty($namespace)) {
-            if (\strcasecmp($type_name, 'array') === 0 && !empty($template_parameter_type_name_list)) {
-                // template parameter type list
-                $template_parameter_type_list = \array_map(function (string $type_name) {
-                    return UnionType::fromFullyQualifiedString($type_name);
-                }, $template_parameter_type_name_list);
-                return self::parseGenericArrayTypeFromTemplateParameterList($template_parameter_type_list, $is_nullable);
+            if (\count($template_parameter_type_name_list) > 0) {
+                if (\strcasecmp($type_name, 'array') === 0) {
+                    // template parameter type list
+                    $template_parameter_type_list = self::createTemplateParameterTypeList($template_parameter_type_name_list);
+                    return self::parseGenericArrayTypeFromTemplateParameterList($template_parameter_type_list, $is_nullable);
+                } elseif (\strcasecmp($type_name, 'iterable') === 0) {
+                    // template parameter type list
+                    $template_parameter_type_list = self::createTemplateParameterTypeList($template_parameter_type_name_list);
+                    return self::parseGenericIterableTypeFromTemplateParameterList($template_parameter_type_list, $is_nullable);
+                }
             }
             return self::fromInternalTypeName(
                 $fully_qualified_string,
@@ -762,9 +768,7 @@ class Type
 
         // Map the names of the types to actual types in the
         // template parameter type list
-        $template_parameter_type_list = \array_map(function (string $type_name) {
-            return UnionType::fromFullyQualifiedString($type_name);
-        }, $template_parameter_type_name_list);
+        $template_parameter_type_list = self::createTemplateParameterTypeList($template_parameter_type_name_list);
 
         if (0 !== \strpos($namespace, '\\')) {
             $namespace = '\\' . $namespace;
@@ -787,6 +791,17 @@ class Type
     }
 
     /**
+     * @param array<int,string> $template_parameter_type_name_list
+     * @return array<int,UnionType>
+     */
+    private static function createTemplateParameterTypeList(array $template_parameter_type_name_list)
+    {
+        return \array_map(function (string $type_name) : UnionType {
+            return UnionType::fromFullyQualifiedString($type_name);
+        }, $template_parameter_type_name_list);
+    }
+
+    /**
      * @param bool $is_closure_type
      * @param array<int,string> $shape_components
      * @param bool $is_nullable
@@ -799,7 +814,7 @@ class Type
         $return_type = \array_pop($shape_components);
         if (!$return_type) {
             // shouldn't happen
-            throw new \AssertionError("Expected at least one component of a closure phpdoc type");
+            throw new AssertionError("Expected at least one component of a closure phpdoc type");
         }
         if ($return_type[0] === '(' && \substr($return_type, -1) === ')') {
             // TODO: Maybe catch that in UnionType parsing instead
@@ -821,12 +836,13 @@ class Type
     private static function parseGenericArrayTypeFromTemplateParameterList(
         array $template_parameter_type_list,
         bool $is_nullable
-    ) : Type {
+    ) : ArrayType {
         $template_count = \count($template_parameter_type_list);
         if ($template_count <= 2) {  // array<T> or array<key, T>
             $key_type = ($template_count === 2)
                 ? GenericArrayType::keyTypeFromUnionTypeValues($template_parameter_type_list[0])
                 : GenericArrayType::KEY_MIXED;
+
             $types = $template_parameter_type_list[$template_count - 1]->getTypeSet();
             if (\count($types) === 1) {
                 return GenericArrayType::fromElementType(
@@ -843,6 +859,25 @@ class Type
             }
         }
         return ArrayType::instance($is_nullable);
+    }
+
+    /**
+     * @param array<int,UnionType> $template_parameter_type_list
+     * @param bool $is_nullable
+     */
+    private static function parseGenericIterableTypeFromTemplateParameterList(
+        array $template_parameter_type_list,
+        bool $is_nullable
+    ) : Type {
+        $template_count = \count($template_parameter_type_list);
+        if ($template_count <= 2) {  // iterable<T> or iterable<key, T>
+            $key_union_type = ($template_count === 2)
+                ? $template_parameter_type_list[0]
+                : UnionType::empty();
+            $value_union_type = $template_parameter_type_list[$template_count - 1];
+            return GenericIterableType::fromKeyAndValueTypes($key_union_type, $value_union_type, $is_nullable);
+        }
+        return IterableType::instance($is_nullable);
     }
 
     /**
@@ -1018,6 +1053,9 @@ class Type
                 if (\strtolower($type_name) === 'array') {
                     return self::parseGenericArrayTypeFromTemplateParameterList($template_parameter_type_list, $is_nullable);
                 }
+                if (\strtolower($type_name) === 'iterable') {
+                    return self::parseGenericIterableTypeFromTemplateParameterList($template_parameter_type_list, $is_nullable);
+                }
                 // TODO: Warn about unrecognized types.
             }
             return self::fromInternalTypeName($type_name, $is_nullable, $source);
@@ -1101,7 +1139,7 @@ class Type
     ) : FunctionLikeDeclarationType {
         $return_type = \array_pop($shape_components);
         if (!$return_type) {
-            throw new \AssertionError("Expected a return type");
+            throw new AssertionError("Expected a return type");
         }
         if ($return_type[0] === '(' && \substr($return_type, -1) === ')') {
             $return_type = \substr($return_type, 1, -1);
@@ -1547,6 +1585,16 @@ class Type
     }
 
     /**
+     * @return bool - Returns true if this is \Generator (nullable or not)
+     * @suppress PhanUnreferencedPublicMethod
+     */
+    public function isGenerator() : bool
+    {
+        return (\strcasecmp($this->getName(), 'Generator') === 0
+            && $this->getNamespace() === '\\');
+    }
+
+    /**
      * @param string $type_name
      * A non-namespaced type name like 'int[]'
      *
@@ -1851,23 +1899,73 @@ class Type
             return true;
         }
 
+        if (!($type instanceof NativeType)) {
+            return false;
+        }
+
         if ($type instanceof MixedType) {
             return true;
         }
-        // A matrix of allowable type conversions
-        static $matrix = [
-            '\Generator' => [
-                'iterable' => true,
-            ],
-            '\Traversable' => [
-                'iterable' => true,
-            ],
-            '\Closure' => [
-                'callable' => true,
-            ],
-        ];
 
-        return $matrix[$this->__toString()][$type->__toString()] ?? false;
+        // Check for allowable type conversions from object types to native types
+        if ($type::NAME === 'iterable') {
+            if ($this->namespace === '\\' && \in_array($this->name, ['\Generator', '\Traversable', '\Iterator'], true)) {
+                if (\count($this->template_parameter_type_list) === 0 || !($type instanceof GenericIterableType)) {
+                    return true;
+                }
+                return $this->canCastTraversableToIterable($type);
+            }
+        } elseif (\get_class($type) === CallableType::class) {
+            return $this->namespace === '\\' && $this->name === 'Closure';
+        }
+        return false;
+    }
+
+    private function canCastTraversableToIterable(GenericIterableType $type) : bool
+    {
+        $template_types = $this->template_parameter_type_list;
+        $N = \count($template_types);
+        $name = $this->name;
+        if ($name === 'Traversable' || $name === 'Iterator') {
+            // Phan supports Traversable<TValue> and Traversable<TKey, TValue>
+            if ($N > 2 || $N < 1) {
+                // No idea what this means, assume it passes.
+                return true;
+            }
+            if (!$this->template_parameter_type_list[$N - 1]->canCastToUnionType($type->getElementUnionType())) {
+                return false;
+            }
+            if ($N === 2) {
+                if (!$this->template_parameter_type_list[0]->canCastToUnionType($type->getKeyUnionType())) {
+                    return false;
+                }
+            }
+            return true;
+        } elseif ($name === 'Generator') {
+            // Phan partially supports the following syntaxes for PHP doc comments
+            // 1. Generator<TValue>
+            // 2. Generator<TKey, TValue>
+            // 3. Generator<TKey, TValue, TYield>
+            // 4. Generator<TKey, TValue, TYield, TReturn> (PHP generators can return a final value, but HHVM cannot)
+
+            // TODO: Handle casting Generator to a Generator with a different number of template parameters
+            if ($N > 4 || $N < 1) {
+                // No idea what this means, assume it passes
+                return true;
+            }
+
+            if (!$this->template_parameter_type_list[\min(1, $N - 1)]->canCastToUnionType($type->getElementUnionType())) {
+                return false;
+            }
+            if ($N >= 2) {
+                if (!$this->template_parameter_type_list[0]->canCastToUnionType($type->getKeyUnionType())) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        // TODO: Check for template parameters, cast those
+        return true;
     }
 
     /**
@@ -2142,9 +2240,9 @@ class Type
 
         return new Tuple5(
             '\\',
-            \strncmp($type_string, 'callable', 8) === 0 ? 'callable' : 'Closure',
+            preg_match('/^\??callable/i', $type_string) > 0 ? 'callable' : 'Closure',
             [],
-            false,
+            $type_string[0] === '?',
             $parts
         );
     }

--- a/src/Phan/Language/Type/ArrayType.php
+++ b/src/Phan/Language/Type/ArrayType.php
@@ -161,7 +161,7 @@ class ArrayType extends IterableType
     protected function canCastToNonNullableType(Type $type) : bool
     {
         // CallableDeclarationType is not a native type, we check separately here
-        return parent::canCastToNonNullableType($type) || $type instanceof CallableDeclarationType;
+        return parent::canCastToNonNullableType($type) || $type instanceof ArrayType || $type instanceof CallableDeclarationType;
     }
 }
 // Trigger the autoloader for GenericArrayType so that it won't be called

--- a/src/Phan/Language/Type/CallableDeclarationType.php
+++ b/src/Phan/Language/Type/CallableDeclarationType.php
@@ -16,9 +16,6 @@ final class CallableDeclarationType extends FunctionLikeDeclarationType
     public function canCastToNonNullableType(Type $type) : bool
     {
         if ($type->isCallable()) {
-            if ($this->getIsNullable()) {
-                return false;
-            }
             if ($type instanceof FunctionLikeDeclarationType) {
                 // TODO: Weaker mode to allow callable to cast to Closure
                 return $type instanceof CallableDeclarationType && $this->canCastToNonNullableFunctionLikeDeclarationType($type);

--- a/src/Phan/Language/Type/FunctionLikeDeclarationType.php
+++ b/src/Phan/Language/Type/FunctionLikeDeclarationType.php
@@ -236,7 +236,10 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
         throw new \AssertionError('unexpected call to ' . __METHOD__);
     }
 
-    /** @override */
+    /**
+     * @phan-return \Generator<FunctionLikeDeclarationType>
+     * @override
+     */
     public function alternateGenerator(CodeBase $_) : \Generator
     {
         yield $this;
@@ -626,6 +629,12 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
             $stub[$name] = $type_string;
         }
         return $stub;
+    }
+
+    public function getReturnTypeAsGeneratorTemplateType() : Type
+    {
+        // Probably unused
+        return Type::fromFullyQualifiedString('\Generator');
     }
 
     ////////////////////////////////////////////////////////////////////////////////

--- a/src/Phan/Language/Type/GenericIterableType.php
+++ b/src/Phan/Language/Type/GenericIterableType.php
@@ -1,0 +1,79 @@
+<?php declare(strict_types=1);
+namespace Phan\Language\Type;
+
+use Phan\Language\Type;
+use Phan\Language\UnionType;
+
+use function json_encode;
+
+final class GenericIterableType extends IterableType
+{
+    /** @phan-override */
+    const NAME = 'iterable';
+
+    /**
+     * @var UnionType
+     */
+    private $key_union_type;
+
+    /**
+     * @var UnionType
+     */
+    private $element_union_type;
+
+    protected function __construct(UnionType $key_union_type, UnionType $element_union_type, bool $is_nullable)
+    {
+        parent::__construct('', self::NAME, [], $is_nullable);
+        $this->key_union_type = $key_union_type;
+        $this->element_union_type = $element_union_type;
+    }
+
+    public function getKeyUnionType() : UnionType
+    {
+        return $this->key_union_type;
+    }
+
+    public function getElementUnionType() : UnionType
+    {
+        return $this->element_union_type;
+    }
+
+    public static function fromKeyAndValueTypes(UnionType $key_union_type, UnionType $element_union_type, bool $is_nullable) : GenericIterableType
+    {
+        static $cache = [];
+        $key = ($is_nullable ? '?' : '') . json_encode($key_union_type->generateUniqueId()) . ':' . json_encode($element_union_type->generateUniqueId());
+        return $cache[$key] ?? ($cache[$key] = new self($key_union_type, $element_union_type, $is_nullable));
+    }
+
+    public function canCastToNonNullableType(Type $type) : bool
+    {
+        if ($type instanceof GenericIterableType) {
+            // TODO: Account for scalar key casting config?
+            if (!$this->key_union_type->canCastToUnionType($type->key_union_type)) {
+                return false;
+            }
+            if (!$this->element_union_type->canCastToUnionType($type->element_union_type)) {
+                return false;
+            }
+            return true;
+        }
+        return parent::canCastToType($type);
+    }
+
+    public function __toString() : string
+    {
+        $string = $this->element_union_type->__toString();
+        if (!$this->key_union_type->isEmpty()) {
+            $string = $this->key_union_type->__toString() . ',' . $string;
+        }
+        $string = "iterable<$string>";
+
+        if ($this->getIsNullable()) {
+            $string = '?' . $string;
+        }
+
+        return $string;
+    }
+}
+// Trigger autoloader for subclass before make() can get called.
+\class_exists(ArrayType::class);

--- a/src/Phan/Language/Type/IterableType.php
+++ b/src/Phan/Language/Type/IterableType.php
@@ -1,8 +1,6 @@
 <?php declare(strict_types=1);
 namespace Phan\Language\Type;
 
-use Phan\Language\Type;
-
 class IterableType extends NativeType
 {
     /** @phan-override */
@@ -15,40 +13,14 @@ class IterableType extends NativeType
 
     public function isPrintableScalar() : bool
     {
-        return false;  // Overridden in subclass IterableType
+        return false;
     }
 
     public function isPossiblyObject() : bool
     {
         return true;  // can be Traversable, which is an object
     }
-
-    /**
-     * @return bool
-     * True if this type is array-like (is of type array, is
-     * a generic array, or implements ArrayAccess).
-     */
-    public function isArrayLike() : bool
-    {
-        // TODO: the base `iterable` isn't always array-like (no array access on Traversable).
-        // In another PR, change `iterable` behavior?
-        return true;
-    }
-
-    /**
-     * @return bool
-     * True if this Type can be cast to the given Type
-     * cleanly
-     */
-    protected function canCastToNonNullableType(Type $type) : bool
-    {
-        // TODO: Really?
-        if ($type instanceof GenericArrayType) {
-            return true;
-        }
-
-        return parent::canCastToNonNullableType($type);
-    }
 }
 // Trigger autoloader for subclass before make() can get called.
+\class_exists(GenericIterableType::class);
 \class_exists(ArrayType::class);

--- a/src/Phan/Language/Type/NativeType.php
+++ b/src/Phan/Language/Type/NativeType.php
@@ -60,6 +60,11 @@ abstract class NativeType extends Type
         return false;
     }
 
+    public function isGenerator() : bool
+    {
+        return false;
+    }
+
     public function isObject() : bool
     {
         return false;

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -22,6 +22,7 @@ use Phan\Language\Type\MixedType;
 use Phan\Language\Type\MultiType;
 use Phan\Language\Type\NullType;
 use Phan\Language\Type\StaticType;
+use Phan\Language\Type\StringType;
 use Phan\Language\Type\TemplateType;
 use Phan\Language\Type\TrueType;
 use ast\Node;
@@ -1523,6 +1524,7 @@ class UnionType implements \Serializable
      * type.
      *
      * @return \Generator
+     * @phan-return \Generator<FullyQualifiedClassName>
      *
      * A list of class FQSENs representing the non-native types
      * associated with this UnionType
@@ -1548,6 +1550,10 @@ class UnionType implements \Serializable
             }
             // Get the class FQSEN
             $class_fqsen = $class_type->asFQSEN();
+            if (!($class_fqsen instanceof FullyQualifiedClassName)) {
+                // Should be impossible, but skip to satisfy the type checker
+                continue;
+            }
 
             if ($class_type->isStaticType()) {
                 if (!$context->isInClassScope()) {
@@ -2469,6 +2475,40 @@ class UnionType implements \Serializable
             // Swallow "Cannot find class", go on to emit issue
         }
         return false;
+    }
+
+    public function asGeneratorTemplateType() : Type
+    {
+        $fallback_values = UnionType::empty();
+        $fallback_keys = UnionType::empty();
+
+        foreach ($this->getTypeSet() as $type) {
+            if ($type->isGenerator()) {
+                if ($type->hasTemplateParameterTypes()) {
+                    return $type;
+                }
+            }
+            // TODO: support Iterator<T> or Traversable<T> or iterable<T>
+            if ($type instanceof GenericArrayType) {
+                $fallback_values = $fallback_values->withType($type->genericArrayElementType());
+                $key_type = $type->getKeyType();
+                if ($key_type === GenericArrayType::KEY_INT) {
+                    $fallback_keys = $fallback_keys->withType(IntType::instance(false));
+                } elseif ($key_type === GenericArrayType::KEY_STRING) {
+                    $fallback_keys = $fallback_keys->withType(StringType::instance(false));
+                }
+            } elseif ($type instanceof ArrayShapeType && $type->isNotEmptyArrayShape()) {
+                $fallback_values = $fallback_values->withUnionType($type->genericArrayElementUnionType());
+                $fallback_keys = $fallback_keys->withUnionType(GenericArrayType::unionTypeForKeyType($type->getKeyType()));
+            }
+        }
+
+        $result = Type::fromFullyQualifiedString('\Generator');
+        if ($fallback_keys->typeCount() > 0 || $fallback_values->typeCount() > 0) {
+            $template_types = $fallback_keys->typeCount() > 0 ? [$fallback_keys, $fallback_values] : [$fallback_values];
+            $result = $result->fromType($result, $template_types);
+        }
+        return $result;
     }
 }
 

--- a/src/Phan/LanguageServer/LanguageServer.php
+++ b/src/Phan/LanguageServer/LanguageServer.php
@@ -139,7 +139,7 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
         /** @suppress PhanUndeclaredClassMethod https://github.com/fruux/sabre-event/pull/52 */
         $reader->on('message', function (Message $msg) {
             /** @suppress PhanUndeclaredProperty Request->body->id is a request with an id */
-            coroutine(function () use ($msg) {
+            coroutine(function () use ($msg) : \Generator {
                 // Ignore responses, this is the handler for requests and notifications
                 if (AdvancedJsonRpc\Response::isResponse($msg->body)) {
                     return;
@@ -679,7 +679,7 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
         return coroutine(function () : \Generator {
             // Eventually, this might block on something. Leave it as a generator.
             if (false) {
-                yield null;
+                yield;
             }
 
             // There would be an asynchronous indexing step, but the startup already did the indexing.

--- a/tests/files/expected/0473_typed_generator.php.expected
+++ b/tests/files/expected/0473_typed_generator.php.expected
@@ -1,0 +1,11 @@
+%s:7 PhanTypeMismatchGeneratorYieldValue Yield statement has a value with type int but test_key_generator() is declared to yield values of type string in \Generator<int,string>
+%s:8 PhanTypeMismatchGeneratorYieldKey Yield statement has a key with type string but test_key_generator() is declared to yield keys of type int in \Generator<int,string>
+%s:10 PhanTypeMismatchGeneratorYieldKey Yield statement has a key with type string but test_key_generator() is declared to yield keys of type int in \Generator<int,string>
+%s:10 PhanTypeMismatchGeneratorYieldValue Yield statement has a value with type \stdClass but test_key_generator() is declared to yield values of type string in \Generator<int,string>
+%s:18 PhanTypeMismatchGeneratorYieldValue Yield statement has a value with type void but test_generator() is declared to yield values of type \stdClass in \Generator<\stdClass>
+%s:19 PhanTypeMismatchGeneratorYieldValue Yield statement has a value with type null but test_generator() is declared to yield values of type \stdClass in \Generator<\stdClass>
+%s:21 PhanTypeMismatchGeneratorYieldValue Yield statement has a value with type int but test_generator() is declared to yield values of type \stdClass in \Generator<\stdClass>
+%s:23 PhanTypeMismatchGeneratorYieldValue Yield statement has a value with type string but test_generator() is declared to yield values of type \stdClass in \Generator<\stdClass>
+%s:30 PhanTypeMismatchGeneratorYieldKey Yield statement has a key with type string but test_void_generator() is declared to yield keys of type void in \Generator<void,\stdClass>
+%s:38 PhanTypeMismatchGeneratorYieldValue Yield statement has a value with type void but test_alternate_generator_syntax() is declared to yield values of type int in \Generator<int>
+%s:39 PhanTypeMismatchGeneratorYieldValue Yield statement has a value with type null but test_alternate_generator_syntax() is declared to yield values of type int in \Generator<int>

--- a/tests/files/expected/0474_typed_iterable.php.expected
+++ b/tests/files/expected/0474_typed_iterable.php.expected
@@ -1,0 +1,5 @@
+%s:28 PhanTypeMismatchArgument Argument 1 (tsi) is \Traversable|\Traversable<int,int>|iterable but \expect_traversable_string_int() takes \Traversable<string,int> defined at %s:16
+%s:30 PhanTypeMismatchArgument Argument 1 (tsi) is \Traversable|\Traversable<string,string>|iterable but \expect_traversable_string_int() takes \Traversable<string,int> defined at %s:16
+%s:39 PhanTypeMismatchArgument Argument 1 (isi) is array<string,string> but \expect_iterable_string_int() takes iterable<string,int> defined at %s:6
+%s:40 PhanTypeMismatchArgument Argument 1 (isi) is array<int,string> but \expect_iterable_string_int() takes iterable<string,int> defined at %s:6
+%s:42 PhanTypeMismatchArgument Argument 1 (tsi) is array<string,int> but \expect_traversable_string_int() takes \Traversable<string,int> defined at %s:16

--- a/tests/files/expected/0475_analyze_yield_from.php.expected
+++ b/tests/files/expected/0475_analyze_yield_from.php.expected
@@ -1,0 +1,6 @@
+%s:23 PhanTypeMismatchGeneratorYieldValue Yield statement has a value with type int but test_yield_from() is declared to yield values of type string in \Generator<int,string>
+%s:24 PhanTypeMismatchGeneratorYieldKey Yield statement has a key with type string but test_yield_from() is declared to yield keys of type int in \Generator<int,string>
+%s:28 PhanTypeMismatchGeneratorYieldKey Yield statement has a key with type void but test_yield_from() is declared to yield keys of type int in \Generator<int,string>
+%s:29 PhanTypeMismatchGeneratorYieldValue Yield statement has a value with type \stdClass but test_yield_from() is declared to yield values of type string in \Generator<int,string>
+%s:31 PhanTypeInvalidYieldFrom Yield from statement was passed an invalid expression of type string (expected Traversable/array)
+%s:32 PhanTypeInvalidYieldFrom Yield from statement was passed an invalid expression of type \stdClass (expected Traversable/array)

--- a/tests/files/src/0473_typed_generator.php
+++ b/tests/files/src/0473_typed_generator.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @phan-return Generator<int,string>
+ */
+function test_key_generator() : Generator {
+    yield 2 => 3;
+    yield 'x' => 'y';
+    yield 3 => 'y';
+    yield 'y' => new stdClass();
+}
+
+/**
+ * @phan-return Generator<stdClass>
+ */
+function test_generator() : Generator {
+    yield new stdClass();
+    yield;
+    yield 2 => null;
+    yield 'x' => new stdClass();  // The expected key type is unspecified, so don't warn about the key?
+    yield 2;
+
+    yield from test_key_generator();
+}
+
+/**
+ * @phan-return Generator<void,stdClass>
+ */
+function test_void_generator() : Generator {
+    yield 'x' => new stdClass();
+    yield new stdClass();
+}
+
+/**
+ * @return Generator|int[]
+ */
+function test_alternate_generator_syntax() {
+    yield;
+    yield null;
+    yield 2;
+}

--- a/tests/files/src/0474_typed_iterable.php
+++ b/tests/files/src/0474_typed_iterable.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * @param iterable<string,int> $isi
+ */
+function expect_iterable_string_int($isi) {
+    foreach ($isi as $k => $v) {
+        echo strlen($v);
+        echo intdiv($k, $v);
+    }
+}
+
+/**
+ * @param Traversable<string, int> $tsi
+ */
+function expect_traversable_string_int(Traversable $tsi) {
+    foreach ($tsi as $k => $v) {
+        echo strlen($v);
+        echo intdiv($k, $v);
+    }
+}
+/**
+ * @param Traversable<int,int> $tii
+ * @param Traversable<string,int> $tsi
+ * @param Traversable<string,string> $tss
+ */
+function expect_traversables(Traversable $tii, Traversable $tsi, Traversable $tss) {
+    expect_traversable_string_int($tii);
+    expect_traversable_string_int($tsi);
+    expect_traversable_string_int($tss);
+    // TODO: Make a subset of the below casts to iterable<TKey,TValue> emit appropriate warnings
+    expect_iterable_string_int($tii);
+    expect_iterable_string_int($tsi);
+    expect_iterable_string_int($tss);
+}
+
+function test_iterable(string $s, int $i) {
+    expect_iterable_string_int([$s => $i]);
+    expect_iterable_string_int([$s => $s]);
+    expect_iterable_string_int([$i => $s]);
+
+    expect_traversable_string_int([$s => $i]);  // should warn
+}
+// TODO: Add tests of casting generators and subclasses of Traversable to iterable (and implement the functionality)

--- a/tests/files/src/0475_analyze_yield_from.php
+++ b/tests/files/src/0475_analyze_yield_from.php
@@ -1,0 +1,33 @@
+<?php
+
+/** @return Generator<int,string> */
+function yields_correct_generator() {
+    yield 2 => 'x';
+}
+
+/** @return Generator<void,string> */
+function yields_generator_without_key() {
+    yield 'x';
+}
+
+/** @return Generator<int,stdClass> */
+function yields_generator_with_wrong_value() {
+    yield 0 => new stdClass();
+}
+
+/**
+ * @return Generator<int,string>
+ */
+function test_yield_from() {
+    yield from [2 => 'x'];
+    yield from [2 => 4];
+    yield from ['x' => 'y'];
+    yield from [2 => 'y', 3 => new stdClass()];
+
+    yield from yields_correct_generator();
+    yield from yields_generator_without_key();
+    yield from yields_generator_with_wrong_value();
+
+    yield from 'not valid';
+    yield from new stdClass();
+}


### PR DESCRIPTION
For #824. See NEWS.md for more details.

This PR allows yield values and keys within a Generator to be type checked (if provided in phpdoc)

TODO: Implement support for analyzing TSend and TReturn of
`Generator<TKey, TValue, TSend, TReturn>` in another PR

TODO: Override the comparison of Generators,
e.g. allow `Generator<int,T>` to cast to `Generator<T>`.

Use the new generator syntax in Phan's own codebase.

- Fix detected bugs.

Add unit tests