### PR TITLE
Make unused variable detection account for caught exceptions

### DIFF
--- a/.phan/plugins/DuplicateArrayKeyPlugin.php
+++ b/.phan/plugins/DuplicateArrayKeyPlugin.php
@@ -180,9 +180,9 @@ class DuplicateArrayKeyVisitor extends PluginAwarePostAnalysisVisitor
                 $this->context,
                 $e->getIssueInstance()
             );
-        } catch (CodeBaseException $e) {
+        } catch (CodeBaseException $_) {
             // e.g. Can't find the class (ignore)
-        } catch (NodeException $e) {
+        } catch (NodeException $_) {
             // E.g. Can't figure out constant class in node
             // (ignore)
         }

--- a/.phan/plugins/NonBoolBranchPlugin.php
+++ b/.phan/plugins/NonBoolBranchPlugin.php
@@ -56,7 +56,7 @@ class NonBoolBranchVisitor extends PluginAwarePostAnalysisVisitor
             // evaluate the type of conditional expression
             try {
                 $union_type = UnionTypeVisitor::unionTypeFromNode($this->code_base, $this->context, $condition);
-            } catch (IssueException $e) {
+            } catch (IssueException $_) {
                 return $this->context;
             }
             if (!$union_type->isExclusivelyBoolTypes()) {

--- a/.phan/plugins/PrintfCheckerPlugin.php
+++ b/.phan/plugins/PrintfCheckerPlugin.php
@@ -493,7 +493,7 @@ class PrintfCheckerPlugin extends PluginV2 implements AnalyzeFunctionCallCapabil
                                 break;
                             }
                         }
