### PR TITLE
Add suggestions for undeclared class errors (in different namespace)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,9 @@ New features(Analysis)
 + Warn about properties that are read but not written to when dead code detection is enabled
   (Similar to existing warnings about properties that are written to but never read)
   New issue types: `PhanReadOnlyPrivateProperty`, `PhanReadOnlyProtectedProperty`, `PhanReadOnlyPublicProperty`
++ When warning about undeclared classes, mention any classes that have the same name (but a different namespace) as suggestions.
+
+  E.g. `test.php:26 PhanUndeclaredClassInstanceof Checking instanceof against undeclared class \MyNS\InvalidArgumentException (Did you mean class \InvalidArgumentException)`
 + Warn about string and numeric literals that are no-ops. (E.g. `<?php 'notEchoedStr'; "notEchoed $x"; ?>`)
   New issue types: `PhanNoopStringLiteral`, `PhanNoopEncapsulatedStringLiteral`, `PhanNoopNumericLiteral`.
 

--- a/src/Phan/AST/AnalysisVisitor.php
+++ b/src/Phan/AST/AnalysisVisitor.php
@@ -66,4 +66,35 @@ abstract class AnalysisVisitor extends KindVisitorImplementation
             $parameters
         );
     }
+
+    /**
+     * @param string $issue_type
+     * The type of issue to emit such as Issue::ParentlessClass
+     *
+     * @param int $lineno
+     * The line number where the issue was found
+     *
+     * @param array<int,int|string|FQSEN|UnionType|Type> $parameters
+     * Template parameters for the issue's error message
+     *
+     * @param ?string $suggestion
+     * A suggestion (may be null)
+     *
+     * @return void
+     */
+    protected function emitIssueWithSuggestion(
+        string $issue_type,
+        int $lineno,
+        array $parameters,
+        $suggestion
+    ) {
+        Issue::maybeEmitWithParameters(
+            $this->code_base,
+            $this->context,
+            $issue_type,
+            $lineno,
+            $parameters,
+            $suggestion
+        );
+    }
 }

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -583,11 +583,13 @@ class ContextNode
                     ?? $this->node->children['class']
             ))->getClassList(false, self::CLASS_LIST_ACCEPT_ANY);
         } catch (CodeBaseException $exception) {
+            $exception_fqsen = $exception->getFQSEN();
             throw new IssueException(
                 Issue::fromType(Issue::UndeclaredClassMethod)(
                     $this->context->getFile(),
                     $this->node->lineno ?? 0,
-                    [ $method_name, (string)$exception->getFQSEN() ]
+                    [$method_name, (string)$exception_fqsen],
+                    Issue::suggestSimilarClassForGenericFQSEN($this->code_base, $this->context, $exception_fqsen)
                 )
             );
         }
@@ -1437,11 +1439,13 @@ class ContextNode
                 $this->node->children['class']
             ))->getClassList(false, self::CLASS_LIST_ACCEPT_OBJECT_OR_CLASS_NAME);
         } catch (CodeBaseException $exception) {
+            $exception_fqsen = $exception->getFQSEN();
             throw new IssueException(
                 Issue::fromType(Issue::UndeclaredClassConstant)(
                     $this->context->getFile(),
                     $this->node->lineno ?? 0,
-                    [ $constant_name, $exception->getFQSEN() ]
+                    [$constant_name, (string)$exception_fqsen],
+                    Issue::suggestSimilarClassForGenericFQSEN($this->code_base, $this->context, $exception_fqsen)
                 )
             );
         }

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -91,6 +91,9 @@ final class TolerantASTConverter
     // (For debugging, may be removed in the future)
     const ENV_AST_THROW_INVALID = 'AST_THROW_INVALID';
 
