### PR TITLE
Stop using UnusedVariablePlugin in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ cache:
   directories:
     - $HOME/.composer/cache
     - $HOME/.cache/phan-ast/build
-    - $HOME/.phan-ci
 
 # We invoke php multiple times via CLI in several tests, so enable the opcache file cache.
 before_install:

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -1341,7 +1341,6 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
      * @param \Generator|UnionType[] $types
      * @return \Generator|array<int,UnionType>
      * @phan-return \Generator<int,UnionType>
-     * @suppress PhanPluginUnusedVariable
      */
     private static function deduplicateUnionTypes($types)
     {

--- a/src/Phan/Bootstrap.php
+++ b/src/Phan/Bootstrap.php
@@ -45,7 +45,6 @@ set_exception_handler(function (Throwable $throwable) {
 
 /**
  * @return mixed
- * @suppress PhanPluginUnusedVariable
  */
 function with_disabled_phan_error_handler(Closure $closure)
 {

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -2382,7 +2382,6 @@ class Type
     /**
      * Extracts the inner parts of a template name list (i.e. within <>) or a shape component list (i.e. within {})
      * @return array<int,string>
-     * @suppress PhanPluginUnusedVariable
      */
     private static function extractNameList(string $list_string) : array
     {

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -290,7 +290,6 @@ class UnionType implements \Serializable
      * @param string[] $parts (already trimmed)
      * @return string[]
      * @see Type::extractTemplateParameterTypeNameList (Similar method)
-     * @suppress PhanPluginUnusedVariable $prev_parts is used in loop
      */
     private static function mergeTypeParts(array $parts) : array
     {

--- a/tests/run_test
+++ b/tests/run_test
@@ -28,15 +28,8 @@ case "$TEST_SUITE" in
 		exit $?
 		;;
 	__FakeSelfFallbackTest)
-		PLUGIN_PATH=$HOME/.phan-ci/UnusedVariablePlugin-c20aea3e.php
-
-		ARGS=""
-		if [ -e "$PLUGIN_PATH" ]; then
-			ARGS="--plugin $PLUGIN_PATH"
-		fi
 		./phan --plugin PHPUnitNotDeadCodePlugin \
 			--plugin InvokePHPNativeSyntaxCheckPlugin \
-			$ARGS \
 			--dead-code-detection \
 			--polyfill-parse-all-element-doc-comments \
 			--force-polyfill-parser \

--- a/tests/travis_setup.sh
+++ b/tests/travis_setup.sh
@@ -35,13 +35,6 @@ else
   echo "Using cached extension."
 fi
 
-PLUGIN_PATH=$HOME/.phan-ci/UnusedVariablePlugin-c20aea3e.php
-
-if [[ ! -e "$PLUGIN_PATH" ]]; then
-    rm -r "$HOME/.phan-ci"
-    curl --create-dirs -fsS https://raw.githubusercontent.com/phan/PhanUnusedVariable/c20aea3e468654481c8bfb1d9c4938ff5fe107ba/src/UnusedVariablePlugin.php -o "$PLUGIN_PATH" || rm "$PLUGIN_PATH"
-fi
-
 echo "extension=$EXPECTED_AST_FILE" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 
 php -r 'function_exists("ast\parse_code") || (print("Failed to enable php-ast\n") && exit(1));'


### PR DESCRIPTION
Phan added `--unused-variable-detection`
in #1727 (and followup work),
which had fewer false positives and caught other types of issues.

Tickets are in the backlog to catch more types of unused variable
definitions (e.g. be more aggressive for static/global/references).