-                    } catch (CodeBaseException $e) {
+                    } catch (CodeBaseException $_) {
                         // Swallow "Cannot find class", go on to emit issue.
                     }
                     if ($can_cast_to_string) {

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,10 @@ Phan NEWS
 08 Jul 2018, Phan 0.12.15 (dev)
 -------------------------
 
-New features(CLI, Configs)
+New features(Analysis)
++ Make Phan's unused variable detection also treat exception variables as variable definitions,
+  and warn if the caught exception is unused. (#1810)
+  New issue types: `PhanUnusedVariableCaughtException`
 + Be more aggressive about inferring that a method has a void return type, when it is safe to do so
 + Emit `PhanInvalidConstantExpression` in some places where PHP would emit `"Constant expression contains invalid operations"`
 
@@ -42,6 +45,8 @@ New features(CLI, Configs)
   Phan will not warn about lack of documentation of `@throws` for any of the configured classes or their subclasses.
   The default is the empty array (Don't suppress any warnings.)
   (E.g. Phan suppresses `['RuntimeException', 'AssertionError', 'TypeError']` for self-analysis)
+
+New Features (Analysis):
 + Warn when string literals refer to invalid class names (E.g. `$myClass::SOME_CONSTANT`). (#1794)
   New issue types: `PhanTypeExpectedObjectOrClassNameInvalidName` (emitted if the name can't be used as a class)
   This will also emit `PhanUndeclaredClass` if the class name could not be found.

--- a/internal/sanitycheck.php
+++ b/internal/sanitycheck.php
@@ -120,7 +120,7 @@ function check_fields(string $function_name, array $fields, array $signatures)
     // echo $function_name . "\n";
     try {
         $function = load_internal_function($function_name);
-    } catch (ReflectionException $e) {
+    } catch (ReflectionException $_) {
         return;
     }
     assert($function instanceof ReflectionFunctionAbstract);

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -453,7 +453,7 @@ class ContextNode
                 $result = [$union_type, $class_list];
                 $context->setCachedClassListOfNode($node_id, $result);
                 return $result;
-            } catch (CodeBaseException $exception) {
+            } catch (CodeBaseException $_) {
                 // swallow it
                 // TODO: Is it appropriate to return class_list
                 return [$union_type, $class_list];
@@ -1037,7 +1037,7 @@ class ContextNode
     {
         try {
             return $this->getVariable();
-        } catch (IssueException $exception) {
+        } catch (IssueException $_) {
             // Swallow it
         }
 
@@ -1933,7 +1933,7 @@ class ContextNode
             }
             try {
                 $constant = (new ContextNode($this->code_base, $this->context, $node))->getConst();
-            } catch (\Exception $e) {
+            } catch (\Exception $_) {
                 return $node;
             }
             // TODO: Recurse, but don't try to resolve constants again
@@ -1949,7 +1949,7 @@ class ContextNode
             }
             try {
                 $constant = (new ContextNode($this->code_base, $this->context, $node))->getClassConst();
-            } catch (\Exception $e) {
+            } catch (\Exception $_) {
                 return $node;
             }
             // TODO: Recurse, but don't try to resolve constants again

--- a/src/Phan/AST/Parser.php
+++ b/src/Phan/AST/Parser.php
@@ -78,7 +78,7 @@ class Parser
             $errors = [];
             try {
                 $node = $converter->parseCodeAsPHPAST($file_contents, Config::AST_VERSION, $errors);
-            } catch (\Exception $e) {
+            } catch (\Exception $_) {
                 // Generic fallback. TODO: log.
                 throw $native_parse_error;
             }

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -268,7 +268,7 @@ class TolerantASTConverter
         foreach ($parser_nodes as $parser_node) {
             try {
                 $child_node = static::phpParserNodeToAstNode($parser_node);
-            } catch (InvalidNodeException $e) {
+            } catch (InvalidNodeException $_) {
                 continue;
             }
             if (\is_array($child_node)) {
@@ -459,7 +459,7 @@ class TolerantASTConverter
             'Microsoft\PhpParser\Node\Expression\AssignmentExpression' => function (PhpParser\Node\Expression\AssignmentExpression $n, int $start_line) {
                 try {
                     $var_node = static::phpParserNodeToAstNode($n->leftOperand);
-                } catch (InvalidNodeException $e) {
+                } catch (InvalidNodeException $_) {
                     if (self::$should_add_placeholders) {
                         $var_node = new ast\Node(ast\AST_VAR, 0, ['name' => '__INCOMPLETE_VARIABLE__'], $start_line);
                     } else {
@@ -2166,7 +2166,7 @@ class TolerantASTConverter
     {
         try {
             $left_node = static::phpParserNodeToAstNode($n->leftOperand);
-        } catch (InvalidNodeException $e) {
+        } catch (InvalidNodeException $_) {
             if (self::$should_add_placeholders) {
                 $left_node = static::newPlaceholderExpression($n->leftOperand);
             } else {
@@ -2176,7 +2176,7 @@ class TolerantASTConverter
         }
         try {
             $right_node = static::phpParserNodeToAstNode($n->rightOperand);
-        } catch (InvalidNodeException $e) {
+        } catch (InvalidNodeException $_) {
             if (self::$should_add_placeholders) {
                 $right_node = static::newPlaceholderExpression($n->rightOperand);
             } else {
@@ -2201,7 +2201,7 @@ class TolerantASTConverter
     {
         try {
             $var_node = static::phpParserNodeToAstNode($n->leftOperand);
-        } catch (InvalidNodeException $e) {
+        } catch (InvalidNodeException $_) {
             if (self::$should_add_placeholders) {
                 $var_node = new ast\Node(ast\AST_VAR, 0, ['name' => '__INCOMPLETE_VARIABLE__'], $start_line);
             } else {

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -604,7 +604,7 @@ class UnionTypeVisitor extends AnalysisVisitor
             if ($node->kind === \ast\AST_CONST || $node->kind === \ast\AST_CLASS_CONST) {
                 try {
                     return UnionTypeVisitor::unionTypeFromNode($code_base, $context, $node, false);
-                } catch (IssueException $e) {
+                } catch (IssueException $_) {
                     return null;
                 }
             }
@@ -1158,7 +1158,7 @@ class UnionTypeVisitor extends AnalysisVisitor
                     );
                 }
             }
-        } catch (TypeException $exception) {
+        } catch (TypeException $_) {
             // TODO: log it?
         }
 
@@ -1332,7 +1332,7 @@ class UnionTypeVisitor extends AnalysisVisitor
                         return $element_types;
                     }
                 }
-            } catch (CodeBaseException $exception) {
+            } catch (CodeBaseException $_) {
             }
 
             if (!$union_type->hasArrayLike()) {
@@ -1712,7 +1712,7 @@ class UnionTypeVisitor extends AnalysisVisitor
             ))->getClassConst();
 
             return $constant->getUnionType();
-        } catch (NodeException $exception) {
+        } catch (NodeException $_) {
             // ignore, this should warn elsewhere
         }
 
@@ -1801,10 +1801,10 @@ class UnionTypeVisitor extends AnalysisVisitor
                 ["{$exception_fqsen}->{$property_name}"],
                 $suggestion
             );
-        } catch (UnanalyzableException $exception) {
+        } catch (UnanalyzableException $_) {
             // Swallow it. There are some constructs that we
             // just can't figure out.
-        } catch (NodeException $exception) {
+        } catch (NodeException $_) {
             // Swallow it. There are some constructs that we
             // just can't figure out.
         }
@@ -1970,7 +1970,7 @@ class UnionTypeVisitor extends AnalysisVisitor
                     return UnionType::empty();
                 }
             }
-        } catch (IssueException $exception) {
+        } catch (IssueException $_) {
             // Swallow it
         } catch (CodeBaseException $exception) {
             $exception_fqsen = $exception->getFQSEN();

--- a/src/Phan/Analysis/ArgumentType.php
+++ b/src/Phan/Analysis/ArgumentType.php
@@ -51,7 +51,7 @@ class ArgumentType
         if ($method->hasFunctionCallAnalyzer()) {
             try {
                 $method->analyzeFunctionCall($code_base, $context->withLineNumberStart($node->lineno ?? 0), $node->children['args']->children);
-            } catch (StopParamAnalysisException $e) {
+            } catch (StopParamAnalysisException $_) {
                 return;
             }
         }
@@ -531,7 +531,7 @@ class ArgumentType
                             return;
                         }
                     }
-                } catch (CodeBaseException $e) {
+                } catch (CodeBaseException $_) {
                     // Swallow "Cannot find class", go on to emit issue
                 }
             }
