### PR TITLE
Read "vendor-dir" from composer.json

### DIFF
--- a/src/Phan/Config/Initializer.php
+++ b/src/Phan/Config/Initializer.php
@@ -49,7 +49,12 @@ class Initializer
                 return 1;
             }
 
-            $vendor_path = "$cwd/vendor";
+            if (!empty($composer_settings['config']['vendor_dir'])) {
+                $vendor_path = $composer_settings['config']['vendor_dir'];
+            } else {
+                $vendor_path = "$cwd/vendor";
+            }
+
             if (!is_dir($vendor_path)) {
                 printf("phan --init assumes that 'composer.phar install' was run already (expected to find '$vendor_path')\n");
                 return 1;

--- a/src/Phan/Config/Initializer.php
+++ b/src/Phan/Config/Initializer.php
@@ -49,11 +49,7 @@ class Initializer
                 return 1;
             }
 
-            if (!empty($composer_settings['config']['vendor_dir'])) {
-                $vendor_path = $composer_settings['config']['vendor_dir'];
-            } else {
-                $vendor_path = "$cwd/vendor";
-            }
+            $vendor_path = $composer_settings['config']['vendor-dir'] ?? "$cwd/vendor";
 
             if (!is_dir($vendor_path)) {
                 printf("phan --init assumes that 'composer.phar install' was run already (expected to find '$vendor_path')\n");


### PR DESCRIPTION
Phan is currently assuming that `vendor` dir is at its default location, but that might not always be the case. `vendor`'s location can be manipulated via composer's `config` option [vendor-dir](https://getcomposer.org/doc/06-config.md#vendor-dir).

Issue: #1612 