### PR TITLE
Improve inheritance checks of constants and properties

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,11 @@ Phan NEWS
 New features(Analysis)
 + Warn about using `void`/`iterable`/`object` in use statements based on `target_php_version`. (#449)
   New issue types: `PhanCompatibleUseVoidPHP70`, `PhanCompatibleUseObjectPHP71`, `PhanCompatibleUseObjectPHP71`
++ Warn about making overrides of inherited property and constants less visible (#788)
+  New issue types: `PhanPropertyAccessSignatureMismatch`, `PhanPropertyAccessSignatureMismatchInternal`,
+  `PhanConstantAccessSignatureMismatch`, `PhanConstantAccessSignatureMismatchInternal`.
++ Warn about making static properties into non-static properties (and vice-versa) (#615)
+  New issue types: `PhanAccessNonStaticToStaticProperty`, `PhanAccessStaticToNonStaticProperty`
 
 Bug fixes:
 + Fix uncaught `AssertionError` when `parent` is used in PHPDoc (#1758)

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -103,6 +103,12 @@ This issue is emitted when a class redeclares an inherited instance method as a 
 Cannot make non static method {METHOD}() static
 ```
 
+## PhanAccessNonStaticToStaticProperty
+
+```
+Cannot make non static property {PROPERTY} into the static property {PROPERTY}
+```
+
 ## PhanAccessOverridesFinalMethod
 
 This issue is emitted when a class attempts to override an inherited final method.
@@ -214,6 +220,12 @@ This issue is emitted when a class redeclares an inherited static method as an i
 Cannot make static method {METHOD}() non static
 ```
 
+## PhanAccessStaticToNonStaticProperty
+
+```
+Cannot make static property {PROPERTY} into the non static property {PROPERTY}
+```
+
 ## PhanAccessWrongInheritanceCategory
 
 ```
@@ -224,6 +236,30 @@ Attempting to inherit {CLASSLIKE} defined at {FILE}:{LINE} as if it were a {CLAS
 
 ```
 Attempting to inherit internal {CLASSLIKE} as if it were a {CLASSLIKE}
+```
+
+## PhanConstantAccessSignatureMismatch
+
+```
+Access level to {CONST} must be compatible with {CONST} defined in {FILE}:{LINE}
+```
+
+## PhanConstantAccessSignatureMismatchInternal
+
+```
+Access level to {CONST} must be compatible with internal {CONST}
+```
+
+## PhanPropertyAccessSignatureMismatch
+
+```
+Access level to {PROPERTY} must be compatible with {PROPERTY} defined in {FILE}:{LINE}
+```
+
+## PhanPropertyAccessSignatureMismatchInternal
+
+```
+Access level to {PROPERTY} must be compatible with internal {PROPERTY}
 ```
 
 # Analysis
@@ -306,6 +342,24 @@ $c->$m[0]();
 
 ```
 Square bracket syntax for an array destructuring assignment is not compatible with PHP 7.0
+```
+
+## PhanCompatibleUseIterablePHP71
+
+```
+Using '{TYPE}' as iterable will be a syntax error in PHP 7.2 (iterable becomes a native type with subtypes Array and Iterator).
+```
+
+## PhanCompatibleUseObjectPHP71
+
+```
+Using '{TYPE}' as object will be a syntax error in PHP 7.2 (object becomes a native type that accepts any class instance).
+```
+
+## PhanCompatibleUseVoidPHP70
+
+```
+Using '{TYPE}' as void will be a syntax error in PHP 7.1 (void becomes the absense of a return type).
 ```
 
 ## PhanCompatibleVoidTypePHP70

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -591,9 +591,7 @@ class ParameterTypesAnalyzer
         }
 
         // Access must be compatible
-        if ($o_method->isProtected() && $method->isPrivate()
-            || $o_method->isPublic() && !$method->isPublic()
-        ) {
+        if ($o_method->isStrictlyMoreVisibileThan($method)) {
             if ($o_method->isPHPInternal()) {
                 if (!$method->checkHasSuppressIssueAndIncrementCount(Issue::AccessSignatureMismatchInternal)) {
                     Issue::maybeEmit(

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -266,15 +266,21 @@ class Issue
     const AccessMethodPrivateWithCallMagicMethod = 'PhanAccessMethodPrivateWithCallMagicMethod';
     const AccessMethodProtected     = 'PhanAccessMethodProtected';
     const AccessMethodProtectedWithCallMagicMethod = 'PhanAccessMethodProtectedWithCallMagicMethod';
-    const AccessSignatureMismatch   = 'PhanAccessSignatureMismatch';
+    const AccessSignatureMismatch         = 'PhanAccessSignatureMismatch';
     const AccessSignatureMismatchInternal = 'PhanAccessSignatureMismatchInternal';
-    const AccessStaticToNonStatic   = 'PhanAccessStaticToNonStatic';
-    const AccessNonStaticToStatic   = 'PhanAccessNonStaticToStatic';
-    const AccessClassConstantPrivate     = 'PhanAccessClassConstantPrivate';
-    const AccessClassConstantProtected   = 'PhanAccessClassConstantProtected';
+    const PropertyAccessSignatureMismatch = 'PhanPropertyAccessSignatureMismatch';
+    const PropertyAccessSignatureMismatchInternal  = 'PhanPropertyAccessSignatureMismatchInternal';
+    const AccessConstantSignatureMismatch = 'PhanConstantAccessSignatureMismatch';
+    const AccessConstantSignatureMismatchInternal  = 'PhanConstantAccessSignatureMismatchInternal';
+    const AccessStaticToNonStatic         = 'PhanAccessStaticToNonStatic';
+    const AccessNonStaticToStatic         = 'PhanAccessNonStaticToStatic';
+    const AccessStaticToNonStaticProperty = 'PhanAccessStaticToNonStaticProperty';
+    const AccessNonStaticToStaticProperty = 'PhanAccessNonStaticToStaticProperty';
+    const AccessClassConstantPrivate      = 'PhanAccessClassConstantPrivate';
+    const AccessClassConstantProtected    = 'PhanAccessClassConstantProtected';
     const AccessPropertyStaticAsNonStatic = 'PhanAccessPropertyStaticAsNonStatic';
     const AccessPropertyNonStaticAsStatic = 'PhanAccessPropertyNonStaticAsStatic';
-    const AccessOwnConstructor = 'PhanAccessOwnConstructor';
+    const AccessOwnConstructor            = 'PhanAccessOwnConstructor';
 
     const AccessConstantInternal    = 'PhanAccessConstantInternal';
     const AccessClassInternal       = 'PhanAccessClassInternal';
@@ -2305,6 +2311,54 @@ class Issue
                 "Access level to {METHOD} must be compatible with internal {METHOD}",
                 self::REMEDIATION_B,
                 1005
+            ),
+            new Issue(
+                self::PropertyAccessSignatureMismatch,
+                self::CATEGORY_ACCESS,
+                self::SEVERITY_CRITICAL,
+                "Access level to {PROPERTY} must be compatible with {PROPERTY} defined in {FILE}:{LINE}",
+                self::REMEDIATION_B,
+                1022
+            ),
+            new Issue(
+                self::PropertyAccessSignatureMismatchInternal,
+                self::CATEGORY_ACCESS,
+                self::SEVERITY_CRITICAL,
+                "Access level to {PROPERTY} must be compatible with internal {PROPERTY}",
+                self::REMEDIATION_B,
+                1023
+            ),
+            new Issue(
+                self::AccessConstantSignatureMismatch,
+                self::CATEGORY_ACCESS,
+                self::SEVERITY_CRITICAL,
+                "Access level to {CONST} must be compatible with {CONST} defined in {FILE}:{LINE}",
+                self::REMEDIATION_B,
+                1024
+            ),
+            new Issue(
+                self::AccessConstantSignatureMismatchInternal,
+                self::CATEGORY_ACCESS,
+                self::SEVERITY_CRITICAL,
+                "Access level to {CONST} must be compatible with internal {CONST}",
+                self::REMEDIATION_B,
+                1025
+            ),
+            new Issue(
+                self::AccessStaticToNonStaticProperty,
+                self::CATEGORY_ACCESS,
+                self::SEVERITY_CRITICAL,
+                "Cannot make static property {PROPERTY} into the non static property {PROPERTY}",
+                self::REMEDIATION_B,
+                1026
+            ),
+            new Issue(
+                self::AccessNonStaticToStaticProperty,
+                self::CATEGORY_ACCESS,
+                self::SEVERITY_CRITICAL,
+                "Cannot make non static property {PROPERTY} into the static property {PROPERTY}",
+                self::REMEDIATION_B,
+                1027
             ),
             new Issue(
                 self::AccessStaticToNonStatic,

--- a/src/Phan/Language/Element/AddressableElement.php
+++ b/src/Phan/Language/Element/AddressableElement.php
@@ -88,6 +88,28 @@ abstract class AddressableElement extends TypedElement implements AddressableEle
     }
 
     /**
+     * @return bool true if this element's visibility
+     *                   is strictly more visible than $other (public > protected > private)
+     */
+    public function isStrictlyMoreVisibileThan(AddressableElementInterface $other) : bool
+    {
+        if ($this->isPrivate()) {
+            return false;
+        } // $this is public or protected
+
+        if ($other->isPrivate()) {
+            return true;
+        }
+
+        if ($other->isProtected()) {
+            // True if this is public.
+            return !$this->isProtected();
+        }
+        // $other is public
+        return false;
+    }
+
+    /**
      * @return bool
      * True if this is a public property
      */

--- a/src/Phan/Language/Element/AddressableElementInterface.php
+++ b/src/Phan/Language/Element/AddressableElementInterface.php
@@ -24,6 +24,12 @@ interface AddressableElementInterface extends TypedElementInterface
     public function setFQSEN(FQSEN $fqsen);
 
     /**
+     * @return bool true if this element's visibility
+     *                   is strictly more visible than $other (public > protected > private)
+     */
+    public function isStrictlyMoreVisibileThan(AddressableElementInterface $other) : bool;
+
+    /**
      * @return bool
      * True if this is a public property
      */

--- a/src/Phan/Language/Element/ClassConstant.php
+++ b/src/Phan/Language/Element/ClassConstant.php
@@ -78,17 +78,18 @@ class ClassConstant extends ClassElement implements ConstantInterface
 
     public function __toString() : string
     {
-        $string = '';
+        return $this->getVisibilityName() . ' const ' . $this->getName();
+    }
 
-        if ($this->isPublic()) {
-            $string .= 'public ';
-        } elseif ($this->isProtected()) {
-            $string .= 'protected ';
-        } elseif ($this->isPrivate()) {
-            $string .= 'private ';
-        }
-
-        return $string . 'const ' . $this->getName();
+    /**
+     * Used for generating issue messages
+     */
+    public function asVisibilityAndFQSENString()
+    {
+        return $this->getVisibilityName() . ' ' .
+            $this->getClassFQSEN()->__toString() .
+            '::' .
+            $this->getName();
     }
 
     /**
@@ -116,17 +117,20 @@ class ClassConstant extends ClassElement implements ConstantInterface
         );
     }
 
+    private function getVisibilityName() : string
+    {
+        if ($this->isPrivate()) {
+            return 'private';
+        } elseif ($this->isProtected()) {
+            return 'protected';
+        } else {
+            return 'public';
+        }
+    }
+
     public function toStub() : string
     {
-        $string = '    ';
-
-        if ($this->isPublic()) {
-            $string .= 'public ';
-        } elseif ($this->isProtected()) {
-            $string .= 'protected ';
-        } elseif ($this->isPrivate()) {
-            $string .= 'private ';
-        }
+        $string = '    ' . $this->getVisibilityName() . ' ';
 
         $string .= 'const ' . $this->getName() . ' = ';
         $fqsen = (string)$this->getFQSEN();

--- a/src/Phan/Language/Type/FunctionLikeDeclarationType.php
+++ b/src/Phan/Language/Type/FunctionLikeDeclarationType.php
@@ -3,6 +3,7 @@ namespace Phan\Language\Type;
 
 use Phan\CodeBase;
 use Phan\Language\Context;
+use Phan\Language\Element\AddressableElementInterface;
 use Phan\Language\Element\Comment;
 use Phan\Language\Element\FunctionInterface;
 use Phan\Language\Element\Parameter;
@@ -229,6 +230,15 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
     public function isPublic() : bool
     {
         return true;
+    }
+
+    /**
+     * @return bool true if this element's visibility
+     *                   is strictly more visible than $other (public > protected > private)
+     */
+    public function isStrictlyMoreVisibileThan(AddressableElementInterface $other) : bool
+    {
+        return false;
     }
 
     /** @override */

--- a/tests/files/expected/0492_class_constant_visibility.php.expected
+++ b/tests/files/expected/0492_class_constant_visibility.php.expected
@@ -1,0 +1,8 @@
+%s:23 PhanPropertyAccessSignatureMismatch Access level to protected $prop must be compatible with public $prop defined in %s:4
+%s:25 PhanAccessNonStaticToStaticProperty Cannot make non static property \X->instance_prop into the static property \Y::$instance_prop
+%s:26 PhanAccessStaticToNonStaticProperty Cannot make static property \X::$static_prop into the non static property \Y->static_prop
+%s:28 PhanAccessSignatureMismatch Access level to function test() must be compatible with function test() defined in %s:7
+%s:34 PhanConstantAccessSignatureMismatch Access level to private \Y::pro1 must be compatible with protected \X::pro1 defined in %s:13
+%s:38 PhanConstantAccessSignatureMismatch Access level to private \Y::pub1 must be compatible with public \X::pub1 defined in %s:17
+%s:39 PhanConstantAccessSignatureMismatch Access level to protected \Y::pub2 must be compatible with public \X::pub2 defined in %s:18
+%s:42 PhanAccessClassConstantProtected Cannot access protected class constant \Y::pub2 defined at %s:39

--- a/tests/files/expected/0492_class_constant_visibility.php.expected70
+++ b/tests/files/expected/0492_class_constant_visibility.php.expected70
@@ -1,0 +1,4 @@
+%s:23 PhanPropertyAccessSignatureMismatch Access level to protected $prop must be compatible with public $prop defined in %s:4
+%s:25 PhanAccessNonStaticToStaticProperty Cannot make non static property \X->instance_prop into the static property \Y::$instance_prop
+%s:26 PhanAccessStaticToNonStaticProperty Cannot make static property \X::$static_prop into the non static property \Y->static_prop
+%s:28 PhanAccessSignatureMismatch Access level to function test() must be compatible with function test() defined in %s:7

--- a/tests/files/src/0492_class_constant_visibility.php
+++ b/tests/files/src/0492_class_constant_visibility.php
@@ -1,0 +1,42 @@
+<?php
+
+class X {
+    public $prop;
+    public $instance_prop;
+    public static $static_prop;
+    public function test() {}
+
+    private const pri1 = 11;
+    private const pri2 = 12;
+    private const pri3 = 13;
+
+    protected const pro1 = 21;
+    protected const pro2 = 22;
+    protected const pro3 = 23;
+
+    public const pub1    = 31;
+    public const pub2    = 32;
+    public const pub3    = 33;
+}
+
+class Y extends X {
+    protected $prop;
+
+    public static $instance_prop;
+    public $static_prop;
+
+    protected function test() {}
+
+    private const pri1   = 111;
+    protected const pri2 = 112;
+    public const pri3    = 113;
+
+    private const pro1   = 121;
+    protected const pro2 = 122;
+    public const pro3    = 123;
+
+    private const pub1   = 131;
+    protected const pub2 = 132;
+    public const pub3    = 133;
+}
+var_export(Y::pub2);

--- a/tests/files/src/0492_class_constant_visibility.php70
+++ b/tests/files/src/0492_class_constant_visibility.php70
@@ -1,0 +1,41 @@
+<?php
+
+class X {
+    public $prop;
+    public $instance_prop;
+    public static $static_prop;
+    public function test() {}
+
+
+
+
+
+
+
+
+
+
+
+
+}
+
+class Y extends X {
+    protected $prop;
+
+    public static $instance_prop;
+    public $static_prop;
+
+    protected function test() {}
+
+
+
+
+
+
+
+
+
+
+
+
+}


### PR DESCRIPTION
Fixes #615 (warn about casting static property to/from non static)
Fixes #788 (warn about property and constant visibility)