### PR TITLE
Support "go to definition" of classes in comments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,8 +29,10 @@ New features(CLI, Configs)
 Language Server/Daemon mode:
 + Fix another rare bug that can cause crashes in the polyfill/fallback parser when parsing invalid or incomplete ASTs.
 + Add a `--language-server-hide-category` setting to hide the issue category from diagnostic messages.
-+ Remove the numeric diagnostic code from the language server diagnostics (issues).
-  (E.g. LanguageClient-neovim would render that the code in the quickfix menu)
++ Remove the numeric diagnostic code from the language server diagnostics (a.k.a. issues).
+  (Certain language clients such as LanguageClient-neovim would render that the code in the quickfix menu, wasting space)
++ Support "go to definition" for union types within all code comment types  (#1704)
+  (e.g. can go to definition in `// some annotation or comment mentioning MyType`)
 
 New features(Analysis)
 + Support analysis of [`list()` reference assignment](https://wiki.php.net/rfc/list_reference_assignment) for php 7.3 (which is still in alpha). (#1537)

--- a/src/Phan/AST/Parser.php
+++ b/src/Phan/AST/Parser.php
@@ -11,6 +11,7 @@ use Phan\Daemon\Request;
 use Phan\Issue;
 use Phan\Language\Context;
 use Phan\Phan;
+use Phan\Plugin\ConfigPluginSet;
 
 use ast\Node;
 use ParseError;
@@ -157,7 +158,13 @@ class Parser
     {
         if ($request && $request->shouldUseMappingPolyfill($file_path)) {
             // TODO: Rename to something better
-            return new TolerantASTConverterWithNodeMapping($request->getTargetByteOffset($file_contents));
+            return new TolerantASTConverterWithNodeMapping(
+                $request->getTargetByteOffset($file_contents),
+                function (Node $node) {
+                    // @phan-suppress-next-line PhanAccessMethodInternal
+                    ConfigPluginSet::instance()->prepareNodeSelectionPluginForNode($node);
+                }
+            );
         }
 
         return new TolerantASTConverter();

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverterWithNodeMapping.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverterWithNodeMapping.php
@@ -3,12 +3,15 @@
 namespace Phan\AST\TolerantASTConverter;
 
 use ast;
+use Closure;
 use InvalidArgumentException;
 use Microsoft\PhpParser;
 use Microsoft\PhpParser\Diagnostic;
 use Microsoft\PhpParser\Token;
 use Microsoft\PhpParser\TokenKind;
 use Throwable;
+
+use function preg_match;
 
 /**
  * This is a subclass of TolerantASTConverter
@@ -38,17 +41,47 @@ use Throwable;
 class TolerantASTConverterWithNodeMapping extends TolerantASTConverter
 {
     /**
-     * @var PhpParser\Node|PhpParser\Token|null
-     * TODO: If this is null, then just create a parent instance and call that.
+     * @var PhpParser\Node|Token|null
+     * This is the closest node or token from tolerant-php-parser
+     * (among the nodes being parsed **that will have a corresponding ast\Node be created**)
+     *
+     * TODO: If this is null, then just use TolerantASTConverter's node generation logic to be a bit faster
      */
     private static $closest_node_or_token;
 
-    /** @var int */
-    private $expected_byte_offset;
+    /**
+     * @var ?Token
+     * TODO: If this is null, then just use TolerantASTConverter's node generation logic to be a bit faster
+     */
+    private static $closest_node_or_token_symbol;
 
-    public function __construct(int $expected_byte_offset)
+    /** @var int */
+    private static $expected_byte_offset;
+
+    /** @var int */
+    private $instance_expected_byte_offset;
+
+    /**
+     * @var null|Closure(ast\Node):void
+     * @see $this->instance_handle_selected_node
+     */
+    private static $handle_selected_node;
+
+    /**
+     * @var null|Closure(ast\Node):void This is optional. If it is set, this is invoked on the Node we marked.
+     * Currently, this is used to add plugin methods at runtime (limited to what is needed to handle that node's kind)
+     */
+    private $instance_handle_selected_node;
+
+    /**
+     * @param int $expected_byte_offset the byte offset of the cursor
+     * @param null|Closure(ast\Node):void $handle_selected_node this can be passed in.
+     *                      If a node corresponding to a reference was found, then this closure will be invoked once with that node.
+     */
+    public function __construct(int $expected_byte_offset, Closure $handle_selected_node = null)
     {
-        $this->expected_byte_offset = $expected_byte_offset;
+        $this->instance_expected_byte_offset = $expected_byte_offset;
+        $this->instance_handle_selected_node = $handle_selected_node;
     }
 
     /**
@@ -62,7 +95,9 @@ class TolerantASTConverterWithNodeMapping extends TolerantASTConverter
     public function parseCodeAsPHPAST(string $file_contents, int $version, array &$errors = [])
     {
         // Force the byte offset to be within the
-        $byte_offset = \max(0, \min(\strlen($file_contents), $this->expected_byte_offset));
+        $byte_offset = \max(0, \min(\strlen($file_contents), $this->instance_expected_byte_offset));
+        self::$expected_byte_offset = $byte_offset;
+        self::$handle_selected_node = $this->instance_handle_selected_node;
 
         if (!\in_array($version, self::SUPPORTED_AST_VERSIONS)) {
             throw new InvalidArgumentException(sprintf("Unexpected version: want %s, got %d", \implode(', ', self::SUPPORTED_AST_VERSIONS), $version));
@@ -72,13 +107,14 @@ class TolerantASTConverterWithNodeMapping extends TolerantASTConverter
         try {
             $parser_node = static::phpParserParse($file_contents, $errors);
             self::findNodeAtOffset($parser_node, $byte_offset);
-            // fwrite(STDERR, "Seeking node: " . json_encode(self::$closest_node_or_token). "\n");
+            // fwrite(STDERR, "Seeking node: " . json_encode(self::$closest_node_or_token) . "nearby: " . json_encode(self::$closest_node_or_token_symbol) . "\n");
             return $this->phpParserToPhpast($parser_node, $version, $file_contents);
         } catch (Throwable $e) {
-            fprintf(STDERR, "saw exception: %s\n", $e->getMessage());
+            // fprintf(STDERR, "saw exception: %s\n", $e->getMessage());
             throw $e;
         } finally {
             self::$closest_node_or_token = null;
+            self::$closest_node_or_token_symbol = null;
         }
     }
 
@@ -92,14 +128,19 @@ class TolerantASTConverterWithNodeMapping extends TolerantASTConverter
     private static function findNodeAtOffset(PhpParser\Node $parser_node, int $offset)
     {
         self::$closest_node_or_token = null;
+        self::$closest_node_or_token_symbol = null;
+        // fprintf(STDERR, "Seeking offset %d\n", $offset);
         self::findNodeAtOffsetRecursive($parser_node, $offset);
     }
 
-    const _KINDS_TO_RETURN_PARENT = [
-        TokenKind::Name,
-        TokenKind::VariableName,
-        TokenKind::StringLiteralToken,  // TODO: Make this depend on context
-        TokenKind::BackslashToken,
+    /**
+     * We use a blacklist because there are more many more tokens we want to use the parent for.
+     * For example, when navigating to class names in comments, the comment can be prior to pretty much any token (e.g. AmpersandToken, PublicKeyword, etc.)
+     *
+     * @internal
+     */
+    const KINDS_TO_NOT_RETURN_PARENT = [
+        TokenKind::QualifiedName => true,
     ];
 
     /**
@@ -109,13 +150,20 @@ class TolerantASTConverterWithNodeMapping extends TolerantASTConverter
     {
         foreach ($parser_node->getChildNodesAndTokens() as $key => $node_or_token) {
             if ($node_or_token instanceof Token) {
+                // fprintf(STDERR, "Scanning over Token %s %d %d-%d\n", Token::getTokenKindNameFromValue($node_or_token->kind), $node_or_token->fullStart, $node_or_token->start, $node_or_token->getEndPosition());
                 if ($node_or_token->getEndPosition() > $offset) {
                     if ($node_or_token->start > $offset) {
-                        // The cursor is hovering over whitespace.
-                        // Give up.
-                        return true;
+                        if ($node_or_token->fullStart <= $offset) {
+                            // The cursor falls within the leading comments (doc comment or otherwise)
+                            // of this token.
+                            self::$closest_node_or_token_symbol = $node_or_token;
+                        } elseif (self::$closest_node_or_token_symbol === null) {
+                            // The cursor is hovering over whitespace.
+                            // Give up.
+                            return true;
+                        }
                     }
-                    if (\in_array($node_or_token->kind, self::_KINDS_TO_RETURN_PARENT, true)) {
+                    if (!\in_array($node_or_token->kind, self::KINDS_TO_NOT_RETURN_PARENT, true)) {
                         // We want the parent of a Name, e.g. a class
                         self::$closest_node_or_token = $parser_node;
                         // fwrite(STDERR, "Found node: " . json_encode($parser_node) . "\n");
@@ -128,6 +176,12 @@ class TolerantASTConverterWithNodeMapping extends TolerantASTConverter
                 }
             }
             if ($node_or_token instanceof PhpParser\Node) {
+                $end_position = $node_or_token->getEndPosition();
+                // fprintf(STDERR, "Scanning over Node %s %d-%d\n", get_class($node_or_token), $node_or_token->getStart(), $end_position);
+                if ($end_position < $offset) {
+                    // End this early if this token ends before the cursor even starts
+                    continue;
+                }
                 $state = self::findNodeAtOffsetRecursive($node_or_token, $offset);
                 if ($state) {
                     // fwrite(STDERR, "Found parent node for $key: " . get_class($parser_node) . "\n");
@@ -143,6 +197,10 @@ class TolerantASTConverterWithNodeMapping extends TolerantASTConverter
     }
 
     /**
+     * This optionally adjusts the closest_node_or_token to a more useful value.
+     * (so that functionality such as "go to definition" for classes, properties, etc. will work as expected)
+     *
+     * @param PhpParser\Node $node the parent node of the old value of
      * @return PhpParser\Node|true
      */
     private static function adjustClosestNodeOrToken(PhpParser\Node $node, $key)
@@ -176,16 +234,76 @@ class TolerantASTConverterWithNodeMapping extends TolerantASTConverter
     }
 
     /**
-     * @param PhpParser\Node|Token $n @phan-unused-param
-     * @param mixed $ast_node
+     * This marks the tolerant-php-parser Node as being selected,
+     * and adds any information that will be useful to code handling the corresponding
+     *
+     * @param PhpParser\Node|Token $n @phan-unused-param the tolerant-php-parser node that generated the $ast_node
+     * @param mixed $ast_node the node that was selected because it was under the cursor
      */
     private static function markNodeAsSelected($n, $ast_node)
     {
         // fwrite(STDERR, "Marking corresponding node as flagged: " . json_encode($n) . "\n" . json_encode($ast_node) . "\n");
         // fflush(STDERR);
         if ($ast_node instanceof ast\Node) {
+            if (self::$closest_node_or_token_symbol !== null) {
+                // fwrite(STDERR, "Marking corresponding node as flagged: " . json_encode($n) . "\n" . json_encode($ast_node) . "\n");
+                // fflush(STDERR);
+
+                // TODO: This won't work if the comment is at the end of the file. Add a dummy statement or something to associate it with.
+                //
+                // TODO: Extract the longest class name or method name from the doc comment
+                $fragment = self::extractFragmentFromCommentLike();
+                if ($fragment === null) {
+                    // We're inside of a string or doc comment but failed to extract a class name
+                    return;
+                }
+                // fwrite(STDERR, "Marking selectedFragment = $fragment\n");
+                $ast_node->isSelectedApproximate = self::$closest_node_or_token_symbol;
+                $ast_node->selectedFragment = $fragment;
+            }
             $ast_node->isSelected = true;
+            $closure = self::$handle_selected_node;
+            if ($closure) {
+                $closure($ast_node);
+            }
         }
+    }
+
+    /**
+     * @internal
+     */
+    const VALID_FRAGMENT_CHARACTER_REGEX = '/[\\\\a-z0-9_\x7f-\xff]/i';
+
+    /**
+     * @return ?string A fragment that is a potentially valid class or function identifier (e.g. 'MyNs\MyClass', '\MyClass')
+     *                 for the comment or string under the cursor
+     *
+     * TODO: Support method identifiers?
+     * TODO: Support variables?
+     * TODO: Implement support for going to function definitions if no class could be found
+     */
+    private static function extractFragmentFromCommentLike()
+    {
+        $offset = self::$expected_byte_offset;
+        $contents = self::$file_contents;
+
+        // fwrite(STDERR, __METHOD__ . " looking for $offset\n");
+        if (!preg_match(self::VALID_FRAGMENT_CHARACTER_REGEX, $contents[$offset] ?? '')) {
+            // fwrite(STDERR, "Giving up, invalid character at $offset\n");
+            // Give up if the character under the cursor is an invalid character for a token
+            return null;
+        }
+        // Iterate backwards to find the start of this class identifier
+        while ($offset > 0 && preg_match(self::VALID_FRAGMENT_CHARACTER_REGEX, $contents[$offset - 1])) {
+            $offset--;
+        }
+        // fwrite(STDERR, "Moved back to $offset, searching at " . json_encode(substr($contents, $offset, 20)) . "\n");
+
+        if (preg_match('/\\\\?[a-z_\x7f-\xff][a-z0-9_\x7f-\xff]*(\\\\[a-z_\x7f-\xff][a-z0-9_\x7f-\xff]*)*/i', $contents, $matches, 0, $offset) > 0) {
+            // fwrite(STDERR, "Returning $matches[0]\n");
+            return $matches[0];
+        }
+        return null;
     }
 
     /**

--- a/src/Phan/Daemon/Transport/Responder.php
+++ b/src/Phan/Daemon/Transport/Responder.php
@@ -13,11 +13,11 @@ interface Responder
     /**
      * @return ?array the request data(E.g. returns null if JSON is malformed)
      */
-    function getRequestData();
+    public function getRequestData();
 
     /**
      * This must be called exactly once
      * @return void
      */
-    function sendResponseAndClose(array $data);
+    public function sendResponseAndClose(array $data);
 }

--- a/src/Phan/Plugin/Internal/NodeSelectionPlugin.php
+++ b/src/Phan/Plugin/Internal/NodeSelectionPlugin.php
@@ -31,35 +31,6 @@ class NodeSelectionPlugin extends PluginV2 implements PostAnalyzeNodeCapability
     }
 }
 
