### PR TITLE
Fix incorrect logic when type checking casts from certain nullable types

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,10 +13,10 @@ environment:
       PHP_VERSION: '7.0.30'
       VC_VERSION: 14
     - PHP_EXT_VERSION: '7.1'
-      PHP_VERSION: '7.1.17'
+      PHP_VERSION: '7.1.19'
       VC_VERSION: 14
     - PHP_EXT_VERSION: '7.2'
-      PHP_VERSION: '7.2.5'
+      PHP_VERSION: '7.2.7'
       VC_VERSION: 15
 
 init:
@@ -33,7 +33,6 @@ branches:
     - master
     - 0.8
     - 0.9
-    - php72
 
 install:
 - cmd: choco feature enable -n=allowGlobalConfirmation

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@ Bug fixes:
   - `?'a string'`      can cast to `?string`
   - `?Closure(T1):T2`  can cast to `?Closure`
   - `?callable(T1):T2` can cast to `?callable`,
++ Make `exclude_file_list` work more consistently on Windows
 
 08 Jul 2018, Phan 0.12.14
 -------------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,15 @@ Phan NEWS
 08 Jul 2018, Phan 0.12.15 (dev)
 -------------------------
 
+Bug fixes:
++ Fix a bug in checking if nullable versions of specialized type were compatible with other nullable types. (#1839, #1852)
+  Phan now correctly allows the following type casts:
+
+  - `?1`               can cast to `?int`
+  - `?'a string'`      can cast to `?string`
+  - `?Closure(T1):T2`  can cast to `?Closure`
+  - `?callable(T1):T2` can cast to `?callable`,
+
 08 Jul 2018, Phan 0.12.14
 -------------------------
 

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -568,13 +568,16 @@ class CLI
         if (count(Config::getValue('exclude_file_list')) > 0) {
             $exclude_file_set = [];
             foreach (Config::getValue('exclude_file_list') as $file) {
-                $exclude_file_set[$file] = true;
+                $normalized_file = str_replace('\\', '/', $file);
+                $exclude_file_set[$normalized_file] = true;
+                $exclude_file_set["./$normalized_file"] = true;
             }
 
             $this->file_list = array_filter(
                 $this->file_list,
                 function (string $file) use ($exclude_file_set) : bool {
-                    return empty($exclude_file_set[$file]);
+                    // Handle edge cases such as 'mydir/subdir\subsubdir' on Windows, if mydir/subdir was in the Phan config.
+                    return !isset($exclude_file_set[\str_replace('\\', '/', $file)]);
                 }
             );
         }

--- a/src/Phan/Language/Type/ClosureDeclarationType.php
+++ b/src/Phan/Language/Type/ClosureDeclarationType.php
@@ -16,9 +16,6 @@ final class ClosureDeclarationType extends FunctionLikeDeclarationType
     public function canCastToNonNullableType(Type $type) : bool
     {
         if ($type->isCallable()) {
-            if ($this->getIsNullable()) {
-                return false;
-            }
             if ($type instanceof FunctionLikeDeclarationType) {
                 return $this->canCastToNonNullableFunctionLikeDeclarationType($type);
             }

--- a/src/Phan/Language/Type/ClosureType.php
+++ b/src/Phan/Language/Type/ClosureType.php
@@ -78,9 +78,6 @@ final class ClosureType extends Type
     protected function canCastToNonNullableType(Type $type) : bool
     {
         if ($type->isCallable()) {
-            if ($this->getIsNullable() && !$type->getIsNullable()) {
-                return false;
-            }
             if ($type instanceof FunctionLikeDeclarationType) {
                 // Check if the function declaration is known and available. It's not available for the generic \Closure.
                 if ($this->func) {

--- a/src/Phan/Language/Type/LiteralIntType.php
+++ b/src/Phan/Language/Type/LiteralIntType.php
@@ -123,8 +123,11 @@ final class LiteralIntType extends IntType implements LiteralTypeInterface
      */
     protected function canCastToNonNullableType(Type $type) : bool
     {
-        if ($type instanceof LiteralIntType) {
-            return $type->getValue() === $this->getValue();
+        if ($type instanceof IntType) {
+            if ($type instanceof LiteralIntType) {
+                return $type->getValue() === $this->getValue();
+            }
+            return true;
         }
 
         return parent::canCastToNonNullableType($type);

--- a/src/Phan/Language/Type/LiteralStringType.php
+++ b/src/Phan/Language/Type/LiteralStringType.php
@@ -195,8 +195,11 @@ final class LiteralStringType extends StringType implements LiteralTypeInterface
      */
     protected function canCastToNonNullableType(Type $type) : bool
     {
-        if ($type instanceof LiteralStringType) {
-            return $type->getValue() === $this->getValue();
+        if ($type instanceof StringType) {
+            if ($type instanceof LiteralStringType) {
+                return $type->getValue() === $this->getValue();
+            }
+            return true;
         }
 
         return parent::canCastToNonNullableType($type);

--- a/src/Phan/Language/Type/NativeType.php
+++ b/src/Phan/Language/Type/NativeType.php
@@ -104,10 +104,6 @@ abstract class NativeType extends Type
         // Cast this to a native type
         \assert($type instanceof NativeType);
 
-        // A nullable type cannot cast to a non-nullable type
-        if ($this->getIsNullable() && !$type->getIsNullable()) {
-            return false;
-        }
         static $matrix;
         if ($matrix === null) {
             $matrix = self::initializeTypeCastingMatrix();

--- a/tests/Phan/Language/TypeTest.php
+++ b/tests/Phan/Language/TypeTest.php
@@ -451,11 +451,64 @@ class TypeTest extends BaseTest
     {
         return [
             ['int', 'int'],
+            ['1', 'int'],
+            ['int', '1'],
+            ['1', '?int'],
+            ['?1', '?int'],
+            ['?string', "?''"],
+            ["?''", '?string'],
+            ["''", '?string'],
+            ["?'a string'", '?string'],
+            ["?'a string'", "?'a string'"],
             ['int', 'float'],
             ['int', 'mixed'],
             ['mixed', 'int'],
             ['null', 'mixed'],
             ['null[]', 'mixed[]'],
+            ['?Closure(int):int', '?Closure'],
+            ['?Closure(int):int', '?callable'],
+            ['?Closure', '?Closure(int):int'],
+            ['?callable(int):int', '?callable'],
+            ['?callable', '?callable(int):int'],
+        ];
+    }
+
+    /**
+     * @dataProvider cannotCastToTypeProvider
+     */
+    public function testCannotCastToType(string $from_type_string, string $to_type_string)
+    {
+        $from_type = self::makePHPDocType($from_type_string);
+        $to_type = self::makePHPDocType($to_type_string);
+        $this->assertFalse($from_type->canCastToType($to_type), "expected $from_type_string to be unable to cast to $to_type_string");
+    }
+
+    public function cannotCastToTypeProvider() : array
+    {
+        return [
+            ['?int', 'int'],
+            ['?1', 'int'],
+            ['?int', '1'],
+            ['0', '1'],
+            ['float', 'int'],
+            ['callable', 'Closure'],
+            ['?Closure(int):int', '?Closure(int):void'],
+            ['?Closure(int):int', 'Closure(int):int'],
+            ['?Closure(int):int', '?Closure(string):int'],
+            ['?callable(int):int', '?callable(int):void'],
+            ['?callable(int):int', 'callable(int):int'],
+            ['?callable(int):int', '?callable(string):int'],
+
+            ['?float', 'float'],
+            ['?string', 'string'],
+            ['?bool', 'bool'],
+            ['?true', 'true'],
+            ['?true', 'bool'],
+            ['?false', 'false'],
+            ['?object', 'object'],
+            ['?iterable', 'iterable'],
+            ['?array', 'array'],
+            // not sure about desired semantics of ['?mixed', 'mixed'],
         ];
     }
 


### PR DESCRIPTION
Fixes #1839
Fixes #1852

Phan now correctly allows the following type casts:

- `?1`               can cast to `?int`
- `?'a string'`      can cast to `?string`
- `?Closure(T1):T2`  can cast to `?Closure`
- `?callable(T1):T2` can cast to `?callable`,

Type casting in the other direction was already working properly.