### PR TITLE
Implement support for hover requests in the language server

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,17 @@ New features(Analysis)
 
   Previously, this could cause Phan to crash, especially with `--use-fallback-parser` on invalid ASTs.
 
+Language Server/Daemon mode:
++ Implement support for hover requests in the Language Server (#1738)
+
+  This will show a preview of the element definition (showing signature types instead of PHPDoc types)
+  along with the snippet of the element description from the doc comment.
+
+  Clients that use this should pass in the CLI option `--language-server-enable-hover` when starting the language server.
+
+  - Note that this implementation assumes that clients sanitize the mix of markdown and HTML before rendering it.
+  - Note that this may slow down some language server clients if they pause while waiting for the hover request to finish.
+
 Bug fixes:
 + Fix a bug in checking if nullable versions of specialized type were compatible with other nullable types. (#1839, #1852)
   Phan now correctly allows the following type casts:

--- a/src/Phan/AST/ASTReverter.php
+++ b/src/Phan/AST/ASTReverter.php
@@ -1,0 +1,94 @@
+<?php declare(strict_types=1);
+namespace Phan\AST;
+
+use ast\Node;
+use ast;
+use function implode;
+
+/**
+ * This converts a PHP AST into an approximate string representation.
+ * This ignores line numbers and spacing.
+ *
+ * Eventual goals:
+ *
+ * 1. Short representations of constants for LSP hover requests.
+ * 2. Short representations for errors (e.g. "Error at $x->foo(self::MY_CONST)")
+ * 3. Configuration of rendering this.
+ *
+ * Similar utilities:
+ *
+ * - https://github.com/tpunt/php-ast-reverter is a pretty printer.
+ * - \Phan\Debug::nodeToString() converts nodes to strings.
+ */
+class ASTReverter
+{
+    /** @var array<int,Closure(Node):string> */
+    private static $closure_map;
+    /** @var Closure(Node):string */
+    private static $noop;
+
+    // TODO: Make this configurable, copy instance properties to static properties.
+    public function __construct()
+    {
+    }
+
+    public static function toShortString($node)
+    {
+        if (!($node instanceof Node)) {
+            // TODO: One-line representations for strings, minimal representations for floats, etc.
+            return \var_export($node, true);
+        }
+        return (self::$closure_map[$node->kind] ?? self::$noop)($node);
+    }
+
+    public static function init()
+    {
+        self::$noop = function (Node $_) {
+            return '(unknown)';
+        };
+        self::$closure_map = [
+            ast\AST_CLASS_CONST => function (Node $node) : string {
+                return self::toShortString($node->children['class']) . '::' . $node->children['const'];
+            },
+            ast\AST_CONST => function (Node $node) : string {
+                return self::toShortString($node->children['name']);
+            },
+            ast\AST_NAME => function (Node $node) : string {
+                $result = $node->children['name'];
+                switch ($node->flags) {
+                    case ast\flags\NAME_FQ:
+                        return '\\' . $result;
+                    case ast\flags\NAME_RELATIVE;
+                        return 'namespace\\' . $result;
+                    default:
+                        return (string)$result;
+                }
+            },
+            ast\AST_ARRAY => function (Node $node) : string {
+                $parts = [];
+                foreach ($node->children as $elem) {
+                    if (!$elem) {
+                        $parts[] = '';
+                        continue;
+                    }
+                    $part = self::toShortString($elem->children['value']);
+                    $key_node = $elem->children['key'];
+                    if ($key_node !== null) {
+                        $part = self::toShortString($key_node) . '=>' . $part;
+                    }
+                    $parts[] = $part;
+                }
+                $string = implode(',', $parts);
+                switch ($node->flags) {
+                    case ast\flags\ARRAY_SYNTAX_SHORT:
+                    case ast\flags\ARRAY_SYNTAX_LONG:
+                    default:
+                        return "[$string]";
+                    case ast\flags\ARRAY_SYNTAX_LIST:
+                        return "list($string)";
+                }
+            },
+        ];
+    }
+}
+ASTReverter::init();

--- a/src/Phan/AST/ASTReverter.php
+++ b/src/Phan/AST/ASTReverter.php
@@ -58,7 +58,7 @@ class ASTReverter
                 switch ($node->flags) {
                     case ast\flags\NAME_FQ:
                         return '\\' . $result;
-                    case ast\flags\NAME_RELATIVE;
+                    case ast\flags\NAME_RELATIVE:
                         return 'namespace\\' . $result;
                     default:
                         return (string)$result;

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -118,6 +118,7 @@ class CLI
                 'language-server-require-pcntl',
                 'language-server-enable',
                 'language-server-enable-go-to-definition',
+                'language-server-enable-hover',
                 'markdown-issue-messages',
                 'memory-limit:',
                 'minimum-severity:',
@@ -429,6 +430,9 @@ class CLI
                     break;
                 case 'language-server-enable-go-to-definition':
                     Config::setValue('language_server_enable_go_to_definition', true);
+                    break;
+                case 'language-server-enable-hover':
+                    Config::setValue('language_server_enable_hover', true);
                     break;
                 case 'language-server-verbose':
                     Config::setValue('language_server_debug_level', 'info');
@@ -855,6 +859,10 @@ Extended help:
 
  --language-server-enable-go-to-definition
   Enables support for "Go To Definition" and "Go To Type Definition" in the Phan Language Server.
+  Disabled by default.
+
+ --language-server-enable-hover
+  Enables support for "Hover" in the Phan Language Server.
   Disabled by default.
 
  --language-server-verbose

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -743,8 +743,12 @@ class Config
         'language_server_use_pcntl_fallback' => true,
 
         // This should only be set via CLI (--language-server-enable-go-to-definition)
-        // Affects "go to definition" and "go to type definition"
+        // Affects "go to definition" and "go to type definition" of LSP.
         'language_server_enable_go_to_definition' => false,
+
+        // This should only be set via CLI (--language-server-enable-hover)
+        // Affects "hover" of LSP.
+        'language_server_enable_hover' => false,
 
         // Don't show the category name in issue messages.
         // This makes error messages slightly shorter.

--- a/src/Phan/Debug.php
+++ b/src/Phan/Debug.php
@@ -28,10 +28,10 @@ class Debug
     }
 
     /**
+     * Print an AST node
+     *
      * @param string|int|float|Node|null $node
      * An AST node
-     *
-     * Print an AST node
      *
      * @return void
      *
@@ -55,7 +55,7 @@ class Debug
     }
 
     /**
-     * Print a thing with the given indent level
+     * Print $message with the given indent level
      *
      * @suppress PhanUnreferencedPublicMethod
      */
@@ -66,9 +66,10 @@ class Debug
     }
 
     /**
+     * Return the name of a node
+     *
      * @param Node|string|null $node
-     * @return string
-     * The name of the node
+     * @return string The name of the node
      */
     public static function nodeName($node) : string
     {
@@ -89,6 +90,8 @@ class Debug
     }
 
     /**
+     * Convert an AST node to a compact string representation of that node.
+     *
      * @param string|int|float|Node|null $node
      * An AST node
      *
@@ -156,9 +159,11 @@ class Debug
     }
 
     /**
-     * @return string
-     * Get a string representation of AST node flags such as
+     * Computes a string representation of AST node flags such as
      * 'ASSIGN_DIV|TYPE_ARRAY'
+     *
+     * @return string
+     *
      * @see self::formatFlags for a similar function also printing the integer flag value.
      */
     public static function astFlagDescription(int $flags, int $kind) : string
@@ -272,8 +277,11 @@ class Debug
 
     /**
      * Source: https://github.com/nikic/php-ast/blob/master/util.php
+     *
+     * Returns the information necessary to map the node id to the flag id to the name.
+     *
      * @return array<int,array<int,array<int,string>>>
-     * Return value is [string[][] $exclusive, string[][] $combinable]. Maps node id to flag id to name.
+     * Returns [string[][] $exclusive, string[][] $combinable].
      */
     private static function getFlagInfo() : array
     {

--- a/src/Phan/Language/Element/AddressableElement.php
+++ b/src/Phan/Language/Element/AddressableElement.php
@@ -28,6 +28,11 @@ abstract class AddressableElement extends TypedElement implements AddressableEle
     protected $reference_list = [];
 
     /**
+     * @var ?string
+     */
+    protected $doc_comment;
+
+    /**
      * @param Context $context
      * The context in which the structural element lives
      *
@@ -283,4 +288,20 @@ abstract class AddressableElement extends TypedElement implements AddressableEle
      * @return ?Closure
      */
     abstract public function createRestoreCallback();
+
+    /**
+     * @param ?string $doc_comment the 'docComment' for this element, if any exists.
+     */
+    public function setDocComment(string $doc_comment = null)
+    {
+        $this->doc_comment = $doc_comment;
+    }
+
+    /**
+     * @return ?string the 'docComment' for this element, if any exists.
+     */
+    public function getDocComment()
+    {
+        return $this->doc_comment;
+    }
 }

--- a/src/Phan/Language/Element/AddressableElementInterface.php
+++ b/src/Phan/Language/Element/AddressableElementInterface.php
@@ -73,4 +73,14 @@ interface AddressableElementInterface extends TypedElementInterface
     public function getReferenceCount(
         CodeBase $code_base
     ) : int;
+
+    /**
+     * @return string For use in the language server protocol.
+     */
+    public function getMarkupDescription() : string;
+
+    /**
+     * @return ?string the 'docComment' for this element, if any exists.
+     */
+    public function getDocComment();
 }

