### PR TITLE
Fix or suppress pre-existing phpcs warnings

### DIFF
--- a/internal/phpcbf
+++ b/internal/phpcbf
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# This has been tested with phpcbf.phar 3.1.1 (3.1.1 or newer is suggested)
+# This has been tested with phpcbf.phar 3.3.0 (3.3.0 or newer is required)
 set -eu
 if [[ "$#" != 0 ]]; then
 	echo "Executing phpcbf.phar --standard=ruleset.xml $@"  1>&2

--- a/internal/phpcs
+++ b/internal/phpcs
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# This has been tested with phpcs.phar 3.1.1 (3.1.1 or newer is suggested)
+# This has been tested with phpcs.phar 3.3.0 (3.3.0 or newer is required)
 set -xu
-# Automatically detect PSR-2 syntax issues in Phan itself
+# Automatically detect PSR-2 and PSR-12 syntax issues in Phan itself
 if [[ "$#" != 0 ]]; then
 	echo "Executing phpcs.phar --standard=ruleset.xml $@"  1>&2
 	phpcs.phar --standard=ruleset.xml "$@"

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -7,12 +7,13 @@
   <rule ref="PSR1" />
   <rule ref="PSR2">
     <exclude name="Generic.Files.LineLength.TooLong" />
+    <!-- We put class initialization in the same file as methods -->
     <exclude name="PSR1.Files.SideEffects.FoundWithSymbols" />
+    <exclude name="PSR1.Classes.ClassDeclaration.MultipleClasses" />
   </rule>
-  <exclude-pattern>*SignatureMap*.php</exclude-pattern>
 
   <rule ref="PSR12" />
-  <!-- Arbitrary increase of line length limit -->
+  <!-- Arbitrary increase of the line length limit -->
   <rule ref="Generic.Files.LineLength">
     <properties>
       <property name="lineLimit" value="150"/>

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -405,7 +405,7 @@ class ContextNode
         $node = $this->node;
         if (!($node instanceof Node)) {
             if (\is_string($node)) {
-                return [LiteralStringType::instance_for_value($node, false)->asUnionType(), []];
+                return [LiteralStringType::instanceForValue($node, false)->asUnionType(), []];
             }
             return [UnionType::empty(), []];
         }

--- a/src/Phan/AST/TolerantASTConverter/StringUtil.php
+++ b/src/Phan/AST/TolerantASTConverter/StringUtil.php
@@ -46,7 +46,7 @@ use Error;
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-final class String_
+final class StringUtil
 {
     const REPLACEMENTS = [
         '\\' => '\\',

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -930,7 +930,7 @@ class TolerantASTConverter
                             $raw_string = static::tokenToRawString($part);
 
                             // Pass in '"\\n"' and get "\n" (somewhat inefficient)
-                            $represented_string = String_::parse($start_quote_text . $raw_string . $end_quote_text);
+                            $represented_string = StringUtil::parse($start_quote_text . $raw_string . $end_quote_text);
                             $inner_node_parts[] = $represented_string;
                         }
                     }
@@ -2544,14 +2544,14 @@ class TolerantASTConverter
             return $float;
         }
 