-trait NodeSelectionTrait
-{
-    /**
-     * @var Context $context
-     * @suppress PhanReadOnlyProtectedProperty
-     */
-    protected $context;
-
-    /**
-     * @param Node $node
-     * A node to check
-     *
-     * @return void
-     * @suppress PhanUnreferencedPublicMethod (TODO: Fix false positive. The aliases are used)
-     */
-    public function visitCommonImplementation(Node $node)
-    {
-        if (!\property_exists($node, 'isSelected')) {
-            return;
-        }
-        if (!NodeSelectionVisitor::$closure) {
-            // This should not be possible.
-            // fwrite(STDERR, "Calling NodeSelectionVisitor without a closure\n");
-            return;
-        }
-        (NodeSelectionVisitor::$closure)($this->context, $node);
-    }
-}
-
 /**
  * When __invoke on this class is called with a node, a method
  * will be dispatched based on the `kind` of the given node.
@@ -73,21 +44,25 @@ class NodeSelectionVisitor extends PluginAwarePostAnalysisVisitor
 
     // A plugin's visitors should not override visit() unless they need to.
 
-    use NodeSelectionTrait {
-        visitCommonImplementation as visitClass;
-        visitCommonImplementation as visitCall;
-        visitCommonImplementation as visitStaticCall;
-        visitCommonImplementation as visitMethodCall;
-        visitCommonImplementation as visitName;
-        visitCommonImplementation as visitProp;
-        visitCommonImplementation as visitStaticProp;
-        visitCommonImplementation as visitClassConst;
-        visitCommonImplementation as visitConst;
-        visitCommonImplementation as visitUse;  // Uses visitUse instead of visitUseElem to be sure if it's a class/func/constant
-
-        visitCommonImplementation as visitVar;  // For "go to type definition"
-        // TODO: VisitNew
-        // TODO: implement, extend, use trait, etc.
+    /**
+     * @param Node $node
+     * A node to check
+     *
+     * @return void
+     * @see ConfigPluginSet->prepareNodeSelectionPlugin() for how this is called
+     */
+    public function visitCommonImplementation(Node $node)
+    {
+        if (!\property_exists($node, 'isSelected')) {
+            return;
+        }
+        $closure = NodeSelectionVisitor::$closure;
+        if (!$closure) {
+            // This should not be possible.
+            // fwrite(STDERR, "Calling NodeSelectionVisitor without a closure\n");
+            return;
+        }
+        $closure($this->context, $node);
     }
 }
 


### PR DESCRIPTION
Fixes #1704

Implement support for go to definition in comments.

Refactor the internal NodeSelectionPlugin so that it can add closures for
**any** node type, and to stop adding unnecessary closures for

The comment can be associated with any token type,
so switch from a whitelist to a blacklist for moving to the parent
definition.

- This might affect go to definition for function calls, etc. in other ways,

  Not a high priority to fix that right now

Refactor some code and add comments