### PR TITLE
Fix false positives for unused variable detection

### DIFF
--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -709,7 +709,6 @@ class ParameterTypesAnalyzer
                     ($is_reference ? Issue::ParamSignaturePHPDocMismatchParamIsReference       : Issue::ParamSignaturePHPDocMismatchParamIsNotReference),
                     $offset
                 );
-                $is_possibly_compatible = false;
                 return;
             }
 
@@ -726,7 +725,6 @@ class ParameterTypesAnalyzer
                     ($is_variadic ? Issue::ParamSignaturePHPDocMismatchParamVariadic       : Issue::ParamSignaturePHPDocMismatchParamNotVariadic),
                     $offset
                 );
-                $is_possibly_compatible = false;
                 return;
             }
 

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackingBranchScope.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackingBranchScope.php
@@ -5,7 +5,7 @@ namespace Phan\Plugin\Internal\VariableTracker;
  * This will represent a variable scope, similar to \Phan\Language\Scope.
  * Instead of tracking the union types for variable names, this will instead track definitions of variable names.
  */
-final class VariableTrackingBranchScope extends VariableTrackingScope
+class VariableTrackingBranchScope extends VariableTrackingScope
 {
     /**
      * @var VariableTrackingScope the parent of this branch scope.
@@ -22,6 +22,7 @@ final class VariableTrackingBranchScope extends VariableTrackingScope
 
     /**
      * @return ?array<int,true>
+     * @override
      */
     public function getDefinition(string $variable_name)
     {
@@ -35,5 +36,20 @@ final class VariableTrackingBranchScope extends VariableTrackingScope
         }
         $definitions += $parent_definitions;
         return $definitions;
+    }
+
+    /**
+     * Record a statement that was unreachable due to break/continue statements.
+     *
+     * @param VariableTrackingBranchScope $inner_scope @phan-unused-param
+     * @param bool $exits true if this branch will exit.
+     *             This would mean that the branch uses variables, but does not define them outside of that scope.
+     *
+     * @return void
+     * @override
+     */
+    public function recordSkippedScope(VariableTrackingBranchScope $inner_scope, bool $exits)
+    {
+        $this->parent_scope->recordSkippedScope($inner_scope, $exits);
     }
 }

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackingLoopScope.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackingLoopScope.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+namespace Phan\Plugin\Internal\VariableTracker;
+
+/**
+ * This is the same as VariableTrackingBranchScope, but records a level for break/continue.
+ */
+final class VariableTrackingLoopScope extends VariableTrackingBranchScope
+{
+    /**
+     * @var array<int,VariableTrackingBranchScope>
+     * The scopes that broke out early within the inner body of this loop
+     */
+    public $skipped_loop_scopes = [];
+
+    /**
+     * @var array<int,VariableTrackingBranchScope>
+     * The scopes that broke out early within the inner body of this loop
+     */
+    public $skipped_exiting_loop_scopes = [];
+
+    // inherits defs, uses
+
+    // inherit VariableTrackingBranchScope::__construct()
+
+    /**
+     * Record a statement that was unreachable due to break/continue statements.
+     *
+     * @param VariableTrackingBranchScope $skipped_loop_scope
+     * @param bool $exits
+     * @return void
+     */
+    public function recordSkippedScope(VariableTrackingBranchScope $skipped_loop_scope, bool $exits)
+    {
+        if ($exits) {
+            $this->skipped_exiting_loop_scopes[] = $skipped_loop_scope;
+        } else {
+            $this->skipped_loop_scopes[] = $skipped_loop_scope;
+        }
+        // Subclasses will implement this
+    }
+}

