### PR TITLE
Make Phan consistently use $var_name instead of $varName for variables and properties

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -445,7 +445,9 @@ return [
     //
     // This is useful for excluding hopelessly unanalyzable
     // files that can't be removed for whatever reason.
-    'exclude_file_list' => [],
+    'exclude_file_list' => [
+        'internal/Sniffs/ValidUnderscoreVariableNameSniff.php',
+    ],
 
     // The number of processes to fork off during the analysis
     // phase.

--- a/internal/Sniffs/ValidUnderscoreVariableNameSniff.php
+++ b/internal/Sniffs/ValidUnderscoreVariableNameSniff.php
@@ -12,7 +12,6 @@
 
 namespace PHP_CodeSniffer\Standards\Phan\Sniffs\NamingConventions;
 
-// use PHP_CodeSniffer\Standards\Zend\Sniffs\NamingConventions;
 use PHP_CodeSniffer\Sniffs\AbstractVariableSniff;
 use PHP_CodeSniffer\Files\File;
 
@@ -23,30 +22,30 @@ class ValidUnderscoreVariableNameSniff extends AbstractVariableSniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $stackPtr  The position of the current token in the
-     *                                               stack passed in $tokens.
+     * @param \PHP_CodeSniffer\Files\File $phpcs_file The file being scanned.
+     * @param int                         $stack_ptr  The position of the current token in the
+     *                                                stack passed in $tokens.
      *
      * @return void
      */
-    protected function processVariable(File $phpcsFile, $stackPtr)
+    protected function processVariable(File $phpcs_file, $stack_ptr)
     {
-        if ($this->isExcluded($phpcsFile)) {
+        if ($this->isExcluded($phpcs_file)) {
             return;
         }
-        $tokens  = $phpcsFile->getTokens();
-        $varName = ltrim($tokens[$stackPtr]['content'], '$');
+        $tokens  = $phpcs_file->getTokens();
+        $var_name = ltrim($tokens[$stack_ptr]['content'], '$');
 
         // If it's a php reserved var, then its ok.
-        if (isset($this->phpReservedVars[$varName]) === true) {
+        if (isset($this->phpReservedVars[$var_name]) === true) {
             return;
         }
 
-        $objOperator = $phpcsFile->findNext([T_WHITESPACE], ($stackPtr + 1), null, true);
-        if ($tokens[$objOperator]['code'] === T_OBJECT_OPERATOR) {
+        $obj_operator = $phpcs_file->findNext([T_WHITESPACE], ($stack_ptr + 1), null, true);
+        if ($tokens[$obj_operator]['code'] === T_OBJECT_OPERATOR) {
             // Check to see if we are using a variable from an object.
             // TODO: This workaround doesn't check variables that are the expression of a member property access expression
-            $var = $phpcsFile->findNext([T_WHITESPACE], ($objOperator + 1), null, true);
+            $var = $phpcs_file->findNext([T_WHITESPACE], ($obj_operator + 1), null, true);
             if ($tokens[$var]['code'] === T_STRING) {
                 return;
             }//end if
@@ -55,126 +54,125 @@ class ValidUnderscoreVariableNameSniff extends AbstractVariableSniff
         // There is no way for us to know if the var is public or private,
         // so we have to ignore a leading underscore if there is one and just
         // check the main part of the variable name.
-        $originalVarName = $varName;
-        if (substr($varName, 0, 1) === '_') {
+        $original_var_name = $var_name;
+        if (substr($var_name, 0, 1) === '_') {
             // Let PSR-12 checks deal with this
             return;
         }
 
-        if (self::isUnderscoreVariableName($originalVarName) === false) {
+        if (self::isUnderscoreVariableName($original_var_name) === false) {
             $error = 'Variable "%s" is not in valid underscore name format';
-            $data  = [$originalVarName];
-            $phpcsFile->addError($error, $stackPtr, 'NotUnderscore', $data);
-        } else if (preg_match('|\d|', $varName) === 1) {
+            $data  = [$original_var_name];
+            $phpcs_file->addError($error, $stack_ptr, 'NotUnderscore', $data);
+        } elseif (preg_match('|\d|', $var_name) === 1) {
             $warning = 'Variable "%s" contains numbers but this is discouraged';
-            $data    = [$originalVarName];
-            $phpcsFile->addWarning($warning, $stackPtr, 'ContainsNumbers', $data);
+            $data    = [$original_var_name];
+            $phpcs_file->addWarning($warning, $stack_ptr, 'ContainsNumbers', $data);
         }
-
     }//end processVariable()
 
 
     /**
      * Processes class member variables.
      *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $stackPtr  The position of the current token in the
+     * @param \PHP_CodeSniffer\Files\File $phpcs_file The file being scanned.
+     * @param int                         $stack_ptr  The position of the current token in the
      *                                               stack passed in $tokens.
      *
      * @return void
      */
-    protected function processMemberVar(File $phpcsFile, $stackPtr)
+    protected function processMemberVar(File $phpcs_file, $stack_ptr)
     {
-        if ($this->isExcluded($phpcsFile)) {
+        if ($this->isExcluded($phpcs_file)) {
             return;
         }
-        $tokens      = $phpcsFile->getTokens();
-        $varName     = ltrim($tokens[$stackPtr]['content'], '$');
-        $memberProps = $phpcsFile->getMemberProperties($stackPtr);
-        if (empty($memberProps) === true) {
+        $tokens      = $phpcs_file->getTokens();
+        $var_name     = ltrim($tokens[$stack_ptr]['content'], '$');
+        $member_props = $phpcs_file->getMemberProperties($stack_ptr);
+        if (empty($member_props) === true) {
             // Exception encountered.
             return;
         }
 
-        $public = ($memberProps['scope'] === 'public');
+        $public = ($member_props['scope'] === 'public');
 
-        if (substr($varName, 0, 1) === '_') {
+        if (substr($var_name, 0, 1) === '_') {
             // Phan's coding style uses PSR-12.
             // PSR-12 already checks for this, so skip these
             return;
         }
 
         // Remove a potential underscore prefix for testing CamelCaps.
-        if (self::isUnderscoreVariableName($varName) === false) {
+        if (self::isUnderscoreVariableName($var_name) === false) {
             $error = 'Member variable "%s" is not in valid underscore format';
-            $data  = [$varName];
-            $phpcsFile->addError($error, $stackPtr, 'MemberVarNotUnderscore', $data);
-        } else if (preg_match('|\d|', $varName) === 1) {
+            $data  = [$var_name];
+            $phpcs_file->addError($error, $stack_ptr, 'MemberVarNotUnderscore', $data);
+        } elseif (preg_match('|\d|', $var_name) === 1) {
             $warning = 'Member variable "%s" contains numbers but this is discouraged';
-            $data    = [$varName];
-            $phpcsFile->addWarning($warning, $stackPtr, 'MemberVarContainsNumbers', $data);
+            $data    = [$var_name];
+            $phpcs_file->addWarning($warning, $stack_ptr, 'MemberVarContainsNumbers', $data);
         }
-
     }//end processMemberVar()
 
 
     /**
      * Processes the variable found within a double quoted string.
      *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $stackPtr  The position of the double quoted
+     * @param \PHP_CodeSniffer\Files\File $phpcs_file The file being scanned.
+     * @param int                         $stack_ptr  The position of the double quoted
      *                                               string.
      *
      * @return void
      */
-    protected function processVariableInString(File $phpcsFile, $stackPtr)
+    protected function processVariableInString(File $phpcs_file, $stack_ptr)
     {
-        if ($this->isExcluded($phpcsFile)) {
+        if ($this->isExcluded($phpcs_file)) {
             return;
         }
-        $tokens = $phpcsFile->getTokens();
+        $tokens = $phpcs_file->getTokens();
 
-        if (preg_match_all('|[^\\\]\$([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)|', $tokens[$stackPtr]['content'], $matches) !== 0) {
-            foreach ($matches[1] as $varName) {
+        if (preg_match_all('|[^\\\]\$([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)|', $tokens[$stack_ptr]['content'], $matches) !== 0) {
+            foreach ($matches[1] as $var_name) {
                 // If it's a php reserved var, then its ok.
-                if (isset($this->phpReservedVars[$varName]) === true) {
+                if (isset($this->phpReservedVars[$var_name]) === true) {
                     continue;
                 }
 
-                if (self::isUnderscoreVariableName($varName) === false) {
+                if (self::isUnderscoreVariableName($var_name) === false) {
                     $error = 'Variable "%s" is not in valid undercase format';
-                    $data  = [$varName];
-                    $phpcsFile->addError($error, $stackPtr, 'StringVarNotUnderscore', $data);
-                } else if (preg_match('|\d|', $varName) === 1) {
+                    $data  = [$var_name];
+                    $phpcs_file->addError($error, $stack_ptr, 'StringVarNotUnderscore', $data);
+                } elseif (preg_match('|\d|', $var_name) === 1) {
                     $warning = 'Variable "%s" contains numbers but this is discouraged';
-                    $data    = [$varName];
-                    $phpcsFile->addWarning($warning, $stackPtr, 'StringVarContainsNumbers', $data);
+                    $data    = [$var_name];
+                    $phpcs_file->addWarning($warning, $stack_ptr, 'StringVarContainsNumbers', $data);
                 }
             }//end foreach
         }//end if
-
     }//end processVariableInString()
 
-    protected static function isUnderscoreVariableName(string $varName) {
-        if ($varName === '_') {
+    protected static function isUnderscoreVariableName(string $var_name)
+    {
+        if ($var_name === '_') {
             return true;
         }
-        if (preg_match("/^[a-z]/", $varName) === 0) {
+        if (preg_match("/^[a-z]/", $var_name) === 0) {
             return false;
         }
         // Check that the name only contains legal characters.
-        $legalChars = 'a-z_0-9';
-        if (preg_match("|[^$legalChars]|", $varName) > 0) {
+        $legal_chars = 'a-z_0-9';
+        if (preg_match("|[^$legal_chars]|", $var_name) > 0) {
             return false;
         }
-        if (strpos($varName, '__') !== false) {
+        if (strpos($var_name, '__') !== false) {
             return false;
         }
         return true;
     }
 
     // Can't get exclude-pattern to work in ruleset.xml, so just hardcode this
-    private function isExcluded(File $phpcsFile) : bool {
-        return preg_match('@[/\\\\]LanguageServer[/\\\\]@', $phpcsFile->path) > 0;
+    private function isExcluded(File $phpcs_file) : bool
+    {
+        return preg_match('@[/\\\\]LanguageServer[/\\\\]@', $phpcs_file->path) > 0;
     }
 }//end class

--- a/internal/Sniffs/ValidUnderscoreVariableNameSniff.php
+++ b/internal/Sniffs/ValidUnderscoreVariableNameSniff.php
@@ -102,6 +102,10 @@ class ValidUnderscoreVariableNameSniff extends AbstractVariableSniff
             return;
         }
 
+        if ($var_name === 'backupStaticAttributesBlacklist') {
+            // PHPUnit built-in
+            return;
+        }
         // Remove a potential underscore prefix for testing CamelCaps.
         if (self::isUnderscoreVariableName($var_name) === false) {
             $error = 'Member variable "%s" is not in valid underscore format';

--- a/internal/Sniffs/ValidUnderscoreVariableNameSniff.php
+++ b/internal/Sniffs/ValidUnderscoreVariableNameSniff.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * Checks the naming of variables and member variables.
+ *
+ * This is a modified version of Zend.Sniffs.NamingConventions.ValidVariableNameSniff by Greg Sherwood <gsherwood@squiz.net>
+ *
+ * The original file's license:
+ *
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Standards\Phan\Sniffs\NamingConventions;
+
+// use PHP_CodeSniffer\Standards\Zend\Sniffs\NamingConventions;
+use PHP_CodeSniffer\Sniffs\AbstractVariableSniff;
+use PHP_CodeSniffer\Files\File;
+
+class ValidUnderscoreVariableNameSniff extends AbstractVariableSniff
+{
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in the
+     *                                               stack passed in $tokens.
+     *
+     * @return void
+     */
+    protected function processVariable(File $phpcsFile, $stackPtr)
+    {
+        $tokens  = $phpcsFile->getTokens();
+        $varName = ltrim($tokens[$stackPtr]['content'], '$');
+
+        // If it's a php reserved var, then its ok.
+        if (isset($this->phpReservedVars[$varName]) === true) {
+            return;
+        }
+
+        $objOperator = $phpcsFile->findNext([T_WHITESPACE], ($stackPtr + 1), null, true);
+        if ($tokens[$objOperator]['code'] === T_OBJECT_OPERATOR) {
+            // Check to see if we are using a variable from an object.
+            $var = $phpcsFile->findNext([T_WHITESPACE], ($objOperator + 1), null, true);
+            if ($tokens[$var]['code'] === T_STRING) {
+                // Either a var name or a function call, so check for bracket.
+                $bracket = $phpcsFile->findNext([T_WHITESPACE], ($var + 1), null, true);
+
+                if ($tokens[$bracket]['code'] !== T_OPEN_PARENTHESIS) {
+                    $objVarName = $tokens[$var]['content'];
+
+                    // There is no way for us to know if the var is public or private,
+                    // so we have to ignore a leading underscore if there is one and just
+                    // check the main part of the variable name.
+                    $originalVarName = $objVarName;
+                    if (substr($objVarName, 0, 1) === '_') {
+                        $objVarName = substr($objVarName, 1);
+                    }
+
+                    if (self::isUnderscoreVariableName($originalVarName) === false) {
+                        $error = 'Variable "%s" is not in valid underscore format';
+                        $data  = [$originalVarName];
+                        $phpcsFile->addError($error, $var, 'NotCamelCaps', $data);
+                    } else if (preg_match('|\d|', $objVarName) === 1) {
+                        $warning = 'Variable "%s" contains numbers but this is discouraged';
+                        $data    = [$originalVarName];
+                        $phpcsFile->addWarning($warning, $stackPtr, 'ContainsNumbers', $data);
+                    }
+                }//end if
+            }//end if
+        }//end if
+
+        // There is no way for us to know if the var is public or private,
+        // so we have to ignore a leading underscore if there is one and just
+        // check the main part of the variable name.
+        $originalVarName = $varName;
+        if (substr($varName, 0, 1) === '_') {
+            $objOperator = $phpcsFile->findPrevious([T_WHITESPACE], ($stackPtr - 1), null, true);
+            if ($tokens[$objOperator]['code'] === T_DOUBLE_COLON) {
+                // The variable lives within a class, and is referenced like
+                // this: MyClass::$_variable, so we don't know its scope.
+                $inClass = true;
+            } else {
+                $inClass = $phpcsFile->hasCondition($stackPtr, [T_CLASS, T_INTERFACE, T_TRAIT]);
+            }
+
+            if ($inClass === true) {
+                $varName = substr($varName, 1);
+            }
+        }
+
+        if (self::isUnderscoreVariableName($originalVarName) === false) {
+            $error = 'Variable "%s" is not in valid underscore name format';
+            $data  = [$originalVarName];
+            $phpcsFile->addError($error, $stackPtr, 'NotUnderscore', $data);
+        } else if (preg_match('|\d|', $varName) === 1) {
+            $warning = 'Variable "%s" contains numbers but this is discouraged';
+            $data    = [$originalVarName];
+            $phpcsFile->addWarning($warning, $stackPtr, 'ContainsNumbers', $data);
+        }
+
+    }//end processVariable()
+
+
+    /**
+     * Processes class member variables.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in the
+     *                                               stack passed in $tokens.
+     *
+     * @return void
+     */
+    protected function processMemberVar(File $phpcsFile, $stackPtr)
+    {
+        $tokens      = $phpcsFile->getTokens();
+        $varName     = ltrim($tokens[$stackPtr]['content'], '$');
+        $memberProps = $phpcsFile->getMemberProperties($stackPtr);
+        if (empty($memberProps) === true) {
+            // Exception encountered.
+            return;
+        }
+
+        $public = ($memberProps['scope'] === 'public');
+
+        if (substr($varName, 0, 1) === '_') {
+            // Phan's coding style uses PSR-12.
+            // PSR-12 already checks for this, so skip these
+            return;
+        }
+
+        // Remove a potential underscore prefix for testing CamelCaps.
+        if (self::isUnderscoreVariableName($varName) === false) {
+            $error = 'Member variable "%s" is not in valid underscore format';
+            $data  = [$varName];
+            $phpcsFile->addError($error, $stackPtr, 'MemberVarNotUnderscore', $data);
+        } else if (preg_match('|\d|', $varName) === 1) {
+            $warning = 'Member variable "%s" contains numbers but this is discouraged';
+            $data    = [$varName];
+            $phpcsFile->addWarning($warning, $stackPtr, 'MemberVarContainsNumbers', $data);
+        }
+
+    }//end processMemberVar()
+
+
+    /**
+     * Processes the variable found within a double quoted string.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the double quoted
+     *                                               string.
+     *
+     * @return void
+     */
+    protected function processVariableInString(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if (preg_match_all('|[^\\\]\$([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)|', $tokens[$stackPtr]['content'], $matches) !== 0) {
+            foreach ($matches[1] as $varName) {
+                // If it's a php reserved var, then its ok.
+                if (isset($this->phpReservedVars[$varName]) === true) {
+                    continue;
+                }
+
+                if (self::isUnderscoreVariableName($varName) === false) {
+                    $error = 'Variable "%s" is not in valid undercase format';
+                    $data  = [$varName];
+                    $phpcsFile->addError($error, $stackPtr, 'StringVarNotUnderscore', $data);
+                } else if (preg_match('|\d|', $varName) === 1) {
+                    $warning = 'Variable "%s" contains numbers but this is discouraged';
+                    $data    = [$varName];
+                    $phpcsFile->addWarning($warning, $stackPtr, 'StringVarContainsNumbers', $data);
+                }
+            }//end foreach
+        }//end if
+
+    }//end processVariableInString()
+
+    protected static function isUnderscoreVariableName(string $varName) {
+        if ($varName === '_') {
+            return true;
+        }
+        if (preg_match("/^[a-z]/", $varName) === 0) {
+            return false;
+        }
+        // Check that the name only contains legal characters.
+        $legalChars = 'a-z_0-9';
+        if (preg_match("|[^$legalChars]|", $varName) > 0) {
+            return false;
+        }
+        if (strpos($varName, '__') !== false) {
+            return false;
+        }
+        return true;
+    }
+
+}//end class

--- a/internal/Sniffs/ValidUnderscoreVariableNameSniff.php
+++ b/internal/Sniffs/ValidUnderscoreVariableNameSniff.php
@@ -31,6 +31,9 @@ class ValidUnderscoreVariableNameSniff extends AbstractVariableSniff
      */
     protected function processVariable(File $phpcsFile, $stackPtr)
     {
+        if ($this->isExcluded($phpcsFile)) {
+            return;
+        }
         $tokens  = $phpcsFile->getTokens();
         $varName = ltrim($tokens[$stackPtr]['content'], '$');
 
@@ -82,6 +85,9 @@ class ValidUnderscoreVariableNameSniff extends AbstractVariableSniff
      */
     protected function processMemberVar(File $phpcsFile, $stackPtr)
     {
+        if ($this->isExcluded($phpcsFile)) {
+            return;
+        }
         $tokens      = $phpcsFile->getTokens();
         $varName     = ltrim($tokens[$stackPtr]['content'], '$');
         $memberProps = $phpcsFile->getMemberProperties($stackPtr);
@@ -123,6 +129,9 @@ class ValidUnderscoreVariableNameSniff extends AbstractVariableSniff
      */
     protected function processVariableInString(File $phpcsFile, $stackPtr)
     {
+        if ($this->isExcluded($phpcsFile)) {
+            return;
+        }
         $tokens = $phpcsFile->getTokens();
 
         if (preg_match_all('|[^\\\]\$([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)|', $tokens[$stackPtr]['content'], $matches) !== 0) {
@@ -164,4 +173,8 @@ class ValidUnderscoreVariableNameSniff extends AbstractVariableSniff
         return true;
     }
 
+    // Can't get exclude-pattern to work in ruleset.xml, so just hardcode this
+    private function isExcluded(File $phpcsFile) : bool {
+        return preg_match('@[/\\\\]LanguageServer[/\\\\]@', $phpcsFile->path) > 0;
+    }
 }//end class

--- a/internal/phpcbf
+++ b/internal/phpcbf
@@ -5,6 +5,6 @@ if [[ "$#" != 0 ]]; then
 	echo "Executing phpcbf.phar --standard=ruleset.xml $@"  1>&2
 	phpcbf.phar --standard=ruleset.xml "$@"
 else
-	# Automatically fix PSR-2 syntax issues in Phan itself
+	# Automatically fix PSR-2 and PSR-12 syntax issues in Phan itself
 	phpcbf.phar --standard=ruleset.xml tests/Phan src internal .phan tool/make_stubs phan_client
 fi

--- a/internal/phpcs
+++ b/internal/phpcs
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
 # This has been tested with phpcs.phar 3.3.0 (3.3.0 or newer is required)
 set -xu
-# Automatically detect PSR-2 and PSR-12 syntax issues in Phan itself
 if [[ "$#" != 0 ]]; then
 	echo "Executing phpcs.phar --standard=ruleset.xml $@"  1>&2
 	phpcs.phar --standard=ruleset.xml "$@"
 else
-	# Automatically fix PSR-2 syntax issues in Phan itself
-	phpcs.phar --standard=ruleset.xml tests/Phan src .phan tool phan_client
+	# Automatically detect PSR-2 and PSR-12 syntax issues in Phan itself
+	phpcs.phar --standard=ruleset.xml tests/Phan src internal .phan tool/make_stubs phan_client
 fi

--- a/internal/sanitycheck.php
+++ b/internal/sanitycheck.php
@@ -16,44 +16,44 @@ function load_internal_function(string $function_name) : ReflectionFunctionAbstr
 
 function getParametersCountsFromPhan(array $fields)
 {
-    $numRequired = 0;
+    $num_required = 0;
     unset($fields[0]);
-    $numOptional = count($fields);
-    $sawOptional = false;
-    $sawOptionalAfterRequired = false;
+    $num_optional = count($fields);
+    $saw_optional = false;
+    $saw_optional_after_required = false;
     foreach ($fields as $type => $_) {
         assert(is_string($type));
         if (strpos($type, '...') !== false) {
-            $numOptional = 10000;
+            $num_optional = 10000;
             break;
         } elseif (strpos($type, '=') === false) {
-            $numRequired++;
-            if ($sawOptional) {
-                $sawOptionalAfterRequired = true;
+            $num_required++;
+            if ($saw_optional) {
+                $saw_optional_after_required = true;
             }
         } else {
-            $sawOptional = true;
+            $saw_optional = true;
         }
     }
-    return [$numRequired, $numOptional, $sawOptionalAfterRequired];
+    return [$num_required, $num_optional, $saw_optional_after_required];
 }
 /**
  * @param ReflectionParameter[] $args
  */
 function getParameterCountsFromReflection(array $args)
 {
-    $numRequired = 0;
-    $numOptional = count($args);
+    $num_required = 0;
+    $num_optional = count($args);
     foreach ($args as $reflection_parameter) {
         if ($reflection_parameter->isVariadic()) {
-            $numOptional = 10000;
+            $num_optional = 10000;
             break;
         } elseif ($reflection_parameter->isOptional() || $reflection_parameter->isDefaultValueAvailable()) {
         } else {
-            $numRequired++;
+            $num_required++;
         }
     }
-    return [$numRequired, $numOptional];
+    return [$num_required, $num_optional];
 }
 
 // TODO: reuse code?
@@ -171,6 +171,7 @@ function check_fields(string $function_name, array $fields, array $signatures)
                     echo "(Has alternate): ";
                 }
                 if ($reflection_is_by_reference) {
+                    // TODO: Switch to printf
                     echo "Found mismatch for $original_function_name param \${$reflection_parameter->getName()} and phan param \${$phan_parameter->name}: PHP says param is by reference, but phan doesn't: " . json_encode($fields) . "\n";
                 } else {
                     echo "Found mismatch for $original_function_name param \${$reflection_parameter->getName()} and phan param \${$phan_parameter->name}: PHP says param is not by reference, but phan does: " . json_encode($fields) . "\n";

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -23,5 +23,7 @@
   </rule>
 
   <!-- Phan's coding style is to always use underscores for variable names and property declarations -->
-  <rule ref="./internal" />
+  <rule ref="./internal">
+    <exclude name="Phan.NamingConventions.ValidUnderscoreVariableName.ContainsNumbers" />
+  </rule>
 </ruleset>

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -4,6 +4,7 @@
 <!-- phpcbf.phar can be used to automatically fix many issues -->
 <!-- Use this with PHP_CodeSniffer 3.3.0 or newer -->
 <ruleset name="Custom Standard">
+  <description>Coding standard for Phan</description>
   <rule ref="PSR1" />
   <rule ref="PSR2">
     <exclude name="Generic.Files.LineLength.TooLong" />
@@ -20,4 +21,7 @@
       <property name="absoluteLineLimit" value="200"/>
     </properties>
   </rule>
+
+  <!-- Phan's coding style is to always use underscores for variable names and property declarations -->
+  <rule ref="./internal" />
 </ruleset>

--- a/src/Phan/AST/TolerantASTConverter/StringUtil.php
+++ b/src/Phan/AST/TolerantASTConverter/StringUtil.php
@@ -65,28 +65,28 @@ final class StringUtil
      * Parses a string token.
      *
      * @param string $str String token content
-     * @param bool $parseUnicodeEscape Whether to parse PHP 7 \u escapes
+     * @param bool $parse_unicode_escape Whether to parse PHP 7 \u escapes
      *
      * @return string The parsed string
      */
-    public static function parse(string $str, bool $parseUnicodeEscape = true) : string
+    public static function parse(string $str, bool $parse_unicode_escape = true) : string
     {
-        $bLength = 0;
+        $binary_length = 0;
         if ('b' === $str[0] || 'B' === $str[0]) {
-            $bLength = 1;
+            $binary_length = 1;
         }
 
-        if ('\'' === $str[$bLength]) {
+        if ('\'' === $str[$binary_length]) {
             return \str_replace(
                 ['\\\\', '\\\''],
                 ['\\', '\''],
-                \substr($str, $bLength + 1, -1)
+                \substr($str, $binary_length + 1, -1)
             );
         } else {
             return self::parseEscapeSequences(
-                substr($str, $bLength + 1, -1),
+                substr($str, $binary_length + 1, -1),
                 '"',
-                $parseUnicodeEscape
+                $parse_unicode_escape
             );
         }
     }
@@ -98,18 +98,18 @@ final class StringUtil
      *
      * @param string      $str   String without quotes
      * @param null|string $quote Quote type
-     * @param bool $parseUnicodeEscape Whether to parse PHP 7 \u escapes
+     * @param bool $parse_unicode_escape Whether to parse PHP 7 \u escapes
      *
      * @return string String with escape sequences parsed
      */
-    public static function parseEscapeSequences(string $str, $quote, bool $parseUnicodeEscape = true) : string
+    public static function parseEscapeSequences(string $str, $quote, bool $parse_unicode_escape = true) : string
     {
         if (null !== $quote) {
             $str = \str_replace('\\' . $quote, $quote, $str);
         }
 
         $extra = '';
-        if ($parseUnicodeEscape) {
+        if ($parse_unicode_escape) {
             $extra = '|u\{([0-9a-fA-F]+)\}';
         }
 

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -974,14 +974,14 @@ class TolerantASTConverter
             'Microsoft\PhpParser\Node\Statement\BreakOrContinueStatement' => function (PhpParser\Node\Statement\BreakOrContinueStatement $n, int $start_line) : ast\Node {
                 $kind = $n->breakOrContinueKeyword->kind === TokenKind::ContinueKeyword ? ast\AST_CONTINUE : ast\AST_BREAK;
                 if ($n->breakoutLevel !== null) {
-                    $breakoutLevel = static::phpParserNodeToAstNode($n->breakoutLevel);
-                    if (!\is_int($breakoutLevel)) {
-                        $breakoutLevel = null;
+                    $breakout_level = static::phpParserNodeToAstNode($n->breakoutLevel);
+                    if (!\is_int($breakout_level)) {
+                        $breakout_level = null;
                     }
                 } else {
-                    $breakoutLevel = null;
+                    $breakout_level = null;
                 }
-                return new ast\Node($kind, 0, ['depth' => $breakoutLevel], $start_line);
+                return new ast\Node($kind, 0, ['depth' => $breakout_level], $start_line);
             },
             'Microsoft\PhpParser\Node\CatchClause' => function (PhpParser\Node\CatchClause $n, int $start_line) : ast\Node {
                 $qualified_name = $n->qualifiedName;
@@ -2613,10 +2613,10 @@ class TolerantASTConverter
      */
     private static function phpParserNameToString(PhpParser\Node\QualifiedName $name) : string
     {
-        $nameParts = $name->nameParts;
+        $name_parts = $name->nameParts;
         // TODO: Handle error case (can there be missing parts?)
         $result = '';
-        foreach ($nameParts as $part) {
+        foreach ($name_parts as $part) {
             $part_as_string = static::tokenToString($part);
             if ($part_as_string !== '') {
                 $result .= \trim($part_as_string);
@@ -2637,14 +2637,14 @@ class TolerantASTConverter
      */
     private static function newAstDecl(int $kind, int $flags, array $children, int $lineno, string $doc_comment = null, string $name = null, int $end_lineno = 0, int $decl_id = -1) : ast\Node
     {
-        $children50 = [];
-        $children50['name'] = $name;
-        $children50['docComment'] = $doc_comment;
-        $children50 += $children;
+        $decl_children = [];
+        $decl_children['name'] = $name;
+        $decl_children['docComment'] = $doc_comment;
+        $decl_children += $children;
         if ($decl_id >= 0) {
-            $children50['__declId'] = $decl_id;
+            $decl_children['__declId'] = $decl_id;
         }
-        $node = new ast\Node($kind, $flags, $children50, $lineno);
+        $node = new ast\Node($kind, $flags, $decl_children, $lineno);
         if (\is_int($end_lineno)) {
             $node->endLineno = $end_lineno;
         }

--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -127,8 +127,8 @@ class Analysis
 
         if (Config::getValue('simplify_ast')) {
             try {
-                $newNode = ASTSimplifier::applyStatic($node);  // Transform the original AST, leaving the original unmodified.
-                $node = $newNode;  // Analyze the new AST instead.
+                // Transform the original AST, and if successful, then analyze the new AST instead of the original
+                $node = ASTSimplifier::applyStatic($node);
             } catch (\Exception $e) {
                 Issue::maybeEmit(
                     $code_base,
@@ -514,8 +514,8 @@ class Analysis
 
         if (Config::getValue('simplify_ast')) {
             try {
-                $newNode = ASTSimplifier::applyStatic($node);  // Transform the original AST, leaving the original unmodified.
-                $node = $newNode;  // Analyze the new AST instead.
+                // Transform the original AST, and if successful, then analyze the new AST instead of the original
+                $node = ASTSimplifier::applyStatic($node);
             } catch (\Exception $e) {
                 Issue::maybeEmit(
                     $code_base,

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -629,17 +629,17 @@ class ConditionVisitor extends KindVisitorImplementation
             // Change the type to match the is_a relationship
             // If we already have possible scalar types, then keep those
             // (E.g. T|false becomes bool, T becomes int|float|bool|string|null)
-            $newType = $variable->getUnionType()->scalarTypes();
-            if ($newType->containsNullable()) {
-                $newType = $newType->nonNullableClone();
+            $new_type = $variable->getUnionType()->scalarTypes();
+            if ($new_type->containsNullable()) {
+                $new_type = $new_type->nonNullableClone();
             }
-            if ($newType->isEmpty()) {
+            if ($new_type->isEmpty()) {
                 // If there are no inferred types, or the only type we saw was 'null',
                 // assume there this can be any possible scalar.
                 // (Excludes `resource`, which is technically a scalar)
-                $newType = UnionType::fromFullyQualifiedString('int|float|bool|string');
+                $new_type = UnionType::fromFullyQualifiedString('int|float|bool|string');
             }
-            $variable->setUnionType($newType);
+            $variable->setUnionType($new_type);
         };
         $callable_callback = static function (Variable $variable, array $args) {
             // Change the type to match the is_a relationship

--- a/src/Phan/Analysis/ConditionVisitorUtil.php
+++ b/src/Phan/Analysis/ConditionVisitorUtil.php
@@ -214,8 +214,8 @@ trait ConditionVisitorUtil
         // Don't analyze variables such as $$a
         if (\is_string($var_name) && $var_name) {
             try {
-                $exprType = UnionTypeVisitor::unionTypeFromLiteralOrConstant($this->code_base, $context, $expr);
-                if ($exprType) {
+                $expr_type = UnionTypeVisitor::unionTypeFromLiteralOrConstant($this->code_base, $context, $expr);
+                if ($expr_type) {
                     // Get the variable we're operating on
                     $variable = $this->getVariableFromScope($var_node, $context);
                     if (\is_null($variable)) {
@@ -225,7 +225,7 @@ trait ConditionVisitorUtil
                     // Make a copy of the variable
                     $variable = clone($variable);
 
-                    $variable->setUnionType($exprType);
+                    $variable->setUnionType($expr_type);
 
                     // Overwrite the variable with its new type in this
                     // scope without overwriting other scopes
@@ -255,11 +255,11 @@ trait ConditionVisitorUtil
         if (\is_string($var_name)) {
             try {
                 if ($expr instanceof Node && $expr->kind === \ast\AST_CONST) {
-                    $exprNameNode = $expr->children['name'];
-                    if ($exprNameNode->kind === \ast\AST_NAME) {
+                    $expr_name_node = $expr->children['name'];
+                    if ($expr_name_node->kind === \ast\AST_NAME) {
                         // Currently, only add this inference when we're absolutely sure this is a check rejecting null/false/true
-                        $exprName = $exprNameNode->children['name'];
-                        switch (\strtolower($exprName)) {
+                        $expr_name = $expr_name_node->children['name'];
+                        switch (\strtolower($expr_name)) {
                             case 'null':
                                 return $this->removeNullFromVariable($var_node, $context, false);
                             case 'false':
@@ -292,11 +292,11 @@ trait ConditionVisitorUtil
             try {
                 if ($expr instanceof Node) {
                     if ($expr->kind === \ast\AST_CONST) {
-                        $exprNameNode = $expr->children['name'];
-                        if ($exprNameNode->kind === \ast\AST_NAME) {
+                        $expr_name_node = $expr->children['name'];
+                        if ($expr_name_node->kind === \ast\AST_NAME) {
                             // Currently, only add this inference when we're absolutely sure this is a check rejecting null/false/true
-                            $exprName = $exprNameNode->children['name'];
-                            switch (\strtolower($exprName)) {
+                            $expr_name = $expr_name_node->children['name'];
+                            switch (\strtolower($expr_name)) {
                                 case 'null':
                                 case 'false':
                                     return $this->removeFalseyFromVariable($var_node, $context, false);

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -722,9 +722,9 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
     {
         $context = $this->context;
         try {
-            $nameNode = $node->children['name'];
+            $name_node = $node->children['name'];
             // Based on UnionTypeVisitor::visitConst
-            if ($nameNode->kind == \ast\AST_NAME) {
+            if ($name_node->kind == \ast\AST_NAME) {
                 $constant = (new ContextNode(
                     $this->code_base,
                     $context,

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -363,8 +363,8 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
         // pass it down into the closure
         if ($context->getScope()->hasVariableWithName('this')) {
             // Normal case: Closures inherit $this from parent scope.
-            $thisVarFromScope = $context->getScope()->getVariableByName('this');
-            $func->getInternalScope()->addVariable($thisVarFromScope);
+            $this_var_from_scope = $context->getScope()->getVariableByName('this');
+            $func->getInternalScope()->addVariable($this_var_from_scope);
         }
     }
 

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -1047,7 +1047,7 @@ class CodeBase
             $signature = [(string)$function_or_method->getUnionType()];
             foreach ($function_or_method->getParameterList() as $param) {
                 $name = $param->getName();
-                $paramType = (string)$param->getUnionType();
+                $param_type = (string)$param->getUnionType();
                 if ($param->isVariadic()) {
                     $name = '...' . $name;
                 }
@@ -1057,7 +1057,7 @@ class CodeBase
                 if ($param->isOptional()) {
                     $name = $name . '=';
                 }
-                $signature[$name] = $paramType;
+                $signature[$name] = $param_type;
             }
             $result[$function_or_method_name] = $signature;
         }

--- a/src/Phan/CodeBase/UndoTracker.php
+++ b/src/Phan/CodeBase/UndoTracker.php
@@ -30,12 +30,12 @@ class UndoTracker
      * @var array<string,array<int,Closure>> operations to undo for a current path
      * @phan-var array<string,array<int,Closure(CodeBase)>>
      */
-    private $undoOperationsForPath = [];
+    private $undo_operations_for_path = [];
 
     /**
      * @var array<string,?string> Maps file paths to the modification dates and file size of the paths. - On ext4, milliseconds are available, but php APIs all return seconds.
      */
-    private $fileModificationState = [];
+    private $file_modification_state = [];
 
     public function __construct()
     {
@@ -51,7 +51,7 @@ class UndoTracker
      */
     public function getParsedFilePathList() : array
     {
-        return array_keys($this->fileModificationState);
+        return array_keys($this->file_modification_state);
     }
 
     /**
@@ -59,7 +59,7 @@ class UndoTracker
      */
     public function getParsedFilePathCount() : int
     {
-        return count($this->fileModificationState);
+        return count($this->file_modification_state);
     }
 
     /**
@@ -71,7 +71,7 @@ class UndoTracker
         if (\is_string($current_parsed_file)) {
             Daemon::debugf("Recording file modification state for %s", $current_parsed_file);
             // This shouldn't be null. TODO: Figure out what to do if it is.
-            $this->fileModificationState[$current_parsed_file] = self::getFileState($current_parsed_file);
+            $this->file_modification_state[$current_parsed_file] = self::getFileState($current_parsed_file);
         }
         $this->current_parsed_file = $current_parsed_file;
     }
@@ -107,7 +107,7 @@ class UndoTracker
         Daemon::debugf("%s was unparseable, had a syntax error", $current_parsed_file);
         Phan::getIssueCollector()->removeIssuesForFiles([$current_parsed_file]);
         $this->undoFileChanges($code_base, $current_parsed_file);
-        unset($this->fileModificationState[$current_parsed_file]);
+        unset($this->file_modification_state[$current_parsed_file]);
     }
 
     /**
@@ -117,10 +117,10 @@ class UndoTracker
     private function undoFileChanges(CodeBase $code_base, string $path)
     {
         Daemon::debugf("Undoing file changes for $path");
-        foreach ($this->undoOperationsForPath[$path] ?? [] as $undo_operation) {
+        foreach ($this->undo_operations_for_path[$path] ?? [] as $undo_operation) {
             $undo_operation($code_base);
         }
-        unset($this->undoOperationsForPath[$path]);
+        unset($this->undo_operations_for_path[$path]);
     }
 
     /**
@@ -135,10 +135,10 @@ class UndoTracker
         if (!\is_string($file)) {
             throw new \RuntimeException("Called recordUndo in CodeBaseMutable, but not parsing a file");
         }
-        if (!isset($this->undoOperationsForPath[$file])) {
-            $this->undoOperationsForPath[$file] = [];
+        if (!isset($this->undo_operations_for_path[$file])) {
+            $this->undo_operations_for_path[$file] = [];
         }
-        $this->undoOperationsForPath[$file][] = $undo_operation;
+        $this->undo_operations_for_path[$file][] = $undo_operation;
     }
 
     /**
@@ -160,29 +160,29 @@ class UndoTracker
         $removed_file_list = [];
         $changed_or_added_file_list = [];
         foreach ($new_file_set as $path => $_) {
-            if (!isset($this->fileModificationState[$path])) {
+            if (!isset($this->file_modification_state[$path])) {
                 $changed_or_added_file_list[] = $path;
             }
         }
-        foreach ($this->fileModificationState as $path => $state) {
+        foreach ($this->file_modification_state as $path => $state) {
             if (!isset($new_file_set[$path])) {
                 $this->undoFileChanges($code_base, $path);
                 $removed_file_list[] = $path;
-                unset($this->fileModificationState[$path]);
+                unset($this->file_modification_state[$path]);
                 continue;
             }
             if (isset($file_mapping_contents[$path])) {
                 // TODO: Move updateFileList to be called before fork()?
-                $newState = 'daemon:' . sha1($file_mapping_contents[$path]);
+                $new_state = 'daemon:' . sha1($file_mapping_contents[$path]);
             } else {
-                $newState = self::getFileState($path);
+                $new_state = self::getFileState($path);
             }
-            if ($newState !== $state) {
+            if ($new_state !== $state) {
                 $removed_file_list[] = $path;
                 $this->undoFileChanges($code_base, $path);
                 // TODO: This will call stat() twice as much as necessary for the modified files. Not important.
-                unset($this->fileModificationState[$path]);
-                if ($newState !== null) {
+                unset($this->file_modification_state[$path]);
+                if ($new_state !== null) {
                     $changed_or_added_file_list[] = $path;
                 }
             }
@@ -200,13 +200,13 @@ class UndoTracker
      */
     public function beforeReplaceFileContents(CodeBase $code_base, string $file_path)
     {
-        if (!isset($this->fileModificationState[$file_path])) {
+        if (!isset($this->file_modification_state[$file_path])) {
             Daemon::debugf("Tried to replace contents of '$file_path', but that path does not yet exist");
             return false;
         }
         Phan::getIssueCollector()->removeIssuesForFiles([$file_path]);
         $this->undoFileChanges($code_base, $file_path);
-        unset($this->fileModificationState[$file_path]);
+        unset($this->file_modification_state[$file_path]);
         return true;
     }
 }

--- a/src/Phan/Daemon.php
+++ b/src/Phan/Daemon.php
@@ -49,13 +49,13 @@ class Daemon
         // TODO: Limit the maximum number of active processes to a small number(4?)
         // TODO: accept SIGCHLD when child terminates, somehow?
         try {
-            $gotSignal = false;
-            pcntl_signal(SIGCHLD, function (...$args) use (&$gotSignal) {
-                $gotSignal = true;
+            $got_signal = false;
+            pcntl_signal(SIGCHLD, function (...$args) use (&$got_signal) {
+                $got_signal = true;
                 Request::childSignalHandler(...$args);
             });
             while (true) {
-                $gotSignal = false;  // reset this.
+                $got_signal = false;  // reset this.
                 // We get an error from stream_socket_accept. After the RuntimeException is thrown, pcntl_signal is called.
                 /**
                  * @param int $severity
@@ -64,10 +64,10 @@ class Daemon
                  * @param int $line
                  * @return bool
                  * @phan-suppress-next-line PhanPluginUnusedVariable https://github.com/mattriverm/PhanUnusedVariable/issues/30 */
-                $previousErrorHandler = set_error_handler(function ($severity, $message, $file, $line) use (&$previousErrorHandler) {
+                $previous_error_handler = set_error_handler(function ($severity, $message, $file, $line) use (&$previous_error_handler) {
                     self::debugf("In new error handler '$message'");
                     if (!preg_match('/stream_socket_accept/i', $message)) {
-                        return $previousErrorHandler($severity, $message, $file, $line);
+                        return $previous_error_handler($severity, $message, $file, $line);
                     }
                     throw new \RuntimeException("Got signal");
                 });
@@ -79,7 +79,7 @@ class Daemon
                     self::debugf("Got signal");
                     pcntl_signal_dispatch();
                     self::debugf("done processing signals");
-                    if ($gotSignal) {
+                    if ($got_signal) {
                         continue;  // Ignore notices from stream_socket_accept if it's due to being interrupted by a child process terminating.
                     }
                 } finally {
@@ -117,13 +117,13 @@ class Daemon
         $socket_server = self::createDaemonStreamSocketServer();
         try {
             while (true) {
-                $gotSignal = false;  // reset this.
+                $got_signal = false;  // reset this.
                 // We get an error from stream_socket_accept. After the RuntimeException is thrown, pcntl_signal is called.
                 // @phan-suppress-next-line PhanPluginUnusedVariable
-                $previousErrorHandler = set_error_handler(function ($severity, $message, $file, $line) use (&$previousErrorHandler) {
+                $previous_error_handler = set_error_handler(function ($severity, $message, $file, $line) use (&$previous_error_handler) {
                     self::debugf("In new error handler '$message'");
                     if (!preg_match('/stream_socket_accept/i', $message)) {
-                        return $previousErrorHandler($severity, $message, $file, $line);
+                        return $previous_error_handler($severity, $message, $file, $line);
                     }
                     throw new \RuntimeException("Got signal");
                 });
@@ -135,7 +135,7 @@ class Daemon
                     self::debugf("Got signal");
                     pcntl_signal_dispatch();
                     self::debugf("done processing signals");
-                    if ($gotSignal) {
+                    if ($got_signal) {
                         continue;  // Ignore notices from stream_socket_accept if it's due to being interrupted by a child process terminating.
                     }
                 } finally {

--- a/src/Phan/Daemon/Request.php
+++ b/src/Phan/Daemon/Request.php
@@ -175,7 +175,7 @@ class Request
      * Respond with issues in the requested format
      * @return void
      */
-    public function respondWithIssues(int $issueCount)
+    public function respondWithIssues(int $issue_count)
     {
         $raw_issues = $this->buffered_output->fetch();
         if (($this->config[self::PARAM_FORMAT] ?? null) === 'json') {
@@ -188,7 +188,7 @@ class Request
         }
         $response = [
             "status" => self::STATUS_OK,
-            "issue_count" => $issueCount,
+            "issue_count" => $issue_count,
             "issues" => $issues,
         ];
         if ($this->most_recent_definition_request) {
@@ -220,21 +220,21 @@ class Request
         }
 
         $analyze_file_path_set = array_flip($analyze_file_path_list);
-        $filteredFiles = [];
+        $filtered_files = [];
         foreach ($this->files as $file) {
             // Must be relative to project, allow absolute paths to be passed in.
             $file = FileRef::getProjectRelativePathForPath($file);
 
             if (\array_key_exists($file, $analyze_file_path_set)) {
-                $filteredFiles[] = $file;
+                $filtered_files[] = $file;
             } else {
                 // TODO: Reload file list once before processing request?
                 // TODO: Change this to also support analyzing files that would normally be parsed but not analyzed?
                 Daemon::debugf("Failed to find requested file '%s' in parsed file list", $file, json_encode($analyze_file_path_list));
             }
         }
-        Daemon::debugf("Returning file set: %s", json_encode($filteredFiles));
-        return $filteredFiles;
+        Daemon::debugf("Returning file set: %s", json_encode($filtered_files));
+        return $filtered_files;
     }
 
     /**

--- a/src/Phan/Debug.php
+++ b/src/Phan/Debug.php
@@ -137,9 +137,9 @@ class Debug
             $string .= ' #' . $node->lineno;
         }
 
-        $endLineno = $node->endLineno ?? null;
-        if (!\is_null($endLineno)) {
-            $string .= ':' . $endLineno;
+        $end_lineno = $node->endLineno ?? null;
+        if (!\is_null($end_lineno)) {
+            $string .= ':' . $end_lineno;
         }
 
         $string .= "\n";
@@ -166,13 +166,13 @@ class Debug
         list($exclusive, $combinable) = self::getFlagInfo();
         $flag_names = [];
         if (isset($exclusive[$kind])) {
-            $flagInfo = $exclusive[$kind];
-            if (isset($flagInfo[$flags])) {
-                $flag_names[] = $flagInfo[$flags];
+            $flag_info = $exclusive[$kind];
+            if (isset($flag_info[$flags])) {
+                $flag_names[] = $flag_info[$flags];
             }
         } elseif (isset($combinable[$kind])) {
-            $flagInfo = $combinable[$kind];
-            foreach ($flagInfo as $flag => $name) {
+            $flag_info = $combinable[$kind];
+            foreach ($flag_info as $flag => $name) {
                 if ($flags & $flag) {
                     $flag_names[] = $name;
                 }
@@ -192,14 +192,14 @@ class Debug
     {
         list($exclusive, $combinable) = self::getFlagInfo();
         if (isset($exclusive[$kind])) {
-            $flagInfo = $exclusive[$kind];
-            if (isset($flagInfo[$flags])) {
-                return "{$flagInfo[$flags]} ($flags)";
+            $flag_info = $exclusive[$kind];
+            if (isset($flag_info[$flags])) {
+                return "{$flag_info[$flags]} ($flags)";
             }
         } elseif (isset($combinable[$kind])) {
-            $flagInfo = $combinable[$kind];
+            $flag_info = $combinable[$kind];
             $names = [];
-            foreach ($flagInfo as $flag => $name) {
+            foreach ($flag_info as $flag => $name) {
                 if ($flags & $flag) {
                     $names[] = $name;
                 }
@@ -245,9 +245,9 @@ class Debug
 
             if ($options & self::AST_DUMP_LINENOS) {
                 $result .= " @ $ast->lineno";
-                $endLineno = $ast->endLineno ?? null;
-                if (!\is_null($endLineno)) {
-                    $result .= "-$endLineno";
+                $end_lineno = $ast->endLineno ?? null;
+                if (!\is_null($end_lineno)) {
+                    $result .= "-$end_lineno";
                 }
             }
 
@@ -277,6 +277,7 @@ class Debug
      */
     private static function getFlagInfo() : array
     {
+        // TODO: Use AST's built in flag info if available.
         static $exclusive, $combinable;
         if ($exclusive !== null) {
             return [$exclusive, $combinable];
@@ -304,12 +305,12 @@ class Debug
             flags\TYPE_VOID => 'TYPE_VOID',
             flags\TYPE_ITERABLE => 'TYPE_ITERABLE',
         ];
-        $useTypes = [
+        $use_types = [
             flags\USE_NORMAL => 'USE_NORMAL',
             flags\USE_FUNCTION => 'USE_FUNCTION',
             flags\USE_CONST => 'USE_CONST',
         ];
-        $sharedBinaryOps = [
+        $shared_binary_ops = [
             flags\BINARY_BITWISE_OR => 'BINARY_BITWISE_OR',
             flags\BINARY_BITWISE_AND => 'BINARY_BITWISE_AND',
             flags\BINARY_BITWISE_XOR => 'BINARY_BITWISE_XOR',
@@ -350,7 +351,7 @@ class Debug
                 flags\UNARY_PLUS => 'UNARY_PLUS',
                 flags\UNARY_SILENCE => 'UNARY_SILENCE',
             ],
-            \ast\AST_BINARY_OP => $sharedBinaryOps + [
+            \ast\AST_BINARY_OP => $shared_binary_ops + [
                 flags\BINARY_BOOL_AND => 'BINARY_BOOL_AND',
                 flags\BINARY_BOOL_OR => 'BINARY_BOOL_OR',
                 flags\BINARY_BOOL_XOR => 'BINARY_BOOL_XOR',
@@ -365,7 +366,7 @@ class Debug
                 flags\BINARY_SPACESHIP => 'BINARY_SPACESHIP',
                 flags\BINARY_COALESCE => 'BINARY_COALESCE',
             ],
-            \ast\AST_ASSIGN_OP => $sharedBinaryOps + [
+            \ast\AST_ASSIGN_OP => $shared_binary_ops + [
                 // Old version 10 flags
                 flags\ASSIGN_BITWISE_OR => 'ASSIGN_BITWISE_OR',
                 flags\ASSIGN_BITWISE_AND => 'ASSIGN_BITWISE_AND',
@@ -390,9 +391,9 @@ class Debug
                 flags\MAGIC_CLASS => 'MAGIC_CLASS',
                 flags\MAGIC_TRAIT => 'MAGIC_TRAIT',
             ],
-            \ast\AST_USE => $useTypes,
-            \ast\AST_GROUP_USE => $useTypes,
-            \ast\AST_USE_ELEM => $useTypes,
+            \ast\AST_USE => $use_types,
+            \ast\AST_GROUP_USE => $use_types,
+            \ast\AST_USE_ELEM => $use_types,
             \ast\AST_INCLUDE_OR_EVAL => [
                 flags\EXEC_EVAL => 'EXEC_EVAL',
                 flags\EXEC_INCLUDE => 'EXEC_INCLUDE',

--- a/src/Phan/Debug/Breakpoint.php
+++ b/src/Phan/Debug/Breakpoint.php
@@ -3,9 +3,9 @@ namespace Phan\Debug;
 
 readline_completion_function(function ($input) {
     $matches = [];
-    foreach (\get_declared_classes() as $className) {
-        if (\strpos($className, $input) == 0) {
-            $matches[] = $className;
+    foreach (\get_declared_classes() as $class_name) {
+        if (\strpos($class_name, $input) == 0) {
+            $matches[] = $class_name;
         }
     }
     return $matches;

--- a/src/Phan/IssueFixSuggester.php
+++ b/src/Phan/IssueFixSuggester.php
@@ -423,7 +423,7 @@ class IssueFixSuggester
             return [];
         }
         $search_name = strtolower($target);
-        $N = strlen($search_name);
+        $target_length = strlen($search_name);
         $max_levenshtein_distance = (int)(1 + strlen($search_name) / 6);
         $best_matches = [];
         $min_found_distance = $max_levenshtein_distance;
@@ -431,7 +431,7 @@ class IssueFixSuggester
         foreach ($potential_candidates as $name => $_) {
             $name = (string)$name;
 
-            if (\abs(strlen($name) - $N) > $max_levenshtein_distance) {
+            if (\abs(strlen($name) - $target_length) > $max_levenshtein_distance) {
                 continue;
             }
             $distance = levenshtein(strtolower($name), $search_name);

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -1457,9 +1457,9 @@ class Clazz extends AddressableElement
         }
         if ($method->getHasYield()) {
             // There's no phpdoc standard for template types of Generators at the moment.
-            $newType = UnionType::fromFullyQualifiedString('\\Generator');
-            if (!$newType->canCastToUnionType($method->getUnionType())) {
-                $method->setUnionType($newType);
+            $new_type = UnionType::fromFullyQualifiedString('\\Generator');
+            if (!$new_type->canCastToUnionType($method->getUnionType())) {
+                $method->setUnionType($new_type);
             }
         }
 

--- a/src/Phan/Language/Element/Comment.php
+++ b/src/Phan/Language/Element/Comment.php
@@ -386,15 +386,15 @@ class Comment
         $comment_lines_count = \count($lines);
 
         /**
-         * @param array<int,int> $validTypes
+         * @param array<int,int> $valid_types
          * @return void
          */
-        $check_compatible = function (string $paramName, array $validTypes, int $i, string $line) use ($code_base, $context, $comment_type, $lineno, $comment_lines_count) {
-            if (!\in_array($comment_type, $validTypes, true)) {
+        $check_compatible = function (string $param_name, array $valid_types, int $i, string $line) use ($code_base, $context, $comment_type, $lineno, $comment_lines_count) {
+            if (!\in_array($comment_type, $valid_types, true)) {
                 self::emitInvalidCommentForDeclarationType(
                     $code_base,
                     $context,
-                    $paramName,
+                    $param_name,
                     $comment_type,
                     self::guessActualLineLocation($context, $lineno, $i, $comment_lines_count, $line)
                 );

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -412,9 +412,9 @@ trait FunctionTrait
         if ($parameter) {
             return $parameter->asNonVariadic();
         }
-        $lastParameter = $list[count($list) - 1];
-        if ($lastParameter->isVariadic()) {
-            return $lastParameter->asNonVariadic();
+        $last_parameter = $list[count($list) - 1];
+        if ($last_parameter->isVariadic()) {
+            return $last_parameter->asNonVariadic();
         }
         return null;
     }
@@ -713,20 +713,20 @@ trait FunctionTrait
             // If there are no types on the parameter, the
             // default shouldn't be treated as the one
             // and only allowable type.
-            $wasEmpty = $parameter->getUnionType()->isEmpty();
+            $was_empty = $parameter->getUnionType()->isEmpty();
 
             // If we have no other type info about a parameter,
             // just because it has a default value of null
             // doesn't mean that is its type. Any type can default
             // to null
             if ($default_is_null) {
-                if ($wasEmpty) {
+                if ($was_empty) {
                     $parameter->addUnionType(MixedType::instance(false)->asUnionType());
                 }
                 // The parameter constructor or above check for wasEmpty already took care of null default case
             } else {
                 $default_type = $default_type->withFlattenedArrayShapeOrLiteralTypeInstances();
-                if ($wasEmpty) {
+                if ($was_empty) {
                     $parameter->addUnionType(self::inferNormalizedTypesOfDefault($default_type));
                     if (!Config::getValue('guess_unknown_parameter_type_using_default')) {
                         $parameter->addUnionType(MixedType::instance(false)->asUnionType());

--- a/src/Phan/Language/Element/Parameter.php
+++ b/src/Phan/Language/Element/Parameter.php
@@ -471,9 +471,9 @@ class Parameter extends Variable
     {
         $string = '';
 
-        $typeObj = $this->getNonVariadicUnionType();
-        if (!$typeObj->isEmpty()) {
-            $string .= (string)$typeObj . ' ';
+        $union_type = $this->getNonVariadicUnionType();
+        if (!$union_type->isEmpty()) {
+            $string .= $union_type->__toString() . ' ';
         }
 
         if ($this->isPassByReference()) {
@@ -502,9 +502,9 @@ class Parameter extends Variable
     {
         $string = '';
 
-        $typeObj = $this->getNonVariadicUnionType();
-        if (!$typeObj->isEmpty()) {
-            $string .= (string)$typeObj . ' ';
+        $union_type = $this->getNonVariadicUnionType();
+        if (!$union_type->isEmpty()) {
+            $string .= $union_type->__toString() . ' ';
         }
 
         if ($this->isPassByReference()) {

--- a/src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php
@@ -341,7 +341,7 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN
     }
 
     /** @var string|null */
-    private $asString = null;
+    private $as_string = null;
 
     /**
      * @return string
@@ -350,15 +350,15 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN
      */
     public function __toString() : string
     {
-        $asString = $this->asString;
-        if ($asString === null) {
-            $asString = static::toString(
+        $as_string = $this->as_string;
+        if ($as_string === null) {
+            $as_string = static::toString(
                 $this->getNamespace(),
                 $this->getName(),
                 $this->getAlternateId()
             );
-            $this->asString = $asString;
+            $this->as_string = $as_string;
         }
-        return $asString;
+        return $as_string;
     }
 }

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -1770,9 +1770,9 @@ class Type
     private function valueTypeOfTraversable()
     {
         $template_type_list = $this->template_parameter_type_list;
-        $N = \count($template_type_list);
-        if ($N >= 1 && $N <= 2) {
-            return $template_type_list[$N - 1];
+        $count = \count($template_type_list);
+        if ($count >= 1 && $count <= 2) {
+            return $template_type_list[$count - 1];
         }
         return null;
     }
@@ -2095,18 +2095,18 @@ class Type
     private function canCastTraversableToIterable(GenericIterableType $type) : bool
     {
         $template_types = $this->template_parameter_type_list;
-        $N = \count($template_types);
+        $count = \count($template_types);
         $name = $this->name;
         if ($name === 'Traversable' || $name === 'Iterator') {
             // Phan supports Traversable<TValue> and Traversable<TKey, TValue>
-            if ($N > 2 || $N < 1) {
+            if ($count > 2 || $count < 1) {
                 // No idea what this means, assume it passes.
                 return true;
             }
-            if (!$this->template_parameter_type_list[$N - 1]->canCastToUnionType($type->getElementUnionType())) {
+            if (!$this->template_parameter_type_list[$count - 1]->canCastToUnionType($type->getElementUnionType())) {
                 return false;
             }
-            if ($N === 2) {
+            if ($count === 2) {
                 if (!$this->template_parameter_type_list[0]->canCastToUnionType($type->getKeyUnionType())) {
                     return false;
                 }
@@ -2120,15 +2120,15 @@ class Type
             // 4. Generator<TKey, TValue, TYield, TReturn> (PHP generators can return a final value, but HHVM cannot)
 
             // TODO: Handle casting Generator to a Generator with a different number of template parameters
-            if ($N > 4 || $N < 1) {
+            if ($count > 4 || $count < 1) {
                 // No idea what this means, assume it passes
                 return true;
             }
 
-            if (!$this->template_parameter_type_list[\min(1, $N - 1)]->canCastToUnionType($type->getElementUnionType())) {
+            if (!$this->template_parameter_type_list[\min(1, $count - 1)]->canCastToUnionType($type->getElementUnionType())) {
                 return false;
             }
-            if ($N >= 2) {
+            if ($count >= 2) {
                 if (!$this->template_parameter_type_list[0]->canCastToUnionType($type->getKeyUnionType())) {
                     return false;
                 }

--- a/src/Phan/Language/Type/NativeType.php
+++ b/src/Phan/Language/Type/NativeType.php
@@ -122,23 +122,23 @@ abstract class NativeType extends Type
      */
     private static function initializeTypeCastingMatrix() : array
     {
-        $generateRow = function (string ...$permittedCastTypeNames) {
+        $generate_row = function (string ...$permitted_cast_type_names) {
             return [
-                ArrayType::NAME    => in_array(ArrayType::NAME, $permittedCastTypeNames, true),
-                IterableType::NAME => in_array(IterableType::NAME, $permittedCastTypeNames, true),
-                BoolType::NAME     => in_array(BoolType::NAME, $permittedCastTypeNames, true),
-                CallableType::NAME => in_array(CallableType::NAME, $permittedCastTypeNames, true),
-                FalseType::NAME    => in_array(FalseType::NAME, $permittedCastTypeNames, true),
-                FloatType::NAME    => in_array(FloatType::NAME, $permittedCastTypeNames, true),
-                IntType::NAME      => in_array(IntType::NAME, $permittedCastTypeNames, true),
+                ArrayType::NAME    => in_array(ArrayType::NAME, $permitted_cast_type_names, true),
+                IterableType::NAME => in_array(IterableType::NAME, $permitted_cast_type_names, true),
+                BoolType::NAME     => in_array(BoolType::NAME, $permitted_cast_type_names, true),
+                CallableType::NAME => in_array(CallableType::NAME, $permitted_cast_type_names, true),
+                FalseType::NAME    => in_array(FalseType::NAME, $permitted_cast_type_names, true),
+                FloatType::NAME    => in_array(FloatType::NAME, $permitted_cast_type_names, true),
+                IntType::NAME      => in_array(IntType::NAME, $permitted_cast_type_names, true),
                 MixedType::NAME    => true,
-                NullType::NAME     => in_array(NullType::NAME, $permittedCastTypeNames, true),
-                ObjectType::NAME   => in_array(ObjectType::NAME, $permittedCastTypeNames, true),
-                ResourceType::NAME => in_array(ResourceType::NAME, $permittedCastTypeNames, true),
-                ScalarRawType::NAME => in_array(ScalarRawType::NAME, $permittedCastTypeNames, true),
-                StringType::NAME   => in_array(StringType::NAME, $permittedCastTypeNames, true),
-                TrueType::NAME     => in_array(TrueType::NAME, $permittedCastTypeNames, true),
-                VoidType::NAME     => in_array(VoidType::NAME, $permittedCastTypeNames, true),
+                NullType::NAME     => in_array(NullType::NAME, $permitted_cast_type_names, true),
+                ObjectType::NAME   => in_array(ObjectType::NAME, $permitted_cast_type_names, true),
+                ResourceType::NAME => in_array(ResourceType::NAME, $permitted_cast_type_names, true),
+                ScalarRawType::NAME => in_array(ScalarRawType::NAME, $permitted_cast_type_names, true),
+                StringType::NAME   => in_array(StringType::NAME, $permitted_cast_type_names, true),
+                TrueType::NAME     => in_array(TrueType::NAME, $permitted_cast_type_names, true),
+                VoidType::NAME     => in_array(VoidType::NAME, $permitted_cast_type_names, true),
             ];
         };
 
@@ -147,20 +147,20 @@ abstract class NativeType extends Type
         // (Represented in a readable format, with only the true entries (omitting Mixed, which is always true))
 
         return [
-            ArrayType::NAME    => $generateRow(ArrayType::NAME, IterableType::NAME, CallableType::NAME),
-            BoolType::NAME     => $generateRow(BoolType::NAME, FalseType::NAME, TrueType::NAME, ScalarRawType::NAME),
-            CallableType::NAME => $generateRow(CallableType::NAME),
-            FalseType::NAME    => $generateRow(FalseType::NAME, BoolType::NAME, ScalarRawType::NAME),
-            FloatType::NAME    => $generateRow(FloatType::NAME, ScalarRawType::NAME),
-            IntType::NAME      => $generateRow(IntType::NAME, FloatType::NAME, ScalarRawType::NAME),
-            IterableType::NAME => $generateRow(IterableType::NAME),
-            MixedType::NAME    => $generateRow(MixedType::NAME),  // MixedType overrides the methods which would use this
-            NullType::NAME     => $generateRow(NullType::NAME),
-            ObjectType::NAME   => $generateRow(ObjectType::NAME),
-            ResourceType::NAME => $generateRow(ResourceType::NAME),
-            StringType::NAME   => $generateRow(StringType::NAME, CallableType::NAME, ScalarRawType::NAME),
-            TrueType::NAME     => $generateRow(TrueType::NAME, BoolType::NAME, ScalarRawType::NAME),
-            VoidType::NAME     => $generateRow(VoidType::NAME),
+            ArrayType::NAME    => $generate_row(ArrayType::NAME, IterableType::NAME, CallableType::NAME),
+            BoolType::NAME     => $generate_row(BoolType::NAME, FalseType::NAME, TrueType::NAME, ScalarRawType::NAME),
+            CallableType::NAME => $generate_row(CallableType::NAME),
+            FalseType::NAME    => $generate_row(FalseType::NAME, BoolType::NAME, ScalarRawType::NAME),
+            FloatType::NAME    => $generate_row(FloatType::NAME, ScalarRawType::NAME),
+            IntType::NAME      => $generate_row(IntType::NAME, FloatType::NAME, ScalarRawType::NAME),
+            IterableType::NAME => $generate_row(IterableType::NAME),
+            MixedType::NAME    => $generate_row(MixedType::NAME),  // MixedType overrides the methods which would use this
+            NullType::NAME     => $generate_row(NullType::NAME),
+            ObjectType::NAME   => $generate_row(ObjectType::NAME),
+            ResourceType::NAME => $generate_row(ResourceType::NAME),
+            StringType::NAME   => $generate_row(StringType::NAME, CallableType::NAME, ScalarRawType::NAME),
+            TrueType::NAME     => $generate_row(TrueType::NAME, BoolType::NAME, ScalarRawType::NAME),
+            VoidType::NAME     => $generate_row(VoidType::NAME),
         ];
     }
 

--- a/src/Phan/Library/Hasher/Consistent.php
+++ b/src/Phan/Library/Hasher/Consistent.php
@@ -13,25 +13,25 @@ class Consistent implements Hasher
     const VIRTUAL_COPY_COUNT = 16;  // Larger number means a more balanced distribution.
     const MAX = 0x40000000;  // i.e. (1 << 30)
     /** @var array<int,int> - Sorted list of hash values, for binary search. */
-    protected $hashRingIds;
-    /** @var array<int,int> - Groups corresponding to hash values in hashRingIds */
-    protected $hashRingGroups;
+    protected $hash_ring_ids;
+    /** @var array<int,int> - Groups corresponding to hash values in hash_ring_ids */
+    protected $hash_ring_groups;
 
     public function __construct(int $groupCount)
     {
         $map = self::generateMap($groupCount);
-        $hashRingIds = [];
-        $hashRingGroups = [];
+        $hash_ring_ids = [];
+        $hash_ring_groups = [];
         foreach ($map as $key => $group) {
-            $hashRingIds[] = $key;
-            $hashRingGroups[] = $group;
+            $hash_ring_ids[] = $key;
+            $hash_ring_groups[] = $group;
         }
         // ... and make the map wrap around.
-        $hashRingIds[] = self::MAX - 1;
-        $hashRingGroups[] = \reset($map) ?: 0;
+        $hash_ring_ids[] = self::MAX - 1;
+        $hash_ring_groups[] = \reset($map) ?: 0;
 
-        $this->hashRingIds = $hashRingIds;
-        $this->hashRingGroups = $hashRingGroups;
+        $this->hash_ring_ids = $hash_ring_ids;
+        $this->hash_ring_groups = $hash_ring_groups;
     }
 
     /**
@@ -54,22 +54,22 @@ class Consistent implements Hasher
      */
     public function getGroup(string $key) : int
     {
-        $searchHash = self::generateKeyHash($key);
+        $search_hash = self::generateKeyHash($key);
         $begin = 0;
-        $end = count($this->hashRingIds) - 1;
+        $end = count($this->hash_ring_ids) - 1;
         while ($begin <= $end) {
             $pos = $begin + (($end - $begin) >> 1);
-            $curVal = $this->hashRingIds[$pos];
-            if ($searchHash > $curVal) {
+            $cur_val = $this->hash_ring_ids[$pos];
+            if ($search_hash > $cur_val) {
                 $begin = $pos + 1;
             } else {
                 $end = $pos - 1;
             }
         }
-        // Postcondition: $this->hashRingIds[$begin] >= $searchHash, and $this->hashRingIds[$begin - 1] does not exist or is less than $searchHash.
+        // Postcondition: $this->hash_ring_ids[$begin] >= $search_hash, and $this->hash_ring_ids[$begin - 1] does not exist or is less than $search_hash.
 
         // Fetch the group corresponding to that hash in the hash ring.
-        return $this->hashRingGroups[$begin];
+        return $this->hash_ring_groups[$begin];
     }
 
     /**

--- a/src/Phan/Library/Hasher/Consistent.php
+++ b/src/Phan/Library/Hasher/Consistent.php
@@ -17,9 +17,9 @@ class Consistent implements Hasher
     /** @var array<int,int> - Groups corresponding to hash values in hash_ring_ids */
     protected $hash_ring_groups;
 
-    public function __construct(int $groupCount)
+    public function __construct(int $group_count)
     {
-        $map = self::generateMap($groupCount);
+        $map = self::generateMap($group_count);
         $hash_ring_ids = [];
         $hash_ring_groups = [];
         foreach ($map as $key => $group) {
@@ -37,10 +37,10 @@ class Consistent implements Hasher
     /**
      * @return array<int,int> maps points in the field to the corresponding group (for consistent hashing)
      */
-    private static function generateMap(int $groupCount)
+    private static function generateMap(int $group_count)
     {
         $map = [];
-        for ($group = 0; $group < $groupCount; $group++) {
+        for ($group = 0; $group < $group_count; $group++) {
             foreach (self::getHashesForGroup($group) as $hash) {
                 $map[$hash] = $group;
             }
@@ -50,7 +50,7 @@ class Consistent implements Hasher
     }
     /**
      * Do a binary search in the consistent hashing ring to find the group.
-     * @return int - an integer between 0 and $this->groupCount - 1, inclusive
+     * @return int - an integer between 0 and $this->group_count - 1, inclusive
      */
     public function getGroup(string $key) : int
     {

--- a/src/Phan/Library/Hasher/Sequential.php
+++ b/src/Phan/Library/Hasher/Sequential.php
@@ -12,21 +12,21 @@ class Sequential implements Hasher
     /** @var int */
     protected $counter;
     /** @var int */
-    protected $groupCount;
+    protected $group_count;
 
-    public function __construct(int $groupCount)
+    public function __construct(int $group_count)
     {
         $this->counter = 1;
-        $this->groupCount = $groupCount;
+        $this->group_count = $group_count;
     }
 
     /**
      * @param string $key (Used by sibling class Consistent) (@phan-unused-param)
-     * @return int - an integer between 0 and $this->groupCount - 1, inclusive
+     * @return int - an integer between 0 and $this->group_count - 1, inclusive
      */
     public function getGroup(string $key) : int
     {
-        return ($this->counter++) % $this->groupCount;
+        return ($this->counter++) % $this->group_count;
     }
 
     /**

--- a/src/Phan/Output/Filter/FileIssueFilter.php
+++ b/src/Phan/Output/Filter/FileIssueFilter.php
@@ -9,17 +9,17 @@ final class FileIssueFilter implements IssueFilterInterface
 {
 
     /** @var IgnoredFilesFilterInterface */
-    private $ignoredFilesFilter;
+    private $ignored_files_filter;
 
     /**
      * FileIssueFilter constructor.
      *
-     * @param IgnoredFilesFilterInterface $ignoredFilesFilter
+     * @param IgnoredFilesFilterInterface $ignored_files_filter
      */
     public function __construct(
-        IgnoredFilesFilterInterface $ignoredFilesFilter
+        IgnoredFilesFilterInterface $ignored_files_filter
     ) {
-        $this->ignoredFilesFilter = $ignoredFilesFilter;
+        $this->ignored_files_filter = $ignored_files_filter;
     }
 
     /**
@@ -28,6 +28,6 @@ final class FileIssueFilter implements IssueFilterInterface
      */
     public function supports(IssueInstance $issue):bool
     {
-        return !$this->ignoredFilesFilter->isFilenameIgnored($issue->getFile());
+        return !$this->ignored_files_filter->isFilenameIgnored($issue->getFile());
     }
 }

--- a/src/Phan/Output/Filter/MinimumSeverityFilter.php
+++ b/src/Phan/Output/Filter/MinimumSeverityFilter.php
@@ -9,15 +9,15 @@ final class MinimumSeverityFilter implements IssueFilterInterface
 {
 
     /** @var int */
-    private $minimumSeverity;
+    private $minimum_severity;
 
     /**
      * MinimumSeverityFilter constructor.
-     * @param $minimumSeverity
+     * @param int $minimum_severity should be a constant from Issue::SEVERITY_*
      */
-    public function __construct(int $minimumSeverity = Issue::SEVERITY_LOW)
+    public function __construct(int $minimum_severity = Issue::SEVERITY_LOW)
     {
-        $this->minimumSeverity = $minimumSeverity;
+        $this->minimum_severity = $minimum_severity;
     }
 
 
@@ -27,6 +27,6 @@ final class MinimumSeverityFilter implements IssueFilterInterface
      */
     public function supports(IssueInstance $issue):bool
     {
-        return $issue->getIssue()->getSeverity() >= $this->minimumSeverity;
+        return $issue->getIssue()->getSeverity() >= $this->minimum_severity;
     }
 }

--- a/src/Phan/Output/Printer/CodeClimatePrinter.php
+++ b/src/Phan/Output/Printer/CodeClimatePrinter.php
@@ -39,13 +39,13 @@ final class CodeClimatePrinter implements BufferedPrinterInterface
     }
 
     /**
-     * @param int $rawSeverity
+     * @param int $raw_severity
      * @return string
      */
-    private static function mapSeverity(int $rawSeverity):string
+    private static function mapSeverity(int $raw_severity) : string
     {
         $severity = self::CODECLIMATE_SEVERITY_INFO;
-        switch ($rawSeverity) {
+        switch ($raw_severity) {
             case Issue::SEVERITY_CRITICAL:
                 $severity = self::CODECLIMATE_SEVERITY_CRITICAL;
                 break;
@@ -64,8 +64,8 @@ final class CodeClimatePrinter implements BufferedPrinterInterface
         // See https://github.com/codeclimate/spec/blob/master/SPEC.md#output
         // for details on the CodeClimate output format
         foreach ($this->messages as $message) {
-            $encodedMessage = json_encode($message, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . "\0";
-            $this->output->write($encodedMessage, false, OutputInterface::OUTPUT_RAW);
+            $encoded_message = json_encode($message, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . "\0";
+            $this->output->write($encoded_message, false, OutputInterface::OUTPUT_RAW);
         }
         $this->messages = [];
     }

--- a/src/Phan/Output/Printer/JSONPrinter.php
+++ b/src/Phan/Output/Printer/JSONPrinter.php
@@ -48,8 +48,8 @@ final class JSONPrinter implements BufferedPrinterInterface
     {
         // NOTE: Need to use OUTPUT_RAW for JSON.
         // Otherwise, error messages such as "...Unexpected << (T_SL)" don't get formatted properly (They get escaped into unparseable JSON)
-        $encodedMessage = json_encode($this->messages, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
-        $this->output->write($encodedMessage, false, OutputInterface::OUTPUT_RAW);
+        $encoded_message = json_encode($this->messages, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $this->output->write($encoded_message, false, OutputInterface::OUTPUT_RAW);
         $this->messages = [];
     }
 

--- a/src/Phan/Output/Printer/PylintPrinter.php
+++ b/src/Phan/Output/Printer/PylintPrinter.php
@@ -37,14 +37,14 @@ final class PylintPrinter implements IssuePrinterInterface
     public static function getSeverityCode(IssueInstance $instance) : string
     {
         $issue = $instance->getIssue();
-        $categoryId = $issue->getTypeId();
+        $category_id = $issue->getTypeId();
         switch ($issue->getSeverity()) {
             case Issue::SEVERITY_LOW:
-                return 'C' . $categoryId;
+                return 'C' . $category_id;
             case Issue::SEVERITY_NORMAL:
-                return 'W' . $categoryId;
+                return 'W' . $category_id;
             case Issue::SEVERITY_CRITICAL:
-                return 'E' . $categoryId;
+                return 'E' . $category_id;
             default:
                 throw new \AssertionError("Unrecognized severity for " . __METHOD__ . ": " . $issue->getSeverity());
         }

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -379,14 +379,14 @@ class ParseVisitor extends ScopeVisitor
     {
         // Bomb out if we're not in a class context
         $class = $this->getContextClass();
-        $docComment = '';
+        $doc_comment = '';
         $first_child_node = $node->children[0] ?? null;
         if ($first_child_node instanceof Node) {
-            $docComment = $first_child_node->children['docComment'] ?? '';
+            $doc_comment = $first_child_node->children['docComment'] ?? '';
         }
         // Get a comment on the property declaration
         $comment = Comment::fromStringInContext(
-            $docComment,
+            $doc_comment,
             $this->code_base,
             $this->context,
             $node->lineno ?? 0,

--- a/src/Phan/Phan.php
+++ b/src/Phan/Phan.php
@@ -40,14 +40,14 @@ class Phan implements IgnoredFilesFilterInterface
     }
 
     /**
-     * @param IssueCollectorInterface $issueCollector
+     * @param IssueCollectorInterface $issue_collector
      *
      * @return void
      */
     public static function setIssueCollector(
-        IssueCollectorInterface $issueCollector
+        IssueCollectorInterface $issue_collector
     ) {
-        self::$issue_collector = $issueCollector;
+        self::$issue_collector = $issue_collector;
     }
 
     /**

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -85,53 +85,53 @@ final class ConfigPluginSet extends PluginV2 implements
 {
 
     /** @var array<int,Plugin>|null - Cached plugin set for this instance. Lazily generated. */
-    private $pluginSet;
+    private $plugin_set;
 
     /**
      * @var array<int,Closure>|null - plugins to analyze nodes in pre order.
      * @phan-var array<int,Closure(CodeBase,Context,Node):void>|null
      */
-    private $preAnalyzeNodePluginSet;
+    private $pre_analyze_node_plugin_set;
 
     /**
      * @var array<int,Closure> - plugins to analyze files
      * @phan-var array<int,Closure(string,Node):void>|null
      */
-    private $postAnalyzeNodePluginSet;
+    private $post_analyze_node_plugin_set;
 
     /**
      * @var array<int,BeforeAnalyzeFileCapability> - plugins to analyze files before phan's analysis of that file is completed.
      */
-    private $beforeAnalyzeFilePluginSet;
+    private $before_analyze_file_plugin_set;
 
     /**
      * @var array<int,AfterAnalyzeFileCapability> - plugins to analyze files after phan's analysis of that file is completed.
      */
-    private $afterAnalyzeFilePluginSet;
+    private $after_analyze_file_plugin_set;
 
     /** @var array<int,AnalyzeClassCapability>|null - plugins to analyze class declarations. */
-    private $analyzeClassPluginSet;
+    private $analyze_class_plugin_set;
 
     /** @var array<int,AnalyzeFunctionCallCapability>|null - plugins to analyze invocations of subsets of functions and methods. */
-    private $analyzeFunctionCallPluginSet;
+    private $analyze_function_call_plugin_set;
 
     /** @var array<int,AnalyzeFunctionCapability>|null - plugins to analyze function declarations. */
-    private $analyzeFunctionPluginSet;
+    private $analyze_function_plugin_set;
 
     /** @var array<int,AnalyzePropertyCapability>|null - plugins to analyze property declarations. */
-    private $analyzePropertyPluginSet;
+    private $analyze_property_plugin_set;
 
     /** @var array<int,AnalyzeMethodCapability>|null - plugins to analyze method declarations.*/
-    private $analyzeMethodPluginSet;
+    private $analyze_method_plugin_set;
 
     /** @var array<int,FinalizeProcessCapability>|null - plugins to call finalize() on after analysis is finished. */
-    private $finalizeProcessPluginSet;
+    private $finalize_process_plugin_set;
 
     /** @var array<int,ReturnTypeOverrideCapability>|null - plugins which generate return UnionTypes of functions based on arguments. */
-    private $returnTypeOverridePluginSet;
+    private $return_type_override_plugin_set;
 
     /** @var array<int,SuppressionCapability>|null - plugins which generate return UnionTypes of functions based on arguments. */
-    private $suppressionPluginSet;
+    private $suppression_plugin_set;
 
     /** @var ?UnusedSuppressionPlugin - TODO: Refactor*/
     private $unused_suppression_plugin = null;
@@ -192,7 +192,7 @@ final class ConfigPluginSet extends PluginV2 implements
         Context $context,
         Node $node
     ) {
-        $plugin_callback = $this->preAnalyzeNodePluginSet[$node->kind] ?? null;
+        $plugin_callback = $this->pre_analyze_node_plugin_set[$node->kind] ?? null;
         if ($plugin_callback !== null) {
             $plugin_callback(
                 $code_base,
@@ -226,7 +226,7 @@ final class ConfigPluginSet extends PluginV2 implements
         Node $node,
         array $parent_node_list = []
     ) {
-        $plugin_callback = $this->postAnalyzeNodePluginSet[$node->kind] ?? null;
+        $plugin_callback = $this->post_analyze_node_plugin_set[$node->kind] ?? null;
         if ($plugin_callback !== null) {
             $plugin_callback(
                 $code_base,
@@ -255,7 +255,7 @@ final class ConfigPluginSet extends PluginV2 implements
         string $file_contents,
         Node $node
     ) {
-        foreach ($this->beforeAnalyzeFilePluginSet as $plugin) {
+        foreach ($this->before_analyze_file_plugin_set as $plugin) {
             $plugin->beforeAnalyzeFile(
                 $code_base,
                 $context,
@@ -283,7 +283,7 @@ final class ConfigPluginSet extends PluginV2 implements
         string $file_contents,
         Node $node
     ) {
-        foreach ($this->afterAnalyzeFilePluginSet as $plugin) {
+        foreach ($this->after_analyze_file_plugin_set as $plugin) {
             $plugin->afterAnalyzeFile(
                 $code_base,
                 $context,
@@ -307,7 +307,7 @@ final class ConfigPluginSet extends PluginV2 implements
         CodeBase $code_base,
         Clazz $class
     ) {
-        foreach ($this->analyzeClassPluginSet as $plugin) {
+        foreach ($this->analyze_class_plugin_set as $plugin) {
             $plugin->analyzeClass(
                 $code_base,
                 $class
@@ -334,7 +334,7 @@ final class ConfigPluginSet extends PluginV2 implements
         CodeBase $code_base,
         Method $method
     ) {
-        foreach ($this->analyzeMethodPluginSet as $plugin) {
+        foreach ($this->analyze_method_plugin_set as $plugin) {
             $plugin->analyzeMethod(
                 $code_base,
                 $method
@@ -369,7 +369,7 @@ final class ConfigPluginSet extends PluginV2 implements
         array $parameters,
         $suggestion
     ) : bool {
-        foreach ($this->suppressionPluginSet as $plugin) {
+        foreach ($this->suppression_plugin_set as $plugin) {
             if ($plugin->shouldSuppressIssue(
                 $code_base,
                 $context,
@@ -399,7 +399,7 @@ final class ConfigPluginSet extends PluginV2 implements
         string $file_path
     ) : array {
         $result = [];
-        foreach ($this->suppressionPluginSet as $plugin) {
+        foreach ($this->suppression_plugin_set as $plugin) {
             $result += $plugin->getIssueSuppressionList(
                 $code_base,
                 $file_path
@@ -411,7 +411,7 @@ final class ConfigPluginSet extends PluginV2 implements
     /** @return array<int,SuppressionCapability> */
     public function getSuppressionPluginSet() : array
     {
-        return $this->suppressionPluginSet;
+        return $this->suppression_plugin_set;
     }
 
     /**
@@ -428,7 +428,7 @@ final class ConfigPluginSet extends PluginV2 implements
         CodeBase $code_base,
         Func $function
     ) {
-        foreach ($this->analyzeFunctionPluginSet as $plugin) {
+        foreach ($this->analyze_function_plugin_set as $plugin) {
             $plugin->analyzeFunction(
                 $code_base,
                 $function
@@ -452,7 +452,7 @@ final class ConfigPluginSet extends PluginV2 implements
         CodeBase $code_base,
         Property $property
     ) {
-        foreach ($this->analyzePropertyPluginSet as $plugin) {
+        foreach ($this->analyze_property_plugin_set as $plugin) {
             try {
                 $plugin->analyzeProperty(
                     $code_base,
@@ -480,7 +480,7 @@ final class ConfigPluginSet extends PluginV2 implements
     public function finalizeProcess(
         CodeBase $code_base
     ) {
-        foreach ($this->finalizeProcessPluginSet as $plugin) {
+        foreach ($this->finalize_process_plugin_set as $plugin) {
             $plugin->finalizeProcess($code_base);
         }
     }
@@ -490,8 +490,8 @@ final class ConfigPluginSet extends PluginV2 implements
      */
     public function hasAnalyzeFunctionPlugins() : bool
     {
-        \assert(!\is_null($this->pluginSet));
-        return \count($this->analyzeFunctionPluginSet) > 0;
+        \assert(!\is_null($this->plugin_set));
+        return \count($this->analyze_function_plugin_set) > 0;
     }
 
     /**
@@ -499,8 +499,8 @@ final class ConfigPluginSet extends PluginV2 implements
      */
     public function hasAnalyzeMethodPlugins() : bool
     {
-        \assert(!\is_null($this->pluginSet));
-        return \count($this->analyzeMethodPluginSet) > 0;
+        \assert(!\is_null($this->plugin_set));
+        return \count($this->analyze_method_plugin_set) > 0;
     }
 
     /**
@@ -510,8 +510,8 @@ final class ConfigPluginSet extends PluginV2 implements
     public function getAnalyzeFunctionCallClosures(CodeBase $code_base) : array
     {
         $result = [];
-        \assert(!\is_null($this->pluginSet));
-        foreach ($this->analyzeFunctionCallPluginSet as $plugin) {
+        \assert(!\is_null($this->plugin_set));
+        foreach ($this->analyze_function_call_plugin_set as $plugin) {
             // TODO: Make this case insensitive.
             foreach ($plugin->getAnalyzeFunctionCallClosures($code_base) as $fqsen_name => $closure) {
                 $other_closure = $result[$fqsen_name] ?? null;
@@ -535,8 +535,8 @@ final class ConfigPluginSet extends PluginV2 implements
     public function getReturnTypeOverrides(CodeBase $code_base) : array
     {
         $result = [];
-        \assert(!\is_null($this->pluginSet));
-        foreach ($this->returnTypeOverridePluginSet as $plugin) {
+        \assert(!\is_null($this->plugin_set));
+        foreach ($this->return_type_override_plugin_set as $plugin) {
             $result += $plugin->getReturnTypeOverrides($code_base);
         }
         return $result;
@@ -592,7 +592,7 @@ final class ConfigPluginSet extends PluginV2 implements
         $node_selection_plugin->setNodeSelectorClosure(DefinitionResolver::createGoToDefinitionClosure($go_to_definition_request, $code_base));
         $this->node_selection_plugin = $node_selection_plugin;
 
-        $old_post_analyze_node_plugin_set = $this->postAnalyzeNodePluginSet;
+        $old_post_analyze_node_plugin_set = $this->post_analyze_node_plugin_set;
 
         /*
         $new_post_analyze_node_plugins = self::filterPostAnalysisPlugins([$node_selection_plugin]);
@@ -607,7 +607,7 @@ final class ConfigPluginSet extends PluginV2 implements
          */
 
         return new RAII(function () use ($old_post_analyze_node_plugin_set) {
-            $this->postAnalyzeNodePluginSet = $old_post_analyze_node_plugin_set;
+            $this->post_analyze_node_plugin_set = $old_post_analyze_node_plugin_set;
             $this->node_selection_plugin = null;
         });
     }
@@ -617,14 +617,14 @@ final class ConfigPluginSet extends PluginV2 implements
      */
     private function addNodeSelectionClosureForKind(int $kind, Closure $new_plugin)
     {
-        $old_plugin_for_kind = $this->postAnalyzeNodePluginSet[$kind] ?? null;
+        $old_plugin_for_kind = $this->post_analyze_node_plugin_set[$kind] ?? null;
         if ($old_plugin_for_kind) {
-            $this->postAnalyzeNodePluginSet[$kind] = static function (CodeBase $code_base, Context $context, Node $node, array $parent_node_list = []) use ($old_plugin_for_kind, $new_plugin) {
+            $this->post_analyze_node_plugin_set[$kind] = static function (CodeBase $code_base, Context $context, Node $node, array $parent_node_list = []) use ($old_plugin_for_kind, $new_plugin) {
                 $old_plugin_for_kind($code_base, $context, $node, $parent_node_list);
                 $new_plugin($code_base, $context, $node, $parent_node_list);
             };
         } else {
-            $this->postAnalyzeNodePluginSet[$kind] = $new_plugin;
+            $this->post_analyze_node_plugin_set[$kind] = $new_plugin;
         }
     }
 
@@ -633,8 +633,8 @@ final class ConfigPluginSet extends PluginV2 implements
      */
     private function hasAnalyzePropertyPlugins() : bool
     {
-        \assert(!\is_null($this->pluginSet));
-        return \count($this->analyzePropertyPluginSet) > 0;
+        \assert(!\is_null($this->plugin_set));
+        return \count($this->analyze_property_plugin_set) > 0;
     }
 
     /**
@@ -643,7 +643,7 @@ final class ConfigPluginSet extends PluginV2 implements
      */
     private function ensurePluginsExist()
     {
-        if (!\is_null($this->pluginSet)) {
+        if (!\is_null($this->plugin_set)) {
             return;
         }
         // Add user-defined plugins.
@@ -702,21 +702,21 @@ final class ConfigPluginSet extends PluginV2 implements
         }
 
         // Register the entire set.
-        $this->pluginSet = $plugin_set;
+        $this->plugin_set = $plugin_set;
 
-        $this->preAnalyzeNodePluginSet      = self::filterPreAnalysisPlugins($plugin_set);
-        $this->postAnalyzeNodePluginSet     = self::filterPostAnalysisPlugins($plugin_set);
-        $this->beforeAnalyzeFilePluginSet   = self::filterByClass($plugin_set, BeforeAnalyzeFileCapability::class);
-        $this->afterAnalyzeFilePluginSet    = self::filterByClass($plugin_set, AfterAnalyzeFileCapability::class);
-        $this->analyzeMethodPluginSet       = self::filterOutEmptyMethodBodies(self::filterByClass($plugin_set, AnalyzeMethodCapability::class), 'analyzeMethod');
-        $this->analyzeFunctionPluginSet     = self::filterOutEmptyMethodBodies(self::filterByClass($plugin_set, AnalyzeFunctionCapability::class), 'analyzeFunction');
-        $this->analyzePropertyPluginSet     = self::filterOutEmptyMethodBodies(self::filterByClass($plugin_set, AnalyzePropertyCapability::class), 'analyzeProperty');
-        $this->analyzeClassPluginSet        = self::filterOutEmptyMethodBodies(self::filterByClass($plugin_set, AnalyzeClassCapability::class), 'analyzeClass');
-        $this->finalizeProcessPluginSet     = self::filterOutEmptyMethodBodies(self::filterByClass($plugin_set, FinalizeProcessCapability::class), 'finalizeProcess');
-        $this->returnTypeOverridePluginSet  = self::filterByClass($plugin_set, ReturnTypeOverrideCapability::class);
-        $this->suppressionPluginSet         = self::filterByClass($plugin_set, SuppressionCapability::class);
-        $this->analyzeFunctionCallPluginSet = self::filterByClass($plugin_set, AnalyzeFunctionCallCapability::class);
-        $this->unused_suppression_plugin    = self::findUnusedSuppressionPlugin($plugin_set);
+        $this->pre_analyze_node_plugin_set      = self::filterPreAnalysisPlugins($plugin_set);
+        $this->post_analyze_node_plugin_set     = self::filterPostAnalysisPlugins($plugin_set);
+        $this->before_analyze_file_plugin_set   = self::filterByClass($plugin_set, BeforeAnalyzeFileCapability::class);
+        $this->after_analyze_file_plugin_set    = self::filterByClass($plugin_set, AfterAnalyzeFileCapability::class);
+        $this->analyze_method_plugin_set        = self::filterOutEmptyMethodBodies(self::filterByClass($plugin_set, AnalyzeMethodCapability::class), 'analyzeMethod');
+        $this->analyze_function_plugin_set      = self::filterOutEmptyMethodBodies(self::filterByClass($plugin_set, AnalyzeFunctionCapability::class), 'analyzeFunction');
+        $this->analyze_property_plugin_set      = self::filterOutEmptyMethodBodies(self::filterByClass($plugin_set, AnalyzePropertyCapability::class), 'analyzeProperty');
+        $this->analyze_class_plugin_set         = self::filterOutEmptyMethodBodies(self::filterByClass($plugin_set, AnalyzeClassCapability::class), 'analyzeClass');
+        $this->finalize_process_plugin_set      = self::filterOutEmptyMethodBodies(self::filterByClass($plugin_set, FinalizeProcessCapability::class), 'finalizeProcess');
+        $this->return_type_override_plugin_set  = self::filterByClass($plugin_set, ReturnTypeOverrideCapability::class);
+        $this->suppression_plugin_set           = self::filterByClass($plugin_set, SuppressionCapability::class);
+        $this->analyze_function_call_plugin_set = self::filterByClass($plugin_set, AnalyzeFunctionCallCapability::class);
+        $this->unused_suppression_plugin        = self::findUnusedSuppressionPlugin($plugin_set);
     }
 
     private static function requiresPluginBasedBuiltinSuppressions() : bool

--- a/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
+++ b/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
@@ -195,8 +195,8 @@ final class VariableTrackerElementVisitor extends PluginAwarePostAnalysisVisitor
                 $issue_type = $issue_overrides_for_definition_ids[$definition_id] ?? Issue::UnusedVariable;
                 if ($issue_type === Issue::UnusedPublicMethodParameter) {
                     // Narrow down issues about parameters into more specific issues
-                    $docComment = $method_node->children['docComment'] ?? null;
-                    if ($docComment && preg_match('/@param[^$]*\$' . preg_quote($variable_name) . '\b.*@phan-unused-param\b/', $docComment)) {
+                    $doc_comment = $method_node->children['docComment'] ?? null;
+                    if ($doc_comment && preg_match('/@param[^$]*\$' . preg_quote($variable_name) . '\b.*@phan-unused-param\b/', $doc_comment)) {
                         // Don't warn about parameters marked with phan-unused-param
                         break;
                     }

--- a/tests/Phan/AST/TolerantASTConverter/ConversionTest.php
+++ b/tests/Phan/AST/TolerantASTConverter/ConversionTest.php
@@ -24,7 +24,7 @@ class ConversionTest extends BaseTest
     /**
      * @return array<int,string>
      */
-    protected function _scanSourceDirForPHP(string $source_dir) : array
+    protected function scanSourceDirForPHP(string $source_dir) : array
     {
         $files = [];
         foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($source_dir)) as $file_path => $file_info) {
@@ -82,7 +82,7 @@ class ConversionTest extends BaseTest
     {
         $tests = [];
         $source_dir = dirname(dirname(dirname(realpath(__DIR__)))) . '/misc/fallback_ast_src';
-        $paths = $this->_scanSourceDirForPHP($source_dir);
+        $paths = $this->scanSourceDirForPHP($source_dir);
 
         self::sortByTokenCount($paths);
         $supports50 = self::hasNativeASTSupport(50);

--- a/tests/Phan/AST/TolerantASTConverter/ErrorTolerantConversionTest.php
+++ b/tests/Phan/AST/TolerantASTConverter/ErrorTolerantConversionTest.php
@@ -23,7 +23,7 @@ function foo() {
 
 }
 EOT;
-        $this->_testFallbackFromParser($incomplete_contents, $valid_contents);
+        $this->runTestFallbackFromParser($incomplete_contents, $valid_contents);
     }
 
     public function testIncompleteVarWithPlaceholderShort()
@@ -36,7 +36,7 @@ EOT;
 <?php
 $a = $__INCOMPLETE_VARIABLE__;
 EOT;
-        $this->_testFallbackFromParser($incomplete_contents, $valid_contents, true);
+        $this->runTestFallbackFromParser($incomplete_contents, $valid_contents, true);
     }
 
     public function testIncompleteVarWithPlaceholder()
@@ -53,7 +53,7 @@ function foo() {
   $a = $__INCOMPLETE_VARIABLE__;
 }
 EOT;
-        $this->_testFallbackFromParser($incomplete_contents, $valid_contents, true);
+        $this->runTestFallbackFromParser($incomplete_contents, $valid_contents, true);
     }
 
     public function testIncompleteProperty()
@@ -72,7 +72,7 @@ function foo() {
 
 }
 EOT;
-        $this->_testFallbackFromParser($incomplete_contents, $valid_contents);
+        $this->runTestFallbackFromParser($incomplete_contents, $valid_contents);
     }
 
     public function testIncompletePropertyWithPlaceholder()
@@ -91,7 +91,7 @@ function foo() {
   $a = $b->__INCOMPLETE_PROPERTY__;
 }
 EOT;
-        $this->_testFallbackFromParser($incomplete_contents, $valid_contents, true);
+        $this->runTestFallbackFromParser($incomplete_contents, $valid_contents, true);
     }
 
     public function testIncompleteMethod()
@@ -110,7 +110,7 @@ function foo() {
 
 }
 EOT;
-        $this->_testFallbackFromParser($incomplete_contents, $valid_contents);
+        $this->runTestFallbackFromParser($incomplete_contents, $valid_contents);
     }
 
     public function testIncompleteMethodWithPlaceholder()
@@ -129,7 +129,7 @@ function foo() {
   $a = Bar::__INCOMPLETE_CLASS_CONST__;
 }
 EOT;
-        $this->_testFallbackFromParser($incomplete_contents, $valid_contents, true);
+        $this->runTestFallbackFromParser($incomplete_contents, $valid_contents, true);
     }
 
     public function testMiscNoise()
@@ -148,7 +148,7 @@ function foo() {
 
 }
 EOT;
-        $this->_testFallbackFromParser($incomplete_contents, $valid_contents);
+        $this->runTestFallbackFromParser($incomplete_contents, $valid_contents);
     }
 
     public function testMiscNoiseWithPlaceholders()
@@ -167,7 +167,7 @@ function foo() {
 
 }
 EOT;
-        $this->_testFallbackFromParser($incomplete_contents, $valid_contents, true);
+        $this->runTestFallbackFromParser($incomplete_contents, $valid_contents, true);
     }
 
     public function testIncompleteArithmeticWithPlaceholders()
@@ -184,7 +184,7 @@ function foo() {
   $b * $c + \__INCOMPLETE_EXPR__;
 }
 EOT;
-        $this->_testFallbackFromParser($incomplete_contents, $valid_contents, true);
+        $this->runTestFallbackFromParser($incomplete_contents, $valid_contents, true);
     }
 
     public function testIncompleteArithmeticWithoutPlaceholders()
@@ -201,7 +201,7 @@ function foo() {
   $b * $c;
 }
 EOT;
-        $this->_testFallbackFromParser($incomplete_contents, $valid_contents, false);
+        $this->runTestFallbackFromParser($incomplete_contents, $valid_contents, false);
     }
 
     public function testMissingMember()
@@ -221,7 +221,7 @@ class Test {
 } notAFunction()[];
 function aFunction() {}
 EOT;
-        $this->_testFallbackFromParser($incomplete_contents, $valid_contents, false);
+        $this->runTestFallbackFromParser($incomplete_contents, $valid_contents, false);
     }
 
     public function testEmptyConstList()
@@ -234,7 +234,7 @@ EOT;
 <?php
 class Test { }
 EOT;
-        $this->_testFallbackFromParser($incomplete_contents, $valid_contents, false);
+        $this->runTestFallbackFromParser($incomplete_contents, $valid_contents, false);
     }
 
     public function testMissingSemicolon()
@@ -253,7 +253,7 @@ function foo() {
     $x = intdiv(3, 2);
 }
 EOT;
-        $this->_testFallbackFromParser($incomplete_contents, $valid_contents);
+        $this->runTestFallbackFromParser($incomplete_contents, $valid_contents);
     }
 
 // Another test (Won't work with php-parser, might work with tolerant-php-parser
@@ -282,16 +282,16 @@ class C{
 EOT;
  */
 
-    private function _testFallbackFromParser(string $incomplete_contents, string $valid_contents, bool $should_add_placeholders = false)
+    private function runTestFallbackFromParser(string $incomplete_contents, string $valid_contents, bool $should_add_placeholders = false)
     {
         $supports50 = ConversionTest::hasNativeASTSupport(50);
         if (!$supports50) {
             $this->fail('No supported AST versions to test');
         }
-        $this->_testFallbackFromParserForASTVersion($incomplete_contents, $valid_contents, 50, $should_add_placeholders);
+        $this->runTestFallbackFromParserForASTVersion($incomplete_contents, $valid_contents, 50, $should_add_placeholders);
     }
 
-    private function _testFallbackFromParserForASTVersion(string $incomplete_contents, string $valid_contents, int $ast_version, bool $should_add_placeholders)
+    private function runTestFallbackFromParserForASTVersion(string $incomplete_contents, string $valid_contents, int $ast_version, bool $should_add_placeholders)
     {
         $ast = \ast\parse_code($valid_contents, $ast_version);
         $this->assertInstanceOf('\ast\Node', $ast, 'Examples(for validContents) must be syntactically valid PHP parseable by php-ast');

--- a/tests/Phan/ASTRewriterTest.php
+++ b/tests/Phan/ASTRewriterTest.php
@@ -42,17 +42,17 @@ class ASTRewriterTest extends AbstractPhanFileTest
 
         $ast_version = Config::AST_VERSION;
         $expected = \ast\parse_code($expected_src, $ast_version);
-        $beforeTransform = \ast\parse_code($original_src, $ast_version);
+        $before_transform = \ast\parse_code($original_src, $ast_version);
 
         // We use identical files for testing ASTs which aren't expected to change.
         if (trim($expected_src) !== trim($original_src)) {
-            $this->assertNotEquals(Debug::astDump($expected), Debug::astDump($beforeTransform), 'Expected the input asts to be different');
+            $this->assertNotEquals(Debug::astDump($expected), Debug::astDump($before_transform), 'Expected the input asts to be different');
         }
-        $actual = ASTSimplifier::applyStatic($beforeTransform);
+        $actual = ASTSimplifier::applyStatic($before_transform);
         $this->assertInstanceOf(\ast\Node::class, $actual, 'should return an AST');
         $this->assertSame(\ast\AST_STMT_LIST, $actual->kind, 'should return an AST of kind AST_STMT_LIST');
-        $actualRepr = Debug::astDump($actual);
-        $expectedRepr = Debug::astDump($expected);
-        $this->assertEquals($expectedRepr, $actualRepr, 'Expected the AST representation to be the same as the expected source\'s after transformations');
+        $actual_repr = Debug::astDump($actual);
+        $expected_repr = Debug::astDump($expected);
+        $this->assertEquals($expected_repr, $actual_repr, 'Expected the AST representation to be the same as the expected source\'s after transformations');
     }
 }

--- a/tests/Phan/AbstractPhanFileTest.php
+++ b/tests/Phan/AbstractPhanFileTest.php
@@ -69,15 +69,15 @@ abstract class AbstractPhanFileTest extends BaseTest implements CodeBaseAwareTes
     /**
      * Placeholder for getTestFiles dataProvider
      *
-     * @param string $sourceDir
+     * @param string $source_dir
      * @return string[][]
      */
-    protected function scanSourceFilesDir(string $sourceDir, string $expectedDir)
+    protected function scanSourceFilesDir(string $source_dir, string $expected_dir)
     {
         // TODO: Make Phan know that array_filter with a single argument implies elements aren't falsey
         $files = array_filter(
             array_filter(
-                scandir($sourceDir),
+                scandir($source_dir),
                 function ($filename) {
                     // Ignore directories and hidden files.
                     return !in_array($filename, ['.', '..'], true) && substr($filename, 0, 1) !== '.' && preg_match('@\.php$@', $filename);
@@ -97,10 +97,10 @@ abstract class AbstractPhanFileTest extends BaseTest implements CodeBaseAwareTes
         return array_combine(
             $files,
             array_map(
-                function ($filename) use ($sourceDir, $expectedDir, $suffix) {
+                function ($filename) use ($source_dir, $expected_dir, $suffix) {
                     return [
-                        [self::getFileForPHPVersion($sourceDir . DIRECTORY_SEPARATOR . $filename, $suffix)],
-                        self::getFileForPHPVersion($expectedDir . DIRECTORY_SEPARATOR . $filename . self::EXPECTED_SUFFIX, $suffix),
+                        [self::getFileForPHPVersion($source_dir . DIRECTORY_SEPARATOR . $filename, $suffix)],
+                        self::getFileForPHPVersion($expected_dir . DIRECTORY_SEPARATOR . $filename . self::EXPECTED_SUFFIX, $suffix),
                     ];
                 },
                 $files
@@ -186,10 +186,10 @@ abstract class AbstractPhanFileTest extends BaseTest implements CodeBaseAwareTes
         // do preg_quote, but miss out any %r delimited sections
         $temp = "";
         $r = "%r";
-        $startOffset = 0;
+        $start_offset = 0;
         $length = strlen($wanted_re);
-        while ($startOffset < $length) {
-            $start = strpos($wanted_re, $r, $startOffset);
+        while ($start_offset < $length) {
+            $start = strpos($wanted_re, $r, $start_offset);
             if ($start !== false) {
                 // we have found a start tag
                 $end = strpos($wanted_re, $r, $start + 2);
@@ -202,12 +202,12 @@ abstract class AbstractPhanFileTest extends BaseTest implements CodeBaseAwareTes
                 $start = $end = $length;
             }
             // quote a non re portion of the string
-            $temp = $temp . preg_quote(substr($wanted_re, $startOffset, ($start - $startOffset)), '/');
+            $temp = $temp . preg_quote(substr($wanted_re, $start_offset, ($start - $start_offset)), '/');
             // add the re unquoted.
             if ($end > $start) {
                 $temp = $temp . '(' . substr($wanted_re, $start + 2, ($end - $start - 2)) . ')';
             }
-            $startOffset = $end + 2;
+            $start_offset = $end + 2;
         }
         $wanted_re = $temp;
         $wanted_re = str_replace(['%binary_string_optional%'], 'string', $wanted_re);

--- a/tests/Phan/Analysis/BlockExitStatusCheckerTest.php
+++ b/tests/Phan/Analysis/BlockExitStatusCheckerTest.php
@@ -56,11 +56,11 @@ class BlockExitStatusCheckerTest extends BaseTest
     /**
      * @dataProvider exitStatusProvider
      */
-    public function testExitStatus(string $expectedStatusRepresentation, string $codeSnippet)
+    public function testExitStatus(string $expected_status_representation, string $code_snippet)
     {
-        $ast = \ast\parse_code("<" . "?php " . $codeSnippet, Config::AST_VERSION);
+        $ast = \ast\parse_code("<" . "?php " . $code_snippet, Config::AST_VERSION);
         $status_code = (new BlockExitStatusChecker())($ast);
-        $this->assertSame($expectedStatusRepresentation, $this->representStatus($status_code), sprintf("Unexpected status 0x%x\nCode:\n%s\n", $status_code, $codeSnippet));
+        $this->assertSame($expected_status_representation, $this->representStatus($status_code), sprintf("Unexpected status 0x%x\nCode:\n%s\n", $status_code, $code_snippet));
     }
 
     public function exitStatusProvider() : array

--- a/tests/Phan/CodeBaseAwareTestInterface.php
+++ b/tests/Phan/CodeBaseAwareTestInterface.php
@@ -7,6 +7,6 @@ use Phan\CodeBase;
 interface CodeBaseAwareTestInterface
 {
 
-    /** @param ?CodeBase $codeBase */
-    public function setCodeBase(CodeBase $codeBase = null);
+    /** @param ?CodeBase $code_base */
+    public function setCodeBase(CodeBase $code_base = null);
 }

--- a/tests/Phan/Language/Element/CommentTest.php
+++ b/tests/Phan/Language/Element/CommentTest.php
@@ -18,7 +18,7 @@ class CommentTest extends BaseTest
     /** @var CodeBase */
     protected $code_base;
 
-    const overrides = [
+    const OVERRIDES = [
         'read_type_annotations' => true,
         'read_magic_property_annotations' => true,
         'read_magic_method_annotations' => true,
@@ -30,7 +30,7 @@ class CommentTest extends BaseTest
     protected function setUp()
     {
         $this->code_base = new CodeBase([], [], [], [], []);
-        foreach (self::overrides as $key => $value) {
+        foreach (self::OVERRIDES as $key => $value) {
             $this->old_values[$key] = Config::getValue($key);
             Config::setValue($key, $value);
         }
@@ -194,32 +194,32 @@ class CommentTest extends BaseTest
 
     public function testGetMagicMethod()
     {
-        $commentText = <<<'EOT'
+        $comment_text = <<<'EOT'
 /**
  * @method static int|string my_method(int $x, stdClass ...$rest) description
  * @method myInstanceMethod2(int, $other = 'myString') description
  */
 EOT;
         $comment = Comment::fromStringInContext(
-            $commentText,
+            $comment_text,
             $this->code_base,
             new Context(),
             1,
             Comment::ON_CLASS
         );
-        $methodMap = $comment->getMagicMethodMap();
-        $this->assertSame(['my_method', 'myInstanceMethod2'], \array_keys($methodMap));
-        $methodDefinition = $methodMap['my_method'];
-        $this->assertSame('static function my_method(int $x, \stdClass ...$rest) : int|string', (string)$methodDefinition);
-        $this->assertSame('my_method', $methodDefinition->getName());
-        $instanceMethodDefinition = $methodMap['myInstanceMethod2'];
-        $this->assertSame('function myInstanceMethod2(int $p1, $other = default) : void', (string)$instanceMethodDefinition);
-        $this->assertSame('myInstanceMethod2', $instanceMethodDefinition->getName());
+        $method_map = $comment->getMagicMethodMap();
+        $this->assertSame(['my_method', 'myInstanceMethod2'], \array_keys($method_map));
+        $method_definition = $method_map['my_method'];
+        $this->assertSame('static function my_method(int $x, \stdClass ...$rest) : int|string', (string)$method_definition);
+        $this->assertSame('my_method', $method_definition->getName());
+        $instance_method_definition = $method_map['myInstanceMethod2'];
+        $this->assertSame('function myInstanceMethod2(int $p1, $other = default) : void', (string)$instance_method_definition);
+        $this->assertSame('myInstanceMethod2', $instance_method_definition->getName());
     }
 
     public function testGetTemplateType()
     {
-        $commentText = <<<'EOT'
+        $comment_text = <<<'EOT'
 /**
  * The check for template is case sensitive.
  * @template T1
@@ -228,31 +228,31 @@ EOT;
  */
 EOT;
         $comment = Comment::fromStringInContext(
-            $commentText,
+            $comment_text,
             $this->code_base,
             new Context(),
             1,
             Comment::ON_CLASS
         );
-        $templateTypes = $comment->getTemplateTypeList();
-        $this->assertCount(2, $templateTypes);
-        $t1Info = $templateTypes[0];
-        $this->assertSame('T1', $t1Info->getName());
-        $uInfo = $templateTypes[1];
-        $this->assertSame('u', $uInfo->getName());
+        $template_types = $comment->getTemplateTypeList();
+        $this->assertCount(2, $template_types);
+        $t1_info = $template_types[0];
+        $this->assertSame('T1', $t1_info->getName());
+        $u_info = $template_types[1];
+        $this->assertSame('u', $u_info->getName());
     }
 
     public function testGetParameterArrayNew()
     {
         // Currently, we ignore the array key. This may change in a future release.
-        $commentText = <<<'EOT'
+        $comment_text = <<<'EOT'
 /**
  * @param array<mixed, string> $myParam
  * @param array<string , stdClass> ...$rest
  */
 EOT;
         $comment = Comment::fromStringInContext(
-            $commentText,
+            $comment_text,
             $this->code_base,
             new Context(),
             1,
@@ -269,18 +269,18 @@ EOT;
         $this->assertSame('myParam', $my_param_doc->getName());
 
         // Argument #2, #3, etc. passed by callers are arrays of stdClasses
-        $restDoc = $parameter_map['rest'];
-        $this->assertSame('array<string,\stdClass> ...$rest', (string)$restDoc);
-        $this->assertTrue($restDoc->isOptional());
-        $this->assertFalse($restDoc->isRequired());
-        $this->assertTrue($restDoc->isVariadic());
-        $this->assertSame('rest', $restDoc->getName());
+        $rest_doc = $parameter_map['rest'];
+        $this->assertSame('array<string,\stdClass> ...$rest', (string)$rest_doc);
+        $this->assertTrue($rest_doc->isOptional());
+        $this->assertFalse($rest_doc->isRequired());
+        $this->assertTrue($rest_doc->isVariadic());
+        $this->assertSame('rest', $rest_doc->getName());
     }
 
     public function testGetVarArrayNew()
     {
         // Currently, we ignore the array key. This may change in a future release.
-        $commentText = <<<'EOT'
+        $comment_text = <<<'EOT'
 /**
  * @var int $my_int
  * @var array<string , stdClass> $array
@@ -288,7 +288,7 @@ EOT;
  */
 EOT;
         $comment = Comment::fromStringInContext(
-            $commentText,
+            $comment_text,
             $this->code_base,
             new Context(),
             1,

--- a/tests/Phan/Language/TypeTest.php
+++ b/tests/Phan/Language/TypeTest.php
@@ -48,11 +48,11 @@ class TypeTest extends BaseTest
         $this->assertParsesAsType(ArrayType::instance(false), '((array))');
     }
 
-    const delimited_type_regex_or_this = '@^' . Type::type_regex_or_this . '$@';
+    const DELIMITED_TYPE_REGEX_OR_THIS = '@^' . Type::type_regex_or_this . '$@';
 
     public function assertParsesAsType(Type $expected_type, string $type_string)
     {
-        $this->assertTrue(\preg_match(self::delimited_type_regex_or_this, $type_string) > 0, "Failed to parse '$type_string'");
+        $this->assertTrue(\preg_match(self::DELIMITED_TYPE_REGEX_OR_THIS, $type_string) > 0, "Failed to parse '$type_string'");
         $this->assertSameType($expected_type, self::makePHPDocType($type_string));
     }
 
@@ -122,17 +122,17 @@ class TypeTest extends BaseTest
 
     public function testGenericArray()
     {
-        $genericArrayType = self::makePHPDocType('int[][]');
-        $expectedGenericArrayType = self::createGenericArrayTypeWithMixedKey(
+        $generic_array_type = self::makePHPDocType('int[][]');
+        $expected_generic_array_type = self::createGenericArrayTypeWithMixedKey(
             self::createGenericArrayTypeWithMixedKey(
                 IntType::instance(false),
                 false
             ),
             false
         );
-        $this->assertSameType($expectedGenericArrayType, $genericArrayType);
-        $this->assertSame('int[][]', (string)$expectedGenericArrayType);
-        $this->assertSameType($expectedGenericArrayType, self::makePHPDocType('(int)[][]'));
+        $this->assertSameType($expected_generic_array_type, $generic_array_type);
+        $this->assertSame('int[][]', (string)$expected_generic_array_type);
+        $this->assertSameType($expected_generic_array_type, self::makePHPDocType('(int)[][]'));
         // TODO: Parse (int[])[]?
     }
 
@@ -189,119 +189,119 @@ class TypeTest extends BaseTest
      */
     public function testGenericArrayNullable()
     {
-        $genericArrayType = self::makePHPDocType('?int[]');
-        $expectedGenericArrayType = self::createGenericArrayTypeWithMixedKey(
+        $generic_array_type = self::makePHPDocType('?int[]');
+        $expected_generic_array_type = self::createGenericArrayTypeWithMixedKey(
             IntType::instance(false),
             true
         );
-        $this->assertSameType($expectedGenericArrayType, $genericArrayType);
-        $genericArrayArrayType = self::makePHPDocType('?int[][]');
-        $expectedGenericArrayArrayType = self::createGenericArrayTypeWithMixedKey(
+        $this->assertSameType($expected_generic_array_type, $generic_array_type);
+        $generic_array_array_type = self::makePHPDocType('?int[][]');
+        $expected_generic_array_array_type = self::createGenericArrayTypeWithMixedKey(
             self::createGenericArrayTypeWithMixedKey(
                 IntType::instance(false),
                 false
             ),
             true
         );
-        $this->assertSameType($expectedGenericArrayArrayType, $genericArrayArrayType);
+        $this->assertSameType($expected_generic_array_array_type, $generic_array_array_type);
     }
 
     public function testIterable()
     {
-        $stringIterableType = self::makePHPDocType('iterable<string>');
-        $expectedStringIterableType = GenericIterableType::fromKeyAndValueTypes(
+        $string_iterable_type = self::makePHPDocType('iterable<string>');
+        $expected_string_iterable_type = GenericIterableType::fromKeyAndValueTypes(
             UnionType::empty(),
             StringType::instance(false)->asUnionType(),
             false
         );
-        $this->assertSameType($expectedStringIterableType, $stringIterableType);
+        $this->assertSameType($expected_string_iterable_type, $string_iterable_type);
 
-        $stringToStdClassArrayType = self::makePHPDocType('iterable<string,stdClass>');
-        $expectedStringToStdClassArrayType = GenericIterableType::fromKeyAndValueTypes(
+        $string_to_stdclass_array_type = self::makePHPDocType('iterable<string,stdClass>');
+        $expectedstring_to_std_class_array_type = GenericIterableType::fromKeyAndValueTypes(
             StringType::instance(false)->asUnionType(),
             UnionType::fromFullyQualifiedString('\stdClass'),
             false
         );
-        $this->assertSameType($expectedStringToStdClassArrayType, $stringToStdClassArrayType);
+        $this->assertSameType($expectedstring_to_std_class_array_type, $string_to_stdclass_array_type);
     }
 
     public function testArrayAlternate()
     {
-        $stringArrayType = self::makePHPDocType('array<string>');
-        $expectedStringArrayType = self::createGenericArrayTypeWithMixedKey(
+        $string_array_type = self::makePHPDocType('array<string>');
+        $expected_string_array_type = self::createGenericArrayTypeWithMixedKey(
             StringType::instance(false),
             false
         );
-        $this->assertSameType($expectedStringArrayType, $stringArrayType);
+        $this->assertSameType($expected_string_array_type, $string_array_type);
 
-        $stringArrayType2 = self::makePHPDocType('array<mixed,string>');
-        $this->assertSameType($expectedStringArrayType, $stringArrayType2);
+        $string_array_type2 = self::makePHPDocType('array<mixed,string>');
+        $this->assertSameType($expected_string_array_type, $string_array_type2);
 
         // We track key types.
-        $expectedStringArrayTypeWithIntKey = GenericArrayType::fromElementType(
+        $expected_string_array_type_with_int_key = GenericArrayType::fromElementType(
             StringType::instance(false),
             false,
             GenericArrayType::KEY_INT
         );
-        $stringArrayType3 = self::makePHPDocType('array<int,string>');
-        $this->assertSameType($expectedStringArrayTypeWithIntKey, $stringArrayType3);
+        $string_array_type3 = self::makePHPDocType('array<int,string>');
+        $this->assertSameType($expected_string_array_type_with_int_key, $string_array_type3);
 
         // Allow space
-        $stringArrayType4 = self::makePHPDocType('array<mixed, string>');
-        $this->assertSameType($expectedStringArrayType, $stringArrayType4);
+        $string_array_type4 = self::makePHPDocType('array<mixed, string>');
+        $this->assertSameType($expected_string_array_type, $string_array_type4);
 
         // Combination of int|string in array key results in mixed key
-        $stringArrayType5 = self::makePHPDocType('array<int|string, string>');
-        $this->assertSameType($expectedStringArrayType, $stringArrayType5);
+        $string_array_type5 = self::makePHPDocType('array<int|string, string>');
+        $this->assertSameType($expected_string_array_type, $string_array_type5);
 
         // Nested array types.
-        $expectedStringArrayArrayType = self::createGenericArrayTypeWithMixedKey(
-            $expectedStringArrayType,
+        $expected_string_array_array_type = self::createGenericArrayTypeWithMixedKey(
+            $expected_string_array_type,
             false
         );
-        $this->assertParsesAsType($expectedStringArrayArrayType, 'array<string[]>');
-        $this->assertParsesAsType($expectedStringArrayArrayType, 'array<string>[]');
-        $this->assertParsesAsType($expectedStringArrayArrayType, 'array<array<string>>');
-        $this->assertParsesAsType($expectedStringArrayArrayType, 'array<mixed,array<mixed,string>>');
+        $this->assertParsesAsType($expected_string_array_array_type, 'array<string[]>');
+        $this->assertParsesAsType($expected_string_array_array_type, 'array<string>[]');
+        $this->assertParsesAsType($expected_string_array_array_type, 'array<array<string>>');
+        $this->assertParsesAsType($expected_string_array_array_type, 'array<mixed,array<mixed,string>>');
     }
 
     public function testArrayNested()
     {
-        $deeplyNestedArray = self::makePHPDocType('array<int,array<mixed,array<mixed,stdClass>>>');
-        $this->assertSame('array<int,\stdClass[][]>', (string)$deeplyNestedArray);
+        $deeply_nested_array = self::makePHPDocType('array<int,array<mixed,array<mixed,stdClass>>>');
+        $this->assertSame('array<int,\stdClass[][]>', (string)$deeply_nested_array);
     }
 
     public function testArrayExtraBrackets()
     {
-        $stringArrayType = self::makePHPDocType('?(float[])');
-        $expectedStringArrayType = self::createGenericArrayTypeWithMixedKey(
+        $string_array_type = self::makePHPDocType('?(float[])');
+        $expected_string_array_type = self::createGenericArrayTypeWithMixedKey(
             FloatType::instance(false),
             true
         );
-        $this->assertSameType($expectedStringArrayType, $stringArrayType);
-        $this->assertSame('?float[]', (string)$stringArrayType);
+        $this->assertSameType($expected_string_array_type, $string_array_type);
+        $this->assertSame('?float[]', (string)$string_array_type);
     }
 
     public function testArrayExtraBracketsForElement()
     {
-        $stringArrayType = self::makePHPDocType('(?float)[]');
-        $expectedStringArrayType = self::createGenericArrayTypeWithMixedKey(
+        $string_array_type = self::makePHPDocType('(?float)[]');
+        $expected_string_array_type = self::createGenericArrayTypeWithMixedKey(
             FloatType::instance(true),
             false
         );
-        $this->assertSameType($expectedStringArrayType, $stringArrayType);
-        $this->assertSame('(?float)[]', (string)$stringArrayType);
+        $this->assertSameType($expected_string_array_type, $string_array_type);
+        $this->assertSame('(?float)[]', (string)$string_array_type);
     }
 
     public function testArrayExtraBracketsAfterNullable()
     {
-        $stringArrayType = self::makePHPDocType('?(float)[]');
-        $expectedStringArrayType = self::createGenericArrayTypeWithMixedKey(
+        $string_array_type = self::makePHPDocType('?(float)[]');
+        $expected_string_array_type = self::createGenericArrayTypeWithMixedKey(
             FloatType::instance(false),
             true
         );
-        $this->assertSameType($expectedStringArrayType, $stringArrayType);
-        $this->assertSame('?float[]', (string)$stringArrayType);
+        $this->assertSameType($expected_string_array_type, $string_array_type);
+        $this->assertSame('?float[]', (string)$string_array_type);
     }
 
     private static function makeBasicClosureParam(string $type_string) : ClosureDeclarationParameter
@@ -317,7 +317,7 @@ class TypeTest extends BaseTest
 
     private function verifyClosureParam(FunctionLikeDeclarationType $expected_closure_type, string $union_type_string, string $normalized_type_string)
     {
-        $this->assertTrue(\preg_match(self::delimited_type_regex_or_this, $union_type_string) > 0, "Failed to parse '$union_type_string'");
+        $this->assertTrue(\preg_match(self::DELIMITED_TYPE_REGEX_OR_THIS, $union_type_string) > 0, "Failed to parse '$union_type_string'");
         $parsed_closure_type = self::makePHPDocType($union_type_string);
         $this->assertSame(get_class($expected_closure_type), get_class($parsed_closure_type), "expected closure/callable class for $normalized_type_string");
         $this->assertSame($normalized_type_string, (string)$parsed_closure_type, "failed parsing $union_type_string");
@@ -440,11 +440,11 @@ class TypeTest extends BaseTest
     /**
      * @dataProvider canCastToTypeProvider
      */
-    public function testCanCastToType(string $fromTypeString, string $toTypeString)
+    public function testCanCastToType(string $from_type_string, string $to_type_string)
     {
-        $fromType = self::makePHPDocType($fromTypeString);
-        $toType = self::makePHPDocType($toTypeString);
-        $this->assertTrue($fromType->canCastToType($toType), "expected $fromTypeString to be able to cast to $toTypeString");
+        $from_type = self::makePHPDocType($from_type_string);
+        $to_type = self::makePHPDocType($to_type_string);
+        $this->assertTrue($from_type->canCastToType($to_type), "expected $from_type_string to be able to cast to $to_type_string");
     }
 
     public function canCastToTypeProvider() : array

--- a/tests/Phan/Language/UnionTypeTest.php
+++ b/tests/Phan/Language/UnionTypeTest.php
@@ -47,6 +47,7 @@ class UnionTypeTest extends BaseTest
      * TODO: Investigate instantiating CodeBase in a cheaper way (lazily?)
      * @suppress PhanReadOnlyProtectedProperty read by phpunit framework
      */
+    // phpcs:ignore
     protected $backupStaticAttributesBlacklist = [
         'Phan\AST\PhanAnnotationAdder' => [
             'closures_for_kind',

--- a/tests/Phan/LanguageServer/LanguageServerIntegrationTest.php
+++ b/tests/Phan/LanguageServer/LanguageServerIntegrationTest.php
@@ -206,9 +206,9 @@ EOT;
     public function testDefinitionInOtherFile(string $new_file_contents, Position $position, string $expected_definition_uri, $expected_definition_line, string $requested_uri = null)
     {
         if (function_exists('pcntl_fork')) {
-            $this->_testDefinitionInOtherFileWithPcntlSetting($new_file_contents, $position, $expected_definition_uri, $expected_definition_line, $requested_uri, true);
+            $this->runTestDefinitionInOtherFileWithPcntlSetting($new_file_contents, $position, $expected_definition_uri, $expected_definition_line, $requested_uri, true);
         }
-        $this->_testDefinitionInOtherFileWithPcntlSetting($new_file_contents, $position, $expected_definition_uri, $expected_definition_line, $requested_uri, false);
+        $this->runTestDefinitionInOtherFileWithPcntlSetting($new_file_contents, $position, $expected_definition_uri, $expected_definition_line, $requested_uri, false);
     }
 
     /**
@@ -220,9 +220,9 @@ EOT;
     public function testTypeDefinitionInOtherFile(string $new_file_contents, Position $position, string $expected_definition_uri, $expected_definition_line, string $requested_uri = null)
     {
         if (function_exists('pcntl_fork')) {
-            $this->_testTypeDefinitionInOtherFileWithPcntlSetting($new_file_contents, $position, $expected_definition_uri, $expected_definition_line, $requested_uri, true);
+            $this->runTestTypeDefinitionInOtherFileWithPcntlSetting($new_file_contents, $position, $expected_definition_uri, $expected_definition_line, $requested_uri, true);
         }
-        $this->_testTypeDefinitionInOtherFileWithPcntlSetting($new_file_contents, $position, $expected_definition_uri, $expected_definition_line, $requested_uri, false);
+        $this->runTestTypeDefinitionInOtherFileWithPcntlSetting($new_file_contents, $position, $expected_definition_uri, $expected_definition_line, $requested_uri, false);
     }
 
     /**
@@ -240,7 +240,7 @@ EOT;
      * @param ?int $expected_definition_line
      * @param ?string $requested_uri
      */
-    public function _testDefinitionInOtherFileWithPcntlSetting(
+    public function runTestDefinitionInOtherFileWithPcntlSetting(
         string $new_file_contents,
         Position $position,
         string $expected_definition_uri,
@@ -326,7 +326,7 @@ EOT;
      * @param ?int $expected_definition_line
      * @param ?string $requested_uri
      */
-    public function _testTypeDefinitionInOtherFileWithPcntlSetting(
+    public function runTestTypeDefinitionInOtherFileWithPcntlSetting(
         string $new_file_contents,
         Position $position,
         string $expected_definition_uri,

--- a/tests/Phan/Library/FileCacheTest.php
+++ b/tests/Phan/Library/FileCacheTest.php
@@ -38,20 +38,20 @@ class FileCacheTest extends BaseTest
 
     public function testLRU()
     {
-        $expectedPaths = [];
+        $expected_paths = [];
         $this->assertGreaterThanOrEqual(5, FileCache::MINIMUM_CACHE_SIZE);
         for ($i = 0; $i < FileCache::MINIMUM_CACHE_SIZE; $i++) {
             $path = "/path/to/$i";
-            $expectedPaths[] = $path;
+            $expected_paths[] = $path;
             FileCache::addEntry($path, "contents of $i");
         }
-        $this->assertSame($expectedPaths, FileCache::getCachedFileList());
+        $this->assertSame($expected_paths, FileCache::getCachedFileList());
 
         $this->assertSame("contents of 0", FileCache::getEntry("/path/to/0")->getContents());
 
-        $firstEntry = array_shift($expectedPaths);
-        $expectedPaths[] = $firstEntry;
-        $this->assertSame($expectedPaths, FileCache::getCachedFileList());
+        $first_entry = array_shift($expected_paths);
+        $expected_paths[] = $first_entry;
+        $this->assertSame($expected_paths, FileCache::getCachedFileList());
 
         FileCache::addEntry("/path/to/extra", "Other contents");
         $this->assertNull(FileCache::getEntry("/path/to/1"), "Least recently used entry should be evicted");
@@ -63,9 +63,9 @@ class FileCacheTest extends BaseTest
     {
         $this->assertNull(FileCache::getEntry(__FILE__));
         $line = __LINE__;  // Comment placeholder
-        $expectedLineContents = "        \$line = __LINE__;  // Comment placeholder\n";
+        $expected_line_contents = "        \$line = __LINE__;  // Comment placeholder\n";
         $entry = FileCache::getOrReadEntry(__FILE__);
-        $this->assertSame($expectedLineContents, $entry->getLine($line));
+        $this->assertSame($expected_line_contents, $entry->getLine($line));
     }
 
     public function testGetOrReadEntryThrows()

--- a/tests/Phan/Output/Printer/CSVPrinterTest.php
+++ b/tests/Phan/Output/Printer/CSVPrinterTest.php
@@ -33,11 +33,11 @@ class CSVPrinterTest extends BaseTest
 
     /**
      * @param string $string String to check against
-     * @param string $messageExpected Message component of expected CSV line
+     * @param string $expected_message Message component of expected CSV line
      *
      * @dataProvider specialCharacterCasesProvider
      */
-    public function testSpecialCharactersAreProperlyEncoded($string, $messageExpected)
+    public function testSpecialCharactersAreProperlyEncoded($string, $expected_message)
     {
         $output = new BufferedOutput();
 
@@ -46,7 +46,7 @@ class CSVPrinterTest extends BaseTest
         $printer->print(new IssueInstance(Issue::fromType(Issue::SyntaxError), 'test.php', 0, [$string]));
         $printer->flush();
 
-        $expected = 'test.php,0,10,critical,Syntax,PhanSyntaxError,' . $messageExpected;
+        $expected = 'test.php,0,10,critical,Syntax,PhanSyntaxError,' . $expected_message;
         $actual = explode("\n", $output->fetch())[1]; // Ignore header
         $this->assertEquals($expected, $actual);
     }

--- a/tests/Phan/Output/Printer/CodeClimatePrinterTest.php
+++ b/tests/Phan/Output/Printer/CodeClimatePrinterTest.php
@@ -23,9 +23,11 @@ class CodeClimatePrinterTest extends BaseTest
         $printer->flush();
 
         $expected_output = '';
+        // phpcs:disable
         $expected_output .= '{"type":"issue","check_name":"PhanUndeclaredVariableDim","description":"Variable $varName was undeclared, but array fields are being added to it.","categories":["Bug Risk"],"severity":"info","location":{"path":"dim.php","lines":{"begin":10,"end":10}}}' . "\x00";
         $expected_output .= '{"type":"issue","check_name":"PhanSyntaxError","description":"fake error","categories":["Bug Risk"],"severity":"critical","location":{"path":"test.php","lines":{"begin":1,"end":1}}}' . "\x00";
         $expected_output .= '{"type":"issue","check_name":"PhanUndeclaredMethod","description":"Call to undeclared method \\\\Foo::bar","categories":["Bug Risk"],"severity":"critical","location":{"path":"undefinedmethod.php","lines":{"begin":1,"end":1}}}' . "\x00";
+        // phpcs:enable
         $this->assertSame($expected_output, $output->fetch());
     }
 }

--- a/tests/Phan/Output/Printer/JSONPrinterTest.php
+++ b/tests/Phan/Output/Printer/JSONPrinterTest.php
@@ -20,6 +20,7 @@ class JSONPrinterTest extends BaseTest
         $printer->print(new IssueInstance(Issue::fromType(Issue::UndeclaredVariableDim), 'dim.php', 10, ['varName']));
         $printer->print(new IssueInstance(Issue::fromType(Issue::SyntaxError), 'test.php', 1, ['fake error']));
         $printer->flush();
+        // phpcs:ignore
         $expected_output = '[{"type":"issue","type_id":11027,"check_name":"PhanUndeclaredVariableDim","description":"UndefError PhanUndeclaredVariableDim Variable $varName was undeclared, but array fields are being added to it.","severity":0,"location":{"path":"dim.php","lines":{"begin":10,"end":10}}},{"type":"issue","type_id":17000,"check_name":"PhanSyntaxError","description":"Syntax PhanSyntaxError fake error","severity":10,"location":{"path":"test.php","lines":{"begin":1,"end":1}}}]';
         $this->assertSame($expected_output, $output->fetch());
     }

--- a/tests/Phan/Output/Printer/PlaintextPrinterTest.php
+++ b/tests/Phan/Output/Printer/PlaintextPrinterTest.php
@@ -32,9 +32,11 @@ class PlainTextPrinterTest extends BaseTest
         $printer->print(new IssueInstance(Issue::fromType(Issue::SyntaxError), 'test.php', 1, ['fake error']));
         $printer->print(new IssueInstance(Issue::fromType(Issue::UndeclaredMethod), 'undefinedmethod.php', 1, ['\\Foo::bar']));
         $expected_output = '';
+        // phpcs:disable
         $expected_output .= "\x1b[96mdim.php\x1b[0m:\x1b[37m10\x1b[0m \x1b[93mPhanUndeclaredVariableDim\x1b[0m Variable $\x1b[96mvarName\x1b[0m was undeclared, but array fields are being added to it." . PHP_EOL;
         $expected_output .= "\x1b[96mtest.php\x1b[0m:\x1b[37m1\x1b[0m \x1b[31mPhanSyntaxError\x1b[0m fake error" . PHP_EOL;
         $expected_output .= "\x1b[96mundefinedmethod.php\x1b[0m:\x1b[37m1\x1b[0m \x1b[31mPhanUndeclaredMethod\x1b[0m Call to undeclared method \x1b[93m\\Foo::bar\x1b[0m" . PHP_EOL;
+        // phpcs:enable
         $actual_output = $output->fetch();
         $this->assertSame(json_encode($expected_output), json_encode($actual_output));
         $this->assertSame($expected_output, $actual_output);

--- a/tests/Phan/PHP70Test.php
+++ b/tests/Phan/PHP70Test.php
@@ -6,7 +6,7 @@ use Phan\Config;
 
 class PHP70Test extends AbstractPhanFileTest
 {
-    const overrides = [
+    const OVERRIDES = [
         'target_php_version' => '7.0',
         'use_polyfill_parser' => true, // We use the polyfill parser because it behaves consistently in all php versions.
         'backward_compatibility_checks' => false,
@@ -19,7 +19,7 @@ class PHP70Test extends AbstractPhanFileTest
     public function setUp()
     {
         parent::setUp();
-        foreach (self::overrides as $key => $value) {
+        foreach (self::OVERRIDES as $key => $value) {
             Config::setValue($key, $value);
         }
     }

--- a/tests/Phan/PHP72Test.php
+++ b/tests/Phan/PHP72Test.php
@@ -6,7 +6,7 @@ use Phan\Config;
 
 class PHP72Test extends AbstractPhanFileTest
 {
-    const overrides = [
+    const OVERRIDES = [
         'allow_method_param_type_widening' => true,
         'target_php_version' => '7.2',
     ];
@@ -14,7 +14,7 @@ class PHP72Test extends AbstractPhanFileTest
     public function setUp()
     {
         parent::setUp();
-        foreach (self::overrides as $key => $value) {
+        foreach (self::OVERRIDES as $key => $value) {
             Config::setValue($key, $value);
         }
     }

--- a/tests/Phan/PHP73Test.php
+++ b/tests/Phan/PHP73Test.php
@@ -6,7 +6,7 @@ use Phan\Config;
 
 class PHP73Test extends AbstractPhanFileTest
 {
-    const overrides = [
+    const OVERRIDES = [
         'allow_method_param_type_widening' => true,
         'target_php_version' => '7.3',
     ];
@@ -14,7 +14,7 @@ class PHP73Test extends AbstractPhanFileTest
     public function setUp()
     {
         parent::setUp();
-        foreach (self::overrides as $key => $value) {
+        foreach (self::OVERRIDES as $key => $value) {
             Config::setValue($key, $value);
         }
     }


### PR DESCRIPTION
And implement a PHP_CodeSniffer rule to do that (Requires PHP_CodeSniffer 3.3.0 to do that).

Do this in a way that will avoid duplicate warnings and false positives.

See individual commits for more details.