### PR TITLE
Add built-in support for unused variable detection. 

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -173,6 +173,10 @@ return [
     // to make sense of.
     'dead_code_detection' => false,
 
+    // Set to true in order to attempt to detect unused variables.
+    // dead_code_detection will also enable unused variable detection.
+    'unused_variable_detection' => false,
+
     // Set to true in order to force tracking references to elements
     // (functions/methods/consts/protected).
     // dead_code_detection is another option which also causes references

--- a/.phan/plugins/PregRegexCheckerPlugin.php
+++ b/.phan/plugins/PregRegexCheckerPlugin.php
@@ -66,6 +66,7 @@ class PregRegexCheckerPlugin extends PluginV2 implements AnalyzeFunctionCallCapa
     }
 
     /**
+     * @param CodeBase $code_base @phan-unused-param
      * @return array<string,\Closure>
      * @phan-return array<string, Closure(CodeBase,Context,Func,array):void>
      */

--- a/.phan/plugins/PrintfCheckerPlugin.php
+++ b/.phan/plugins/PrintfCheckerPlugin.php
@@ -56,8 +56,8 @@ class PrintfCheckerPlugin extends PluginV2 implements AnalyzeFunctionCallCapabil
 
     /**
      * People who have translations may subclass this plugin and return a mapping from other locales to those locales translations of $fmt_str.
+     * @param string $fmt_str @phan-unused-param
      * @return string[] mapping locale to the translation (e.g. ['fr_FR' => 'Bonjour'] for $fmt_str == 'Hello')
-     * @suppress PhanPluginUnusedProtectedMethodArgument
      */
     protected static function gettextForAllLocales(string $fmt_str)
     {
@@ -170,6 +170,7 @@ class PrintfCheckerPlugin extends PluginV2 implements AnalyzeFunctionCallCapabil
     }
 
     /**
+     * @param CodeBase $code_base @phan-unused-param
      * @return \Closure[]
      */
     public function getAnalyzeFunctionCallClosures(CodeBase $code_base) : array

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,32 @@ Phan NEWS
 ?? ??? 2018, Phan 0.12.10 (dev)
 -------------------------
 
+New features(CLI, Configs)
++ Add CLI flag `--unused-variable-detection`.
++ Add config setting `unused_variable_detection`.
+  Unused variable detection can be enabled by `--unused-variable-detection`, `--dead-code-detection`, or the config.
+
+New features(Analysis):
++ Add built-in support for unused variable detection.
+  Currently, this is limited to analyzing inside of functions, methods, and closures.
+
+  Warnings about unused parameters can be suppressed via `@param MyClass $x @phan-unused-param`.
+
+  The built in unused variable detection support will not warn about the following
+  - variables beginning with $raii (case insensitive)
+  - variables beginning with $unused (case insensitive)
+  - `$_`
+  - Superglobals, used globals, and static variables within function scopes.
+  - Any references
+
+  New Issue types:
+  - `PhanUnusedVariable`,
+  - `PhanUnusedPublicMethodParameter`, `PhanUnusedPublicFinalMethodParameter`,
+  - `PhanUnusedProtectedMethodParameter`, `PhanUnusedProtectedFinalMethodParameter`,
+  - `PhanUnusedPrivateMethodParameter`, `PhanUnusedProtectedFinalMethodParameter`,
+  - `PhanUnusedClosureUseVariable`, `PhanUnusedClosureParameter`,
+  - `PhanUnusedGlobalFunctionParameter`
+
 22 May 2018, Phan 0.12.9
 ------------------------
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,21 +5,24 @@ Phan NEWS
 
 New features(CLI, Configs)
 + Add CLI flag `--unused-variable-detection`.
-+ Add config setting `unused_variable_detection`.
++ Add config setting `unused_variable_detection` (disabled by default).
   Unused variable detection can be enabled by `--unused-variable-detection`, `--dead-code-detection`, or the config.
 
 New features(Analysis):
