### PR TITLE
Don't accidentally make inferred array properties more generic

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,8 @@ Maintenance:
 + Upgrade tolerant-php-parser, making the polyfill/fallback able to parse PHP 7.1's multi exception catch.
 
 Bug fixes:
++ Don't add more generic types to properties with more specific PHPDoc types (#1783).
+  For example, don't add `array` to a property declared with PHPDoc type `/** @var string[] */`
 + Fix uncaught `AssertionError` when `parent` is used in PHPDoc (#1758)
 + Fix various bugs that can cause crashes in the polyfill/fallback parser when parsing invalid or incomplete ASTs.
 + Fix unparseable/invalid function signature entries of rarely used functions

--- a/internal/internalsignatures.php
+++ b/internal/internalsignatures.php
@@ -761,7 +761,7 @@ class IncompatibleXMLSignatureDetector extends IncompatibleSignatureDetectorBase
 
 
     /**
-     * @var array<string,string>
+     * @var array<string,true>
      */
     private $known_entities = null;
 
@@ -779,6 +779,9 @@ class IncompatibleXMLSignatureDetector extends IncompatibleSignatureDetectorBase
         return $this->known_entities;
     }
 
+    /**
+     * @return array<string,true>
+     */
     private function getKnownEntities()
     {
         if (!is_array($this->known_entities)) {

--- a/phan_client
+++ b/phan_client
@@ -446,6 +446,11 @@ EOB;
                 case 'l':
                 case 'syntax-check':
                     $path = $value;
+					if (!is_string($path)) {
+                        $this->print_usage_on_error = $print_usage_on_error;
+                        $this->usage(sprintf("Error: asked to analyze path %s which is not a string", json_encode($path)), 1);
+                        exit(1);
+					}
                     if (!file_exists($path)) {
                         $this->print_usage_on_error = $print_usage_on_error;
                         $this->usage(sprintf("Error: asked to analyze file %s which does not exist", json_encode($path)), 1);

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -251,9 +251,9 @@ class CLI
                             }
                             $this->file_list_in_config = array_merge(
                                 $this->file_list,
-                                $this->directoryNameToFileList(
+                                array_values($this->directoryNameToFileList(
                                     $directory_name
-                                )
+                                ))
                             );
                         }
                     }
@@ -549,7 +549,7 @@ class CLI
             foreach (Config::getValue('directory_list') as $directory_name) {
                 $this->file_list = array_merge(
                     $this->file_list,
-                    $this->directoryNameToFileList($directory_name)
+                    array_values($this->directoryNameToFileList($directory_name))
                 );
             }
 

--- a/src/Phan/CodeBase/UndoTracker.php
+++ b/src/Phan/CodeBase/UndoTracker.php
@@ -33,7 +33,7 @@ class UndoTracker
     private $undoOperationsForPath = [];
 
     /**
-     * @var array<string,string> Maps file paths to the modification dates and file size of the paths. - On ext4, milliseconds are available, but php APIs all return seconds.
+     * @var array<string,?string> Maps file paths to the modification dates and file size of the paths. - On ext4, milliseconds are available, but php APIs all return seconds.
      */
     private $fileModificationState = [];
 
@@ -70,6 +70,7 @@ class UndoTracker
     {
         if (\is_string($current_parsed_file)) {
             Daemon::debugf("Recording file modification state for %s", $current_parsed_file);
+            // This shouldn't be null. TODO: Figure out what to do if it is.
             $this->fileModificationState[$current_parsed_file] = self::getFileState($current_parsed_file);
         }
         $this->current_parsed_file = $current_parsed_file;

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -62,7 +62,7 @@ class Clazz extends AddressableElement
     private $trait_fqsen_list = [];
 
     /**
-     * @var array<int,TraitAdaptations>
+     * @var array<string,TraitAdaptations>
      * Maps lowercase fqsen of a method to the trait names which are hidden
      * and the trait aliasing info
      */

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -145,8 +145,8 @@ trait FunctionTrait
     private $phpdoc_parameter_type_map = [];
 
     /**
-     * @var array<string,true>
-     * A set of parameter names that are output-only references
+     * @var array<int,string>
+     * A list of parameter names that are output-only references
      */
     private $phpdoc_output_references = [];
 

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -422,6 +422,8 @@ class Type
                     $template_parameter_type_list,
                     $is_nullable
                 );
+                // FIXME Phan warns that array<string,static> can't be assigned to array<string,Type>
+                '@phan-var Type $value';
             }
             self::$canonical_object_map[$key] = $value;
         }

--- a/src/Phan/Language/UnionTypeBuilder.php
+++ b/src/Phan/Language/UnionTypeBuilder.php
@@ -48,6 +48,7 @@ final class UnionTypeBuilder
             // TODO: How do other versions affect performance on large projects?
             $replacement_type = \array_pop($this->type_set);
             if ($replacement_type !== $type) {
+                // @phan-suppress-next-line PhanPartialTypeMismatchProperty $replacement_type is guaranteed to not be false
                 $this->type_set[$i] = $replacement_type;
             }
         }

--- a/src/Phan/LanguageServer/GoToDefinitionRequest.php
+++ b/src/Phan/LanguageServer/GoToDefinitionRequest.php
@@ -38,7 +38,7 @@ final class GoToDefinitionRequest
     /** @var bool true if this is "Go to Type Definition" */
     private $is_type_definition_request;
 
-    /** @var array<int,Location> */
+    /** @var array<string,Location> */
     private $locations = [];
 
     public function __construct(string $uri, Position $position, bool $is_type_definition_request)

--- a/tests/files/expected/0500_specific_property.php.expected
+++ b/tests/files/expected/0500_specific_property.php.expected
@@ -1,0 +1,2 @@
+%s:15 PhanTypeMismatchProperty Assigning array<int,int> to property but \Example500::propWithArrayDefault is string[]
+%s:19 PhanTypeMismatchProperty Assigning array<int,int> to property but \Example500::propSetInConstructor is string[]

--- a/tests/files/src/0500_specific_property.php
+++ b/tests/files/src/0500_specific_property.php
@@ -1,0 +1,21 @@
+<?php
+
+class Example500 {
+    /** @var string[] */
+    private $propWithArrayDefault = [];
+
+    /** @var string[] */
+    private $propSetInConstructor;
+
+    public function __construct() {
+        $this->propSetInConstructor = [];
+    }
+
+    public function badAssign(int $val) {
+        $this->propWithArrayDefault[] = $val;
+    }
+
+    public function badAssign2(int $val) {
+        $this->propSetInConstructor[] = $val;
+    }
+}


### PR DESCRIPTION
Fixes #1783

There's still the same issue with nested arrays,
but this fixes the common case.

Fix bugs in usage/declaration of properties with
array types (detected by self-analysis)

This uncovered a bug in the analysis of arrays with `static`,
which will be addressed later.