### PR TITLE
Avoid a crash when ext-tokenizer isn't installed. Fix a bug.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,10 @@ Language Server/Daemon mode:
 + By default, allow the language server and daemon mode to start with the fallback even if `pcntl` is unavailable.
   (`--language-server-require-pcntl` can be used to make the language server refuse to start without `pcntl`)
 
+Bug fixes:
++ Don't crash if `ext-tokenizer` isn't installed (#1747)
++ Fix invalid output of `tool/make_stubs` for apcu (#1745)
+
 27 May 2018, Phan 0.12.10
 -------------------------
 

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,9 @@
         "sabre/event": "^5.0",
         "symfony/console": "^2.3|^3.0|~4.0"
     },
+    "suggest": {
+        "ext-tokenizer": "Needed for non-AST support and file/line-based suppressions"
+    },
     "require-dev": {
         "phpunit/phpunit": "^6.3.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -1330,16 +1330,16 @@
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "5.0.6",
+            "version": "5.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "33fd41a76e746b8fa96d00b49a23dadfa8334cdf"
+                "reference": "3eaf040f20154d27d6da59ca2c6e28ac8fd56dce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/33fd41a76e746b8fa96d00b49a23dadfa8334cdf",
-                "reference": "33fd41a76e746b8fa96d00b49a23dadfa8334cdf",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/3eaf040f20154d27d6da59ca2c6e28ac8fd56dce",
+                "reference": "3eaf040f20154d27d6da59ca2c6e28ac8fd56dce",
                 "shasum": ""
             },
             "require": {
@@ -1385,7 +1385,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2018-01-06T05:45:45+00:00"
+            "time": "2018-05-29T13:50:43+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -671,6 +671,9 @@ class Config
         // (e.g. PHP is compiled with --enable-debug or when using XDebug)
         'skip_slow_php_options_warning' => false,
 
+        // By default, Phan will warn if 'tokenizer' isn't installed.
+        'skip_missing_tokenizer_warning' => false,
+
         // You can put paths to stubs of internal extensions in this config option.
         // If the corresponding extension is **not** loaded, then phan will use the stubs instead.
         // Phan will continue using its detailed type annotations,

--- a/src/Phan/Language/Element/GlobalConstant.php
+++ b/src/Phan/Language/Element/GlobalConstant.php
@@ -97,7 +97,7 @@ class GlobalConstant extends AddressableElement implements ConstantInterface
             $comment = '  // could not find';
         }
         $namespace = \ltrim($this->getFQSEN()->getNamespace(), '\\');
-        if (\preg_match('@[a-zA-Z_\x7f-\xff\\\][a-zA-Z0-9_\x7f-\xff\\\]*@', $name)) {
+        if (\preg_match('@^[a-zA-Z_\x7f-\xff\\\][a-zA-Z0-9_\x7f-\xff\\\]*$@', $name)) {
             $string = "const $name = $repr;$comment\n";
         } else {
             // Internal extension defined a constant with an invalid identifier.

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -640,7 +640,12 @@ final class ConfigPluginSet extends PluginV2 implements
             $plugin_set[] = new VariableTrackerPlugin();
         }
         if (self::requiresPluginBasedBuiltinSuppressions()) {
-            $plugin_set[] = new BuiltinSuppressionPlugin();
+            if (function_exists('token_get_all')) {
+                $plugin_set[] = new BuiltinSuppressionPlugin();
+            } else {
+                fwrite(STDERR, "ext-tokenizer is required for file-based and line-based suppressions to work, as well as the error-tolerant parser fallback." . PHP_EOL);
+                fwrite(STDERR, "(This warning can be disabled by setting skip_missing_tokenizer_warning in the project's config)" . PHP_EOL);
+            }
         }
 
         // Register the entire set.


### PR DESCRIPTION
Fixes #1747 (skip token_get_all if tokenizer isn't installed)
Fixes #1745 (Don't emit invalid constant names)