### PR TITLE
Check assignments in complex conditions, simplify for/while loops

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@ Bug fixes
 + Fix a crash seen with --use-fallback-parser with an invalid expression after `new`
 + Properly infer that closures have a class name of `Closure` for some issue types.
   (e.g. `call_user_func([function() {}, 'invalidMethod'])`)
++ Fix a bug analyzing nested assignment in conditionals (#1919)
 
 26 Aug 2018, Phan 1.0.1
 -----------------------

--- a/src/Phan/Analysis/ConditionVisitorUtil.php
+++ b/src/Phan/Analysis/ConditionVisitorUtil.php
@@ -2,6 +2,7 @@
 namespace Phan\Analysis;
 
 use Phan\AST\UnionTypeVisitor;
+use Phan\BlockAnalysisVisitor;
 use Phan\CodeBase;
 use Phan\Config;
 use Phan\Exception\IssueException;
@@ -388,6 +389,7 @@ trait ConditionVisitorUtil
                 }
                 $kind = $tmp->kind;
                 if ($kind === \ast\AST_VAR) {
+                    $this->context = (new BlockAnalysisVisitor($this->code_base, $this->context))->__invoke($tmp);
                     return $analyzer($tmp, $right);
                 }
             }
@@ -403,6 +405,7 @@ trait ConditionVisitorUtil
                 if (!$tmp instanceof Node) {
                     break;
                 }
+                $this->context = (new BlockAnalysisVisitor($this->code_base, $this->context))->__invoke($right);
                 $kind = $tmp->kind;
                 if ($kind === \ast\AST_VAR) {
                     return $analyzer($tmp, $left);

--- a/tests/Phan/AST/ASTSimplifierTest.php
+++ b/tests/Phan/AST/ASTSimplifierTest.php
@@ -1,12 +1,13 @@
 <?php declare(strict_types=1);
 
-namespace Phan\Tests;
+namespace Phan\Tests\AST;
 
 use Phan\AST\ASTSimplifier;
+use Phan\Tests\AbstractPhanFileTest;
 use Phan\Config;
 use Phan\Debug;
 
-final class ASTRewriterTest extends AbstractPhanFileTest
+final class ASTSimplifierTest extends AbstractPhanFileTest
 {
     /**
      * @suppress PhanUndeclaredConstant

--- a/tests/files/src/0522_complex_cond_loop.php
+++ b/tests/files/src/0522_complex_cond_loop.php
@@ -1,0 +1,7 @@
+<?php
+call_user_func(function() {
+    $dir = opendir('.');
+    while ($dir && (false !== ($file = readdir($dir)))) {
+        echo $file;
+    }
+});

--- a/tests/misc/ast/expected/020_negate_return.php.expected
+++ b/tests/misc/ast/expected/020_negate_return.php.expected
@@ -1,5 +1,5 @@
 <?php
-
-function f344(?string $x) : int {
+/** @param ?string $x */
+function f344($x) : int {
     if (is_string($x)) {} else {return $x;} return strlen($x); 
 }

--- a/tests/misc/ast/expected/021_return.php.expected
+++ b/tests/misc/ast/expected/021_return.php.expected
@@ -1,5 +1,6 @@
 <?php
 // Phan's BlockAnalysisVisitor is already aware that the branch with `return $x` is unreachable.
-function f344(?string $x) : int {
+/** @param ?string $x */
+function f344($x) : int {
     if (is_string($x)) { } else { return $x; } return 2;
 }

--- a/tests/misc/ast/expected/022_rewrite_loop.php.expected
+++ b/tests/misc/ast/expected/022_rewrite_loop.php.expected
@@ -1,0 +1,16 @@
+<?php
+
+while ($x) { if (!$y) { break; }
+    var_export($x);
+    var_export($y);
+}
+
+for ($i = 0; true, $i < 2; $i++) { if (!is_string($x)) { break; }
+    var_export([$i, $x]);
+}
+
+while ($x) {
+}
+
+for (;$i=0,$x;) {
+}

--- a/tests/misc/ast/src/020_negate_return.php
+++ b/tests/misc/ast/src/020_negate_return.php
@@ -1,5 +1,5 @@
 <?php
-
-function f344(?string $x) : int {
+/** @param ?string $x */
+function f344($x) : int {
     if (!is_string($x)) { return $x; } else {} return strlen($x);
 }

--- a/tests/misc/ast/src/021_return.php
+++ b/tests/misc/ast/src/021_return.php
@@ -1,5 +1,6 @@
 <?php
 // Phan's BlockAnalysisVisitor is already aware that the branch with `return $x` is unreachable.
-function f344(?string $x) : int {
+/** @param ?string $x */
+function f344($x) : int {
     if (is_string($x)) { } else { return $x; } return 2;
 }

--- a/tests/misc/ast/src/022_rewrite_loop.php
+++ b/tests/misc/ast/src/022_rewrite_loop.php
@@ -1,0 +1,16 @@
+<?php
+
+while ($x && $y) {
+    var_export($x);
+    var_export($y);
+}
+
+for ($i = 0; true, $i < 2 && is_string($x); $i++) {
+    var_export([$i, $x]);
+}
+
+while (!!$x) {
+}
+
+for (;$i=0,!!$x;) {
+}


### PR DESCRIPTION
Fix a false positive undefined variable analyzing conditionals similar
to `cond && constant === ($x = expr())`

Also, simplify conditions of for/while loops when simplify_ast is enabled.

Fixes #1919
Fixes #1920