### PR TITLE
Fix a false positive in the binary operator of `&&` conditional

### DIFF
--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -878,11 +878,7 @@ class ConditionVisitor extends KindVisitorImplementation
     {
         $context = (new BlockAnalysisVisitor($this->code_base, $this->context))->visitAssign($node);
         $left = $node->children['var'];
-        if ($left instanceof Node) {
-            return $this->__invoke($left);
-        }
-
-        return $context;
+        return (new self($this->code_base, $context))->__invoke($left);
     }
 
     /**
@@ -899,10 +895,6 @@ class ConditionVisitor extends KindVisitorImplementation
     {
         $context = (new BlockAnalysisVisitor($this->code_base, $this->context))->visitAssignRef($node);
         $left = $node->children['var'];
-        if ($left instanceof Node) {
-            return $this->__invoke($left);
-        }
-
-        return $context;
+        return (new self($this->code_base, $context))->__invoke($left);
     }
 }

--- a/src/Phan/Analysis/NegatedConditionVisitor.php
+++ b/src/Phan/Analysis/NegatedConditionVisitor.php
@@ -933,11 +933,7 @@ class NegatedConditionVisitor extends KindVisitorImplementation
     {
         $context = (new BlockAnalysisVisitor($this->code_base, $this->context))->visitAssign($node);
         $left = $node->children['var'];
-        if ($left instanceof Node) {
-            return $this->__invoke($left);
-        }
-
-        return $context;
+        return (new self($this->code_base, $context))->__invoke($left);
     }
 
     /**
@@ -954,10 +950,6 @@ class NegatedConditionVisitor extends KindVisitorImplementation
     {
         $context = (new BlockAnalysisVisitor($this->code_base, $this->context))->visitAssignRef($node);
         $left = $node->children['var'];
-        if ($left instanceof Node) {
-            return $this->__invoke($left);
-        }
-
-        return $context;
+        return (new self($this->code_base, $context))->__invoke($left);
     }
 }

--- a/tests/files/expected/0517_false_positive_assign.php.expected
+++ b/tests/files/expected/0517_false_positive_assign.php.expected
@@ -1,0 +1,1 @@
+%s:22 PhanTypeMismatchArgumentInternal Argument 1 (var) is string but \count() takes \Countable|array

--- a/tests/files/src/0517_false_positive_assign.php
+++ b/tests/files/src/0517_false_positive_assign.php
@@ -1,0 +1,26 @@
+<?php
+
+class Formatter517 {
+    public static function format($file, $line) : string {
+        return "$file:$line";
+    }
+}
+
+
+/**
+ * Regression test for a false positive about a variable assigned in an `if` statement
+ * being undefined.
+ */
+class Example517 {
+    /**
+     * @param ?Formatter517 $fmt
+     */
+    public function access($fmt, string $file, int $line) {
+        if ($file) {
+            if ($fmt && $link = \is_string($fmt) ? strtr($fmt, array('%f' => $file, '%l' => $line)) : $fmt->format($file, $line)) {
+                echo $link;
+                echo count($link);  // should warn
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1904

This issue started occurring when Phan analyzed `&&` and `||` in more
depth for issues.