### PR TITLE
Warn about `new $notAClass()`, improve inference about Closures

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,11 +9,15 @@ New features(Analysis)
 + Warn about array destructuring assignments from non-arrays (#1818)
   (E.g. `[$x] = 2`)
   New issue type: `PhanTypeInvalidExpressionArrayDestructuring`
++ Emit `PhanTypeExpectedClassName` when attempting to use an invalid type where a class name was expected.
+  (e.g. `new $notAClassName()`)
 
 Bug fixes
 + Fix a crash seen when using a temporary expression in a write context. (#1915)
   New issue type: `PhanInvalidWriteToTemporaryExpression`
 + Fix a crash seen with --use-fallback-parser with an invalid expression after `new`
++ Properly infer that closures have a class name of `Closure` for some issue types.
+  (e.g. `call_user_func([function() {}, 'invalidMethod'])`)
 
 26 Aug 2018, Phan 1.0.1
 -----------------------

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -1450,6 +1450,12 @@ if (42 == [1, 2]) {}
 array to {TYPE} conversion
 ```
 
+## PhanTypeExpectedClassName
+
+```
+Expected the name of a class but saw expression with type {TYPE}
+```
+
 ## PhanTypeExpectedObject
 
 ```

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -776,7 +776,7 @@ class ContextNode
                     if ($type instanceof ClosureType) {
                         $closure_fqsen =
                             FullyQualifiedFunctionName::fromFullyQualifiedString(
-                                (string)$type->asFQSEN()
+                                $type->asFQSEN()->__toString()
                             );
 
                         if ($code_base->hasFunctionWithFQSEN(

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -1165,7 +1165,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
     ) {
         $type_set = $expression_type->getTypeSet();
         $context = $this->context;
-        if (\count($type_set)< 2) {
+        if (\count($type_set) < 2) {
             throw new AssertionError("Expected at least two types for strict return type checks");
         }
 

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -1211,7 +1211,8 @@ EOB;
                 Config::AST_VERSION
             );
         } catch (\LogicException $_) {
-            fwrite(STDERR,
+            fwrite(
+                STDERR,
                 'Unknown AST version ('
                 . Config::AST_VERSION
                 . ') in configuration. '

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -140,6 +140,7 @@ class Issue
     const TypeExpectedObject        = 'PhanTypeExpectedObject';
     const TypeExpectedObjectOrClassName = 'PhanTypeExpectedObjectOrClassName';
     const TypeExpectedObjectOrClassNameInvalidName = 'PhanTypeExpectedObjectOrClassNameInvalidName';
+    const TypeExpectedClassName = 'PhanTypeExpectedClassName';
     const TypeExpectedObjectPropAccess = 'PhanTypeExpectedObjectPropAccess';
     const TypeExpectedObjectPropAccessButGotNull = 'PhanTypeExpectedObjectPropAccessButGotNull';
     const TypeExpectedObjectStaticPropAccess = 'PhanTypeExpectedObjectStaticPropAccess';
@@ -1389,6 +1390,14 @@ class Issue
                 'Expected an object instance or the name of a class but saw an invalid class name \'{STRING_LITERAL}\'',
                 self::REMEDIATION_B,
                 10074
+            ),
+            new Issue(
+                self::TypeExpectedClassName,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                'Expected the name of a class but saw expression with type {TYPE}',
+                self::REMEDIATION_B,
+                10078
             ),
             new Issue(
                 self::TypeExpectedObjectPropAccess,

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -446,7 +446,7 @@ class Clazz extends AddressableElement
             throw new \Exception("Class $this has no parent");
         }
 
-        return $parent_type_option->get()->asFQSEN();
+        return FullyQualifiedClassName::fromType($parent_type_option->get());
     }
 
     /**
@@ -2498,7 +2498,7 @@ class Clazz extends AddressableElement
 
         $parent_type = $this->parent_type;
         if ($parent_type) {
-            $extend_types[] = $parent_type->asFQSEN();
+            $extend_types[] = FullyQualifiedClassName::fromType($parent_type);
             $parent_class = $this->getParentClass($code_base);
             $parent_implements_types = $parent_class->interface_fqsen_list;
         }

--- a/src/Phan/Language/Element/Func.php
+++ b/src/Phan/Language/Element/Func.php
@@ -91,13 +91,13 @@ class Func extends AddressableElement implements FunctionInterface
     private static function getClosureOverrideFQSEN(
         CodeBase $code_base,
         Context $context,
-        Type $closure_scope,
+        Type $closure_scope_type,
         Node $node
     ) {
         if ($node->kind !== \ast\AST_CLOSURE) {
             return null;
         }
-        if ($closure_scope->isNativeType()) {
+        if ($closure_scope_type->isNativeType()) {
             // TODO: Handle final internal classes (Can't call bindTo on those)
             // TODO: What about 'null' (for code planning to bindTo(null))
             // Emit an error
@@ -106,25 +106,19 @@ class Func extends AddressableElement implements FunctionInterface
                 $context,
                 Issue::TypeInvalidClosureScope,
                 $node->lineno ?? 0,
-                (string)$closure_scope
+                (string)$closure_scope_type
             );
             return null;
         } else {
             // TODO: handle 'parent'?
             // TODO: Check if isInClassScope
-            if ($closure_scope->isSelfType() || $closure_scope->isStaticType()) {
+            if ($closure_scope_type->isSelfType() || $closure_scope_type->isStaticType()) {
                 // nothing to do.
                 return null;
             }
         }
 
-        $class_fqsen = $closure_scope->asFQSEN();
-        if (!($class_fqsen instanceof FullyQualifiedClassName)) {
-            // shouldn't happen
-            return null;
-        }
-
-        return $class_fqsen;
+        return FullyQualifiedClassName::fromType($closure_scope_type);
     }
 
 

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -1838,7 +1838,7 @@ class Type
     public function getTemplateParameterTypeMap(CodeBase $code_base)
     {
         return $this->memoize(__METHOD__, function () use ($code_base) : array {
-            $fqsen = $this->asFQSEN();
+            $fqsen = FullyQualifiedClassName::fromType($this);
 
             if (!($fqsen instanceof FullyQualifiedClassName)) {
                 return [];

--- a/src/Phan/Language/Type/ClosureType.php
+++ b/src/Phan/Language/Type/ClosureType.php
@@ -67,11 +67,7 @@ final class ClosureType extends Type
      */
     public function asFQSEN() : FQSEN
     {
-        if (!empty($this->fqsen)) {
-            return $this->fqsen;
-        }
-
-        return parent::asFQSEN();
+        return $this->fqsen ?? parent::asFQSEN();
     }
 
     /**

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -304,11 +304,8 @@ final class GenericArrayType extends ArrayType implements GenericArrayInterface
         return $this->memoize(__METHOD__, function () use ($code_base, $recursion_depth) : UnionType {
             $union_type = $this->asUnionType();
 
-            $class_fqsen = $this->genericArrayElementType()->asFQSEN();
+            $class_fqsen = FullyQualifiedClassName::fromType($this->genericArrayElementType());
 
-            if (!($class_fqsen instanceof FullyQualifiedClassName)) {
-                return $union_type;
-            }
 
             if (!$code_base->hasClassWithFQSEN($class_fqsen)) {
                 return $union_type;

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -1513,7 +1513,8 @@ class UnionType implements \Serializable
     /**
      * @return UnionType
      */
-    public function asArrayOrArrayAccessSubTypes(CodeBase $code_base) : UnionType {
+    public function asArrayOrArrayAccessSubTypes(CodeBase $code_base) : UnionType
+    {
         $result = UnionType::empty();
         foreach ($this->type_set as $type) {
             if ($type->isArrayOrArrayAccessSubType($code_base)) {
@@ -1630,11 +1631,7 @@ class UnionType implements \Serializable
                 continue;
             }
             // Get the class FQSEN
-            $class_fqsen = $class_type->asFQSEN();
-            if (!($class_fqsen instanceof FullyQualifiedClassName)) {
-                // Should be impossible, but skip to satisfy the type checker
-                continue;
-            }
+            $class_fqsen = FullyQualifiedClassName::fromType($class_type);
 
             if ($class_type->isStaticType()) {
                 if (!$context->isInClassScope()) {

--- a/src/Phan/LanguageServer/DefinitionResolver.php
+++ b/src/Phan/LanguageServer/DefinitionResolver.php
@@ -121,10 +121,7 @@ class DefinitionResolver
             if ($type->isNativeType()) {
                 continue;
             }
-            $class_fqsen = $type->asFQSEN();
-            if (!$class_fqsen instanceof FullyQualifiedClassName) {
-                continue;
-            }
+            $class_fqsen = FullyQualifiedClassName::fromType($type);
             if (!$code_base->hasClassWithFQSEN($class_fqsen)) {
                 continue;
             }

--- a/src/Phan/LanguageServer/GoToDefinitionRequest.php
+++ b/src/Phan/LanguageServer/GoToDefinitionRequest.php
@@ -135,6 +135,7 @@ final class GoToDefinitionRequest
                 }
                 $type_fqsen = $context->getClassFQSEN();
             } else {
+                // Get the FQSEN of the class or closure.
                 $type_fqsen = $type->asFQSEN();
             }
             try {

--- a/src/Phan/Output/Collector/ParallelChildCollector.php
+++ b/src/Phan/Output/Collector/ParallelChildCollector.php
@@ -39,7 +39,7 @@ class ParallelChildCollector implements IssueCollectorInterface
      * @throws AssertionError if PHP modules needed for shared communication aren't loaded
      * @internal
      */
-    public static final function assertSharedMemoryCommunicationEnabled()
+    final public static function assertSharedMemoryCommunicationEnabled()
     {
         if (!extension_loaded('sysvsem')) {
             throw new AssertionError(

--- a/tests/Phan/BaseTest.php
+++ b/tests/Phan/BaseTest.php
@@ -11,6 +11,14 @@ use PHPUnit\Framework\TestCase;
 abstract class BaseTest extends TestCase
 {
     /**
+     * @return void
+     */
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+        ini_set('memory_limit', '1G');
+    }
+    /**
      * Needed to prevent phpunit from backing up these private static variables.
      * See https://phpunit.de/manual/current/en/fixtures.html#fixtures.global-state
      *

--- a/tests/files/expected/0521_misuse_closure_type.php.expected
+++ b/tests/files/expected/0521_misuse_closure_type.php.expected
@@ -1,0 +1,8 @@
+%s:6 PhanNonClassMethodCall Call to method __construct on non-class type int
+%s:6 PhanTypeExpectedClassName Expected the name of a class but saw expression with type int
+%s:8 PhanTypeExpectedClassName Expected the name of a class but saw expression with type \stdClass
+%s:10 PhanAccessMethodPrivate Cannot access private method \Closure::__construct defined at internal:0
+%s:10 PhanTypeExpectedClassName Expected the name of a class but saw expression with type Closure(string):void
+%s:11 PhanUndeclaredMethodInCallable Call to undeclared method name in callable. Possible object type(s) for that method are Closure():void
+%s:12 PhanUndeclaredMethod Call to undeclared method \Closure::name
+%s:13 PhanTypeInvalidCallableObjectOfMethod In a place where phan was expecting a callable, saw a two-element array with a class or expression with an unexpected type 2 (expected a class type or string). Method name was name

--- a/tests/files/src/0521_misuse_closure_type.php
+++ b/tests/files/src/0521_misuse_closure_type.php
@@ -1,0 +1,14 @@
+<?php
+
+call_user_func(function(string $arg) {
+    // Phan detects invalid uses of Closures and classes.
+    $i = rand(0,1);
+    var_export(new $i());
+    $o = new stdClass();
+    var_export(new $o());
+    $c = function(string $x) {};
+    var_export(new $c());
+    call_user_func([function () {}, 'name']);
+    echo (function() {})->name();
+    call_user_func([2, 'name']);
+}, 'stdClass');


### PR DESCRIPTION
Add a new issue type of `PhanTypeExpectedClassName`

And clean up uses of asFQSEN()

Also, when running tests, ensure that memory_limit is set to 1G
(fail early if there would be infinite recursion)