### PR TITLE
Release 0.12.8: Fix a crash that occurs with new iterable type syntax

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 Phan NEWS
 
+12 May 2018, Phan 0.12.8
+------------------------
+
+Bug fixes
++ Fix a crash that occurs when the `iterable<[KeyType,]ValueType>` annotation is used in phpdoc. (#1685)
+
 08 May 2018, Phan 0.12.7
 ------------------------
 

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -24,7 +24,7 @@ class CLI
     /**
      * This should be updated to x.y.z-dev after every release, and x.y.z before a release.
      */
-    const PHAN_VERSION = '0.12.7';
+    const PHAN_VERSION = '0.12.8';
 
     /**
      * @var OutputInterface

--- a/src/Phan/Language/Type/GenericIterableType.php
+++ b/src/Phan/Language/Type/GenericIterableType.php
@@ -83,7 +83,7 @@ final class GenericIterableType extends IterableType
             }
             return true;
         }
-        return parent::canCastToType($type);
+        return parent::canCastToNonNullableType($type);
     }
 
     public function __toString() : string

--- a/tests/files/expected/0486_crash_test.php.expected
+++ b/tests/files/expected/0486_crash_test.php.expected
@@ -1,0 +1,2 @@
+%s:8 PhanTypeMismatchDeclaredReturn Doc-block of g contains declared return type iterable<int> which is incompatible with the return type \Traversable declared in the signature
+%s:11 PhanTypeMismatchDeclaredReturn Doc-block of h contains declared return type iterable<int> which is incompatible with the return type int declared in the signature

--- a/tests/files/src/0486_crash_test.php
+++ b/tests/files/src/0486_crash_test.php
@@ -1,0 +1,12 @@
+<?php
+interface T
+{
+     /** @return iterable<int> */
+     public function f(): iterable;
+
+     /** @return iterable<int> should warn */
+     public function g(): Traversable;
+
+     /** @return iterable<int> should warn */
+     public function h(): int;
+}


### PR DESCRIPTION
Fixes #1685 

This caused an infinite loop because canCastToType called canCastToNullableType, which called canCastToType