### PR TITLE
Make the language server work more reliably when PCNTL is unavailable

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 Phan NEWS
 
+?? ??? 2018, Phan 0.12.11 (dev)
+-------------------------
+
+Language Server/Daemon mode:
++ Make the language server work more reliably when `pcntl` is unavailable. (E.g. on Windows) (#1739)
++ By default, allow the language server and daemon mode to start with the fallback even if `pcntl` is unavailable.
+  (`--language-server-require-pcntl` can be used to make the language server refuse to start without `pcntl`)
+
 27 May 2018, Phan 0.12.10
 -------------------------
 

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -24,7 +24,7 @@ class CLI
     /**
      * This should be updated to x.y.z-dev after every release, and x.y.z before a release.
      */
-    const PHAN_VERSION = '0.12.10';
+    const PHAN_VERSION = '0.12.11-dev';
 
     /**
      * @var OutputInterface
@@ -112,6 +112,7 @@ class CLI
                 'language-server-verbose',
                 'language-server-allow-missing-pcntl',
                 'language-server-force-missing-pcntl',
+                'language-server-require-pcntl',
                 'language-server-enable',
                 'language-server-enable-go-to-definition',
                 'markdown-issue-messages',
@@ -190,7 +191,8 @@ class CLI
 
         if (isset($opts['language-server-force-missing-pcntl'])) {
             Config::setValue('language_server_use_pcntl_fallback', true);
-        } elseif (isset($opts['language-server-allow-missing-pcntl'])) {
+        } elseif (!isset($opts['language-server-require-pcntl'])) {
+            // --language-server-allow-missing-pcntl is now the default
             if (!extension_loaded('pcntl')) {
                 Config::setValue('language_server_use_pcntl_fallback', true);
             }
@@ -350,6 +352,7 @@ class CLI
                     break;  // handled earlier.
                 case 'language-server-allow-missing-pcntl':
                 case 'language-server-force-missing-pcntl':
+                case 'language-server-require-pcntl':
                     break;  // handled earlier
                 case 'disable-plugins':
                     // Slightly faster, e.g. for daemon mode with lowest latency (along with --quick).
@@ -851,11 +854,15 @@ Extended help:
   This is useful when developing or debugging language server clients.
 
  --language-server-allow-missing-pcntl
+  Noop (This is the default behavior).
   Allow the fallback that doesn't use pcntl (New and experimental) to be used if the pcntl extension is not installed.
   This is useful for running the language server on Windows.
 
  --language-server-force-missing-pcntl
   Force Phan to use the fallback for when pcntl is absent (New and experimental). Useful for debugging that fallback.
+
+ --language-server-require-pcntl
+  Don't start the language server if PCNTL isn't installed (don't use the fallback). Useful for debugging.
 
  --require-config-exists
   Exit immediately with an error code if .phan/config.php does not exist.

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -492,25 +492,14 @@ class CodeBase
     public function restoreFromRestorePoint(array $restore_point)
     {
         $clone = $restore_point['clone'];
-        $this->undo_tracker             = $clone->undo_tracker;
-        $this->has_enabled_undo_tracker = $clone->has_enabled_undo_tracker;
 
         // TODO: Restore the inner state of Clazz objects as well
         // (e.g. memoizations, types added in method/analysis phases, plugin changes, etc.
         // NOTE: Type::clearAllMemoizations is called elsewhere already.
-        $this->fqsen_class_map              = $clone->fqsen_class_map;
-        $this->fqsen_class_map_user_defined = $clone->fqsen_class_map_user_defined;
-        $this->fqsen_class_map_internal     = $clone->fqsen_class_map_internal;
-        $this->fqsen_class_map_reflection   = $clone->fqsen_class_map_reflection;
-        $this->fqsen_alias_map              = $clone->fqsen_alias_map;
-        $this->fqsen_global_constant_map    = $clone->fqsen_global_constant_map;
-        $this->fqsen_func_map               = $clone->fqsen_func_map;
-        $this->internal_function_fqsen_set  = $clone->internal_function_fqsen_set;
-        $this->method_set                   = $clone->method_set;
-        $this->class_fqsen_class_map_map    = $clone->class_fqsen_class_map_map;
-        $this->name_method_map              = $clone->name_method_map;
+        foreach ($clone as $key => $value) {
+            $this->{$key} = $value;
+        }
 
-        $this->parsed_namespace_maps        = $clone->parsed_namespace_maps;
         foreach ($restore_point['callbacks'] as $callback) {
             if ($callback) {
                 $callback();

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -721,7 +721,7 @@ class Config
         'language_server_debug_level' => null,
 
         // Use the command line option instead
-        'language_server_use_pcntl_fallback' => false,
+        'language_server_use_pcntl_fallback' => true,
 
         // This should only be set via CLI (--language-server-enable-go-to-definition)
         // Affects "go to definition" and "go to type definition"

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -2683,17 +2683,15 @@ class Clazz extends AddressableElement
     public function createRestoreCallback()
     {
         // NOTE: Properties, Methods, and closures are restored separately.
-        $are_constants_hydrated = $this->are_constants_hydrated;
-        $is_hydrated = $this->is_hydrated;
+        $original_this = clone($this);
         $original_union_type = $this->getUnionType();
-        $additional_union_types = $this->additional_union_types;
 
-        return function () use ($original_union_type, $is_hydrated, $are_constants_hydrated, $additional_union_types) {
-            $this->memoizeFlushAll();
-            $this->are_constants_hydrated = $are_constants_hydrated;
-            $this->is_hydrated = $is_hydrated;
+        return function () use ($original_union_type, $original_this) {
+            foreach ($original_this as $key => $value) {
+                $this->{$key} = $value;
+            }
             $this->setUnionType($original_union_type);
-            $this->additional_union_types = $additional_union_types;
+            $this->memoizeFlushAll();
         };
     }
 

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -1016,24 +1016,21 @@ trait FunctionTrait
      */
     public function createRestoreCallback()
     {
-        // NOTE: Properties, Methods, and closures are restored separately.
-        $parameter_list_hash = $this->parameter_list_hash;
-        $parameter_list = [];
-        foreach ($this->parameter_list as $parameter) {
-            $parameter_list[] = clone($parameter);
+        $clone_this = clone($this);
+        foreach ($clone_this->parameter_list as $i => $parameter) {
+            $clone_this->parameter_list[$i] = clone($parameter);
+        }
+        foreach ($clone_this->real_parameter_list as $i => $parameter) {
+            $clone_this->real_parameter_list[$i] = clone($parameter);
         }
         $union_type = $this->getUnionType();
-        $return_type_callback = $this->return_type_callback;
-        $function_call_analyzer_callback = $this->function_call_analyzer_callback;
 
-        return function () use ($parameter_list, $parameter_list_hash, $union_type, $return_type_callback, $function_call_analyzer_callback) {
+        return function () use ($clone_this, $union_type) {
             $this->memoizeFlushAll();
-            $this->parameter_list_hash = $parameter_list_hash;
-            $this->parameter_list = $parameter_list;
+            foreach ($clone_this as $key => $value) {
+                $this->{$key} = $value;
+            }
             $this->setUnionType($union_type);
-            $this->checked_parameter_list_hashes = [];
-            $this->return_type_callback = $return_type_callback;
-            $this->function_call_analyzer_callback = $function_call_analyzer_callback;
         };
     }
 


### PR DESCRIPTION
e.g. on windows, Unix systems where `pcntl` isn't installed, etc.

This works more reliably than before when tested with the VS code plugin (using `--language-server-force-missing-pcntl` for debugging)

For #1738