--- a/src/Phan/Language/Element/ClassAliasRecord.php
+++ b/src/Phan/Language/Element/ClassAliasRecord.php
@@ -11,7 +11,7 @@ class ClassAliasRecord
     /** @var FullyQualifiedClassName the FQSEN of the alias that will be created. */
     public $alias_fqsen;
 
-    /** @var Context - the context of the class_alias() call*/
+    /** @var Context - the context of the class_alias() call */
     public $context;
 
     /** @var int - the line number of the class_alias() call */

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -2526,6 +2526,32 @@ class Clazz extends AddressableElement
         return $string;
     }
 
+    public function getMarkupDescription() : string
+    {
+        $string = '';
+
+        if ($this->isFinal()) {
+            $string .= 'final ';
+        }
+
+        if ($this->isAbstract() && !$this->isInterface()) {
+            $string .= 'abstract ';
+        }
+
+        if ($this->isInterface()) {
+            $string .= 'interface ';
+        } elseif ($this->isTrait()) {
+            $string .= 'trait ';
+        } else {
+            $string .= 'class ';
+        }
+
+        // TODO: Also render the namespace?
+        $string .= (string)$this->getFQSEN()->getName();
+        return $string;
+    }
+
+
     /**
      * @suppress PhanUnreferencedPublicMethod (toStubInfo is used by callers for more flexibility)
      */