--- a/tests/Phan/Analysis/ParameterTypesAnalyzerTest.php
+++ b/tests/Phan/Analysis/ParameterTypesAnalyzerTest.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types = 1);
+namespace Phan\Tests\Analysis;
+
+use Phan\Analysis\ParameterTypesAnalyzer;
+use Phan\Config;
+use Phan\Tests\BaseTest;
+use Phan\Language\UnionType;
+
+class ParameterTypesAnalyzerTest extends BaseTest
+{
+    public function setUp() {
+        parent::setUp();
+        Config::setValue('prefer_narrowed_phpdoc_return_type', true);
+        Config::setValue('check_docblock_signature_return_type_match', true);
+    }
+
+    private function assertSameNarrowedType(
+        string $expected_type_string,
+        string $phpdoc_return_type_string,
+        string $real_return_type_string
+    ) {
+        $expected_type = UnionType::fromFullyQualifiedString($expected_type_string);
+        $phpdoc_return_type = UnionType::fromFullyQualifiedString($phpdoc_return_type_string);
+        $real_return_type = UnionType::fromFullyQualifiedString($real_return_type_string);
+
+        $actual_normalized_type = ParameterTypesAnalyzer::normalizeNarrowedParamType($phpdoc_return_type, $real_return_type);
+
+
+        $msg = "Expected normalizeNarrowedParamType($phpdoc_return_type, $real_return_type) to be $expected_type_string";
+        $this->assertSame($expected_type_string, (string)$actual_normalized_type, $msg);
+        $this->assertTrue($actual_normalized_type->isEqualTo($expected_type), $msg);
+    }
+
+    private function assertNullNarrowedType(
+        string $phpdoc_return_type_string,
+        string $real_return_type_string
+    ) {
+        $phpdoc_return_type = UnionType::fromFullyQualifiedString($phpdoc_return_type_string);
+        $real_return_type = UnionType::fromFullyQualifiedString($real_return_type_string);
+
+        $actual_normalized_type = ParameterTypesAnalyzer::normalizeNarrowedParamType($phpdoc_return_type, $real_return_type);
+
+
+        $msg = "Expected normalizeNarrowedParamType($phpdoc_return_type, $real_return_type) to be null";
+        $this->assertNull($actual_normalized_type, $msg);
+    }
+
+    public function testNormalizeNarrowedParamType() {
+        $this->assertSameNarrowedType('int', 'int', 'int');
+        $this->assertSameNarrowedType('array<int,string>', 'array<int,string>', 'array');
+        $this->assertSameNarrowedType('array<int,string>', 'array<int,string>', 'iterable');
+        $this->assertSameNarrowedType('array{0:\stdClass}', 'array{0:\stdClass}', 'array');
+        $this->assertSameNarrowedType('array{0:\stdClass}', 'array{0:\stdClass}', 'iterable');
+        $this->assertNullNarrowedType('null', '');
+    }
+}

--- a/tests/files/expected/0344_negate_unconditional_return.php.expected
+++ b/tests/files/expected/0344_negate_unconditional_return.php.expected
@@ -1,3 +1,4 @@
+%s:5 PhanUnusedVariable Unused definition of variable $b
 %s:6 PhanTypeMismatchReturn Returning type null but f344() is declared to return int
 %s:10 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is string but \intdiv() takes int
 %s:11 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is string but \intdiv() takes int

--- a/tests/plugin_test/expected/034_loop_checks.php.expected
+++ b/tests/plugin_test/expected/034_loop_checks.php.expected
@@ -1,0 +1,1 @@
+src/034_loop_checks.php:5 PhanReadOnlyPublicProperty Possibly zero write references to public property \Example34::array

--- a/tests/plugin_test/expected/035_break_unused.php.expected
+++ b/tests/plugin_test/expected/035_break_unused.php.expected
@@ -1,0 +1,3 @@
+src/035_break_unused.php:7 PhanUnusedVariable Unused definition of variable $myUnusedVar
+src/035_break_unused.php:8 PhanUnusedVariable Unused definition of variable $myUnusedVar3
+src/035_break_unused.php:12 PhanUnusedVariable Unused definition of variable $myUnusedVar3

--- a/tests/plugin_test/expected/036_switch.php.expected
+++ b/tests/plugin_test/expected/036_switch.php.expected
@@ -1,0 +1,1 @@
+src/036_switch.php:4 PhanUnusedVariable Unused definition of variable $x

--- a/tests/plugin_test/expected/037_unused_return.php.expected
+++ b/tests/plugin_test/expected/037_unused_return.php.expected
@@ -1,0 +1,8 @@
+src/037_unused_return.php:8 PhanUnusedVariable Unused definition of variable $myVar
+src/037_unused_return.php:9 PhanUnusedVariable Unused definition of variable $myUnusedVar
+src/037_unused_return.php:13 PhanUnusedVariable Unused definition of variable $myUnusedVar
+src/037_unused_return.php:17 PhanUnusedVariable Unused definition of variable $myVar
+src/037_unused_return.php:20 PhanUnusedVariable Unused definition of variable $myVar
+src/037_unused_return.php:21 PhanUnusedVariable Unused definition of variable $myUnusedVar
+src/037_unused_return.php:23 PhanUnusedVariable Unused definition of variable $myVar
+src/037_unused_return.php:24 PhanUnusedVariable Unused definition of variable $myUnusedVar

--- a/tests/plugin_test/expected/038_unused_loop_var.php.expected
+++ b/tests/plugin_test/expected/038_unused_loop_var.php.expected
@@ -1,0 +1,1 @@
+src/038_unused_loop_var.php:16 PhanUnusedVariable Unused definition of variable $myUnusedVariable

