### PR TITLE
Suggest alternate classes/types in param,return,etc. types

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,15 @@ Phan NEWS
 ?? ??? 2018, Phan 0.12.9 (dev)
 ------------------------
 
+New features:
++ Emit class name suggestions for undeclared types in param, property, return type, and thrown type declarations. (#1689)
+
+  Affects `PhanUndeclaredTypeParameter`, `PhanUndeclaredTypeProperty`, `PhanUndeclaredTypeReturnType`,
+  `PhanUndeclaredTypeThrowsType`, and `PhanInvalidThrowsIs*`
+
+Bug fixes
++ Be more consistent about emitting `PhanUndeclaredType*` for invalid types within array shapes.
+
 12 May 2018, Phan 0.12.8
 ------------------------
 

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -1123,7 +1123,6 @@ class AssignmentVisitor extends AnalysisVisitor
         }
 
         if (!$assign_type_expanded->hasArrayLike()) {
-
             if ($assign_type->hasType($string_type)) {
                 // Are we assigning to a variable/property of type 'string' (with no ArrayAccess or array types)?
                 if (\is_null($dim_type)) {

--- a/src/Phan/Analysis/ClassInheritanceAnalyzer.php
+++ b/src/Phan/Analysis/ClassInheritanceAnalyzer.php
@@ -87,16 +87,16 @@ class ClassInheritanceAnalyzer
     ) : bool {
         if (!$code_base->hasClassWithFQSEN($fqsen)) {
             $filter = null;
-            switch($issue_type) {
-            case Issue::UndeclaredExtendedClass:
-                $filter = IssueFixSuggester::createFQSENFilterForClasslikeCategories($code_base, true, false, false);
-                break;
-            case Issue::UndeclaredTrait:
-                $filter = IssueFixSuggester::createFQSENFilterForClasslikeCategories($code_base, false, true, false);
-                break;
-            case Issue::UndeclaredInterface:
-                $filter = IssueFixSuggester::createFQSENFilterForClasslikeCategories($code_base, false, false, true);
-                break;
+            switch ($issue_type) {
+                case Issue::UndeclaredExtendedClass:
+                    $filter = IssueFixSuggester::createFQSENFilterForClasslikeCategories($code_base, true, false, false);
+                    break;
+                case Issue::UndeclaredTrait:
+                    $filter = IssueFixSuggester::createFQSENFilterForClasslikeCategories($code_base, false, true, false);
+                    break;
+                case Issue::UndeclaredInterface:
+                    $filter = IssueFixSuggester::createFQSENFilterForClasslikeCategories($code_base, false, false, true);
+                    break;
             }
             $suggestion = IssueFixSuggester::suggestSimilarClass($code_base, $clazz->getContext(), $fqsen, $filter);
 

--- a/src/Phan/Analysis/PropertyTypesAnalyzer.php
+++ b/src/Phan/Analysis/PropertyTypesAnalyzer.php
@@ -4,6 +4,7 @@ namespace Phan\Analysis;
 use Phan\CodeBase;
 use Phan\Exception\IssueException;
 use Phan\Issue;
+use Phan\IssueFixSuggester;
 use Phan\Language\Element\Clazz;
 use Phan\Language\FQSEN\FullyQualifiedClassName;
 use Phan\Language\Type\GenericArrayType;
@@ -32,7 +33,7 @@ class PropertyTypesAnalyzer
             }
 
             // Look at each type in the parameter's Union Type
-            foreach ($union_type->getTypeSet() as $outer_type) {
+            foreach ($union_type->withFlattenedArrayShapeTypeInstances()->getTypeSet() as $outer_type) {
                 $type = $outer_type;
                 // TODO: Expand this to ArrayShapeType
                 while ($type instanceof GenericArrayType) {
@@ -67,13 +68,13 @@ class PropertyTypesAnalyzer
                             || $property->getDefiningFQSEN() == $property->getFQSEN()
                         )
                     ) {
-                        Issue::maybeEmit(
+                        Issue::maybeEmitWithParameters(
                             $code_base,
                             $property->getContext(),
                             Issue::UndeclaredTypeProperty,
                             $property->getFileRef()->getLineNumberStart(),
-                            (string)$property->getFQSEN(),
-                            (string)$outer_type
+                            [(string)$property->getFQSEN(), (string)$outer_type],
+                            IssueFixSuggester::suggestSimilarClass($code_base, $property->getContext(), $type_fqsen, null, 'Did you mean', IssueFixSuggester::CLASS_SUGGEST_CLASSES_AND_TYPES)
                         );
                     }
                 }

--- a/src/Phan/Analysis/ThrowsTypesAnalyzer.php
+++ b/src/Phan/Analysis/ThrowsTypesAnalyzer.php
@@ -1,8 +1,12 @@
 <?php declare(strict_types=1);
 namespace Phan\Analysis;
 
+use Phan\Suggestion;
 use Phan\CodeBase;
 use Phan\Issue;
+use Phan\IssueFixSuggester;
+use Phan\Language\Context;
+use Phan\Language\Element\Clazz;
 use Phan\Language\Element\FunctionInterface;
 use Phan\Language\Element\Method;
 use Phan\Language\FQSEN\FullyQualifiedClassName;
@@ -77,39 +81,60 @@ class ThrowsTypesAnalyzer
         $type_fqsen = $type->asFQSEN();
         \assert($type_fqsen instanceof FullyQualifiedClassName, 'non-native types must be class names');
         if (!$code_base->hasClassWithFQSEN($type_fqsen)) {
-            Issue::maybeEmit(
+            Issue::maybeEmitWithParameters(
                 $code_base,
                 $method->getContext(),
                 Issue::UndeclaredTypeThrowsType,
                 $method->getFileRef()->getLineNumberStart(),
-                $method->getName(),
-                $type
+                [$method->getName(), $type],
+                self::suggestSimilarClassForThrownClass($code_base, $method->getContext(), $type_fqsen)
             );
             return;
         }
         $exception_class = $code_base->getClassByFQSEN($type_fqsen);
         if ($exception_class->isTrait() || $exception_class->isInterface()) {
-            Issue::maybeEmit(
+            Issue::maybeEmitWithParameters(
                 $code_base,
                 $method->getContext(),
                 $exception_class->isTrait() ? Issue::TypeInvalidThrowsIsTrait : Issue::TypeInvalidThrowsIsInterface,
                 $method->getFileRef()->getLineNumberStart(),
-                $method->getName(),
-                $type
+                [$method->getName(), $type],
+                self::suggestSimilarClassForThrownClass($code_base, $method->getContext(), $type_fqsen)
             );
             return;
         }
 
         if (!($type->asExpandedTypes($code_base)->hasType($throwable))) {
-            Issue::maybeEmit(
+            Issue::maybeEmitWithParameters(
                 $code_base,
                 $method->getContext(),
                 Issue::TypeInvalidThrowsNonThrowable,
                 $method->getFileRef()->getLineNumberStart(),
-                $method->getName(),
-                $type
+                [$method->getName(), $type],
+                self::suggestSimilarClassForThrownClass($code_base, $method->getContext(), $type_fqsen)
             );
             return;
         }
+    }
+
+    /**
+     * @return ?Suggestion
+     */
+    protected static function suggestSimilarClassForThrownClass(
+        CodeBase $code_base,
+        Context $context,
+        FullyQualifiedClassName $type_fqsen
+    ) {
+        return IssueFixSuggester::suggestSimilarClass(
+            $code_base,
+            $context,
+            $type_fqsen,
+            IssueFixSuggester::createFQSENFilterFromClassFilter($code_base, function (Clazz $class) use ($code_base) : bool {
+                if ($class->isTrait()) {
+                    return false;
+                }
+                return $class->getFQSEN()->asType()->asExpandedTypes($code_base)->hasType(Type::fromFullyQualifiedString('\Throwable'));
+            })
+        );
     }
 }

--- a/src/Phan/Language/Element/ClassElement.php
+++ b/src/Phan/Language/Element/ClassElement.php
@@ -230,7 +230,8 @@ abstract class ClassElement extends AddressableElement
      *
      * Precondition: The property in $defining_fqsen is protected.
      */
-    private function checkCanAccessProtectedElement(CodeBase $code_base, FullyQualifiedClassName $defining_fqsen, FullyQualifiedClassName $accessing_class_fqsen) : bool {
+    private function checkCanAccessProtectedElement(CodeBase $code_base, FullyQualifiedClassName $defining_fqsen, FullyQualifiedClassName $accessing_class_fqsen) : bool
+    {
         $accessing_class_type = $accessing_class_fqsen->asType();
         $type_of_class_of_property = $defining_fqsen->asType();
 

--- a/src/Phan/Language/Type/CallableDeclarationType.php
+++ b/src/Phan/Language/Type/CallableDeclarationType.php
@@ -27,7 +27,7 @@ final class CallableDeclarationType extends FunctionLikeDeclarationType
     }
 
     /**
-     * @override to stop PhanUndeclaredTypeParameter
+     * @override to prevent Phan from emitting PhanUndeclaredTypeParameter when using this in phpdoc
      */
     public function isNativeType() : bool
     {

--- a/src/Phan/Suggestion.php
+++ b/src/Phan/Suggestion.php
@@ -10,7 +10,8 @@ final class Suggestion
     /** @var string the text of the suggestion */
     private $message;
 
-    private function __construct(string $message) {
+    private function __construct(string $message)
+    {
         $this->message = $message;
     }
 

--- a/tests/files/expected/0070_closure_type.php.expected
+++ b/tests/files/expected/0070_closure_type.php.expected
@@ -1,3 +1,3 @@
-%s:3 PhanUndeclaredTypeParameter Parameter of undeclared type \A\Closure
+%s:3 PhanUndeclaredTypeParameter Parameter of undeclared type \A\Closure (Did you mean class \Closure)
 %s:4 PhanTypeMismatchArgument Argument 1 (c) is Closure():void but \A\f() takes \A\Closure defined at %s:3
 %s:14 PhanTypeMismatchArgument Argument 1 (c) is callable but \C\f() takes \Closure defined at %s:13

--- a/tests/files/expected/0101_one_of_each.php.expected
+++ b/tests/files/expected/0101_one_of_each.php.expected
@@ -54,5 +54,5 @@
 %s:206 PhanUndeclaredProperty Reference to undeclared property \C14->undef
 %s:210 PhanUndeclaredStaticMethod Static call to undeclared method \C21::f
 %s:214 PhanUndeclaredStaticProperty Static property 'p' on \C22 is undeclared
-%s:217 PhanUndeclaredTrait Class uses undeclared trait \T2
+%s:217 PhanUndeclaredTrait Class uses undeclared trait \T2 (Did you mean trait \T1)
 %s:220 PhanUndeclaredVariable Variable $v10 is undeclared

--- a/tests/files/expected/0117_property_missing_class.php.expected
+++ b/tests/files/expected/0117_property_missing_class.php.expected
@@ -1,2 +1,1 @@
-%s:2 PhanUndeclaredExtendedClass Class extends undeclared class \C2
-
+%s:2 PhanUndeclaredExtendedClass Class extends undeclared class \C2 (Did you mean class \C1)

--- a/tests/files/expected/0203_generic_errors.php.expected
+++ b/tests/files/expected/0203_generic_errors.php.expected
@@ -5,7 +5,7 @@
 %s:24 PhanUnextractableAnnotationElementName Saw possibly unextractable annotation for a fragment of comment '* @param int': after int, did not see an element name (will guess based on comment order)
 %s:25 PhanUnextractableAnnotationElementName Saw possibly unextractable annotation for a fragment of comment '* @param X': after X, did not see an element name (will guess based on comment order)
 %s:27 PhanGenericConstructorTypes Missing template parameters T on constructor for generic class \C
-%s:27 PhanUndeclaredTypeParameter Parameter of undeclared type \X
+%s:27 PhanUndeclaredTypeParameter Parameter of undeclared type \X (Did you mean class \C)
 %s:30 PhanParamTooFew Call with 0 arg(s) to \C::__construct() which requires 2 arg(s) defined at %s:27
 %s:36 PhanUnextractableAnnotationElementName Saw possibly unextractable annotation for a fragment of comment '* @param int': after int, did not see an element name (will guess based on comment order)
 %s:37 PhanUnextractableAnnotationElementName Saw possibly unextractable annotation for a fragment of comment '* @param T': after T, did not see an element name (will guess based on comment order)

--- a/tests/files/expected/0360_undeclared_array_class_in_namespace.php.expected
+++ b/tests/files/expected/0360_undeclared_array_class_in_namespace.php.expected
@@ -1,3 +1,4 @@
 %s:12 PhanUndeclaredTypeParameter Parameter of undeclared type \Foo\Baz\MissingClass[][][]
 %s:12 PhanUndeclaredTypeReturnType Return type of myMethod is undeclared type \Foo\Bat\OtherMissingClass[][]
-%s:18 PhanUndeclaredTypeProperty Property \Foo\Bar\MyClass::y has undeclared type \Foo\Bar\Closure[][]
+%s:18 PhanUndeclaredTypeProperty Property \Foo\Bar\MyClass::y has undeclared type \Foo\Bar\Closure[][] (Did you mean class \Closure)
+%s:22 PhanUndeclaredTypeProperty Property \Foo\Bar\MyClass::str has undeclared type \Foo\Bar\strong (Did you mean string)

--- a/tests/files/expected/0487_alternate_suggestions.php.expected
+++ b/tests/files/expected/0487_alternate_suggestions.php.expected
@@ -1,0 +1,8 @@
+%s:21 PhanUndeclaredTypeProperty Property \A487::x has undeclared type \avoid (Did you mean class \Avid)
+%s:28 PhanTypeMissingReturn Method \A487::test_suggestions is declared to return \avoid but has no return value
+%s:28 PhanUndeclaredTypeParameter Parameter of undeclared type \avoid (Did you mean class \Avid)
+%s:28 PhanUndeclaredTypeReturnType Return type of test_suggestions is undeclared type \avoid (Did you mean class \Avid or void)
+%s:28 PhanUndeclaredTypeThrowsType @throws type of test_suggestions has undeclared type \avoid (Did you mean class \Avid)
+%s:40 PhanUndeclaredTypeParameter Parameter of undeclared type array<string,\imt>[] (Did you mean trait \Ime or class \Imf or class \Img or interface \Imi or interface \Imj or int)
+%s:40 PhanUndeclaredTypeReturnType Return type of test_throw_suggestions is undeclared type array<string,\imt>[] (Did you mean trait \Ime or class \Imf or class \Img or interface \Imi or interface \Imj or int)
+%s:40 PhanUndeclaredTypeThrowsType @throws type of test_throw_suggestions has undeclared type \imt (Did you mean class \Imf or interface \Imi)

--- a/tests/files/src/0360_undeclared_array_class_in_namespace.php
+++ b/tests/files/src/0360_undeclared_array_class_in_namespace.php
@@ -18,4 +18,6 @@ class MyClass {
     public static $y;
     /** @var \Closure[][] should not warn */
     public static $z;
+    /** @var strong should warn and suggest */
+    public static $str;
 }

--- a/tests/files/src/0487_alternate_suggestions.php
+++ b/tests/files/src/0487_alternate_suggestions.php
@@ -1,0 +1,46 @@
+<?php
+
+// NOTE: Suggestions in may fail to be made
+// for some classes in namespaces with many classes,
+// because of the 'suggestion_check_limit' config being too low.
+class Avid extends Exception {
+}
+
+interface Imj extends ArrayAccess {
+}
+interface Imi extends  throwable {
+}
+trait Ime {}
+class Imf extends Exception {
+}
+class Img {
+}
+
+class A487 {
+    /** @var avoid */
+    public $x;
+
+    /**
+     * @param avoid $x
+     * @return avoid
+     * @throws avoid
+     */
+    public function test_suggestions($x) {
+        if (rand() % 2) {
+            throw $x;
+        }
+        var_export($x);
+    }
+
+    /**
+     * @throws imt (should only suggest classes)
+     * @param array{a:stdClass,x:imt}[] $x
+     * @return array{a:stdClass,x:imt}[]
+     */
+    public function test_throw_suggestions($x) {
+        if (rand() % 2) {
+            throw $_GLOBALS['_exception'];
+        }
+        return $x;
+    }
+}

--- a/tests/rasmus_files/expected/0025_catch.php.expected
+++ b/tests/rasmus_files/expected/0025_catch.php.expected
@@ -1,4 +1,3 @@
 %s:4 PhanUndeclaredClassMethod Call to method __construct from undeclared class \Ex
-%s:5 PhanUndeclaredClassCatch Catching undeclared class \Exceptio
-%s:6 PhanUndeclaredClassMethod Call to method getMessage from undeclared class \Exceptio
-
+%s:5 PhanUndeclaredClassCatch Catching undeclared class \Exceptio (Did you mean class \Exception)
+%s:6 PhanUndeclaredClassMethod Call to method getMessage from undeclared class \Exceptio (Did you mean class \Exception)


### PR DESCRIPTION
As well as throws/property types.

Additionally, be more consistent about warning about undeclared types in
array shapes.

Fixes #1689

Run phpcbf