### PR TITLE
Be better at handling invalid constant expressions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,11 @@ Phan NEWS
 
 New features(CLI, Configs)
 + Be more aggressive about inferring that a method has a void return type, when it is safe to do so
++ Emit `PhanInvalidConstantExpression` in some places where PHP would emit `"Constant expression contains invalid operations"`
+
+  Phan will replace the default parameter type (or constant type) with `mixed` for constants and class constants.
+
+  Previously, this could cause Phan to crash, especially with `--use-fallback-parser` on invalid ASTs.
 
 Bug fixes:
 + Fix a bug in checking if nullable versions of specialized type were compatible with other nullable types. (#1839, #1852)

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -3014,6 +3014,9 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
      */
     private function declOnlyThrows(Node $node) : bool
     {
-        return BlockExitStatusChecker::willUnconditionallyThrowOrReturn($node->children['stmts']);
+        // Work around fallback parser generating methods without statements list.
+        // Otherwise, 'stmts' would always be a Node due to preconditions.
+        $stmts_node = $node->children['stmts'];
+        return $stmts_node instanceof Node && BlockExitStatusChecker::willUnconditionallyThrowOrReturn($stmts_node);
     }
 }

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -19,6 +19,7 @@ class Issue
     // this is deliberate for issue names
     // Issue::CATEGORY_SYNTAX
     const SyntaxError               = 'PhanSyntaxError';
+    const InvalidConstantExpression = 'PhanInvalidConstantExpression';
 
     // Issue::CATEGORY_UNDEFINED
     const AmbiguousTraitAliasSource = 'PhanAmbiguousTraitAliasSource';
@@ -534,6 +535,14 @@ class Issue
                 "%s",
                 self::REMEDIATION_A,
                 17000
+            ),
+            new Issue(
+                self::InvalidConstantExpression,
+                self::CATEGORY_SYNTAX,
+                self::SEVERITY_CRITICAL,
+                "Constant expression contains invalid operations",
+                self::REMEDIATION_A,
+                17001
             ),
 
             // Issue::CATEGORY_UNDEFINED

--- a/src/Phan/Language/Internal/PropertyMap.php
+++ b/src/Phan/Language/Internal/PropertyMap.php
@@ -22,7 +22,7 @@ $ast_node_shape_inner = \implode(',', [
     "stmts?:?ast\Node",
 ]);
 
-$ast_node_children_types = 'array{' . $ast_node_shape_inner . '}|ast\Node[]|array[]|int[]|string[]|float[]|bool[]|null[]';
+$ast_node_children_types = 'array{' . $ast_node_shape_inner . '}|ast\Node[]|array[]|int[]|string[]|float[]|null[]';
 
 /**
  * A mapping from class name to property name to property type.

--- a/tests/misc/fallback_test/expected/015_class_const_declaration9.php.expected
+++ b/tests/misc/fallback_test/expected/015_class_const_declaration9.php.expected
@@ -1,4 +1,5 @@
 src/015_class_const_declaration9.php:2 PhanRedefineClass Class \A defined at src/015_class_const_declaration9.php:2 was previously defined as Class \A at src/007_class_base_clause_2.php:3
+src/015_class_const_declaration9.php:3 PhanInvalidConstantExpression Constant expression contains invalid operations
 src/015_class_const_declaration9.php:3 PhanSyntaxError syntax error, unexpected '=', expecting ',' or ';'
 src/015_class_const_declaration9.php:3 PhanUnanalyzable Expression is unanalyzable or feature is unimplemented. Please create an issue at https://github.com/phan/phan/issues/new.
 src/015_class_const_declaration9.php:3 PhanUndeclaredConstant Reference to undeclared constant \b

--- a/tests/misc/fallback_test/expected/024_crash.php.expected
+++ b/tests/misc/fallback_test/expected/024_crash.php.expected
@@ -1,0 +1,2 @@
+src/024_crash.php:5 PhanInvalidConstantExpression Constant expression contains invalid operations
+src/024_crash.php:5 PhanSyntaxError syntax error, unexpected '$notAFunction' (T_VARIABLE)

--- a/tests/misc/fallback_test/expected/025_invalid_const.php.expected
+++ b/tests/misc/fallback_test/expected/025_invalid_const.php.expected
@@ -1,0 +1,3 @@
+src/025_invalid_const.php:3 PhanInvalidConstantExpression Constant expression contains invalid operations
+src/025_invalid_const.php:4 PhanUndeclaredConstant Reference to undeclared constant \X25
+src/025_invalid_const.php:8 PhanInvalidConstantExpression Constant expression contains invalid operations

--- a/tests/misc/fallback_test/src/024_crash.php
+++ b/tests/misc/fallback_test/src/024_crash.php
@@ -1,0 +1,7 @@
+<?php
+// Phan should not crash.
+// The fallback parser starts parsing `$notAFunction = function() ...` as if it were a parameter with an invalid default
+class example {
+    private function $notAFunction = function() : void {
+    };
+}

--- a/tests/misc/fallback_test/src/025_invalid_const.php
+++ b/tests/misc/fallback_test/src/025_invalid_const.php
@@ -1,0 +1,12 @@
+<?php
+
+const X25 = function() {};
+echo X25;
+class Example25 {
+    // This will emit PhanInvalidConstantExpression and then be inferred as type mixed
+    // to avoid impossible results or crashes.
+    const X = function() {};
+}
+// This won't warn, because the type is inferred as mixed instead
+echo count(Example25::X);
+echo Example25::X;

--- a/tests/plugin_test/expected/044_crash.php.expected
+++ b/tests/plugin_test/expected/044_crash.php.expected
@@ -1,0 +1,1 @@
+src/044_crash.php:5 PhanSyntaxError Fallback parser diagnostic error: '}' expected.

--- a/tests/plugin_test/expected/045_invalid_const.php.expected
+++ b/tests/plugin_test/expected/045_invalid_const.php.expected
@@ -1,0 +1,1 @@
+src/045_invalid_const.php:3 PhanSyntaxError Fallback parser diagnostic error: ';' expected.

--- a/tests/plugin_test/src/044_crash.php
+++ b/tests/plugin_test/src/044_crash.php
@@ -1,0 +1,8 @@
+<?php
+// Phan should not crash
+class example {
+    private function validFunction() : void {
+    };
+    private function $notAFunction = function() : void {
+    };
+}

--- a/tests/plugin_test/src/045_invalid_const.php
+++ b/tests/plugin_test/src/045_invalid_const.php
@@ -1,0 +1,3 @@
+<?php
+
+const X = function() {}


### PR DESCRIPTION
This is more of an issue with the fallback parser,
which might accidentally treat code fragments as if they were constant
expressions instead of the original expression type.

- Previously, Phan would crash. This fixes that by casting those invalid
  types to mixed.
- Note that `php-ast` won't run these checks for parameter defaults,
  so this was moved into the parse phase.