-        return String_::parse($str);
+        return StringUtil::parse($str);
     }
 
     private static function parseQuotedString(PhpParser\Node\StringLiteral $n) : string
     {
         $start = $n->getStart();
         $text = \substr(self::$file_contents, $start, $n->getEndPosition() - $start);
-        return String_::parse($text);
+        return StringUtil::parse($text);
     }
 
     /**

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverterWithNodeMapping.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverterWithNodeMapping.php
@@ -150,7 +150,14 @@ class TolerantASTConverterWithNodeMapping extends TolerantASTConverter
     {
         foreach ($parser_node->getChildNodesAndTokens() as $key => $node_or_token) {
             if ($node_or_token instanceof Token) {
-                // fprintf(STDERR, "Scanning over Token %s %d %d-%d\n", Token::getTokenKindNameFromValue($node_or_token->kind), $node_or_token->fullStart, $node_or_token->start, $node_or_token->getEndPosition());
+                // fprintf(
+                //     STDERR,
+                //     "Scanning over Token %s (fullStart=%d) %d-%d\n",
+                //     Token::getTokenKindNameFromValue($node_or_token->kind),
+                //     $node_or_token->fullStart,
+                //     $node_or_token->start,
+                //     $node_or_token->getEndPosition()
+                // );
                 if ($node_or_token->getEndPosition() > $offset) {
                     if ($node_or_token->start > $offset) {
                         if ($node_or_token->fullStart <= $offset) {

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -348,12 +348,12 @@ class UnionTypeVisitor extends AnalysisVisitor
 
     private static function literalIntUnionType(int $value) : UnionType
     {
-        return LiteralIntType::instance_for_value($value, false)->asUnionType();
+        return LiteralIntType::instanceForValue($value, false)->asUnionType();
     }
 
     private static function literalStringUnionType(string $value) : UnionType
     {
-        return LiteralStringType::instance_for_value($value, false)->asUnionType();
+        return LiteralStringType::instanceForValue($value, false)->asUnionType();
     }
 
     /**
@@ -1624,7 +1624,7 @@ class UnionTypeVisitor extends AnalysisVisitor
             }
             $result .= $part_string;
         }
-        return LiteralStringType::instance_for_value($result, false)->asUnionType();
+        return LiteralStringType::instanceForValue($result, false)->asUnionType();
     }
 
     /**

--- a/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
+++ b/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
@@ -269,7 +269,7 @@ class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
         if ($right_value === null) {
             return StringType::instance(false)->asUnionType();
         }
-        return LiteralStringType::instance_for_value($left_value . $right_value, false)->asUnionType();
+        return LiteralStringType::instanceForValue($left_value . $right_value, false)->asUnionType();
     }
 
     /**

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -1099,6 +1099,7 @@ EOB;
         }
         assert(
             extension_loaded('ast'),
+            // phpcs:ignore Generic.Files.LineLength.MaxExceeded
             'The php-ast extension must be loaded in order for Phan to work. See https://github.com/phan/phan#getting-it-running for more details. Alternately, invoke Phan with the CLI option --allow-polyfill-parser (which is noticeably slower)'
         );
 

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -838,7 +838,8 @@ class Config
         return self::$configuration;
     }
 
-    // @codingStandardsIgnoreStart method naming is deliberate to make these getters easier to search.
+    // method naming is deliberate to make these getters easier to search.
+    // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
 
     public static function get_null_casts_as_any_type() : bool
     {
@@ -889,7 +890,7 @@ class Config
     {
         return self::$closest_target_php_version_id;
     }
-    // @codingStandardsIgnoreEnd
+    // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
 
     /**
      * @return mixed

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -15,7 +15,8 @@ use Phan\Plugin\ConfigPluginSet;
  */
 class Issue
 {
-    // @codingStandardsIgnoreStart
+    // phpcs:disable Generic.NamingConventions.UpperCaseConstantName.ClassConstantNotUpperCase
+    // this is deliberate for issue names
     // Issue::CATEGORY_SYNTAX
     const SyntaxError               = 'PhanSyntaxError';
 
@@ -83,15 +84,15 @@ class Issue
     const TypeInvalidInstanceof     = 'PhanTypeInvalidInstanceof';
     const TypeInvalidDimOffset      = 'PhanTypeInvalidDimOffset';
     const TypeInvalidDimOffsetArrayDestructuring = 'PhanTypeInvalidDimOffsetArrayDestructuring';
-    const TypeInvalidThrowsNonObject = 'PhanTypeInvalidThrowsNonObject';
-    const TypeInvalidThrowsNonThrowable = 'PhanTypeInvalidThrowsNonThrowable';
-    const TypeInvalidThrowsIsTrait = 'PhanTypeInvalidThrowsIsTrait';
-    const TypeInvalidThrowsIsInterface = 'PhanTypeInvalidThrowsIsInterface';
-    const TypeMagicVoidWithReturn   = 'PhanTypeMagicVoidWithReturn';
-    const TypeMismatchArgument      = 'PhanTypeMismatchArgument';
-    const TypeMismatchArgumentInternal = 'PhanTypeMismatchArgumentInternal';
-    const PartialTypeMismatchArgument = 'PhanPartialTypeMismatchArgument';
-    const PartialTypeMismatchArgumentInternal= 'PhanPartialTypeMismatchArgumentInternal';
+    const TypeInvalidThrowsNonObject             = 'PhanTypeInvalidThrowsNonObject';
+    const TypeInvalidThrowsNonThrowable          = 'PhanTypeInvalidThrowsNonThrowable';
+    const TypeInvalidThrowsIsTrait               = 'PhanTypeInvalidThrowsIsTrait';
+    const TypeInvalidThrowsIsInterface           = 'PhanTypeInvalidThrowsIsInterface';
+    const TypeMagicVoidWithReturn                = 'PhanTypeMagicVoidWithReturn';
+    const TypeMismatchArgument                   = 'PhanTypeMismatchArgument';
+    const TypeMismatchArgumentInternal           = 'PhanTypeMismatchArgumentInternal';
+    const PartialTypeMismatchArgument            = 'PhanPartialTypeMismatchArgument';
+    const PartialTypeMismatchArgumentInternal    = 'PhanPartialTypeMismatchArgumentInternal';
     const PossiblyNullTypeArgument  = 'PhanPossiblyNullTypeArgument';
     const PossiblyNullTypeArgumentInternal = 'PhanPossiblyNullTypeArgumentInternal';
     const PossiblyFalseTypeArgument  = 'PhanPossiblyFalseTypeArgument';
@@ -344,6 +345,8 @@ class Issue
     const ThrowTypeAbsentForCall           = 'PhanThrowTypeAbsentForCall';
     const ThrowTypeMismatch                = 'PhanThrowTypeMismatch';
     const ThrowTypeMismatchForCall         = 'PhanThrowTypeMismatchForCall';
+    // phpcs:enable Generic.NamingConventions.UpperCaseConstantName.ClassConstantNotUpperCase
+    // end of issue name constants
 
 
     const CATEGORY_ACCESS            = 1 << 1;
@@ -409,7 +412,7 @@ class Issue
     const TYPE_ID_UNKNOWN = 999;
 
     // Keep sorted and in sync with Colorizing::default_color_for_template
-    const uncolored_format_string_for_template = [
+    const UNCOLORED_FORMAT_STRING_FOR_TEMPLATE = [
         'CLASS'         => '%s',
         'CLASSLIKE'     => '%s',
         'COMMENT'       => '%s',  // contents of a phpdoc comment
@@ -437,7 +440,6 @@ class Issue
         'TRAIT'         => '%s',
         'VARIABLE'      => '%s',
     ];
-    // @codingStandardsIgnoreEnd
 
     /** @var string */
     private $type;
@@ -491,17 +493,17 @@ class Issue
         /** @param array<int,string> $matches */
         return preg_replace_callback('/{([A-Z_]+)}/', function (array $matches) use ($template): string {
             $key = $matches[1];
-            $replacement_exists = \array_key_exists($key, self::uncolored_format_string_for_template);
+            $replacement_exists = \array_key_exists($key, self::UNCOLORED_FORMAT_STRING_FOR_TEMPLATE);
             if (!$replacement_exists) {
                 error_log(sprintf(
                     "No coloring info for issue message (%s), key {%s}. Valid template types: %s",
                     $template,
                     $key,
-                    implode(', ', array_keys(self::uncolored_format_string_for_template))
+                    implode(', ', array_keys(self::UNCOLORED_FORMAT_STRING_FOR_TEMPLATE))
                 ));
                 return '%s';
             }
-            return self::uncolored_format_string_for_template[$key];
+            return self::UNCOLORED_FORMAT_STRING_FOR_TEMPLATE[$key];
         }, $template);
     }
 
@@ -516,6 +518,7 @@ class Issue
             return $error_map;
         }
 
