### PR TITLE
Be more aggressive about inferring a return type of void

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@ Phan NEWS
 08 Jul 2018, Phan 0.12.15 (dev)
 -------------------------
 
+New features(CLI, Configs)
++ Be more aggressive about inferring that a method has a void return type, when it is safe to do so
+
 Bug fixes:
 + Fix a bug in checking if nullable versions of specialized type were compatible with other nullable types. (#1839, #1852)
   Phan now correctly allows the following type casts:

--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -187,7 +187,6 @@ class Analysis
             $context->withLineNumberStart($node->lineno ?? 0)
         ))->{Element::VISIT_LOOKUP_TABLE[$node->kind] ?? 'handleMissingNodeKind'}($node);
 
-        \assert(!empty($context), 'Context cannot be null');
         $kind = $node->kind;
 
         // \ast\AST_GROUP_USE has \ast\AST_USE as a child.
@@ -209,14 +208,12 @@ class Analysis
             // Step into each child node and get an
             // updated context for the node
             $child_context = self::parseNodeInContext($code_base, $child_context, $child_node);
-
-            \assert(!empty($child_context), 'Context cannot be null');
         }
 
         // For closed context elements (that have an inner scope)
         // return the outer context instead of their inner context
         // after we finish parsing their children.
-        if (in_array($kind, [
+        if (\in_array($kind, [
             \ast\AST_CLASS,
             \ast\AST_METHOD,
             \ast\AST_FUNC_DECL,

--- a/src/Phan/Analysis/ReturnTypesAnalyzer.php
+++ b/src/Phan/Analysis/ReturnTypesAnalyzer.php
@@ -6,10 +6,12 @@ use Phan\Config;
 use Phan\Issue;
 use Phan\IssueFixSuggester;
 use Phan\Language\Element\FunctionInterface;
+use Phan\Language\Element\Func;
 use Phan\Language\Element\Method;
 use Phan\Language\FQSEN\FullyQualifiedClassName;
 use Phan\Language\Type\GenericArrayType;
 use Phan\Language\Type\TemplateType;
+use Phan\Language\Type\VoidType;
 use Phan\Language\UnionType;
 
 class ReturnTypesAnalyzer
@@ -119,6 +121,11 @@ class ReturnTypesAnalyzer
                         }
                     }
                 }
+            }
+        }
+        if ($return_type->isEmpty() && !$method->getHasReturn()) {
+            if ($method instanceof Func || ($method instanceof Method && $method->isPrivate())) {
+                $method->setUnionType(VoidType::instance(false)->asUnionType());
             }
         }
     }

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -101,11 +101,6 @@ class ParseVisitor extends ScopeVisitor
             $this->context
         );
 
-        \assert(
-            $class_fqsen instanceof FullyQualifiedClassName,
-            "The class FQSEN must be a FullyQualifiedClassName"
-        );
-
         // Hunt for an available alternate ID if necessary
         $alternate_id = 0;
         while ($this->code_base->hasClassWithFQSEN($class_fqsen)) {
@@ -395,12 +390,11 @@ class ParseVisitor extends ScopeVisitor
 
         foreach ($node->children as $i => $child_node) {
             // Ignore children which are not property elements
-            if (!$child_node
+            if (!($child_node instanceof Node)
                 || $child_node->kind != \ast\AST_PROP_ELEM
             ) {
                 continue;
             }
-            \assert($child_node instanceof Node, 'expected property element to be Node');
 
             // If something goes wrong will getting the type of
             // a property, we'll store it as a future union
@@ -860,13 +854,8 @@ class ParseVisitor extends ScopeVisitor
             $this->code_base
         );
 
-        \assert(
-            !empty($method),
-            "We're supposed to be in either method or closure scope."
-        );
-
-        // Mark the method as returning something
-        if (($node->children['expr'] ?? null) !== null) {
+        // Mark the method as returning something if expr is not null
+        if (isset($node->children['expr'])) {
             $method->setHasReturn(true);
         }
 
@@ -928,11 +917,6 @@ class ParseVisitor extends ScopeVisitor
         // Get the method/function/closure we're in
         $method = $this->context->getFunctionLikeInScope(
             $this->code_base
-        );
-
-        \assert(
-            !empty($method),
-            "We're supposed to be in either method or closure scope."
         );
 
         // Mark the method as yielding something (and returning a generator)

--- a/tests/files/expected/0510_implied_void.php.expected
+++ b/tests/files/expected/0510_implied_void.php.expected
@@ -1,0 +1,1 @@
+%s:10 PhanTypeSuspiciousEcho Suspicious argument void for an echo/print statement

--- a/tests/files/src/0510_implied_void.php
+++ b/tests/files/src/0510_implied_void.php
@@ -1,0 +1,12 @@
+<?php
+
+class X510 {
+    // This is private and has no return statements, so Phan infers that it is guaranteed to be a void.
+    private function returnsVoid() {
+        echo "This does something";
+    }
+
+    public function other() {
+        echo $this->returnsVoid();
+    }
+}


### PR DESCRIPTION
When it is safe to do so, e.g. for global functions, closures, and
private methods with no return statements and no type declarations.