### PR TITLE
Reduce false positives when ArrayAccess interface is used in property

### DIFF
--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1226,7 +1226,7 @@ class UnionTypeVisitor extends AnalysisVisitor
         // so we'll add the string type to the result if we're
         // indexing something that could be a string
         if ($union_type->isType($string_type)
-            || $union_type->canCastToUnionType($string_type->asUnionType())
+            || ($union_type->canCastToUnionType($string_type->asUnionType()) && !$union_type->hasMixedType())
         ) {
             if (!$dim_type->isEmpty() && !$dim_type->canCastToUnionType($int_union_type)) {
                 // TODO: Efficient implementation of asExpandedTypes()->hasArrayAccess()?

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -1548,12 +1548,9 @@ class Type
      */
     public function isArrayLike() : bool
     {
-        // includes both nullable and non-nullable ArrayAccess/array/iterable
-        return (
-            $this->isIterable()
-            || $this->isGenericArray()
-            || $this->isArrayAccess()
-        );
+        // includes both nullable and non-nullable ArrayAccess/array
+        // (Overridden by ArrayType)
+        return $this->isArrayAccess();
     }
 
     /**

--- a/src/Phan/Language/Type/ArrayType.php
+++ b/src/Phan/Language/Type/ArrayType.php
@@ -27,6 +27,11 @@ class ArrayType extends IterableType
         return false;  // Overrides IterableType returning true
     }
 
+    public function isArrayLike() : bool
+    {
+        return true;  // Overrides Type
+    }
+
     /**
      * @return UnionType with ArrayType subclass(es)
      * @suppress PhanUnreferencedPublicMethod may be used in the future or for plugins as array shape support improves.

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -360,12 +360,12 @@ final class GenericArrayType extends ArrayType
         foreach ($union_type->getTypeSet() as $type) {
             if ($type instanceof GenericArrayType) {
                 $key_types |= $type->key_type;
-                // TODO: support array shape as well?
             } elseif ($type instanceof ArrayShapeType) {
                 if ($type->isNotEmptyArrayShape()) {
                     $key_types |= $type->getKeyType();
                 }
             }
+            // Treating ArrayType as mixed or excluding ArrayType would both cause false positives. Ignore ArrayType.
         }
         // int|string corresponds to KEY_MIXED (KEY_INT|KEY_STRING)
         // And if we're unable to find any types, return KEY_MIXED.

--- a/tests/files/expected/0480_array_access_iteration.php.expected
+++ b/tests/files/expected/0480_array_access_iteration.php.expected
@@ -1,0 +1,2 @@
+%s:12 PhanTypeMismatchArgumentInternal Argument 1 (string) is \ArrayAccess|\Countable|\Iterator|\Serializable|\SplObjectStorage|\Traversable|iterable but \strlen() takes string
+%s:14 PhanTypeMismatchArgumentInternal Argument 1 (string) is \ArrayAccess|\Countable|\Iterator|\Serializable|\SplObjectStorage|\Traversable|iterable but \strlen() takes string

--- a/tests/files/src/0480_array_access_iteration.php
+++ b/tests/files/src/0480_array_access_iteration.php
@@ -1,0 +1,20 @@
+<?php
+
+class MyExample {
+    /**
+     * @var SplObjectStorage
+     */
+    private $prop;
+
+    public function __construct() {
+        $this->prop = new SplObjectStorage();
+        $o = new stdClass;
+        echo strlen($this->prop);
+        $this->prop[$o] = 42;
+        echo strlen($this->prop);
+        foreach ($this->prop as $k => $v) {
+            // Should not emit false positive warnings for invoking spl_object_id
+            echo spl_object_id($k);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1671

This bug was introduced by the refactoring to support Traversable/Iterator
templates