+        // phpcs:disable Generic.Files.LineLength
         /**
          * @var array<int,Issue>
          * Note: All type ids should be unique, and be grouped by the category.
@@ -2911,6 +2914,7 @@ class Issue
                 16014
             ),
         ];
+        // phpcs:enable Generic.Files.LineLength
 
         self::sanityCheckErrorList($error_list);
         // Verified the error meets preconditions, now add it.

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -2601,7 +2601,7 @@ class Clazz extends AddressableElement
         $class_constant = new ClassConstant(
             $this->getContext(),
             'class',
-            LiteralStringType::instance_for_value(
+            LiteralStringType::instanceForValue(
                 \ltrim($this->getFQSEN()->__toString(), '\\'),
                 false
             )->asUnionType(),

--- a/src/Phan/Language/Element/Comment.php
+++ b/src/Phan/Language/Element/Comment.php
@@ -633,7 +633,8 @@ class Comment
     }
 
     // TODO: Is `@return &array` valid phpdoc2?
-    const return_comment_regex = '/@(?:phan-)?(?:return|throws)\s+(&\s*)?(' . UnionType::union_type_regex_or_this . '+)/';
+    /** @internal */
+    const RETURN_COMMENT_REGEX = '/@(?:phan-)?(?:return|throws)\s+(&\s*)?(' . UnionType::union_type_regex_or_this . '+)/';
 
     /**
      * @param Context $context
@@ -655,7 +656,7 @@ class Comment
     ) {
         $return_union_type_string = '';
 
-        if (\preg_match(self::return_comment_regex, $line, $match)) {
+        if (\preg_match(self::RETURN_COMMENT_REGEX, $line, $match)) {
             $return_union_type_string = $match[2];
             $raw_match = $match[0];
             $char_at_end_offset = $line[\strpos($line, $raw_match) + \strlen($raw_match)] ?? ' ';
@@ -703,7 +704,8 @@ class Comment
         return $original_type;
     }
 
-    const param_comment_regex =
+    /** @internal */
+    const PARAM_COMMENT_REGEX =
         '/@(?:phan-)?(param|var)\b\s*(' . UnionType::union_type_regex . ')?(?:\s*(\.\.\.)?\s*&?(?:\\$' . self::WORD_REGEX . '))?/';
 
     /**
@@ -737,7 +739,7 @@ class Comment
         int $i,
         int $comment_lines_count
     ) {
-        $matched = \preg_match(self::param_comment_regex, $line, $match);
+        $matched = \preg_match(self::PARAM_COMMENT_REGEX, $line, $match);
         // Parse https://docs.phpdoc.org/references/phpdoc/tags/param.html
         // Exceptions: Deliberately allow "&" in "@param int &$x" when documenting references.
         // Warn if there is neither a union type nor a variable
@@ -922,7 +924,7 @@ class Comment
     }
 
     /** @internal */
-    const magic_param_regex = '/^(' . UnionType::union_type_regex . ')?\s*(?:(\.\.\.)\s*)?(?:\$' . self::WORD_REGEX . ')?((?:\s*=.*)?)$/';
+    const MAGIC_PARAM_REGEX = '/^(' . UnionType::union_type_regex . ')?\s*(?:(\.\.\.)\s*)?(?:\$' . self::WORD_REGEX . ')?((?:\s*=.*)?)$/';
 
     /**
      * Parses a magic method based on https://phpdoc.org/docs/latest/references/phpdoc/tags/method.html
@@ -943,7 +945,7 @@ class Comment
         // https://github.com/phpDocumentor/phpDocumentor2/pull/1271/files - phpdoc allows passing an default value.
         // Phan allows `=.*`, to indicate that a parameter is optional
         // TODO: in another PR, check that optional parameters aren't before required parameters.
-        if (preg_match(self::magic_param_regex, $param_string, $param_match)) {
+        if (preg_match(self::MAGIC_PARAM_REGEX, $param_string, $param_match)) {
             // Note: a magic method parameter can be variadic, but it can't be pass-by-reference? (No support in __call)
             $union_type_string = $param_match[1];
             $union_type = UnionType::fromStringInContext(

--- a/src/Phan/Language/Element/ConstantTrait.php
+++ b/src/Phan/Language/Element/ConstantTrait.php
@@ -6,10 +6,10 @@ use Closure;
 
 trait ConstantTrait
 {
+    use ElementFutureUnionType;
+
     /** @var Node|string|float|int */
     protected $defining_node;