+    /**
+     * @var int - A version in SUPPORTED_AST_VERSIONS
+     */
     private static $php_version_id_parsing = PHP_VERSION_ID;
 
     /**
@@ -2548,7 +2551,6 @@ final class TolerantASTConverter
             'const' => $name,
         ], $start_line);
     }
-
 
     /**
      * @return string

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1864,11 +1864,11 @@ class UnionTypeVisitor extends AnalysisVisitor
         } catch (IssueException $exception) {
             // Swallow it
         } catch (CodeBaseException $exception) {
-            $this->emitIssue(
+            $this->emitIssueWithSuggestion(
                 Issue::UndeclaredClassMethod,
                 $node->lineno ?? 0,
-                $method_name,
-                (string)$exception->getFQSEN()
+                [$method_name, (string)$exception->getFQSEN()],
+                Issue::suggestSimilarClassForGenericFQSEN($this->code_base, $this->context, $exception->getFQSEN())
             );
         }
 
@@ -2147,7 +2147,8 @@ class UnionTypeVisitor extends AnalysisVisitor
                     Issue::fromType(Issue::UndeclaredClass)(
                         $context->getFile(),
                         $node->lineno ?? 0,
-                        [ (string)$parent_class_fqsen ]
+                        [ (string)$parent_class_fqsen ],
+                        Issue::suggestSimilarClass($code_base, $context, $parent_class_fqsen)
                     )
                 );
             } else {

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -1566,10 +1566,11 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 $node->children['class']
             ))->getClassList(false, ContextNode::CLASS_LIST_ACCEPT_OBJECT_OR_CLASS_NAME, Issue::TypeInvalidInstanceof);
         } catch (CodeBaseException $exception) {
-            $this->emitIssue(
+            $this->emitIssueWithSuggestion(
                 Issue::UndeclaredClassInstanceof,
                 $node->lineno ?? 0,
-                (string)$exception->getFQSEN()
+                [(string)$exception->getFQSEN()],
+                Issue::suggestSimilarClassForGenericFQSEN($this->code_base, $this->context, $exception->getFQSEN())
             );
         }
 

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -903,10 +903,13 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
                 $class->addReference($this->context);
             }
         } catch (CodeBaseException $exception) {
-            $this->emitIssue(
+            Issue::maybeEmitWithParameters(
+                $this->code_base,
+                $this->context,
                 Issue::UndeclaredClassCatch,
                 $node->lineno ?? 0,
-                (string)$exception->getFQSEN()
+                [(string)$exception->getFQSEN()],
+                Issue::suggestSimilarClassForGenericFQSEN($this->code_base, $this->context, $exception->getFQSEN())
             );
 
             $union_type = $union_type->withType(Type::fromFullyQualifiedString('\Throwable'));

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -27,6 +27,8 @@ use Phan\Library\Set;
 
 use ReflectionClass;
 
+use function strtolower;
+
 /**
  * A CodeBase represents the known state of a code base
  * we're analyzing.
@@ -370,6 +372,8 @@ class CodeBase
     public function updateFileList(array $new_file_list, array $file_mapping_contents = [])
     {
         if ($this->undo_tracker) {
+            $this->invalidateDependentCacheEntries();
+
             return $this->undo_tracker->updateFileList($this, $new_file_list, $file_mapping_contents);
         }
         throw new \RuntimeException("Calling updateFileList without undo tracker");
@@ -382,6 +386,8 @@ class CodeBase
     public function beforeReplaceFileContents(string $file_name)
     {
         if ($this->undo_tracker) {
+            $this->invalidateDependentCacheEntries();
+
             return $this->undo_tracker->beforeReplaceFileContents($this, $file_name);
         }
         throw new \RuntimeException("Calling replaceFileContents without undo tracker");
@@ -739,14 +745,15 @@ class CodeBase
             // The original class does not exist.
             // Emit issues at the point of every single class_alias call with that original class.
             foreach ($alias_set as $alias_record) {
+                $suggestion = Issue::suggestSimilarClass($this, $alias_record->context, $original_fqsen);
                 \assert($alias_record instanceof ClassAliasRecord);
-                Issue::maybeEmit(
+                Issue::maybeEmitWithParameters(
                     $this,
                     $alias_record->context,
                     Issue::UndeclaredClassAliasOriginal,
                     $alias_record->lineno,
-                    $original_fqsen,
-                    $alias_record->alias_fqsen
+                    [$original_fqsen, $alias_record->alias_fqsen],
+                    $suggestion
                 );
             }
             return;
@@ -1489,5 +1496,65 @@ class CodeBase
             return true;
         }
         return false;
+    }
+
+    /** @var array<string,array<string,string>>|null */
+    private $suggested_class_names = null;
+
+    private function invalidateDependentCacheEntries()
+    {
+        $this->suggested_class_names = null;
+    }
+
+    private function getSuggestedClassNames()
+    {
+        return $this->suggested_class_names ?? ($this->suggested_class_names = $this->computeSuggestedClassNames());
+    }
+
+    /**
+     * @return array<string,array<string,string>> a list of namespaces which have each class name
+     */
+    private function computeSuggestedClassNames() : array
+    {
+        $class_fqsen_list = [];
+        // NOTE: This helper performs shallow clones to avoid interfering with the iteration pointer
+        // in other iterations over these class maps
+        foreach (clone($this->fqsen_class_map_user_defined) as $class_fqsen => $_) {
+            $class_fqsen_list[] = $class_fqsen;
+        }
+        foreach (clone($this->fqsen_class_map_internal) as $class_fqsen => $_) {
+            $class_fqsen_list[] = $class_fqsen;
+        }
+
+        $suggestion_set = [];
+        foreach ($class_fqsen_list as $class_fqsen) {
+            $namespace = $class_fqsen->getNamespace();
+            $suggestion_set[strtolower($class_fqsen->getName())][strtolower($namespace)] = $namespace;
+        }
+        foreach (clone($this->fqsen_class_map_reflection) as $reflection_class) {
+            $namespace = '\\' . $reflection_class->getNamespaceName();
+            // https://secure.php.net/manual/en/reflectionclass.getnamespacename.php
+            $suggestion_set[\strtolower($reflection_class->getShortName())][strtolower($namespace)] = $namespace;
+        }
+        return $suggestion_set;
+    }
+
+    /**
+     * @return array<int,FullyQualifiedClassName> 0 or more namespaced class names found in this code base
+     */
+    public function suggestSimilarClass(
+        FullyQualifiedClassName $missing_class,
+        Context $unused_context
+    ) {
+        $class_name = $missing_class->getName();
+        $class_name_lower = \strtolower($class_name);
+        $suggestions = $this->getSuggestedClassNames();
+
+        $namespaces_for_class = array_values($suggestions[$class_name_lower] ?? []);
+        usort($namespaces_for_class, 'strcmp');
+
+        return array_map(function(string $namespace_name) use ($class_name) : FullyQualifiedClassName {
+            return FullyQualifiedClassName::make($namespace_name, $class_name);
+        }, $namespaces_for_class);
     }
 }

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -1139,13 +1139,14 @@ class Clazz extends AddressableElement
 
         if (!$code_base->hasClassConstantWithFQSEN($constant_fqsen)) {
             throw new IssueException(
-                Issue::fromType(Issue::UndeclaredClassConstant)(
+                Issue::fromType(Issue::UndeclaredConstant)(
                     $context->getFile(),
                     $context->getLineNumberStart(),
                     [
                         (string)$constant_fqsen,
                         (string)$this->getFQSEN()
-                    ]
+                    ],
+                    Issue::suggestSimilarClass($code_base, $context, $this->getFQSEN())
                 )
             );
         }

