### PR TITLE
Don't add '$this' to static closure's scope

### DIFF
--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -339,6 +339,12 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
         Context $context,
         Func $func
     ) {
+        // skip adding $this to internal scope if the closure is a static one
+        if ($func->getNode() instanceof Node && ($func->getNode()->flags == \ast\flags\MODIFIER_STATIC))
+        {
+            return;
+        }
+
         $override_this_fqsen = self::getOverrideClassFQSEN($code_base, $func);
         if ($override_this_fqsen !== null) {
             if ($context->getScope()->hasVariableWithName('this') || !$context->isInClassScope()) {

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -340,7 +340,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
         Func $func
     ) {
         // skip adding $this to internal scope if the closure is a static one
-        if ($func->getNode() instanceof Node && ($func->getNode()->flags == \ast\flags\MODIFIER_STATIC))
+        if ($func->getFlags() == \ast\flags\MODIFIER_STATIC)
         {
             return;
         }

--- a/tests/files/expected/0012_closures.php.expected
+++ b/tests/files/expected/0012_closures.php.expected
@@ -1,2 +1,3 @@
 %s:13 PhanUndeclaredVariable Variable $c is undeclared
 %s:13 PhanUnusedClosureUseVariable Closure use variable $c is never used
+%s:24 PhanUndeclaredVariable Variable $this is undeclared

--- a/tests/files/src/0012_closures.php
+++ b/tests/files/src/0012_closures.php
@@ -17,4 +17,11 @@ class A {
 
         return $closure(3);
     }
+
+    public function staticClosure()
+    {
+        return static function() {
+            return $this->a;
+        };
+    }
 }


### PR DESCRIPTION
Fixes #768 

Note: had to add `instanceof` check because AppVeyor build failed. Not sure why `getNode()` is `null` there and I can't check (I don't have any Windows system at hands)