### PR TITLE
Implement a plugin to warn about missing `@throws`

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -209,6 +209,10 @@ return [
     // class types.
     'generic_types_enabled' => true,
 
+    // If enabled, warn about throw statement where the exception types
+    // are not documented in the PHPDoc of functions, methods, and closures.
+    'warn_about_undocumented_throw_statements' => true,
+
     // Setting this to true makes the process assignment for file analysis
     // as predictable as possible, using consistent hashing.
     // Even if files are added or removed, or process counts change,
@@ -238,7 +242,7 @@ return [
         'PhanPossiblyNullTypeArgument',
         'PhanPossiblyNullTypeArgumentInternal',
         'PhanPossiblyNullTypeReturn',
-        // 'PhanUndeclaredMethod',
+        'PhanThrowTypeAbsent',  // TODO: Remove this suppression
     ],
 
     // If empty, no filter against issues types will be applied.

--- a/.phan/plugins/InvokePHPNativeSyntaxCheckPlugin.php
+++ b/.phan/plugins/InvokePHPNativeSyntaxCheckPlugin.php
@@ -302,6 +302,7 @@ class InvokeExecutionPromise
 
     /**
      * @return void
+     * @throws Error if reading failed
      */
     public function blockingRead()
     {
@@ -318,6 +319,7 @@ class InvokeExecutionPromise
 
     /**
      * @return ?string
+     * @throws RangeException if this was called before the process finished
      */
     public function getError()
     {

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,13 @@ Phan NEWS
 ?? ??? 2018, Phan 0.12.14 (dev)
 -------------------------
 
+New features(CLI, Configs)
++ Add `warn_about_undocumented_throw_statements` config. (#90)
+  If this is enabled, Phan will warn about uncaught throw statements that aren't documented in the function's PHPDoc.
+  This does not yet check function and method calls within the checked function that may themselves throw.
+
+  New issue types: `PhanThrowTypeAbsent`, `PhanThrowTypeMismatch`
+
 16 Jun 2018, Phan 0.12.13
 -------------------------
 

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -2346,6 +2346,18 @@ The phpdoc comment for {COMMENT} cannot occur on a {TYPE}
 Saw misspelled annotation {COMMENT}, should be one of {COMMENT}
 ```
 
+## PhanThrowTypeAbsent
+
+```
+{METHOD}() can throw {TYPE} here, but has no '@throws' declarations
+```
+
+## PhanThrowTypeMismatch
+
+```
+{METHOD}() throws {TYPE}, but it only has declarations of '@throws {TYPE}'
+```
+
 ## PhanUnextractableAnnotation
 
 ```

--- a/internal/internalsignatures.php
+++ b/internal/internalsignatures.php
@@ -235,7 +235,7 @@ EOT;
     }
 
     /**
-     * @suppress PhanPluginUnusedVariable $header in loop not detected
+     * @throws RuntimeException if the file could not be read
      */
     public static function readSignatureHeader() : string
     {
@@ -343,6 +343,9 @@ class IncompatibleXMLSignatureDetector extends IncompatibleSignatureDetectorBase
         $this->doc_base_directory = self::realpath($dir);
     }
 
+    /**
+     * @throws RuntimeException if the real path could not be determined
+     */
     private static function realpath(string $dir) : string
     {
         $realpath = realpath($dir);

--- a/internal/update_wiki_issue_types.php
+++ b/internal/update_wiki_issue_types.php
@@ -93,7 +93,10 @@ EOT;
         return $text_for_section;
     }
 
-    /** @return void */
+    /**
+     * @return void
+     * @throws InvalidArgumentException (uncaught) if the documented issue types can't be found.
+     */
     public static function main()
     {
         global $argv;

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -254,6 +254,7 @@ class ContextNode
      * @param array<string,TraitAdaptations> $adaptations_map
      * @param Node $adaptation_node
      * @return void
+     * @throws UnanalyzableException (should be caught and emitted as an issue)
      */
     private function handleTraitPrecedence(array $adaptations_map, Node $adaptation_node)
     {
@@ -861,6 +862,9 @@ class ContextNode
         // TODO: AST_CLOSURE
     }
 
+    /**
+     * @throws IssueException for PhanUndeclaredFunction to be caught and reported by the caller
+     */
     private function throwUndeclaredFunctionIssueException(FullyQualifiedFunctionName $function_fqsen)
     {
         throw new IssueException(
@@ -1373,6 +1377,9 @@ class ContextNode
      * @throws CodeBaseException
      * An exception is thrown if we can't find the given
      * global constant
+     *
+     * @throws IssueException
+     * should be emitted by the caller if caught.
      */
     public function getConst() : GlobalConstant
     {
@@ -1604,6 +1611,7 @@ class ContextNode
 
     /**
      * @return Func
+     * @throws CodeBaseException if the closure could not be found
      */
     public function getClosure() : Func
     {

--- a/src/Phan/AST/TolerantASTConverter/NodeDumper.php
+++ b/src/Phan/AST/TolerantASTConverter/NodeDumper.php
@@ -97,6 +97,7 @@ class NodeDumper
      * @param Node|Token $ast_node
      * @param string $padding (to be echoed before the current node
      * @return string
+     * @throws \InvalidArgumentException for invalid $ast_node values
      */
     public function dumpTreeAsString($ast_node, string $key = '', string $padding = '') : string
     {

--- a/src/Phan/AST/TolerantASTConverter/String_.php
+++ b/src/Phan/AST/TolerantASTConverter/String_.php
@@ -138,6 +138,8 @@ final class String_
      * @param int $num Code point
      *
      * @return string UTF-8 representation of code point
+     *
+     * @throws \Error for invalid code points
      */
     private static function codePointToUtf8(int $num) : string
     {

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -50,6 +50,7 @@ use Phan\Language\UnionType;
 use Phan\Language\UnionTypeBuilder;
 use ast\Node;
 use ast;
+use AssertionError;
 
 /**
  * Determine the UnionType associated with a
@@ -530,6 +531,8 @@ class UnionTypeVisitor extends AnalysisVisitor
      * @return UnionType
      * The set of types that are possibly produced by the
      * given node
+     *
+     * @throws AssertionError if the type flags were unknown
      */
     public function visitType(Node $node) : UnionType
     {
@@ -555,7 +558,7 @@ class UnionTypeVisitor extends AnalysisVisitor
             case \ast\flags\TYPE_VOID:
                 return VoidType::instance(false)->asUnionType();
             default:
-                throw new \AssertionError("All flags must match. Found "
+                throw new AssertionError("All flags must match. Found "
                     . Debug::astFlagDescription($node->flags ?? 0, $node->kind));
         }
     }
@@ -1008,6 +1011,8 @@ class UnionTypeVisitor extends AnalysisVisitor
      * @return UnionType
      * The set of types that are possibly produced by the
      * given node
+     *
+     * @throws NodeException if the flags are a value we aren't expecting
      */
     public function visitCast(Node $node) : UnionType
     {
@@ -1171,6 +1176,9 @@ class UnionTypeVisitor extends AnalysisVisitor
      * @return UnionType
      * The set of types that are possibly produced by the
      * given node
+     *
+     * @throws IssueException
+     * if the dimension access is invalid
      */
     public function visitDim(Node $node) : UnionType
     {
@@ -1427,7 +1435,7 @@ class UnionTypeVisitor extends AnalysisVisitor
     }
 
     /**
-     * Visit a node with kind `\ast\AST_DIM`
+     * Visit a node with kind `\ast\AST_UNPACK`
      *
      * @param Node $node
      * A node of the type indicated by the method name that we'd
@@ -1436,6 +1444,9 @@ class UnionTypeVisitor extends AnalysisVisitor
      * @return UnionType
      * The set of types that are possibly produced by the
      * given node
+     *
+     * @throws IssueException
+     * if the unpack is on an invalid expression
      */
     public function visitUnpack(Node $node) : UnionType
     {
@@ -1525,6 +1536,9 @@ class UnionTypeVisitor extends AnalysisVisitor
      * @return UnionType
      * The set of types that are possibly produced by the
      * given node
+     *
+     * @throws IssueException
+     * if variable is undeclined and being fetched
      */
     public function visitVar(Node $node) : UnionType
     {

--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -23,6 +23,7 @@ use Phan\Parse\ParseVisitor;
 use Phan\Plugin\ConfigPluginSet;
 
 use ast\Node;
+use InvalidArgumentException;
 use ParseError;
 
 /**
@@ -54,6 +55,8 @@ class Analysis
      * See autoload_internal_extension_signatures.
      *
      * @return Context
+     *
+     * @throws InvalidArgumentException for invalid stub files
      */
     public static function parseFile(CodeBase $code_base, string $file_path, bool $suppress_parse_errors = false, string $override_contents = null, bool $is_php_internal_stub = false) : Context
     {
@@ -79,7 +82,7 @@ class Analysis
         $file_contents = $cache_entry->getContents();
         if ($file_contents === '') {
             if ($is_php_internal_stub) {
-                throw new \InvalidArgumentException("Unexpected empty php file for autoload_internal_extension_signatures: path=" . json_encode($original_file_path, JSON_UNESCAPED_SLASHES));
+                throw new InvalidArgumentException("Unexpected empty php file for autoload_internal_extension_signatures: path=" . json_encode($original_file_path, JSON_UNESCAPED_SLASHES));
             }
             // php-ast would return null for 0 byte files as an implementation detail.
             // Make Phan consistently emit this warning.

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -58,6 +58,12 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
      * @return Context
      * A new or an unchanged context resulting from
      * parsing the node
+     *
+     * @throws UnanalyzableException
+     * if the class name is unexpectedly empty
+     *
+     * @throws CodeBaseException
+     * if the class could not be located
      */
     public function visitClass(Node $node) : Context
     {
@@ -118,6 +124,8 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
      * @return Context
      * A new or an unchanged context resulting from
      * parsing the node
+     *
+     * @throws CodeBaseException if the method could not be found
      */
     public function visitMethod(Node $node) : Context
     {
@@ -209,6 +217,8 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
      * @return Context
      * A new or an unchanged context resulting from
      * parsing the node
+     * @throws CodeBaseException
+     * if this function declaration could not be found
      */
     public function visitFuncDecl(Node $node) : Context
     {
@@ -216,18 +226,14 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
         $code_base = $this->code_base;
         $original_context = $this->context;
 
-        try {
-            $canonical_function = (new ContextNode(
-                $code_base,
-                $original_context,
-                $node
-            ))->getFunction($function_name, true);
-        } catch (CodeBaseException $exception) {
-            // This really ought not happen given that
-            // we already successfully parsed the code
-            // base
-            throw $exception;
-        }
+        // This really ought not to throw given that
+        // we already successfully parsed the code
+        // base
+        $canonical_function = (new ContextNode(
+            $code_base,
+            $original_context,
+            $node
+        ))->getFunction($function_name, true);
 
         // Hunt for the alternate associated with the file we're
         // looking at currently in this context.
@@ -556,6 +562,9 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
      * @return Context
      * A new or an unchanged context resulting from
      * parsing the node
+     *
+     * @throws NodeException
+     * if the key is invalid
      */
     public function visitForeach(Node $node) : Context
     {

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -8,6 +8,8 @@ use Phan\Output\Filter\ChainedIssueFilter;
 use Phan\Output\Filter\FileIssueFilter;
 use Phan\Output\Filter\MinimumSeverityFilter;
 use Phan\Output\PrinterFactory;
+
+use InvalidArgumentException;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
@@ -877,6 +879,9 @@ EOB;
      *
      * @return array<string,string>
      * A list of PHP files in the given directory
+     *
+     * @throws InvalidArgumentException
+     * if there is nothing to analyze
      */
     private function directoryNameToFileList(
         string $directory_name
@@ -887,7 +892,7 @@ EOB;
             $file_extensions = Config::getValue('analyzed_file_extensions');
 
             if (!\is_array($file_extensions) || count($file_extensions) === 0) {
-                throw new \InvalidArgumentException(
+                throw new InvalidArgumentException(
                     'Empty list in config analyzed_file_extensions. Nothing to analyze.'
                 );
             }

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -367,6 +367,10 @@ class Config
         // types expressed in code.
         'read_type_annotations' => true,
 
+        // If enabled, warn about throw statement where the exception types
+        // are not documented in the PHPDoc of functions, methods, and closures.
+        'warn_about_undocumented_throw_statements' => false,
+
         // This setting maps case insensitive strings to union types.
         // This is useful if a project uses phpdoc that differs from the phpdoc2 standard.
         // If the corresponding value is the empty string, Phan will ignore that union type (E.g. can ignore 'the' in `@return the value`)

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -337,6 +337,8 @@ class Issue
     const CommentOverrideOnNonOverrideMethod = 'PhanCommentOverrideOnNonOverrideMethod';
     const CommentOverrideOnNonOverrideConstant = 'PhanCommentOverrideOnNonOverrideConstant';
     const CommentParamOutOfOrder           = 'PhanCommentParamOutOfOrder';
+    const ThrowTypeAbsent                  = 'PhanThrowTypeAbsent';
+    const ThrowTypeMismatch                = 'PhanThrowTypeMismatch';
 
 
     const CATEGORY_ACCESS            = 1 << 1;
@@ -2846,6 +2848,22 @@ class Issue
                 "Expected @param annotation for {VARIABLE} to be before the @param annotation for {VARIABLE}",
                 self::REMEDIATION_A,
                 16008
+            ),
+            new Issue(
+                self::ThrowTypeAbsent,
+                self::CATEGORY_COMMENT,
+                self::SEVERITY_LOW,
+                "{METHOD}() can throw {TYPE} here, but has no '@throws' declarations",
+                self::REMEDIATION_A,
+                16011
+            ),
+            new Issue(
+                self::ThrowTypeMismatch,
+                self::CATEGORY_COMMENT,
+                self::SEVERITY_LOW,
+                "{METHOD}() throws {TYPE}, but it only has declarations of '@throws {TYPE}'",
+                self::REMEDIATION_A,
+                16012
             ),
         ];
 

--- a/src/Phan/Phan.php
+++ b/src/Phan/Phan.php
@@ -12,6 +12,8 @@ use Phan\Output\IgnoredFilesFilterInterface;
 use Phan\Output\IssueCollectorInterface;
 use Phan\Output\IssuePrinterInterface;
 use Phan\Plugin\ConfigPluginSet;
+use Exception;
+use InvalidArgumentException;
 
 /**
  * This executes the the parse, method/function, then the analysis phases.
@@ -234,6 +236,8 @@ class Phan implements IgnoredFilesFilterInterface
      * @param ?Request $request
      * @param array<int,string> $analyze_file_path_list
      * @param array<string,string> $temporary_file_mapping
+     *
+     * @throws Exception if analysis failed catastrophically
      */
     public static function finishAnalyzingRemainingStatements(
         CodeBase $code_base,
@@ -390,7 +394,7 @@ class Phan implements IgnoredFilesFilterInterface
             if (Config::get()->print_memory_usage_summary) {
                 self::printMemoryUsageSummary();
             }
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             if ($request instanceof Request) {
                 // Give people using the language server client/daemon a somewhat useful response.
                 $request->sendJSONResponse([
@@ -588,6 +592,7 @@ class Phan implements IgnoredFilesFilterInterface
     /**
      * Loads configured stubs for internal PHP extensions.
      * @return void
+     * @throws InvalidArgumentException if the stubs or stub config is invalid
      */
     private static function loadConfiguredPHPExtensionStubs(CodeBase $code_base)
     {

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -30,6 +30,7 @@ use Phan\Plugin\Internal\DependentReturnTypeOverridePlugin;
 use Phan\Plugin\Internal\MiscParamPlugin;
 use Phan\Plugin\Internal\NodeSelectionPlugin;
 use Phan\Plugin\Internal\StringFunctionPlugin;
+use Phan\Plugin\Internal\ThrowAnalyzerPlugin;
 use Phan\Plugin\Internal\VariableTrackerPlugin;
 use Phan\Plugin\PluginImplementation;
 use Phan\PluginV2;
@@ -550,9 +551,6 @@ final class ConfigPluginSet extends PluginV2 implements
             return null;
         }
         $completion_plugin = new NodeSelectionPlugin();
-        /**
-         * @return void
-         */
         $completion_plugin->setNodeSelectorClosure(DefinitionResolver::createGoToDefinitionClosure($go_to_definition_request, $code_base));
         $new_post_analyze_node_plugins = self::filterPostAnalysisPlugins([$completion_plugin]);
         if (!$new_post_analyze_node_plugins) {
@@ -571,10 +569,8 @@ final class ConfigPluginSet extends PluginV2 implements
             }
         }
 
-        // TODO: Add plugins
         return new RAII(function () use ($old_post_analyze_node_plugin_set) {
             $this->postAnalyzeNodePluginSet = $old_post_analyze_node_plugin_set;
-            // TODO: Clean up all of the plugins that were added
         });
     }
 
@@ -635,6 +631,9 @@ final class ConfigPluginSet extends PluginV2 implements
                 new MiscParamPlugin(),
             ];
             $plugin_set = array_merge($internal_return_type_plugins, $plugin_set);
+        }
+        if (Config::getValue('warn_about_undocumented_throw_statements')) {
+            $plugin_set[] = new ThrowAnalyzerPlugin();
         }
         if (Config::getValue('unused_variable_detection') || Config::getValue('dead_code_detection')) {
             $plugin_set[] = new VariableTrackerPlugin();

--- a/src/Phan/Plugin/Internal/ThrowAnalyzerPlugin.php
+++ b/src/Phan/Plugin/Internal/ThrowAnalyzerPlugin.php
@@ -1,0 +1,86 @@
+<?php declare(strict_types=1);
+namespace Phan\Plugin\Internal;
+
+use Phan\AST\UnionTypeVisitor;
+use Phan\Issue;
+use Phan\PluginV2;
+use Phan\PluginV2\PostAnalyzeNodeCapability;
+use Phan\PluginV2\PluginAwarePostAnalysisVisitor;
+use ast\Node;
+use ast;
+
+// ThrowAnalyzerPlugin analyzes throw statements and
+// compares them against the phpdoc (at)throws annotations
+
+class ThrowAnalyzerPlugin extends PluginV2 implements PostAnalyzeNodeCapability
+{
+    public static function getPostAnalyzeNodeVisitorClassName() : string
+    {
+        return ThrowVisitor::class;
+    }
+}
+
+class ThrowVisitor extends PluginAwarePostAnalysisVisitor
+{
+    /**
+     * @var Node[] Dynamic
+     * @suppress PhanReadOnlyProtectedProperty set by the framework
+     */
+    protected $parent_node_list;
+
+    public function visitThrow(Node $node)
+    {
+        $context = $this->context;
+        if (!$context->isInFunctionLikeScope()) {
+            return;
+        }
+        $code_base = $this->code_base;
+
+        // TODO: Does phan warn about invalid throw statement types in visitThrow already?
+        $union_type = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $node->children['expr']);
+        if ($union_type->isEmpty()) {
+            // Give up if we don't know
+            // TODO: Infer throwable, if there are no try/catch blocks
+            return;
+        }
+        $function = $context->getFunctionLikeInScope($code_base);
+
+        foreach ($this->parent_node_list as $parent) {
+            if ($parent->kind !== ast\AST_TRY) {
+                continue;
+            }
+            foreach ($parent->children['catches']->children as $catch_node) {
+                $caught_union_type = UnionTypeVisitor::unionTypeFromClassNode($code_base, $context, $catch_node->children['class']);
+                foreach ($union_type->getTypeSet() as $type) {
+                    if (!$type->asExpandedTypes($code_base)->canCastToUnionType($caught_union_type)) {
+                        $union_type = $union_type->withoutType($type);
+                        if ($union_type->isEmpty()) {
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+        $throws_union_type = $function->getThrowsUnionType();
+        foreach ($union_type->getTypeSet() as $type) {
+            if ($throws_union_type->isEmpty()) {
+                $this->emitIssue(
+                    Issue::ThrowTypeAbsent,
+                    $node->lineno,
+                    (string)$function->getFQSEN(),
+                    (string)$union_type
+                );
+                continue;
+            }
+            if (!$type->asExpandedTypes($code_base)->canCastToUnionType($throws_union_type)) {
+                $this->emitIssue(
+                    Issue::ThrowTypeMismatch,
+                    $node->lineno,
+                    (string)$function->getFQSEN(),
+                    (string)$union_type,
+                    $throws_union_type
+                );
+            }
+        }
+    }
+}

--- a/tests/Phan/AST/TolerantASTConverter/ConversionTest.php
+++ b/tests/Phan/AST/TolerantASTConverter/ConversionTest.php
@@ -14,6 +14,11 @@ use RuntimeException;
 
 use ast;
 
+/**
+ * Tests that the polyfill works with valid ASTs
+ *
+ * @phan-file-suppress PhanThrowTypeAbsent it's a test
+ */
 class ConversionTest extends BaseTest
 {
     /**

--- a/tests/Phan/AST/TolerantASTConverter/TolerantASTConverterWithNodeMappingTest.php
+++ b/tests/Phan/AST/TolerantASTConverter/TolerantASTConverterWithNodeMappingTest.php
@@ -10,6 +10,11 @@ use InvalidArgumentException;
 use ast;
 use ast\Node;
 
+/**
+ * Tests that the fallback works with ASTs, and can point an ast\Node to the original.
+ *
+ * @phan-file-suppress PhanThrowTypeAbsent it's a test
+ */
 class TolerantASTConverterWithNodeMappingTest extends BaseTest
 {
     public static function setUpBeforeClass()

--- a/tests/Phan/Language/EmptyUnionTypeTest.php
+++ b/tests/Phan/Language/EmptyUnionTypeTest.php
@@ -23,6 +23,10 @@ use ReflectionParameter;
 use RuntimeException;
 use TypeError;
 
+/**
+ * Checks that EmptyUnionType behaves the same way as an empty UnionType instance
+ * @phan-file-suppress PhanThrowTypeAbsent it's a test
+ */
 class EmptyUnionTypeTest extends BaseTest
 {
     const SKIPPED_METHOD_NAMES = [

--- a/tests/Phan/LanguageServer/LanguageServerIntegrationTest.php
+++ b/tests/Phan/LanguageServer/LanguageServerIntegrationTest.php
@@ -18,6 +18,8 @@ use stdClass;
  *
  * Note: This test file is not enabled in CI because they may hang indefinitely.
  * (integration test timeouts weren't implemented or tested yet).
+ *
+ * @phan-file-suppress PhanThrowTypeAbsent it's a test
  */
 class LanguageServerIntegrationTest extends BaseTest
 {

--- a/tests/plugin_test/.phan/config.php
+++ b/tests/plugin_test/.phan/config.php
@@ -77,6 +77,10 @@ return [
 
     'guess_unknown_parameter_type_using_default' => true,
 
+    // If enabled, warn about throw statement where the exception types
+    // are not documented in the PHPDoc of functions, methods, and closures.
+    'warn_about_undocumented_throw_statements' => true,
+
     'minimum_severity' => Issue::SEVERITY_LOW,
 
     'directory_list' => ['src'],

--- a/tests/plugin_test/expected/000_plugins.php.expected
+++ b/tests/plugin_test/expected/000_plugins.php.expected
@@ -18,6 +18,8 @@ src/000_plugins.php:66 PhanUnreferencedClass Possibly zero references to class \
 src/000_plugins.php:67 PhanUnreferencedConstant Possibly zero references to global constant \__autoload
 src/000_plugins.php:69 PhanPluginAlwaysReturnFunction Function \missingReturnType has a return type of int, but may fail to return a value
 src/000_plugins.php:77 PhanPluginAlwaysReturnMethod Method \ReturnChecks::missingReturnTypeSwitch has a return type of int, but may fail to return a value
+src/000_plugins.php:80 PhanThrowTypeAbsent \ReturnChecks::missingReturnTypeSwitch() can throw \RuntimeException here, but has no '@throws' declarations
+src/000_plugins.php:93 PhanThrowTypeAbsent \ReturnChecks::missingReturnTypeSwitchGood() can throw \RuntimeException here, but has no '@throws' declarations
 src/000_plugins.php:114 PhanUnusedVariable Unused definition of variable $x
 src/000_plugins.php:127 PhanTypeMismatchArgumentInternal Argument 1 (string) is int but \strlen() takes string
 src/000_plugins.php:138 DemoPluginMethodName Method \TestDemoPlugin::function cannot be called `function`

--- a/tests/plugin_test/expected/002_unreachable_code.php.expected
+++ b/tests/plugin_test/expected/002_unreachable_code.php.expected
@@ -1,3 +1,4 @@
+src/002_unreachable_code.php:4 PhanThrowTypeAbsent \unreachableCode() can throw \RuntimeException here, but has no '@throws' declarations
 src/002_unreachable_code.php:5 PhanPluginUnreachableCode Unreachable statement detected
 src/002_unreachable_code.php:23 PhanPluginUnreachableCode Unreachable statement detected
 src/002_unreachable_code.php:25 PhanPluginUnreachableCode Unreachable statement detected

--- a/tests/plugin_test/expected/011_goto_not_unreachable.php.expected
+++ b/tests/plugin_test/expected/011_goto_not_unreachable.php.expected
@@ -1,1 +1,2 @@
+src/011_goto_not_unreachable.php:12 PhanThrowTypeAbsent \goto11() can throw \RuntimeException here, but has no '@throws' declarations
 src/011_goto_not_unreachable.php:13 PhanPluginUnreachableCode Unreachable statement detected

--- a/tests/plugin_test/expected/037_unused_return.php.expected
+++ b/tests/plugin_test/expected/037_unused_return.php.expected
@@ -6,3 +6,4 @@ src/037_unused_return.php:20 PhanUnusedVariable Unused definition of variable $m
 src/037_unused_return.php:21 PhanUnusedVariable Unused definition of variable $myUnusedVar
 src/037_unused_return.php:23 PhanUnusedVariable Unused definition of variable $myVar
 src/037_unused_return.php:24 PhanUnusedVariable Unused definition of variable $myUnusedVar
+src/037_unused_return.php:25 PhanThrowTypeAbsent \unused_return() can throw \RuntimeException here, but has no '@throws' declarations

--- a/tests/plugin_test/expected/040_if_assign.php.expected
+++ b/tests/plugin_test/expected/040_if_assign.php.expected
@@ -1,1 +1,3 @@
+src/040_if_assign.php:4 PhanThrowTypeAbsent \test_if_assign() can throw \RuntimeException here, but has no '@throws' declarations
 src/040_if_assign.php:9 PhanUnusedVariable Unused definition of variable $x
+src/040_if_assign.php:10 PhanThrowTypeAbsent \test_unused_if_assign() can throw \RuntimeException here, but has no '@throws' declarations


### PR DESCRIPTION
This implements part of the work for #90
(It doesn't check invocation of other methods via function/method/new yet.)

Partially document `@throws` in Phan (hundreds of missing occurences)