@@ -702,7 +702,7 @@ class ArgumentType
                             return true;
                         }
                     }
-                } catch (IssueException $e) {
+                } catch (IssueException $_) {
                     // Swallow any issue esceptions here. They'll be caught elsewhere.
                 }
             }

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -358,9 +358,9 @@ class AssignmentVisitor extends AnalysisVisitor
                 // Set the element type on each element of
                 // the list
                 $property->setUnionType($element_type);
-            } catch (UnanalyzableException $exception) {
+            } catch (UnanalyzableException $_) {
                 // Ignore it. There's nothing we can do.
-            } catch (NodeException $exception) {
+            } catch (NodeException $_) {
                 // Ignore it. There's nothing we can do.
             } catch (IssueException $exception) {
                 Issue::maybeEmitInstance(
@@ -704,7 +704,7 @@ class AssignmentVisitor extends AnalysisVisitor
                 ))->getOrCreateProperty($property_name, false);
 
                 $this->addTypesToProperty($property, $node);
-            } catch (\Exception $exception) {
+            } catch (\Exception $_) {
                 // swallow it
             }
         } elseif (!empty($class_list)) {

--- a/src/Phan/Analysis/CompositionAnalyzer.php
+++ b/src/Phan/Analysis/CompositionAnalyzer.php
@@ -38,7 +38,7 @@ class CompositionAnalyzer
         foreach ($class->getPropertyMap($code_base) as $property) {
             try {
                 $property_union_type = $property->getUnionType();
-            } catch (IssueException $exception) {
+            } catch (IssueException $_) {
                 $property_union_type = UnionType::empty();
             }
 
@@ -68,7 +68,7 @@ class CompositionAnalyzer
                 // inherited definition's type.
                 try {
                     $inherited_property_union_type = $inherited_property->getUnionType();
-                } catch (IssueException $exception) {
+                } catch (IssueException $_) {
                     $inherited_property_union_type = UnionType::empty();
                 }
                 $can_cast =

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -528,7 +528,7 @@ class ConditionVisitor extends KindVisitorImplementation
             );
         } catch (IssueException $exception) {
             Issue::maybeEmitInstance($this->code_base, $context, $exception->getIssueInstance());
-        } catch (\Exception $exception) {
+        } catch (\Exception $_) {
             // Swallow it
         }
 
@@ -754,7 +754,7 @@ class ConditionVisitor extends KindVisitorImplementation
             );
         } catch (IssueException $exception) {
             Issue::maybeEmitInstance($this->code_base, $context, $exception->getIssueInstance());
-        } catch (\Exception $exception) {
+        } catch (\Exception $_) {
             // Swallow it (E.g. IssueException for undefined variable)
         }
 

--- a/src/Phan/Analysis/ConditionVisitorUtil.php
+++ b/src/Phan/Analysis/ConditionVisitorUtil.php
@@ -159,7 +159,7 @@ trait ConditionVisitorUtil
             if (!$suppress_issues) {
                 Issue::maybeEmitInstance($this->code_base, $context, $exception->getIssueInstance());
             }
-        } catch (\Exception $exception) {
+        } catch (\Exception $_) {
             // Swallow it
         }
         return $context;
@@ -194,7 +194,7 @@ trait ConditionVisitorUtil
             if (!$suppress_issues) {
                 Issue::maybeEmitInstance($this->code_base, $context, $exception->getIssueInstance());
             }
-        } catch (\Exception $exception) {
+        } catch (\Exception $_) {
             // Swallow it
         }
         return $context;
@@ -234,7 +234,7 @@ trait ConditionVisitorUtil
                     );
                     return $context;
                 }
-            } catch (\Exception $e) {
+            } catch (\Exception $_) {
                 // Swallow it (E.g. IssueException for undefined variable)
             }
         }
@@ -269,7 +269,7 @@ trait ConditionVisitorUtil
                         }
                     }
                 }
-            } catch (\Exception $e) {
+            } catch (\Exception $_) {
                 // Swallow it (E.g. IssueException for undefined variable)
             }
         }
@@ -316,7 +316,7 @@ trait ConditionVisitorUtil
                 } elseif ($expr == true) {  // e.g. 1, "1", -1
                     return $this->removeTrueFromVariable($var_node, $context);
                 }
-            } catch (\Exception $e) {
+            } catch (\Exception $_) {
                 // Swallow it (E.g. IssueException for undefined variable)
             }
         }

