### PR TITLE
Improve wording for classlike suggestions  (of undeclared classlike issues)

### DIFF
--- a/src/Phan/Analysis/ClassInheritanceAnalyzer.php
+++ b/src/Phan/Analysis/ClassInheritanceAnalyzer.php
@@ -96,7 +96,6 @@ class ClassInheritanceAnalyzer
                 };
             };
             $filter = null;
-            $prefix = 'Did you mean class';
             switch($issue_type) {
             case Issue::UndeclaredExtendedClass:
                 $filter = $generate_filter(function(Clazz $class) : bool {
@@ -107,16 +106,14 @@ class ClassInheritanceAnalyzer
                 $filter = $generate_filter(function(Clazz $class) : bool {
                     return $class->isTrait();
                 });
-                $prefix = 'Did you mean trait';
                 break;
             case Issue::UndeclaredInterface:
                 $filter = $generate_filter(function(Clazz $class) : bool {
                     return $class->isInterface();
                 });
-                $prefix = 'Did you mean interface';
                 break;
             }
-            $suggestion = Issue::suggestSimilarClass($code_base, $clazz->getContext(), $fqsen, $filter, $prefix);
+            $suggestion = Issue::suggestSimilarClass($code_base, $clazz->getContext(), $fqsen, $filter);
 
             Issue::maybeEmitWithParameters(
                 $code_base,

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -2972,7 +2972,7 @@ class Issue
     /**
      * @param ?Closure(FullyQualifiedClassName):bool $filter
      */
-    public static function suggestSimilarClass(CodeBase $code_base, Context $context, FullyQualifiedClassName $class_fqsen, $filter = null, string $prefix = 'Did you mean class')
+    public static function suggestSimilarClass(CodeBase $code_base, Context $context, FullyQualifiedClassName $class_fqsen, $filter = null, string $prefix = 'Did you mean')
     {
         $suggested_fqsens = $code_base->suggestSimilarClass($class_fqsen, $context);
         if ($filter) {
@@ -2981,14 +2981,27 @@ class Issue
         if (count($suggested_fqsens) === 0) {
             return null;
         }
-        return $prefix . ' ' . implode(' or ', array_map('strval', $suggested_fqsens));
+        return $prefix . ' ' . implode(' or ', array_map(function (FullyQualifiedClassName $fqsen) use ($code_base) : string {
+            $category = 'classlike';
+            if ($code_base->hasClassWithFQSEN($fqsen)) {
+                $class = $code_base->getClassByFQSEN($fqsen);
+                if ($class->isInterface()) {
+                    $category = 'interface';
+                } elseif ($class->isTrait()) {
+                    $category = 'trait';
+                } else {
+                    $category = 'class';
+                }
+            }
+            return $category . ' ' . $fqsen->__toString();
+        }, $suggested_fqsens));
     }
 
     /**
      * @param ?\Closure $filter
      * TODO: Figure out why ?Closure(NS\X):bool can't cast to ?Closure(NS\X):bool
      */
-    public static function suggestSimilarClassForGenericFQSEN(CodeBase $code_base, Context $context, FQSEN $fqsen, $filter = null, string $prefix = 'Did you mean class')
+    public static function suggestSimilarClassForGenericFQSEN(CodeBase $code_base, Context $context, FQSEN $fqsen, $filter = null, string $prefix = 'Did you mean')
     {
         if (!($fqsen instanceof FullyQualifiedClassName)) {
             return null;

--- a/tests/files/expected/0478_undeclared_classlike_suggestions.php.expected
+++ b/tests/files/expected/0478_undeclared_classlike_suggestions.php.expected
@@ -3,6 +3,6 @@
 %s:7 PhanUndeclaredExtendedClass Class extends undeclared class \ExampleBaseClass (Did you mean class \NS2\ExampleBaseClass)
 %s:7 PhanUndeclaredInterface Class implements undeclared interface \ExampleInterface (Did you mean interface \NS2\ExampleInterface)
 %s:7 PhanUndeclaredTrait Class uses undeclared trait \ExampleTrait (Did you mean trait \NS2\ExampleTrait)
-%s:16 PhanUndeclaredClassConstant Reference to constant class from undeclared class \NS3\ClassWithRepeatedName (Did you mean class \ClassWithRepeatedName or \NS2\ClassWithRepeatedName)
+%s:16 PhanUndeclaredClassConstant Reference to constant class from undeclared class \NS3\ClassWithRepeatedName (Did you mean class \ClassWithRepeatedName or class \NS2\ClassWithRepeatedName)
 %s:23 PhanUndeclaredClassCatch Catching undeclared class \NS2\Exception (Did you mean class \Exception)
 %s:26 PhanUndeclaredClassInstanceof Checking instanceof against undeclared class \NS2\InvalidArgumentException (Did you mean class \InvalidArgumentException)


### PR DESCRIPTION
Always refer to interfaces as interfaces, etc.
(E.g. for `instanceof` (which can refer both to classes and interfaces))