--- a/src/Phan/Language/Type/FunctionLikeDeclarationType.php
+++ b/src/Phan/Language/Type/FunctionLikeDeclarationType.php
@@ -124,6 +124,7 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
         return $result;
     }
 
+    // TODO: Figure out why ?Closure():bool can't cast to ?Closure(): bool
     public function canCastToNonNullableFunctionLikeDeclarationType(FunctionLikeDeclarationType $type) : bool
     {
         if ($this->required_param_count > $type->required_param_count) {

--- a/src/Phan/LanguageServer/LanguageServer.php
+++ b/src/Phan/LanguageServer/LanguageServer.php
@@ -136,7 +136,6 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
             $this->shutdown();
             $this->exit();
         });
-        /** @suppress PhanUndeclaredClassMethod https://github.com/fruux/sabre-event/pull/52 */
         $reader->on('message', function (Message $msg) {
             /** @suppress PhanUndeclaredProperty Request->body->id is a request with an id */
             coroutine(function () use ($msg) : \Generator {

--- a/src/Phan/Output/Colorizing.php
+++ b/src/Phan/Output/Colorizing.php
@@ -85,6 +85,7 @@ class Colorizing
         'PROPERTY'      => 'cyan',
         'SCALAR'        => 'light_magenta',
         'STRING_LITERAL' => 'light_magenta',
+        'SUGGESTION'    => 'light_gray',
         'TYPE'          => 'light_gray',
         'TRAIT'         => 'green',
         'VARIABLE'      => 'light_cyan',
@@ -97,7 +98,7 @@ class Colorizing
 
     /**
      * @param string $template
-     * @param array<int,int|string|FQSEN|Type|UnionType> $template_parameters
+     * @param array<int,int|string|float|FQSEN|Type|UnionType> $template_parameters
      */
     public static function colorizeTemplate(
         string $template,
@@ -123,7 +124,7 @@ class Colorizing
 
     /**
      * @param string $template_type (A key of _uncolored_format_string_for_template, e.g. "FILE")
-     * @param int|string|FQSEN|Type|UnionType $arg (Argument for format string, e.g. a type name, method fqsen, line number, etc.)
+     * @param int|string|float|FQSEN|Type|UnionType $arg (Argument for format string, e.g. a type name, method fqsen, line number, etc.)
      * @return string - Colorized for unix terminals.
      */
     public static function colorizeField(string $template_type, $arg) : string

--- a/src/Phan/Output/Printer/JSONPrinter.php
+++ b/src/Phan/Output/Printer/JSONPrinter.php
@@ -19,7 +19,7 @@ final class JSONPrinter implements BufferedPrinterInterface
     public function print(IssueInstance $instance)
     {
         $issue = $instance->getIssue();
-        $this->messages[] = [
+        $message = [
             'type' => 'issue',
             'type_id' => $issue->getTypeId(),
             'check_name' => $issue->getType(),
@@ -36,6 +36,11 @@ final class JSONPrinter implements BufferedPrinterInterface
                 ],
             ],
         ];
+        $suggestion = $instance->getSuggestion();
+        if ($suggestion) {
+            $message['suggestion'] = $suggestion;
+        }
+        $this->messages[] = $message;
     }
 
     /** flush printer buffer */

--- a/src/Phan/Output/Printer/PlainTextPrinter.php
+++ b/src/Phan/Output/Printer/PlainTextPrinter.php
@@ -25,6 +25,8 @@ final class PlainTextPrinter implements IssuePrinterInterface
         $issue   = $instance->getIssue();
         $type    = $issue->getType();
         $message = $instance->getMessage();
+        $suggestion = $instance->getSuggestion();
+
         if (Config::getValue('color_issue_messages')) {
             switch ($issue->getSeverity()) {
                 case Issue::SEVERITY_CRITICAL:
@@ -43,6 +45,9 @@ final class PlainTextPrinter implements IssuePrinterInterface
                 $type,
                 $message
             ]);
+            if ($suggestion) {
+                $issue .= Colorizing::colorizeTemplate(" ({SUGGESTION})", [$suggestion]);
+            }
         } else {
             $issue = sprintf(
                 '%s:%d %s %s',
@@ -51,6 +56,9 @@ final class PlainTextPrinter implements IssuePrinterInterface
                 $type,
                 $message
             );
+            if ($suggestion) {
+                $issue .= " ($suggestion)";
+            }
         }
 
         $this->output->writeln($issue);

--- a/src/Phan/Output/Printer/PylintPrinter.php
+++ b/src/Phan/Output/Printer/PylintPrinter.php
@@ -26,6 +26,10 @@ final class PylintPrinter implements IssuePrinterInterface
             self::getSeverityCode($instance),
             $message
         );
+        $suggestion = $instance->getSuggestion();
+        if ($suggestion) {
+            $line .= " ($suggestion)";
+        }
 
         $this->output->writeln($line);
     }

--- a/src/Phan/Plugin/Internal/MiscParamPlugin.php
+++ b/src/Phan/Plugin/Internal/MiscParamPlugin.php
@@ -421,6 +421,8 @@ final class MiscParamPlugin extends PluginV2 implements
 
             'min' => $min_max_callback,
             'max' => $min_max_callback,
+
+            // TODO: sort and usort should convert array<string,T> to array<int,T> (same for array shapes)
         ];
     }
 

