### PR TITLE
Fix a crash analyzing a dynamic call to a static method

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,7 @@ Bug fixes:
 + Properly handle `CompileError` (that are not the subclass `ParseError`). CompileError was added in PHP 7.3.
   (Phan now logs these the same way it would log other syntax errors, instead of treating this like an unexpected Error.)
 + Make sure that private methods that are generators, that are inherited from a trait, aren't treated like a `void`.
++ Fix a crash analyzing a dynamic call to a static method, which occurred when dead code detection or reference tracking was enabled. (#1889)
 
 12 Aug 2018, Phan 1.0.0
 -----------------------

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -1633,7 +1633,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             $static_class = (string)$node->children['class']->children['name'];
         }
 
-        $method = $this->getStaticMethodOrEmitIssue($node);
+        $method = $this->getStaticMethodOrEmitIssue($node, $method_name);
 
         if ($method === null) {
             // Short circuit on a constructor being called statically
@@ -1816,12 +1816,12 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
 
     /**
      * gets the static method, or emits an issue.
-     * @return Method|null
+     * @param Node $node
+     * @param string $method_name - NOTE: The caller should convert constants/class constants/etc in $node->children['method'] to a string.
+     * @return ?Method
      */
-    private function getStaticMethodOrEmitIssue(Node $node)
+    private function getStaticMethodOrEmitIssue(Node $node, string $method_name)
     {
-        $method_name = $node->children['method'];
-
         try {
             // Get a reference to the method being called
             return (new ContextNode(
@@ -1852,6 +1852,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             // If we can't figure out what kind of a call
             // this is, don't worry about it
         }
+        return null;
     }
 
     /**

--- a/tests/plugin_test/expected/047_crash.php.expected
+++ b/tests/plugin_test/expected/047_crash.php.expected
@@ -1,0 +1,3 @@
+src/047_crash.php:6 PhanUnusedPublicMethodParameter Parameter $arg is never used
+src/047_crash.php:11 PhanUnreferencedFunction Possibly zero references to function \example
+src/047_crash.php:12 PhanTypeMismatchArgument Argument 1 (arg) is 'my arg' but \X47::myMethod() takes int defined at src/047_crash.php:6

--- a/tests/plugin_test/src/047_crash.php
+++ b/tests/plugin_test/src/047_crash.php
@@ -1,0 +1,16 @@
+<?php
+// NOTE: This is a regression test for a bug that occurs only when dead code detection/reference tracking is enabled.
+
+class X47 {
+    const MY_METHOD = 'myMethod';
+    public static function myMethod(int $arg) {}
+}
+/**
+ * @param object $unknown
+ */
+function example($unknown) {
+    X47::{X47::MY_METHOD}('my arg');
+
+    // We don't expect this to warn, the class is unknown
+    $unknown::{X47::MY_METHOD}(42);
+}


### PR DESCRIPTION
Fixes #1889

This will only occur when dead code detection or reference tracking is
enabled.