### PR TITLE
Warn about use void/iterable/object.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,8 +3,13 @@ Phan NEWS
 ?? ??? 2018, Phan 0.12.13 (dev)
 -------------------------
 
+New features(Analysis)
++ Warn about using `void`/`iterable`/`object` in use statements based on `target_php_version`. (#449)
+  New issue types: `PhanCompatibleUseVoidPHP70`, `PhanCompatibleUseObjectPHP71`, `PhanCompatibleUseObjectPHP71`
+
 Bug fixes:
 + Fix uncaught `AssertionError` when `parent` is used in PHPDoc (#1758)
++ Fix an uncaught error in the polyfill parser.
 
 08 Jun 2018, Phan 0.12.12
 -------------------------

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -958,6 +958,12 @@ class TolerantASTConverter
              * int|string for no-op scalar statements like `;2;`
              */
             'Microsoft\PhpParser\Node\Statement\ExpressionStatement' => function (PhpParser\Node\Statement\ExpressionStatement $n, int $_) {
+                $expression = $n->expression;
+                // tolerant-php-parser uses parseExpression(..., $force=true), which can return an array.
+                // It is the only thing that uses $force=true at the time of writing.
+                if (!\is_object($expression)) {
+                    return null;
+                }
                 return static::phpParserNodeToAstNode($n->expression);
             },
             'Microsoft\PhpParser\Node\Statement\BreakOrContinueStatement' => function (PhpParser\Node\Statement\BreakOrContinueStatement $n, int $start_line) : ast\Node {

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -298,6 +298,9 @@ class Issue
     const CompatibleVoidTypePHP70           = 'PhanCompatibleVoidTypePHP70';
     const CompatibleIterableTypePHP70       = 'PhanCompatibleIterableTypePHP70';
     const CompatibleObjectTypePHP71         = 'PhanCompatibleNullableTypePHP71';
+    const CompatibleUseVoidPHP70            = 'PhanCompatibleUseVoidPHP70';
+    const CompatibleUseIterablePHP71        = 'PhanCompatibleUseIterablePHP71';
+    const CompatibleUseObjectPHP71          = 'PhanCompatibleUseObjectPHP71';
 
     // Issue::CATEGORY_GENERIC
     const TemplateTypeConstant       = 'PhanTemplateTypeConstant';
@@ -2496,6 +2499,30 @@ class Issue
                 "Type '{TYPE}' refers to any object starting in PHP 7.2. In PHP 7.1 and earlier, it refers to a class/interface with the name 'object'",
                 self::REMEDIATION_B,
                 3007
+            ),
+            new Issue(
+                self::CompatibleUseVoidPHP70,
+                self::CATEGORY_COMPATIBLE,
+                self::SEVERITY_CRITICAL,
+                "Using '{TYPE}' as void will be a syntax error in PHP 7.1 (void becomes the absense of a return type).",
+                self::REMEDIATION_B,
+                3008
+            ),
+            new Issue(
+                self::CompatibleUseIterablePHP71,
+                self::CATEGORY_COMPATIBLE,
+                self::SEVERITY_CRITICAL,
+                "Using '{TYPE}' as iterable will be a syntax error in PHP 7.2 (iterable becomes a native type with subtypes Array and Iterator).",
+                self::REMEDIATION_B,
+                3009
+            ),
+            new Issue(
+                self::CompatibleUseObjectPHP71,
+                self::CATEGORY_COMPATIBLE,
+                self::SEVERITY_CRITICAL,
+                "Using '{TYPE}' as object will be a syntax error in PHP 7.2 (object becomes a native type that accepts any class instance).",
+                self::REMEDIATION_B,
+                3010
             ),
 
             // Issue::CATEGORY_GENERIC

--- a/tests/misc/fallback_test/expected/006_crash.php.expected
+++ b/tests/misc/fallback_test/expected/006_crash.php.expected
@@ -1,0 +1,2 @@
+src/006_crash.php:6 PhanNoopVariable Unused variable
+src/006_crash.php:6 PhanSyntaxError syntax error, unexpected ','

--- a/tests/misc/fallback_test/src/006_crash.php
+++ b/tests/misc/fallback_test/src/006_crash.php
@@ -1,0 +1,8 @@
+<?php
+
+$x = rand(0,10);
+$b = 4;
+
+if (true && $x < 2, $b) {
+    print("test");
+}

--- a/tests/php70_test/expected/007_use.php.expected
+++ b/tests/php70_test/expected/007_use.php.expected
@@ -1,0 +1,11 @@
+src/007_use.php:3 PhanCompatibleUseVoidPHP70 Using '\A\void' as void will be a syntax error in PHP 7.1 (void becomes the absense of a return type).
+src/007_use.php:3 PhanUnreferencedUseNormal Possibly zero references to use statement for classlike/namespace void (\A\void)
+src/007_use.php:4 PhanCompatibleUseIterablePHP71 Using '\NS\iterable' as iterable will be a syntax error in PHP 7.2 (iterable becomes a native type with subtypes Array and Iterator).
+src/007_use.php:4 PhanUnreferencedUseNormal Possibly zero references to use statement for classlike/namespace iterable (\NS\iterable)
+src/007_use.php:5 PhanCompatibleUseObjectPHP71 Using '\My\Framework\object' as object will be a syntax error in PHP 7.2 (object becomes a native type that accepts any class instance).
+src/007_use.php:5 PhanUnreferencedUseNormal Possibly zero references to use statement for classlike/namespace object (\My\Framework\object)
+src/007_use.php:7 PhanCompatibleIterableTypePHP70 Return type 'iterable' means a Traversable/array value starting in PHP 7.1. In PHP 7.0, iterable refers to a class/interface with the name 'iterable'
+src/007_use.php:7 PhanCompatibleNullableTypePHP71 Type 'object' refers to any object starting in PHP 7.2. In PHP 7.1 and earlier, it refers to a class/interface with the name 'object'
+src/007_use.php:7 PhanCompatibleVoidTypePHP70 Return type 'void' means the absense of a return value starting in PHP 7.1. In PHP 7.0, void refers to a class/interface with the name 'void'
+src/007_use.php:11 PhanTypeMismatchArgument Argument 1 (o) is null but \example() takes object defined at src/007_use.php:7
+src/007_use.php:11 PhanTypeMismatchArgument Argument 2 (i) is null but \example() takes iterable defined at src/007_use.php:7

--- a/tests/php70_test/src/007_use.php
+++ b/tests/php70_test/src/007_use.php
@@ -1,0 +1,11 @@
+<?php
+
+use A\void;
+use NS\iterable;
+use My\Framework\object;
+
+function example(object $o, iterable $i) : void {
+    var_export($o);
+    var_export($i);
+}
+example(null, null);


### PR DESCRIPTION
Fixes #449

Also, fix a crash in the fallback parser when parsing invalid code.
(ExpressionStatement->expression can be an array)