--- a/src/Phan/PluginV2/IssueEmitter.php
+++ b/src/Phan/PluginV2/IssueEmitter.php
@@ -30,7 +30,7 @@ trait IssueEmitter
      * The list of placeholders for between braces can be found
      * in \Phan\Issue::uncolored_format_string_for_template.
      *
-     * @param array<int,string> $issue_message_args
+     * @param array<int,string|int|float> $issue_message_args
      * The arguments for this issue format.
      * If this array is empty, $issue_message_args is kept in place
      *

--- a/tests/files/expected/0355_namespace_relative.php.expected
+++ b/tests/files/expected/0355_namespace_relative.php.expected
@@ -1,5 +1,5 @@
-%s:32 PhanUndeclaredInterface Class implements undeclared interface \NS355\I355
+%s:32 PhanUndeclaredInterface Class implements undeclared interface \NS355\I355 (Did you mean interface \I355)
 %s:34 PhanCommentOverrideOnNonOverrideMethod Saw an @override annotation for method \NS355\E355::functionOfI, but could not find an overridden method and it is not a magic method
-%s:46 PhanUndeclaredClassMethod Call to method __construct from undeclared class \NS355\B355
+%s:46 PhanUndeclaredClassMethod Call to method __construct from undeclared class \NS355\B355 (Did you mean class \B355)
 %s:53 PhanTypeMismatchArgument Argument 1 (x) is \NS355\B355 but \NS355\accepts_B355() takes \B355 defined at %s:48
