### PR TITLE
Add config to stop warning about a small list of `@throws` exceptions.

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -213,6 +213,15 @@ return [
     // are not documented in the PHPDoc of functions, methods, and closures.
     'warn_about_undocumented_throw_statements' => true,
 
+    // Phan will not warn about lack of documentation of (at)throws for any of the configured classes or their subclasses.
+    // This only matters when warn_about_undocumented_throw_statements is true.
+    // The default is the empty array (Warn about every kind of Throwable)
+    'exception_classes_with_optional_throws_phpdoc' => [
+        '\RuntimeException',
+        '\AssertionError',
+        '\TypeError',
+    ],
+
     // Setting this to true makes the process assignment for file analysis
     // as predictable as possible, using consistent hashing.
     // Even if files are added or removed, or process counts change,
@@ -242,7 +251,6 @@ return [
         'PhanPossiblyNullTypeArgument',
         'PhanPossiblyNullTypeArgumentInternal',
         'PhanPossiblyNullTypeReturn',
-        'PhanThrowTypeAbsent',  // TODO: Remove this suppression
     ],
 
     // If empty, no filter against issues types will be applied.

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,14 +4,17 @@ Phan NEWS
 -------------------------
 
 New features(CLI, Configs)
-+ Add `warn_about_undocumented_throw_statements` config. (#90)
-  If this is enabled, Phan will warn about uncaught throw statements that aren't documented in the function's PHPDoc.
++ Add `warn_about_undocumented_throw_statements` and `exception_classes_with_optional_throws_phpdoc` config. (#90)
+
+  If `warn_about_undocumented_throw_statements` is true, Phan will warn about uncaught throw statements that aren't documented in the function's PHPDoc.
+  (excluding classes listed in `exception_classes_with_optional_throws_phpdoc` and their subclasses)
   This does not yet check function and method calls within the checked function that may themselves throw.
 
   New issue types: `PhanThrowTypeAbsent`, `PhanThrowTypeMismatch`
 
 Bug fixes:
 + Start warning about assignment operations (e.g. `+=`) when the modified variable isn't referenced later in the function.
++ Fix another rare bug that can cause crashes in the polyfill/fallback parser when parsing invalid or incomplete ASTs.
 
 16 Jun 2018, Phan 0.12.13
 -------------------------

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -219,6 +219,7 @@ class CodeBase
     public function enableUndoTracking()
     {
         if ($this->has_enabled_undo_tracker) {
+            // @phan-suppress-next-line PhanThrowTypeAbsent should be impossible.
             throw new \RuntimeException("Undo tracking already enabled");
         }
         $this->has_enabled_undo_tracker = true;

--- a/src/Phan/CodeBase/UndoTracker.php
+++ b/src/Phan/CodeBase/UndoTracker.php
@@ -133,7 +133,7 @@ class UndoTracker
     {
         $file = $this->current_parsed_file;
         if (!\is_string($file)) {
-            throw new \Error("Called recordUndo in CodeBaseMutable, but not parsing a file");
+            throw new \RuntimeException("Called recordUndo in CodeBaseMutable, but not parsing a file");
         }
         if (!isset($this->undoOperationsForPath[$file])) {
             $this->undoOperationsForPath[$file] = [];

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -371,6 +371,12 @@ class Config
         // are not documented in the PHPDoc of functions, methods, and closures.
         'warn_about_undocumented_throw_statements' => false,
 
+        // Phan will not warn about lack of documentation of (at)throws for any of the configured classes or their subclasses.
+        // This only matters when warn_about_undocumented_throw_statements is true.
+        // The default is the empty array (Warn about every kind of Throwable)
+        // (E.g. ['\RuntimeException', '\AssertionError', '\TypeError'])
+        'exception_classes_with_optional_throws_phpdoc' => [ ],
+
         // This setting maps case insensitive strings to union types.
         // This is useful if a project uses phpdoc that differs from the phpdoc2 standard.
         // If the corresponding value is the empty string, Phan will ignore that union type (E.g. can ignore 'the' in `@return the value`)

--- a/src/Phan/Daemon.php
+++ b/src/Phan/Daemon.php
@@ -4,7 +4,9 @@ namespace Phan;
 use Phan\Daemon\Request;
 use Phan\Daemon\Transport\StreamResponder;
 use Phan\Daemon\ExitException;
+
 use Closure;
+use InvalidArgumentException;
 
 /**
  * A simple analyzing daemon that can be used by IDEs. (see `phan_client`)
@@ -197,6 +199,7 @@ class Daemon
 
     /**
      * @return resource (resource is not a reserved keyword)
+     * @throws InvalidArgumentException if the config does not specify a method. (should not happen)
      */
     private static function createDaemonStreamSocketServer()
     {
@@ -206,7 +209,7 @@ class Daemon
         } elseif (Config::getValue('daemonize_tcp_port')) {
             $listen_url = sprintf('tcp://127.0.0.1:%d', Config::getValue('daemonize_tcp_port'));
         } else {
-            throw new \InvalidArgumentException("Should not happen, no port/socket for daemon to listen on.");
+            throw new InvalidArgumentException("Should not happen, no port/socket for daemon to listen on.");
         }
         printf(
             "Listening for Phan analysis requests at %s\nAwaiting analysis requests for directory %s\n",

--- a/src/Phan/Daemon/Request.php
+++ b/src/Phan/Daemon/Request.php
@@ -106,6 +106,9 @@ class Request
         return -1;
     }
 
+    /**
+     * @throws ExitException to imitate an exit without actually exiting
+     */
     public function exit(int $exit_code)
     {
         if ($this->should_exit) {

--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -559,14 +559,12 @@ class Context extends FileRef
      * The element who's scope we're in. If we're in the global
      * scope this method will go down in flames and take your
      * process with it.
+     *
+     * @throws CodeBaseException if this was called without first checking
+     * if this context is in an element scope
      */
     public function getElementInScope(CodeBase $code_base) : TypedElement
     {
-        \assert(
-            $this->isInElementScope(),
-            "Cannot get element in scope if we're in the global scope"
-        );
-
         if ($this->isInFunctionLikeScope()) {
             return $this->getFunctionLikeInScope($code_base);
         } elseif ($this->isInPropertyScope()) {

--- a/src/Phan/Language/Element/ClassElement.php
+++ b/src/Phan/Language/Element/ClassElement.php
@@ -68,6 +68,9 @@ abstract class ClassElement extends AddressableElement
      * @return FullyQualifiedClassName
      * The FQSEN of this class element from where it was
      * originally defined
+     *
+     * @throws CodeBaseException if this was called without first checking
+     * if hasDefiningFQSEN()
      */
     public function getDefiningClassFQSEN() : FullyQualifiedClassName
     {
@@ -94,6 +97,7 @@ abstract class ClassElement extends AddressableElement
     /**
      * @return Clazz
      * The class on which this element was originally defined
+     * @throws CodeBaseException if hasDefiningFQSEN is false
      */
     public function getDefiningClass(CodeBase $code_base) : Clazz
     {

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -1510,6 +1510,8 @@ class Clazz extends AddressableElement
     /**
      * @return Method
      * The method with the given name
+     *
+     * @throws CodeBaseException if the method (or a placeholder) could not be found (or created)
      */
     public function getMethodByName(
         CodeBase $code_base,

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -1085,6 +1085,7 @@ trait FunctionTrait
 
     /**
      * @return array<mixed,string> in the same format as FunctionSignatureMap.php
+     * @throws \InvalidArgumentException if this function has invalid parameters for generating a stub (e.g. param names, types, etc.)
      */
     public function toFunctionSignatureArray() : array
     {

--- a/src/Phan/Language/Element/GlobalConstant.php
+++ b/src/Phan/Language/Element/GlobalConstant.php
@@ -44,6 +44,9 @@ class GlobalConstant extends AddressableElement implements ConstantInterface
      * @return GlobalConstant
      * A GlobalConstant structural element representing the given named
      * builtin constant.
+     *
+     * @throws \InvalidArgumentException
+     * If reflection could not locate the builtin constant.
      */
     public static function fromGlobalConstantName(
         string $name

--- a/src/Phan/Language/FQSEN/AbstractFQSEN.php
+++ b/src/Phan/Language/FQSEN/AbstractFQSEN.php
@@ -3,6 +3,8 @@ namespace Phan\Language\FQSEN;
 
 use Phan\Language\Context;
 use Phan\Language\FQSEN;
+
+use Error;
 use Serializable;
 
 /**
@@ -92,21 +94,30 @@ abstract class AbstractFQSEN implements FQSEN, Serializable
      */
     abstract public function __toString() : string;
 
+    /**
+     * @throws Error to prevent accidentally calling this
+     */
     public function __clone()
     {
         // We compare and look up FQSENs by their identity
-        throw new \Error("cloning an FQSEN (" . (string)$this . ") is forbidden\n");
+        throw new Error("cloning an FQSEN (" . (string)$this . ") is forbidden\n");
     }
 
+    /**
+     * @throws Error to prevent accidentally calling this
+     */
     public function serialize()
     {
         // We compare and look up FQSENs by their identity
-        throw new \Error("serializing an FQSEN (" . (string)$this . ") is forbidden\n");
+        throw new Error("serializing an FQSEN (" . (string)$this . ") is forbidden\n");
     }
 
+    /**
+     * @throws Error to prevent accidentally calling this
+     */
     public function unserialize($unused_serialized)
     {
         // We compare and look up FQSENs by their identity
-        throw new \Error("unserializing an FQSEN ($unused_serialized) is forbidden\n");
+        throw new Error("unserializing an FQSEN ($unused_serialized) is forbidden\n");
     }
 }

--- a/src/Phan/Language/FQSEN/FullyQualifiedFunctionName.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedFunctionName.php
@@ -38,6 +38,9 @@ class FullyQualifiedFunctionName extends FullyQualifiedGlobalStructuralElement i
      *
      * @param Context $context
      * The context in which the FQSEN string was found
+     *
+     * @throws EmptyFQSENException
+     * if $fqsen_string has an empty name component.
      */
     public static function fromStringInContext(
         string $fqsen_string,

--- a/src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php
@@ -31,6 +31,9 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN
      * @param int $alternate_id
      * An alternate ID for the element for use when
      * there are multiple definitions of the element
+     *
+     * @throws EmptyFQSENException
+     * if the name component of this FullyQualifiedGlobalStructuralElement is empty
      */
     protected function __construct(
         string $namespace,

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -11,6 +11,7 @@ use Phan\CodeBase;
 use Phan\Config;
 
 use ast\Node;
+use InvalidArgumentException;
 
 final class GenericArrayType extends ArrayType
 {
@@ -61,11 +62,13 @@ final class GenericArrayType extends ArrayType
      *
      * @param int $key_type
      * Corresponds to the type of the array keys. Set this to a GenericArrayType::KEY_* constant.
+     *
+     * @throws InvalidArgumentException if $key_type is an invalid constant
      */
     protected function __construct(Type $type, bool $is_nullable, int $key_type)
     {
         if ($key_type & ~3) {
-            throw new \InvalidArgumentException("Invalid key_type $key_type");
+            throw new InvalidArgumentException("Invalid key_type $key_type");
         }
         parent::__construct('\\', self::NAME, [], $is_nullable);
         $this->element_type = $type;

--- a/src/Phan/Language/Type/LiteralStringType.php
+++ b/src/Phan/Language/Type/LiteralStringType.php
@@ -4,6 +4,7 @@ namespace Phan\Language\Type;
 use Phan\Config;
 use Phan\Language\Type;
 
+use InvalidArgumentException;
 use RuntimeException;
 
 final class LiteralStringType extends StringType implements LiteralTypeInterface
@@ -21,8 +22,9 @@ final class LiteralStringType extends StringType implements LiteralTypeInterface
     }
 
     /**
-     * @internal - Only exists to prevent accidentally calling this
+     * @internal - Only exists to prevent accidentally calling this on the parent class
      * @deprecated
+     * @throws RuntimeException to prevent this from being called
      */
     public static function instance(bool $unused_is_nullable)
     {
@@ -94,11 +96,14 @@ final class LiteralStringType extends StringType implements LiteralTypeInterface
     /**
      * The opposite of __toString()
      * @return StringType|LiteralStringType
+     * @throws InvalidArgumentException
+     * if the $escaped_string is not using the proper escaping
+     * (should not happen if UnionType's regex is used)
      */
     public static function fromEscapedString(string $escaped_string, bool $is_nullable) : StringType
     {
         if (\strlen($escaped_string) < 2 || $escaped_string[0] !== "'" || \substr($escaped_string, -1) !== "'") {
-            throw new \InvalidArgumentException("Expected the literal type string to begin and end with \"'\"");
+            throw new InvalidArgumentException("Expected the literal type string to begin and end with \"'\"");
         }
         $escaped_string = \substr($escaped_string, 1, -1);
         $escaped_string = preg_replace_callback(

--- a/src/Phan/LanguageServer/Logger.php
+++ b/src/Phan/LanguageServer/Logger.php
@@ -67,7 +67,7 @@ class Logger
     public static function setLogFile($newFile)
     {
         if (!is_resource($newFile)) {
-            throw new \InvalidArgumentException("Expected newFile to be a resource, got " . gettype($newFile));
+            throw new \TypeError("Expected newFile to be a resource, got " . gettype($newFile));
         }
         if (is_resource(self::$file)) {
             if (self::$file === $newFile) {

--- a/src/Phan/LanguageServer/Utils.php
+++ b/src/Phan/LanguageServer/Utils.php
@@ -24,6 +24,7 @@ class Utils
     public static function crash(Throwable $err)
     {
         Loop\nextTick(function () use ($err) {
+            // @phan-suppress-next-line PhanThrowTypeAbsent this is meant to crash the loop for debugging.
             throw $err;
         });
     }

--- a/src/Phan/Library/None.php
+++ b/src/Phan/Library/None.php
@@ -1,6 +1,8 @@
 <?php declare(strict_types=1);
 namespace Phan\Library;
 
+use Exception;
+
 /**
  * @inherits Option<null>
  */
@@ -32,10 +34,11 @@ class None extends Option
 
     /**
      * @return null
+     * @throws Exception to indicate that get() was called without checking for a value.
      */
     public function get()
     {
-        throw new \Exception("Cannot call get on None");
+        throw new Exception("Cannot call get on None");
     }
 
     /**

--- a/src/Phan/Plugin/Internal/MiscParamPlugin.php
+++ b/src/Phan/Plugin/Internal/MiscParamPlugin.php
@@ -125,6 +125,8 @@ final class MiscParamPlugin extends PluginV2 implements
         };
         /**
          * @return void
+         * @throws StopParamAnalysisException
+         * to prevent Phan's default incorrect analysis of a call to join()
          */
         $join_callback = function (
             CodeBase $code_base,

--- a/tests/files/expected/0503_unused_assign_op.php.expected
+++ b/tests/files/expected/0503_unused_assign_op.php.expected
@@ -1,0 +1,3 @@
+%s:4 PhanUnusedVariable Unused definition of variable $y
+%s:5 PhanUnusedVariable Unused definition of variable $x
+%s:8 PhanUnusedVariable Unused definition of variable $str

--- a/tests/files/src/0503_unused_assign_op.php
+++ b/tests/files/src/0503_unused_assign_op.php
@@ -1,0 +1,10 @@
+<?php
+call_user_func(function() {
+    $x = 2;
+    $y = 2;
+    $x += 3;
+    $str = 'prefix';
+    $str .= 'And';
+    $str .= 'Suffix';
+});
+


### PR DESCRIPTION
Add `exception_classes_with_optional_throws_phpdoc`.

Also, fully enable this plugin for self-analysis.
(Will add recursive checks later)

For #90

RuntimeException, TypeError, AssertionError etc are used within Phan
itself when something is horribly wrong.

Commit missing test files, fix a small bug in the language server.