-+ Add built-in support for unused variable detection.
++ Add built-in support for unused variable detection. (#345)
   Currently, this is limited to analyzing inside of functions, methods, and closures.
+  This has some minor false positives with loops and conditional branches.
 
-  Warnings about unused parameters can be suppressed via `@param MyClass $x @phan-unused-param`.
+  Warnings about unused parameters can be suppressed by adding `@phan-unused-param` on the same line as `@param`,
+  e.g. `@param MyClass $x @phan-unused-param`.
+  (as well as via standard issue suppression methods.)
 
-  The built in unused variable detection support will not warn about the following
-  - variables beginning with $raii (case insensitive)
-  - variables beginning with $unused (case insensitive)
-  - `$_`
-  - Superglobals, used globals, and static variables within function scopes.
-  - Any references
+  The built in unused variable detection support will currently not warn about any of the following issue types, to reduce false positives.
+
+  - Variables beginning with `$unused` or `$raii` (case insensitive)
+  - `$_` (the exact variable name)
+  - Superglobals, used globals (`global $myGlobal;`), and static variables within function scopes.
+  - Any references, globals, or static variables in a function scope.
 
   New Issue types:
   - `PhanUnusedVariable`,
@@ -28,6 +31,17 @@ New features(Analysis):
   - `PhanUnusedPrivateMethodParameter`, `PhanUnusedProtectedFinalMethodParameter`,
   - `PhanUnusedClosureUseVariable`, `PhanUnusedClosureParameter`,
   - `PhanUnusedGlobalFunctionParameter`
+
+  This is similar to the third party plugin `PhanUnusedVariable`.
+  The built-in support has the following changes:
+
+  - Emits fewer/different false positives (e.g. when analyzing loops), but also detects fewer potential issues.
+  - Reimplemented using visitors extensively (Similar to the code for `BlockAnalysisVisitor`)
+  - Uses a different data structure from `PhanUnusedVariable`.
+    This represent all definitions of a variable, instead of just the most recent one.
+    This approximately tracks the full graph of definitions and uses of variables within a function body.
+    (This allows warning about all unused definitions, or about definitions that are hidden by subsequent definitions)
+  - Integration: This is planned to be integrated with other features of Phan, e.g. "Go to Definition" for variables. (Planned for #1211 and #1705)
 
 22 May 2018, Phan 0.12.9
 ------------------------

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Phan is able to perform the following kinds of analysis.
 * Check for valid and type safe return values on methods, functions, and closures.
 * Check for No-Ops on arrays, closures, constants, properties, variables, unary operators, and binary operators.
 * Check for unused/dead/[unreachable](https://github.com/phan/phan/tree/master/.phan/plugins#unreachablecodepluginphp) code. (Pass in `--dead-code-detection`)
+* Check for unused variables and parameters. (Pass in `--unused-variable-detection`)
 * Check for unused `use` statements.
 * Check for classes, functions and methods being redefined.
 * Check for sanity with class inheritance (e.g. checks method signature compatibility).
@@ -292,7 +293,12 @@ Usage: ./phan [options] [files...]
  -x, --dead-code-detection
   Emit issues for classes, methods, functions, constants and
   properties that are probably never referenced and can
-  possibly be removed.
+  possibly be removed. This implies `--unused-variable-detection`.
+
+ --unused-variable-detection
+  Emit issues for variables, parameters and closure use variables
+  that are probably never referenced.
+  This has a few known false positives, e.g. for loops or branches.
 
  -j, --processes <int>
   The number of parallel processes to run during the analysis

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -649,6 +649,72 @@ Possibly zero references to use statement for function {FUNCTION} ({FUNCTION})
 Possibly zero references to use statement for classlike/namespace {CLASSLIKE} ({CLASSLIKE})
 ```
 
+## PhanUnusedClosureParameter
+
+Phan has various checks (See the `unused_variable_detection` config)
+to detect if a variable or parameter is unused.
+
+```
+Parameter ${PARAMETER} is never used
+```
+
+## PhanUnusedClosureUseVariable
+
+```
+Closure use variable ${VARIABLE} is never used
+```
+
+## PhanUnusedGlobalFunctionParameter
+
+```
+Parameter ${PARAMETER} is never used
+```
+
+## PhanUnusedPrivateFinalMethodParameter
+
+```
+Parameter ${PARAMETER} is never used
+```
+
+## PhanUnusedPrivateMethodParameter
+
+```
+Parameter ${PARAMETER} is never used
+```
+
+## PhanUnusedProtectedFinalMethodParameter
+
+```
+Parameter ${PARAMETER} is never used
+```
+
+## PhanUnusedProtectedMethodParameter
+
+```
+Parameter ${PARAMETER} is never used
+```
+
+## PhanUnusedPublicFinalMethodParameter
+
+```
+Parameter ${PARAMETER} is never used
+```
+
+## PhanUnusedPublicMethodParameter
+
+```
+Parameter ${PARAMETER} is never used
+```
+
+## PhanUnusedVariable
+
+Phan has various checks (See the `unused_variable_detection` config)
+to detect if a variable or parameter is unused.
+
+```
+Unused definition of variable ${VARIABLE}
+```
+
 ## PhanWriteOnlyPrivateProperty
 
 ```

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -2067,7 +2067,6 @@ class TolerantASTConverter
 
     private static function phpParserIfStmtToAstIfStmt(PhpParser\Node\Statement\IfStatementNode $node, int $start_line) : ast\Node
     {
-        $start_line = self::getStartLine($node);
         $if_elem = static::astIfElem(
             static::phpParserNodeToAstNode($node->expression),
             static::phpParserStmtlistToAstNode($node->statements, self::getStartLine($node->statements), true),

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverterWithNodeMapping.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverterWithNodeMapping.php
@@ -172,8 +172,7 @@ class TolerantASTConverterWithNodeMapping extends TolerantASTConverter
     }
 
     /**
-     * @suppress PhanPluginUnusedPrivateMethodArgument $n (code can be uncommented for debugging)
-     * @param PhpParser\Node|Token $n
+     * @param PhpParser\Node|Token $n @phan-unused-param
      * @param mixed $ast_node
      */
     private static function markNodeAsSelected($n, $ast_node)

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1958,7 +1958,7 @@ class UnionTypeVisitor extends AnalysisVisitor
     /**
      * `print($str)` always returns 1.
      * See https://secure.php.net/manual/en/function.print.php#refsect1-function.print-returnvalues
-     * @suppress PhanPluginUnusedPublicMethodArgument
+     * @param Node $node @phan-unused-param
      */
     public function visitPrint(Node $node) : UnionType
     {
@@ -2262,9 +2262,9 @@ class UnionTypeVisitor extends AnalysisVisitor
      * @param CodeBase $code_base
      * @param Context $context
      * @param string|Node $node the node to fetch CallableType instances for.
-     * @param bool $log_error whether or not to log errors while searching
+     * @param bool $log_error whether or not to log errors while searching @phan-unused-param
      * @return array<int,FunctionInterface>
-     * @suppress PhanPluginUnusedPublicMethodArgument (TODO: Implement $log_error)
+     * TODO: use log_error
      */
     public static function functionLikeListFromNodeAndContext(CodeBase $code_base, Context $context, $node, bool $log_error) : array
     {

--- a/src/Phan/Analysis/AssignOperatorFlagVisitor.php
+++ b/src/Phan/Analysis/AssignOperatorFlagVisitor.php
@@ -199,13 +199,11 @@ class AssignOperatorFlagVisitor extends FlagVisitorImplementation
     }
 
     /**
-     * @param Node $node
+     * @param Node $node @phan-unused-param
      * A node to check types on
      *
      * @return UnionType
      * The resulting type(s) of the binary operation
-     *
-     * @suppress PhanPluginUnusedPublicMethodArgument
      */
     public function visitBinaryConcat(Node $node) : UnionType
     {

--- a/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
+++ b/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
@@ -222,14 +222,12 @@ class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
     }
 
     /**
-     * @param Node $node
-     * A node to check types on
+     * @param Node $node A node to check types on (@phan-unused-param)
+     *
      * TODO: Check that both types can cast to string or scalars?
      *
      * @return UnionType
      * The resulting type(s) of the binary operation
-     *
-     * @suppress PhanPluginUnusedPublicMethodArgument
      */
     public function visitBinaryConcat(Node $node) : UnionType
     {

--- a/src/Phan/Analysis/BlockExitStatusChecker.php
+++ b/src/Phan/Analysis/BlockExitStatusChecker.php
@@ -25,7 +25,7 @@ use Phan\AST\Visitor\KindVisitorImplementation;
  * TODO: Change to AnalysisVisitor if this ever emits issues.
  * TODO: Analyze switch (if there is a default) in another PR (And handle fallthrough)
  *
- * @phan-file-suppress PhanPluginUnusedPublicFinalMethodArgument
+ * @phan-file-suppress PhanPluginUnusedPublicFinalMethodArgument, PhanUnusedPublicFinalMethodParameter
  * @phan-file-suppress PhanPartialTypeMismatchArgument
  */
 final class BlockExitStatusChecker extends KindVisitorImplementation

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -28,7 +28,7 @@ use Closure;
  * TODO: Make $x > 0, $x < 0, $x >= 50, etc.  remove FalseType and NullType from $x
  * TODO: if (a || b || c || d) might get really slow, due to creating both ConditionVisitor and NegatedConditionVisitor
  *
- * @phan-file-suppress PhanPluginUnusedClosureArgument
+ * @phan-file-suppress PhanPluginUnusedClosureArgument, PhanUnusedClosureParameter
  */
 class ConditionVisitor extends KindVisitorImplementation
 {

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -254,13 +254,12 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
     }
 
     /**
-     * @param Node $node
+     * @param Node $node @phan-unused-param
      * A node to parse
      *
      * @return Context
      * A new or an unchanged context resulting from
      * parsing the node
-     * @suppress PhanPluginUnusedPublicMethodArgument
      */
     public function visitWhile(Node $node) : Context
     {
@@ -268,13 +267,12 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
     }
 
     /**
-     * @param Node $node
+     * @param Node $node @phan-unused-param
      * A node to parse
      *
      * @return Context
      * A new or an unchanged context resulting from
      * parsing the node
-     * @suppress PhanPluginUnusedPublicMethodArgument
      */
     public function visitSwitch(Node $node) : Context
     {
@@ -282,13 +280,12 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
     }
 
     /**
-     * @param Node $node
+     * @param Node $node @phan-unused-param
      * A node to parse
      *
      * @return Context
      * A new or an unchanged context resulting from
      * parsing the node
-     * @suppress PhanPluginUnusedPublicMethodArgument
      */
     public function visitSwitchCase(Node $node) : Context
     {
@@ -296,13 +293,11 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
     }
 
     /**
-     * @param Node $node
-     * A node to parse
+     * @param Node $node @phan-unused-param
      *
      * @return Context
      * A new or an unchanged context resulting from
      * parsing the node
-     * @suppress PhanPluginUnusedPublicMethodArgument
      */
     public function visitExprList(Node $node) : Context
     {

--- a/src/Phan/Analysis/ScopeVisitor.php
+++ b/src/Phan/Analysis/ScopeVisitor.php
@@ -37,13 +37,12 @@ abstract class ScopeVisitor extends AnalysisVisitor
      * Default visitor for node kinds that do not have
      * an overriding method
      *
-     * @param Node $node
+     * @param Node $node @phan-unused-param
      * A node to parse
      *
      * @return Context
      * A new or an unchanged context resulting from
      * parsing the node
-     * @suppress PhanPluginUnusedPublicMethodArgument
      */
     public function visit(Node $node) : Context
     {

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -99,7 +99,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
     }
 
     /**
-     * @suppress PhanPluginUnusedPublicMethodArgument
+     * @param Node $node @phan-unused-param this was analyzed in visitUse
      */
     public function visitUseElem(Node $node) : Context
     {

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -723,7 +723,12 @@ Usage: {$argv[0]} [options] [files...]
  -x, --dead-code-detection
   Emit issues for classes, methods, functions, constants and
   properties that are probably never referenced and can
-  possibly be removed.
+  possibly be removed. This implies `--unused-variable-detection`.
+
+ --unused-variable-detection
+  Emit issues for variables, parameters and closure use variables
+  that are probably never referenced.
+  This has a few known false positives, e.g. for loops or branches.
 
  -j, --processes <int>
   The number of parallel processes to run during the analysis

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -134,6 +134,7 @@ class CLI
                 'strict-return-checking',
                 'strict-type-checking',
                 'target-php-version',
+                'unused-variable-detection',
                 'use-fallback-parser',
                 'version',
             ]
@@ -427,6 +428,9 @@ class CLI
                 case 'x':
                 case 'dead-code-detection':
                     Config::setValue('dead_code_detection', true);
+                    break;
+                case 'unused-variable-detection':
+                    Config::setValue('unused_variable_detection', true);
                     break;
                 case 'allow-polyfill-parser':
                     // Just check if it's installed and of a new enough version.

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -1436,8 +1436,8 @@ class CodeBase
     }
 
     /**
+     * @param string $file_path @phan-unused-param
      * @return void
-     * @suppress PhanPluginUnusedPublicMethodArgument
      */
     public function flushDependenciesForFile(string $file_path)
     {
@@ -1445,10 +1445,10 @@ class CodeBase
     }
 
     /**
+     * @param string $file_path @phan-unused-param
      * @return string[]
      * The list of files that depend on the code in the given
      * file path
-     * @suppress PhanPluginUnusedPublicMethodArgument
      */
     public function dependencyListForFile(string $file_path) : array
     {

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -312,7 +312,7 @@ class Config
         'dead_code_detection' => false,
 
         // Set to true in order to attempt to detect unused variables.
-        // dead_code_detection will also enable this.
+        // dead_code_detection will also enable unused variable detection.
         'unused_variable_detection' => false,
 
         // Set to true in order to force tracking references to elements

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -311,6 +311,10 @@ class Config
         // to make sense of.
         'dead_code_detection' => false,
 
+        // Set to true in order to attempt to detect unused variables.
+        // dead_code_detection will also enable this.
+        'unused_variable_detection' => false,
+
         // Set to true in order to force tracking references to elements
         // (functions/methods/consts/protected).
         // dead_code_detection is another option which also causes references

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -883,7 +883,7 @@ class Config
     {
         self::$configuration = self::DEFAULT_CONFIGURATION;
         // Trigger magic behavior
-        self::get();
+        self::get()->init();
     }
 
     /**

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -313,6 +313,7 @@ class Config
 
         // Set to true in order to attempt to detect unused variables.
         // dead_code_detection will also enable unused variable detection.
+        // This has a few known false positives, e.g. for loops or branches.
         'unused_variable_detection' => false,
 
         // Set to true in order to force tracking references to elements

--- a/src/Phan/Daemon.php
+++ b/src/Phan/Daemon.php
@@ -228,10 +228,8 @@ class Daemon
      * Debug (non-error) statement related to the daemon.
      * Uncomment this when debugging issues (E.g. changes not being picked up)
      *
-     * @param string $format - printf style format string
-     * @param mixed ...$args - printf args
-     *
-     * @suppress PhanPluginUnusedPublicMethodArgument (Currently commented out)
+     * @param string $format - printf style format string @phan-unused-param
+     * @param mixed ...$args - printf args @phan-unused-param
      */
     public static function debugf(string $format, ...$args)
     {

--- a/src/Phan/ForkPool.php
+++ b/src/Phan/ForkPool.php
@@ -66,8 +66,8 @@ class ForkPool
             }
 
             // Fork
-            $pid = 0;
-            if (($pid = pcntl_fork()) < 0) {
+            $pid = pcntl_fork();
+            if ($pid < 0) {
                 error_log(posix_strerror(posix_get_last_error()));
                 exit(EXIT_FAILURE);
             }

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -238,6 +238,17 @@ class Issue
     const UnreferencedUseFunction       = 'PhanUnreferencedUseFunction';
     const UnreferencedUseConstant       = 'PhanUnreferencedUseConstant';
 
+    const UnusedVariable                        = 'PhanUnusedVariable';
+    const UnusedPublicMethodParameter           = 'PhanUnusedPublicMethodParameter';
+    const UnusedPublicFinalMethodParameter      = 'PhanUnusedPublicFinalMethodParameter';
+    const UnusedProtectedMethodParameter        = 'PhanUnusedProtectedMethodParameter';
+    const UnusedProtectedFinalMethodParameter   = 'PhanUnusedProtectedFinalMethodParameter';
+    const UnusedPrivateMethodParameter          = 'PhanUnusedPrivateMethodParameter';
+    const UnusedPrivateFinalMethodParameter     = 'PhanUnusedPrivateFinalMethodParameter';
+    const UnusedClosureUseVariable              = 'PhanUnusedClosureUseVariable';
+    const UnusedClosureParameter                = 'PhanUnusedClosureParameter';
+    const UnusedGlobalFunctionParameter         = 'PhanUnusedGlobalFunctionParameter';
+
     // Issue::CATEGORY_REDEFINE
     const RedefineClass             = 'PhanRedefineClass';
     const RedefineClassAlias        = 'PhanRedefineClassAlias';
@@ -2094,6 +2105,87 @@ class Issue
                 self::REMEDIATION_B,
                 6028
             ),
+            new Issue(
+                self::UnusedVariable,
+                self::CATEGORY_NOOP,
+                self::SEVERITY_NORMAL,
+                'Unused definition of variable ${VARIABLE}',
+                self::REMEDIATION_B,
+                6035
+            ),
+            new Issue(
+                self::UnusedPublicMethodParameter,
+                self::CATEGORY_NOOP,
+                self::SEVERITY_NORMAL,
+                'Parameter ${PARAMETER} is never used',
+                self::REMEDIATION_B,
+                6036
+            ),
+            new Issue(
+                self::UnusedPublicFinalMethodParameter,
+                self::CATEGORY_NOOP,
+                self::SEVERITY_NORMAL,
+                'Parameter ${PARAMETER} is never used',
+                self::REMEDIATION_B,
+                6037
+            ),
+            new Issue(
+                self::UnusedProtectedMethodParameter,
+                self::CATEGORY_NOOP,
+                self::SEVERITY_NORMAL,
+                'Parameter ${PARAMETER} is never used',
+                self::REMEDIATION_B,
+                6038
+            ),
+            new Issue(
+                self::UnusedProtectedFinalMethodParameter,
+                self::CATEGORY_NOOP,
+                self::SEVERITY_NORMAL,
+                'Parameter ${PARAMETER} is never used',
+                self::REMEDIATION_B,
+                6039
+            ),
+            new Issue(
+                self::UnusedPrivateMethodParameter,
+                self::CATEGORY_NOOP,
+                self::SEVERITY_NORMAL,
+                'Parameter ${PARAMETER} is never used',
+                self::REMEDIATION_B,
+                6040
+            ),
+            new Issue(
+                self::UnusedPrivateFinalMethodParameter,
+                self::CATEGORY_NOOP,
+                self::SEVERITY_NORMAL,
+                'Parameter ${PARAMETER} is never used',
+                self::REMEDIATION_B,
+                6041
+            ),
+            new Issue(
+                self::UnusedClosureUseVariable,
+                self::CATEGORY_NOOP,
+                self::SEVERITY_NORMAL,
+                'Closure use variable ${VARIABLE} is never used',
+                self::REMEDIATION_B,
+                6042
+            ),
+            new Issue(
+                self::UnusedClosureParameter,
+                self::CATEGORY_NOOP,
+                self::SEVERITY_NORMAL,
+                'Closure parameter ${PARAMETER} is never used',
+                self::REMEDIATION_B,
+                6043
+            ),
+            new Issue(
+                self::UnusedGlobalFunctionParameter,
+                self::CATEGORY_NOOP,
+                self::SEVERITY_NORMAL,
+                'Global function parameter ${PARAMETER} is never used',
+                self::REMEDIATION_B,
+                6044
+            ),
+
 
             // Issue::CATEGORY_REDEFINE
             new Issue(

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -2173,7 +2173,7 @@ class Issue
                 self::UnusedClosureParameter,
                 self::CATEGORY_NOOP,
                 self::SEVERITY_NORMAL,
-                'Closure parameter ${PARAMETER} is never used',
+                'Parameter ${PARAMETER} is never used',
                 self::REMEDIATION_B,
                 6043
             ),
@@ -2181,7 +2181,7 @@ class Issue
                 self::UnusedGlobalFunctionParameter,
                 self::CATEGORY_NOOP,
                 self::SEVERITY_NORMAL,
-                'Global function parameter ${PARAMETER} is never used',
+                'Parameter ${PARAMETER} is never used',
                 self::REMEDIATION_B,
                 6044
             ),

--- a/src/Phan/Language/Element/GlobalConstant.php
+++ b/src/Phan/Language/Element/GlobalConstant.php
@@ -84,10 +84,8 @@ class GlobalConstant extends AddressableElement implements ConstantInterface
         $pos = \strrpos($fqsen, '\\');
         if ($pos !== false) {
             $name = \substr($fqsen, $pos + 1);
-            $namespace = \substr($fqsen, 0, $pos);
         } else {
             $name = $fqsen;
-            $namespace = '';
         }
 
         $is_defined = \defined($fqsen);

--- a/src/Phan/Language/Element/Property.php
+++ b/src/Phan/Language/Element/Property.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 namespace Phan\Language\Element;
 
+use Phan\Exception\IssueException;
 use Phan\Language\Context;
 use Phan\Language\FQSEN\FullyQualifiedPropertyName;
 use Phan\Language\Scope\PropertyScope;

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -11,7 +11,7 @@ use Generator;
 /**
  * NOTE: there may also be instances of UnionType that are empty, due to the constructor being public
  *
- * @phan-file-suppress PhanPluginUnusedPublicFinalMethodArgument the results don't depend on passed in parameters
+ * @phan-file-suppress PhanPluginUnusedPublicFinalMethodArgument, PhanUnusedPublicFinalMethodParameter the results don't depend on passed in parameters
  */
 final class EmptyUnionType extends UnionType
 {

--- a/src/Phan/Language/Internal/PropertyMap.php
+++ b/src/Phan/Language/Internal/PropertyMap.php
@@ -5,6 +5,7 @@ $ordinary_ast_node = 'ast\Node|float|int|string';
 $ast_node_shape_inner = \implode(',', [
     "args?:ast\Node",
     "catches?:ast\Node",
+    "finally?:ast\Node",
     "class?:ast\Node",
     "cond?:$ordinary_ast_node",
     "const?:string",

--- a/src/Phan/Language/Internal/PropertyMap.php
+++ b/src/Phan/Language/Internal/PropertyMap.php
@@ -4,6 +4,7 @@ namespace Phan\Language\Internal;
 $ordinary_ast_node = 'ast\Node|float|int|string';
 $ast_node_shape_inner = \implode(',', [
     "args?:ast\Node",
+    "catches?:ast\Node",
     "class?:ast\Node",
     "cond?:$ordinary_ast_node",
     "const?:string",
@@ -16,6 +17,7 @@ $ast_node_shape_inner = \implode(',', [
     "right?:$ordinary_ast_node",
     "var?:ast\Node",
     "value?:$ordinary_ast_node",
+    "try?:ast\Node",
     "stmts?:?ast\Node",
 ]);
 

--- a/src/Phan/Language/Type/FunctionLikeDeclarationType.php
+++ b/src/Phan/Language/Type/FunctionLikeDeclarationType.php
@@ -16,7 +16,7 @@ use Closure;
 use ast\Node;
 
 /**
- * @phan-file-suppress PhanPluginUnusedPublicMethodArgument
+ * @phan-file-suppress PhanPluginUnusedPublicMethodArgument, PhanUnusedPublicMethodParameter
  */
 abstract class FunctionLikeDeclarationType extends Type implements FunctionInterface
 {

--- a/src/Phan/Language/Type/MixedType.php
+++ b/src/Phan/Language/Type/MixedType.php
@@ -19,10 +19,9 @@ final class MixedType extends NativeType
     }
 
     /**
-     * @param Type[] $target_type_set 1 or more types
+     * @param Type[] $target_type_set 1 or more types @phan-unused-param
      * @return bool
      * @override
-     * @suppress PhanPluginUnusedPublicFinalMethodArgument (mixed can cast to any type, probably won't get called)
      */
     public function canCastToAnyTypeInSet(array $target_type_set) : bool
     {
@@ -47,7 +46,8 @@ final class MixedType extends NativeType
     }
 
     /**
-     * @suppress PhanPluginUnusedPublicFinalMethodArgument (TODO: maybe use it in the future?)
+     * @param int $key_type @phan-unused-param
+     * (TODO: maybe use $key_type in the future?)
      */
     public function asGenericArrayType(int $key_type) : Type
     {

--- a/src/Phan/LanguageServer/LanguageServer.php
+++ b/src/Phan/LanguageServer/LanguageServer.php
@@ -739,11 +739,10 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
     /**
      * The initialize request is sent as the first request from the client to the server.
      *
-     * @param ClientCapabilities $capabilities The capabilities provided by the client (editor)
-     * @param string|null $rootPath The rootPath of the workspace. Is null if no folder is open.
-     * @param int|null $processId The process Id of the parent process that started the server. Is null if the process has not been started by another process. If the parent process is not alive then the server should exit (see exit notification) its process.
+     * @param ClientCapabilities $capabilities The capabilities provided by the client (editor) @phan-unused-param
+     * @param string|null $rootPath The rootPath of the workspace. Is null if no folder is open. @phan-unused-param
+     * @param int|null $processId The process Id of the parent process that started the server. Is null if the process has not been started by another process. If the parent process is not alive then the server should exit (see exit notification) its process. @phan-unused-param
      * @return Promise <InitializeResult>
-     * @suppress PhanPluginUnusedPublicMethodArgument
      */
     public function initialize(ClientCapabilities $capabilities, string $rootPath = null, int $processId = null): Promise
     {

--- a/src/Phan/LanguageServer/Server/TextDocument.php
+++ b/src/Phan/LanguageServer/Server/TextDocument.php
@@ -185,10 +185,11 @@ class TextDocument
 
     /**
      * Placeholder to avoid a crash on malformed clients
-     * @suppress PhanPluginUnusedPublicMethodArgument
+     * @param TextDocumentIdentifier $textDocument @phan-unused-param
+     * @param Position $position @phan-unused-param
      * @suppress PhanUnreferencedPublicMethod called by client via AdvancedJsonRpc
      */
-    public function hover(TextDocumentIdentifier $unusedTtextDocument, Position $position)
+    public function hover(TextDocumentIdentifier $textDocument, Position $position)
     {
         return null;
     }

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -43,7 +43,7 @@ use ast\Node;
  *
  * @property-read CodeBase $code_base
  *
- * @phan-file-suppress PhanPluginUnusedPublicMethodArgument implementing faster no-op methods for common visit*
+ * @phan-file-suppress PhanPluginUnusedPublicMethodArgument, PhanUnusedPublicMethodParameter implementing faster no-op methods for common visit*
  * @phan-file-suppress PhanPartialTypeMismatchArgument
  * @phan-file-suppress PhanPartialTypeMismatchArgumentInternal
  */

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -30,6 +30,7 @@ use Phan\Plugin\Internal\DependentReturnTypeOverridePlugin;
 use Phan\Plugin\Internal\MiscParamPlugin;
 use Phan\Plugin\Internal\NodeSelectionPlugin;
 use Phan\Plugin\Internal\StringFunctionPlugin;
+use Phan\Plugin\Internal\VariableTrackerPlugin;
 use Phan\Plugin\PluginImplementation;
 use Phan\PluginV2;
 use Phan\PluginV2\AfterAnalyzeFileCapability;
@@ -621,6 +622,9 @@ final class ConfigPluginSet extends PluginV2 implements
                 new MiscParamPlugin(),
             ];
             $plugin_set = array_merge($internal_return_type_plugins, $plugin_set);
+        }
+        if (Config::getValue('unused_variable_detection') || Config::getValue('dead_code_detection')) {
+            $plugin_set[] = new VariableTrackerPlugin();
         }
         if (self::requiresPluginBasedBuiltinSuppressions()) {
             $plugin_set[] = new BuiltinSuppressionPlugin();

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -157,6 +157,19 @@ final class ConfigPluginSet extends PluginV2 implements
     }
 
     /**
+     * @suppress PhanDeprecatedInterface
+     * @internal - Used only for testing
+     */
+    public static function reset() {
+        $instance = self::instance();
+        // Set all of the private properties to their uninitialized default values
+        foreach (new self() as $k => $v) {
+            $instance->{$k} = $v;
+        }
+        $instance->ensurePluginsExist();
+    }
+
+    /**
      * @param CodeBase $code_base
      * The code base in which the node exists
      *

--- a/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
@@ -24,7 +24,7 @@ use Phan\PluginV2;
  *
  * TODO: Refactor this.
  *
- * @phan-file-suppress PhanPluginUnusedClosureArgument
+ * @phan-file-suppress PhanPluginUnusedClosureArgument, PhanUnusedClosureParameter
  */
 final class ArrayReturnTypeOverridePlugin extends PluginV2 implements
     ReturnTypeOverrideCapability
@@ -33,7 +33,7 @@ final class ArrayReturnTypeOverridePlugin extends PluginV2 implements
     /**
      * @return array<string,\Closure>
      */
-    private static function getReturnTypeOverridesStatic(CodeBase $code_base) : array
+    private static function getReturnTypeOverridesStatic() : array
     {
         $mixed_type  = MixedType::instance(false);
         $false_type  = FalseType::instance(false);
@@ -354,6 +354,7 @@ final class ArrayReturnTypeOverridePlugin extends PluginV2 implements
     }
 
     /**
+     * @param CodeBase $code_base @phan-unused-param
      * @return array<string,\Closure>
      */
     public function getReturnTypeOverrides(CodeBase $code_base) : array
@@ -361,7 +362,7 @@ final class ArrayReturnTypeOverridePlugin extends PluginV2 implements
         // Unit tests invoke this repeatedly. Cache it.
         static $overrides = null;
         if ($overrides === null) {
-            $overrides = self::getReturnTypeOverridesStatic($code_base);
+            $overrides = self::getReturnTypeOverridesStatic();
         }
         return $overrides;
     }

--- a/src/Phan/Plugin/Internal/BuiltinSuppressionPlugin.php
+++ b/src/Phan/Plugin/Internal/BuiltinSuppressionPlugin.php
@@ -134,8 +134,13 @@ final class BuiltinSuppressionPlugin extends PluginV2 implements
         string $file_contents
     ) : array {
         $suggestion_list = [];
-        foreach (self::yieldSuppressionComments($file_contents)
-                 as list($comment_text, $comment_start_line, $comment_start_offset, $comment_name, $kind_list_text)) {
+        foreach (self::yieldSuppressionComments($file_contents) as list(
+            $comment_text,
+            $comment_start_line,
+            $comment_start_offset,
+            $comment_name,
+            $kind_list_text
+        )) {
             $kind_list = array_map('trim', explode(',', $kind_list_text));
             foreach ($kind_list as $issue_kind) {
                 if ($comment_name === 'file-suppress') {

--- a/src/Phan/Plugin/Internal/ClosureReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ClosureReturnTypeOverridePlugin.php
@@ -50,7 +50,7 @@ final class ClosureReturnTypeOverridePlugin extends PluginV2 implements
     /**
      * @return array<string,\Closure>
      */
-    private static function getReturnTypeOverridesStatic(CodeBase $code_base) : array
+    private static function getReturnTypeOverridesStatic() : array
     {
         $call_user_func_callback = static function (
             CodeBase $code_base,
@@ -170,7 +170,7 @@ final class ClosureReturnTypeOverridePlugin extends PluginV2 implements
     /**
      * @return array<string,\Closure>
      */
-    private static function getAnalyzeFunctionCallClosuresStatic(CodeBase $code_base) : array
+    private static function getAnalyzeFunctionCallClosuresStatic() : array
     {
         /**
          * @return void
@@ -226,6 +226,7 @@ final class ClosureReturnTypeOverridePlugin extends PluginV2 implements
     }
 
     /**
+     * @param $code_base @phan-unused-param
      * @return array<string,\Closure>
      * @override
      */
@@ -234,12 +235,13 @@ final class ClosureReturnTypeOverridePlugin extends PluginV2 implements
         // Unit tests invoke this repeatedly. Cache it.
         static $overrides = null;
         if ($overrides === null) {
-            $overrides = self::getReturnTypeOverridesStatic($code_base);
+            $overrides = self::getReturnTypeOverridesStatic();
         }
         return $overrides;
     }
 
     /**
+     * @param CodeBase $code_base @phan-unused-param
      * @return array<string,\Closure>
      * @override
      */
@@ -248,7 +250,7 @@ final class ClosureReturnTypeOverridePlugin extends PluginV2 implements
         // Unit tests invoke this repeatedly. Cache it.
         static $analyzers = null;
         if ($analyzers === null) {
-            $analyzers = self::getAnalyzeFunctionCallClosuresStatic($code_base);
+            $analyzers = self::getAnalyzeFunctionCallClosuresStatic();
         }
         return $analyzers;
     }

--- a/src/Phan/Plugin/Internal/CompactPlugin.php
+++ b/src/Phan/Plugin/Internal/CompactPlugin.php
@@ -18,12 +18,15 @@ final class CompactPlugin extends PluginV2 implements
     AnalyzeFunctionCallCapability
 {
 
+    /**
+     * @param CodeBase $code_base @phan-unused-param
+     */
     public function getAnalyzeFunctionCallClosures(CodeBase $code_base) : array
     {
         // Unit tests invoke this repeatedly. Cache it.
         static $analyzers = null;
         if ($analyzers === null) {
-            $analyzers = self::getAnalyzeFunctionCallClosuresStatic($code_base);
+            $analyzers = self::getAnalyzeFunctionCallClosuresStatic();
         }
         return $analyzers;
     }
@@ -31,7 +34,7 @@ final class CompactPlugin extends PluginV2 implements
     /**
      * @return array<string,\Closure>
      */
-    private static function getAnalyzeFunctionCallClosuresStatic(CodeBase $code_base) : array
+    private static function getAnalyzeFunctionCallClosuresStatic() : array
     {
         /**
          * @return void

--- a/src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php
@@ -26,6 +26,7 @@ final class DependentReturnTypeOverridePlugin extends PluginV2 implements
     ReturnTypeOverrideCapability
 {
     /**
+     * @param CodeBase $code_base @phan-unused-param
      * @return array<string,\Closure>
      * @phan-return array<string, Closure(CodeBase,Context,Func,array):UnionType>
      */
@@ -42,8 +43,8 @@ final class DependentReturnTypeOverridePlugin extends PluginV2 implements
          */
         $make_dependent_type_method = static function (int $expected_bool_pos, $type_if_true, $type_if_false, $type_if_unknown) : Closure {
             /**
+             * @param Func $function @phan-unused-param
              * @return UnionType
-             * @suppress PhanPluginUnusedClosureArgument
              */
             return static function (
                 CodeBase $code_base,
@@ -83,7 +84,7 @@ final class DependentReturnTypeOverridePlugin extends PluginV2 implements
 
         /**
          * @return UnionType
-         * @suppress PhanPluginUnusedClosureArgument
+         * @param Func $function @phan-unused-param
          */
         $json_decode_return_type_handler = static function (
             CodeBase $code_base,

--- a/src/Phan/Plugin/Internal/MiscParamPlugin.php
+++ b/src/Phan/Plugin/Internal/MiscParamPlugin.php
@@ -33,7 +33,7 @@ final class MiscParamPlugin extends PluginV2 implements
      * @return array<string,Closure>
      * @phan-return array<string,Closure(CodeBase,Context,FunctionInterface,array):void>
      */
-    private function getAnalyzeFunctionCallClosuresStatic(CodeBase $code_base) : array
+    private function getAnalyzeFunctionCallClosuresStatic() : array
     {
         $stop_exception = new StopParamAnalysisException();
 
@@ -427,6 +427,7 @@ final class MiscParamPlugin extends PluginV2 implements
     }
 
     /**
+     * @param Codebase $code_base @phan-unused-param
      * @return array<string,Closure>
      * @phan-return array<string,Closure(CodeBase,Context,FunctionInterface,array):void>
      */
@@ -435,7 +436,7 @@ final class MiscParamPlugin extends PluginV2 implements
         // Unit tests invoke this repeatedly. Cache it.
         static $analyzers = null;
         if ($analyzers === null) {
-            $analyzers = self::getAnalyzeFunctionCallClosuresStatic($code_base);
+            $analyzers = self::getAnalyzeFunctionCallClosuresStatic();
         }
         return $analyzers;
     }

--- a/src/Phan/Plugin/Internal/StringFunctionPlugin.php
+++ b/src/Phan/Plugin/Internal/StringFunctionPlugin.php
@@ -196,9 +196,9 @@ final class StringFunctionPlugin extends PluginV2 implements
     }
 
     /**
+     * @param CodeBase $code_base @phan-unused-param
      * @return array<string,\Closure>
      * @override
-     * @suppress PhanPluginUnusedPublicFinalMethodArgument
      */
     public function getAnalyzeFunctionCallClosures(CodeBase $code_base) : array
     {

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableGraph.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableGraph.php
@@ -62,7 +62,7 @@ final class VariableGraph
         $node_id = \spl_object_id($node);
         $scope->recordUsageById($name, $node_id);
         foreach ($defs_for_variable as $def_id => $_) {
-            if ($def_id !== $node_id)  {
+            if ($def_id !== $node_id) {
                 $this->def_uses[$name][$def_id][$node_id] = true;
             }
         }

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableGraph.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableGraph.php
@@ -83,6 +83,30 @@ final class VariableGraph
      */
     public function markAsReference(string $name)
     {
-        $this->variable_types[$name] = (($this->variable_types[$name] ?? 0) | self::IS_REFERENCE);
+        $this->markBitForVariableName($name, self::IS_REFERENCE);
+    }
+
+    /**
+     * @return void
+     */
+    public function markAsStaticVariable(string $name)
+    {
+        $this->markBitForVariableName($name, self::IS_STATIC);
+    }
+
+    /**
+     * @return void
+     */
+    public function markAsGlobalVariable(string $name)
+    {
+        $this->markBitForVariableName($name, self::IS_GLOBAL);
+    }
+
+    /**
+     * @return void
+     */
+    private function markBitForVariableName(string $name, int $bit)
+    {
+        $this->variable_types[$name] = (($this->variable_types[$name] ?? 0) | $bit);
     }
 }

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableGraph.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableGraph.php
@@ -36,6 +36,9 @@ final class VariableGraph
     {
     }
 
+    /**
+     * @return void
+     */
     public function recordVariableDefinition(string $name, Node $node, VariableTrackingScope $scope)
     {
         // TODO: Measure performance against SplObjectHash
@@ -47,6 +50,9 @@ final class VariableGraph
         $scope->recordDefinitionById($name, $id);
     }
 
+    /**
+     * @return void
+     */
     public function recordVariableUsage(string $name, Node $node, VariableTrackingScope $scope)
     {
         $defs_for_variable = $scope->getDefinition($name);
@@ -54,11 +60,27 @@ final class VariableGraph
             return;
         }
         $node_id = \spl_object_id($node);
+        $scope->recordUsageById($name, $node_id);
         foreach ($defs_for_variable as $def_id => $_) {
+            if ($def_id !== $node_id)  {
+                $this->def_uses[$name][$def_id][$node_id] = true;
+            }
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function recordLoopSelfUsage(string $name, int $def_id, array $loop_uses_of_own_variable)
+    {
+        foreach ($loop_uses_of_own_variable as $node_id => $_) {
             $this->def_uses[$name][$def_id][$node_id] = true;
         }
     }
 
+    /**
+     * @return void
+     */
     public function markAsReference(string $name)
     {
         $this->variable_types[$name] = (($this->variable_types[$name] ?? 0) | self::IS_REFERENCE);

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableGraph.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableGraph.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+namespace Phan\Plugin\Internal\VariableTracker;
+
+use ast\Node;
+
+/**
+ * This represents a summary of all of the definitions and uses of all variable within a scope.
+ */
+final class VariableGraph
+{
+    /**
+     * @var array<string,array<int,array<int,true>>>
+     *
+     * Maps variable name to (definition id to (list of uses of that given definition))
+     */
+    public $defs_uses = [];
+
+    /**
+     * @var array<string,array<int,int>>
+     *
+     * Maps variable id to variable line
+     */
+    public $def_lines = [];
+
+    const IS_REFERENCE = 1<<0;
+    const IS_GLOBAL    = 1<<1;
+    const IS_STATIC    = 1<<2;
+
+    /**
+     * @var array<string,int> maps variable names to whether
+     *    they have ever occurred as a given self::IS_* category in the current scope
+     */
+    public $variable_types = [];
+
+    public function __construct()
+    {
+    }
+
+    public function recordVariableDefinition(string $name, Node $node)
+    {
+        // TODO: Measure performance against SplObjectHash
+        $id = \spl_object_id($node);
+        if (!isset($this->defs_uses[$name][$id])) {
+            $this->defs_uses[$name][$id] = [];
+        }
+        $this->def_lines[$name][$id] = $node->lineno;
+    }
+
+    public function markAsReference(string $name)
+    {
+        $this->variable_types[$name] = (($this->variable_types[$name] ?? 0) | self::IS_REFERENCE);
+    }
+}

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableGraph.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableGraph.php
@@ -49,7 +49,7 @@ final class VariableGraph
 
     public function recordVariableUsage(string $name, Node $node, VariableTrackingScope $scope)
     {
-        $defs_for_variable = $scope->defs[$name] ?? null;
+        $defs_for_variable = $scope->getDefinition($name);
         if (!$defs_for_variable) {
             return;
         }

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
@@ -114,6 +114,9 @@ final class VariableTrackerVisitor extends AnalysisVisitor
                 if (!is_string($name)) {
                     break;
                 }
+                if ($is_ref) {
+                    self::$variable_graph->markAsReference($name);
+                }
                 self::$variable_graph->recordVariableDefinition($name, $node, $this->scope);
                 $this->scope->recordDefinition($name, $node);
                 break;

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
@@ -519,7 +519,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
 
         // TODO: Use BlockExitStatusChecker, like BlockAnalysisVisitor
         // TODO: Optimize
-        // @phan-suppress-next-line PhanPartialTypeMismatchArgument
+        // @phan-suppress-next-line PhanTypeMismatchArgument
         $main_scope = $outer_scope->mergeBranchScopeList([$try_scope], true);
 
         $catch_node_list = $node->children['catches']->children;

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
@@ -1,0 +1,110 @@
+<?php declare(strict_types=1);
+namespace Phan\Plugin\Internal\VariableTracker;
+
+use Phan\AST\AnalysisVisitor;
+use Phan\AST\Visitor\Element;
+use Phan\Language\Context;
+use ast\Node;
+
+/**
+ * The planned design for this is similar to the way BlockAnalysisVisitor tracks union types of variables
+ * (Tracks locations instead of union types).
+ *
+ * 1. Track definitions and uses, on a per-statement basis.
+ * 2. Use visit*() overrides for individual element types.
+ * 3. Split tracking variables into pre-analysis, recursive, and post-analysis steps
+ * 4. Track based on an identifier corresponding to the \ast\Node of the assignment (e.g. using \spl_object_id())
+ */
+final class VariableTrackerVisitor extends AnalysisVisitor
+{
+    public static $variable_graph;
+
+    /** @var VariableTrackingScope */
+    private $scope;
+
+    /** @var array<int,Node> */
+    private $parent_node_list = [];
+
+    public function __construct(VariableTrackingScope $scope)
+    {
+        $this->scope = $scope;
+    }
+
+    /**
+     * This is the default implementation for node types which don't have any overrides
+     * @return void
+     */
+    public function visit(Node $node)
+    {
+        foreach ($node->children as $child_node) {
+            if (!($child_node instanceof Node)) {
+                continue;
+            }
+
+            $this->{Element::VISIT_LOOKUP_TABLE[$child_node->kind] ?? 'handleMissingNodeKind'}($child_node);
+        }
+    }
+
+    public function handleMissingNodeKind(Node $node)
+    {
+        // do nothing
+    }
+
+    /**
+     * This is an abstraction for getting a new, updated context for a child node.
+     *
+     * @param Node $child_node - The node which will be analyzed to create the updated context.
+     *
+     * @return Context (The unmodified $context, or a different Context instance with modifications)
+     */
+    private function analyze(VariableTrackingScope $scope, Node $node, Node $child_node) : Context
+    {
+        // Modify the original object instead of creating a new BlockAnalysisVisitor.
+        // this is slightly more efficient, especially if a large number of unchanged parameters would exist.
+        $old_scope = $this->scope;
+        $this->scope = $scope;
+        $this->parent_node_list[] = $node;
+        try {
+            return $this->{Element::VISIT_LOOKUP_TABLE[$child_node->kind] ?? 'handleMissingNodeKind'}($child_node);
+        } finally {
+            $this->scope = $scope;
+            \array_pop($this->parent_node_list);
+        }
+    }
+
+    /**
+     * Do not recurse into function declarations within a scope
+     */
+    public function visitFuncDecl(Node $unused_node)
+    {
+        return;
+    }
+
+    /**
+     * Do not recurse into class declarations within a scope
+     */
+    public function visitClass(Node $unused_node)
+    {
+        return;
+    }
+
+    /**
+     * Do not recurse into closure declarations within a scope.
+     *
+     * FIXME: Check closure use variables without checking statements
+     */
+    public function visitClosure(Node $unused_node)
+    {
+        return;
+    }
+
+    // TODO: public function visitAssignment()
+    public function visitVariable(Node $node)
+    {
+        $name = $node->children['name'];
+        if (\is_string($name)) {
+            // TODO: Determine if the given usage is an assignment, a definition, or both (modifying by reference, $x++, etc.
+            // See the way this is done in BlockAnalysisVisitor
+        }
+    }
+}

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
@@ -16,6 +16,8 @@ use function is_string;
  * 2. Use visit*() overrides for individual element types.
  * 3. Split tracking variables into pre-analysis, recursive, and post-analysis steps
  * 4. Track based on an identifier corresponding to the \ast\Node of the assignment (e.g. using \spl_object_id())
+ *
+ * TODO: Improve analysis within the ternary operator (cond() ? ($x = 2) : ($x = 3);
  */
 final class VariableTrackerVisitor extends AnalysisVisitor
 {

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
@@ -19,6 +19,7 @@ use function is_string;
  * 4. Track based on an identifier corresponding to the \ast\Node of the assignment (e.g. using \spl_object_id())
  *
  * TODO: Improve analysis within the ternary operator (cond() ? ($x = 2) : ($x = 3);
+ * TODO: Support unset
  */
 final class VariableTrackerVisitor extends AnalysisVisitor
 {

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
@@ -341,7 +341,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
     {
         $name = $node->children['var']->children['name'] ?? null;
         if (\is_string($name)) {
-            self::$variable_graph->markAsStaticVariable($name);
+            self::$variable_graph->markAsGlobalVariable($name);
         }
         return $this->scope;
     }
@@ -519,6 +519,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
 
         // TODO: Use BlockExitStatusChecker, like BlockAnalysisVisitor
         // TODO: Optimize
+        // @phan-suppress-next-line PhanPartialTypeMismatchArgument
         $main_scope = $outer_scope->mergeBranchScopeList([$try_scope], true);
 
         $catch_node_list = $node->children['catches']->children;

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
@@ -4,6 +4,7 @@ namespace Phan\Plugin\Internal\VariableTracker;
 use Phan\AST\AnalysisVisitor;
 use Phan\AST\Visitor\Element;
 use ast\Node;
+use ast;  // TODO: Figure out why Phan isn't warning about Phan\Plugin\Internal\VariableTracker\ast\AST_VAR without this.
 
 use function is_string;
 
@@ -26,9 +27,6 @@ final class VariableTrackerVisitor extends AnalysisVisitor
     /** @var VariableTrackingScope */
     private $scope;
 
-    /** @var array<int,Node> */
-    private $parent_node_list = [];
-
     public function __construct(VariableTrackingScope $scope)
     {
         $this->scope = $scope;
@@ -36,7 +34,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
 
     /**
      * This is the default implementation for node types which don't have any overrides
-     * @return void
+     * @return VariableTrackingScope
      * @override
      */
     public function visit(Node $node)
@@ -46,118 +44,171 @@ final class VariableTrackerVisitor extends AnalysisVisitor
                 continue;
             }
 
-            $this->{Element::VISIT_LOOKUP_TABLE[$child_node->kind] ?? 'handleMissingNodeKind'}($child_node);
+            $this->scope = $this->{Element::VISIT_LOOKUP_TABLE[$child_node->kind] ?? 'handleMissingNodeKind'}($child_node);
         }
+        return $this->scope;
     }
 
     /**
+     * This is the default implementation for node types which don't have any overrides
+     * @return VariableTrackingScope
+     * @override
+     */
+    public function visitStmtList(Node $node)
+    {
+        foreach ($node->children as $child_node) {
+            if (!($child_node instanceof Node)) {
+                continue;
+            }
+
+            // TODO: Specialize?
+            $this->scope = $this->{Element::VISIT_LOOKUP_TABLE[$child_node->kind] ?? 'handleMissingNodeKind'}($child_node);
+        }
+        return $this->scope;
+    }
+
+    /**
+     * @return VariableTrackingScope
      * @override
      */
     public function visitAssignRef(Node $node)
     {
-        $this->analyzeAssign($node, true);
+        return $this->analyzeAssign($node, true);
     }
 
 
     /**
+     * @return VariableTrackingScope
      * @override
      */
     public function visitAssign(Node $node)
     {
-        $this->analyzeAssign($node, false);
+        return $this->analyzeAssign($node, false);
     }
 
+    /**
+     * @return VariableTrackingScope
+     */
     private function analyzeAssign(Node $node, bool $is_ref)
     {
         $expr = $node->children['expr'];
         if ($expr instanceof Node) {
-            $this->analyze($this->scope, $node, $expr);
+            $this->scope = $this->analyze($this->scope, $expr);
         }
-        $this->analyzeAssignmentTarget($node->children['var'], $is_ref);
+        return $this->analyzeAssignmentTarget($node->children['var'], $is_ref);
     }
 
+    /**
+     * @return VariableTrackingScope
+     */
     private function analyzeAssignmentTarget($node, bool $is_ref)
     {
+        // TODO: Push onto the node list?
         if (!($node instanceof Node)) {
-            return;
+            return $this->scope;
         }
         $kind = $node->kind;
-        if ($kind === \ast\AST_VAR) {
-            $name = $node->children['name'];
-            if (!is_string($name)) {
-                return;
-            }
-            self::$variable_graph->recordVariableDefinition($name, $node, $this->scope);
-            $this->scope->recordDefinition($name, $node);
+        switch ($kind) {
+            case ast\AST_VAR:
+                $name = $node->children['name'];
+                if (!is_string($name)) {
+                    break;
+                }
+                self::$variable_graph->recordVariableDefinition($name, $node, $this->scope);
+                $this->scope->recordDefinition($name, $node);
+                break;
+            case ast\AST_REF:
+                $this->scope = $this->analyzeAssignmentTarget($node->children['var'], true);
+                break;
+            // TODO: Analyze properties, array access, and function calls.
         }
-        // TODO: Analyze properties, array access, and function calls.
+        return $this->scope;
     }
 
+    /**
+     * @return VariableTrackingScope
+     */
     public function handleMissingNodeKind(Node $node)
     {
         // do nothing
+        return $this->scope;
+    }
+
+    /**
+     * @return VariableTrackingScope
+     */
+    private function analyzeWhenValidNode(VariableTrackingScope $scope, $child_node)
+    {
+        if ($child_node instanceof Node) {
+            return $this->analyze($scope, $child_node);
+        }
+        return $scope;
     }
 
     /**
      * This is an abstraction for getting a new, updated context for a child node.
      *
      * @param Node $child_node - The node which will be analyzed to create the updated context.
+     * @return VariableTrackingScope
      */
-    private function analyze(VariableTrackingScope $scope, Node $node, Node $child_node)
+    private function analyze(VariableTrackingScope $scope, Node $child_node)
     {
         // Modify the original object instead of creating a new BlockAnalysisVisitor.
         // this is slightly more efficient, especially if a large number of unchanged parameters would exist.
         $old_scope = $this->scope;
         $this->scope = $scope;
-        $this->parent_node_list[] = $node;
         try {
             return $this->{Element::VISIT_LOOKUP_TABLE[$child_node->kind] ?? 'handleMissingNodeKind'}($child_node);
         } finally {
             $this->scope = $scope;
-            \array_pop($this->parent_node_list);
         }
     }
 
     /**
      * Do not recurse into function declarations within a scope
+     * @return VariableTrackingScope
      * @override
      */
     public function visitFuncDecl(Node $unused_node)
     {
-        return;
+        return $this->scope;
     }
 
     /**
      * Do not recurse into class declarations within a scope
+     * @return VariableTrackingScope
      * @override
      */
     public function visitClass(Node $unused_node)
     {
-        return;
+        return $this->scope;
     }
 
     /**
      * Do not recurse into closure declarations within a scope.
      *
      * FIXME: Check closure use variables without checking statements
+     * @return VariableTrackingScope
      * @override
      */
     public function visitClosure(Node $unused_node)
     {
-        return;
+        return $this->scope;
     }
 
     /**
      * @override
+     * @return VariableTrackingScope
      * Common no-op
      */
     public function visitName(Node $unused_node)
     {
-        return;
+        return $this->scope;
     }
 
     /**
      * TODO: Check if the current context is a function call passing an argument by reference
+     * @return VariableTrackingScope
      * @override
      */
     public function visitVar(Node $node)
@@ -168,5 +219,26 @@ final class VariableTrackerVisitor extends AnalysisVisitor
             // TODO: Determine if the given usage is an assignment, a definition, or both (modifying by reference, $x++, etc.
             // See the way this is done in BlockAnalysisVisitor
         }
+        return $this->scope;
+    }
+
+    /**
+     * @return VariableTrackingScope
+     */
+    public function visitForeach(Node $node) {
+        // foreach ($expr as $key => $value) { stmts }
+        $expr_node = $node->children['expr'];
+        $this->analyzeWhenValidNode($this->scope, $expr_node);
+
+        $key_node = $node->children['key'];
+        $this->analyzeAssignmentTarget($key_node, false);
+
+        $value_node = $node->children['value'];
+        $this->analyzeAssignmentTarget($value_node, false);  // analyzeAssignmentTarget checks for AST_REF
+
+        // TODO: Update graph: inner loop definitions can be used inside the loop.
+        // TODO: Create a branchScope? - Loop iterations can run 0 times.
+        $inner_scope = $this->visitStmtList($node->children['stmts']);
+        return $this->scope;
     }
 }

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
@@ -20,6 +20,7 @@ use function is_string;
  *
  * TODO: Improve analysis within the ternary operator (cond() ? ($x = 2) : ($x = 3);
  * TODO: Support unset
+ * TODO: Fix tests/files/src/0426_inline_var_force.php
  */
 final class VariableTrackerVisitor extends AnalysisVisitor
 {
@@ -139,7 +140,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
                 }
                 self::$variable_graph->recordVariableDefinition($name, $node, $this->scope);
                 $this->scope->recordDefinition($name, $node);
-                break;
+                return $this->scope;
             case ast\AST_ARRAY:
                 return $this->analyzeArrayAssignmentTarget($node);
 
@@ -150,6 +151,10 @@ final class VariableTrackerVisitor extends AnalysisVisitor
             case ast\AST_DIM:
                 return $this->analyzeDimAssignmentTarget($node);
                 // TODO: Analyze array access and param/return references of function/method calls.
+            default:
+                // Static property or an unexpected target.
+                // Analyze this normally.
+                return $this->analyze($this->scope, $node);
         }
         return $this->scope;
     }

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
@@ -264,8 +264,8 @@ final class VariableTrackerVisitor extends AnalysisVisitor
         $inner_scope = $this->analyze($this->scope, $node->children['stmts']);
 
         // Merge inner scope into outer scope
-        // @phan-suppress-next-line PhanPartialTypeMismatchArgument
-        return $outer_scope->mergeInnerLoopScope($this->scope, self::$variable_graph);
+        // @phan-suppress-next-line PhanTypeMismatchArgument
+        return $outer_scope->mergeInnerLoopScope($inner_scope, self::$variable_graph);
     }
 
     /**
@@ -274,6 +274,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
      * @return VariableTrackingScope
      *
      * @see BlockAnalysisVisitor->visitIf (TODO: Use BlockExitStatusChecker)
+     * @override
      */
     public function visitIf(Node $node) {
         $outer_scope = $this->scope;

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackingBranchScope.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackingBranchScope.php
@@ -15,7 +15,8 @@ final class VariableTrackingBranchScope extends VariableTrackingScope
 
     // inherits defs, uses
 
-    public function __construct(VariableTrackingScope $parent_scope) {
+    public function __construct(VariableTrackingScope $parent_scope)
+    {
         $this->parent_scope = $parent_scope;
     }
 

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackingBranchScope.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackingBranchScope.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+namespace Phan\Plugin\Internal\VariableTracker;
+
+/**
+ * This will represent a variable scope, similar to \Phan\Language\Scope.
+ * Instead of tracking the union types for variable names, this will instead track definitions of variable names.
+ */
+final class VariableTrackingBranchScope extends VariableTrackingScope
+{
+    /**
+     * @var VariableTrackingScope the parent of this branch scope.
+     * Definitions will be merged later on.
+     */
+    public $parent_scope;
+
+    // inherits defs, uses
+
+    public function __construct(VariableTrackingScope $parent_scope) {
+        $this->parent_scope = $parent_scope;
+    }
+
+    /**
+     * @return ?array<int,true>
+     */
+    public function getDefinition(string $variable_name)
+    {
+        $parent_definitions = $this->parent_scope->getDefinition($variable_name);
+        $definitions = $this->defs[$variable_name] ?? null;
+        if ($parent_definitions === null) {
+            return $definitions;
+        }
+        if ($definitions === null) {
+            return $parent_definitions;
+        }
+        $definitions += $parent_definitions;
+        return $definitions;
+    }
+}

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackingScope.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackingScope.php
@@ -9,7 +9,7 @@ use function spl_object_id;
  * This will represent a variable scope, similar to \Phan\Language\Scope.
  * Instead of tracking the union types for variable names, this will instead track definitions of variable names.
  */
-final class VariableTrackingScope
+class VariableTrackingScope
 {
     /**
      * @var array<string,array<int,bool>>
@@ -18,13 +18,13 @@ final class VariableTrackingScope
      * This is true if 100% of the definitions are made within the scope,
      * false if a fraction of the definitions could be from preceding scopes.
      */
-    public $defs = [];
+    protected $defs = [];
 
     /**
      * @var array<string,int>
      * Maps a variable id to a list of uses which occurred before that scope begins.
      */
-    public $uses = [];
+    protected $uses = [];
 
     public function recordDefinition(string $variable_name, Node $node)
     {
@@ -38,5 +38,14 @@ final class VariableTrackingScope
         // Create a new definition for variable_name.
         // Replace the definitions for $variable_name.
         $this->defs[$variable_name] = [$node_id => true];
+    }
+
+    /**
+     * Overridden by subclasses
+     * @return ?array<int,true>
+     */
+    public function getDefinition(string $variable_name)
+    {
+        return $this->defs[$variable_name] ?? null;
     }
 }

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackingScope.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackingScope.php
@@ -45,6 +45,9 @@ class VariableTrackingScope
         $this->defs[$variable_name] = [$node_id => true];
     }
 
+    /**
+     * @suppress PhanUnreferencedPublicMethod used by reference
+     */
     public function recordUsage(string $variable_name, Node $node)
     {
         $node_id = spl_object_id($node);
@@ -87,7 +90,7 @@ class VariableTrackingScope
             $defs_for_variable = $result->defs[$variable_name] ?? [];
             $loop_uses_of_own_variable = $scope->uses[$variable_name] ?? null;
 
-            foreach ($defs as $def_id => $use_set) {
+            foreach ($defs as $def_id => $_) {
                 if ($loop_uses_of_own_variable) {
                     $graph->recordLoopSelfUsage($variable_name, $def_id, $loop_uses_of_own_variable);
                 }
@@ -118,8 +121,7 @@ class VariableTrackingScope
      */
     public function mergeBranchScopeList(
         array $branch_scopes,
-        bool $merge_parent_scope,
-        VariableGraph $graph
+        bool $merge_parent_scope
     ) : VariableTrackingScope {
         // Compute the keys which were redefined in branch scopes
         // TODO: Optimize
@@ -142,7 +144,7 @@ class VariableTrackingScope
                 return true;
             };
         } else {
-            $is_redefined_in_all_scopes = function (string $variable_name) : bool {
+            $is_redefined_in_all_scopes = function (string $unused_variable_name) : bool {
                 return false;
             };
         }
@@ -154,7 +156,7 @@ class VariableTrackingScope
             }
 
             foreach ($branch_scopes as $scope) {
-                foreach ($scope->defs[$variable_name] ?? [] as $def_id => $use_set) {
+                foreach ($scope->defs[$variable_name] ?? [] as $def_id => $_) {
                     $defs_for_variable[$def_id] = true;
                 }
             }

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackingScope.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackingScope.php
@@ -133,7 +133,7 @@ class VariableTrackingScope
             $result->mergeUses($scope->uses);
         }
         if ($merge_parent_scope) {
-            $is_redefined_in_all_scopes = function(string $variable_name) use ($branch_scopes) : bool {
+            $is_redefined_in_all_scopes = function (string $variable_name) use ($branch_scopes) : bool {
                 foreach ($branch_scopes as $scope) {
                     if (isset($scope->defs[$variable_name])) {
                         return false;
@@ -142,7 +142,7 @@ class VariableTrackingScope
                 return true;
             };
         } else {
-            $is_redefined_in_all_scopes = function(string $variable_name) : bool {
+            $is_redefined_in_all_scopes = function (string $variable_name) : bool {
                 return false;
             };
         }

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackingScope.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackingScope.php
@@ -8,6 +8,8 @@ use function spl_object_id;
 /**
  * This will represent a variable scope, similar to \Phan\Language\Scope.
  * Instead of tracking the union types for variable names, this will instead track definitions of variable names.
+ *
+ * @see ContextMergeVisitor for something similar for union types.
  */
 class VariableTrackingScope
 {
@@ -91,6 +93,56 @@ class VariableTrackingScope
                     $graph->recordLoopSelfUsage($variable_name, $def_id, $loop_uses_of_own_variable);
                 }
                 $defs_for_variable[$def_id] = true;
+            }
+            $result->defs[$variable_name] = $defs_for_variable;
+        }
+        return $result;
+    }
+
+    /**
+     * @param array<int,VariableTrackingBranchScope> $branch_scopes
+     */
+    public function mergeBranchScopeList(
+        array $branch_scopes,
+        bool $merge_parent_scope,
+        VariableGraph $graph
+    ) : VariableTrackingScope {
+        // Compute the keys which were redefined in branch scopes
+        // TODO: Optimize
+        $result = clone($this);
+        $def_key_set = [];
+        foreach ($branch_scopes as $scope) {
+            foreach ($scope->defs as $variable_name => $_) {
+                $def_key_set[$variable_name] = true;
+            }
+            // Anything which is used within a branch is used within the parent
+            $result->uses += $scope->uses;
+        }
+        if ($merge_parent_scope) {
+            $is_redefined_in_all_scopes = function(string $variable_name) use ($branch_scopes) : bool {
+                foreach ($branch_scopes as $scope) {
+                    if (isset($scope->defs[$variable_name])) {
+                        return false;
+                    }
+                }
+                return true;
+            };
+        } else {
+            $is_redefined_in_all_scopes = function(string $variable_name) : bool {
+                return false;
+            };
+        }
+        foreach ($def_key_set as $variable_name => $_) {
+            if ($is_redefined_in_all_scopes($variable_name)) {
+                $defs_for_variable = [];
+            } else {
+                $defs_for_variable = $result->defs[$variable_name] ?? [];
+            }
+
+            foreach ($branch_scopes as $scope) {
+                foreach ($scope->defs[$variable_name] ?? [] as $def_id => $use_set) {
+                    $defs_for_variable[$def_id] = true;
+                }
             }
             $result->defs[$variable_name] = $defs_for_variable;
         }

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackingScope.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackingScope.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+namespace Phan\Plugin\Internal\VariableTracker;
+
+/**
+ * This will represent a variable scope, similar to \Phan\Language\Scope.
+ * Instead of tracking the union types for variable names, this will instead track definitions of variable names.
+ */
+final class VariableTrackingScope
+{
+    /**
+     * @var array<string,array<int,bool>>
+     * Maps a variable id to a list of definitions in that scope.
+     *
+     * This is true if 100% of the definitions are made within the scope,
+     * false if a fraction of the definitions could be from preceding scopes.
+     */
+    public $defs = [];
+
+    /**
+     * @var array<string,int>
+     * Maps a variable id to a list of uses which occurred before that scope begins.
+     */
+    public $uses = [];
+}

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackingScope.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackingScope.php
@@ -1,6 +1,10 @@
 <?php declare(strict_types=1);
 namespace Phan\Plugin\Internal\VariableTracker;
 
+use ast\Node;
+
+use function spl_object_id;
+
 /**
  * This will represent a variable scope, similar to \Phan\Language\Scope.
  * Instead of tracking the union types for variable names, this will instead track definitions of variable names.
@@ -21,4 +25,18 @@ final class VariableTrackingScope
      * Maps a variable id to a list of uses which occurred before that scope begins.
      */
     public $uses = [];
+
+    public function recordDefinition(string $variable_name, Node $node)
+    {
+        // Create a new definition for variable_name.
+        // Replace the definitions for $variable_name.
+        $this->defs[$variable_name] = [spl_object_id($node) => true];
+    }
+
+    public function recordDefinitionById(string $variable_name, int $node_id)
+    {
+        // Create a new definition for variable_name.
+        // Replace the definitions for $variable_name.
+        $this->defs[$variable_name] = [$node_id => true];
+    }
 }

--- a/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
+++ b/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
@@ -8,6 +8,7 @@ use Phan\Plugin\Internal\VariableTracker\VariableGraph;
 use Phan\Plugin\Internal\VariableTracker\VariableTrackingScope;
 use Phan\Plugin\Internal\VariableTracker\VariableTrackerVisitor;
 use ast\Node;
+use ast;
 
 /**
  * NOTE: This is automatically loaded by phan based on config settings.
@@ -80,6 +81,7 @@ final class VariableTrackerElementVisitor extends PluginAwarePostAnalysisVisitor
     }
 
     private function addParametersAndUseVariablesToGraph(Node $node, VariableGraph $graph) {
+        // AST_PARAM_LIST of AST_PARAM
         foreach ($node->children['params']->children as $parameter) {
             $parameter_name = $parameter->children['name'];
             if (!is_string($parameter_name)) {
@@ -88,6 +90,15 @@ final class VariableTrackerElementVisitor extends PluginAwarePostAnalysisVisitor
             $graph->recordVariableDefinition($parameter_name, $node);
             if ($parameter->flags & ast\flags\PARAM_REF) {
                 $graph->markAsReference($parameter_name);
+            }
+        }
+        foreach ($node->children['uses']->children ?? [] as $closure_use) {
+            $name = $closure_use->children['name'];
+            if (!is_string($name)) {
+                continue;
+            }
+            if ($closure_use->flags & ast\flags\PARAM_REF) {
+                $graph->markAsReference($name);
             }
         }
     }

--- a/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
+++ b/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
@@ -113,7 +113,7 @@ final class VariableTrackerElementVisitor extends PluginAwarePostAnalysisVisitor
             }
             $result[\spl_object_id($closure_use)] = Issue::UnusedClosureUseVariable;
 
-            $graph->recordVariableDefinition($parameter_name, $closure_use, $scope);
+            $graph->recordVariableDefinition($name, $closure_use, $scope);
             if ($closure_use->flags & ast\flags\PARAM_REF) {
                 $graph->markAsReference($name);
             }

--- a/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
+++ b/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
@@ -166,6 +166,9 @@ final class VariableTrackerElementVisitor extends PluginAwarePostAnalysisVisitor
     ) {
         $result = [];
         foreach ($graph->def_uses as $variable_name => $def_uses_for_variable) {
+            if ($variable_name === 'this') {
+                continue;
+            }
             if (preg_match('/^(_$|(unused|raii))/i', $variable_name) > 0) {
                 // Skip over $_, $unused*, and $raii*
                 continue;

--- a/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
+++ b/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
@@ -121,7 +121,8 @@ final class VariableTrackerElementVisitor extends PluginAwarePostAnalysisVisitor
         return $result;
     }
 
-    private function getParameterCategory(Node $method_node) {
+    private function getParameterCategory(Node $method_node)
+    {
         $kind = $method_node->kind;
         if ($kind === ast\AST_CLOSURE) {
             return Issue::UnusedClosureParameter;
@@ -140,7 +141,8 @@ final class VariableTrackerElementVisitor extends PluginAwarePostAnalysisVisitor
         return $final ? Issue::UnusedPublicFinalMethodParameter : Issue::UnusedPublicMethodParameter;
     }
 
-    private function isParameterFinal(int $flags) : bool {
+    private function isParameterFinal(int $flags) : bool
+    {
         if (($flags & ast\flags\MODIFIER_FINAL) !== 0) {
             return true;
         }

--- a/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
+++ b/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
@@ -3,6 +3,7 @@ namespace Phan\Plugin\Internal;
 
 use Phan\Exception\CodeBaseException;
 use Phan\Issue;
+use Phan\Language\Element\Variable;
 use Phan\PluginV2\PostAnalyzeNodeCapability;
 use Phan\PluginV2\PluginAwarePostAnalysisVisitor;
 use Phan\PluginV2;
@@ -173,6 +174,9 @@ final class VariableTrackerElementVisitor extends PluginAwarePostAnalysisVisitor
             }
             if (preg_match('/^(_$|(unused|raii))/i', $variable_name) > 0) {
                 // Skip over $_, $unused*, and $raii*
+                continue;
+            }
+            if (Variable::isSuperglobalVariableWithName($variable_name)) {
                 continue;
             }
             $type_bitmask = $graph->variable_types[$variable_name] ?? 0;

--- a/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
+++ b/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
@@ -163,7 +163,7 @@ final class VariableTrackerElementVisitor extends PluginAwarePostAnalysisVisitor
      * @return void
      */
     private function warnAboutVariableGraph(
-        Node $node,
+        Node $method_node,
         VariableGraph $graph,
         $issue_overrides_for_definition_ids
     ) {
@@ -193,7 +193,12 @@ final class VariableTrackerElementVisitor extends PluginAwarePostAnalysisVisitor
                 $issue_type = $issue_overrides_for_definition_ids[$definition_id] ?? Issue::UnusedVariable;
                 if ($issue_type === Issue::UnusedPublicMethodParameter) {
                     // Narrow down issues about parameters into more specific issues
-                    $issue_type = $this->getParameterCategory($node);
+                    $docComment = $method_node->children['docComment'] ?? null;
+                    if ($docComment && preg_match('/@param[^$]*\$' . preg_quote($variable_name) . '\b.*@phan-unused-param\b/', $docComment)) {
+                        // Don't warn about parameters marked with phan-unused-param
+                        break;
+                    }
+                    $issue_type = $this->getParameterCategory($method_node);
                 }
                 Issue::maybeEmit(
                     $this->code_base,

--- a/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
+++ b/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
@@ -167,7 +167,6 @@ final class VariableTrackerElementVisitor extends PluginAwarePostAnalysisVisitor
         VariableGraph $graph,
         $issue_overrides_for_definition_ids
     ) {
-        $result = [];
         foreach ($graph->def_uses as $variable_name => $def_uses_for_variable) {
             if ($variable_name === 'this') {
                 continue;

--- a/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
+++ b/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
@@ -1,0 +1,120 @@
+<?php declare(strict_types=1);
+namespace Phan\Plugin\Internal;
+
+use Phan\PluginV2\PostAnalyzeNodeCapability;
+use Phan\PluginV2\PluginAwarePostAnalysisVisitor;
+use Phan\PluginV2;
+use Phan\Plugin\Internal\VariableTracker\VariableGraph;
+use Phan\Plugin\Internal\VariableTracker\VariableTrackingScope;
+use Phan\Plugin\Internal\VariableTracker\VariableTrackerVisitor;
+use ast\Node;
+
+/**
+ * NOTE: This is automatically loaded by phan based on config settings.
+ * Do not include it in the 'plugins' config.
+ */
+final class VariableTrackerPlugin extends PluginV2 implements
+    PostAnalyzeNodeCapability
+{
+
+    /**
+     * @return string the name of a visitor
+     */
+    public static function getPostAnalyzeNodeVisitorClassName() : string
+    {
+        return VariableTrackerElementVisitor::class;
+    }
+}
+
+/**
+ * TODO: Hook into the global scope as well?
+ */
+final class VariableTrackerElementVisitor extends PluginAwarePostAnalysisVisitor
+{
+    public function visitMethod(Node $node)
+    {
+        $this->analyzeMethodLike($node);
+    }
+
+    /**
+     * @override
+     */
+    public function visitFuncDecl(Node $node)
+    {
+        $this->analyzeMethodLike($node);
+    }
+
+    /**
+     * @override
+     */
+    public function visitClosure(Node $node)
+    {
+        $this->analyzeMethodLike($node);
+    }
+
+    /**
+     * @return void
+     */
+    private function analyzeMethodLike(Node $node)
+    {
+        // \Phan\Debug::printNode($node);
+        $stmts_node = $node->children['stmts'] ?? null;
+        if (!($stmts_node instanceof Node)) {
+            return;
+        }
+        $variable_graph = new VariableGraph();
+        $this->addParametersAndUseVariablesToGraph($node, $variable_graph);
+
+        try {
+            VariableTrackerVisitor::$variable_graph = $variable_graph;
+            $variable_tracker_visitor = new VariableTrackerVisitor(
+                new VariableTrackingScope()
+            );
+            // TODO: Add params and use variables.
+            $variable_tracker_visitor->__invoke($stmts_node);
+        } finally {
+            // @phan-suppress-next-line PhanTypeMismatchProperty
+            VariableTrackerVisitor::$variable_graph = null;
+        }
+        $this->warnAboutVariableGraph($node, $variable_graph);
+    }
+
+    private function addParametersAndUseVariablesToGraph(Node $node, VariableGraph $graph) {
+        foreach ($node->children['params']->children as $parameter) {
+            $parameter_name = $parameter->children['name'];
+            if (!is_string($parameter_name)) {
+                continue;
+            }
+            $graph->recordVariableDefinition($parameter_name, $node);
+            if ($parameter->flags & ast\flags\PARAM_REF) {
+                $graph->markAsReference($parameter_name);
+            }
+        }
+    }
+
+    private function warnAboutVariableGraph(Node $node, VariableGraph $graph)
+    {
+        foreach ($graph->defs_uses as $variable_name => $defs_uses) {
+            $type_bitmask = $graph->variable_types[$variable_name] ?? 0;
+            if ($type_bitmask > 0) {
+                // don't warn about static/global/references
+                continue;
+            }
+            foreach ($defs_uses as $definition_id => $use_list) {
+                if (\count($use_list) > 0) {
+                    // Don't warn if there's at least one usage of that definition
+                    continue;
+                }
+                $line = $graph->def_lines[$variable_name][$definition_id] ?? 1;
+                // TODO: Emit a different issue type for plugins.
+                $this->emitPluginIssue(
+                    $this->code_base,
+                    clone($this->context)->withLineNumberStart($line),
+                    'PhanUnusedVariable',
+                    'Unused definition of variable {VARIABLE}',
+                    [$variable_name]
+                );
+            }
+        }
+    }
+}

--- a/tests/.phan_for_test/config.php
+++ b/tests/.phan_for_test/config.php
@@ -56,6 +56,10 @@ return [
     // This is set to true for a unit test.
     'ignore_undeclared_functions_with_known_signatures' => true,
 
+    // Set to true in order to attempt to detect unused variables.
+    // dead_code_detection will also enable unused variable detection.
+    'unused_variable_detection' => true,
+
     // If true, Phan will read `class_alias` calls in the global scope,
     // then (1) create aliases from the *parsed* files if no class definition was found,
     // and (2) emit issues in the global scope if the source or target class is invalid.
@@ -63,4 +67,11 @@ return [
     //  the one which will be created is unspecified.)
     // NOTE: THIS IS EXPERIMENTAL, and the implementation may change.
     'enable_class_alias_support' => true,
+
+    'suppress_issue_types' => [
+        'PhanUnusedPublicMethodParameter',
+        'PhanUnusedPublicFinalMethodParameter',
+        'PhanUnusedGlobalFunctionParameter',
+        'PhanUnusedClosureParameter',
+    ],
 ];

--- a/tests/Phan/AbstractPhanFileTest.php
+++ b/tests/Phan/AbstractPhanFileTest.php
@@ -7,6 +7,7 @@ use Phan\Output\Collector\BufferingCollector;
 use Phan\Output\Printer\PlainTextPrinter;
 use Phan\Language\Type;
 use Phan\Phan;
+use Phan\Plugin\ConfigPluginSet;
 use Symfony\Component\Console\Output\BufferedOutput;
 
 abstract class AbstractPhanFileTest extends BaseTest implements CodeBaseAwareTestInterface
@@ -14,8 +15,6 @@ abstract class AbstractPhanFileTest extends BaseTest implements CodeBaseAwareTes
     const EXPECTED_SUFFIX = '.expected';
 
     private $code_base;
-    /** @var array<string,mixed> */
-    private $original_config = [];
 
     public function setCodeBase(CodeBase $code_base = null)
     {
@@ -27,6 +26,24 @@ abstract class AbstractPhanFileTest extends BaseTest implements CodeBaseAwareTes
      */
     abstract public function getTestFiles();
 
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+        // Reset the config file
+        Config::reset();
+        // Clear the plugins
+        ConfigPluginSet::reset();  // @phan-suppress-current-line PhanAccessMethodInternal
+    }
+
+    public static function tearDownAfterClass()
+    {
+        parent::tearDownAfterClass();
+        // Reset the config file
+        Config::reset();
+        // Clear the plugins
+        ConfigPluginSet::reset();  // @phan-suppress-current-line PhanAccessMethodInternal
+    }
+
     /**
      * Setup our state before running each test
      *
@@ -35,11 +52,6 @@ abstract class AbstractPhanFileTest extends BaseTest implements CodeBaseAwareTes
     public function setUp()
     {
         parent::setUp();
-
-        // Backup the config file
-        foreach (Config::get()->toArray() as $key => $value) {
-            $this->original_config[$key] = $value;
-        }
 
         Type::clearAllMemoizations();
     }
@@ -50,11 +62,6 @@ abstract class AbstractPhanFileTest extends BaseTest implements CodeBaseAwareTes
     public function tearDown()
     {
         parent::tearDown();
-
-        // Reinstate the original config
-        foreach ($this->original_config as $key => $value) {
-            Config::setValue($key, $value);
-        }
 
         Type::clearAllMemoizations();
     }

--- a/tests/Phan/AnalyzerTest.php
+++ b/tests/Phan/AnalyzerTest.php
@@ -23,14 +23,13 @@ class AnalyzerTest extends BaseTest
 
     protected function setUp()
     {
-        $this->code_base =
-            $code_base = new CodeBase(
-                [], // $this->class_name_list,
-                [], // $this->interface_name_list,
-                [], // $this->trait_name_list,
-                [], // $this->const_name_list,
-                []  // $this->function_name_list
-            );
+        $this->code_base = new CodeBase(
+            [], // $this->class_name_list,
+            [], // $this->interface_name_list,
+            [], // $this->trait_name_list,
+            [], // $this->const_name_list,
+            []  // $this->function_name_list
+        );
     }
 
     public function testClassInCodeBase()

--- a/tests/Phan/PHP72Test.php
+++ b/tests/Phan/PHP72Test.php
@@ -11,21 +11,12 @@ class PHP72Test extends AbstractPhanFileTest
         'target_php_version' => '7.2',
     ];
 
-    /** @var array<string,mixed> */
-    protected $old_values = [];
-
     public function setUp()
     {
         parent::setUp();
         foreach (self::overrides as $key => $value) {
             Config::setValue($key, $value);
         }
-    }
-
-    public function tearDown()
-    {
-        parent::tearDown();
-        Config::reset();
     }
 
     /**

--- a/tests/Phan/PHP72Test.php
+++ b/tests/Phan/PHP72Test.php
@@ -18,7 +18,6 @@ class PHP72Test extends AbstractPhanFileTest
     {
         parent::setUp();
         foreach (self::overrides as $key => $value) {
-            $this->old_values[$key] = Config::getValue($key);
             Config::setValue($key, $value);
         }
     }
@@ -26,9 +25,7 @@ class PHP72Test extends AbstractPhanFileTest
     public function tearDown()
     {
         parent::tearDown();
-        foreach ($this->old_values as $key => $value) {
-            Config::setValue($key, $value);
-        }
+        Config::reset();
     }
 
     /**

--- a/tests/Phan/PhanTest.php
+++ b/tests/Phan/PhanTest.php
@@ -6,11 +6,8 @@ use Phan\Config;
 
 class PhanTest extends AbstractPhanFileTest
 {
-    /**
-     * @suppress PhanUndeclaredConstant
-     */
-    public function getTestFiles()
-    {
+    public static function setUpBeforeClass() {
+        parent::setUpBeforeClass();
 
         // Read and apply any custom configuration
         // overrides for the tests.
@@ -18,6 +15,13 @@ class PhanTest extends AbstractPhanFileTest
         foreach (require($test_config_file_name) as $key => $value) {
             Config::setValue($key, $value);
         }
+    }
+
+    /**
+     * @suppress PhanUndeclaredConstant
+     */
+    public function getTestFiles()
+    {
 
         return $this->scanSourceFilesDir(TEST_FILE_DIR, EXPECTED_DIR);
     }

--- a/tests/Phan/PhanTest.php
+++ b/tests/Phan/PhanTest.php
@@ -3,6 +3,7 @@
 namespace Phan\Tests;
 
 use Phan\Config;
+use Phan\Plugin\ConfigPluginSet;
 
 class PhanTest extends AbstractPhanFileTest
 {
@@ -15,6 +16,7 @@ class PhanTest extends AbstractPhanFileTest
         foreach (require($test_config_file_name) as $key => $value) {
             Config::setValue($key, $value);
         }
+        ConfigPluginSet::reset();  // @phan-suppress-current-line PhanAccessMethodInternal
     }
 
     /**

--- a/tests/files/expected/0012_closures.php.expected
+++ b/tests/files/expected/0012_closures.php.expected
@@ -1,2 +1,2 @@
 %s:13 PhanUndeclaredVariable Variable $c is undeclared
-
+%s:13 PhanUnusedClosureUseVariable Closure use variable $c is never used

--- a/tests/files/expected/0013_assignment_types.php.expected
+++ b/tests/files/expected/0013_assignment_types.php.expected
@@ -1,2 +1,6 @@
+%s:28 PhanUnusedVariable Unused definition of variable $str
+%s:31 PhanUnusedVariable Unused definition of variable $str
 %s:34 PhanTypeVoidAssignment Cannot assign void return value
+%s:34 PhanUnusedVariable Unused definition of variable $str
+%s:35 PhanUnusedVariable Unused definition of variable $str
 %s:36 PhanTypeVoidAssignment Cannot assign void return value

--- a/tests/files/expected/0025_invalid_array_operator.php.expected
+++ b/tests/files/expected/0025_invalid_array_operator.php.expected
@@ -1,0 +1,1 @@
+%s:3 PhanUnusedVariable Unused definition of variable $x

--- a/tests/files/expected/0056_aggressive_return_types.php.expected
+++ b/tests/files/expected/0056_aggressive_return_types.php.expected
@@ -1,0 +1,1 @@
+%s:3 PhanUnusedProtectedMethodParameter Parameter $data is never used

--- a/tests/files/expected/0079_conditional_types.php.expected
+++ b/tests/files/expected/0079_conditional_types.php.expected
@@ -1,0 +1,1 @@
+%s:10 PhanUnusedVariable Unused definition of variable $v2

--- a/tests/files/expected/0098_undef.php.expected
+++ b/tests/files/expected/0098_undef.php.expected
@@ -5,6 +5,7 @@
 %s:19 PhanUndeclaredTypeProperty Property \D::p has undeclared type \Undef
 %s:22 PhanUndeclaredExtendedClass Class extends undeclared class \Undef
 %s:25 PhanParentlessClass Reference to parent of class \F that does not extend anything
+%s:25 PhanUnusedVariable Unused definition of variable $v
 %s:28 PhanUndeclaredProperty Reference to undeclared property \C->undef
 %s:31 PhanUndeclaredProperty Reference to undeclared property \C->undef
 %s:34 PhanUndeclaredClassMethod Call to method f from undeclared class \Undef
@@ -14,3 +15,4 @@
 %s:43 PhanUndeclaredExtendedClass Class extends undeclared class \Undef
 %s:46 PhanUndeclaredTypeReturnType Return type of j is undeclared type \Undef
 %s:49 PhanUndeclaredTypeReturnType Return type of k is undeclared type \self
+

--- a/tests/files/expected/0109_conditional_ignored_types.php.expected
+++ b/tests/files/expected/0109_conditional_ignored_types.php.expected
@@ -1,0 +1,1 @@
+%s:5 PhanUnusedVariable Unused definition of variable $v2

--- a/tests/files/expected/0127_override_access.php.expected
+++ b/tests/files/expected/0127_override_access.php.expected
@@ -1,4 +1,5 @@
 %s:8 PhanAccessNonStaticToStatic Cannot make non static method \C0::f() static
 %s:12 PhanAccessSignatureMismatch Access level to function f($p) must be compatible with function f($p) defined in %s:4
+%s:12 PhanUnusedPrivateMethodParameter Parameter $p is never used
 %s:16 PhanAccessSignatureMismatch Access level to function f($p) must be compatible with function f($p) defined in %s:4
-
+%s:16 PhanUnusedProtectedMethodParameter Parameter $p is never used

--- a/tests/files/expected/0166_is_a.php.expected
+++ b/tests/files/expected/0166_is_a.php.expected
@@ -15,3 +15,4 @@
 %s:37 PhanTypeMismatchArgument Argument 1 (var) is bool|float|int|string but \emitType() takes resource defined at %s:3
 %s:39 PhanTypeMismatchArgument Argument 1 (var) is string but \emitType() takes resource defined at %s:3
 %s:41 PhanTypeMismatchArgument Argument 1 (var) is iterable but \emitType() takes resource defined at %s:3
+%s:42 PhanUnusedVariable Unused definition of variable $v

--- a/tests/files/expected/0189_2d_array.php.expected
+++ b/tests/files/expected/0189_2d_array.php.expected
@@ -1,0 +1,1 @@
+%s:8 PhanUnusedVariable Unused definition of variable $x

--- a/tests/files/expected/0198_list_property.php.expected
+++ b/tests/files/expected/0198_list_property.php.expected
@@ -1,0 +1,2 @@
+%s:8 PhanUnusedVariable Unused definition of variable $x
+%s:8 PhanUnusedVariable Unused definition of variable $y

--- a/tests/files/expected/0205_undeclared_property.php.expected
+++ b/tests/files/expected/0205_undeclared_property.php.expected
@@ -1,0 +1,3 @@
+%s:7 PhanUnusedVariable Unused definition of variable $v
+%s:9 PhanUnusedVariable Unused definition of variable $v2
+%s:9 PhanUnusedVariable Unused definition of variable $v3

--- a/tests/files/expected/0219_superglobal_type_check.php.expected
+++ b/tests/files/expected/0219_superglobal_type_check.php.expected
@@ -10,5 +10,6 @@
 %s:34 PhanTypeMismatchArgumentInternal Argument 1 (string) is array<string,array<int,int>>|array<string,array<int,string>>|array<string,int>|array<string,string> but \strlen() takes string
 %s:37 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is array<string,array<int,int>>|array<string,array<int,string>>|array<string,int>|array<string,string> but \intdiv() takes int
 %s:40 PhanTypeMismatchArgumentInternal Argument 1 (string) is array<int,string>|null but \strlen() takes string
+%s:43 PhanUnusedVariable Unused definition of variable $http_response_headers
 %s:49 PhanUndeclaredVariable Variable $argc is undeclared
 %s:50 PhanUndeclaredVariable Variable $argv is undeclared

--- a/tests/files/expected/0235_internal_args_required.php.expected
+++ b/tests/files/expected/0235_internal_args_required.php.expected
@@ -1,0 +1,3 @@
+%s:5 PhanUnusedVariable Unused definition of variable $period
+%s:6 PhanUnusedVariable Unused definition of variable $period
+%s:7 PhanUnusedVariable Unused definition of variable $period

--- a/tests/files/expected/0246_iterable.php.expected
+++ b/tests/files/expected/0246_iterable.php.expected
@@ -1,3 +1,7 @@
+%s:3 PhanUnusedVariable Unused definition of variable $v
+%s:6 PhanUnusedVariable Unused definition of variable $v
+%s:9 PhanUnusedVariable Unused definition of variable $v
+%s:12 PhanUnusedVariable Unused definition of variable $v
 %s:16 PhanTypeMismatchArgument Argument 1 (p) is iterable but \f246_1() takes array defined at %s:5
 %s:17 PhanTypeMismatchArgument Argument 1 (p) is iterable but \f246_2() takes \ArrayAccess defined at %s:8
 %s:18 PhanTypeMismatchArgument Argument 1 (p) is iterable but \f246_3() takes \Traversable defined at %s:11

--- a/tests/files/expected/0246_iterable.php.expected70
+++ b/tests/files/expected/0246_iterable.php.expected70
@@ -1,3 +1,7 @@
+%s:4 PhanUnusedVariable Unused definition of variable $v
+%s:7 PhanUnusedVariable Unused definition of variable $v
+%s:10 PhanUnusedVariable Unused definition of variable $v
+%s:13 PhanUnusedVariable Unused definition of variable $v
 %s:18 PhanTypeMismatchArgument Argument 1 (p) is iterable but \f246_1() takes array defined at %s:6
 %s:19 PhanTypeMismatchArgument Argument 1 (p) is iterable but \f246_2() takes \ArrayAccess defined at %s:9
 %s:20 PhanTypeMismatchArgument Argument 1 (p) is iterable but \f246_3() takes \Traversable defined at %s:12

--- a/tests/files/expected/0264_closure_override_context.php.expected
+++ b/tests/files/expected/0264_closure_override_context.php.expected
@@ -1,10 +1,17 @@
 %s:17 PhanTypeMissingReturn Method \NS264\TestFramework::mockA is declared to return string but has no return value
 %s:22 PhanUnextractableAnnotation Saw unextractable annotation for comment '* @phan-closure-scope'
+%s:24 PhanUnusedVariable Unused definition of variable $w
+%s:32 PhanUnusedVariable Unused definition of variable $x
+%s:41 PhanUnusedVariable Unused definition of variable $y
 %s:44 PhanUndeclaredProperty Reference to undeclared property \NS264\BoundClass264->d
 %s:50 PhanTypeInvalidClosureScope Invalid @phan-closure-scope: expected a class name, got string
+%s:50 PhanUnusedVariable Unused definition of variable $z
 %s:51 PhanUndeclaredProperty Reference to undeclared property \NS264\TestFramework->b
 %s:51 PhanUndeclaredProperty Reference to undeclared property \NS264\TestFramework->d
+%s:53 PhanUnusedVariable Unused definition of variable $prefix
+%s:59 PhanUnusedVariable Unused definition of variable $a
 %s:60 PhanUndeclaredVariable Variable $prefix is undeclared
 %s:69 PhanUndeclaredClosureScope Reference to undeclared class \NS264\UndeclaredClass264 in @phan-closure-scope
+%s:69 PhanUnusedVariable Unused definition of variable $b
 %s:70 PhanUndeclaredProperty Reference to undeclared property \NS264\TestFramework->b
 %s:80 PhanUndeclaredProperty Reference to undeclared property \NS264\BoundClass264->undefVar

--- a/tests/files/expected/0275_warn_extra_undef.php.expected
+++ b/tests/files/expected/0275_warn_extra_undef.php.expected
@@ -1,1 +1,2 @@
 %s:5 PhanUndeclaredVariable Variable $undefVar is undeclared
+%s:8 PhanUnusedPrivateMethodParameter Parameter $targetId is never used

--- a/tests/files/expected/0276_assign_and_missing_static_property.php.expected
+++ b/tests/files/expected/0276_assign_and_missing_static_property.php.expected
@@ -2,4 +2,5 @@
 %s:8 PhanUndeclaredStaticProperty Static property 'prop' on \ClassMissingStaticProps is undeclared
 %s:11 PhanUndeclaredStaticProperty Static property 'firstProp' on \stdClass is undeclared
 %s:12 PhanUndeclaredStaticProperty Static property 'secondProp' on \stdClass is undeclared
+%s:12 PhanUnusedVariable Unused definition of variable $b
 %s:13 PhanUndeclaredStaticProperty Static property 'thirdProp' on \stdClass is undeclared

--- a/tests/files/expected/0278_internal_elements.php.expected
+++ b/tests/files/expected/0278_internal_elements.php.expected
@@ -1,5 +1,16 @@
 %s:35 PhanTypeVoidAssignment Cannot assign void return value
 %s:61 PhanTypeVoidAssignment Cannot assign void return value
+%s:61 PhanUnusedVariable Unused definition of variable $v01
+%s:62 PhanUnusedVariable Unused definition of variable $v02
+%s:63 PhanUnusedVariable Unused definition of variable $v03
+%s:66 PhanUnusedVariable Unused definition of variable $v11
+%s:67 PhanUnusedVariable Unused definition of variable $v12
+%s:68 PhanUnusedVariable Unused definition of variable $v13
+%s:71 PhanUnusedVariable Unused definition of variable $v21
+%s:72 PhanUnusedVariable Unused definition of variable $v22
+%s:73 PhanUnusedVariable Unused definition of variable $v23
+%s:74 PhanUnusedVariable Unused definition of variable $v24
+%s:75 PhanUnusedVariable Unused definition of variable $v25
 %s:92 PhanAccessMethodInternal Cannot access internal method \NS278\A\f of namespace \NS278\A defined at %s:33 from namespace \NS278\B
 %s:92 PhanTypeVoidAssignment Cannot assign void return value
 %s:94 PhanAccessConstantInternal Cannot access internal constant \NS278\A\CONST_INTERNAL of namepace \NS278\A defined at %s:8 from namespace \NS278\B

--- a/tests/files/expected/0278_internal_elements.php.expected70
+++ b/tests/files/expected/0278_internal_elements.php.expected70
@@ -1,5 +1,16 @@
 %s:35 PhanTypeVoidAssignment Cannot assign void return value
 %s:61 PhanTypeVoidAssignment Cannot assign void return value
+%s:61 PhanUnusedVariable Unused definition of variable $v01
+%s:62 PhanUnusedVariable Unused definition of variable $v02
+%s:63 PhanUnusedVariable Unused definition of variable $v03
+%s:66 PhanUnusedVariable Unused definition of variable $v11
+%s:67 PhanUnusedVariable Unused definition of variable $v12
+%s:68 PhanUnusedVariable Unused definition of variable $v13
+%s:71 PhanUnusedVariable Unused definition of variable $v21
+%s:72 PhanUnusedVariable Unused definition of variable $v22
+%s:73 PhanUnusedVariable Unused definition of variable $v23
+%s:74 PhanUnusedVariable Unused definition of variable $v24
+%s:75 PhanUnusedVariable Unused definition of variable $v25
 %s:92 PhanAccessMethodInternal Cannot access internal method \NS278\A\f of namespace \NS278\A defined at %s:33 from namespace \NS278\B
 %s:92 PhanTypeVoidAssignment Cannot assign void return value
 %s:96 PhanAccessMethodInternal Cannot access internal method \NS278\A\C1::__construct of namespace \NS278\A defined at %s:11 from namespace \NS278\B

--- a/tests/files/expected/0281_magic_method_support.php.expected
+++ b/tests/files/expected/0281_magic_method_support.php.expected
@@ -1,5 +1,6 @@
 %s:37 PhanUndeclaredMethod Call to undeclared method \A281::undeclaredMagicMethod
 %s:38 PhanTypeVoidAssignment Cannot assign void return value
+%s:38 PhanUnusedVariable Unused definition of variable $b
 %s:40 PhanParamTooMany Call with 1 arg(s) to \A281::fooWithReturnType() which only takes 0 arg(s) defined at %s:19
 %s:41 PhanTypeMismatchArgument Argument 1 (x) is int but \expects_a281() takes \A281 defined at %s:30
 %s:45 PhanTypeMismatchArgument Argument 2 (b) is null but \A281::fooWithOptionalSecondParam() takes int defined at %s:19
@@ -21,3 +22,4 @@
 %s:75 PhanTypeMismatchArgument Argument 3 (c) is string but \A281::fooWithOptionalArrayParam2() takes int defined at %s:19
 %s:80 PhanUndeclaredMethod Call to undeclared method \C281::undeclaredMagicMethod
 %s:81 PhanTypeVoidAssignment Cannot assign void return value
+%s:81 PhanUnusedVariable Unused definition of variable $d

--- a/tests/files/expected/0302_trait_abstract_signature.php.expected
+++ b/tests/files/expected/0302_trait_abstract_signature.php.expected
@@ -1,1 +1,3 @@
+%s:13 PhanUnusedVariable Unused definition of variable $args
+%s:18 PhanUnusedVariable Unused definition of variable $args
 %s:28 PhanTypeMismatchArgument Argument 1 (x) is string but \C::fn2() takes int defined at %s:17

--- a/tests/files/expected/0307_inheritdoc_tests.php.expected
+++ b/tests/files/expected/0307_inheritdoc_tests.php.expected
@@ -1,7 +1,9 @@
 %s:18 PhanTypeMissingReturn Method \B307::offsetExists is declared to return bool but has no return value
 %s:22 PhanTypeMissingReturn Method \B307::offsetGet is declared to return mixed but has no return value
 %s:34 PhanTypeMismatchReturn Returning type int but serialize() is declared to return string
+%s:39 PhanUnusedVariable Unused definition of variable $x
 %s:40 PhanTypeMismatchReturn Returning type true but unserialize() is declared to return void
+%s:44 PhanUnusedVariable Unused definition of variable $result
 %s:51 PhanTypeMismatchArgument Argument 1 (offset) is null but \B307::offsetExists() takes string defined at %s:18
 %s:52 PhanTypeMismatchArgument Argument 1 (offset) is null but \B307::offsetGet() takes string defined at %s:22
 %s:53 PhanTypeMismatchArgument Argument 1 (offset) is null but \B307::offsetSet() takes string defined at %s:26

--- a/tests/files/expected/0313_undefined_array_push.php.expected
+++ b/tests/files/expected/0313_undefined_array_push.php.expected
@@ -1,3 +1,4 @@
+%s:7 PhanUnusedVariable Unused definition of variable $myVar
 %s:8 PhanUndeclaredVariableDim Variable $myvar was undeclared, but array fields are being added to it.
 %s:9 PhanUndeclaredVariableDim Variable $myvAR was undeclared, but array fields are being added to it.
 %s:11 PhanUndeclaredProperty Reference to undeclared property \Foo313->prop

--- a/tests/files/expected/0321_phan_undefined_variable.php.expected
+++ b/tests/files/expected/0321_phan_undefined_variable.php.expected
@@ -1,6 +1,8 @@
 %s:3 PhanUndeclaredVariable Variable $cond is undeclared
+%s:3 PhanUnusedVariable Unused definition of variable $x
 %s:5 PhanUndeclaredVariable Variable $undef is undeclared
 %s:6 PhanUndeclaredVariable Variable $undefB is undeclared
+%s:6 PhanUnusedVariable Unused definition of variable $y
 %s:8 PhanUndeclaredVariable Variable $cond321 is undeclared
 %s:10 PhanUndeclaredVariable Variable $undef321 is undeclared
 %s:11 PhanUndeclaredVariable Variable $undefB321 is undeclared

--- a/tests/files/expected/0326_references_warn.php.expected
+++ b/tests/files/expected/0326_references_warn.php.expected
@@ -1,3 +1,4 @@
 %s:4 PhanTypeNonVarPassByRef Only variables can be passed by reference at argument 1 of \sort()
 %s:6 PhanTypeMismatchArgumentInternal Argument 1 (array_arg) is int but \sort() takes array
 %s:8 PhanTypeMismatchArgumentInternal Argument 1 (stack) is string but \array_shift() takes array
+%s:8 PhanUnusedVariable Unused definition of variable $y

--- a/tests/files/expected/0332_undeclared_variable_nested.php.expected
+++ b/tests/files/expected/0332_undeclared_variable_nested.php.expected
@@ -2,5 +2,6 @@
 %s:5 PhanUndeclaredVariable Variable $undefVar3 is undeclared
 %s:5 PhanUndeclaredVariable Variable $x is undeclared
 %s:6 PhanUndeclaredVariable Variable $undefInt2 is undeclared
+%s:6 PhanUnusedVariable Unused definition of variable $c
 %s:9 PhanUndeclaredVariable Variable $undefInt is undeclared
 %s:10 PhanUndeclaredVariable Variable $undefVar4 is undeclared

--- a/tests/files/expected/0341_negated_condition_visitor.php.expected
+++ b/tests/files/expected/0341_negated_condition_visitor.php.expected
@@ -1,3 +1,4 @@
+%s:11 PhanUnusedVariable Unused definition of variable $z
 %s:15 PhanTypeMismatchArgumentInternal Argument 1 (string) is int but \strlen() takes string
 %s:17 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is string but \intdiv() takes int
 %s:23 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is null but \intdiv() takes int

--- a/tests/files/expected/0351_protected_constructor.php.expected
+++ b/tests/files/expected/0351_protected_constructor.php.expected
@@ -1,3 +1,4 @@
+%s:4 PhanUnusedProtectedMethodParameter Parameter $x is never used
 %s:6 PhanTypeMismatchArgument Argument 1 (x) is string but \Foo351::__construct() takes int defined at %s:4
 %s:10 PhanAccessMethodProtected Cannot access protected method \Foo351::__construct defined at %s:4
 %s:11 PhanAccessMethodProtected Cannot access protected method \Foo351::__construct defined at %s:4

--- a/tests/files/expected/0397_complex_array_prop.php.expected
+++ b/tests/files/expected/0397_complex_array_prop.php.expected
@@ -1,2 +1,3 @@
 %s:15 PhanTypeMismatchArgumentInternal Argument 1 (string) is array<int,\stdClass[][]> but \strlen() takes string
+%s:16 PhanUnusedVariable Unused definition of variable $phoneFlow
 %s:17 PhanTypeMismatchArgumentInternal Argument 1 (string) is \stdClass[][] but \strlen() takes string

--- a/tests/files/expected/0419_email.php.expected
+++ b/tests/files/expected/0419_email.php.expected
@@ -1,2 +1,3 @@
+%s:11 PhanUnusedProtectedMethodParameter Parameter $uid is never used
 %s:29 PhanParamTooMany Call with 2 arg(s) to \VerificationEmail419::__construct() which only takes 1 arg(s) defined at %s:4
 %s:30 PhanTypeMismatchReturn Returning type string but _getMethod() is declared to return int

--- a/tests/files/expected/0420_loop.php.expected
+++ b/tests/files/expected/0420_loop.php.expected
@@ -1,0 +1,2 @@
+%s:7 PhanUnusedVariable Unused definition of variable $reviewItem
+%s:9 PhanUnusedVariable Unused definition of variable $params

--- a/tests/files/expected/0431_use_ref_scope.php.expected
+++ b/tests/files/expected/0431_use_ref_scope.php.expected
@@ -1,0 +1,1 @@
+%s:7 PhanUnusedVariable Unused definition of variable $c

--- a/tests/files/expected/0455_closure_type_cast.php.expected
+++ b/tests/files/expected/0455_closure_type_cast.php.expected
@@ -14,6 +14,7 @@
 %s:48 PhanTypeMismatchArgument Argument 1 (fn) is Closure():array but \expects_int_return() takes Closure():int defined at %s:40
 %s:49 PhanTypeMismatchArgument Argument 1 (fn) is Closure(array):int but \expects_int_return() takes Closure():int defined at %s:40
 %s:57 PhanTypeVoidAssignment Cannot assign void return value
+%s:57 PhanUnusedVariable Unused definition of variable $result
 %s:58 PhanTypeMismatchArgument Argument 1 (fn) is Closure():void but \expects_int_param() takes Closure(int):void defined at %s:6
 %s:59 PhanTypeMismatchArgument Argument 1 (fn) is Closure():void but \expects_int_return() takes Closure():int defined at %s:40
 %s:67 PhanTypeMismatchArgument Argument 1 (fn) is Closure(mixed):void but \expects_void() takes Closure():void defined at %s:56

--- a/tests/files/expected/0457_callable_type_cast.php.expected
+++ b/tests/files/expected/0457_callable_type_cast.php.expected
@@ -14,6 +14,7 @@
 %s:48 PhanTypeMismatchArgument Argument 1 (fn) is Closure():array but \expects_cb_int_return() takes callable():int defined at %s:40
 %s:49 PhanTypeMismatchArgument Argument 1 (fn) is Closure(array):int but \expects_cb_int_return() takes callable():int defined at %s:40
 %s:55 PhanTypeVoidAssignment Cannot assign void return value
+%s:55 PhanUnusedVariable Unused definition of variable $result
 %s:56 PhanTypeMismatchArgument Argument 1 (fn) is callable():void but \expects_cb_int_param() takes callable(int):void defined at %s:6
 %s:57 PhanTypeMismatchArgument Argument 1 (fn) is callable():void but \expects_cb_int_return() takes callable():int defined at %s:40
 %s:65 PhanTypeMismatchArgument Argument 1 (fn) is Closure(mixed):void but \expects_cb_void() takes callable():void defined at %s:54

--- a/tests/files/expected/0461_array_key_exists.php.expected
+++ b/tests/files/expected/0461_array_key_exists.php.expected
@@ -1,0 +1,1 @@
+%s:16 PhanUnusedVariable Unused definition of variable $object

--- a/tests/files/expected/0479_typo_suggest.php.expected
+++ b/tests/files/expected/0479_typo_suggest.php.expected
@@ -1,7 +1,16 @@
+%s:4 PhanUnusedVariable Unused definition of variable $myValue
 %s:5 PhanUndeclaredVariable Variable $Param2 is undeclared (Did you mean $param2)
+%s:5 PhanUnusedVariable Unused definition of variable $x
 %s:7 PhanUndeclaredVariable Variable $my_value is undeclared (Did you mean $myValue)
+%s:7 PhanUnusedVariable Unused definition of variable $y
 %s:9 PhanUndeclaredVariable Variable $notDeclaredAnywhere is undeclared
+%s:9 PhanUnusedVariable Unused definition of variable $z
 %s:11 PhanUndeclaredVariable Variable $PARAM is undeclared (Did you mean $param1 or $param2)
+%s:11 PhanUnusedVariable Unused definition of variable $w
 %s:17 PhanUndeclaredVariable Variable $_prop is undeclared (Did you mean $this->_prop)
+%s:17 PhanUnusedVariable Unused definition of variable $x
+%s:18 PhanUnusedVariable Unused definition of variable $prop
 %s:19 PhanUndeclaredVariable Variable $_prop is undeclared (Did you mean $prop or $this->_prop)
+%s:19 PhanUnusedVariable Unused definition of variable $y
+%s:20 PhanUnusedVariable Unused definition of variable $my_really_longname
 %s:21 PhanUndeclaredVariable Variable $myReallyLongname is undeclared (Did you mean $my_really_longname)

--- a/tests/files/expected/0480_array_access_iteration.php.expected
+++ b/tests/files/expected/0480_array_access_iteration.php.expected
@@ -1,2 +1,3 @@
 %s:12 PhanTypeMismatchArgumentInternal Argument 1 (string) is \ArrayAccess|\Countable|\Iterator|\Serializable|\SplObjectStorage|\Traversable|iterable but \strlen() takes string
 %s:14 PhanTypeMismatchArgumentInternal Argument 1 (string) is \ArrayAccess|\Countable|\Iterator|\Serializable|\SplObjectStorage|\Traversable|iterable but \strlen() takes string
+%s:15 PhanUnusedVariable Unused definition of variable $v

--- a/tests/files/expected/0488_crash.php.expected
+++ b/tests/files/expected/0488_crash.php.expected
@@ -1,0 +1,1 @@
+%s:3 PhanUnusedVariable Unused definition of variable $groupDef

--- a/tests/files/src/0101_one_of_each.php
+++ b/tests/files/src/0101_one_of_each.php
@@ -158,7 +158,7 @@ function f4(Undef $p) {}
 class C11 { /** @var Undef */ public $p; }
 
 // Issue::PhanParentlessClass
-class C12 { function f() { $v = parent::f(); } }
+class C12 { function f() { parent::f(); } }
 
 // Issue::PhanTraitParentReference
 trait T1 { function f() { return parent::f(); } }

--- a/tests/files/src/0129_suppress_stmts.php
+++ b/tests/files/src/0129_suppress_stmts.php
@@ -4,7 +4,7 @@ class C {
 
     /**
      * @suppress PhanCompatiblePHP7
-     * @suppress PhanNonClassMethodCall
+     * @suppress PhanNonClassMethodCall, PhanUnusedVariable testing CSV
      * @suppress PhanNoopArray
      * @suppress PhanNoopVariable
      * @suppress PhanParamTooFew

--- a/tests/files/src/0223_generator_closure_return_type.php
+++ b/tests/files/src/0223_generator_closure_return_type.php
@@ -1,5 +1,5 @@
 <?php
-
+/** @phan-file-suppress PhanUnusedVariable */
 function closure_generator_tests() {
     $bad_generator = function() : Generator {
         return 1;  // Should print an error

--- a/tests/files/src/0275_warn_extra_undef.php
+++ b/tests/files/src/0275_warn_extra_undef.php
@@ -1,5 +1,5 @@
 <?php
-
+// TODO: Should func_get_args affect unused parameter detection?
 class UndefAndUndeclaredParam {
     public static function foo($targetId) {
         return self::_private_method($targetId, $undefVar);

--- a/tests/files/src/0354_string_index.php
+++ b/tests/files/src/0354_string_index.php
@@ -1,5 +1,5 @@
 <?php
-
+/** @phan-file-suppress PhanUnusedVariable common here */
 class A354 {
     /** @var string */
     public $foo = 'aaa';

--- a/tests/files/src/0380_compact.php
+++ b/tests/files/src/0380_compact.php
@@ -1,5 +1,5 @@
 <?php
-
+/** @phan-file-suppress PhanUnusedVariable this does not account for compact */
 class C380 {
     const C = ['varName', 'otherVarName'];
     const V1 = 'v1';

--- a/tests/files/src/0401_varargs.php
+++ b/tests/files/src/0401_varargs.php
@@ -15,4 +15,5 @@ function unpack_varargs401(array $args, iterable $iterable) {
     test_varargs401(...$int);
     test_varargs401(...$stdClass);
     test_varargs401(...$iterable);
+    test_varargs401(...$arrayObject);
 }

--- a/tests/files/src/0426_inline_var_force.php
+++ b/tests/files/src/0426_inline_var_force.php
@@ -1,7 +1,7 @@
 <?php
 
 function example(int ...$values) {
-    $data = ['key' => 'value'];
+
     $first = true;
     $sum = 0;
     '@phan-var int $prev';
@@ -10,14 +10,14 @@ function example(int ...$values) {
             $sum += $prev * $value;
         } else {
             $first = false;
-            $prev = $value;
+            $prev = $value;  // FIXME should not warn about $prev being unused
         }
     }
     return $sum;
 }
 
 function example2(int ...$values) {
-    $data = ['key' => 'value'];
+
     $first = true;
     $sum = 0;
     <<<'PHAN'

--- a/tests/files/src/0426_inline_var_force.php
+++ b/tests/files/src/0426_inline_var_force.php
@@ -1,5 +1,5 @@
 <?php
-
+/** @phan-file-suppress PhanUnusedVariable FIXME improve on this */
 function example(int ...$values) {
 
     $first = true;

--- a/tests/php70_test/expected/003_short_array.php.expected
+++ b/tests/php70_test/expected/003_short_array.php.expected
@@ -4,5 +4,6 @@ src/003_short_array.php:9 PhanTypeMismatchArgumentInternal Argument 1 (string) i
 src/003_short_array.php:13 PhanTypeMismatchArgumentInternal Argument 1 (string) is array{0:int} but \strlen() takes string
 src/003_short_array.php:15 PhanCompatibleShortArrayAssignPHP70 Square bracket syntax for an array destructuring assignment is not compatible with PHP 7.0
 src/003_short_array.php:17 PhanTypeMismatchArgumentInternal Argument 1 (string) is array{0:int} but \strlen() takes string
+src/003_short_array.php:20 PhanUnusedVariable Unused definition of variable $a
 src/003_short_array.php:21 PhanCompatibleKeyedArrayAssignPHP70 Using array keys in an array destructuring assignment is not compatible with PHP 7.0
 src/003_short_array.php:24 PhanTypeMismatchArgumentInternal Argument 1 (string) is array{0:int} but \strlen() takes string

--- a/tests/php70_test/expected/005_nullable.php.expected
+++ b/tests/php70_test/expected/005_nullable.php.expected
@@ -1,4 +1,6 @@
 src/005_nullable.php:3 PhanCompatibleNullableTypePHP70 Nullable type '?int' is not compatible with PHP 7.0
+src/005_nullable.php:3 PhanUnusedGlobalFunctionParameter Parameter $y is never used
 src/005_nullable.php:5 PhanCompatibleNullableTypePHP70 Nullable type '?int' is not compatible with PHP 7.0
 src/005_nullable.php:9 PhanCompatibleNullableTypePHP70 Nullable type '?int' is not compatible with PHP 7.0
+src/005_nullable.php:9 PhanUnusedGlobalFunctionParameter Parameter $x is never used
 src/005_nullable.php:17 PhanCompatibleNullableTypePHP70 Nullable type '?int' is not compatible with PHP 7.0

--- a/tests/plugin_test/.phan/config.php
+++ b/tests/plugin_test/.phan/config.php
@@ -66,6 +66,9 @@ return [
     // Test dead code detection
     'dead_code_detection' => true,
 
+    // TODO: Test unused variable detection
+    'unused_variable_detection' => true,
+
     'globals_type_map' => ['test_global_exception' => 'Exception', 'test_global_error' => '\\Error'],
 
     "quick_mode" => false,

--- a/tests/plugin_test/expected/000_plugins.php.expected
+++ b/tests/plugin_test/expected/000_plugins.php.expected
@@ -1,5 +1,6 @@
 src/000_plugins.php:4 PhanPluginInstanceOfObject Cannot call instanceof against `object`
 src/000_plugins.php:4 PhanUndeclaredClassInstanceof Checking instanceof against undeclared class \object
+src/000_plugins.php:9 PhanUnusedGlobalFunctionParameter Parameter $a is never used
 src/000_plugins.php:10 PhanPluginDollarDollar $$ Variables are not allowed.
 src/000_plugins.php:18 PhanPluginDuplicateArrayKey Duplicate/Equivalent array key value(0) detected in array - the earlier entry will be ignored.
 src/000_plugins.php:21 PhanPluginMixedKeyNoKey Should not mix array entries of the form [key => value,] with entries of the form [value,].
@@ -12,10 +13,12 @@ src/000_plugins.php:47 PhanPluginNumericalComparison non numerical values compar
 src/000_plugins.php:49 PhanPluginNumericalComparison numerical values compared by the operators '===' or '!=='
 src/000_plugins.php:55 UnusedSuppression Element \testUnusedSuppressionPlugin suppresses issue PhanParamTooFew but does not use it
 src/000_plugins.php:61 PhanUnreferencedFunction Possibly zero references to function \testUnreferencedFunction
+src/000_plugins.php:64 PhanUnusedGlobalFunctionParameter Parameter $className is never used
 src/000_plugins.php:66 PhanUnreferencedClass Possibly zero references to class \__autoload
 src/000_plugins.php:67 PhanUnreferencedConstant Possibly zero references to global constant \__autoload
 src/000_plugins.php:69 PhanPluginAlwaysReturnFunction Function \missingReturnType has a return type of int, but may fail to return a value
 src/000_plugins.php:77 PhanPluginAlwaysReturnMethod Method \ReturnChecks::missingReturnTypeSwitch has a return type of int, but may fail to return a value
+src/000_plugins.php:114 PhanUnusedVariable Unused definition of variable $x
 src/000_plugins.php:127 PhanTypeMismatchArgumentInternal Argument 1 (string) is int but \strlen() takes string
 src/000_plugins.php:138 DemoPluginMethodName Method \TestDemoPlugin::function cannot be called `function`
 src/000_plugins.php:139 DemoPluginPropertyName Property \TestDemoPlugin::property should not be called `property`

--- a/tests/plugin_test/expected/004_unused_suppression_plugin.php.expected
+++ b/tests/plugin_test/expected/004_unused_suppression_plugin.php.expected
@@ -1,4 +1,5 @@
 src/004_unused_suppression_plugin.php:6 UnusedSuppression Element \SuppressionTest suppresses issue PhanPluginNotARealIssue but does not use it
 src/004_unused_suppression_plugin.php:11 UnusedSuppression Element \SuppressionTest::foo suppresses issue PhanParamTooMany but does not use it
+src/004_unused_suppression_plugin.php:15 PhanUnusedPublicMethodParameter Parameter $x is never used
 src/004_unused_suppression_plugin.php:23 UnusedSuppression Element \suppression_test_fn suppresses issue PhanParamTooFew but does not use it
 src/004_unused_suppression_plugin.php:27 PhanTypeMismatchArgument Argument 1 (x) is array{} but \SuppressionTest::bar() takes int defined at src/004_unused_suppression_plugin.php:15

--- a/tests/plugin_test/expected/006_preg_regex.php.expected
+++ b/tests/plugin_test/expected/006_preg_regex.php.expected
@@ -1,11 +1,17 @@
 src/006_preg_regex.php:3 PhanPluginInvalidPregRegex Call to \preg_match was passed an invalid regex '@foo': No ending delimiter '@' found
 src/006_preg_regex.php:6 PhanPluginInvalidPregRegex Call to \preg_replace was passed an invalid regex '@foo(@': Compilation failed: missing ) at offset 4
+src/006_preg_regex.php:12 PhanUnusedClosureParameter Parameter $x is never used
 src/006_preg_regex.php:13 PhanPluginInvalidPregRegex Call to \preg_replace_callback_array was passed an invalid regex '@a': No ending delimiter '@' found
+src/006_preg_regex.php:13 PhanUnusedClosureParameter Parameter $x is never used
+src/006_preg_regex.php:14 PhanUnusedClosureParameter Parameter $x is never used
 src/006_preg_regex.php:15 PhanPluginInvalidPregRegex Call to \preg_replace_callback was passed an invalid regex '^a': No ending delimiter '^' found
+src/006_preg_regex.php:15 PhanUnusedClosureParameter Parameter $x is never used
 src/006_preg_regex.php:16 PhanPluginInvalidPregRegex Call to \preg_split was passed an invalid regex '/\\s//': Unknown modifier '/'
 src/006_preg_regex.php:17 PhanPluginInvalidPregRegex Call to \preg_match_all was passed an invalid regex '/\\w/i/': Unknown modifier '/'
 src/006_preg_regex.php:18 PhanPluginInvalidPregRegex Call to \preg_grep was passed an invalid regex '/\\w/i/': Unknown modifier '/'
 src/006_preg_regex.php:21 PhanPluginInvalidPregRegex Call to \preg_replace_callback_array was passed an invalid regex '0': Delimiter must not be alphanumeric or backslash
 src/006_preg_regex.php:21 PhanTypeMismatchArgumentInternal Argument 1 (pattern) is array{0:Closure(mixed):string} but \preg_replace_callback_array() takes array<string,callable(array):string>
+src/006_preg_regex.php:21 PhanUnusedClosureParameter Parameter $x is never used
 src/006_preg_regex.php:22 PhanPluginInvalidPregRegex Call to \preg_replace_callback_array was passed an invalid regex '0': Delimiter must not be alphanumeric or backslash
 src/006_preg_regex.php:22 PhanTypeMismatchArgumentInternal Argument 1 (pattern) is array{0:Closure(mixed):string} but \preg_replace_callback_array() takes array<string,callable(array):string>
+src/006_preg_regex.php:22 PhanUnusedClosureParameter Parameter $x is never used

--- a/tests/plugin_test/expected/023_write_only_property.php.expected
+++ b/tests/plugin_test/expected/023_write_only_property.php.expected
@@ -2,5 +2,7 @@ src/023_write_only_property.php:4 PhanWriteOnlyPublicProperty Possibly zero read
 src/023_write_only_property.php:5 PhanWriteOnlyProtectedProperty Possibly zero read references to protected property \MyClass23::b
 src/023_write_only_property.php:6 PhanWriteOnlyPrivateProperty Possibly zero read references to private property \MyClass23::c
 src/023_write_only_property.php:15 PhanUnreferencedPublicProperty Possibly zero references to public property \MyClass23::g
+src/023_write_only_property.php:28 PhanUnusedVariable Unused definition of variable $m
 src/023_write_only_property.php:34 PhanWriteOnlyPublicProperty Possibly zero read references to public property \OtherClass::subclassProp
 src/023_write_only_property.php:35 PhanUnreferencedPublicProperty Possibly zero references to public property \OtherClass::subclassPropUnused
+src/023_write_only_property.php:39 PhanUnusedVariable Unused definition of variable $m

--- a/tests/plugin_test/expected/023_write_only_property.php.expected
+++ b/tests/plugin_test/expected/023_write_only_property.php.expected
@@ -2,7 +2,5 @@ src/023_write_only_property.php:4 PhanWriteOnlyPublicProperty Possibly zero read
 src/023_write_only_property.php:5 PhanWriteOnlyProtectedProperty Possibly zero read references to protected property \MyClass23::b
 src/023_write_only_property.php:6 PhanWriteOnlyPrivateProperty Possibly zero read references to private property \MyClass23::c
 src/023_write_only_property.php:15 PhanUnreferencedPublicProperty Possibly zero references to public property \MyClass23::g
-src/023_write_only_property.php:28 PhanUnusedVariable Unused definition of variable $m
 src/023_write_only_property.php:34 PhanWriteOnlyPublicProperty Possibly zero read references to public property \OtherClass::subclassProp
 src/023_write_only_property.php:35 PhanUnreferencedPublicProperty Possibly zero references to public property \OtherClass::subclassPropUnused
-src/023_write_only_property.php:39 PhanUnusedVariable Unused definition of variable $m

--- a/tests/plugin_test/expected/031_sleep.php.expected
+++ b/tests/plugin_test/expected/031_sleep.php.expected
@@ -5,6 +5,7 @@ src/031_sleep.php:17 SleepCheckerInvalidPropName __sleep is returning an array t
 src/031_sleep.php:17 SleepCheckerInvalidPropName __sleep is returning an array that includes _x, which cannot be found
 src/031_sleep.php:17 SleepCheckerMagicPropName __sleep is returning an array that includes z, which is a magic property
 src/031_sleep.php:19 SleepCheckerInvalidPropName __sleep is returning an array that includes _Z, which cannot be found
+src/031_sleep.php:22 PhanUnusedPublicMethodParameter Parameter $x is never used
 src/031_sleep.php:35 SleepCheckerInvalidReturnStatement __sleep must return an array of strings. This is definitely not an array.
 src/031_sleep.php:37 SleepCheckerInvalidReturnStatement __sleep must return an array of strings. This is definitely not an array.
 src/031_sleep.php:39 SleepCheckerInvalidPropName __sleep is returning an array that includes _myprop, which cannot be found

--- a/tests/plugin_test/expected/032_line_suppression.php.expected
+++ b/tests/plugin_test/expected/032_line_suppression.php.expected
@@ -7,4 +7,5 @@ src/032_line_suppression.php:11 PhanUnreferencedFunction Possibly zero reference
 src/032_line_suppression.php:13 PhanUndeclaredVariable Variable $x is undeclared
 src/032_line_suppression.php:15 PhanUndeclaredVariable Variable $z is undeclared
 src/032_line_suppression.php:18 PhanUndeclaredFunction Call to undeclared function \call_undeclared_function_not_suppressed()
+src/032_line_suppression.php:18 PhanUnusedVariable Unused definition of variable $result
 src/032_line_suppression.php:20 UnusedPluginSuppression Plugin BuiltinSuppressionPlugin suppresses issue PhanUndeclaredVariable on this line but this suppression is unused or suppressed elsewhere

--- a/tests/plugin_test/expected/033_loop_usage.php.expected
+++ b/tests/plugin_test/expected/033_loop_usage.php.expected
@@ -1,2 +1,3 @@
 src/033_loop_usage.php:4 PhanUnusedVariable Unused definition of variable $b
 src/033_loop_usage.php:10 PhanUnusedVariable Unused definition of variable $b
+src/033_loop_usage.php:15 PhanUnusedVariable Unused definition of variable $a

--- a/tests/plugin_test/expected/033_loop_usage.php.expected
+++ b/tests/plugin_test/expected/033_loop_usage.php.expected
@@ -1,0 +1,2 @@
+src/033_loop_usage.php:4 PhanUnusedVariable Unused definition of variable $b
+src/033_loop_usage.php:10 PhanUnusedVariable Unused definition of variable $b

--- a/tests/plugin_test/src/000_plugins.php
+++ b/tests/plugin_test/src/000_plugins.php
@@ -7,7 +7,7 @@ testInstanceofObject(new stdClass());
 
 
 function testDollarDollarPlugin($a, $b = 'a') {
-    var_dump($$b);
+    var_dump($$b);  // Phan tracks types, not values, so it treats $a as unused
 }
 testDollarDollarPlugin(42);
 

--- a/tests/plugin_test/src/033_loop_usage.php
+++ b/tests/plugin_test/src/033_loop_usage.php
@@ -10,4 +10,12 @@ function example_loop() {
         $b = $a;
     }
 }
+function example_loop2() {
+    foreach ([2,3] as $x) {
+        $a = $x;
+        $a = 2 + $x;
+        echo $a;
+    }
+}
 example_loop();
+example_loop2();

--- a/tests/plugin_test/src/033_loop_usage.php
+++ b/tests/plugin_test/src/033_loop_usage.php
@@ -1,0 +1,13 @@
+<?php
+function example_loop() {
+    $a = 2;
+    $b = 3;
+    foreach ([2,3] as $x) {
+        if ($a % 2 > 0) {
+            echo "odd\n";
+        }
+        $a = $a + $x;
+        $b = $a;
+    }
+}
+example_loop();


### PR DESCRIPTION
Currently, this is limited to analyzing inside of functions, methods, and closures.
This has some minor false positives with loops and conditional branches.

Warnings about unused parameters can be suppressed by adding `@phan-unused-param` on the same line as `@param`,
e.g. `@param MyClass $x @phan-unused-param`.
(as well as via standard issue suppression methods.)

The built in unused variable detection support will currently not warn about any of the following issue types, to reduce false positives.

- Variables beginning with `$unused` or `$raii` (case insensitive)
- `$_` (the exact variable name)
- Superglobals, used globals (`global $myGlobal;`), and static variables within function scopes.
- Any references, globals, or static variables in a function scope.

New Issue types:
- `PhanUnusedVariable`,
- `PhanUnusedPublicMethodParameter`, `PhanUnusedPublicFinalMethodParameter`,
- `PhanUnusedProtectedMethodParameter`, `PhanUnusedProtectedFinalMethodParameter`,
- `PhanUnusedPrivateMethodParameter`, `PhanUnusedProtectedFinalMethodParameter`,
- `PhanUnusedClosureUseVariable`, `PhanUnusedClosureParameter`,
- `PhanUnusedGlobalFunctionParameter`

This is similar to the third party plugin `PhanUnusedVariable`.
The built-in support has the following changes:

- Emits fewer/different false positives (e.g. when analyzing loops), but also detects fewer potential issues.
- Reimplemented using visitors extensively (Similar to the code for `BlockAnalysisVisitor`)
- Uses a different data structure from `PhanUnusedVariable`.
  This represent all definitions of a variable, instead of just the most recent one.
  This approximately tracks the full graph of definitions and uses of variables within a function body.
  (This allows warning about all unused definitions, or about definitions that are hidden by subsequent definitions)
- Integration: This is planned to be integrated with other features of Phan, e.g. "Go to Definition" for variables. (Planned for #1211 and #1705)