-%s:53 PhanUndeclaredClassMethod Call to method __construct from undeclared class \NS355\B355
+%s:53 PhanUndeclaredClassMethod Call to method __construct from undeclared class \NS355\B355 (Did you mean class \B355)

--- a/tests/files/expected/0478_undeclared_classlike_suggestions.php.expected
+++ b/tests/files/expected/0478_undeclared_classlike_suggestions.php.expected
@@ -1,0 +1,8 @@
+%s:4 PhanUndeclaredClassMethod Call to method __construct from undeclared class \past\MyNode (Did you mean class \NS3\MyNode)
+%s:5 PhanUndeclaredClassConstant Reference to constant class from undeclared class \MyNode (Did you mean class \NS3\MyNode)
+%s:7 PhanUndeclaredExtendedClass Class extends undeclared class \ExampleBaseClass (Did you mean class \NS2\ExampleBaseClass)
+%s:7 PhanUndeclaredInterface Class implements undeclared interface \ExampleInterface (Did you mean interface \NS2\ExampleInterface)
+%s:7 PhanUndeclaredTrait Class uses undeclared trait \ExampleTrait (Did you mean trait \NS2\ExampleTrait)
+%s:16 PhanUndeclaredClassConstant Reference to constant class from undeclared class \NS3\ClassWithRepeatedName (Did you mean class \ClassWithRepeatedName or \NS2\ClassWithRepeatedName)
+%s:23 PhanUndeclaredClassCatch Catching undeclared class \NS2\Exception (Did you mean class \Exception)
+%s:26 PhanUndeclaredClassInstanceof Checking instanceof against undeclared class \NS2\InvalidArgumentException (Did you mean class \InvalidArgumentException)

--- a/tests/files/src/0478_undeclared_classlike_suggestions.php
+++ b/tests/files/src/0478_undeclared_classlike_suggestions.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace {
+    $x = new \past\MyNode();
+    $v = MyNode::class;
+
+    class ExampleWarning extends ExampleBaseClass implements ExampleInterface {
+        use ExampleTrait;
+    }
+
+    class ClassWithRepeatedName {}
+}
+
+namespace NS3 {
+    class MyNode{}
+    $other = ClassWithRepeatedName::class;
+}
+
+namespace NS2 {
+    class ClassWithRepeatedName {}
+
+    try {
+    } catch (Exception $e) {
+    }
+    $x = null;
+    var_export($x instanceof InvalidArgumentException);
+
+    class ExampleBaseClass {}
+    interface ExampleInterface{}
+    trait ExampleTrait{}
+}


### PR DESCRIPTION
And add a framework to emit suggestions alongside issue messages.
Currently, the suggestions have no inner coloring with `--color`

Currently, this requires an exact (case-insensitive) match on the name
to show a match (From other namespaces).