--- a/src/Phan/Analysis/NegatedConditionVisitor.php
+++ b/src/Phan/Analysis/NegatedConditionVisitor.php
@@ -384,7 +384,7 @@ class NegatedConditionVisitor extends KindVisitorImplementation
             );
         } catch (IssueException $exception) {
             Issue::maybeEmitInstance($code_base, $context, $exception->getIssueInstance());
-        } catch (\Exception $exception) {
+        } catch (\Exception $_) {
             // Swallow it
         }
 

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -267,7 +267,7 @@ class ParameterTypesAnalyzer
         //      then this has to check two different overrides (Subclass overriding parent class, and subclass overriding abstract method in interface)
         try {
             $o_method_list = $method->getOverriddenMethods($code_base);
-        } catch (CodeBaseException $e) {
+        } catch (CodeBaseException $_) {
             // TODO: Remove if no edge cases are seen.
             Issue::maybeEmit(
                 $code_base,

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -374,7 +374,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                         return;
                     }
                 }
-            } catch (CodeBaseException $e) {
+            } catch (CodeBaseException $_) {
                 // Swallow "Cannot find class", go on to emit issue
             }
             $this->emitIssue(
@@ -560,7 +560,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                             return $context;
                         }
                     }
-                } catch (CodeBaseException $e) {
+                } catch (CodeBaseException $_) {
                     // Swallow "Cannot find class", go on to emit issue
                 }
             }
@@ -744,7 +744,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 $context,
                 $exception->getIssueInstance()
             );
-        } catch (\Exception $exception) {
+        } catch (\Exception $_) {
             // Swallow any other types of exceptions. We'll log the errors
             // elsewhere.
         }
@@ -783,7 +783,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 $this->context,
                 $exception->getIssueInstance()
             );
-        } catch (\Exception $exception) {
+        } catch (\Exception $_) {
             // Swallow any other types of exceptions. We'll log the errors
             // elsewhere.
         }
@@ -1437,7 +1437,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                     $node
                 );
             }
-        } catch (CodeBaseException $e) {
+        } catch (CodeBaseException $_) {
             // ignore it.
         }
 
@@ -1547,7 +1547,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 $this->context,
                 $exception->getIssueInstance()
             );
-        } catch (\Exception $exception) {
+        } catch (\Exception $_) {
             // If we can't figure out what kind of a call
             // this is, don't worry about it
             return $this->context;
@@ -1720,7 +1720,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 $this->context,
                 $exception->getIssueInstance()
             );
-        } catch (\Exception $exception) {
+        } catch (\Exception $_) {
             // If we can't figure out the class for this method
             // call, cry YOLO and mark every method with that
             // name with a reference.
@@ -1830,7 +1830,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 $this->context,
                 $exception->getIssueInstance()
             );
-        } catch (\Exception $exception) {
+        } catch (\Exception $_) {
             // If we can't figure out the class for this method
             // call, cry YOLO and mark every method with that
             // name with a reference.
@@ -1873,12 +1873,12 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             "Function found where method expected"
         );
 
-        $has_interface_class = false;
         if ($method instanceof Method) {
+            $has_interface_class = false;
             try {
                 $class = $method->getClass($this->code_base);
                 $has_interface_class = $class->isInterface();
-            } catch (\Exception $exception) {
+            } catch (\Exception $_) {
             }
 
             if (!$method->isAbstract()
@@ -2013,7 +2013,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 $exception->getIssueInstance()
             );
             return $this->context;
-        } catch (NodeException $exception) {
+        } catch (NodeException $_) {
             // If we can't figure out the class for this method
             // call, cry YOLO and mark every method with that
             // name with a reference.
@@ -2082,7 +2082,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             );
             // TODO: check if array_type has array but not ArrayAccess.
             // If that is true, then assert that $dim_type can cast to `int|string`
-        } catch (IssueException $exception) {
+        } catch (IssueException $_) {
             // Detect this elsewhere, e.g. want to detect PhanUndeclaredVariableDim but not PhanUndeclaredVariable
         }
         return $context;
@@ -2407,7 +2407,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                             $context,
                             $argument
                         ))->getOrCreateVariable();
-                    } catch (NodeException $e) {
+                    } catch (NodeException $_) {
                         // E.g. `function_accepting_reference(${$varName})` - Phan can't analyze outer type of ${$varName}
                         continue;
                     }
@@ -2523,7 +2523,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                     $context,
                     $argument
                 ))->getOrCreateVariable();
-            } catch (NodeException $e) {
+            } catch (NodeException $_) {
                 // E.g. `function_accepting_reference(${$varName})` - Phan can't analyze outer type of ${$varName}
                 return;
             }
@@ -2548,7 +2548,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                         $context,
                         $exception->getIssueInstance()
                     );
-                } catch (\Exception $exception) {
+                } catch (\Exception $_) {
                     // If we can't figure out what kind of a call
                     // this is, don't worry about it
                 }
@@ -2652,7 +2652,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             ))->getClosure();
 
             $method->addReference($inner_context);
-        } catch (\Exception $exception) {
+        } catch (\Exception $_) {
             // Swallow it
         }
     }
@@ -2960,7 +2960,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                     $argument->children['prop'] ?? '',
                     true
                 );
-            } catch (UnanalyzableException $exception) {
+            } catch (UnanalyzableException $_) {
                 // Ignore it. There's nothing we can do. (E.g. the class name for the static property fetch couldn't be determined.
             }
         }

