### PR TITLE
 Add `DuplicateElementPlugin` to warn about duplicated expressions

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -550,6 +550,7 @@ return [
 
         // UnknownElementTypePlugin warns about unknown types in element signatures.
         'UnknownElementTypePlugin',
+        'DuplicateExpressionPlugin',
         // TODO: warn about the usage of assert() for Phan's self-analysis. See https://github.com/phan/phan/issues/288
         // 'NoAssertPlugin',
 

--- a/.phan/plugins/DuplicateExpressionPlugin.php
+++ b/.phan/plugins/DuplicateExpressionPlugin.php
@@ -1,0 +1,107 @@
+<?php
+
+use Phan\Analysis\PostOrderAnalysisVisitor;
+use Phan\AST\ASTHasher;
+use Phan\AST\ASTReverter;
+use Phan\PluginV2;
+use Phan\PluginV2\PostAnalyzeNodeCapability;
+use Phan\PluginV2\PluginAwarePostAnalysisVisitor;
+use ast\flags;
+use ast\Node;
+
+/**
+ * This plugin checks for duplicate expressions in a statement that is likely to be a bug.
+ *
+ * This file demonstrates plugins for Phan. Plugins hook into various events.
+ * DuplicateExpressionPlugin hooks into one event:
+ *
+ * - getPostAnalyzeNodeVisitorClassName
+ *   This method returns a visitor that is called on every AST node from every
+ *   file being analyzed
+ *
+ * A plugin file must
+ *
+ * - Contain a class that inherits from \Phan\Plugin
+ *
+ * - End by returning an instance of that class.
+ *
+ * It is assumed without being checked that plugins aren't
+ * mangling state within the passed code base or context.
+ *
+ * Note: When adding new plugins,
+ * add them to the corresponding section of README.md
+ */
+class DuplicateExpressionPlugin extends PluginV2 implements PostAnalyzeNodeCapability
+{
+
+    /**
+     * @return string - name of PluginAwarePostAnalysisVisitor subclass
+     */
+    public static function getPostAnalyzeNodeVisitorClassName() : string
+    {
+        return RedundantNodeVisitor::class;
+    }
+}
+
+class RedundantNodeVisitor extends PluginAwarePostAnalysisVisitor
+{
+    /**
+     * These are types of binary operations for which it is
+     * likely to be a typo if both the left and right hand sides
+     * of the operation are the same.
+     */
+    const REDUNDANT_BINARY_OP_SET = [
+        flags\BINARY_BOOL_AND            => true,
+        flags\BINARY_BOOL_OR             => true,
+        flags\BINARY_BOOL_XOR            => true,
+        flags\BINARY_BITWISE_OR          => true,
+        flags\BINARY_BITWISE_AND         => true,
+        flags\BINARY_BITWISE_XOR         => true,
+        flags\BINARY_SUB                 => true,
+        flags\BINARY_DIV                 => true,
+        flags\BINARY_MOD                 => true,
+        flags\BINARY_IS_IDENTICAL        => true,
+        flags\BINARY_IS_NOT_IDENTICAL    => true,
+        flags\BINARY_IS_EQUAL            => true,
+        flags\BINARY_IS_NOT_EQUAL        => true,
+        flags\BINARY_IS_SMALLER          => true,
+        flags\BINARY_IS_SMALLER_OR_EQUAL => true,
+        flags\BINARY_IS_GREATER          => true,
+        flags\BINARY_IS_GREATER_OR_EQUAL => true,
+        flags\BINARY_SPACESHIP           => true,
+        flags\BINARY_COALESCE            => true,
+    ];
+
+    /**
+     * @param Node $node
+     * A node to analyze
+     *
+     * @return void
+     * @override
+     * @suppress PhanAccessClassConstantInternal
+     */
+    public function visitBinaryOp(Node $node)
+    {
+        if (!\array_key_exists($node->flags, self::REDUNDANT_BINARY_OP_SET)) {
+            // Nothing to warn about
+            return;
+        }
+        if (ASTHasher::hash($node->children['left']) === ASTHasher::hash($node->children['right'])) {
+            $this->emitPluginIssue(
+                $this->code_base,
+                $this->context,
+                'PhanPluginDuplicateExpressionBinaryOp',
+                'Both sides of the binary operator {OPERATOR} are the same: {DETAILS}',
+                [
+                    PostOrderAnalysisVisitor::NAME_FOR_BINARY_OP[$node->flags],
+                    ASTReverter::toShortString($node->children['left']),
+                ]
+            );
+        }
+    }
+}
+
+// Every plugin needs to return an instance of itself at the
+// end of the file in which its defined.
+
+return new DuplicateExpressionPlugin();

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,7 +17,13 @@ New features(Analysis)
   (e.g. a variable `$x` of type `?int|?MyClass` will have type `int` after `assert(is_numeric($x))`)
 
 Plugins:
-+ Add `UnknownElementTypePlugin` (currently a work in progress).
++ Add `UnknownElementTypePlugin` to warn about functions/methods
+  that have param/return types that Phan can't infer anything about.
+  (it can still infer some things in non-quick mode about parameters)
++ Add `DuplicateElementPlugin` to warn about duplicated expressions such as:
+  - `X == X`, `X || X`, and many other binary operators (for operators where it is likely to be a bug)
+  - `X ? X : Y` (can often simplify to `X ?: Y`)
+  - `isset(X) ? X : Y` (can simplify to `??` in PHP 7)
 + Improve types inferred for `$matches` for PregRegexCheckerPlugin.
 
 Bug fixes:

--- a/phan_client
+++ b/phan_client
@@ -28,6 +28,7 @@
  *
  * @phan-file-suppress PhanPartialTypeMismatchArgument
  * @phan-file-suppress PhanPartialTypeMismatchArgumentInternal
+ * @phan-file-suppress PhanPluginDuplicateConditionalNullCoalescing this can't use the `??` operator because it's compatible with php 5.6
  */
 class PhanPHPLinter
 {

--- a/src/Phan/AST/ASTHasher.php
+++ b/src/Phan/AST/ASTHasher.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+namespace Phan\AST;
+
+use ast\Node;
+
+use function md5;
+use function is_int;
+use function is_string;
+
+/**
+ * This converts a PHP AST Node into a hash.
+ * This ignores line numbers and spacing.
+ */
+class ASTHasher
+{
+    /**
+     * @return string a 16-byte binary key
+     */
+    public static function hash_key($node) {
+        if (is_string($node)) {
+            return md5('s' . $node, true);
+        }
+        // Both 2.0 and 2 cast to the string '2'
+        if (is_int($node)) {
+            return md5((string) $node, true);
+        }
+        return md5('f' . $node, true);
+    }
+
+    /**
+     * @return string a 16-byte binary key
+     */
+    public static function hash($node)
+    {
+        if (!($node instanceof Node)) {
+            // hash_key
+            if (is_string($node)) {
+                return md5('s' . $node, true);
+            }
+            if (is_int($node)) {
+                return md5((string) $node, true);
+            }
+            return md5('f' . $node, true);
+        }
+        // @phan-suppress-next-line PhanUndeclaredProperty
+        return $node->hash ?? ($node->hash = self::compute_hash($node));
+    }
+
+    /**
+     * @return string a 16-byte binary key
+     */
+    private static function compute_hash($node) {
+        $str = 'N' . $node->kind . ':' . ($node->flags & 0xfffff);
+        foreach ($node->children as $key => $child) {
+            $str .= self::hash_key($key);
+            $str .= self::hash($child);
+        }
+        return md5($str, true);
+    }
+}

--- a/src/Phan/AST/ASTHasher.php
+++ b/src/Phan/AST/ASTHasher.php
@@ -52,6 +52,10 @@ class ASTHasher
     private static function compute_hash($node) {
         $str = 'N' . $node->kind . ':' . ($node->flags & 0xfffff);
         foreach ($node->children as $key => $child) {
+            // added in PhanAnnotationAdder
+            if ($key === 'phan_nf') {
+                continue;
+            }
             $str .= self::hash_key($key);
             $str .= self::hash($child);
         }

--- a/src/Phan/AST/ASTReverter.php
+++ b/src/Phan/AST/ASTReverter.php
@@ -99,6 +99,7 @@ class ASTReverter
                         return "list($string)";
                 }
             },
+            /** @suppress PhanAccessClassConstantInternal */
             ast\AST_BINARY_OP => function (Node $node) : string {
                 return \sprintf(
                     "(%s %s %s)",

--- a/src/Phan/AST/ASTReverter.php
+++ b/src/Phan/AST/ASTReverter.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 namespace Phan\AST;
 
+use Phan\Analysis\PostOrderAnalysisVisitor;
 use ast\Node;
 use ast;
 use function implode;
@@ -59,6 +60,10 @@ class ASTReverter
             ast\AST_CONST => function (Node $node) : string {
                 return self::toShortString($node->children['name']);
             },
+            ast\AST_VAR => function (Node $node) : string {
+                $name_node = $node->children['name'];
+                return '$' . (is_string($name_node) ? $name_node : ('{' . self::toShortString($name_node) . '}'));
+            },
             ast\AST_NAME => function (Node $node) : string {
                 $result = $node->children['name'];
                 switch ($node->flags) {
@@ -93,6 +98,30 @@ class ASTReverter
                     case ast\flags\ARRAY_SYNTAX_LIST:
                         return "list($string)";
                 }
+            },
+            ast\AST_BINARY_OP => function (Node $node) : string {
+                return \sprintf(
+                    "(%s %s %s)",
+                    self::toShortString($node->children['left']),
+                    PostOrderAnalysisVisitor::NAME_FOR_BINARY_OP[$node->flags] ?? ' unknown ',
+                    self::toShortString($node->children['right'])
+                );
+            },
+            ast\AST_PROP => function (Node $node) : string {
+                $prop_node = $node->children['prop'];
+                return \sprintf(
+                    '%s->%s',
+                    self::toShortString($node->children['expr']),
+                    $prop_node instanceof Node ? '{' . self::toShortString($prop_node) . '}' : (string)$prop_node
+                );
+            },
+            ast\AST_STATIC_PROP => function (Node $node) : string {
+                $prop_node = $node->children['prop'];
+                return \sprintf(
+                    '%s::$%s',
+                    self::toShortString($node->children['class']),
+                    $prop_node instanceof Node ? '{' . self::toShortString($prop_node) . '}' : (string)$prop_node
+                );
             },
         ];
     }

--- a/src/Phan/Analysis/AssignOperatorAnalysisVisitor.php
+++ b/src/Phan/Analysis/AssignOperatorAnalysisVisitor.php
@@ -354,13 +354,13 @@ class AssignOperatorAnalysisVisitor extends FlagVisitorImplementation
 
     private function analyzeBitwiseOperation(Node $node) : Context
     {
-        return $this->updateTargetWithType($node, function (UnionType $left) use ($node) : UnionType {
+        return $this->updateTargetWithType($node, function (UnionType $left_type) use ($node) : UnionType {
             // TODO: Warn about invalid left and right hand sides here and in BinaryOperatorFlagVisitor.
             // Expect int|string
 
             $right_type = UnionTypeVisitor::unionTypeFromNode($this->code_base, $this->context, $node->children['expr']);
-            if ($right_type->hasStringType() || $right_type->hasStringType()) {
-                if ($right_type->isNonNullStringType() && $left->isNonNullStringType()) {
+            if ($right_type->hasStringType() || $left_type->hasStringType()) {
+                if ($right_type->isNonNullStringType() && $left_type->isNonNullStringType()) {
                     return StringType::instance(false)->asUnionType();
                 }
                 return UnionType::fromFullyQualifiedString('int|string');

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -418,6 +418,7 @@ class Issue
     const UNCOLORED_FORMAT_STRING_FOR_TEMPLATE = [
         'CLASS'         => '%s',
         'CLASSLIKE'     => '%s',
+        'CODE'          => '%s',  // A snippet from the code
         'COMMENT'       => '%s',  // contents of a phpdoc comment
         'CONST'         => '%s',
         'COUNT'         => '%d',

--- a/src/Phan/Output/Colorizing.php
+++ b/src/Phan/Output/Colorizing.php
@@ -66,6 +66,7 @@ class Colorizing
     const DEFAULT_COLOR_FOR_TEMPLATE = [
         'CLASS'         => 'green',
         'CLASSLIKE'     => 'green',
+        'CODE'          => 'light_magenta',
         'COMMENT'       => 'light_green',
         'CONST'         => 'light_red',
         'COUNT'         => 'light_magenta',

--- a/tests/plugin_test/.phan/config.php
+++ b/tests/plugin_test/.phan/config.php
@@ -114,5 +114,6 @@ return [
         'UnreachableCodePlugin',
         'UnusedSuppressionPlugin',
         'SleepCheckerPlugin',
+        'DuplicateExpressionPlugin',
     ],
 ];

--- a/tests/plugin_test/expected/048_redundant_binary_op.php.expected
+++ b/tests/plugin_test/expected/048_redundant_binary_op.php.expected
@@ -1,0 +1,6 @@
+src/048_redundant_binary_op.php:5 PhanReadOnlyPublicProperty Possibly zero write references to public property \A48::prop
+src/048_redundant_binary_op.php:8 PhanPluginDuplicateExpressionBinaryOp Both sides of the binary operator > are the same: (2 + 2)
+src/048_redundant_binary_op.php:9 PhanPluginDuplicateExpressionBinaryOp Both sides of the binary operator == are the same: $x->prop
+src/048_redundant_binary_op.php:10 PhanPluginDuplicateExpressionBinaryOp Both sides of the binary operator != are the same: A48::$prop
+src/048_redundant_binary_op.php:11 PhanPluginDuplicateExpressionBinaryOp Both sides of the binary operator || are the same: $x
+src/048_redundant_binary_op.php:11 PhanPluginNonBoolInLogicalArith Non bool value of type \stdClass in logical arithmetic

--- a/tests/plugin_test/expected/049_redundant_null_coalescing.php.expected
+++ b/tests/plugin_test/expected/049_redundant_null_coalescing.php.expected
@@ -1,0 +1,4 @@
+src/049_redundant_null_coalescing.php:4 PhanPluginDuplicateConditionalNullCoalescing "isset(X) ? X : Y" can usually be simplified to "X ?? Y" in PHP 7. The duplicated expression X was $a
+src/049_redundant_null_coalescing.php:5 PhanPluginDuplicateConditionalNullCoalescing "isset(X) ? X : Y" can usually be simplified to "X ?? Y" in PHP 7. The duplicated expression X was $x->prop
+src/049_redundant_null_coalescing.php:6 PhanPluginDuplicateExpressionBinaryOp Both sides of the binary operator == are the same: $x->prop
+src/049_redundant_null_coalescing.php:9 PhanPluginDuplicateConditionalTernaryDuplication "X ? X : Y" can usually be simplified to "X ?: Y". The duplicated expression X was $x->prop

--- a/tests/plugin_test/src/048_redundant_binary_op.php
+++ b/tests/plugin_test/src/048_redundant_binary_op.php
@@ -1,0 +1,12 @@
+<?php
+$x = new stdClass();
+$x->prop = 4;
+class A48 {
+    public static $prop = 2;
+}
+
+var_export((2+2) > 2+2);
+var_export($x->prop == $x->prop);
+var_export(A48::$prop != A48::$prop);
+var_export($x || $x);
+var_export($x->prop ** $x->prop);  // should not warn

--- a/tests/plugin_test/src/049_redundant_null_coalescing.php
+++ b/tests/plugin_test/src/049_redundant_null_coalescing.php
@@ -1,0 +1,14 @@
+<?php
+
+function example49(?stdClass $x, string $a = null) {
+    echo isset($a) ? $a : 'default';
+    $v = isset($x->prop) ? $x->prop : 'default';
+    var_export($x->prop == $x->prop);
+    echo $v;
+    if (isset($x->prop)) {
+        echo $x->prop ? $x->prop : 'false';
+        echo $x->prop ?: 'false';
+    }
+}
+example49(null);
+example49((object)['prop' => 'value']);


### PR DESCRIPTION
This will warn about the following:

- `X == X`, `X || X`, and many other binary operators (for operators where it is likely to be a bug)
- `X ? X : Y` (can often simplify to `X ?: Y`)
- `isset(X) ? X : Y` (can simplify to `??` in PHP 7, except in a few edge cases where side effects are relied on)
