### PR TITLE
Fix implode() analysis of single-argument values, add more tests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@ New features(Analysis)
   Phan will replace the default parameter type (or constant type) with `mixed` for constants and class constants.
 
   Previously, this could cause Phan to crash, especially with `--use-fallback-parser` on invalid ASTs.
++ Improve analysis of arguments passed to `implode()`
 
 Language Server/Daemon mode:
 + Implement support for hover requests in the Language Server (#1738)

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -1618,10 +1618,9 @@ class ContextNode
         );
 
         $class_name = 'anonymous_class_'
-            . \substr(\md5(\implode('|', [
-                $this->context->getFile(),
-                $this->context->getLineNumberStart()
-            ])), 0, 8);
+            . \substr(\md5(
+                $this->context->getFile() . $this->context->getLineNumberStart()
+            ), 0, 8);
 
         return $class_name;
     }

--- a/src/Phan/Plugin/Internal/MiscParamPlugin.php
+++ b/src/Phan/Plugin/Internal/MiscParamPlugin.php
@@ -123,6 +123,7 @@ final class MiscParamPlugin extends PluginV2 implements
                 );
             }
         };
+
         /**
          * @return void
          * @throws StopParamAnalysisException
@@ -135,16 +136,15 @@ final class MiscParamPlugin extends PluginV2 implements
             array $args
         ) use ($stop_exception) {
             $argcount = \count($args);
-            // (string glue, array pieces),
-            // (array pieces, string glue) or
-            // (array pieces)
+            // (string glue, string[] pieces),
+            // (string[] pieces, string glue) or
+            // (string[] pieces)
             if ($argcount == 1) {
-                self::analyzeNodeUnionTypeCast(
+                self::analyzeNodeUnionTypeCastStringArrayLike(
                     $args[0],
                     $context,
                     $code_base,
-                    ArrayType::instance(false)->asUnionType(),
-                    function (UnionType $unused_node_type) use ($context, $function) {
+                    function (UnionType $node_type) use ($context, $function) {
                         // "arg#1(pieces) is %s but {$function->getFQSEN()}() takes array when passed only 1 arg"
                         return Issue::fromType(Issue::ParamSpecial2)(
                             $context->getFile(),
@@ -152,13 +152,14 @@ final class MiscParamPlugin extends PluginV2 implements
                             [
                                 1,
                                 'pieces',
+                                $node_type->asNonLiteralType(),
                                 (string)$function->getFQSEN(),
-                                'string',
-                                'array'
+                                'string[]'
                             ]
                         );
                     }
                 );
+                throw $stop_exception;
             } elseif ($argcount == 2) {
                 $arg1_type = UnionTypeVisitor::unionTypeFromNode(
                     $code_base,
@@ -184,11 +185,24 @@ final class MiscParamPlugin extends PluginV2 implements
                             $context->getLineNumberStart(),
                             2,
                             'glue',
-                            (string)$arg2_type,
-                            (string)$function->getFQSEN(),
+                            (string)$arg2_type->asNonLiteralType(),
+                            (string)$function->getRepresentationForIssue(),
                             'string',
                             1,
                             'array'
+                        );
+                    }
+                    if (!self::canCastToStringArrayLike($code_base, $context, $arg1_type)) {
+                        Issue::maybeEmit(
+                            $code_base,
+                            $context,
+                            Issue::TypeMismatchArgumentInternal,
+                            $context->getLineNumberStart(),
+                            1,
+                            'pieces',
+                            $arg1_type,
+                            $function->getRepresentationForIssue(),
+                            'string[]'
                         );
                     }
                     throw $stop_exception;
@@ -203,13 +217,26 @@ final class MiscParamPlugin extends PluginV2 implements
                             $context->getLineNumberStart(),
                             2,
                             'pieces',
-                            (string)$arg2_type,
+                            (string)$arg2_type->asNonLiteralType(),
                             (string)$function->getFQSEN(),
-                            'array',
+                            'string[]',
                             1,
                             'string'
                         );
+                    } elseif (!self::canCastToStringArrayLike($code_base, $context, $arg2_type)) {
+                        Issue::maybeEmit(
+                            $code_base,
+                            $context,
+                            Issue::TypeMismatchArgumentInternal,
+                            $context->getLineNumberStart(),
+                            2,
+                            'pieces',
+                            $arg2_type,
+                            $function->getRepresentationForIssue(),
+                            'string[]'
+                        );
                     }
+                    throw $stop_exception;
                 }
             }
         };
@@ -474,5 +501,48 @@ final class MiscParamPlugin extends PluginV2 implements
         }
 
         return $can_cast;
+    }
+
+    private static function analyzeNodeUnionTypeCastStringArrayLike(
+        $node,
+        Context $context,
+        CodeBase $code_base,
+        \Closure $issue_instance
+    ) : bool {
+
+        // Get the type of the node
+        $node_type = UnionTypeVisitor::unionTypeFromNode(
+            $code_base,
+            $context,
+            $node,
+            true
+        );
+
+        // See if it can be cast to the given type
+        if (self::canCastToStringArrayLike($code_base, $context, $node_type)) {
+            return true;
+        }
+
+        // If it can't, emit the log message
+        Issue::maybeEmitInstance(
+            $code_base,
+            $context,
+            $issue_instance($node_type)
+        );
+
+        return false;
+    }
+
+    /**
+     * Sadly, MyStringable[] is frequently used
+     */
+    private static function canCastToStringArrayLike(CodeBase $code_base, Context $context, UnionType $union_type)
+    {
+        if ($union_type->canCastToUnionType(
+            UnionType::fromFullyQualifiedString('string[]|int[]')
+        )) {
+            return true;
+        }
+        return $union_type->genericArrayElementTypes()->hasClassWithToStringMethod($code_base, $context);
     }
 }