--- a/src/Phan/Analysis/ReturnTypesAnalyzer.php
+++ b/src/Phan/Analysis/ReturnTypesAnalyzer.php
@@ -124,7 +124,7 @@ class ReturnTypesAnalyzer
             }
         }
         if ($return_type->isEmpty() && !$method->getHasReturn()) {
-            if ($method instanceof Func || ($method instanceof Method && $method->isPrivate())) {
+            if ($method instanceof Func || ($method instanceof Method && ($method->isPrivate() || $method->isFinal()))) {
                 $method->setUnionType(VoidType::instance(false)->asUnionType());
             }
         }

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -1112,7 +1112,7 @@ EOB;
                 '<' . '?php 42;',
                 Config::AST_VERSION
             );
-        } catch (\LogicException $throwable) {
+        } catch (\LogicException $_) {
             assert(
                 false,
                 'Unknown AST version ('
@@ -1137,7 +1137,7 @@ EOB;
                 . 'You may need to rebuild the latest '
                 . 'version of the php-ast extension.'
             );
-        } catch (\ParseError $throwable) {
+        } catch (\ParseError $_) {
             // error message may validate with locale and version, don't validate that.
         }
     }

--- a/src/Phan/Config/Initializer.php
+++ b/src/Phan/Config/Initializer.php
@@ -391,7 +391,7 @@ EOT;
         }
         try {
             $version_constraint = self::parseConstraintsForRange($php_version_constraint);
-        } catch (\UnexpectedValueException $e) {
+        } catch (\UnexpectedValueException $_) {
             return [null, ['TODO: Choose a target_php_version for this project, or leave as null and remove this comment']];
         }
         if ($version_constraint->matches(self::parseConstraintsForRange('<7.1-dev'))) {
@@ -489,9 +489,9 @@ EOT;
             }
             $node = $child_nodes[0];
             return $node->kind !== \ast\AST_ECHO || !is_string($node->children['expr']);
-        } catch (\ParseError $e) {
+        } catch (\ParseError $_) {
             return false;
-        } catch (\Phan\AST\TolerantASTConverter\ParseException $e) {
+        } catch (\Phan\AST\TolerantASTConverter\ParseException $_) {
             return false;
         }
     }

--- a/src/Phan/Daemon.php
+++ b/src/Phan/Daemon.php
@@ -75,7 +75,7 @@ class Daemon
                 $conn = false;
                 try {
                     $conn = stream_socket_accept($socket_server, -1);
-                } catch (\RuntimeException $e) {
+                } catch (\RuntimeException $_) {
                     self::debugf("Got signal");
                     pcntl_signal_dispatch();
                     self::debugf("done processing signals");
@@ -131,7 +131,7 @@ class Daemon
                 $conn = false;
                 try {
                     $conn = stream_socket_accept($socket_server, -1);
-                } catch (\RuntimeException $e) {
+                } catch (\RuntimeException $_) {
                     self::debugf("Got signal");
                     pcntl_signal_dispatch();
                     self::debugf("done processing signals");
@@ -190,7 +190,7 @@ class Daemon
 
         try {
             Phan::finishAnalyzingRemainingStatements($code_base, $request, $analyze_file_path_list, $temporary_file_mapping);
-        } catch (ExitException $e) {
+        } catch (ExitException $_) {
             // This is normal and expected, do nothing
         } finally {
             $code_base->restoreFromRestorePoint($restore_point);

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -259,6 +259,7 @@ class Issue
     const UnusedClosureParameter                = 'PhanUnusedClosureParameter';
     const UnusedGlobalFunctionParameter         = 'PhanUnusedGlobalFunctionParameter';
     const UnusedVariableValueOfForeachWithKey   = 'PhanUnusedVariableValueOfForeachWithKey';  // has higher false positive rates than UnusedVariable
+    const UnusedVariableCaughtException         = 'PhanUnusedVariableCaughtException';  // has higher false positive rates than UnusedVariable
 
     // Issue::CATEGORY_REDEFINE
     const RedefineClass             = 'PhanRedefineClass';
@@ -2300,6 +2301,14 @@ class Issue
                 'Unused definition of variable ${VARIABLE} as the value of a foreach loop that included keys',
                 self::REMEDIATION_B,
                 6045
+            ),
+            new Issue(
+                self::UnusedVariableCaughtException,
+                self::CATEGORY_NOOP,
+                self::SEVERITY_LOW,
+                'Unused definition of variable ${VARIABLE} as a caught exception',
+                self::REMEDIATION_B,
+                6046
             ),
 
 

--- a/src/Phan/Language/Element/Parameter.php
+++ b/src/Phan/Language/Element/Parameter.php
@@ -301,7 +301,7 @@ class Parameter extends Variable
                 // We can't figure out default values during the
                 // parsing phase, unfortunately
                 $has_error = false;
-            } catch (InvalidArgumentException $e) {
+            } catch (InvalidArgumentException $_) {
                 // If the parameter default is an invalid constant expression,
                 // then don't use that value elsewhere.
                 Issue::maybeEmit(

--- a/src/Phan/Language/Element/Property.php
+++ b/src/Phan/Language/Element/Property.php
@@ -106,7 +106,7 @@ class Property extends ClassElement
             if ($union_type !== '') {
                 $string .= "$union_type ";
             } // Don't emit 2 spaces if there is no union type
-        } catch (\Exception $exception) {
+        } catch (\Exception $_) {
             // do nothing
         }
 

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -2697,7 +2697,7 @@ class UnionType implements \Serializable
                     return true;
                 }
             }
