### PR TITLE
Support "Go to Type Definition" in Language Server

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,7 +14,10 @@ New features(Analysis):
 
 Language Server/Daemon mode:
 + Support "Go to definition" for properties, classes, global/class constants, and methods/global functions (Issue #1483)
-  (Must be enabled via the CLI option `--language-server-enable-go-to-definition`)
+  (Must pass the CLI option `--language-server-enable-go-to-definition` when starting the server to enable this)
++ Support "Go to type definition" for variables, properties, classes, and methods/global functions (Issue #1702)
+  (Must pass the CLI option `--language-server-enable-go-to-definition` when starting the server to enable this)
+  Note that constants can't have object types in PHP, so there's no implementation of "Go To Type Definition" for those.
 
 Plugins:
 + Add a new plugin `SleepCheckerPlugin`. (PR #1696)

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -11,7 +11,6 @@ use Phan\Language\Element\FunctionInterface;
 use Phan\Language\Element\Method;
 use Phan\Language\Element\Parameter;
 use Phan\Language\FQSEN\FullyQualifiedClassName;
-use Phan\Language\Type\GenericArrayType;
 use Phan\Language\Type\IterableType;
 use Phan\Language\Type\MixedType;
 use Phan\Language\Type\NullType;
@@ -48,17 +47,9 @@ class ParameterTypesAnalyzer
             $union_type = $parameter->getUnionType();
 
             // Look at each type in the parameter's Union Type
-            foreach ($union_type->withFlattenedArrayShapeTypeInstances()->getTypeSet() as $outer_type) {
-                $type = $outer_type;
-
-                // TODO: Add unit test of `array{key:MissingClazz}`
-                while ($type instanceof GenericArrayType) {
-                    $type = $type->genericArrayElementType();
-                }
-
-                // If its a native type or a reference to
-                // self, its OK
-                if ($type->isNativeType() || ($method instanceof Method && ($type->isSelfType() || $type->isStaticType()))) {
+            foreach ($union_type->getReferencedClasses() as $outer_type => $type) {
+                // If it's a reference to self, its OK
+                if ($method instanceof Method && ($type->isSelfType() || $type->isStaticType())) {
                     continue;
                 }
 

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -834,7 +834,7 @@ Extended help:
   This significantly reduces CPU usage, but clients won't get notifications about issues immediately.
 
  --language-server-enable-go-to-definition
-  Enables/Disables support for "Go To Definition" in the Phan Language Server.
+  Enables support for "Go To Definition" and "Go To Type Definition" in the Phan Language Server.
   Disabled by default.
 
  --language-server-verbose

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -707,6 +707,7 @@ class Config
         'language_server_use_pcntl_fallback' => false,
 
         // This should only be set via CLI (--language-server-enable-go-to-definition)
+        // Affects "go to definition" and "go to type definition"
         'language_server_enable_go_to_definition' => false,
 
         // Can be set to false to disable the plugins Phan uses to infer more accurate return types of array_map, array_filter, etc.

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -6,6 +6,7 @@ use Phan\Exception\CodeBaseException;
 use Phan\Exception\IssueException;
 use Phan\Language\Type\ArrayType;
 use Phan\Language\FQSEN\FullyQualifiedClassName;
+use Generator;
 
 /**
  * NOTE: there may also be instances of UnionType that are empty, due to the constructor being public
@@ -1015,5 +1016,17 @@ final class EmptyUnionType extends UnionType
     public function iterableValueUnionType(CodeBase $unused_code_base) : UnionType
     {
         return $this;
+    }
+
+    /**
+     * @return Generator<Type,Type>
+     * @suppress PhanTypeMismatchGeneratorYieldValue (deliberate empty stub code)
+     * @suppress PhanTypeMismatchGeneratorYieldKey (deliberate empty stub code)
+     */
+    public function getReferencedClasses() : Generator
+    {
+        if (false) {
+            yield;
+        }
     }
 }

--- a/src/Phan/LanguageServer/GoToDefinitionRequest.php
+++ b/src/Phan/LanguageServer/GoToDefinitionRequest.php
@@ -1,8 +1,19 @@
 <?php declare(strict_types=1);
 namespace Phan\LanguageServer;
 
+use Phan\CodeBase;
+use Phan\Exception\CodeBaseException;
+use Phan\Language\Context;
 use Phan\Language\FileRef;
 use Phan\Language\Element\AddressableElementInterface;
+use Phan\Language\Element\Clazz;
+use Phan\Language\Element\Variable;
+use Phan\Language\FQSEN;
+use Phan\Language\FQSEN\FullyQualifiedClassName;
+use Phan\Language\FQSEN\FullyQualifiedFunctionName;
+use Phan\Language\FQSEN\FullyQualifiedMethodName;
+use Phan\Language\Type\TemplateType;
+use Phan\Language\UnionType;
 use Phan\LanguageServer\Protocol\Location;
 use Phan\LanguageServer\Protocol\Position;
 
@@ -19,24 +30,115 @@ final class GoToDefinitionRequest
     private $position;
     /** @var Promise|null */
     private $promise;
+    /** @var bool true if this is "Go to Type Definition" */
+    private $is_type_definition_request;
 
     /** @var array<int,Location> */
     private $locations = [];
 
-    public function __construct(string $uri, Position $position)
+    public function __construct(string $uri, Position $position, bool $is_type_definition_request)
     {
         $this->uri = $uri;
         $this->path = Utils::uriToPath($uri);
         $this->position = $position;
         $this->promise = new Promise();
+        $this->is_type_definition_request = $is_type_definition_request;
+    }
+
+    /**
+     * @param CodeBase $code_base used for resolving type location in "Go To Type Definition"
+     * @return void
+     */
+    public function recordDefinitionElement(
+        CodeBase $code_base,
+        AddressableElementInterface $element,
+        bool $resolve_type_definition_if_needed
+    ) {
+        if ($this->is_type_definition_request && $resolve_type_definition_if_needed) {
+            if (!($element instanceof Clazz)) {
+                $this->recordTypeOfElement($code_base, $element->getContext(), $element->getUnionType());
+                return;
+            }
+        }
+        $this->recordDefinitionContext($element->getContext());
+    }
+
+    /**
+     * @param CodeBase $code_base used for resolving type location in "Go To Type Definition"
+     * @param Context $context used for resolving 'self'/'static', etc.
+     * @return void
+     */
+    public function recordDefinitionOfVariableType(
+        CodeBase $code_base,
+        Context $context,
+        Variable $variable
+    ) {
+        $this->recordTypeOfElement($code_base, $context, $variable->getUnionType());
     }
 
     /**
      * @return void
      */
-    public function recordDefinitionElement(AddressableElementInterface $element)
-    {
-        $this->recordDefinitionContext($element->getContext());
+    private function recordTypeOfElement(
+        CodeBase $code_base,
+        Context $context,
+        UnionType $union_type
+    ) {
+        // Do something similar to the check for undeclared classes
+        foreach ($union_type->getTypeSet() as $type) {
+            if ($type instanceof TemplateType) {
+                continue;
+            }
+            if ($type->isSelfType() || $type->isStaticType()) {
+                if (!$context->isInClassScope()) {
+                    // Phan already warns elsewhere
+                    continue;
+                }
+                $type_fqsen = $context->getClassFQSEN();
+            } else {
+                $type_fqsen = $type->asFQSEN();
+            }
+            try {
+                $this->recordDefinitionOfTypeFQSEN($code_base, $type_fqsen);
+            } catch (CodeBaseException $e) {
+                continue;
+            }
+        }
+    }
+
+    /**
+     * @param FQSEN $type_fqsen the FQSEN of a type. FullyQualifiedClassName or FullyQualifiedFunctionName or FullyQualifiedMethodName (For closures/methods)
+     * @throws CodeBaseException if codebase is somehow missing a definition
+     */
+    private function recordDefinitionOfTypeFQSEN(
+        CodeBase $code_base,
+        FQSEN $type_fqsen
+    ) {
+        $record_definition = function (AddressableElementInterface $element) {
+            if (!$element->isPHPInternal()) {
+                $this->recordDefinitionContext($element->getContext());
+            }
+        };
+        if ($type_fqsen instanceof FullyQualifiedClassName) {
+            if ($code_base->hasClassWithFQSEN($type_fqsen)) {
+                $record_definition($code_base->getClassByFQSEN($type_fqsen));
+            }
+            return;
+        }
+        // Closures can be regular closures (FullyQualifiedFunctionName)
+        // or Closures created from callables (Functions or methods)
+        if ($type_fqsen instanceof FullyQualifiedFunctionName) {
+            if ($code_base->hasFunctionWithFQSEN($type_fqsen)) {
+                $record_definition($code_base->getFunctionByFQSEN($type_fqsen));
+            }
+            return;
+        }
+        if ($type_fqsen instanceof FullyQualifiedMethodName) {
+            if ($code_base->hasMethodWithFQSEN($type_fqsen)) {
+                $record_definition($code_base->getMethodByFQSEN($type_fqsen));
+            }
+            return;
+        }
     }
 
     public function recordDefinitionContext(FileRef $context)
@@ -113,6 +215,11 @@ final class GoToDefinitionRequest
     public function getPromise()
     {
         return $this->promise;
+    }
+
+    public function getIsTypeDefinitionRequest() : bool
+    {
+        return $this->is_type_definition_request;
     }
 
     public function __destruct()

--- a/src/Phan/LanguageServer/LanguageServer.php
+++ b/src/Phan/LanguageServer/LanguageServer.php
@@ -397,17 +397,21 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
      * Asynchronously generates the definition for a given URL
      * @return Promise <Location|Location[]|null>
      */
-    public function awaitDefinition(string $uri, Position $position) : Promise
-    {
+    public function awaitDefinition(
+        string $uri,
+        Position $position,
+        bool $is_type_definition_request
+    ) : Promise {
         // TODO: Add a way to "go to definition" without emitting analysis results as a side effect
         $path_to_analyze = Utils::uriToPath($uri);
-        Logger::logInfo("Called textDocument/awaitDefinition, uri=$uri, position=" . json_encode($position));
+        $logType = $is_type_definition_request ? 'awaitTypeDefinition' : 'awaitDefinition';
+        Logger::logInfo("Called LanguageServer->$logType, uri=$uri, position=" . json_encode($position));
         $prev_definition_request = $this->most_recent_definition_request;
         if ($prev_definition_request) {
             // Discard the previous request silently
             $prev_definition_request->finalize();
         }
-        $request = new GoToDefinitionRequest($uri, $position);
+        $request = new GoToDefinitionRequest($uri, $position, $is_type_definition_request);
         $this->most_recent_definition_request = $request;
 
         // We analyze this url so that Phan is aware enough of the types and namespace maps to trigger "Go to definition"

--- a/src/Phan/LanguageServer/Server/TextDocument.php
+++ b/src/Phan/LanguageServer/Server/TextDocument.php
@@ -164,7 +164,22 @@ class TextDocument
     {
         Logger::logInfo("Called textDocument/definition, uri={$textDocument->uri} position={$position->line}:{$position->character}");
         $uri = Utils::pathToUri(Utils::uriToPath($textDocument->uri));
-        // TODO: Remove unused boilerplate from alternate approach
-        return $this->server->awaitDefinition($uri, $position);
+        return $this->server->awaitDefinition($uri, $position, false);
+    }
+
+    /**
+     * The goto definition request is sent from the client to the server to resolve the definition location of a symbol
+     * at a given text document position.
+     *
+     * @param TextDocumentIdentifier $textDocument The text document
+     * @param Position $position The position inside the text document
+     * @return Promise <Location|Location[]|null>
+     * @suppress PhanUnreferencedPublicMethod called by client via AdvancedJsonRpc
+     */
+    public function typeDefinition(TextDocumentIdentifier $textDocument, Position $position) : Promise
+    {
+        Logger::logInfo("Called textDocument/typeDefinition, uri={$textDocument->uri} position={$position->line}:{$position->character}");
+        $uri = Utils::pathToUri(Utils::uriToPath($textDocument->uri));
+        return $this->server->awaitDefinition($uri, $position, true);
     }
 }

--- a/src/Phan/Plugin/Internal/NodeSelectionPlugin.php
+++ b/src/Phan/Plugin/Internal/NodeSelectionPlugin.php
@@ -83,6 +83,7 @@ class NodeSelectionVisitor extends PluginAwarePostAnalysisVisitor
         visitCommonImplementation as visitStaticProp;
         visitCommonImplementation as visitClassConst;
         visitCommonImplementation as visitConst;
+        visitCommonImplementation as visitVar;  // For "go to type definition"
         // TODO: VisitNew
         // TODO: implement, extend, use trait, etc.
     }

--- a/tests/misc/lsp/src/definitions.php
+++ b/tests/misc/lsp/src/definitions.php
@@ -11,8 +11,8 @@ class MyClass {
     const MyClassConst = 2;
     public static $my_static_property = 2;
 
-    public static function myMethod() {
-    }
+    public static function myMethod() : MyOtherClass { return new MyOtherClass(); }
+
 
     public function myInstanceMethod() {
         echo "In instance method\n";
@@ -32,5 +32,4 @@ const MY_NAMESPACED_CONST = 2;
 class MyNamespacedClass {
     const MyOtherClassConst = [2];
 }
-
 }  // end MyNS\SubNS


### PR DESCRIPTION
Support "Go to type definition" for variables, properties, classes,
and methods/global functions (Issue #1702)

Note that constants can't contain objects,
so there's no **type** definition to point them at.