### PR TITLE
Deprecated Config's __set() and __get()

### DIFF
--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -292,7 +292,7 @@ This category of issue is emitted when there are compatibility issues. They will
 
 This issue will be thrown if there is an expression that may be treated differently in PHP7 than it was in previous major versions of the PHP runtime. Take a look at the [PHP7 Migration Manual](http://php.net/manual/en/migration70.incompatible.php) to understand changes in behavior.
 
-The config `Config::get()->backward_compatibility_checks` must be enabled for this to run such as by passing the command line argument `--backward-compatibility-checks` or by defining it in a `.phan/config.php` file such as [Phan's own config](https://github.com/phan/phan/blob/master/.phan/config.php).
+The config `backward_compatibility_checks` must be enabled for this to run such as by passing the command line argument `--backward-compatibility-checks` or by defining it in a `.phan/config.php` file such as [Phan's own config](https://github.com/phan/phan/blob/master/.phan/config.php).
 
 ```
 {CLASS} expression may not be PHP 7 compatible
@@ -338,7 +338,7 @@ Type '{TYPE}' refers to any object starting in PHP 7.2. In PHP 7.1 and earlier, 
 
 This issue will be thrown if there is an expression that may be treated differently in PHP7 than it was in previous major versions of the PHP runtime. Take a look at the [PHP7 Migration Manual](http://php.net/manual/en/migration70.incompatible.php) to understand changes in behavior.
 
-The config `Config::get()->backward_compatibility_checks` must be enabled for this to run such as by passing the command line argument `--backward-compatibility-checks` or by defining it in a `.phan/config.php` file such as [Phan's own config](https://github.com/phan/phan/blob/master/.phan/config.php).
+The config `backward_compatibility_checks` must be enabled for this to run such as by passing the command line argument `--backward-compatibility-checks` or by defining it in a `.phan/config.php` file such as [Phan's own config](https://github.com/phan/phan/blob/master/.phan/config.php).
 
 ```
 Expression may not be PHP 7 compatible
@@ -600,13 +600,13 @@ Catch statement for {CLASSLIKE} is unreachable. An earlier catch statement at li
 
 Similar issues exist for PhanUnreferencedProperty, PhanUnreferencedConstant, PhanUnreferencedMethod, and PhanUnreferencedFunction
 
-This issue is disabled by default, but can be enabled by setting `Config::get()->dead_code_detection` to enabled. It indicates that the given element is (possibly) unused.
+This issue is disabled by default, but can be enabled by setting `dead_code_detection` to enabled. It indicates that the given element is (possibly) unused.
 
 ```
 Possibly zero references to class {CLASS}
 ```
 
-This will be emitted for the following code so long as `Config::get()->dead_code_detection` is enabled.
+This will be emitted for the following code so long as `dead_code_detection` is enabled.
 
 ```php
 class C {}
@@ -2129,7 +2129,7 @@ Reference to undeclared static method {METHOD} in callable
 
 ## PhanUndeclaredStaticProperty
 
-Attempting to read a property that doesn't exist will result in this issue. You'll also see this issue if you write to an undeclared static property so long as `Config::get()->allow_missing_property` is false (which defaults to true).
+Attempting to read a property that doesn't exist will result in this issue. You'll also see this issue if you write to an undeclared static property so long as `allow_missing_property` is false (which defaults to true).
 
 ```
 Static property '{PROPERTY}' on {CLASS} is undeclared

--- a/plugins/codeclimate/engine
+++ b/plugins/codeclimate/engine
@@ -7,7 +7,6 @@ $code_base = require_once(__DIR__ . '/../../src/codebase.php');
 require_once(__DIR__ . '/../../src/Phan/Bootstrap.php');
 
 use Phan\CLI;
-use Phan\CodeBase;
 use Phan\Config;
 use Phan\Issue;
 use Phan\Output\Collector\BufferingCollector;
@@ -15,7 +14,6 @@ use Phan\Output\Filter\CategoryIssueFilter;
 use Phan\Output\Filter\ChainedIssueFilter;
 use Phan\Output\Filter\FileIssueFilter;
 use Phan\Output\Filter\MinimumSeverityFilter;
-use Phan\Output\ParallelConsoleOutput;
 use Phan\Output\PrinterFactory;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Phan\Phan;
@@ -47,15 +45,15 @@ if ($inner_config['ignore-undeclared'] ?? false) {
 }
 
 if (isset($inner_config['quick'])) {
-    Config::get()->quick_mode = (bool)$inner_config['quick'];
+    Config::setValue('quick_mode', (bool)$inner_config['quick']);
 }
 
 if (isset($inner_config['backward-compatibility-checks'])) {
-    Config::get()->backward_compatibility_checks = (bool)$inner_config['backward-compatibility-checks'];
+    Config::setValue('backward_compatibility_checks', (bool)$inner_config['backward-compatibility-checks']);
 }
 
 if (isset($inner_config['dead-code-detection'])) {
-    Config::get()->dead_code_detection = (bool)$inner_config['dead-code-detection'];
+    Config::setValue('dead_code_detection', (bool)$inner_config['dead-code-detection']);
 }
 
 if (isset($inner_config['file_extensions'])) {
@@ -103,7 +101,7 @@ if (empty($include_paths)) {
 
 $output = new ConsoleOutput();
 $factory = new PrinterFactory();
-Config::get()->markdown_issue_messages = true;
+Config::setValue('markdown_issue_messages', true);
 $printer = $factory->getPrinter('codeclimate', $output);
 Phan::setPrinter($printer);
 

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -1341,7 +1341,7 @@ class CodeBase
             // (All of the functions were loaded during initialization)
             //
             // Also, skip over user-defined global functions defined **by Phan** and its dependencies for analysis
-            if (!Config::get()->ignore_undeclared_functions_with_known_signatures) {
+            if (!Config::getValue('ignore_undeclared_functions_with_known_signatures')) {
                 return false;
             }
             // If we already created the alternates, do nothing.

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -897,6 +897,7 @@ class Config
      */
     public function __get(string $name)
     {
+        trigger_error("Getting Config values using __get is deprecated; use Config::getValue() instead", E_USER_DEPRECATED);
         return self::getValue($name);
     }
 
@@ -923,6 +924,7 @@ class Config
      */
     public function __set(string $name, $value)
     {
+        trigger_error("Setting Config values using __set is deprecated; use Config::setValue() instead", E_USER_DEPRECATED);
         self::setValue($name, $value);
     }
 

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -897,7 +897,6 @@ class Config
      */
     public function __get(string $name)
     {
-        trigger_error("Getting Config values using __get is deprecated; use Config::getValue() instead", E_USER_DEPRECATED);
         return self::getValue($name);
     }
 
@@ -924,7 +923,6 @@ class Config
      */
     public function __set(string $name, $value)
     {
-        trigger_error("Setting Config values using __set is deprecated; use Config::setValue() instead", E_USER_DEPRECATED);
         self::setValue($name, $value);
     }
 

--- a/src/Phan/Language/Element/Comment.php
+++ b/src/Phan/Language/Element/Comment.php
@@ -696,7 +696,7 @@ class Comment
         string $original_type
     ) : string {
         // TODO: Would need to pass in CodeBase to emit an issue:
-        $type = Config::get()->phpdoc_type_mapping[\strtolower($original_type)] ?? null;
+        $type = Config::getValue('phpdoc_type_mapping')[\strtolower($original_type)] ?? null;
         if (\is_string($type)) {
             return $type;
         }

--- a/src/Phan/Phan.php
+++ b/src/Phan/Phan.php
@@ -391,7 +391,7 @@ class Phan implements IgnoredFilesFilterInterface
             // Collect all issues, blocking
             self::display();
 
-            if (Config::get()->print_memory_usage_summary) {
+            if (Config::getValue('print_memory_usage_summary')) {
                 self::printMemoryUsageSummary();
             }
         } catch (Exception $e) {


### PR DESCRIPTION
Another "my eyes bleed so I'm going to fix this" PR.

I've removed `__set()` and `__get()` intially, but changed it later to throw a notice instead, as it could break 3rd-party code? 🤔 