-        } catch (CodeBaseException $e) {
+        } catch (CodeBaseException $_) {
             // Swallow "Cannot find class", go on to emit issue
         }
         return false;

--- a/src/Phan/LanguageServer/DefinitionResolver.php
+++ b/src/Phan/LanguageServer/DefinitionResolver.php
@@ -143,11 +143,11 @@ class DefinitionResolver
         $is_static = $node->kind === ast\AST_STATIC_PROP;
         try {
             $property = (new ContextNode($code_base, $context, $node))->getProperty($is_static);
-        } catch (NodeException $e) {
+        } catch (NodeException $_) {
             return; // ignore
-        } catch (IssueException $e) {
+        } catch (IssueException $_) {
             return; // ignore
-        } catch (CodeBaseException $e) {
+        } catch (CodeBaseException $_) {
             return; // ignore
         }
         $request->recordDefinitionElement($code_base, $property, true);
@@ -169,11 +169,11 @@ class DefinitionResolver
         }
         try {
             $class_const = (new ContextNode($code_base, $context, $node))->getClassConst();
-        } catch (NodeException $e) {
+        } catch (NodeException $_) {
             return; // ignore
-        } catch (IssueException $e) {
+        } catch (IssueException $_) {
             return; // ignore
-        } catch (CodeBaseException $e) {
+        } catch (CodeBaseException $_) {
             return; // ignore
         }
         // Class constants can't be objects, so there's no point in "Go To Type Definition" for now.
@@ -188,11 +188,11 @@ class DefinitionResolver
     {
         try {
             $global_const = (new ContextNode($code_base, $context, $node))->getConst();
-        } catch (NodeException $e) {
+        } catch (NodeException $_) {
             return; // ignore
-        } catch (IssueException $e) {
+        } catch (IssueException $_) {
             return; // ignore
-        } catch (CodeBaseException $e) {
+        } catch (CodeBaseException $_) {
             return; // ignore
         }
         $request->recordDefinitionElement($code_base, $global_const, false);
@@ -231,10 +231,10 @@ class DefinitionResolver
         }
         try {
             $method = (new ContextNode($code_base, $context, $node))->getMethod($method_name, $is_static);
-        } catch (NodeException $e) {
+        } catch (NodeException $_) {
             // ignore
             return;
-        } catch (IssueException $e) {
+        } catch (IssueException $_) {
             // ignore
             return;
         }
@@ -250,10 +250,10 @@ class DefinitionResolver
             foreach ((new ContextNode($code_base, $context, $node->children['expr']))->getFunctionFromNode() as $function_interface) {
                 $request->recordDefinitionElement($code_base, $function_interface, true);
             }
-        } catch (NodeException $e) {
+        } catch (NodeException $_) {
             // ignore
             return;
-        } catch (IssueException $e) {
+        } catch (IssueException $_) {
             // ignore
             return;
         }
@@ -298,8 +298,8 @@ class DefinitionResolver
             if (is_string($name)) {
                 try {
                     $class_fqsen = FullyQualifiedClassName::fromFullyQualifiedString('\\' . ltrim($name, '\\'));
-                } catch (AssertionError $e) {
-                    return;  // ignore, probably still typing it
+                } catch (AssertionError $_) {
+                    return;  // ignore, probably still typing the requested definition
                 }
                 if ($code_base->hasClassWithFQSEN($class_fqsen)) {
                     $class = $code_base->getClassByFQSEN($class_fqsen);

--- a/src/Phan/LanguageServer/GoToDefinitionRequest.php
+++ b/src/Phan/LanguageServer/GoToDefinitionRequest.php
@@ -105,7 +105,7 @@ final class GoToDefinitionRequest
             }
             try {
                 $this->recordDefinitionOfTypeFQSEN($code_base, $type_fqsen);
-            } catch (CodeBaseException $e) {
+            } catch (CodeBaseException $_) {
                 continue;
             }
         }

--- a/src/Phan/LanguageServer/LanguageServer.php
+++ b/src/Phan/LanguageServer/LanguageServer.php
@@ -586,7 +586,7 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
 
         try {
             Phan::finishAnalyzingRemainingStatements($this->code_base, $analysis_request, $analyze_file_path_list, $temporary_file_mapping);
-        } catch (ExitException $e) {
+        } catch (ExitException $_) {
             // This is normal, do nothing
         }
 