-
-    use ElementFutureUnionType;
 
     /**
      * @return string

--- a/src/Phan/Language/Internal/FunctionSignatureMap.php
+++ b/src/Phan/Language/Internal/FunctionSignatureMap.php
@@ -1,9 +1,5 @@
-<?php // @codingStandardsIgnoreFile (phpcs runs out of memory)
+<?php // phpcs:ignoreFile
 namespace Phan\Language\Internal;
-
-<<<PHAN
-@phan-file-suppress PhanPluginMixedKeyNoKey (read by Phan when analyzing this file)
-PHAN;
 
 /**
  * Format
@@ -72,6 +68,7 @@ PHAN;
  * 3. Various websites documenting individual extensions
  * 4. PHPStorm stubs (For anything missing from the above sources)
  *    See internal/internalsignatures.php
+ * @phan-file-suppress PhanPluginMixedKeyNoKey (read by Phan when analyzing this file)
  */
 return [
 '_' => ['string', 'message'=>'string'],

--- a/src/Phan/Language/Internal/FunctionSignatureMap_php71_delta.php
+++ b/src/Phan/Language/Internal/FunctionSignatureMap_php71_delta.php
@@ -1,8 +1,4 @@
-<?php
-
-<<<PHAN
-@phan-file-suppress PhanPluginMixedKeyNoKey (read by Phan when analyzing this file)
-PHAN;
+<?php // phpcs:ignoreFile
 
 /**
  * This contains the information needed to convert the function signatures for php 7.1 to php 7.0 (and vice versa)
@@ -14,6 +10,8 @@ PHAN;
  *   Functions are expected to be removed only in major releases of php. (e.g. php 7.0 removed various functions that were deprecated in 5.6)
  *
  * @see FunctionSignatureMap.php
+ *
+ * @phan-file-suppress PhanPluginMixedKeyNoKey (read by Phan when analyzing this file)
  */
 return [
 'new' => [

--- a/src/Phan/Language/Internal/FunctionSignatureMap_php72_delta.php
+++ b/src/Phan/Language/Internal/FunctionSignatureMap_php72_delta.php
@@ -1,8 +1,4 @@
-<?php // @codingStandardsIgnoreFile
-
-<<<PHAN
-@phan-file-suppress PhanPluginMixedKeyNoKey (read by Phan when analyzing this file)
-PHAN;
+<?php // phpcs:ignoreFile
 
 /**
  * This contains the information needed to convert the function signatures for php 7.2 to php 7.1 (and vice versa)
@@ -14,6 +10,8 @@ PHAN;
  *   Functions are expected to be removed only in major releases of php. (e.g. php 7.0 removed various functions that were deprecated in 5.6)
  *
  * @see FunctionSignatureMap.php
+ *
+ * @phan-file-suppress PhanPluginMixedKeyNoKey (read by Phan when analyzing this file)
  */
 return [
 'new' => [

--- a/src/Phan/Language/Internal/PropertyMap.php
+++ b/src/Phan/Language/Internal/PropertyMap.php
@@ -36,8 +36,14 @@ $ast_node_children_types = 'array{' . $ast_node_shape_inner . '}|ast\Node[]|arra
  *
  * ```sh
  * svn checkout https://svn.php.net/repository/phpdoc/en/trunk phpdoc;
+ *
  * cd phpdoc;
- * find . -type f -path '*.xml -exec cat {} \; | tr "\n" " " | grep -o "<type>[^<]*<\/type>\s*<varname linkend=\"[^\.]*\.props.[^\"]*\"" | while read l; do T=`echo $l | cut -d ">" -f2 | cut -d "<" -f1`; N=`echo $l | cut -d "\"" -f2 | cut -d "." -f1,3`; printf "$T $N\n"; done | tee types
+ *
+ * find . -type f -path '*.xml -exec cat {} \; \
+ *   | tr "\n" " " \
+ *   | grep -o "<type>[^<]*<\/type>\s*<varname linkend=\"[^\.]*\.props.[^\"]*\"" \
+ *   | while read l; do T=`echo $l | cut -d ">" -f2 | cut -d "<" -f1`; N=`echo $l | cut -d "\"" -f2 | cut -d "." -f1,3`; printf "$T $N\n"; done \
+ *   | tee types
  * ```
  *
  * and then pipe that through
@@ -62,6 +68,9 @@ $ast_node_children_types = 'array{' . $ast_node_shape_inner . '}|ast\Node[]|arra
  *     print "\n    ],\n";
  * }
  * ```
+ *
+ * TODO: Migrate the above scripts to be part of the existing php scripts
+ * for working with the phpdoc SVN repo
  */
 return [
     'arrayobject' => [

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -54,6 +54,7 @@ use InvalidArgumentException;
  *
  * @phan-file-suppress PhanPartialTypeMismatchArgument
  * @phan-file-suppress PhanPartialTypeMismatchArgumentInternal
+ * phpcs:disable Generic.NamingConventions.UpperCaseConstantName
  */
 class Type
 {

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -602,10 +602,10 @@ class Type
         switch (\gettype($object)) {
             case 'integer':
                 '@phan-var int $object';
-                return LiteralIntType::instance_for_value($object, false);
+                return LiteralIntType::instanceForValue($object, false);
             case 'string':
                 '@phan-var string $object';
-                return LiteralStringType::instance_for_value($object, false);
+                return LiteralStringType::instanceForValue($object, false);
             case 'NULL':
                 return NullType::instance(false);
             case 'double':
@@ -870,7 +870,7 @@ class Type
         }
         $value = filter_var($escaped_literal, FILTER_VALIDATE_INT);
         if (\is_int($value)) {
-            return LiteralIntType::instance_for_value($value, $is_nullable);
+            return LiteralIntType::instanceForValue($value, $is_nullable);
         }
         return FloatType::instance($is_nullable);
     }

--- a/src/Phan/Language/Type/LiteralIntType.php
+++ b/src/Phan/Language/Type/LiteralIntType.php
@@ -27,8 +27,18 @@ final class LiteralIntType extends IntType implements LiteralTypeInterface
 
     /**
      * @return LiteralIntType
+     * @deprecated
      */
+    // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     public static function instance_for_value(int $value, bool $is_nullable)
+    {
+        return self::instanceForValue($value, $is_nullable);
+    }
+
+    /**
+     * @return LiteralIntType
+     */
+    public static function instanceForValue(int $value, bool $is_nullable)
     {
         if ($is_nullable) {
             static $nullable_cache = [];

--- a/src/Phan/Language/Type/LiteralIntType.php
+++ b/src/Phan/Language/Type/LiteralIntType.php
@@ -22,12 +22,13 @@ final class LiteralIntType extends IntType implements LiteralTypeInterface
      */
     public static function instance(bool $unused_is_nullable)
     {
-        throw new RuntimeException('Call ' . __CLASS__ . '::instance_for_value() instead');
+        throw new RuntimeException('Call ' . __CLASS__ . '::instanceForValue() instead');
     }
 
     /**
      * @return LiteralIntType
      * @deprecated
+     * @suppress PhanUnreferencedPublicMethod
      */
     // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     public static function instance_for_value(int $value, bool $is_nullable)
@@ -144,7 +145,7 @@ final class LiteralIntType extends IntType implements LiteralTypeInterface
             return $this;
         }
 
-        return self::instance_for_value(
+        return self::instanceForValue(
             $this->value,
             $is_nullable
         );

--- a/src/Phan/Language/Type/LiteralStringType.php
+++ b/src/Phan/Language/Type/LiteralStringType.php
@@ -33,8 +33,18 @@ final class LiteralStringType extends StringType implements LiteralTypeInterface
 
     /**
      * @return StringType|LiteralStringType
+     * @deprecated
      */
+    // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     public static function instance_for_value(string $value, bool $is_nullable)
+    {
+        return self::instanceForValue($value, $is_nullable);
+    }
+
+    /**
+     * @return StringType|LiteralStringType
+     */
+    public static function instanceForValue(string $value, bool $is_nullable)
     {
         if (\strlen($value) > self::MINIMUM_MAX_STRING_LENGTH && \strlen($value) > Config::getValue('max_literal_string_type_length')) {
             // The config can only be used to increase this limit, not decrease it.

--- a/src/Phan/Language/Type/LiteralStringType.php
+++ b/src/Phan/Language/Type/LiteralStringType.php
@@ -28,12 +28,13 @@ final class LiteralStringType extends StringType implements LiteralTypeInterface
      */
     public static function instance(bool $unused_is_nullable)
     {
-        throw new RuntimeException('Call ' . __CLASS__ . '::instance_for_value() instead');
+        throw new RuntimeException('Call ' . __CLASS__ . '::instanceForValue() instead');
     }
 
     /**
      * @return StringType|LiteralStringType
      * @deprecated
+     * @suppress PhanUnreferencedPublicMethod
      */
     // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     public static function instance_for_value(string $value, bool $is_nullable)
@@ -130,7 +131,7 @@ final class LiteralStringType extends StringType implements LiteralTypeInterface
             },
             $escaped_string
         );
-        return self::instance_for_value($escaped_string, $is_nullable);
+        return self::instanceForValue($escaped_string, $is_nullable);
     }
 
     /** @var StringType */
@@ -216,7 +217,7 @@ final class LiteralStringType extends StringType implements LiteralTypeInterface
             return $this;
         }
 
-        return self::instance_for_value(
+        return self::instanceForValue(
             $this->value,
             $is_nullable
         );

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -2768,7 +2768,7 @@ class UnionType implements \Serializable
         return $this->applyNumericOperation(function ($value) : ScalarType {
             $result = -$value;
             if (\is_int($result)) {
-                return LiteralIntType::instance_for_value($result, false);
+                return LiteralIntType::instanceForValue($result, false);
             }
             // -INT_MIN is a float.
             return FloatType::instance(false);
@@ -2784,9 +2784,9 @@ class UnionType implements \Serializable
         $type_set = UnionType::empty();
         foreach ($this->type_set as $type) {
             if ($type instanceof LiteralIntType) {
-                $type_set = $type_set->withType(LiteralIntType::instance_for_value(~$type->getValue(), false));
+                $type_set = $type_set->withType(LiteralIntType::instanceForValue(~$type->getValue(), false));
                 if ($type->getIsNullable()) {
-                    $type_set = $type_set->withType(LiteralIntType::instance_for_value(0, false));
+                    $type_set = $type_set->withType(LiteralIntType::instanceForValue(0, false));
                 }
             } elseif ($type instanceof StringType) {
                 // Not going to bother being more specific (this applies bitwise not to each character for LiteralStringType)
@@ -2808,7 +2808,7 @@ class UnionType implements \Serializable
         return $this->applyNumericOperation(function ($value) : ScalarType {
             $result = -$value;
             if (\is_int($result)) {
-                return LiteralIntType::instance_for_value($result, false);
+                return LiteralIntType::instanceForValue($result, false);
             }
             // -INT_MIN is a float.
             return FloatType::instance(false);
@@ -2826,7 +2826,7 @@ class UnionType implements \Serializable
             if ($type instanceof LiteralIntType) {
                 $type_set = $type_set->withType($operation($type->getValue()));
                 if ($type->getIsNullable()) {
-                    $type_set = $type_set->withType(LiteralIntType::instance_for_value(0, false));
+                    $type_set = $type_set->withType(LiteralIntType::instanceForValue(0, false));
                 }
             } else {
                 if ($added_fallbacks) {

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -45,6 +45,7 @@ class UnionType implements \Serializable
      * A list of one or more types delimited by the '|'
      * character (e.g. 'int|DateTime|string[]')
      */
+    // phpcs:ignore Generic.NamingConventions.UpperCaseConstantName
     const union_type_regex =
         Type::type_regex
         . '(\|' . Type::type_regex . ')*';
@@ -57,6 +58,7 @@ class UnionType implements \Serializable
      *
      * TODO: Equivalent variants with no capturing? (May not improve performance much)
      */
+    // phpcs:ignore Generic.NamingConventions.UpperCaseConstantName
     const union_type_regex_or_this =
         Type::type_regex_or_this
         . '(\|' . Type::type_regex_or_this . ')*';

--- a/src/Phan/LanguageServer/LanguageServer.php
+++ b/src/Phan/LanguageServer/LanguageServer.php
@@ -745,7 +745,12 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
      *
      * @param ClientCapabilities $capabilities The capabilities provided by the client (editor) @phan-unused-param
      * @param string|null $rootPath The rootPath of the workspace. Is null if no folder is open. @phan-unused-param
-     * @param int|null $processId The process Id of the parent process that started the server. Is null if the process has not been started by another process. If the parent process is not alive then the server should exit (see exit notification) its process. @phan-unused-param
+     * @param int|null $processId The process Id of the parent process that started the server. @phan-unused-param
+     *                            This is null if the process has not been started by another process.
+     *                            If the parent process is not alive,
+     *                            then the server should exit (see exit notification) its process.
+     *                            NOTE: For most use cases, we'll know about the disconnection because the connection hits the end of file or an error.
+     *
      * @return Promise <InitializeResult>
      */
     public function initialize(ClientCapabilities $capabilities, string $rootPath = null, int $processId = null): Promise

--- a/src/Phan/Library/Some.php
+++ b/src/Phan/Library/Some.php
@@ -6,6 +6,7 @@ namespace Phan\Library;
  * The type of the element
  *
  * @inherits Option<T>
+ * phpcs:disable PSR2.Classes.PropertyDeclaration.Underscore
  */
 class Some extends Option
 {

--- a/src/Phan/Library/Tuple1.php
+++ b/src/Phan/Library/Tuple1.php
@@ -6,6 +6,7 @@ namespace Phan\Library;
  *
  * @template T0
  * The type of element zero
+ * phpcs:disable PSR2.Classes.PropertyDeclaration.Underscore
  */
 class Tuple1 extends Tuple
 {

--- a/src/Phan/Library/Tuple2.php
+++ b/src/Phan/Library/Tuple2.php
@@ -11,6 +11,7 @@ namespace Phan\Library;
  * The type of element one
  *
  * @inherits Tuple1<T0>
+ * phpcs:disable PSR2.Classes.PropertyDeclaration.Underscore
  */
 class Tuple2 extends Tuple1
 {

--- a/src/Phan/Library/Tuple3.php
+++ b/src/Phan/Library/Tuple3.php
@@ -14,6 +14,8 @@ namespace Phan\Library;
  * The type of element one
  *
  * @inherits Tuple2<T0, T1>
+ *
+ * phpcs:disable PSR2.Classes.PropertyDeclaration.Underscore
  */
 class Tuple3 extends Tuple2
 {

--- a/src/Phan/Library/Tuple4.php
+++ b/src/Phan/Library/Tuple4.php
@@ -17,6 +17,8 @@ namespace Phan\Library;
  * The type of element three
  *
  * @inherits Tuple3<T0, T1, T2>
+ *
+ * phpcs:disable PSR2.Classes.PropertyDeclaration.Underscore
  */
 class Tuple4 extends Tuple3
 {

--- a/src/Phan/Library/Tuple5.php
+++ b/src/Phan/Library/Tuple5.php
@@ -20,6 +20,8 @@ namespace Phan\Library;
  * The type of element four
  *
  * @inherits Tuple4<T0, T1, T2, T3>
+ *
+ * phpcs:disable PSR2.Classes.PropertyDeclaration.Underscore
  */
 class Tuple5 extends Tuple4
 {

--- a/src/Phan/Output/Colorizing.php
+++ b/src/Phan/Output/Colorizing.php
@@ -60,7 +60,7 @@ class Colorizing
     const ESC_PATTERN = "\033[%sm";
     const ESC_RESET = "\033[0m";
 
-    // NOTE: Keep sorted and in sync with Issue::uncolored_format_string_for_template
+    // NOTE: Keep sorted and in sync with Issue::UNCOLORED_FORMAT_STRING_FOR_TEMPLATE
     // By using 'color_scheme' in .phan/config.php, these settings can be overridden
     const DEFAULT_COLOR_FOR_TEMPLATE = [
         'CLASS'         => 'green',
@@ -123,18 +123,18 @@ class Colorizing
     }
 
     /**
-     * @param string $template_type (A key of _uncolored_format_string_for_template, e.g. "FILE")
+     * @param string $template_type (A key of _UNCOLORED_FORMAT_STRING_FOR_TEMPLATE, e.g. "FILE")
      * @param int|string|float|FQSEN|Type|UnionType $arg (Argument for format string, e.g. a type name, method fqsen, line number, etc.)
      * @return string - Colorized for unix terminals.
      */
     public static function colorizeField(string $template_type, $arg) : string
     {
-        $fmt_directive = Issue::uncolored_format_string_for_template[$template_type] ?? null;
+        $fmt_directive = Issue::UNCOLORED_FORMAT_STRING_FOR_TEMPLATE[$template_type] ?? null;
         if ($fmt_directive === null) {
             error_log(sprintf(
                 "Unknown template type '%s'. Known template types: %s",
                 $template_type,
-                implode(', ', array_keys(Issue::uncolored_format_string_for_template))
+                implode(', ', array_keys(Issue::UNCOLORED_FORMAT_STRING_FOR_TEMPLATE))
             ));
             return (string)$arg;
         }

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -846,6 +846,7 @@ final class ConfigPluginSet extends PluginV2 implements
             if ($implemented_count > 1) {
                 throw new \TypeError(
                     sprintf(
+                        // phpcs:ignore
                         "plugin %s should implement only one of LegacyAnalyzeNodeCapability, AnalyzeNodeCapability, LegacyPostAnalyzeNodeCapability, or PostAnalyzeNodeCapability. PostAnalyzeNodeCapability is preferred.",
                         \get_class($plugin)
                     )

--- a/src/Phan/PluginV2.php
+++ b/src/Phan/PluginV2.php
@@ -100,7 +100,13 @@ use Phan\PluginV2\IssueEmitter;
  */
 abstract class PluginV2
 {
+    use IssueEmitter {
+        emitPluginIssue as emitIssue;
+    }
+
     /**
+     * The above declares this function signature:
+     *
      * public function emitIssue(
      *     CodeBase $code_base,
      *     Context $context,
@@ -112,7 +118,4 @@ abstract class PluginV2
      *     int $issue_type_id = Issue::TYPE_ID_UNKNOWN
      * )
      */
-    use IssueEmitter {
-        emitPluginIssue as emitIssue;
-    }
 }

--- a/src/Phan/PluginV2/IssueEmitter.php
+++ b/src/Phan/PluginV2/IssueEmitter.php
@@ -28,7 +28,7 @@ trait IssueEmitter
      * 'class with fqsen {CLASS} is broken in some fashion' (preferred)
      * or 'class with fqsen %s is broken in some fashion'
      * The list of placeholders for between braces can be found
-     * in \Phan\Issue::uncolored_format_string_for_template.
+     * in \Phan\Issue::UNCOLORED_FORMAT_STRING_FOR_TEMPLATE.
      *
      * @param array<int,string|int|float> $issue_message_args
      * The arguments for this issue format.

--- a/src/Phan/PluginV2/PluginAwareAnalysisVisitor.php
+++ b/src/Phan/PluginV2/PluginAwareAnalysisVisitor.php
@@ -38,7 +38,7 @@ abstract class PluginAwareAnalysisVisitor extends PluginAwareBaseAnalysisVisitor
      * 'class with fqsen {CLASS} is broken in some fashion' (preferred)
      * or 'class with fqsen %s is broken in some fashion'
      * The list of placeholders for between braces can be found
-     * in \Phan\Issue::uncolored_format_string_for_template.
+     * in \Phan\Issue::UNCOLORED_FORMAT_STRING_FOR_TEMPLATE.
      *
      * @param array<int,string> $issue_message_args
      * The arguments for this issue format.

--- a/src/Phan/PluginV2/PluginAwareBaseAnalysisVisitor.php
+++ b/src/Phan/PluginV2/PluginAwareBaseAnalysisVisitor.php
@@ -34,7 +34,7 @@ abstract class PluginAwareBaseAnalysisVisitor extends AnalysisVisitor
      * 'class with fqsen {CLASS} is broken in some fashion' (preferred)
      * or 'class with fqsen %s is broken in some fashion'
      * The list of placeholders for between braces can be found
-     * in \Phan\Issue::uncolored_format_string_for_template.
+     * in \Phan\Issue::UNCOLORED_FORMAT_STRING_FOR_TEMPLATE.
      *
      * @param array<int,string> $issue_message_args
      * The arguments for this issue format.

--- a/src/Phan/PluginV2/PluginAwarePostAnalysisVisitor.php
+++ b/src/Phan/PluginV2/PluginAwarePostAnalysisVisitor.php
@@ -38,7 +38,7 @@ abstract class PluginAwarePostAnalysisVisitor extends PluginAwareBaseAnalysisVis
      * 'class with fqsen {CLASS} is broken in some fashion' (preferred)
      * or 'class with fqsen %s is broken in some fashion'
      * The list of placeholders for between braces can be found
-     * in \Phan\Issue::uncolored_format_string_for_template.
+     * in \Phan\Issue::UNCOLORED_FORMAT_STRING_FOR_TEMPLATE.
      *
      * @param array<int,string> $issue_message_args
      * The arguments for this issue format.

--- a/tests/Phan/Language/SignatureMapTest.php
+++ b/tests/Phan/Language/SignatureMapTest.php
@@ -23,7 +23,7 @@ class SignatureMapTest extends BaseTest
         foreach ($map as $function_name => $signature) {
             if (!is_string($function_name)) {
                 $failures[] = "Expected array for entry $function_name with values " . var_export($signature, true);
-            } else if (!preg_match(self::FUNCTION_KEY_REGEX, $function_name)) {
+            } elseif (!preg_match(self::FUNCTION_KEY_REGEX, $function_name)) {
                 $failures[] = "Expected $function_name to match the regular expression " . self::FUNCTION_KEY_REGEX;
             }
             if (!is_array($signature)) {
@@ -49,12 +49,12 @@ class SignatureMapTest extends BaseTest
         $this->assertSame('', implode("\n", $failures), "Saw one or more issues for the signature for PHP_VERSION_ID " . $php_version_id);
     }
 
-    public function phpVersionIdProvider() {
+    public function phpVersionIdProvider()
+    {
         return [
             [70000],  // PHP 7.0
             [70100],  // PHP 7.1
             [70200],  // PHP 7.2
         ];
     }
-
 }

--- a/tests/Phan/Language/TypeTest.php
+++ b/tests/Phan/Language/TypeTest.php
@@ -79,38 +79,30 @@ class TypeTest extends BaseTest
 
     public function testLiteralIntType()
     {
-        $this->assertParsesAsType(LiteralIntType::instance_for_value(1, false), '1');
-        $this->assertParsesAsType(LiteralIntType::instance_for_value(0, false), '0');
-        $this->assertParsesAsType(LiteralIntType::instance_for_value(0, false), '-0');
-        $this->assertParsesAsType(LiteralIntType::instance_for_value(-1, false), '-1');
-        $this->assertParsesAsType(LiteralIntType::instance_for_value(9, false), '9');
-        $this->assertParsesAsType(LiteralIntType::instance_for_value(190, false), '190');
+        $this->assertParsesAsType(LiteralIntType::instanceForValue(1, false), '1');
+        $this->assertParsesAsType(LiteralIntType::instanceForValue(0, false), '0');
+        $this->assertParsesAsType(LiteralIntType::instanceForValue(0, false), '-0');
+        $this->assertParsesAsType(LiteralIntType::instanceForValue(-1, false), '-1');
+        $this->assertParsesAsType(LiteralIntType::instanceForValue(9, false), '9');
+        $this->assertParsesAsType(LiteralIntType::instanceForValue(190, false), '190');
         $this->assertParsesAsType(FloatType::instance(false), '1111111111111111111111111111111111');
-        $this->assertParsesAsType(LiteralIntType::instance_for_value(1, true), '?1');
-        $this->assertParsesAsType(LiteralIntType::instance_for_value(-1, true), '?-1');
+        $this->assertParsesAsType(LiteralIntType::instanceForValue(1, true), '?1');
+        $this->assertParsesAsType(LiteralIntType::instanceForValue(-1, true), '?-1');
     }
 
     public function testLiteralStringType()
     {
-        $this->assertParsesAsType(LiteralStringType::instance_for_value('a', false), "'a'");
-        $this->assertParsesAsType(LiteralStringType::instance_for_value('a', true), "?'a'");
-        $this->assertParsesAsType(LiteralStringType::instance_for_value('', false), "''");
-        $this->assertParsesAsType(LiteralStringType::instance_for_value('', true), "?''");
-        $this->assertParsesAsType(LiteralStringType::instance_for_value('\\', false), "'\\\\'");
-        $this->assertParsesAsType(LiteralStringType::instance_for_value("'", false), "'\\''");
-        $this->assertParsesAsType(LiteralStringType::instance_for_value('0', false), "'0'");
-        $this->assertParsesAsType(LiteralStringType::instance_for_value('abcdefghijklmnopqrstuvwxyz01234567889-,./?:;!#$%^&*_-=+', false), "'abcdefghijklmnopqrstuvwxyz01234567889-,./?:;!#\$%^&*_-=+'");
+        $this->assertParsesAsType(LiteralStringType::instanceForValue('a', false), "'a'");
+        $this->assertParsesAsType(LiteralStringType::instanceForValue('a', true), "?'a'");
+        $this->assertParsesAsType(LiteralStringType::instanceForValue('', false), "''");
+        $this->assertParsesAsType(LiteralStringType::instanceForValue('', true), "?''");
+        $this->assertParsesAsType(LiteralStringType::instanceForValue('\\', false), "'\\\\'");
+        $this->assertParsesAsType(LiteralStringType::instanceForValue("'", false), "'\\''");
+        $this->assertParsesAsType(LiteralStringType::instanceForValue('0', false), "'0'");
+        $this->assertParsesAsType(LiteralStringType::instanceForValue('abcdefghijklmnopqrstuvwxyz01234567889-,./?:;!#$%^&*_-=+', false), "'abcdefghijklmnopqrstuvwxyz01234567889-,./?:;!#\$%^&*_-=+'");
 
-        $this->assertParsesAsType(LiteralStringType::instance_for_value("<=>\n", false), "'\\x3c\\x3d\\x3e\\x0a'");
+        $this->assertParsesAsType(LiteralStringType::instanceForValue("<=>\n", false), "'\\x3c\\x3d\\x3e\\x0a'");
     }
-
-    /*
-    // Planned:
-    public function testLiteralStringType()
-    {
-        $this->assertParsesAsType(LiteralStringType::instance_for_value('x', false), '"x"');
-    }
-     */
 
     private function assertSameType(Type $expected, Type $actual, string $extra = '')
     {

--- a/tests/Phan/Output/Printer/CheckstylePrinterTest.php
+++ b/tests/Phan/Output/Printer/CheckstylePrinterTest.php
@@ -24,7 +24,12 @@ class CheckstylePrinterTest extends BaseTest
         $printer->configureOutput($output);
         $printer->print(new IssueInstance(Issue::fromType(Issue::SyntaxError), 'test.php', 0, [$string]));
         $printer->flush();
-        $this->assertContains('PhanSyntaxError', $output->fetch());
+
+        $issue_messages_text = $output->fetch();
+
+        // Note: assertContain would call iconv_strpos(), which would emit a notice if phpunit is using symfony/polyfill-mbstring.
+        // That notice would trigger phan_error_handler
+        $this->assertTrue(strpos($issue_messages_text, 'PhanSyntaxError') !== false, "output should contain PhanSyntaxError");
     }
 
     public function invalidUTF8StringsProvider()


### PR DESCRIPTION
Rename internal methods, classes, and properties to fix them,
or suppress the warnings if that isn't practical.

