### PR TITLE
Improve analysis of variables set in loop conditions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@ New features(CLI,Configs)
 New features(Analysis)
 + Add function signatures for functions added/modified in PHP 7.3. (#1537)
 + Improve the line number for warnings about unextractable `@property*` annotations.
++ Make Phan aware that `$x` is not false inside of loops such as `while ($x = dynamic_value())` (#1646)
 
 Plugins:
 + Add `UnknownElementTypePlugin` (currently a work in progress).

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -854,7 +854,13 @@ class ConditionVisitor extends KindVisitorImplementation
      */
     public function visitAssign(Node $node) : Context
     {
-        return (new BlockAnalysisVisitor($this->code_base, $this->context))->visitAssign($node);
+        $context = (new BlockAnalysisVisitor($this->code_base, $this->context))->visitAssign($node);
+        $left = $node->children['var'];
+        if ($left instanceof Node) {
+            return $this->__invoke($left);
+        }
+
+        return $context;
     }
 
     /**
@@ -869,6 +875,12 @@ class ConditionVisitor extends KindVisitorImplementation
      */
     public function visitAssignRef(Node $node) : Context
     {
-        return (new BlockAnalysisVisitor($this->code_base, $this->context))->visitAssignRef($node);
+        $context = (new BlockAnalysisVisitor($this->code_base, $this->context))->visitAssignRef($node);
+        $left = $node->children['var'];
+        if ($left instanceof Node) {
+            return $this->__invoke($left);
+        }
+
+        return $context;
     }
 }

--- a/src/Phan/Analysis/NegatedConditionVisitor.php
+++ b/src/Phan/Analysis/NegatedConditionVisitor.php
@@ -922,7 +922,13 @@ class NegatedConditionVisitor extends KindVisitorImplementation
      */
     public function visitAssign(Node $node) : Context
     {
-        return (new BlockAnalysisVisitor($this->code_base, $this->context))->visitAssign($node);
+        $context = (new BlockAnalysisVisitor($this->code_base, $this->context))->visitAssign($node);
+        $left = $node->children['var'];
+        if ($left instanceof Node) {
+            return $this->__invoke($left);
+        }
+
+        return $context;
     }
 
     /**
@@ -937,6 +943,12 @@ class NegatedConditionVisitor extends KindVisitorImplementation
      */
     public function visitAssignRef(Node $node) : Context
     {
-        return (new BlockAnalysisVisitor($this->code_base, $this->context))->visitAssignRef($node);
+        $context = (new BlockAnalysisVisitor($this->code_base, $this->context))->visitAssignRef($node);
+        $left = $node->children['var'];
+        if ($left instanceof Node) {
+            return $this->__invoke($left);
+        }
+
+        return $context;
     }
 }

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -995,29 +995,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
         ))->__invoke($cond);
     }
 
-    /**
-     * @param Node $node
-     * A node to parse
-     *
-     * @return Context
-     * A new or an unchanged context resulting from
-     * parsing the node
-     */
-    public function visitWhile(Node $node) : Context
-    {
-        $cond = $node->children['cond'];
-        if (!($cond instanceof Node)) {
-            return $this->context;
-        }
-
-        // Look to see if any proofs we do within the condition of the while
-        // can say anything about types within the statement
-        // list.
-        return (new ConditionVisitor(
-            $this->code_base,
-            $this->context
-        ))->__invoke($cond);
-    }
+    // visitWhile is unnecessary, this has special logic in BlockAnalysisVisitor to handle conditions assigning variables to the loop
 
     /**
      * @param Node $node

--- a/tests/files/expected/0409_or_operator.php.expected
+++ b/tests/files/expected/0409_or_operator.php.expected
@@ -3,4 +3,4 @@
 %s:20 PhanTypeMismatchArgumentInternal Argument 1 (string) is int but \strlen() takes string
 %s:20 PhanTypeMismatchArgumentInternal Argument 1 (var) is int but \count() takes \Countable|array
 %s:29 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is 'a string'|string but \intdiv() takes int
-%s:36 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is false|string but \intdiv() takes int
+%s:36 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is string but \intdiv() takes int

--- a/tests/files/expected/0513_loop_inner_assign.php.expected
+++ b/tests/files/expected/0513_loop_inner_assign.php.expected
@@ -1,0 +1,4 @@
+%s:12 PhanTypeMismatchArgument Argument 1 (arg) is true but \x516() takes array defined at %s:6
+%s:17 PhanTypeMismatchArgument Argument 1 (arg) is 1 but \x516() takes array defined at %s:6
+%s:24 PhanTypeMismatchArgument Argument 1 (arg) is false but \x516() takes array defined at %s:6
+%s:29 PhanTypeMismatchArgument Argument 1 (arg) is 0 but \x516() takes array defined at %s:6

--- a/tests/files/src/0409_or_operator.php
+++ b/tests/files/src/0409_or_operator.php
@@ -33,6 +33,6 @@ function example409Reassign($scalar) {
 /** @param int|string $scalar */
 function exampleReassign($scalar) {
     if (is_string($scalar) || ($scalar = false)) {
-        echo intdiv($scalar, 2);  // should warn because the condition ensures $scalar becomes a string|false
+        echo intdiv($scalar, 2);  // should warn because the condition ensures $scalar becomes a string. The inside of the loop won't be executed with `false`.
     }
 }

--- a/tests/files/src/0513_loop_inner_assign.php
+++ b/tests/files/src/0513_loop_inner_assign.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @param array $arg
+ */
+function x516($arg) {
+    var_export($arg);
+}
+
+call_user_func(function() {
+    while ($x = (rand(0, 2) > 0)) {
+        x516($x);
+    }
+    // TODO: Make Phan aware that $x would be false after the loop
+
+    while ($y = (rand(0, 10) > 0) ? 1 : 0) {
+        x516($y);
+    }
+    // TODO: Make Phan aware that $x would be 0 after the loop
+});
+
+call_user_func(function() {
+    while (!$x = (rand(0, 2) > 0)) {
+        x516($x);
+    }
+    // TODO: Make Phan aware that $x would be true after the loop
+
+    while (!$y = (rand(0, 10) > 0) ? 1 : 0) {
+        x516($y);
+    }
+    // TODO: Make Phan aware that $x would be 1 after the loop
+});


### PR DESCRIPTION
Make Phan aware that `$x` is not false inside of loops such as
`while ($x = dynamic_value())`

Fixes #1646

Note: This does not properly infer types of
variables set after a loop body. See the comment on the example test.