### PR TITLE
Fixes regression in 1.0.2-dev: `new $obj()` is valid PHP

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,8 +10,6 @@ New features(Analysis)
   (E.g. `[$x] = 2`)
 
   New issue type: `PhanTypeInvalidExpressionArrayDestructuring`
-+ Emit `PhanTypeExpectedClassName` when attempting to use an invalid type where a class name was expected.
-  (e.g. `new $notAClassName()`)
 + Infer the number of groups for $matches in `preg_match()`
 
   Named subpatterns, non-capturing patterns, and regular expression options are not supported yet.

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -1450,12 +1450,6 @@ if (42 == [1, 2]) {}
 array to {TYPE} conversion
 ```
 
-## PhanTypeExpectedClassName
-
-```
-Expected the name of a class but saw expression with type {TYPE}
-```
-
 ## PhanTypeExpectedObject
 
 ```

--- a/src/Phan/Analysis/RegexAnalyzer.php
+++ b/src/Phan/Analysis/RegexAnalyzer.php
@@ -17,7 +17,8 @@ use InvalidArgumentException;
  *
  * @see PregRegexPlugin for the plugin that actually emits warnings about invalid regexes
  */
-class RegexAnalyzer {
+class RegexAnalyzer
+{
     public static function getPregMatchUnionType(
         CodeBase $code_base,
         Context $context,

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -140,7 +140,6 @@ class Issue
     const TypeExpectedObject        = 'PhanTypeExpectedObject';
     const TypeExpectedObjectOrClassName = 'PhanTypeExpectedObjectOrClassName';
     const TypeExpectedObjectOrClassNameInvalidName = 'PhanTypeExpectedObjectOrClassNameInvalidName';
-    const TypeExpectedClassName = 'PhanTypeExpectedClassName';
     const TypeExpectedObjectPropAccess = 'PhanTypeExpectedObjectPropAccess';
     const TypeExpectedObjectPropAccessButGotNull = 'PhanTypeExpectedObjectPropAccessButGotNull';
     const TypeExpectedObjectStaticPropAccess = 'PhanTypeExpectedObjectStaticPropAccess';
@@ -1390,14 +1389,6 @@ class Issue
                 'Expected an object instance or the name of a class but saw an invalid class name \'{STRING_LITERAL}\'',
                 self::REMEDIATION_B,
                 10074
-            ),
-            new Issue(
-                self::TypeExpectedClassName,
-                self::CATEGORY_TYPE,
-                self::SEVERITY_NORMAL,
-                'Expected the name of a class but saw expression with type {TYPE}',
-                self::REMEDIATION_B,
-                10078
             ),
             new Issue(
                 self::TypeExpectedObjectPropAccess,

--- a/src/Phan/Library/RegexKeyExtractor.php
+++ b/src/Phan/Library/RegexKeyExtractor.php
@@ -9,7 +9,8 @@ use function strlen;
  *
  * This may not be aware of all edge cases.
  */
-class RegexKeyExtractor {
+class RegexKeyExtractor
+{
     /**
      * @var string the inner pattern of the regular expression
      */

--- a/tests/Phan/Library/RegexKeyExtractorTest.php
+++ b/tests/Phan/Library/RegexKeyExtractorTest.php
@@ -37,12 +37,12 @@ final class RegexKeyExtractorTest extends BaseTest
         ];
     }
 
-    private static function toArraySet(array $list) : array {
+    private static function toArraySet(array $list) : array
+    {
         $set = [];
         foreach ($list as $key) {
             $set[$key] = true;
         }
         return $set;
     }
-
 }

--- a/tests/files/expected/0521_misuse_closure_type.php.expected
+++ b/tests/files/expected/0521_misuse_closure_type.php.expected
@@ -1,8 +1,7 @@
-%s:6 PhanNonClassMethodCall Call to method __construct on non-class type int
-%s:6 PhanTypeExpectedClassName Expected the name of a class but saw expression with type int
-%s:8 PhanTypeExpectedClassName Expected the name of a class but saw expression with type \stdClass
-%s:10 PhanAccessMethodPrivate Cannot access private method \Closure::__construct defined at internal:0
-%s:10 PhanTypeExpectedClassName Expected the name of a class but saw expression with type Closure(string):void
-%s:11 PhanUndeclaredMethodInCallable Call to undeclared method name in callable. Possible object type(s) for that method are Closure():void
-%s:12 PhanUndeclaredMethod Call to undeclared method \Closure::name
-%s:13 PhanTypeInvalidCallableObjectOfMethod In a place where phan was expecting a callable, saw a two-element array with a class or expression with an unexpected type 2 (expected a class type or string). Method name was name
+%s:11 PhanNonClassMethodCall Call to method __construct on non-class type int
+%s:11 PhanTypeExpectedObjectOrClassName Expected an object instance or the name of a class but saw expression with type int
+%s:15 PhanAccessMethodPrivate Cannot access private method \Closure::__construct defined at internal:0
+%s:16 PhanUndeclaredMethodInCallable Call to undeclared method name in callable. Possible object type(s) for that method are Closure():void
+%s:17 PhanUndeclaredMethod Call to undeclared method \Closure::name
+%s:18 PhanTypeInvalidCallableObjectOfMethod In a place where phan was expecting a callable, saw a two-element array with a class or expression with an unexpected type 2 (expected a class type or string). Method name was name
+%s:20 PhanParamTooFew Call with 0 arg(s) to \A521::__construct() which requires 1 arg(s) defined at %s:4

--- a/tests/files/src/0521_misuse_closure_type.php
+++ b/tests/files/src/0521_misuse_closure_type.php
@@ -1,14 +1,21 @@
 <?php
 
+class A521 {
+    public function __construct(string $arg) {
+    }
+}
+
 call_user_func(function(string $arg) {
     // Phan detects invalid uses of Closures and classes.
     $i = rand(0,1);
     var_export(new $i());
     $o = new stdClass();
-    var_export(new $o());
+    var_export(new $o());  // NOTE: This is valid. See https://github.com/phan/phan/issues/1926
     $c = function(string $x) {};
     var_export(new $c());
     call_user_func([function () {}, 'name']);
     echo (function() {})->name();
     call_user_func([2, 'name']);
+    $a = new A521('x');
+    var_export(new $a());
 }, 'stdClass');


### PR DESCRIPTION
Fixes #1926

This is very rarely used functionality, but it is still documented and valid.