--- a/src/Phan/Plugin/Internal/StringFunctionPlugin.php
+++ b/src/Phan/Plugin/Internal/StringFunctionPlugin.php
@@ -114,8 +114,6 @@ final class StringFunctionPlugin extends PluginV2 implements
             'explode'                   => $var_2_const_1,
             'htmlspecialchars_decode'   => $var_1_const_2,
             'htmlspecialchars_encode'   => $var_1_const_2,
-            'implode'                   => $var_2_const_1,
-            'join'                      => $var_2_const_1,
             'ltrim'                     => $var_1_const_2,
             'md5_file'                  => $var_1_const_2,
             'md5'                       => $var_1_const_2,

--- a/tests/files/expected/0101_one_of_each.php.expected
+++ b/tests/files/expected/0101_one_of_each.php.expected
@@ -11,9 +11,8 @@
 %s:37 PhanNoopProperty Unused property
 %s:42 PhanNoopVariable Unused variable
 %s:48 PhanParamReqAfterOpt Required argument follows optional
-%s:51 PhanParamSpecial1 Argument 2 (pieces) is 'str' but \join() takes array when argument 1 is string
-%s:51 PhanTypeMismatchArgumentInternal Argument 2 (pieces) is 'str' but \join() takes array
-%s:54 PhanParamSpecial2 Argument 1 (pieces) is \join but string() takes array when passed only one argument
+%s:51 PhanParamSpecial1 Argument 2 (pieces) is string but \join() takes string[] when argument 1 is string
+%s:54 PhanParamSpecial2 Argument 1 (pieces) is string but \join() takes string[] when passed only one argument
 %s:57 PhanParamSpecial3 The last argument to \array_udiff must be of type callable
 %s:57 PhanTypeConversionFromArray array to string conversion
 %s:60 PhanParamSpecial4 The second to last argument to \array_uintersect_uassoc must be of type callable

--- a/tests/files/expected/0511_implode.php.expected
+++ b/tests/files/expected/0511_implode.php.expected
@@ -1,0 +1,9 @@
+%s:3 PhanParamTooFewInternal Call with 0 arg(s) to \implode() which requires 2 arg(s)
+%s:4 PhanParamSpecial2 Argument 1 (pieces) is string but \implode() takes string[] when passed only one argument
+%s:8 PhanParamSpecial1 Argument 2 (glue) is float but \implode() takes string when argument 1 is array
+%s:9 PhanTypeMismatchArgumentInternal Argument 2 (pieces) is array{0:\stdClass} but \implode() takes string[]
+%s:10 PhanTypeMismatchArgumentInternal Argument 1 (pieces) is array{0:\stdClass} but \implode() takes string[]
+%s:12 PhanTypeMismatchArgumentInternal Argument 2 (pieces) is array{0:\stdClass} but \implode() takes string[]
+%s:13 PhanParamSpecial1 Argument 2 (glue) is array{0:'hello',1:'world'} but \implode() takes string when argument 1 is array
+%s:14 PhanParamTooManyInternal Call with 3 arg(s) to \implode() which only takes 2 arg(s)
+%s:15 PhanTypeMismatchArgumentInternal Argument 1 (string) is array{} but \strlen() takes string

--- a/tests/files/src/0035_alternate_internal_call.php
+++ b/tests/files/src/0035_alternate_internal_call.php
@@ -1,2 +1,3 @@
 <?php
 print join('|', [1, 2]);
+print join('|', ['1', '2']);

--- a/tests/files/src/0511_implode.php
+++ b/tests/files/src/0511_implode.php
@@ -1,0 +1,15 @@
+<?php
+
+echo implode();
+echo implode('literal string');
+echo implode(['hello', 'world']);
+echo implode([2, 3]);
+echo implode(['hello', 'world'], ' ');
+echo implode(['hello', 'world'], 2.2);
+echo implode(' ', [new stdClass()]);
+echo implode([new stdClass()], ' ');
+echo implode(' ', ['hello', 'world']);
+echo implode(' ', [new stdClass()]);
+echo implode(['hello'], ['hello', 'world']);
+echo implode(' ', ['hello', 'world'], 'extra');
+echo strlen([]);

--- a/tests/misc/fallback_test/test.sh
+++ b/tests/misc/fallback_test/test.sh
@@ -18,6 +18,9 @@ sed -i "s/ syntax error, unexpected return (T_RETURN)/ syntax error, unexpected 
 sed -i "s/ syntax error, unexpected new (T_NEW)/ syntax error, unexpected 'new' (T_NEW)/" $ACTUAL_PATH
 # This warns in php 7.0 only, but the important thing to test is that the fallback doesn't crash.
 sed -i "/src\/018_list_expression_18\.php:2 PhanSyntaxError syntax error, unexpected '0'/d" $ACTUAL_PATH
+# This has a varying order for src/020_issue.php
+sed -i "s/anonymous_class_\w\+/anonymous_class_%s/g" $ACTUAL_PATH $EXPECTED_PATH
+
 # diff returns a non-zero exit code if files differ or are missing
 echo
 echo "Comparing the output:"


### PR DESCRIPTION
Note that phan uses implode(int[]) and implode(StringableElement[]) frequently