--- a/src/Phan/Language/Element/Comment.php
+++ b/src/Phan/Language/Element/Comment.php
@@ -352,7 +352,8 @@ class Comment
         int $comment_type
     ) : Comment {
 
-        if (!Config::getValue('read_type_annotations')) {
+        // Don't parse the comment if this doesn't need to.
+        if (!$comment || !Config::getValue('read_type_annotations')) {
             return new Comment(
                 0,
                 [],

--- a/src/Phan/Language/Element/Func.php
+++ b/src/Phan/Language/Element/Func.php
@@ -167,11 +167,13 @@ class Func extends AddressableElement implements FunctionInterface
             $fqsen,
             $parameter_list
         );
+        $doc_comment = $node->children['docComment'] ?? '';
+        $func->setDocComment($doc_comment);
 
         // Parse the comment above the function to get
         // extra meta information about the function.
         $comment = Comment::fromStringInContext(
-            (string)$node->children['docComment'],
+            $doc_comment,
             $code_base,
             $context,
             $node->lineno ?? 0,
@@ -343,6 +345,12 @@ class Func extends AddressableElement implements FunctionInterface
         $namespace_text = $namespace === '' ? '' : "$namespace ";
         $string = sprintf("namespace %s{\n%s}\n", $namespace_text, $string);
         return $string;
+    }
+
+    public function getMarkupDescription() : string
+    {
+        list($unused_namespace, $text) = $this->toStubInfo();
+        return rtrim($text, "\n {}");
     }
 
     /** @return array{0:string,1:string} [string $namespace, string $text] */

--- a/src/Phan/Language/Element/GlobalConstant.php
+++ b/src/Phan/Language/Element/GlobalConstant.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 namespace Phan\Language\Element;
 
+use Phan\AST\ASTReverter;
 use Phan\Language\Context;
 use Phan\Language\FQSEN\FullyQualifiedGlobalConstantName;
 use Phan\Language\Type;
@@ -79,6 +80,15 @@ class GlobalConstant extends AddressableElement implements ConstantInterface
         $string = sprintf("namespace %s{\n%s}\n", $namespace_text, $string);
         return $string;
     }
+
+    public function getMarkupDescription() : string
+    {
+        $string = 'const ' . $this->getName() . ' = ';
+        $value_node = $this->getNodeForValue();
+        $string .= ASTReverter::toShortString($value_node);
+        return $string;
+    }
+
 
     /** @return array{0:string,1:string} [string $namespace, string $text] */
     public function toStubInfo() : array

--- a/src/Phan/Language/Element/GlobalConstant.php
+++ b/src/Phan/Language/Element/GlobalConstant.php
@@ -89,7 +89,6 @@ class GlobalConstant extends AddressableElement implements ConstantInterface
         return $string;
     }
 
-
     /** @return array{0:string,1:string} [string $namespace, string $text] */
     public function toStubInfo() : array
     {

--- a/src/Phan/Language/Element/MarkupDescription.php
+++ b/src/Phan/Language/Element/MarkupDescription.php
@@ -1,0 +1,86 @@
+<?php declare(strict_types=1);
+namespace Phan\Language\Element;
+
+class MarkupDescription
+{
+    public static function buildForElement(
+        AddressableElementInterface $element
+    ) : string {
+        $markup = $element->getMarkupDescription();
+        $result = "```php\n$markup\n```";
+        $doc_comment = $element->getDocComment();
+        if ($doc_comment) {
+            $extracted_doc_comment = self::extractDocComment($doc_comment);
+            if ($extracted_doc_comment) {
+                $result .= "\n\n" . $extracted_doc_comment;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return string non-empty on success
+     * @internal
+     */
+    public static function extractDocComment(string $doc_comment) : string
+    {
+        $doc_comment = preg_replace('@(^/\*\*)|(\*/$)@', '', $doc_comment);
+
+        // TODO: Improve this extraction, add tests
+        $results = [];
+        foreach (explode("\n", $doc_comment) as $line) {
+            $pos = stripos($line, '*');
+            if ($pos !== false) {
+                $line = \substr($line, $pos + 1);
+            } else {
+                $line = \ltrim(rtrim($line), "\n\t ");
+            }
+            if (!is_string($line) || preg_match('/^\s*@/', $line) > 0) {
+                // Assume that the description stopped after the first phpdoc tag.
+                break;
+            }
+            if (\trim($line) === '') {
+                $line = '';
+                if (\in_array(\end($results), ['', false], true)) {
+                    continue;
+                }
+            }
+            $results[] = $line;
+        }
+        if (end($results) === '') {
+            array_pop($results);
+        }
+        $results = self::trimLeadingWhitespace($results);
+        return implode("\n", $results);
+    }
+
+    /**
+     * @param array<int,string> $lines
+     * @return array<int,string>
+     */
+    private static function trimLeadingWhitespace(array $lines) : array {
+        if (count($lines) === 0) {
+            return [];
+        }
+        $min_whitespace = PHP_INT_MAX;
+        foreach ($lines as $line) {
+            if ($line === '') {
+                continue;
+            }
+            $min_whitespace = \min($min_whitespace, \strspn($line, ' ', 0, $min_whitespace));
+            if ($min_whitespace === 0) {
+                return $lines;
+            }
+        }
+        if ($min_whitespace > 0) {
+            foreach ($lines as $i => $line) {
+                if ($line === '') {
+                    continue;
+                }
+                $lines[$i] = (string)\substr($line, $min_whitespace);
+            }
+        }
+        return $lines;
+    }
+}

--- a/src/Phan/Language/Element/MarkupDescription.php
+++ b/src/Phan/Language/Element/MarkupDescription.php
@@ -74,7 +74,8 @@ class MarkupDescription
      * @param array<int,string> $lines
      * @return array<int,string>
      */
-    private static function trimLeadingWhitespace(array $lines) : array {
+    private static function trimLeadingWhitespace(array $lines) : array
+    {
         if (count($lines) === 0) {
             return [];
         }

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -351,11 +351,13 @@ class Method extends ClassElement implements FunctionInterface
             $fqsen,
             $parameter_list
         );
+        $doc_comment = $node->children['docComment'] ?? '';
+        $method->setDocComment($doc_comment);
 
         // Parse the comment above the method to get
         // extra meta information about the method.
         $comment = Comment::fromStringInContext(
-            $node->children['docComment'] ?? '',
+            $doc_comment,
             $code_base,
             $context,
             $node->lineno ?? 0,
@@ -628,6 +630,43 @@ class Method extends ClassElement implements FunctionInterface
         $string .= $this->getName();
 
         $string .= '(' . \implode(', ', $this->getRealParameterList()) . ')';
+
+        if (!$this->getRealReturnType()->isEmpty()) {
+            $string .= ' : ' . (string)$this->getRealReturnType();
+        }
+
+        return $string;
+    }
+
+    public function getMarkupDescription() : string
+    {
+        $string = '';
+        // It's an error to have visibility or abstract in an interface's stub (e.g. JsonSerializable)
+        if ($this->isPrivate()) {
+            $string .= 'private ';
+        } elseif ($this->isProtected()) {
+            $string .= 'protected ';
+        } else {
+            $string .= 'public ';
+        }
+
+        if ($this->isAbstract()) {
+            $string .= 'abstract ';
+        }
+
+        if ($this->isStatic()) {
+            $string .= 'static ';
+        }
+
+        $string .= 'function ';
+        if ($this->returnsRef()) {
+            $string .= '&';
+        }
+        $string .= $this->getName();
+
+        $string .= '(' . implode(', ', array_map(function (Parameter $parameter) : string {
+            return $parameter->toStubString();
+        }, $this->getRealParameterList())) . ')';
 
         if (!$this->getRealReturnType()->isEmpty()) {
             $string .= ' : ' . (string)$this->getRealReturnType();

--- a/src/Phan/Language/Element/Property.php
+++ b/src/Phan/Language/Element/Property.php
@@ -160,7 +160,15 @@ class Property extends ClassElement
 
     public function getMarkupDescription() : string
     {
-        return $this->toStub();
+        $string = $this->getVisibilityName() . ' ';
+
+        if ($this->isStatic()) {
+            $string .= 'static ';
+        }
+
+        $string .= "\${$this->getName()}";
+
+        return $string;
     }
 
 

--- a/src/Phan/Language/Element/Property.php
+++ b/src/Phan/Language/Element/Property.php
@@ -158,6 +158,12 @@ class Property extends ClassElement
         return $this->fqsen;
     }
 
+    public function getMarkupDescription() : string
+    {
+        return $this->toStub();
+    }
+
+
     public function toStub()
     {
         $string = '    ' . $this->getVisibilityName() . ' ';

--- a/src/Phan/Language/Type/FunctionLikeDeclarationType.php
+++ b/src/Phan/Language/Type/FunctionLikeDeclarationType.php
@@ -654,6 +654,32 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
         return Type::fromFullyQualifiedString('\Generator');
     }
 
+    public function getDocComment()
+    {
+        return null;
+    }
+
+    public function getMarkupDescription() : string
+    {
+        $parts = $this->toFunctionSignatureArray();
+        $return_type = $parts[0];
+        unset($parts[0]);
+
+        $fragments = [];
+        foreach ($parts as $name => $signature) {
+            $fragment = '\$' . $name;
+            if ($signature) {
+                $fragment = "$signature $fragment";
+            }
+        }
+        $signature = static::NAME . '(' . implode(',', $fragments) . ')';
+        if ($return_type) {
+            // TODO: Make this unambiguous
+            $signature .= ':' . $return_type;
+        }
+        return $signature;
+    }
+
     ////////////////////////////////////////////////////////////////////////////////
     // End FunctionInterface overrides
     ////////////////////////////////////////////////////////////////////////////////

--- a/src/Phan/LanguageServer/GoToDefinitionRequest.php
+++ b/src/Phan/LanguageServer/GoToDefinitionRequest.php
@@ -7,6 +7,7 @@ use Phan\Language\Context;
 use Phan\Language\FileRef;
 use Phan\Language\Element\AddressableElementInterface;
 use Phan\Language\Element\Clazz;
+use Phan\Language\Element\MarkupDescription;
 use Phan\Language\Element\Variable;
 use Phan\Language\FQSEN;
 use Phan\Language\FQSEN\FullyQualifiedClassName;
@@ -15,6 +16,8 @@ use Phan\Language\FQSEN\FullyQualifiedMethodName;
 use Phan\Language\Type\TemplateType;
 use Phan\Language\UnionType;
 use Phan\LanguageServer\Protocol\Location;
+use Phan\LanguageServer\Protocol\Hover;
+use Phan\LanguageServer\Protocol\MarkupContent;
 use Phan\LanguageServer\Protocol\Position;
 
 use Exception;
@@ -35,19 +38,33 @@ final class GoToDefinitionRequest
     private $position;
     /** @var Promise|null */
     private $promise;
+    /** @var int self::REQUEST_* */
+    private $request_type;
     /** @var bool true if this is "Go to Type Definition" */
     private $is_type_definition_request;
 
-    /** @var array<string,Location> */
+    /**
+     * @var array<string,Location> the list of locations for a "Go to [Type] Definition" request
+     */
     private $locations = [];
 
-    public function __construct(string $uri, Position $position, bool $is_type_definition_request)
+    /**
+     * @var ?Hover the list of locations for a "Hover" request
+     */
+    private $hover_response = null;
+
+    const REQUEST_DEFINITION = 0;
+    const REQUEST_TYPE_DEFINITION = 1;
+    const REQUEST_HOVER = 2;
+
+    public function __construct(string $uri, Position $position, int $request_type)
     {
         $this->uri = $uri;
         $this->path = Utils::uriToPath($uri);
         $this->position = $position;
         $this->promise = new Promise();
-        $this->is_type_definition_request = $is_type_definition_request;
+        $this->is_type_definition_request = $request_type === self::REQUEST_TYPE_DEFINITION;
+        $this->request_type = $request_type;
     }
 
     /**
@@ -64,6 +81,23 @@ final class GoToDefinitionRequest
                 $this->recordTypeOfElement($code_base, $element->getContext(), $element->getUnionType());
                 return;
             }
+        }
+        $this->recordFinalDefinitionElement($element);
+    }
+
+    private function recordFinalDefinitionElement(
+        AddressableElementInterface $element
+    ) {
+        if ($this->request_type === self::REQUEST_HOVER) {
+            if ($this->hover_response === null) {
+                $this->hover_response = new Hover(
+                    new MarkupContent(
+                        MarkupContent::MARKDOWN,
+                        MarkupDescription::buildForElement($element)
+                    )
+                );
+            }
+            return;
         }
         $this->recordDefinitionContext($element->getContext());
     }
@@ -193,7 +227,12 @@ final class GoToDefinitionRequest
     {
         $promise = $this->promise;
         if ($promise) {
-            $promise->fulfill($this->locations ? array_values($this->locations) : null);
+            if ($this->request_type === self::REQUEST_HOVER) {
+                $result = $this->hover_response;
+            } else {
+                $result = $this->locations ? array_values($this->locations) : null;
+            }
+            $promise->fulfill($result);
             $this->promise = null;
         }
     }

--- a/src/Phan/LanguageServer/Protocol/Hover.php
+++ b/src/Phan/LanguageServer/Protocol/Hover.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types = 1);
+
+namespace Phan\LanguageServer\Protocol;
+
+/**
+ * The result of a hover request.
+ * @phan-file-suppress PhanWriteOnlyPublicProperty
+ */
+class Hover
+{
+    /**
+     * @var MarkupContent The hover's content
+     */
+    public $contents;
+
+    /**
+     * @var Range|null an optional range inside a text document
+     * that is used to visualize a hover, e.g. by changing the background color.
+     */
+    public $range;
+
+    public function __construct(MarkupContent $contents, Range $range = null)
+    {
+        $this->contents = $contents;
+        $this->range = $range;
+    }
+}

--- a/src/Phan/LanguageServer/Protocol/MarkupContent.php
+++ b/src/Phan/LanguageServer/Protocol/MarkupContent.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types = 1);
+
+namespace Phan\LanguageServer\Protocol;
+
+/**
+ * A `MarkupContent` literal represents a string value which content is interpreted base on its
+ * kind flag. Currently the protocol supports `plaintext` and `markdown` as markup kinds.
+ *
+ * If the kind is `markdown` then the value can contain fenced code blocks like in GitHub issues.
+ * See https://help.github.com/articles/creating-and-highlighting-code-blocks/#syntax-highlighting
+ *
+ * Here is an example how such a string can be constructed using JavaScript / TypeScript:
+ * ```ts
+ * let markdown: MarkdownContent = {
+ *  kind: MarkupKind.Markdown,
+ *  value: [
+ *      '# Header',
+ *      'Some text',
+ *      '```typescript',
+ *      'someCode();',
+ *      '```'
+ *  ].join('\n')
+ * };
+ * ```
+ *
+ * *Please Note* that clients might sanitize the return markdown. A client could decide to
+ * remove HTML from the markdown to avoid script execution.
+ * @phan-file-suppress PhanUnreferencedPublicClassConstant, PhanWriteOnlyPublicProperty
+ */
+class MarkupContent
+{
+    // MarkupKind values
+    const PLAINTEXT = 'plaintext';
+    const MARKDOWN = 'markdown';
+
+    /**
+     * @var string the type of the Markup
+     */
+    public $kind;
+
+    /**
+     * @var string the content itself
+     */
+    public $value;
+
+    public function __construct(string $kind, string $value)
+    {
+        $this->kind = $kind;
+        $this->value = $value;
+    }
+}

--- a/src/Phan/LanguageServer/Protocol/ServerCapabilities.php
+++ b/src/Phan/LanguageServer/Protocol/ServerCapabilities.php
@@ -37,6 +37,13 @@ class ServerCapabilities
     public $typeDefinitionProvider;
 
     /**
+     * The server provides hover support.
+     *
+     * @var bool|null
+     */
+    public $hoverProvider;
+
+    /**
      * The server provides find references support.
      *
      * @var bool|null

--- a/src/Phan/LanguageServer/Server/TextDocument.php
+++ b/src/Phan/LanguageServer/Server/TextDocument.php
@@ -190,6 +190,7 @@ class TextDocument
      */
     public function hover(TextDocumentIdentifier $textDocument, Position $position)
     {
-        return null;
+        $uri = Utils::pathToUri(Utils::uriToPath($textDocument->uri));
+        return $this->server->awaitHover($uri, $position);
     }
 }

--- a/src/Phan/LanguageServer/Server/TextDocument.php
+++ b/src/Phan/LanguageServer/Server/TextDocument.php
@@ -2,6 +2,7 @@
 
 namespace Phan\LanguageServer\Server;
 
+use Phan\Config;
 use Phan\LanguageServer\FileMapping;
 use Phan\LanguageServer\LanguageClient;
 use Phan\LanguageServer\LanguageServer;
@@ -183,13 +184,26 @@ class TextDocument
     }
 
     /**
-     * Placeholder to avoid a crash on malformed clients
+     * Implements textDocument/hover, to show a preview of the element being hovered over.
+     *
+     * TODO: This can probably be optimized for references to constants, static methods, or tokens that obviously have no corresponding element.
+     * TODO: Implement support for the cancel request LSP operation?
+     *
      * @param TextDocumentIdentifier $textDocument @phan-unused-param
      * @param Position $position @phan-unused-param
      * @suppress PhanUnreferencedPublicMethod called by client via AdvancedJsonRpc
      */
     public function hover(TextDocumentIdentifier $textDocument, Position $position)
     {
+        // Some clients (e.g. emacs-lsp, the last time I checked)
+        // don't respect the server's reported hover capability, and send this unconditionally.
+        if (!Config::getValue('language_server_enable_hover')) {
+            // Placeholder to avoid a performance degradation on clients
+            // that aren't respecting the configuration.
+            //
+            // (computing hover response may or may not slow down those clients)
+            return null;
+        }
         $uri = Utils::pathToUri(Utils::uriToPath($textDocument->uri));
         return $this->server->awaitHover($uri, $position);
     }

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -134,6 +134,9 @@ class ParseVisitor extends ScopeVisitor
                 $class->getInternalScope()
             );
 
+            $doc_comment = $node->children['docComment'] ?? '';
+            $class->setDocComment($doc_comment);
+
             // Add the class to the code base as a globally
             // accessible object
             // This must be done before Comment::fromStringInContext
@@ -142,7 +145,7 @@ class ParseVisitor extends ScopeVisitor
 
             // Get a comment on the class declaration
             $comment = Comment::fromStringInContext(
-                $node->children['docComment'] ?? '',
+                $doc_comment,
                 $this->code_base,
                 $class_context,
                 $node->lineno ?? 0,
@@ -449,6 +452,7 @@ class ParseVisitor extends ScopeVisitor
                 $node->flags ?? 0,
                 $property_fqsen
             );
+            $property->setDocComment($doc_comment);
 
             // Add the property to the class
             $class->addProperty($this->code_base, $property, new None());
@@ -557,8 +561,9 @@ class ParseVisitor extends ScopeVisitor
             );
 
             // Get a comment on the declaration
+            $doc_comment = $child_node->children['docComment'] ?? '';
             $comment = Comment::fromStringInContext(
-                $child_node->children['docComment'] ?? '',
+                $doc_comment,
                 $this->code_base,
                 $this->context,
                 $child_node->lineno ?? 0,
@@ -576,6 +581,7 @@ class ParseVisitor extends ScopeVisitor
                 $fqsen
             );
 
+            $constant->setDocComment($doc_comment);
             $constant->setIsDeprecated($comment->isDeprecated());
             $constant->setIsNSInternal($comment->isNSInternal());
             $constant->setIsOverrideIntended($comment->isOverrideIntended());
@@ -1150,6 +1156,7 @@ class ParseVisitor extends ScopeVisitor
         }
 
         $constant->setNodeForValue($value);
+        $constant->setDocComment($comment_string);
 
         $constant->setIsDeprecated($comment->isDeprecated());
         $constant->setIsNSInternal($comment->isNSInternal());
@@ -1297,7 +1304,8 @@ class ParseVisitor extends ScopeVisitor
      *
      * @internal
      */
-    public static function checkIsAllowedInConstExpr($n) {
+    public static function checkIsAllowedInConstExpr($n)
+    {
         if (!($n instanceof Node)) {
             if (\is_array($n)) {
                 foreach ($n as $child_node) {

--- a/src/phan.php
+++ b/src/phan.php
@@ -33,8 +33,8 @@ $cli = new CLI();
 $is_issue_found =
     Phan::analyzeFileList(
         $code_base,
-        function (bool $recomputeFileList = false) use ($cli) {
-            if ($recomputeFileList) {
+        function (bool $recompute_file_list = false) use ($cli) {
+            if ($recompute_file_list) {
                 $cli->recomputeFileList();
             }
             return $cli->getFileList();

--- a/tests/Phan/AST/ASTReverterTest.php
+++ b/tests/Phan/AST/ASTReverterTest.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types = 1);
+
+namespace Phan\Tests\AST;
+
+use Phan\Tests\BaseTest;
+
+use Phan\AST\ASTReverter;
+use Phan\Config;
+
+class ASTReverterTest extends BaseTest
+{
+    /**
+     * @param string $snippet
+     * @dataProvider revertShorthandProvider
+     */
+    public function testRevertShorthand(string $snippet, string $expected = null)
+    {
+        $expected = $expected ?? $snippet;
+        $file_contents = '<' . '?php ' . $snippet . ';';
+        $statements = \ast\parse_code($file_contents, Config::AST_VERSION);
+        $this->assertSame(1, count($statements->children));
+        $snippet_node = $statements->children[0];
+
+        $reverter = new ASTReverter();
+        $this->assertSame($expected, $reverter->toShortString($snippet_node));
+    }
+
+    public function revertShorthandProvider()
+    {
+        return [
+            ["'2'"],
+            ['2'],
+            ['false'],
+            ['null'],
+            ['NULL'],
+            ['PHP_VERSION_ID'],
+            ['\\PHP_VERSION_ID'],
+            ['namespace\\PHP_VERSION_ID'],
+            ['array(2,3=>4)', '[2,3=>4]'],
+            ["['x'=>'var']"],
+            ['[2]'],
+        ];
+    }
+}

--- a/tests/Phan/BaseTest.php
+++ b/tests/Phan/BaseTest.php
@@ -20,6 +20,9 @@ abstract class BaseTest extends TestCase
         'Phan\AST\PhanAnnotationAdder' => [
             'closures_for_kind',
         ],
+        'Phan\AST\ASTReverter' => [
+            'closure_map',
+        ],
         'Phan\Language\Type' => [
             'canonical_object_map',
             'internal_fn_cache',

--- a/tests/Phan/Language/Element/CommentTest.php
+++ b/tests/Phan/Language/Element/CommentTest.php
@@ -11,7 +11,7 @@ use Phan\Language\Type\StaticType;
 use Phan\Library\None;
 
 /**
- * Unit tests of Type
+ * Unit tests of Comment
  */
 class CommentTest extends BaseTest
 {

--- a/tests/Phan/Language/Element/MarkupDescriptionTest.php
+++ b/tests/Phan/Language/Element/MarkupDescriptionTest.php
@@ -2,6 +2,7 @@
 namespace Phan\Tests\Language\Element;
 
 use Phan\Tests\BaseTest;
+use Phan\Language\Element\Comment;
 use Phan\Language\Element\MarkupDescription;
 
 /**
@@ -12,14 +13,14 @@ class MarkupDescriptionTest extends BaseTest
     /**
      * @dataProvider extractDocCommentProvider
      */
-    public function testExtractDocComment(string $expected, string $doc_comment)
+    public function testExtractDocComment(string $expected, string $doc_comment, int $category = null)
     {
         // @phan-suppress-next-line PhanAccessMethodInternal
-        $this->assertSame($expected, MarkupDescription::extractDocComment($doc_comment));
+        $this->assertSame($expected, MarkupDescription::extractDocComment($doc_comment, $category));
     }
 
     /**
-     * @return array<int,array{0:string,1:string}>
+     * @return array<int,array{0:string,1:string,2?:int}>
      */
     public function extractDocCommentProvider()
     {
@@ -30,7 +31,29 @@ class MarkupDescriptionTest extends BaseTest
             ],
             [
                 '',
-                '/** @var T $x A parameter annotation goes here */',
+                '/** @param T $x A parameter annotation goes here */',
+            ],
+            [
+                '',
+                '/** @var T $x A local variable annotation of a function goes here*/',
+                Comment::ON_METHOD
+            ],
+            [
+                '@var MyClass An annotation of a property goes here',
+                '/** @var MyClass An annotation of a property goes here */',
+                Comment::ON_PROPERTY,
+            ],
+            [
+                '@var MyClass A annotation of a constant goes here',
+                <<<EOT
+/**
+ * @var MyClass A annotation of a constant goes here
+ *
+ * Rest of this comment
+ */
+EOT
+                ,
+                Comment::ON_CONST,
             ],
             [
                 <<<EOT

--- a/tests/Phan/Language/Element/MarkupDescriptionTest.php
+++ b/tests/Phan/Language/Element/MarkupDescriptionTest.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types = 1);
+namespace Phan\Tests\Language\Element;
+
+use Phan\Tests\BaseTest;
+use Phan\Language\Element\MarkupDescription;
+
+/**
+ * Unit tests of MarkupDescription functionality
+ */
+class MarkupDescriptionTest extends BaseTest
+{
+    /**
+     * @dataProvider extractDocCommentProvider
+     */
+    public function testExtractDocComment(string $expected, string $doc_comment)
+    {
+        // @phan-suppress-next-line PhanAccessMethodInternal
+        $this->assertSame($expected, MarkupDescription::extractDocComment($doc_comment));
+    }
+
+    /**
+     * @return array<int,array{0:string,1:string}>
+     */
+    public function extractDocCommentProvider()
+    {
+        return [
+            [
+                'A description goes here',
+                '/** A description goes here */',
+            ],
+            [
+                '',
+                '/** @var T $x A parameter annotation goes here */',
+            ],
+            [
+                <<<EOT
+A description goes here
+
+Rest of this description
+
+-  Example markup list
+   Rest of that list
+EOT
+                ,
+            <<<EOT
+/**
+ * A description goes here
+ *
+ * Rest of this description
+ *
+ * -  Example markup list
+ *    Rest of that list
+ */
+EOT
+            ],
+        ];
+    }
+}

--- a/tests/Phan/LanguageServer/LanguageServerIntegrationTest.php
+++ b/tests/Phan/LanguageServer/LanguageServerIntegrationTest.php
@@ -260,6 +260,9 @@ function example(MyClass $arg) {
     $arg->myMethod();  // line 5
     $arg->myInstanceMethod();
     global_function_with_comment(0, '');
+    $c = new ExampleClass();
+    $c->counter += 1;
+    var_export(ExampleClass::HTTP_500);  // line 10
 }
 EOT;
         return [
@@ -337,6 +340,31 @@ This has a mix of comments and annotations, annotations are excluded from hover
 - Markup in comments is preserved,
   and leading whitespace is as well.
 EOT
+            ],
+            [
+                $example_file_contents,
+                new Position(9, 10),  // ExampleClass->counter
+                <<<'EOT'
+```php
+public $counter
+```
+
+@var int this tracks a count
+EOT
+            ],
+            [
+                $example_file_contents,
+                new Position(10, 30),  // ExampleClass->counter
+                <<<'EOT'
+```php
+const HTTP_500 = 500
+```
+
+@var int value of an HTTP response code
+EOT
+                ,
+                null,
+                true
             ],
         ];
     }

--- a/tests/Phan/LanguageServer/LanguageServerIntegrationTest.php
+++ b/tests/Phan/LanguageServer/LanguageServerIntegrationTest.php
@@ -234,7 +234,7 @@ EOT;
             $this->markTestSkipped('This test requires php 7.1');
         }
         if (function_exists('pcntl_fork')) {
-            $this->_testHoverInOtherFileWithPcntlSetting(
+            $this->runTestHoverInOtherFileWithPcntlSetting(
                 $new_file_contents,
                 $position,
                 $expected_hover_markup,
@@ -242,7 +242,7 @@ EOT;
                 true
             );
         }
-        $this->_testHoverInOtherFileWithPcntlSetting($new_file_contents, $position, $expected_hover_markup, $requested_uri, false);
+        $this->runTestHoverInOtherFileWithPcntlSetting($new_file_contents, $position, $expected_hover_markup, $requested_uri, false);
     }
 
     /**
@@ -549,7 +549,7 @@ EOT
      * @param ?string $expected_hover_string
      * @param ?string $requested_uri
      */
-    public function _testHoverInOtherFileWithPcntlSetting(
+    public function runTestHoverInOtherFileWithPcntlSetting(
         string $new_file_contents,
         Position $position,
         $expected_hover_string,

--- a/tests/Phan/LanguageServer/LanguageServerIntegrationTest.php
+++ b/tests/Phan/LanguageServer/LanguageServerIntegrationTest.php
@@ -6,6 +6,7 @@ use Phan\Tests\BaseTest;
 use Phan\Issue;
 use Phan\LanguageServer\LanguageServer;
 use Phan\LanguageServer\Protocol\ClientCapabilities;
+use Phan\LanguageServer\Protocol\MarkupContent;
 use Phan\LanguageServer\Protocol\Position;
 use Phan\LanguageServer\Protocol\TextDocumentIdentifier;
 use Phan\LanguageServer\ProtocolStreamReader;
@@ -57,7 +58,7 @@ class LanguageServerIntegrationTest extends BaseTest
             $this->markTestSkipped('requires pcntl extension');
         }
         $command = sprintf(
-            '%s -d %s --quick --language-server-on-stdin --language-server-enable-go-to-definition %s',
+            '%s -d %s --quick --language-server-on-stdin --language-server-enable-hover --language-server-enable-go-to-definition %s',
             escapeshellarg(__DIR__ . '/../../../phan'),
             escapeshellarg(self::getLSPFolder()),
             ($pcntlEnabled ? '' : '--language-server-force-missing-pcntl')
@@ -212,7 +213,6 @@ EOT;
     }
 
     /**
-     * @param int $expected_definition_line 0-based line number
      * @param ?int $expected_definition_line null for nothing
      *
      * @dataProvider typeDefinitionInOtherFileProvider
@@ -223,6 +223,122 @@ EOT;
             $this->runTestTypeDefinitionInOtherFileWithPcntlSetting($new_file_contents, $position, $expected_definition_uri, $expected_definition_line, $requested_uri, true);
         }
         $this->runTestTypeDefinitionInOtherFileWithPcntlSetting($new_file_contents, $position, $expected_definition_uri, $expected_definition_line, $requested_uri, false);
+    }
+
+    /**
+     * @dataProvider hoverInOtherFileProvider
+     */
+    public function testHoverInOtherFile(string $new_file_contents, Position $position, $expected_hover_markup, string $requested_uri = null, bool $require_php71_or_newer = false)
+    {
+        if (PHP_VERSION_ID < 70100 && $require_php71_or_newer) {
+            $this->markTestSkipped('This test requires php 7.1');
+        }
+        if (function_exists('pcntl_fork')) {
+            $this->_testHoverInOtherFileWithPcntlSetting(
+                $new_file_contents,
+                $position,
+                $expected_hover_markup,
+                $requested_uri,
+                true
+            );
+        }
+        $this->_testHoverInOtherFileWithPcntlSetting($new_file_contents, $position, $expected_hover_markup, $requested_uri, false);
+    }
+
+    /**
+     * @return array<int,array{0:string,1:Position,2:?string,3?:?string,4?:bool}>
+     */
+    public function hoverInOtherFileProvider() : array
+    {
+        // Refers to elements defined in ../../misc/lsp/src/definitions.php
+        $example_file_contents = <<<'EOT'
+<?php // line 0
+
+function example(MyClass $arg) {
+    echo \MY_GLOBAL_CONST;
+    echo \MyNS\SubNS\MY_NAMESPACED_CONST;
+    $arg->myMethod();  // line 5
+    $arg->myInstanceMethod();
+    global_function_with_comment(0, '');
+}
+EOT;
+        return [
+            // Failure tests
+            [
+                $example_file_contents,
+                new Position(2, 20),  // MyClass (Points to MyClass)
+                <<<'EOT'
+```php
+class MyClass
+```
+
+A description of MyClass
+EOT
+            ],
+            [
+                $example_file_contents,
+                new Position(2, 1),  // Points to nothing
+                null,
+            ],
+            // Global constant without a description
+            [
+                $example_file_contents,
+                new Position(3, 12),  // MY_GLOBAL_CONST
+                <<<'EOT'
+```php
+const MY_GLOBAL_CONST = 2
+```
+EOT
+            ],
+            [
+                $example_file_contents,
+                new Position(4, 22),  // MY_NAMESPACED_CONST
+                <<<'EOT'
+```php
+const MY_NAMESPACED_CONST = 2
+```
+
+This constant is equal to 1+1
+EOT
+                ,
+                null,
+                true
+            ],
+            [
+                $example_file_contents,
+                new Position(5, 12),  // MY_NAMESPACED_CONST
+                <<<'EOT'
+```php
+public static function myMethod() : \MyOtherClass
+```
+EOT
+            ],
+            [
+                $example_file_contents,
+                new Position(6, 12),  // MY_NAMESPACED_CONST
+                <<<'EOT'
+```php
+public function myInstanceMethod()
+```
+
+myInstanceMethod echoes a string
+EOT
+            ],
+            [
+                $example_file_contents,
+                new Position(7, 4),  // MY_NAMESPACED_CONST
+                <<<'EOT'
+```php
+function global_function_with_comment(int $x, $y)
+```
+
+This has a mix of comments and annotations, annotations are excluded from hover
+
+- Markup in comments is preserved,
+  and leading whitespace is as well.
+EOT
+            ],
+        ];
     }
 
     /**
@@ -291,9 +407,6 @@ EOT;
             $cur_line = explode("\n", $new_file_contents)[$position->line] ?? '';
 
             $message = "Unexpected definition for {$position->line}:{$position->character} (0-based) on line \"" . $cur_line . '"';
-            if ($expected_definition_response != $definition_response) {
-                var_export($definition_response);
-            }
             $this->assertEquals($expected_definition_response, $definition_response, $message);  // slightly better diff view than assertSame
             $this->assertSame($expected_definition_response, $definition_response, $message);
 
@@ -377,9 +490,6 @@ EOT;
             $cur_line = explode("\n", $new_file_contents)[$position->line] ?? '';
 
             $message = "Unexpected type definition for {$position->line}:{$position->character} (0-based) on line " . json_encode($cur_line);
-            if ($expected_definition_response != $definition_response) {
-                var_export($definition_response);
-            }
             $this->assertEquals($expected_definition_response, $definition_response, $message);  // slightly better diff view than assertSame
             $this->assertSame($expected_definition_response, $definition_response, $message);
 
@@ -391,6 +501,84 @@ EOT;
             $definition_response = $perform_definition_request();
             $this->assertEquals($expected_definition_response, $definition_response, $message);  // slightly better diff view than assertSame
             $this->assertSame($expected_definition_response, $definition_response, $message);
+
+            $this->writeShutdownRequestAndAwaitResponse($proc_in, $proc_out);
+            $this->writeExitNotification($proc_in);
+        } catch (\Throwable $e) {
+            fwrite(STDERR, "Unexpected exception in " . __METHOD__ . ": " . $e->getMessage());
+            throw $e;
+        } finally {
+            fclose($proc_in);
+            // TODO: Make these pipes async if they aren't already
+            $unread_contents = fread($proc_out, 10000);
+            $this->assertSame('', $unread_contents);
+            fclose($proc_out);
+            proc_close($proc);
+        }
+    }
+
+    /**
+     * @param ?string $expected_hover_string
+     * @param ?string $requested_uri
+     */
+    public function _testHoverInOtherFileWithPcntlSetting(
+        string $new_file_contents,
+        Position $position,
+        $expected_hover_string,
+        $requested_uri,
+        bool $pcntl_enabled
+    ) {
+        $requested_uri = $requested_uri ?? $this->getDefaultFileURI();
+
+        $this->messageId = 0;
+        // TODO: Move this into an OOP abstraction, add time limits, etc.
+        list($proc, $proc_in, $proc_out) = $this->createPhanDaemon($pcntl_enabled);
+        try {
+            $this->writeInitializeRequestAndAwaitResponse($proc_in, $proc_out);
+            $this->writeInitializedNotification($proc_in);
+            $this->writeDidChangeNotificationToFile($proc_in, $requested_uri, $new_file_contents);
+            if (self::shouldExpectDiagnosticNotificationForURI($requested_uri)) {
+                $this->assertHasEmptyPublishDiagnosticsNotification($proc_out, $requested_uri);
+            }
+
+            // Request the definition of the class "MyExample" with the cursor in the middle of that word
+            // NOTE: Line numbers are 0-based for Position
+            $perform_hover_request = function () use ($proc_in, $proc_out, $position, $requested_uri) {
+                return $this->writeHoverRequestAndAwaitResponse($proc_in, $proc_out, $position, $requested_uri);
+            };
+            $hover_response = $perform_hover_request();
+
+            if ($expected_hover_string) {
+                $expected_hover_result = [
+                    'contents' => [
+                        'kind' => MarkupContent::MARKDOWN,
+                        'value' => $expected_hover_string,
+                    ],
+                    'range' => null,
+                ];
+            } else {
+                $expected_hover_result = null;
+            }
+            $expected_hover_response = [
+                'result' => $expected_hover_result,
+                'id' => 2,
+                'jsonrpc' => '2.0',
+            ];
+
+            $cur_line = explode("\n", $new_file_contents)[$position->line] ?? '';
+
+            $message = "Unexpected type definition for {$position->line}:{$position->character} (0-based) on line " . json_encode($cur_line);
+            $this->assertEquals($expected_hover_response, $hover_response, $message);  // slightly better diff view than assertSame
+            $this->assertSame($expected_hover_response, $hover_response, $message);
+
+            // This operation should be idempotent.
+            // If it's repeated, it should give the same response
+            // (and it shouldn't crash the server)
+            $expected_hover_response['id'] = 3;
+
+            $hover_response = $perform_hover_request();
+            $this->assertEquals($expected_hover_response, $hover_response, $message);  // slightly better diff view than assertSame
+            $this->assertSame($expected_hover_response, $hover_response, $message);
 
             $this->writeShutdownRequestAndAwaitResponse($proc_in, $proc_out);
             $this->writeExitNotification($proc_in);
@@ -714,6 +902,7 @@ EOT;
                     ],
                     'definitionProvider' => true,
                     'typeDefinitionProvider' => true,
+                    'hoverProvider' => true,
                 ]
             ],
             'id' => 1,
@@ -767,6 +956,33 @@ EOT;
             'position' => $position,
         ];
         $this->writeMessage($proc_in, 'textDocument/typeDefinition', $params);
+        if (self::shouldExpectDiagnosticNotificationForURI($requested_uri)) {
+            $this->assertHasEmptyPublishDiagnosticsNotification($proc_out, $requested_uri);
+        }
+
+        $response = $this->awaitResponse($proc_out);
+
+        return $response;
+    }
+
+    /**
+     * @param resource $proc_in
+     * @param resource $proc_out
+     * @return array the response
+     * @throws InvalidArgumentException
+     */
+    private function writeHoverRequestAndAwaitResponse($proc_in, $proc_out, Position $position, string $requested_uri = null)
+    {
+        $requested_uri = $requested_uri ?? $this->getDefaultFileURI();
+        // Implementation detail: We simultaneously emit a notification with new diagnostics
+        // and the response for the definition request at the same time, even if files didn't change.
+
+        // NOTE: That could probably be refactored, but there's not much benefit to doing that.
+        $params = [
+            'textDocument' => new TextDocumentIdentifier($requested_uri),
+            'position' => $position,
+        ];
+        $this->writeMessage($proc_in, 'textDocument/hover', $params);
         if (self::shouldExpectDiagnosticNotificationForURI($requested_uri)) {
             $this->assertHasEmptyPublishDiagnosticsNotification($proc_out, $requested_uri);
         }

--- a/tests/misc/lsp/src/definitions.php
+++ b/tests/misc/lsp/src/definitions.php
@@ -47,4 +47,12 @@ namespace {
  */
 function global_function_with_comment(int $x, $y) {
 }
+
+class ExampleClass {
+    /** @var int this tracks a count */
+    public $counter;
+
+    /** @var int value of an HTTP response code */
+    const HTTP_500 = 500;
 }
+}  // end namespace

--- a/tests/misc/lsp/src/definitions.php
+++ b/tests/misc/lsp/src/definitions.php
@@ -3,17 +3,17 @@ namespace {
 function my_global_function() {
     echo "Called global function\n";
 }
-
 /**
+ * A description of MyClass
  * @property-read MyOtherClass $other_class
  */
 class MyClass {
     const MyClassConst = 2;
     public static $my_static_property = 2;
-
+    /** @return MyOtherClass details */
     public static function myMethod() : MyOtherClass { return new MyOtherClass(); }
 
-
+    /** myInstanceMethod echoes a string */
     public function myInstanceMethod() {
         echo "In instance method\n";
     }
@@ -21,15 +21,30 @@ class MyClass {
 
 class MyOtherClass {
 }
-
+/** @some-annotation something */
 const MY_GLOBAL_CONST = 2;
 }  // end global namespace
 
 namespace MyNS\SubNS {
-
+/** This constant is equal to 1+1 */
 const MY_NAMESPACED_CONST = 2;
 
 class MyNamespacedClass {
     const MyOtherClassConst = [2];
 }
 }  // end MyNS\SubNS
+
+namespace {
+/**
+ * This has a mix of comments and annotations, annotations are excluded from hover
+ *
+ * - Markup in comments is preserved,
+ *   and leading whitespace is as well.
+ *
+ * @param ?string $y
+ * @return void
+ * Comment lines after the first phpdoc tag are ignored
+ */
+function global_function_with_comment(int $x, $y) {
+}
+}


### PR DESCRIPTION
This may cause some language server clients to be much slower while they
wait for hover requests, so this is off by default.
    
There's probably ways to further optimize hover requests
(e.g. not triggering full file analysis)
    
See NEWS.md for more details.

Fixes #1738