--- a/tests/plugin_test/expected/039_loop_return.php.expected
+++ b/tests/plugin_test/expected/039_loop_return.php.expected
@@ -1,0 +1,1 @@
+src/039_loop_return.php:11 PhanUnusedVariable Unused definition of variable $myUnusedVariable

--- a/tests/plugin_test/src/034_loop_checks.php
+++ b/tests/plugin_test/src/034_loop_checks.php
@@ -1,0 +1,16 @@
+<?php
+
+class Example34 {
+	const MAX = 3;
+	public $array = [3,4,5,6];
+
+    // TODO: Fix https://github.com/phan/phan/issues/1729
+	function processArray() {
+		// Ensure that array isn't larger than the limit.
+		$count = count($this->array);  // False positive unused variable
+		while ($count-- > static::MAX) {
+			array_pop($this->array);
+		}
+	}
+}
+(new Example34())->processArray();

--- a/tests/plugin_test/src/035_break_unused.php
+++ b/tests/plugin_test/src/035_break_unused.php
@@ -1,0 +1,16 @@
+<?php
+
+$x = function() {
+    for ($i = 0; $i < 10; $i++) {
+        if (rand() % 10 > 8) {
+            $myVar = 2;
+            $myUnusedVar = 3;
+            $myUnusedVar3 = 3;
+            break;
+        }
+        $myVar = $i;
+        $myUnusedVar3 = $i;
+    }
+    echo $myVar;
+};
+call_user_func($x);

--- a/tests/plugin_test/src/036_switch.php
+++ b/tests/plugin_test/src/036_switch.php
@@ -1,0 +1,13 @@
+<?php
+
+function example_switch() {
+    $x = 0;
+    $y = "hello";
+    switch(rand() % 10) {
+        case $x = 2:
+        case 3:
+            echo $x;
+            echo $y;
+    }
+}
+example_switch();

--- a/tests/plugin_test/src/037_unused_return.php
+++ b/tests/plugin_test/src/037_unused_return.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @suppress PhanPluginNumericalComparison
+ */
+function unused_return(int $v) {
+    for ($i = 0; $i < 2; $i++) {
+        if ($v === 3) {
+            $myVar = 3;  // should warn
+            $myUnusedVar = 4;
+            return;
+        } elseif ($v === -3) {
+            $myVar = 3;  // should not warn
+            $myUnusedVar = 4;
+            continue;
+        } elseif ($v === 4) {
+            if (rand() % 2 > 0) {
+                $myVar = 3;  // should warn
+                return;
+            }
+            $myVar = 4;  // *should warn*, this is overwritten below
+            $myUnusedVar = 4;
+        } elseif ($v % 2 > 0) {
+            $myVar = 2;  // should warn, this throws immediately
+            $myUnusedVar = 5;
+            throw new RuntimeException("end");
+        }
+        $myVar = 22;
+    }
+    echo $myVar;
+}
+unused_return(rand() % 20 - 10);

--- a/tests/plugin_test/src/038_unused_loop_var.php
+++ b/tests/plugin_test/src/038_unused_loop_var.php
@@ -1,0 +1,24 @@
+<?php
+
+class ExampleLoopUnused {
+    public static function main()
+    {
+        $ast_items = [];
+        $prev_was_element = false;
+        foreach ([2,3] as $item) {
+            if ($item > 2) {
+                // @phan-suppress-next-line PhanPluginNonBoolBranch TODO: Investigate why
+                if (!$prev_was_element) {
+                    $ast_items[] = null;
+                    continue;
+                }
+                $prev_was_element = false;
+                $myUnusedVariable = new stdClass();
+                continue;
+            } else {
+                $prev_was_element = true;
+            }
+        }
+    }
+}
+ExampleLoopUnused::main();

--- a/tests/plugin_test/src/039_loop_return.php
+++ b/tests/plugin_test/src/039_loop_return.php
@@ -1,0 +1,15 @@
+<?php
+
+function test_loop_var_return() {
+    $index = 3;
+    foreach ([2,3] as $i => $x) {
+        if ($x % 2 > 0) {
+            if (rand() % 2 > 0) {
+                return $index;
+            }
+        }
+        $myUnusedVariable = 2;
+        $index = $i;  // should not warn, it's used in `return $index`
+    }
+}
+test_loop_var_return();


### PR DESCRIPTION
For #1728

And detect unused variables such as
`if (cond()) { $x = 'value'; return; } echo $x;`

- Improve unused variable checks of variable declarations in switch statements
  (e.g. uncommon `case $x = fn()`)
- Improve unused variable checks of variables declared
  within early exits of loop statements.
  e.g. `for(;cond();) { if (cond2()) { $x = 3; break; } $x = 2; } echo $x;`
- Add integration tests of changes to unused variable detection