### PR TITLE
Catch IssueException for inherited property

### DIFF
--- a/src/Phan/Analysis/CompositionAnalyzer.php
+++ b/src/Phan/Analysis/CompositionAnalyzer.php
@@ -66,9 +66,14 @@ class CompositionAnalyzer
 
                 // Figure out if this property type can cast to the
                 // inherited definition's type.
+                try {
+                    $inherited_property_union_type = $inherited_property->getUnionType();
+                } catch (IssueException $exception) {
+                    $inherited_property_union_type = UnionType::empty();
+                }
                 $can_cast =
                     $property_union_type->canCastToExpandedUnionType(
-                        $inherited_property->getUnionType(),
+                        $inherited_property_union_type,
                         $code_base
                     );
 

--- a/src/Phan/Language/Element/Property.php
+++ b/src/Phan/Language/Element/Property.php
@@ -112,6 +112,7 @@ class Property extends ClassElement
     /**
      * Override the default getter to fill in a future
      * union type if available.
+     * @throws IssueException if getFutureUnionType fails.
      */
     public function getUnionType() : UnionType
     {


### PR DESCRIPTION
This is emitted when an inherited class's property refers to an
undeclared element, and the type couldn't be resolved.

Fixes #1725