--- a/src/Phan/LanguageServer/ProtocolStreamReader.php
+++ b/src/Phan/LanguageServer/ProtocolStreamReader.php
@@ -100,7 +100,7 @@ class ProtocolStreamReader extends Emitter implements ProtocolReader
                         // MessageBody::parse can throw an Error, maybe log an error?
                         try {
                             $msg = new Message(MessageBody::parse($this->buffer), $this->headers);
-                        } catch (Exception $e) {
+                        } catch (Exception $_) {
                             $msg = null;
                         }
                         if ($msg) {

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -467,7 +467,7 @@ class ParseVisitor extends ScopeVisitor
                         $original_union_type = $future_union_type->get()->asNonLiteralType();
                         // We successfully resolved the union type. We no longer need $future_union_type
                         $future_union_type = null;
-                    } catch (IssueException $e) {
+                    } catch (IssueException $_) {
                         // Do nothing
                     }
                     if ($future_union_type === null) {
@@ -592,7 +592,7 @@ class ParseVisitor extends ScopeVisitor
                             $value_node
                         )
                     );
-                } catch (InvalidArgumentException $e) {
+                } catch (InvalidArgumentException $_) {
                     $constant->setUnionType(MixedType::instance(false)->asUnionType());
                     $this->emitIssue(
                         Issue::InvalidConstantExpression,
@@ -631,7 +631,7 @@ class ParseVisitor extends ScopeVisitor
             $value_node = $child_node->children['value'];
             try {
                 self::checkIsAllowedInConstExpr($value_node);
-            } catch (InvalidArgumentException $e) {
+            } catch (InvalidArgumentException $_) {
                 $this->emitIssue(
                     Issue::InvalidConstantExpression,
                     $value_node->lineno

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -981,7 +981,7 @@ final class ConfigPluginSet extends PluginV2 implements
         try {
             new ReflectionProperty($plugin_analysis_class, 'parent_node_list');
             $has_parent_node_list = true;
-        } catch (ReflectionException $e) {
+        } catch (ReflectionException $_) {
             $has_parent_node_list = false;
         }
 

--- a/src/Phan/Plugin/Internal/ThrowAnalyzerPlugin.php
+++ b/src/Phan/Plugin/Internal/ThrowAnalyzerPlugin.php
@@ -230,7 +230,7 @@ class ThrowRecursiveVisitor extends ThrowVisitor
                     $this->withoutCaughtUnionTypes($invoked_function->getThrowsUnionType())
                 );
             }
-        } catch (CodeBaseException $e) {
+        } catch (CodeBaseException $_) {
             // ignore it.
         }
     }
@@ -262,10 +262,10 @@ class ThrowRecursiveVisitor extends ThrowVisitor
                 $this->context,
                 $node
             ))->getMethod($method_name, false);
-        } catch (IssueException $exception) {
+        } catch (IssueException $_) {
             // do nothing, PostOrderAnalysisVisitor should catch this
             return;
-        } catch (NodeException $exception) {
+        } catch (NodeException $_) {
             return;
         }
         // Check the types that can be thrown by this call.
@@ -296,7 +296,7 @@ class ThrowRecursiveVisitor extends ThrowVisitor
                 $this->context,
                 $node
             ))->getMethod($method_name, true, true);  // @phan-suppress-current-line PhanPartialTypeMismatchArgument
-        } catch (\Exception $exception) {
+        } catch (\Exception $_) {
             // Ignore IssueException, unexpected exceptions, etc.
             return;
         }

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableGraph.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableGraph.php
@@ -32,6 +32,13 @@ final class VariableGraph
     public $loop_def_ids = [];
 
     /**
+     * @var array<int,true>
+     *
+     * The set of definition ids that are caught exceptions in catch blocks.
+     */
+    public $caught_exception_ids = [];
+
+    /**
      * @var array<string,int> maps variable names to whether
      *    they have ever occurred as a given self::IS_* category in the current scope
      */
