### PR TITLE
Support "go to definition" for namespace and signature types

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -31,6 +31,13 @@ return [
     // of the php executable used to execute phan.
     "target_php_version" => null,
 
+    // Default: true. If this is set to true,
+    // and target_php_version is newer than the version used to run Phan,
+    // Phan will act as though functions added in newer PHP versions exist.
+    //
+    // NOTE: Currently, this only affects Closure::fromCallable
+    'pretend_newer_core_functions_exist' => true,
+
     // If true, missing properties will be created when
     // they are first seen. If false, we'll report an
     // error message.

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,13 @@ New features(Analysis):
 
   Affects `PhanUndeclaredTypeParameter`, `PhanUndeclaredTypeProperty`, `PhanUndeclaredTypeReturnType`,
   `PhanUndeclaredTypeThrowsType`, and `PhanInvalidThrowsIs*`
++ Add `pretend_newer_core_methods_exist` config setting.
+  If this is set to true (the default),
+  and `target_php_version` is newer than the version used to run Phan,
+  Phan will act as though functions added in newer PHP versions exist.
+
+  Note: Currently only affects `Closure::fromCallable()`, which was added in PHP 7.1.
+  This will affect more functions and methods in the future.
 
 Language Server/Daemon mode:
 + Support "Go to definition" for properties, classes, global/class constants, and methods/global functions (Issue #1483)

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverterWithNodeMapping.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverterWithNodeMapping.php
@@ -71,7 +71,7 @@ class TolerantASTConverterWithNodeMapping extends TolerantASTConverter
             // fwrite(STDERR, "Seeking node: " . json_encode(self::$closest_node_or_token). "\n");
             return $this->phpParserToPhpast($parser_node, $version, $file_contents);
         } catch (\Throwable $e) {
-            // fwrite(STDERR, "saw exception: " . $e->getMessage());
+            fprintf(STDERR, "saw exception: %s\n", $e->getMessage());
             throw $e;
         } finally {
             self::$closest_node_or_token = null;
@@ -108,7 +108,7 @@ class TolerantASTConverterWithNodeMapping extends TolerantASTConverter
                 if ($node_or_token->getEndPosition() > $offset) {
                     if ($node_or_token->start > $offset) {
                         // The cursor is hovering over whitespace.
-                        // Give up
+                        // Give up.
                         return true;
                     }
                     if (\in_array($node_or_token->kind, self::_KINDS_TO_RETURN_PARENT, true)) {
@@ -127,6 +127,7 @@ class TolerantASTConverterWithNodeMapping extends TolerantASTConverter
                 $state = self::findNodeAtOffsetRecursive($node_or_token, $offset);
                 if ($state) {
                     // fwrite(STDERR, "Found parent node for $key: " . get_class($parser_node) . "\n");
+                    // fwrite(STDERR, "Found parent node for $key: " . json_encode($parser_node) . "\n");
                     if ($state instanceof PhpParser\Node) {
                         return self::adjustClosestNodeOrToken($parser_node, $key);
                     }
@@ -142,16 +143,14 @@ class TolerantASTConverterWithNodeMapping extends TolerantASTConverter
      */
     private static function adjustClosestNodeOrToken(PhpParser\Node $node, $key)
     {
-        // TODO: Better heuristic
-        if ($key === 'memberName' || $key === 'callableExpression') {
-            // fwrite(STDERR, "Adjusted node: " . json_encode($node) . "\n");
-            self::$closest_node_or_token = $node;
-            return $node;
-        }
-        if ($key === 'callableExpression') {
-            // fwrite(STDERR, "Adjusted node: " . json_encode($node) . "\n");
-            self::$closest_node_or_token = $node;
-            return $node;
+        switch ($key) {
+            case 'memberName':
+            case 'callableExpression':
+            case 'namespaceName':
+            case 'namespaceAliasingClause':
+                // fwrite(STDERR, "Adjusted node: " . json_encode($node) . "\n");
+                self::$closest_node_or_token = $node;
+                return $node;
         }
         return true;
     }
@@ -160,35 +159,65 @@ class TolerantASTConverterWithNodeMapping extends TolerantASTConverter
      * @param PhpParser\Node|Token $n - The node from PHP-Parser
      * @return ast\Node|ast\Node[]|string|int|float|bool - whatever ast\parse_code would return as the equivalent.
      * @throws InvalidNodeException when self::$should_add_placeholders is false, like many of these methods.
+     * @override
      */
     protected static function phpParserNodeToAstNodeOrPlaceholderExpr($n)
     {
         // fprintf(STDERR, "Comparing %s to %s\n", get_class($n), get_class(self::$closest_node_or_token));
         $ast_node = parent::phpParserNodeToAstNodeOrPlaceholderExpr($n);
         if ($n === self::$closest_node_or_token) {
-            // fwrite(STDERR, "Marking corresponding node as flagged: " . json_encode($n) . "\n" . json_encode($ast_node) . "\n");
-            // fflush(STDERR);
-            if ($ast_node instanceof ast\Node) {
-                $ast_node->isSelected = true;
-            }
+            self::markNodeAsSelected($n, $ast_node);
         }
         return $ast_node;
     }
 
     /**
+     * @suppress PhanPluginUnusedPrivateMethodArgument $n (code can be uncommented for debugging)
+     * @param PhpParser\Node|Token $n
+     * @param mixed $ast_node
+     */
+    private static function markNodeAsSelected($n, $ast_node)
+    {
+        // fwrite(STDERR, "Marking corresponding node as flagged: " . json_encode($n) . "\n" . json_encode($ast_node) . "\n");
+        // fflush(STDERR);
+        if ($ast_node instanceof ast\Node) {
+            $ast_node->isSelected = true;
+        }
+    }
+
+    /**
      * @param PhpParser\Node|Token $n - The node from PHP-Parser
      * @return ast\Node|ast\Node[]|string|int|float|bool|null - whatever ast\parse_code would return as the equivalent.
+     * @override
      */
     protected static function phpParserNodeToAstNode($n)
     {
-        $ast_node = parent::phpParserNodeToAstNode($n);
-        if ($n === self::$closest_node_or_token) {
-            // fwrite(STDERR, "Marking corresponding node as flagged: " . json_encode($n) . "\n" . json_encode($ast_node) . "\n");
-            if ($ast_node instanceof ast\Node) {
-                $ast_node->isSelected = true;
-            }
+        static $callback_map;
+        static $fallback_closure;
+        if (\is_null($callback_map)) {
+            // XXX: If initHandleMap is called on TolerantASTConverter in the parent implementation before TolerantASTConverterWithNodeMapping,
+            // then static:: in the callbacks would point to TolerantASTConverter, not this subclass.
+            //
+            // This is worked around by copying and pasting the parent implementation
+            $callback_map = static::initHandleMap();
+            /** @param PhpParser\Node|Token $n */
+            $fallback_closure = function ($n, int $unused_start_line) {
+                if (!($n instanceof PhpParser\Node) && !($n instanceof Token)) {
+                    throw new \InvalidArgumentException("Invalid type for node: " . (\is_object($n) ? \get_class($n) : \gettype($n)) . ": " . static::debugDumpNodeOrToken($n));
+                }
+
+                return static::astStub($n);
+            };
         }
-        return $ast_node;
+        $callback = $callback_map[\get_class($n)] ?? $fallback_closure;
+        $result = $callback($n, self::$file_position_map->getStartLine($n));
+        if (($result instanceof ast\Node) && $result->kind === ast\AST_NAME) {
+            $result = new ast\Node(ast\AST_CONST, 0, ['name' => $result], $result->lineno);
+        }
+        if ($n === self::$closest_node_or_token) {
+            self::markNodeAsSelected($n, $result);
+        }
+        return $result;
     }
 
     /**
@@ -199,13 +228,60 @@ class TolerantASTConverterWithNodeMapping extends TolerantASTConverter
     protected static function phpParserNonValueNodeToAstNode($n)
     {
         // fprintf(STDERR, "Comparing %s to %s\n", get_class($n), get_class(self::$closest_node_or_token));
-        $ast_node = parent::phpParserNonValueNodeToAstNode($n);
+        static $callback_map;
+        static $fallback_closure;
+        if (\is_null($callback_map)) {
+            // XXX: If initHandleMap is called on TolerantASTConverter in the parent implementation before TolerantASTConverterWithNodeMapping,
+            // then static:: in the callbacks would point to TolerantASTConverter, not this subclass.
+            //
+            // This is worked around by copying and pasting the parent implementation
+            $callback_map = static::initHandleMap();
+            /** @param PhpParser\Node|Token $n */
+            $fallback_closure = function ($n, int $unused_start_line) {
+                if (!($n instanceof PhpParser\Node) && !($n instanceof Token)) {
+                    throw new \InvalidArgumentException("Invalid type for node: " . (\is_object($n) ? \get_class($n) : \gettype($n)) . ": " . static::debugDumpNodeOrToken($n));
+                }
+                return static::astStub($n);
+            };
+        }
+        $callback = $callback_map[\get_class($n)] ?? $fallback_closure;
+        $ast_node = $callback($n, self::getStartLine($n));
         if ($n === self::$closest_node_or_token) {
-            // fwrite(STDERR, "Marking corresponding node as flagged: " . json_encode($n) . "\n" . json_encode($ast_node) . "\n");
-            if ($ast_node instanceof ast\Node) {
-                // Create a dynamic property
-                $ast_node->isSelected = true;
-            }
+            self::markNodeAsSelected($n, $ast_node);
+        }
+        return $ast_node;
+    }
+
+    /**
+     * @override
+     */
+    protected static function astStmtUseOrGroupUseFromUseClause(
+        PhpParser\Node\NamespaceUseClause $use_clause,
+        $parser_use_kind,
+        int $start_line
+    ) : ast\Node {
+        // fwrite(STDERR, "Calling astStmtUseOrGroupUseFromUseClause for " . json_encode($use_clause) . "\n");
+        $ast_node = parent::astStmtUseOrGroupUseFromUseClause($use_clause, $parser_use_kind, $start_line);
+        if ($use_clause === self::$closest_node_or_token) {
+            // NOTE: This selects AST_USE instead of AST_USE_ELEM so that we have
+            // full information on whether it is a function, constant, or class/namespace
+            // fwrite(STDERR, "Marking corresponding node as flagged: " . json_encode($use_clause) . "\n" . json_encode($ast_node) . "\n");
+            self::markNodeAsSelected($use_clause, $ast_node);
+        }
+        return $ast_node;
+    }
+
+    /**
+     * @param PhpParser\Node\QualifiedName|Token|null $type
+     * @return ?ast\Node
+     * @override
+     * @suppress PhanUndeclaredProperty
+     */
+    protected static function phpParserTypeToAstNode($type, int $line)
+    {
+        $ast_node = parent::phpParserTypeToAstNode($type, $line);
+        if ($type === self::$closest_node_or_token) {
+            self::markNodeAsSelected($type, $ast_node);
         }
         return $ast_node;
     }

--- a/src/Phan/Analysis/ScopeVisitor.php
+++ b/src/Phan/Analysis/ScopeVisitor.php
@@ -108,7 +108,7 @@ abstract class ScopeVisitor extends AnalysisVisitor
 
         $context = $this->context;
 
-        $alias_target_map = $this->aliasTargetMapFromUseNode(
+        $alias_target_map = self::aliasTargetMapFromUseNode(
             $children['uses'],
             $prefix,
             $node->flags ?? 0
@@ -140,7 +140,7 @@ abstract class ScopeVisitor extends AnalysisVisitor
     {
         $context = $this->context;
 
-        foreach ($this->aliasTargetMapFromUseNode($node) as $alias => list($flags, $target, $lineno)) {
+        foreach (self::aliasTargetMapFromUseNode($node) as $alias => list($flags, $target, $lineno)) {
             $context = $context->withNamespaceMap(
                 $node->flags ?: $flags,
                 $alias,
@@ -165,7 +165,7 @@ abstract class ScopeVisitor extends AnalysisVisitor
      *
      * @suppress PhanPartialTypeMismatchReturn TODO: investigate
      */
-    private function aliasTargetMapFromUseNode(
+    public static function aliasTargetMapFromUseNode(
         Node $node,
         string $prefix = '',
         int $flags = 0

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -80,10 +80,15 @@ class Config
         // of the php executable used to execute phan.
         'target_php_version' => null,
 
-        // Supported values: '7.0', '7.1', '7.2', null.
-        // If this is set to null,
-        // then Phan assumes the PHP version which is closest to the minor version
-        // of the php executable used to execute phan.
+        // Default: true. If this is set to true,
+        // and target_php_version is newer than the version used to run Phan,
+        // Phan will act as though functions added in newer PHP versions exist.
+        //
+        // NOTE: Currently, this only affects Closure::fromCallable
+        'pretend_newer_core_methods_exist' => true,
+
+        // Make the tolerant-php-parser polyfill generate doc comments
+        // for all types of elements, even if php-ast wouldn't (for an older PHP version)
         'polyfill_parse_all_element_doc_comments' => true,
 
         // A list of individual files to include in analysis
@@ -788,7 +793,7 @@ class Config
      * @return array<string,mixed>
      * A map of configuration keys and their values
      */
-    public function toArray() : array
+    public static function toArray() : array
     {
         return self::$configuration;
     }
@@ -861,6 +866,13 @@ class Config
     public static function getValue(string $name)
     {
         return self::$configuration[$name];
+    }
+
+    public static function reset()
+    {
+        self::$configuration = self::DEFAULT_CONFIGURATION;
+        // Trigger magic behavior
+        self::get();
     }
 
     /**

--- a/src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php
@@ -5,6 +5,8 @@ use Phan\Exception\EmptyFQSENException;
 use Phan\Language\Context;
 use Phan\Language\Type;
 
+use AssertionError;
+
 /**
  * A Fully-Qualified Global Structural Element
  */
@@ -116,6 +118,8 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN
      * An fully qualified string like '\Namespace\Class'
      *
      * @return static
+     *
+     * @throws AssertionError on failure. TODO: More consistently throw AssertionError
      */
     public static function fromFullyQualifiedString(
         string $fully_qualified_string
@@ -133,16 +137,19 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN
             $parts = \explode('\\', $fqsen_string);
             $name = \array_pop($parts);
 
-            \assert(!empty($name), "The name cannot be empty");
+            if ($name === '') {
+                throw new AssertionError("The name cannot be empty");
+            }
 
             $namespace = '\\' . \implode('\\', \array_filter($parts));
 
-            \assert(!empty($namespace), "The namespace cannot be empty");
+            if ($namespace === '') {
+                throw new AssertionError("The namespace cannot be empty");
+            }
 
-            \assert(
-                $namespace[0] === '\\',
-                "The first character of the namespace must be \\"
-            );
+            if ($namespace[0] !== '\\') {
+                throw new AssertionError("The first character of the namespace must be \\");
+            }
 
             return static::make(
                 $namespace,

--- a/src/Phan/LanguageServer/GoToDefinitionRequest.php
+++ b/src/Phan/LanguageServer/GoToDefinitionRequest.php
@@ -20,6 +20,11 @@ use Phan\LanguageServer\Protocol\Position;
 use Exception;
 use Sabre\Event\Promise;
 
+/**
+ * @see \Phan\LanguageServer\DefinitionResolver for how this maps the found node to the type in the context.
+ * @see \Phan\Plugin\Internal\NodeSelectionPlugin for how the node is found
+ * @see \Phan\AST\TolerantASTConverter\TolerantASTConverterWithNodeMapping for how isSelected is set
+ */
 final class GoToDefinitionRequest
 {
     /** @var string file URI */

--- a/src/Phan/Plugin/Internal/NodeSelectionPlugin.php
+++ b/src/Phan/Plugin/Internal/NodeSelectionPlugin.php
@@ -83,6 +83,8 @@ class NodeSelectionVisitor extends PluginAwarePostAnalysisVisitor
         visitCommonImplementation as visitStaticProp;
         visitCommonImplementation as visitClassConst;
         visitCommonImplementation as visitConst;
+        visitCommonImplementation as visitUse;  // Uses visitUse instead of visitUseElem to be sure if it's a class/func/constant
+
         visitCommonImplementation as visitVar;  // For "go to type definition"
         // TODO: VisitNew
         // TODO: implement, extend, use trait, etc.

--- a/tests/Phan/AST/TolerantASTConverter/TolerantASTConverterWithNodeMappingTest.php
+++ b/tests/Phan/AST/TolerantASTConverter/TolerantASTConverterWithNodeMappingTest.php
@@ -1,0 +1,150 @@
+<?php declare(strict_types = 1);
+
+namespace Phan\Tests\AST\TolerantASTConverter;
+
+use Phan\AST\TolerantASTConverter\TolerantASTConverterWithNodeMapping;
+use Phan\AST\TolerantASTConverter\TolerantASTConverter;
+use Phan\Config;
+use Phan\Tests\BaseTest;
+use InvalidArgumentException;
+use ast;
+use ast\Node;
+
+class TolerantASTConverterWithNodeMappingTest extends BaseTest
+{
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+        Config::reset();
+    }
+
+    /**
+     * @param int $line 0-based
+     * @param int $column 0-based
+     * @dataProvider byteOffsetLookupProvider
+     * @suppress PhanUndeclaredProperty isSelected
+     */
+    public function testByteOffsetLookup(int $line, int $column, string $file_contents, Node $expected_node)
+    {
+        $expected_node->isSelected = true;
+
+        $byte_offset = self::computeOffset($line, $column, $file_contents);
+        $ast = $this->parseASTWithDefaultOptions($file_contents, $byte_offset);
+        // TODO: Create a reusable abstraction in Util to walk / filter nodes from the AST
+        $selected_node = $this->findSelectedNode($ast);
+        $this->assertEquals(\Phan\Debug::nodeToString($expected_node), \Phan\Debug::nodeToString($selected_node));
+        $this->assertEquals($expected_node, $selected_node);
+    }
+
+    private function findSelectedNode($node) : Node
+    {
+        $candidates = [];
+        $this->findSelectedNodeInner($node, $candidates);
+        $this->assertCount(1, $candidates, 'expected one node to be marked with isSelected');
+        return $candidates[0];
+    }
+
+    /**
+     * @param array<int,Node> &$candidates
+     * @return void
+     * @suppress PhanUndeclaredProperty isSelected is dynamically added by Phan
+     */
+    private function findSelectedNodeInner($node, array &$candidates)
+    {
+        if ($node instanceof Node) {
+            if (\property_exists($node, 'isSelected')) {
+                $candidates[] = $node;
+            }
+            foreach ($node->children as $child_node) {
+                $this->findSelectedNodeInner($child_node, $candidates);
+            }
+        }
+        if (\is_array($node)) {
+            foreach ($node as $child_node) {
+                $this->findSelectedNodeInner($child_node, $candidates);
+            }
+            return;
+        }
+    }
+
+    private function parseASTWithDefaultOptions(string $file_contents, int $byte_offset)
+    {
+        $converter = new TolerantASTConverterWithNodeMapping($byte_offset);
+        $errors = [];
+        $ast = $converter->parseCodeAsPHPAST($file_contents, TolerantASTConverter::AST_VERSION, $errors);
+        if (count($errors) > 0) {
+            throw new InvalidArgumentException("Unexpected errors: " . json_encode($errors));
+        }
+        return $ast;
+    }
+
+    // @param int $line 1-based
+    private static function computeOffset(int $line, int $column, string $file_contents) : int
+    {
+        // TODO: Use a utility function instead?
+        $byte_offset = 0;
+        while ($line > 1) {
+            $line--;
+            $newline_pos = strpos($file_contents, "\n", $byte_offset);
+            if ($newline_pos === false) {
+                throw new \InvalidArgumentException("too many lines");
+            }
+            $byte_offset = $newline_pos + 1;
+        }
+        return $byte_offset + $column;
+    }
+
+    /**
+     * @return array<int,array{0:int,1:int,2:string,3:Node}>
+     */
+    public function byteOffsetLookupProvider()
+    {
+        // using 1-based lines, 0-based columns
+        $default_file = <<<'EOT'
+<?php  // line 1
+
+namespace {
+    use ast\Node;
+    use function ast\parse_code as ParseCode;  // line 5
+    use const ast\AST_NEW;
+
+
+    interface MyInterface { }
+    class MyClass {  // line 10
+        public function myMethod(MyInterface $param) : MyInterface {
+        }
+    }
+    function global_function_using_node($node) : Node {
+        throw new RuntimeException("not implemented");
+    }
+
+
+
+}  // end global namespace
+EOT;
+
+        $use_stmt_ast_node = new Node(ast\AST_USE, ast\flags\USE_NORMAL, [
+            new Node(ast\AST_USE_ELEM, 0, ['name' => 'ast\Node', 'alias' => null], 4)
+        ], 4);
+
+        $use_stmt_ast_parse_code = new Node(ast\AST_USE, ast\flags\USE_FUNCTION, [
+            new Node(ast\AST_USE_ELEM, 0, ['name' => 'ast\parse_code', 'alias' => 'ParseCode'], 5)
+        ], 5);
+
+        $use_stmt_ast_const_new = new Node(ast\AST_USE, ast\flags\USE_CONST, [
+            new Node(ast\AST_USE_ELEM, 0, ['name' => 'ast\AST_NEW', 'alias' => null], 6)
+        ], 6);
+
+        $param_node = new Node(ast\AST_NAME, \ast\flags\NAME_NOT_FQ, [
+            'name' => 'MyInterface',
+        ], 11);
+
+        return [
+            [4, 9, $default_file, $use_stmt_ast_node],
+            [5, 20, $default_file, $use_stmt_ast_parse_code],
+            [5, 40, $default_file, $use_stmt_ast_parse_code],
+            [6, 16, $default_file, $use_stmt_ast_const_new],
+            [11, 40, $default_file, $param_node],
+        ];
+    }
+}

--- a/tests/Phan/LanguageServer/LanguageServerIntegrationTest.php
+++ b/tests/Phan/LanguageServer/LanguageServerIntegrationTest.php
@@ -413,7 +413,7 @@ EOT;
         // Refers to elements defined in ../../misc/lsp/src/definitions.php
         $example_file_contents = <<<'EOT'
 <?php use MyNS\SubNS; // line 0
-function example() {
+function example(MyClass $param_clss) {
     echo MyClass::$my_static_property;
     echo MyClass::MyClassConst;
     var_export(MyClass::myMethod());
@@ -429,9 +429,26 @@ function example() {
     echo SubNS\MY_NAMESPACED_CONST;
     echo count(SubNS\MyNamespacedClass::MyOtherClassConst);  // line 15
 }
+use MyNS\SubNS\MyNamespacedClass;
+echo MyNamespacedClass::class;
 EOT;
         $definitions_file_uri = Utils::pathToUri(self::getLSPFolder() . '/src/definitions.php');
         return [
+            // Failure tests
+            [
+                $example_file_contents,
+                new Position(11, 21),  // MyClass::class (Points to MyClass)
+                $definitions_file_uri,
+                null,
+                Utils::pathToUri(self::getLSPFolder() . '/unanalyzed_directory/definitions.php'),
+            ],
+            // Success tests
+            [
+                $example_file_contents,
+                new Position(17, 5),  // MyNamespacedClass
+                $definitions_file_uri,
+                31,
+            ],
             [
                 $example_file_contents,
                 new Position(2, 21),  // my_static_property
@@ -530,10 +547,15 @@ EOT;
             ],
             [
                 $example_file_contents,
-                new Position(11, 21),  // MyClass::class (Points to MyClass)
+                new Position(1, 19),  // MyNamespacedClass as a signature param type
                 $definitions_file_uri,
-                null,
-                Utils::pathToUri(self::getLSPFolder() . '/unanalyzed_directory/definitions.php'),
+                9,
+            ],
+            [
+                $example_file_contents,
+                new Position(17, 5),  // MyNamespacedClass
+                $definitions_file_uri,
+                31,
             ],
         ];
     }

--- a/tests/files/expected/0456_closure_return.php.expected70
+++ b/tests/files/expected/0456_closure_return.php.expected70
@@ -1,4 +1,0 @@
-%s:11 PhanTypeMismatchReturn Returning type Closure(int):int but return_closure() is declared to return Closure(int):string
-%s:13 PhanUndeclaredStaticMethod Static call to undeclared method \Closure::fromCallable
-%s:15 PhanUndeclaredStaticMethod Static call to undeclared method \Closure::fromCallable
-%s:17 PhanTypeMismatchReturn Returning type Closure():string but return_closure() is declared to return Closure(int):string

--- a/tests/plugin_test/test.sh
+++ b/tests/plugin_test/test.sh
@@ -28,9 +28,7 @@ if [[ "$(php -r 'echo PHP_VERSION_ID;')" < 70100 ]]; then
     echo "Skipping test cases that rely on Closure::fromCallable() or native syntax checks, the current php version is php 7.0";
     # Ignore results of a subset of tests in php 7.0
     # TODO: If we imitate the reflection of php 7.1 in php 7.0, we can restore this.
-    sed -i '/^\S*dead_code_fromCallable\.php/d' $ACTUAL_PATH
     sed -i "/^.*PhanNativePHPSyntaxCheckPlugin.*unexpected '\\?'/d" $ACTUAL_PATH
-    sed -i '/^\S*dead_code_fromCallable\.php/d' $EXPECTED_PATH
 fi
 
 diff $EXPECTED_PATH $ACTUAL_PATH


### PR DESCRIPTION
Fixes #1707

Add `pretend_newer_core_methods_exist` config setting.
(E.g. pretend that `Closure::fromCallable()` exists as an internal
function, even though it doesn't)

Fix an unrelated bug that would affect locating nodes in
TolerantASTConverterWithNodeMapping if TolerantASTConverter was used first.