@@ -132,6 +139,27 @@ final class VariableGraph
     public function isLoopValueDefinitionId(int $definition_id) : bool
     {
         return \array_key_exists($definition_id, $this->loop_def_ids);
+    }
+
+    /**
+     * Marks something as being a loop variable `$v` in `foreach ($arr as $k => $v)`
+     * (Common false positive, since there's no way to avoid setting the value)
+     *
+     * @return void
+     */
+    public function markAsCaughtException($node)
+    {
+        if ($node instanceof Node) {
+            $this->caught_exception_ids[spl_object_id($node)] = true;
+        }
+    }
+
+    /**
+     * Checks if the node for this id is defined as a caught exception
+     */
+    public function isCaughtException(int $definition_id) : bool
+    {
+        return \array_key_exists($definition_id, $this->caught_exception_ids);
     }
 
     /**

--- a/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
+++ b/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
@@ -201,10 +201,10 @@ final class VariableTrackerElementVisitor extends PluginAwarePostAnalysisVisitor
                         break;
                     }
                     $issue_type = $this->getParameterCategory($method_node);
-                } else {
-                    if ($graph->isLoopValueDefinitionId($definition_id)) {
-                        $issue_type = Issue::UnusedVariableValueOfForeachWithKey;
-                    }
+                } elseif ($graph->isLoopValueDefinitionId($definition_id)) {
+                    $issue_type = Issue::UnusedVariableValueOfForeachWithKey;
+                } elseif ($graph->isCaughtException($definition_id)) {
+                    $issue_type = Issue::UnusedVariableCaughtException;
                 }
                 Issue::maybeEmit(
                     $this->code_base,

--- a/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
+++ b/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
@@ -155,7 +155,7 @@ final class VariableTrackerElementVisitor extends PluginAwarePostAnalysisVisitor
             try {
                 $class = $context->getClassInScope($this->code_base);
                 return $class->isFinal();
-            } catch (CodeBaseException $e) {
+            } catch (CodeBaseException $_) {
             }
         }
         return false;

--- a/tests/Phan/AST/TolerantASTConverter/ConversionTest.php
+++ b/tests/Phan/AST/TolerantASTConverter/ConversionTest.php
@@ -51,7 +51,7 @@ class ConversionTest extends BaseTest
         try {
             ast\parse_code('', $ast_version);
             return true;
-        } catch (\LogicException $e) {
+        } catch (\LogicException $_) {
             return false;
         }
     }

--- a/tests/files/expected/0298_weird_variable_name.php.expected
+++ b/tests/files/expected/0298_weird_variable_name.php.expected
@@ -1,4 +1,5 @@
 %s:7 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is array{0:'value'} but \intdiv() takes int
+%s:8 PhanUnusedVariableCaughtException Unused definition of variable $e as a caught exception
 %s:10 PhanTypeSuspiciousIndirectVariable Indirect variable ${(expr)} has invalid inner expression type true, expected string/integer
 %s:11 PhanTypeSuspiciousIndirectVariable Indirect variable ${(expr)} has invalid inner expression type bool, expected string/integer
 %s:12 PhanTypeSuspiciousIndirectVariable Indirect variable ${(expr)} has invalid inner expression type array{0:2}, expected string/integer

--- a/tests/files/expected/0418_try_empty_union_type.php.expected
+++ b/tests/files/expected/0418_try_empty_union_type.php.expected
@@ -1,1 +1,2 @@
+%s:13 PhanUnusedVariableCaughtException Unused definition of variable $e as a caught exception
 %s:21 PhanTypeMismatchArgumentInternal Argument 1 (var) is 2 but \count() takes \Countable|array

--- a/tests/files/src/0129_suppress_stmts.php
+++ b/tests/files/src/0129_suppress_stmts.php
@@ -5,6 +5,7 @@ class C {
     /**
      * @suppress PhanCompatiblePHP7
      * @suppress PhanNonClassMethodCall, PhanUnusedVariable testing CSV
+     * @suppress PhanUnusedVariableCaughtException
      * @suppress PhanNoopArray
      * @suppress PhanNoopVariable
      * @suppress PhanParamTooFew

--- a/tests/files/src/0298_weird_variable_name.php
+++ b/tests/files/src/0298_weird_variable_name.php
@@ -4,7 +4,7 @@ error_reporting(E_ALL);
 function testIrregularVar128() {
     ${42} = ['value'];
     try {
-    echo intdiv(${42}, 3);  // intdiv takes int but this is string[]
+        echo intdiv(${42}, 3);  // intdiv takes int but this is string[]
     } catch(Throwable $e) {}
     echo "Next\n";
     ${true} = ['value'];

--- a/tests/misc/fallback_test/src/024_crash.php
+++ b/tests/misc/fallback_test/src/024_crash.php
@@ -2,6 +2,7 @@
 // Phan should not crash.
 // The fallback parser starts parsing `$notAFunction = function() ...` as if it were a parameter with an invalid default
 class example {
-    private function $notAFunction = function() : void {
+    private function $notAFunction = function() : int {
+        return 2;
     };
 }

--- a/tests/plugin_test/expected/046_unused_exception.php.expected
+++ b/tests/plugin_test/expected/046_unused_exception.php.expected
@@ -1,0 +1,1 @@
+src/046_unused_exception.php:12 PhanUnusedVariableCaughtException Unused definition of variable $e2 as a caught exception

--- a/tests/plugin_test/src/046_unused_exception.php
+++ b/tests/plugin_test/src/046_unused_exception.php
@@ -1,0 +1,14 @@
+<?php
+call_user_func(function() {
+    $e = null;
+    try {
+        if (rand() % 2 > 0) {
+            throw new RuntimeException('x');
+        } else {
+            throw new InvalidArgumentException('y');
+        }
+    } catch (RuntimeException $e) {
+        echo $e;
+    } catch (InvalidArgumentException $e2) {
+    }
+});


### PR DESCRIPTION
Fixes #1810

- Phan will emit `PhanUnusedVariableCaughtException` if the exception is not used

This will also warn if an exception shadows the definition of a similar
variable, preventing that variable from being used.
    
- e.g. `$e` in tests/plugin_test/src/046_unused_exception.php
    
Update NEWS.md

Update Phan's own code and test cases.

- Use `$_` as the unused exception placeholder ($unused_exception would also work)