### PR TITLE
Add missing/uninferable param types to Phan's code

### DIFF
--- a/.phan/plugins/SleepCheckerPlugin.php
+++ b/.phan/plugins/SleepCheckerPlugin.php
@@ -58,6 +58,7 @@ class SleepCheckerVisitor extends PluginAwarePostAnalysisVisitor
     }
 
     /**
+     * @param Node|int|string|float|null $node
      * @return void
      */
     private function analyzeStatements($node)
@@ -90,9 +91,11 @@ class SleepCheckerVisitor extends PluginAwarePostAnalysisVisitor
         ContextNode::RESOLVE_ARRAY_VALUES |
         ContextNode::RESOLVE_CONSTANTS;
 
+    /**
+     * @param Node|string|int|float|null $expr_node
+     */
     private function analyzeReturnValue($expr_node, int $lineno)
     {
-
         $context = clone($this->context)->withLineNumberStart($lineno);
         if (!($expr_node instanceof Node)) {
             $this->emitPluginIssue(

--- a/.phan/plugins/UnknownElementTypePlugin.php
+++ b/.phan/plugins/UnknownElementTypePlugin.php
@@ -35,8 +35,6 @@ class UnknownElementTypePlugin extends PluginV2 implements
         if ($method->getFQSEN() !== $method->getRealDefiningFQSEN()) {
             return;
         }
-        // As an example, we test to see if the name of the
-        // method is `function`, and emit an issue if it is.
         // NOTE: Placeholders can be found in \Phan\Issue::uncolored_format_string_for_replace
         if ($method->getUnionType()->isEmpty()) {
             $this->emitIssue(
@@ -75,8 +73,6 @@ class UnknownElementTypePlugin extends PluginV2 implements
         CodeBase $code_base,
         Func $function
     ) {
-        // As an example, we test to see if the name of the
-        // method is `function`, and emit an issue if it is.
         // NOTE: Placeholders can be found in \Phan\Issue::uncolored_format_string_for_replace
         if ($function->getUnionType()->isEmpty()) {
             if ($function->getFQSEN()->isClosure()) {
@@ -132,8 +128,6 @@ class UnknownElementTypePlugin extends PluginV2 implements
         if ($property->getFQSEN() !== $property->getRealDefiningFQSEN()) {
             return;
         }
-        // As an example, we test to see if the name of the
-        // function is `foo`, and emit an issue if it is.
         if ($property->getUnionType()->isEmpty()) {
             $this->emitIssue(
                 $code_base,

--- a/.phan/plugins/UnknownElementTypePlugin.php
+++ b/.phan/plugins/UnknownElementTypePlugin.php
@@ -43,9 +43,20 @@ class UnknownElementTypePlugin extends PluginV2 implements
                 $code_base,
                 $method->getContext(),
                 'PhanPluginUnknownMethodReturnType',
-                "Method {METHOD} has no declared or inferred return type",
+                'Method {METHOD} has no declared or inferred return type',
                 [(string)$method->getFQSEN()]
             );
+        }
+        foreach ($method->getParameterList() as $parameter) {
+            if ($parameter->getUnionType()->isEmpty()) {
+                $this->emitIssue(
+                    $code_base,
+                    $method->getContext(),
+                    'PhanPluginUnknownMethodParamType',
+                    'Method {METHOD} has no declared or inferred parameter type for ${PARAMETER}',
+                    [(string)$method->getFQSEN(), $parameter->getName()]
+                );
+            }
         }
     }
 
@@ -69,20 +80,35 @@ class UnknownElementTypePlugin extends PluginV2 implements
         // NOTE: Placeholders can be found in \Phan\Issue::uncolored_format_string_for_replace
         if ($function->getUnionType()->isEmpty()) {
             if ($function->getFQSEN()->isClosure()) {
-                $this->emitIssue(
-                    $code_base,
-                    $function->getContext(),
-                    'PhanPluginUnknownClosureReturnType',
-                    "Closure {FUNCTION} has no declared or inferred return type",
-                    [(string)$function->getFQSEN()]
-                );
+                $issue = 'PhanPluginUnknownClosureReturnType';
+                $message = 'Closure {FUNCTION} has no declared or inferred return type';
             } else {
+                $issue = 'PhanPluginUnknownFunctionReturnType';
+                $message = 'Function {FUNCTION} has no declared or inferred return type';
+            }
+            $this->emitIssue(
+                $code_base,
+                $function->getContext(),
+                $issue,
+                $message,
+                [(string)$function->getFQSEN()]
+            );
+        }
+        foreach ($function->getParameterList() as $parameter) {
+            if ($function->getFQSEN()->isClosure()) {
+                $issue = 'PhanPluginUnknownClosureParamType';
+                $message = 'Closure {FUNCTION} has no declared or inferred return type for ${PARAMETER}';
+            } else {
+                $issue = 'PhanPluginUnknownFunctionParamType';
+                $message = 'Function {FUNCTION} has no declared or inferred return type for ${PARAMETER}';
+            }
+            if ($parameter->getUnionType()->isEmpty()) {
                 $this->emitIssue(
                     $code_base,
                     $function->getContext(),
-                    'PhanPluginUnknownFunctionReturnType',
-                    "Function {FUNCTION} has no declared or inferred return type",
-                    [(string)$function->getFQSEN()]
+                    $issue,
+                    $message,
+                    [(string)$function->getFQSEN(), $parameter->getName()]
                 );
             }
         }

--- a/internal/internalsignatures.php
+++ b/internal/internalsignatures.php
@@ -295,6 +295,7 @@ EOT;
         return $parts;
     }
 
+    /** @param int|string|float $scalar */
     private static function encodeScalar($scalar) : string
     {
         if (is_string($scalar)) {
@@ -778,6 +779,7 @@ class IncompatibleXMLSignatureDetector extends IncompatibleSignatureDetectorBase
         return $result;
     }
 
+    /** @param string|int|float $type */
     private static function toTypeString($type) : string
     {
         // TODO: Validate that Phan can parse these?
@@ -828,6 +830,9 @@ class IncompatibleXMLSignatureDetector extends IncompatibleSignatureDetectorBase
     private function normalizeEntityFile(string $contents) : string
     {
         $entities = $this->getKnownEntities();
+        /**
+         * @param array<int,string> $matches
+         */
         return preg_replace_callback('/&([-a-zA-Z_.0-9]+);/', function ($matches) use ($entities) : string {
             $entity_name = $matches[1];
             if (isset($entities[strtolower($entity_name)])) {

--- a/internal/update_wiki_issue_types.php
+++ b/internal/update_wiki_issue_types.php
@@ -176,6 +176,7 @@ EOT;
 
         if ($issue instanceof Issue) {
             fwrite(STDERR, "Found $issue_name\n");
+            /** @param array<int,string> $unused_match */
             $text = preg_replace_callback('@\n```\n[^\n]*\n```@', function ($unused_match) use ($issue) : string {
                 return "\n```\n{$issue->getTemplateRaw()}\n```";
             }, $text);

--- a/phan_client
+++ b/phan_client
@@ -57,12 +57,12 @@ class PhanPHPLinter
         }
     }
 
-	/**
-	 * The main function of the phan_client binary.
-	 * See the doc comment of this file.
-	 *
-	 * @return void
-	 */
+    /**
+     * The main function of the phan_client binary.
+     * See the doc comment of this file.
+     *
+     * @return void
+     */
     public static function run()
     {
         error_reporting(E_ALL);
@@ -451,11 +451,11 @@ EOB;
                 case 'l':
                 case 'syntax-check':
                     $path = $value;
-					if (!is_string($path)) {
+                    if (!is_string($path)) {
                         $this->print_usage_on_error = $print_usage_on_error;
                         $this->usage(sprintf("Error: asked to analyze path %s which is not a string", json_encode($path)), 1);
                         exit(1);
-					}
+                    }
                     if (!file_exists($path)) {
                         $this->print_usage_on_error = $print_usage_on_error;
                         $this->usage(sprintf("Error: asked to analyze file %s which does not exist", json_encode($path)), 1);
@@ -500,6 +500,7 @@ EOB;
 
     /**
      * prints error message if php doesn't support connecting to a daemon with a given protocol.
+     * @param string $protocol
      * @return void
      */
     private function checkCanConnectToDaemon($protocol)

--- a/src/Phan/AST/ASTHasher.php
+++ b/src/Phan/AST/ASTHasher.php
@@ -14,6 +14,7 @@ use function is_string;
 class ASTHasher
 {
     /**
+     * @param string|int|float|null $node
      * @return string a 16-byte binary key
      */
     public static function hash_key($node)
@@ -29,6 +30,7 @@ class ASTHasher
     }
 
     /**
+     * @param Node|string|int|float|null $node
      * @return string a 16-byte binary key
      */
     public static function hash($node)
@@ -48,6 +50,7 @@ class ASTHasher
     }
 
     /**
+     * @param Node $node
      * @return string a 16-byte binary key
      */
     private static function compute_hash($node)

--- a/src/Phan/AST/ASTReverter.php
+++ b/src/Phan/AST/ASTReverter.php
@@ -36,6 +36,7 @@ class ASTReverter
     }
 
     /**
+     * @param Node|string|int|float $node
      * @return string
      */
     public static function toShortString($node)

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -92,6 +92,9 @@ class ContextNode
             return [];
         }
 
+        /**
+         * @param Node|string|int|float|null $name_node
+         */
         return \array_map(function ($name_node) : string {
             return (new ContextNode(
                 $this->code_base,
@@ -122,6 +125,9 @@ class ContextNode
             return [];
         }
 
+        /**
+         * @param Node|int|string|float|null $name_node
+         */
         return \array_map(function ($name_node) : FQSEN {
             return (new ContextNode(
                 $this->code_base,

--- a/src/Phan/AST/PhanAnnotationAdder.php
+++ b/src/Phan/AST/PhanAnnotationAdder.php
@@ -184,6 +184,7 @@ class PhanAnnotationAdder
     }
 
     /**
+     * @param Node|string|int|float|null $node
      * @return void
      */
     private static function applyToScopeInner($node)

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -4,6 +4,7 @@ namespace Phan\AST\TolerantASTConverter;
 
 use AssertionError;
 use ast;
+use ast\flags;
 use Error;
 use InvalidArgumentException;
 use Microsoft\PhpParser;
@@ -487,47 +488,47 @@ class TolerantASTConverter
              */
             'Microsoft\PhpParser\Node\Expression\BinaryExpression' => function (PhpParser\Node\Expression\BinaryExpression $n, int $start_line) {
                 static $lookup = [
-                    TokenKind::AmpersandAmpersandToken              => ast\flags\BINARY_BOOL_AND,
-                    TokenKind::AmpersandToken                       => ast\flags\BINARY_BITWISE_AND,
-                    TokenKind::AndKeyword                           => ast\flags\BINARY_BOOL_AND,
-                    TokenKind::AsteriskAsteriskToken                => ast\flags\BINARY_POW,
-                    TokenKind::AsteriskToken                        => ast\flags\BINARY_MUL,
-                    TokenKind::BarBarToken                          => ast\flags\BINARY_BOOL_OR,
-                    TokenKind::BarToken                             => ast\flags\BINARY_BITWISE_OR,
-                    TokenKind::CaretToken                           => ast\flags\BINARY_BITWISE_XOR,
-                    TokenKind::DotToken                             => ast\flags\BINARY_CONCAT,
-                    TokenKind::EqualsEqualsEqualsToken              => ast\flags\BINARY_IS_IDENTICAL,
-                    TokenKind::EqualsEqualsToken                    => ast\flags\BINARY_IS_EQUAL,
-                    TokenKind::ExclamationEqualsEqualsToken         => ast\flags\BINARY_IS_NOT_IDENTICAL,
-                    TokenKind::ExclamationEqualsToken               => ast\flags\BINARY_IS_NOT_EQUAL,
-                    TokenKind::GreaterThanEqualsToken               => ast\flags\BINARY_IS_GREATER_OR_EQUAL,
-                    TokenKind::GreaterThanGreaterThanToken          => ast\flags\BINARY_SHIFT_RIGHT,
-                    TokenKind::GreaterThanToken                     => ast\flags\BINARY_IS_GREATER,
-                    TokenKind::LessThanEqualsGreaterThanToken       => ast\flags\BINARY_SPACESHIP,
-                    TokenKind::LessThanEqualsToken                  => ast\flags\BINARY_IS_SMALLER_OR_EQUAL,
-                    TokenKind::LessThanLessThanToken                => ast\flags\BINARY_SHIFT_LEFT,
-                    TokenKind::LessThanToken                        => ast\flags\BINARY_IS_SMALLER,
-                    TokenKind::MinusToken                           => ast\flags\BINARY_SUB,
-                    TokenKind::OrKeyword                            => ast\flags\BINARY_BOOL_OR,
-                    TokenKind::PercentToken                         => ast\flags\BINARY_MOD,
-                    TokenKind::PlusToken                            => ast\flags\BINARY_ADD,
-                    TokenKind::QuestionQuestionToken                => ast\flags\BINARY_COALESCE,
-                    TokenKind::SlashToken                           => ast\flags\BINARY_DIV,
-                    TokenKind::XorKeyword                           => ast\flags\BINARY_BOOL_XOR,
+                    TokenKind::AmpersandAmpersandToken              => flags\BINARY_BOOL_AND,
+                    TokenKind::AmpersandToken                       => flags\BINARY_BITWISE_AND,
+                    TokenKind::AndKeyword                           => flags\BINARY_BOOL_AND,
+                    TokenKind::AsteriskAsteriskToken                => flags\BINARY_POW,
+                    TokenKind::AsteriskToken                        => flags\BINARY_MUL,
+                    TokenKind::BarBarToken                          => flags\BINARY_BOOL_OR,
+                    TokenKind::BarToken                             => flags\BINARY_BITWISE_OR,
+                    TokenKind::CaretToken                           => flags\BINARY_BITWISE_XOR,
+                    TokenKind::DotToken                             => flags\BINARY_CONCAT,
+                    TokenKind::EqualsEqualsEqualsToken              => flags\BINARY_IS_IDENTICAL,
+                    TokenKind::EqualsEqualsToken                    => flags\BINARY_IS_EQUAL,
+                    TokenKind::ExclamationEqualsEqualsToken         => flags\BINARY_IS_NOT_IDENTICAL,
+                    TokenKind::ExclamationEqualsToken               => flags\BINARY_IS_NOT_EQUAL,
+                    TokenKind::GreaterThanEqualsToken               => flags\BINARY_IS_GREATER_OR_EQUAL,
+                    TokenKind::GreaterThanGreaterThanToken          => flags\BINARY_SHIFT_RIGHT,
+                    TokenKind::GreaterThanToken                     => flags\BINARY_IS_GREATER,
+                    TokenKind::LessThanEqualsGreaterThanToken       => flags\BINARY_SPACESHIP,
+                    TokenKind::LessThanEqualsToken                  => flags\BINARY_IS_SMALLER_OR_EQUAL,
+                    TokenKind::LessThanLessThanToken                => flags\BINARY_SHIFT_LEFT,
+                    TokenKind::LessThanToken                        => flags\BINARY_IS_SMALLER,
+                    TokenKind::MinusToken                           => flags\BINARY_SUB,
+                    TokenKind::OrKeyword                            => flags\BINARY_BOOL_OR,
+                    TokenKind::PercentToken                         => flags\BINARY_MOD,
+                    TokenKind::PlusToken                            => flags\BINARY_ADD,
+                    TokenKind::QuestionQuestionToken                => flags\BINARY_COALESCE,
+                    TokenKind::SlashToken                           => flags\BINARY_DIV,
+                    TokenKind::XorKeyword                           => flags\BINARY_BOOL_XOR,
                 ];
                 static $assign_lookup = [
-                    TokenKind::AmpersandEqualsToken                 => \ast\flags\BINARY_BITWISE_AND,
-                    TokenKind::AsteriskAsteriskEqualsToken          => \ast\flags\BINARY_POW,
-                    TokenKind::AsteriskEqualsToken                  => \ast\flags\BINARY_MUL,
-                    TokenKind::BarEqualsToken                       => \ast\flags\BINARY_BITWISE_OR,
-                    TokenKind::CaretEqualsToken                     => \ast\flags\BINARY_BITWISE_XOR,
-                    TokenKind::DotEqualsToken                       => \ast\flags\BINARY_CONCAT,
-                    TokenKind::MinusEqualsToken                     => \ast\flags\BINARY_SUB,
-                    TokenKind::PercentEqualsToken                   => \ast\flags\BINARY_MOD,
-                    TokenKind::PlusEqualsToken                      => \ast\flags\BINARY_ADD,
-                    TokenKind::SlashEqualsToken                     => \ast\flags\BINARY_DIV,
-                    TokenKind::GreaterThanGreaterThanEqualsToken    => ast\flags\BINARY_SHIFT_RIGHT,
-                    TokenKind::LessThanLessThanEqualsToken          => ast\flags\BINARY_SHIFT_LEFT,
+                    TokenKind::AmpersandEqualsToken                 => flags\BINARY_BITWISE_AND,
+                    TokenKind::AsteriskAsteriskEqualsToken          => flags\BINARY_POW,
+                    TokenKind::AsteriskEqualsToken                  => flags\BINARY_MUL,
+                    TokenKind::BarEqualsToken                       => flags\BINARY_BITWISE_OR,
+                    TokenKind::CaretEqualsToken                     => flags\BINARY_BITWISE_XOR,
+                    TokenKind::DotEqualsToken                       => flags\BINARY_CONCAT,
+                    TokenKind::MinusEqualsToken                     => flags\BINARY_SUB,
+                    TokenKind::PercentEqualsToken                   => flags\BINARY_MOD,
+                    TokenKind::PlusEqualsToken                      => flags\BINARY_ADD,
+                    TokenKind::SlashEqualsToken                     => flags\BINARY_DIV,
+                    TokenKind::GreaterThanGreaterThanEqualsToken    => flags\BINARY_SHIFT_RIGHT,
+                    TokenKind::LessThanLessThanEqualsToken          => flags\BINARY_SHIFT_LEFT,
                 ];
                 $kind = $n->operator->kind;
                 if ($kind === TokenKind::InstanceOfKeyword) {
@@ -548,34 +549,44 @@ class TolerantASTConverter
             },
             'Microsoft\PhpParser\Node\Expression\UnaryOpExpression' => function (PhpParser\Node\Expression\UnaryOpExpression $n, int $start_line) : ast\Node {
                 static $lookup = [
-                    TokenKind::TildeToken                   => ast\flags\UNARY_BITWISE_NOT,
-                    TokenKind::MinusToken                   => ast\flags\UNARY_MINUS,
-                    TokenKind::PlusToken                    => ast\flags\UNARY_PLUS,
-                    TokenKind::ExclamationToken             => ast\flags\UNARY_BOOL_NOT,
+                    TokenKind::TildeToken                   => flags\UNARY_BITWISE_NOT,
+                    TokenKind::MinusToken                   => flags\UNARY_MINUS,
+                    TokenKind::PlusToken                    => flags\UNARY_PLUS,
+                    TokenKind::ExclamationToken             => flags\UNARY_BOOL_NOT,
                 ];
                 $kind = $n->operator->kind;
                 $ast_kind = $lookup[$kind] ?? null;
                 if ($ast_kind === null) {
                     throw new AssertionError("missing $kind(" . Token::getTokenKindNameFromValue($kind) . ")");
                 }
-                return static::astNodeUnaryOp($ast_kind, static::phpParserNodeToAstNode($n->operand), $start_line);
+                return new ast\Node(
+                    ast\AST_UNARY_OP,
+                    $ast_kind,
+                    ['expr' => static::phpParserNodeToAstNode($n->operand)],
+                    $start_line
+                );
             },
             'Microsoft\PhpParser\Node\Expression\CastExpression' => function (PhpParser\Node\Expression\CastExpression $n, int $start_line) : ast\Node {
                 static $lookup = [
-                    TokenKind::ArrayCastToken   => ast\flags\TYPE_ARRAY,
-                    TokenKind::BoolCastToken    => ast\flags\TYPE_BOOL,
-                    TokenKind::DoubleCastToken  => ast\flags\TYPE_DOUBLE,
-                    TokenKind::IntCastToken     => ast\flags\TYPE_LONG,
-                    TokenKind::ObjectCastToken  => ast\flags\TYPE_OBJECT,
-                    TokenKind::StringCastToken  => ast\flags\TYPE_STRING,
-                    TokenKind::UnsetCastToken   => ast\flags\TYPE_NULL,
+                    TokenKind::ArrayCastToken   => flags\TYPE_ARRAY,
+                    TokenKind::BoolCastToken    => flags\TYPE_BOOL,
+                    TokenKind::DoubleCastToken  => flags\TYPE_DOUBLE,
+                    TokenKind::IntCastToken     => flags\TYPE_LONG,
+                    TokenKind::ObjectCastToken  => flags\TYPE_OBJECT,
+                    TokenKind::StringCastToken  => flags\TYPE_STRING,
+                    TokenKind::UnsetCastToken   => flags\TYPE_NULL,
                 ];
                 $kind = $n->castType->kind;
                 $ast_kind = $lookup[$kind] ?? null;
                 if ($ast_kind === null) {
                     throw new AssertionError("missing $kind");
                 }
-                return static::astNodeCast($ast_kind, $n, $start_line);
+                return new ast\Node(
+                    ast\AST_CAST,
+                    $ast_kind,
+                    ['expr' => static::phpParserNodeToAstNode($n->operand)],
+                    static::getEndLine($n) ?: $start_line
+                );
             },
             'Microsoft\PhpParser\Node\Expression\AnonymousFunctionCreationExpression' => function (PhpParser\Node\Expression\AnonymousFunctionCreationExpression $n, int $start_line) : ast\Node {
                 $ast_return_type = static::phpParserTypeToAstNode($n->returnType, static::getEndLine($n->returnType) ?: $start_line);
@@ -635,14 +646,21 @@ class TolerantASTConverter
                 return new ast\Node(ast\AST_CLONE, 0, ['expr' => static::phpParserNodeToAstNode($n->expression)], $start_line);
             },
             'Microsoft\PhpParser\Node\Expression\ErrorControlExpression' => function (PhpParser\Node\Expression\ErrorControlExpression $n, int $start_line) : ast\Node {
-                return static::astNodeUnaryOp(ast\flags\UNARY_SILENCE, static::phpParserNodeToAstNode($n->operand), $start_line);
+                return new ast\Node(
+                    ast\AST_UNARY_OP,
+                    flags\UNARY_SILENCE,
+                    ['expr' => static::phpParserNodeToAstNode($n->operand)],
+                    $start_line
+                );
             },
             'Microsoft\PhpParser\Node\Expression\EmptyIntrinsicExpression' => function (PhpParser\Node\Expression\EmptyIntrinsicExpression $n, int $start_line) : ast\Node {
                 return new ast\Node(ast\AST_EMPTY, 0, ['expr' => static::phpParserNodeToAstNode($n->expression)], $start_line);
             },
             'Microsoft\PhpParser\Node\Expression\EvalIntrinsicExpression' => function (PhpParser\Node\Expression\EvalIntrinsicExpression $n, int $start_line) : ast\Node {
-                return static::astNodeEval(
-                    static::phpParserNodeToAstNode($n->expression),
+                return new ast\Node(
+                    ast\AST_INCLUDE_OR_EVAL,
+                    flags\EXEC_EVAL,
+                    ['expr' => static::phpParserNodeToAstNode($n->expression)],
                     $start_line
                 );
             },
@@ -651,7 +669,7 @@ class TolerantASTConverter
                 $kind = $token->kind;
                 $str = static::tokenToString($token);
                 if ($kind === TokenKind::StaticKeyword) {
-                    return new ast\Node(ast\AST_NAME, ast\flags\NAME_NOT_FQ, ['name' => $str], $start_line);
+                    return new ast\Node(ast\AST_NAME, flags\NAME_NOT_FQ, ['name' => $str], $start_line);
                 }
                 return $str;
             },
@@ -697,10 +715,12 @@ class TolerantASTConverter
                 }
             },
             'Microsoft\PhpParser\Node\Expression\ScriptInclusionExpression' => function (PhpParser\Node\Expression\ScriptInclusionExpression $n, int $start_line) : ast\Node {
-                return static::astNodeInclude(
-                    static::phpParserNodeToAstNode($n->expression),
-                    $start_line,
-                    $n->requireOrIncludeKeyword
+                $flags = static::phpParserIncludeTokenToAstIncludeFlags($n->requireOrIncludeKeyword);
+                return new ast\Node(
+                    ast\AST_INCLUDE_OR_EVAL,
+                    $flags,
+                    ['expr' => static::phpParserNodeToAstNode($n->expression)],
+                    $start_line
                 );
             },
             /**
@@ -725,7 +745,7 @@ class TolerantASTConverter
                     $right = $ast_issets[$i];
                     $e = new ast\Node(
                         ast\AST_BINARY_OP,
-                        ast\flags\BINARY_BOOL_AND,
+                        flags\BINARY_BOOL_AND,
                         [
                             'left' => $e,
                             'right' => $right,
@@ -747,7 +767,7 @@ class TolerantASTConverter
                 if ($class_type_designator instanceof Token && $class_type_designator->kind === TokenKind::ClassKeyword) {
                     // Node of type AST_CLASS
                     $class_node = static::astStmtClass(
-                        ast\flags\CLASS_ANONYMOUS,
+                        flags\CLASS_ANONYMOUS,
                         null,
                         $n->classBaseClause !== null ? static::phpParserNonValueNodeToAstNode($n->classBaseClause->baseClass) : null,
                         $n->classInterfaceClause,
@@ -863,7 +883,7 @@ class TolerantASTConverter
             'Microsoft\PhpParser\Node\ReservedWord' => function (PhpParser\Node\ReservedWord $n, int $start_line) : ast\Node {
                 return new ast\Node(
                     ast\AST_NAME,
-                    ast\flags\NAME_NOT_FQ,
+                    flags\NAME_NOT_FQ,
                     ['name' => static::tokenToString($n->children)],
                     $start_line
                 );
@@ -887,11 +907,11 @@ class TolerantASTConverter
                     $imploded_parts = static::phpParserNameToString($n);
                 }
                 if ($n->globalSpecifier !== null) {
-                    $ast_kind = ast\flags\NAME_FQ;
+                    $ast_kind = flags\NAME_FQ;
                 } elseif (($n->relativeSpecifier->namespaceKeyword ?? null) !== null) {
-                    $ast_kind = ast\flags\NAME_RELATIVE;
+                    $ast_kind = flags\NAME_RELATIVE;
                 } else {
-                    $ast_kind = ast\flags\NAME_NOT_FQ;
+                    $ast_kind = flags\NAME_NOT_FQ;
                 }
                 return new ast\Node(ast\AST_NAME, $ast_kind, ['name' => $imploded_parts], $start_line);
             },
@@ -1023,7 +1043,7 @@ class TolerantASTConverter
             'Microsoft\PhpParser\Node\Statement\InterfaceDeclaration' => function (PhpParser\Node\Statement\InterfaceDeclaration $n, int $start_line) : ast\Node {
                 $end_line = static::getEndLine($n) ?: $start_line;
                 return static::astStmtClass(
-                    ast\flags\CLASS_INTERFACE,
+                    flags\CLASS_INTERFACE,
                     static::tokenToString($n->name),
                     static::interfaceBaseClauseToNode($n->interfaceBaseClause),
                     null,
@@ -1050,7 +1070,7 @@ class TolerantASTConverter
             'Microsoft\PhpParser\Node\Statement\TraitDeclaration' => function (PhpParser\Node\Statement\TraitDeclaration $n, int $start_line) : ast\Node {
                 $end_line = static::getEndLine($n) ?: $start_line;
                 return static::astStmtClass(
-                    ast\flags\CLASS_TRAIT,
+                    flags\CLASS_TRAIT,
                     static::tokenToString($n->name),
                     null,
                     null,
@@ -1089,7 +1109,7 @@ class TolerantASTConverter
                 }
                 return static::newAstDecl(
                     ast\AST_METHOD,
-                    static::phpParserVisibilityToAstVisibility($n->modifiers) | ($n->byRefToken !== null ? ast\flags\RETURNS_REF : 0),
+                    static::phpParserVisibilityToAstVisibility($n->modifiers) | ($n->byRefToken !== null ? flags\RETURNS_REF : 0),
                     [
                         'params' => static::phpParserParamsToAstParams($n->parameters, $start_line),
                         'uses' => null,
@@ -1471,6 +1491,11 @@ class TolerantASTConverter
         }
     }
 
+    /**
+     * @param ast\Node $try_node
+     * @param ?ast\Node $catches_node
+     * @param ?ast\Node $finally_node
+     */
     private static function astNodeTry(
         $try_node,
         $catches_node,
@@ -1488,6 +1513,9 @@ class TolerantASTConverter
         return new ast\Node(ast\AST_TRY, 0, $children, $start_line);
     }
 
+    /**
+     * @param ast\Node $stmts
+     */
     private static function astStmtCatch(ast\Node $types, string $var, $stmts, int $lineno) : ast\Node
     {
         return new ast\Node(
@@ -1523,7 +1551,10 @@ class TolerantASTConverter
         return new ast\Node(ast\AST_NAME_LIST, 0, $ast_types, $line);
     }
 
-    private static function astNodeWhile($cond, $stmts, int $start_line) : ast\Node
+    /**
+     * @param ast\Node|string|int|float $cond
+     */
+    private static function astNodeWhile($cond, ast\Node $stmts, int $start_line) : ast\Node
     {
         return new ast\Node(
             ast\AST_WHILE,
@@ -1536,6 +1567,10 @@ class TolerantASTConverter
         );
     }
 
+    /**
+     * @param ast\Node|string|int|float $var
+     * @param ast\Node|string|int|float $expr
+     */
     private static function astNodeAssign($var, $expr, int $line, bool $ref) : ast\Node
     {
         return new ast\Node(
@@ -1549,21 +1584,6 @@ class TolerantASTConverter
         );
     }
 
-    private static function astNodeUnaryOp(int $flags, $expr, int $line) : ast\Node
-    {
-        return new ast\Node(ast\AST_UNARY_OP, $flags, ['expr' => $expr], $line);
-    }
-
-    private static function astNodeCast(int $flags, PhpParser\Node\Expression\CastExpression $n, int $line) : ast\Node
-    {
-        return new ast\Node(ast\AST_CAST, $flags, ['expr' => static::phpParserNodeToAstNode($n->operand)], static::getEndLine($n) ?: $line);
-    }
-
-    private static function astNodeEval($expr, int $line) : ast\Node
-    {
-        return new ast\Node(ast\AST_INCLUDE_OR_EVAL, ast\flags\EXEC_EVAL, ['expr' => $expr], $line);
-    }
-
     /**
      * @throws Error if the kind could not be found
      */
@@ -1571,21 +1591,16 @@ class TolerantASTConverter
     {
         switch ($type->kind) {
             case TokenKind::IncludeKeyword:
-                return ast\flags\EXEC_INCLUDE;
+                return flags\EXEC_INCLUDE;
             case TokenKind::IncludeOnceKeyword:
-                return ast\flags\EXEC_INCLUDE_ONCE;
+                return flags\EXEC_INCLUDE_ONCE;
             case TokenKind::RequireKeyword:
-                return ast\flags\EXEC_REQUIRE;
+                return flags\EXEC_REQUIRE;
             case TokenKind::RequireOnceKeyword:
-                return ast\flags\EXEC_REQUIRE_ONCE;
+                return flags\EXEC_REQUIRE_ONCE;
             default:
                 throw new \Error("Unrecognized PhpParser include/require type");
         }
-    }
-    private static function astNodeInclude($expr, int $line, Token $type) : ast\Node
-    {
-        $flags = static::phpParserIncludeTokenToAstIncludeFlags($type);
-        return new ast\Node(ast\AST_INCLUDE_OR_EVAL, $flags, ['expr' => $expr], $line);
     }
 
     /**
@@ -1606,47 +1621,47 @@ class TolerantASTConverter
         if (\is_string($type)) {
             switch (\strtolower($type)) {
                 case 'null':
-                    $flags = ast\flags\TYPE_NULL;
+                    $flags = flags\TYPE_NULL;
                     break;
                 case 'bool':
-                    $flags = ast\flags\TYPE_BOOL;
+                    $flags = flags\TYPE_BOOL;
                     break;
                 case 'int':
-                    $flags = ast\flags\TYPE_LONG;
+                    $flags = flags\TYPE_LONG;
                     break;
                 case 'float':
-                    $flags = ast\flags\TYPE_DOUBLE;
+                    $flags = flags\TYPE_DOUBLE;
                     break;
                 case 'string':
-                    $flags = ast\flags\TYPE_STRING;
+                    $flags = flags\TYPE_STRING;
                     break;
                 case 'array':
-                    $flags = ast\flags\TYPE_ARRAY;
+                    $flags = flags\TYPE_ARRAY;
                     break;
                 case 'object':
-                    $flags = ast\flags\TYPE_OBJECT;
+                    $flags = flags\TYPE_OBJECT;
                     break;
                 case 'callable':
-                    $flags = ast\flags\TYPE_CALLABLE;
+                    $flags = flags\TYPE_CALLABLE;
                     break;
                 case 'void':
-                    $flags = ast\flags\TYPE_VOID;
+                    $flags = flags\TYPE_VOID;
                     break;
                 case 'iterable':
-                    $flags = ast\flags\TYPE_ITERABLE;
+                    $flags = flags\TYPE_ITERABLE;
                     break;
                 default:
                     // TODO: Refactor this into a function accepting a QualifiedName
                     if ($original_type instanceof PhpParser\Node\QualifiedName) {
                         if ($original_type->globalSpecifier !== null) {
-                            $ast_kind = ast\flags\NAME_FQ;
+                            $ast_kind = flags\NAME_FQ;
                         } elseif (($original_type->relativeSpecifier->namespaceKeyword ?? null) !== null) {
-                            $ast_kind = ast\flags\NAME_RELATIVE;
+                            $ast_kind = flags\NAME_RELATIVE;
                         } else {
-                            $ast_kind = ast\flags\NAME_NOT_FQ;
+                            $ast_kind = flags\NAME_NOT_FQ;
                         }
                     } else {
-                        $ast_kind = ast\flags\NAME_NOT_FQ;
+                        $ast_kind = flags\NAME_NOT_FQ;
                     }
                     return new ast\Node(
                         ast\AST_NAME,
@@ -1664,6 +1679,7 @@ class TolerantASTConverter
      * @param bool $by_ref
      * @param ?ast\Node $type
      * @param string $name
+     * @param ?ast\Node|?int|?string|?float $default
      */
     private static function astNodeParam(bool $is_nullable, bool $by_ref, bool $variadic, $type, $name, $default, int $line) : ast\Node
     {
@@ -1677,7 +1693,7 @@ class TolerantASTConverter
         }
         return new ast\Node(
             ast\AST_PARAM,
-            ($by_ref ? ast\flags\PARAM_REF : 0) | ($variadic ? ast\flags\PARAM_VARIADIC : 0),
+            ($by_ref ? flags\PARAM_REF : 0) | ($variadic ? flags\PARAM_VARIADIC : 0),
             [
                 'type' => $type,
                 'name' => $name,
@@ -1705,6 +1721,9 @@ class TolerantASTConverter
         );
     }
 
+    /**
+     * @param PhpParser\Node|PhpParser\Token $parser_node
+     */
     protected static function astStub($parser_node) : ast\Node
     {
         // Debugging code.
@@ -1828,6 +1847,8 @@ class TolerantASTConverter
     }
 
     /**
+     * @param ?ast\Node $uses
+     * @param ?ast\Node $return_type
      * @param ?string $doc_comment
      */
     private static function astDeclClosure(
@@ -1835,7 +1856,7 @@ class TolerantASTConverter
         bool $static,
         ast\Node $params,
         $uses,
-        $stmts,
+        ast\Node $stmts,
         $return_type,
         int $start_line,
         int $end_line,
@@ -1843,7 +1864,7 @@ class TolerantASTConverter
     ) : ast\Node {
         return static::newAstDecl(
             ast\AST_CLOSURE,
-            ($by_ref ? ast\flags\RETURNS_REF : 0) | ($static ? ast\flags\MODIFIER_STATIC : 0),
+            ($by_ref ? flags\RETURNS_REF : 0) | ($static ? flags\MODIFIER_STATIC : 0),
             [
                 'params' => $params,
                 'uses' => $uses,
@@ -1875,7 +1896,7 @@ class TolerantASTConverter
     ) : ast\Node {
         return static::newAstDecl(
             ast\AST_FUNC_DECL,
-            $by_ref ? ast\flags\RETURNS_REF : 0,
+            $by_ref ? flags\RETURNS_REF : 0,
             [
                 'params' => $params,
                 'uses' => null,
@@ -1901,9 +1922,9 @@ class TolerantASTConverter
         }
         switch ($flags->kind) {
             case TokenKind::AbstractKeyword:
-                return ast\flags\CLASS_ABSTRACT;
+                return flags\CLASS_ABSTRACT;
             case TokenKind::FinalKeyword:
-                return ast\flags\CLASS_FINAL;
+                return flags\CLASS_FINAL;
             default:
                 throw new InvalidArgumentException("Unexpected kind '" . Token::getTokenKindNameFromValue($flags->kind) . "'");
         }
@@ -1955,10 +1976,10 @@ class TolerantASTConverter
         // the empty string or '0' is a missing string we pretend is an anonymous class
         // so that Phan won't throw an UnanalyzableException during the analysis phase
         if ($name === null || !$name) {
-            $flags |= ast\flags\CLASS_ANONYMOUS;
+            $flags |= flags\CLASS_ANONYMOUS;
         }
 
-        if (($flags & ast\flags\CLASS_INTERFACE) > 0) {
+        if (($flags & flags\CLASS_INTERFACE) > 0) {
             $children = [
                 'extends'    => null,
                 'implements' => $extends,
@@ -2024,11 +2045,11 @@ class TolerantASTConverter
     {
         switch ($kind ?? 0) {
             case TokenKind::FunctionKeyword:
-                return ast\flags\USE_FUNCTION;
+                return flags\USE_FUNCTION;
             case TokenKind::ConstKeyword:
-                return ast\flags\USE_CONST;
+                return flags\USE_CONST;
             case 0:
-                return ast\flags\USE_NORMAL;
+                return flags\USE_NORMAL;
             default:
                 throw new \InvalidArgumentException("Unexpected kind '" . Token::getTokenKindNameFromValue($kind ?? 0) . "'");
         }
@@ -2065,6 +2086,7 @@ class TolerantASTConverter
     }
 
     /**
+     * @param ?int $type
      * @param ?string $alias
      * @return ast\Node
      */
@@ -2087,7 +2109,7 @@ class TolerantASTConverter
     {
         $flags = static::phpParserNamespaceUseKindToASTUseFlags($type);
         $uses = new ast\Node(ast\AST_USE, 0, $uses, $line);
-        if ($flags === ast\flags\USE_NORMAL) {
+        if ($flags === flags\USE_NORMAL) {
             foreach ($uses->children as $use) {
                 if ($use->flags !== 0) {
                     $flags = 0;
@@ -2096,7 +2118,7 @@ class TolerantASTConverter
             }
         } else {
             foreach ($uses->children as $use) {
-                if ($use->flags === ast\flags\USE_NORMAL) {
+                if ($use->flags === flags\USE_NORMAL) {
                     $use->flags = 0;
                 }
             }
@@ -2113,6 +2135,11 @@ class TolerantASTConverter
         );
     }
 
+    /**
+     * @param ast\Node|string|int|float|null $cond (null for else statements)
+     * @param ast\Node $stmts
+     * @param int $line
+     */
     private static function astIfElem($cond, $stmts, int $line) : ast\Node
     {
         return new ast\Node(ast\AST_IF_ELEM, 0, ['cond' => $cond, 'stmts' => $stmts], $line);
@@ -2312,29 +2339,29 @@ class TolerantASTConverter
         foreach ($visibility as $token) {
             switch ($token->kind) {
                 case TokenKind::PublicKeyword:
-                    $ast_visibility |= ast\flags\MODIFIER_PUBLIC;
+                    $ast_visibility |= flags\MODIFIER_PUBLIC;
                     break;
                 case TokenKind::ProtectedKeyword:
-                    $ast_visibility |= ast\flags\MODIFIER_PROTECTED;
+                    $ast_visibility |= flags\MODIFIER_PROTECTED;
                     break;
                 case TokenKind::PrivateKeyword:
-                    $ast_visibility |= ast\flags\MODIFIER_PRIVATE;
+                    $ast_visibility |= flags\MODIFIER_PRIVATE;
                     break;
                 case TokenKind::StaticKeyword:
-                    $ast_visibility |= ast\flags\MODIFIER_STATIC;
+                    $ast_visibility |= flags\MODIFIER_STATIC;
                     break;
                 case TokenKind::AbstractKeyword:
-                    $ast_visibility |= ast\flags\MODIFIER_ABSTRACT;
+                    $ast_visibility |= flags\MODIFIER_ABSTRACT;
                     break;
                 case TokenKind::FinalKeyword:
-                    $ast_visibility |= ast\flags\MODIFIER_FINAL;
+                    $ast_visibility |= flags\MODIFIER_FINAL;
                     break;
                 default:
                     throw new \RuntimeException("Unexpected visibility modifier '" . Token::getTokenKindNameFromValue($token->kind) . "'");
             }
         }
-        if ($automatically_add_public && !($ast_visibility & (ast\flags\MODIFIER_PUBLIC | ast\flags\MODIFIER_PROTECTED | ast\flags\MODIFIER_PRIVATE))) {
-            $ast_visibility |= ast\flags\MODIFIER_PUBLIC;
+        if ($automatically_add_public && !($ast_visibility & (flags\MODIFIER_PUBLIC | flags\MODIFIER_PROTECTED | flags\MODIFIER_PRIVATE))) {
+            $ast_visibility |= flags\MODIFIER_PUBLIC;
         }
         return $ast_visibility;
     }
@@ -2348,7 +2375,7 @@ class TolerantASTConverter
             if ($prop instanceof Token) {
                 continue;
             }
-            // @phan-suppress-next-line PhanTypeMismatchArgument casting to a more specific node
+            // @phan-suppress-next-line PhanTypeMismatchArgument, PhanPartialTypeMismatchArgument casting to a more specific node
             $prop_elems[] = static::phpParserPropelemToAstPropelem($prop, $i === 0 ? $doc_comment : null);
         }
         $flags = static::phpParserVisibilityToAstVisibility($n->modifiers, false);
@@ -2364,7 +2391,7 @@ class TolerantASTConverter
             if ($const_elem instanceof Token) {
                 continue;
             }
-            // @phan-suppress-next-line PhanTypeMismatchArgument casting to something more specific
+            // @phan-suppress-next-line PhanTypeMismatchArgument, PhanPartialTypeMismatchArgument casting to a more specific node
             $const_elems[] = static::phpParserConstelemToAstConstelem($const_elem, $i === 0 ? $doc_comment : null);
         }
         $flags = static::phpParserVisibilityToAstVisibility($n->modifiers);
@@ -2427,13 +2454,17 @@ class TolerantASTConverter
         return new ast\Node(ast\AST_DECLARE, 0, $children, $start_line);
     }
 
+    /**
+     * @param string|ast\Node $expr
+     * @param ast\Node $args
+     */
     private static function astNodeCall($expr, $args, int $start_line) : ast\Node
     {
         if (\is_string($expr)) {
             if (substr($expr, 0, 1) === '\\') {
                 $expr = substr($expr, 1);
             }
-            $expr = new ast\Node(ast\AST_NAME, ast\flags\NAME_FQ, ['name' => $expr], $start_line);
+            $expr = new ast\Node(ast\AST_NAME, flags\NAME_FQ, ['name' => $expr], $start_line);
         }
         return new ast\Node(ast\AST_CALL, 0, ['expr' => $expr, 'args' => $args], $start_line);
     }
@@ -2458,13 +2489,14 @@ class TolerantASTConverter
             if (\substr($class, 0, 1) === '\\') {
                 $class = \substr($class, 1);
             }
-            $class = new ast\Node(ast\AST_NAME, ast\flags\NAME_FQ, ['name' => $class], $start_line);
+            $class = new ast\Node(ast\AST_NAME, flags\NAME_FQ, ['name' => $class], $start_line);
         }
         return new ast\Node(ast\AST_STATIC_CALL, 0, ['class' => $class, 'method' => $method, 'args' => $args], $start_line);
     }
 
     /**
      * TODO: Get rid of this function?
+     * @param string|PhpParser\Node|null|array $comments
      * @return ?string the doc comment, or null
      */
     private static function extractPhpdocComment($comments)
@@ -2513,7 +2545,7 @@ class TolerantASTConverter
         if (self::$php_version_id_parsing < 70100 && \count($ast_items) === 0) {
             $ast_items[] = null;
         }
-        return new ast\Node(ast\AST_ARRAY, ast\flags\ARRAY_SYNTAX_LIST, $ast_items, $start_line);
+        return new ast\Node(ast\AST_ARRAY, flags\ARRAY_SYNTAX_LIST, $ast_items, $start_line);
     }
 
     private static function phpParserArrayToAstArray(PhpParser\Node\Expression\ArrayCreationExpression $n, int $start_line) : ast\Node
@@ -2534,7 +2566,7 @@ class TolerantASTConverter
             if (!($item instanceof PhpParser\Node\ArrayElement)) {
                 throw new AssertionError("Expected ArrayElement");
             }
-            $flags = $item->byRef ? ast\flags\PARAM_REF : 0;
+            $flags = $item->byRef ? flags\PARAM_REF : 0;
             $ast_items[] = new ast\Node(ast\AST_ARRAY_ELEM, $flags, [
                 'value' => static::phpParserNodeToAstNode($item->elementValue),
                 'key' => $item->elementKey !== null ? static::phpParserNodeToAstNode($item->elementKey) : null,
@@ -2545,9 +2577,9 @@ class TolerantASTConverter
         } else {
             $kind = $n->openParenOrBracket->kind;
             if ($kind === TokenKind::OpenBracketToken) {
-                $flags = ast\flags\ARRAY_SYNTAX_SHORT;
+                $flags = flags\ARRAY_SYNTAX_SHORT;
             } else {
-                $flags = ast\flags\ARRAY_SYNTAX_LONG;
+                $flags = flags\ARRAY_SYNTAX_LONG;
             }
         }
         // Workaround for ast line choice
@@ -2622,14 +2654,14 @@ class TolerantASTConverter
 
     /** @internal */
     const _MAGIC_CONST_LOOKUP = [
-        '__LINE__' => \ast\flags\MAGIC_LINE,
-        '__FILE__' => \ast\flags\MAGIC_FILE,
-        '__DIR__' => \ast\flags\MAGIC_DIR,
-        '__NAMESPACE__' => \ast\flags\MAGIC_NAMESPACE,
-        '__FUNCTION__' => \ast\flags\MAGIC_FUNCTION,
-        '__METHOD__' => \ast\flags\MAGIC_METHOD,
-        '__CLASS__' => \ast\flags\MAGIC_CLASS,
-        '__TRAIT__' => \ast\flags\MAGIC_TRAIT,
+        '__LINE__' => flags\MAGIC_LINE,
+        '__FILE__' => flags\MAGIC_FILE,
+        '__DIR__' => flags\MAGIC_DIR,
+        '__NAMESPACE__' => flags\MAGIC_NAMESPACE,
+        '__FUNCTION__' => flags\MAGIC_FUNCTION,
+        '__METHOD__' => flags\MAGIC_METHOD,
+        '__CLASS__' => flags\MAGIC_CLASS,
+        '__TRAIT__' => flags\MAGIC_TRAIT,
     ];
 
     // FIXME don't use in places expecting non-strings.
@@ -2710,7 +2742,7 @@ class TolerantASTConverter
     private static function newPlaceholderExpression($n) : ast\Node
     {
         $start_line = self::getStartLine($n);
-        $name_node = new ast\Node(ast\AST_NAME, ast\flags\NAME_FQ, ['name' => '__INCOMPLETE_EXPR__'], $start_line);
+        $name_node = new ast\Node(ast\AST_NAME, flags\NAME_FQ, ['name' => '__INCOMPLETE_EXPR__'], $start_line);
         return new ast\Node(ast\AST_CONST, 0, ['name' => $name_node], $start_line);
     }
 }

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverterWithNodeMapping.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverterWithNodeMapping.php
@@ -2,6 +2,7 @@
 
 namespace Phan\AST\TolerantASTConverter;
 
+use AssertionError;
 use ast;
 use Closure;
 use InvalidArgumentException;
@@ -144,6 +145,7 @@ class TolerantASTConverterWithNodeMapping extends TolerantASTConverter
     ];
 
     /**
+     * @param PhpParser\Node $parser_node
      * @return bool|PhpParser\Node|PhpParser\Token (Returns $parser_node if that node was what the cursor is pointing directly to)
      */
     private static function findNodeAtOffsetRecursive($parser_node, int $offset)
@@ -194,6 +196,9 @@ class TolerantASTConverterWithNodeMapping extends TolerantASTConverter
                     // fwrite(STDERR, "Found parent node for $key: " . get_class($parser_node) . "\n");
                     // fwrite(STDERR, "Found parent node for $key: " . json_encode($parser_node) . "\n");
                     if ($state instanceof PhpParser\Node) {
+                        if (!is_string($key)) {
+                            throw new AssertionError("Expected key to be a string");
+                        }
                         return self::adjustClosestNodeOrToken($parser_node, $key);
                     }
                     return true;
@@ -208,9 +213,10 @@ class TolerantASTConverterWithNodeMapping extends TolerantASTConverter
      * (so that functionality such as "go to definition" for classes, properties, etc. will work as expected)
      *
      * @param PhpParser\Node $node the parent node of the old value of
+     * @param string $key
      * @return PhpParser\Node|true
      */
-    private static function adjustClosestNodeOrToken(PhpParser\Node $node, $key)
+    private static function adjustClosestNodeOrToken(PhpParser\Node $node, string $key)
     {
         switch ($key) {
             case 'memberName':

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1114,6 +1114,7 @@ class UnionTypeVisitor extends AnalysisVisitor
                 $class->getMethodByName($this->code_base, '__construct');
 
             // Map each argument to its type
+            /** @param Node|string|int|float $arg_node */
             $arg_type_list = \array_map(function ($arg_node) : UnionType {
                 return UnionTypeVisitor::unionTypeFromNode(
                     $this->code_base,

--- a/src/Phan/Analysis/ArgumentType.php
+++ b/src/Phan/Analysis/ArgumentType.php
@@ -663,6 +663,8 @@ final class ArgumentType
      * Used to check if a place expecting a reference is actually getting a reference from a node.
      * Obvious types which are always references (properties, variables) must be checked for before calling this.
      *
+     * @param Node|string|int|float $node
+     *
      * @return bool - True if this node is a call to a function that may return a reference?
      */
     private static function isFunctionReturningReference(CodeBase $code_base, Context $context, $node) : bool

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -318,6 +318,7 @@ class AssignmentVisitor extends AnalysisVisitor
     }
 
     /**
+     * @param Node|string|int|float $value_node
      * @return void
      */
     private function analyzeValueNodeOfShapedArray(

--- a/src/Phan/Analysis/BlockExitStatusChecker.php
+++ b/src/Phan/Analysis/BlockExitStatusChecker.php
@@ -87,6 +87,9 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
         return self::STATUS_PROCEED;
     }
 
+    /**
+     * @param Node|string|int|float $cond
+     */
     private static function isTruthyLiteral($cond) : bool
     {
         if ($cond instanceof Node) {
@@ -458,9 +461,13 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
         return self::STATUS_PROCEED;
     }
 
+    /**
+     * @param Node|string|int|float $constant_ast
+     */
     private function computeTriggerErrorStatusCodeForConstant($constant_ast) : int
     {
         // return PROCEED if this can't be determined.
+        // TODO: Could check for integer literals
         if (!($constant_ast instanceof Node)) {
             return self::STATUS_PROCEED;
         }

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -1234,6 +1234,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
     }
 
     /**
+     * @param ?Node|?string|?int|?float $node
      * @return \Generator|array<int,UnionType>
      * @phan-return \Generator<int,UnionType>
      */

--- a/src/Phan/Analysis/RegexAnalyzer.php
+++ b/src/Phan/Analysis/RegexAnalyzer.php
@@ -76,6 +76,7 @@ class RegexAnalyzer
         UnionType $type
     ) : UnionType {
         $field_types = array_map(
+            /** @param true $_ */
             function ($_) use ($type) : UnionType {
                 return $type;
             },

--- a/src/Phan/Bootstrap.php
+++ b/src/Phan/Bootstrap.php
@@ -63,6 +63,10 @@ function with_disabled_phan_error_handler(Closure $closure)
  *
  * @suppress PhanUnreferencedFunction
  * @suppress PhanAccessMethodInternal
+ * @param int $errno
+ * @param string $errstr
+ * @param string $errfile
+ * @param int $errline
  * @return bool
  */
 function phan_error_handler($errno, $errstr, $errfile, $errline)

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -278,7 +278,7 @@ class CLI
                     break;
                 case 'm':
                 case 'output-mode':
-                    if (!in_array($value, $factory->getTypes(), true)) {
+                    if (!is_string($value) || !in_array($value, $factory->getTypes(), true)) {
                         $this->usage(
                             sprintf(
                                 'Unknown output mode %s. Known values are [%s]',
@@ -287,6 +287,7 @@ class CLI
                             ),
                             EXIT_FAILURE
                         );
+                        return;  // unreachable
                     }
 
                     $printer_type = $value;
@@ -503,7 +504,8 @@ class CLI
 
         $this->ensureASTParserExists();
 
-        $printer = $factory->getPrinter($printer_type, $this->output);
+        $output = $this->output;
+        $printer = $factory->getPrinter($printer_type, $output);
         $filter  = new ChainedIssueFilter([
             new FileIssueFilter(new Phan()),
             new MinimumSeverityFilter($minimum_severity),

--- a/src/Phan/Config/Initializer.php
+++ b/src/Phan/Config/Initializer.php
@@ -119,6 +119,8 @@ class Initializer
     }
 
     /**
+     * @param string $setting_name
+     * @param string|int|float|bool|array|null $setting_value
      * @param array<int,string> $additional_comment_lines
      */
     public static function generateEntrySnippetForSetting(string $setting_name, $setting_value, array $additional_comment_lines) : string

--- a/src/Phan/Debug.php
+++ b/src/Phan/Debug.php
@@ -47,6 +47,8 @@ class Debug
      * Print the name of a node to the terminal
      *
      * @suppress PhanUnreferencedPublicMethod
+     * @param Node|string|null $node
+     * @param int $indent
      * @return void
      */
     public static function printNodeName($node, $indent = 0)
@@ -245,6 +247,8 @@ class Debug
     /**
      * Dumps abstract syntax tree
      * Source: https://github.com/nikic/php-ast/blob/master/util.php
+     * @param Node|string|int|float|null $ast
+     * @param int $options (self::AST_DUMP_*)
      */
     public static function astDump($ast, int $options = 0) : string
     {

--- a/src/Phan/ForkPool.php
+++ b/src/Phan/ForkPool.php
@@ -212,7 +212,11 @@ class ForkPool
         }
 
         // Unmarshal the content into its original form.
-        return array_values(array_map(/** @return array */ function ($data) {
+        /**
+         * @param string $data
+         * @return array
+         */
+        return array_values(array_map(function ($data) {
             $result = unserialize($data);
             if (!\is_array($result)) {
                 error_log("Child terminated without returning a serialized array (threw or crashed - not enough memory?): response type=" . gettype($result));

--- a/src/Phan/IssueFixSuggester.php
+++ b/src/Phan/IssueFixSuggester.php
@@ -238,15 +238,24 @@ class IssueFixSuggester
             return null;
         }
         $property_set = self::suggestSimilarPropertyMap($code_base, $context, $class, $wanted_property_name, $is_static);
-        if (count($property_set) === 0) {
-            return null;
-        }
-        uksort($property_set, 'strcmp');
         $suggestions = [];
+        if ($is_static) {
+            if ($class->hasConstantWithName($code_base, $wanted_property_name)) {
+                $suggestions[] = '::' . $wanted_property_name;
+            }
+        }
+        if ($class->hasMethodWithName($code_base, $wanted_property_name)) {
+            $method = $class->getMethodByName($code_base, $wanted_property_name);
+            $suggestions[] = ($method->isStatic() ? '::' : '->') . $wanted_property_name . '()';
+        }
         foreach ($property_set as $property_name => $_) {
             $prefix = $is_static ? 'expr::$' : 'expr->' ;
             $suggestions[] = $prefix . $property_name;
         }
+        if (count($suggestions) === 0) {
+            return null;
+        }
+        uksort($suggestions, 'strcmp');
         return Suggestion::fromString(
             'Did you mean ' . implode(' or ', $suggestions)
         );

--- a/src/Phan/IssueFixSuggester.php
+++ b/src/Phan/IssueFixSuggester.php
@@ -36,6 +36,9 @@ class IssueFixSuggester
      */
     public static function createFQSENFilterFromClassFilter(CodeBase $code_base, Closure $class_closure)
     {
+        /**
+         * @param FullyQualifiedClassName $alternate_fqsen
+         */
         return function ($alternate_fqsen) use ($code_base, $class_closure) : bool {
             if (!($alternate_fqsen instanceof FullyQualifiedClassName)) {
                 return false;

--- a/src/Phan/Language/Element/FunctionFactory.php
+++ b/src/Phan/Language/Element/FunctionFactory.php
@@ -150,6 +150,9 @@ class FunctionFactory
         }
 
         $alternate_id = 0;
+        /**
+         * @param array<string,mixed> $map
+         */
         return \array_map(function ($map) use (
             $function,
             &$alternate_id

--- a/src/Phan/Language/FQSEN/AbstractFQSEN.php
+++ b/src/Phan/Language/FQSEN/AbstractFQSEN.php
@@ -113,6 +113,7 @@ abstract class AbstractFQSEN implements FQSEN, Serializable
     }
 
     /**
+     * @param string $unused_serialized
      * @throws Error to prevent accidentally calling this
      */
     public function unserialize($unused_serialized)

--- a/src/Phan/Language/FileRef.php
+++ b/src/Phan/Language/FileRef.php
@@ -142,9 +142,12 @@ class FileRef implements \Serializable
 
     public function serialize()
     {
-        return (string)$this;
+        return $this->__toString();
     }
 
+    /**
+     * @param string $serialized
+     */
     public function unserialize($serialized)
     {
         $map = explode(':', $serialized);

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -572,6 +572,7 @@ class Type
     }
 
     /**
+     * @param mixed $object
      * @return Type
      * Get a type for the given object. Equivalent to Type::fromObject($object)->asNonLiteralType()
      */
@@ -595,6 +596,7 @@ class Type
     }
 
     /**
+     * @param mixed $object
      * @return Type
      * Get a type for the given object
      * @throws AssertionError if the type was unexpected

--- a/src/Phan/Output/Collector/ParallelParentCollector.php
+++ b/src/Phan/Output/Collector/ParallelParentCollector.php
@@ -54,7 +54,7 @@ class ParallelParentCollector implements IssueCollectorInterface
 
         // Listen for ALARMS that indicate we should flush
         // the queue
-        pcntl_sigprocmask(SIG_UNBLOCK, array(SIGUSR1), $old);
+        pcntl_sigprocmask(SIG_UNBLOCK, [SIGUSR1], $old);
         pcntl_signal(SIGUSR1, function () {
             $this->readQueuedIssues();
         });

--- a/src/Phan/Output/PrinterFactory.php
+++ b/src/Phan/Output/PrinterFactory.php
@@ -24,6 +24,9 @@ class PrinterFactory
         return ['text', 'json', 'csv', 'codeclimate', 'checkstyle', 'pylint'];
     }
 
+    /**
+     * @param ?string $type
+     */
     public function getPrinter($type, OutputInterface $output):IssuePrinterInterface
     {
         switch ($type) {

--- a/src/Phan/Phan.php
+++ b/src/Phan/Phan.php
@@ -298,7 +298,7 @@ class Phan implements IgnoredFilesFilterInterface
             // analysis
             $analyze_file_path_list = array_filter(
                 $analyze_file_path_list,
-                function ($file_path) : bool {
+                function (string $file_path) : bool {
                     return !self::isExcludedAnalysisFile($file_path);
                 }
             );
@@ -328,7 +328,7 @@ class Phan implements IgnoredFilesFilterInterface
              * This worker takes a file and analyzes it
              * @return void
              */
-            $analysis_worker = function ($i, $file_path) use ($file_count, $code_base, $temporary_file_mapping, $request) {
+            $analysis_worker = function (int $i, string $file_path) use ($file_count, $code_base, $temporary_file_mapping, $request) {
                 CLI::progress('analyze', ($i + 1) / $file_count);
                 Analysis::analyzeFile($code_base, $file_path, $request, $temporary_file_mapping[$file_path] ?? null);
             };

--- a/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
@@ -20,6 +20,8 @@ use Phan\Language\UnionType;
 use Phan\PluginV2\ReturnTypeOverrideCapability;
 use Phan\PluginV2;
 
+use ast\Node;
+
 /**
  * NOTE: This is automatically loaded by phan. Do not include it in a config.
  *
@@ -212,6 +214,9 @@ final class ArrayReturnTypeOverridePlugin extends PluginV2 implements
             $arguments = \array_slice($args, 1);
             $possible_return_types = UnionType::empty();
             $cache_outer = [];
+            /**
+             * @param Node|int|string|float|null $argument
+             */
             $get_argument_type = function ($argument, int $i) use ($code_base, $context, &$cache_outer) : UnionType {
                 if (isset($cache_outer[$i])) {
                     return $cache_outer[$i];
@@ -227,6 +232,9 @@ final class ArrayReturnTypeOverridePlugin extends PluginV2 implements
             };
             $cache = [];
             // Don't calculate argument types more than once.
+            /**
+             * @param Node|int|string|float|null $argument
+             */
             $get_argument_type_for_array_map = function ($argument, int $i) use ($get_argument_type, &$cache) : UnionType {
                 if (isset($cache[$i])) {
                     return $cache[$i];

--- a/src/Phan/Plugin/Internal/ClosureReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ClosureReturnTypeOverridePlugin.php
@@ -261,6 +261,9 @@ final class ClosureReturnTypeOverridePlugin extends PluginV2 implements
     public static function createNormalArgumentCache(CodeBase $code_base, Context $context) : Closure
     {
         $cache = [];
+        /**
+         * @param Node|int|string|float|null $argument
+         */
         return function ($argument, int $i) use ($code_base, $context, &$cache) : UnionType {
             $argument_type = $cache[$i] ?? null;
             if (isset($argument_type)) {

--- a/src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php
@@ -42,7 +42,7 @@ final class DependentReturnTypeOverridePlugin extends PluginV2 implements
         /**
          * @phan-return Closure(CodeBase,Context,Func,array):UnionType
          */
-        $make_dependent_type_method = static function (int $expected_bool_pos, $type_if_true, $type_if_false, $type_if_unknown) : Closure {
+        $make_dependent_type_method = static function (int $expected_bool_pos, UnionType $type_if_true, UnionType $type_if_false, UnionType $type_if_unknown) : Closure {
             /**
              * @param Func $function @phan-unused-param
              * @return UnionType

--- a/src/Phan/Plugin/Internal/MiscParamPlugin.php
+++ b/src/Phan/Plugin/Internal/MiscParamPlugin.php
@@ -17,8 +17,9 @@ use Phan\Language\UnionType;
 use Phan\PluginV2\AnalyzeFunctionCallCapability;
 use Phan\PluginV2\StopParamAnalysisException;
 use Phan\PluginV2;
-use Closure;
 
+use ast\Node;
+use Closure;
 use function count;
 
 /**
@@ -316,7 +317,10 @@ final class MiscParamPlugin extends PluginV2 implements
             }
         };
 
-        /** @return string */
+        /**
+         * @param Node|int|string|float|null $node
+         * @return string
+         */
         $get_variable_name = function (
             CodeBase $code_base,
             Context $context,
@@ -472,6 +476,7 @@ final class MiscParamPlugin extends PluginV2 implements
     }
 
     /**
+     * @param Node|int|string|float|null $node
      * @param Closure(UnionType):IssueInstance $issue_instance
      */
     private static function analyzeNodeUnionTypeCast(
@@ -508,6 +513,7 @@ final class MiscParamPlugin extends PluginV2 implements
     }
 
     /**
+     * @param Node|int|string|float|null $node
      * @param Closure(UnionType):IssueInstance $issue_instance
      */
     private static function analyzeNodeUnionTypeCastStringArrayLike(

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableGraph.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableGraph.php
@@ -124,6 +124,7 @@ final class VariableGraph
      * Marks something as being a loop variable `$v` in `foreach ($arr as $k => $v)`
      * (Common false positive, since there's no way to avoid setting the value)
      *
+     * @param Node|string|int|float|null $node
      * @return void
      */
     public function markAsLoopValueNode($node)
@@ -145,6 +146,7 @@ final class VariableGraph
      * Marks something as being a loop variable `$v` in `foreach ($arr as $k => $v)`
      * (Common false positive, since there's no way to avoid setting the value)
      *
+     * @param Node|int|string|float|null $node
      * @return void
      */
     public function markAsCaughtException($node)

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
@@ -145,6 +145,9 @@ final class VariableTrackerVisitor extends AnalysisVisitor
         return $this->analyzeAssignmentTarget($node->children['var'], false);
     }
 
+    /**
+     * @param Node|int|string|float|null $node
+     */
     private function analyzeAssignmentTarget($node, bool $is_ref) : VariableTrackingScope
     {
         // TODO: Push onto the node list?
@@ -240,6 +243,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
     }
 
     /**
+     * @param Node|string|int|float|null $child_node
      * @return VariableTrackingScope
      */
     private function analyzeWhenValidNode(VariableTrackingScope $scope, $child_node)

--- a/src/Phan/Profile.php
+++ b/src/Phan/Profile.php
@@ -77,7 +77,7 @@ trait Profile
             }
 
             // Sort such that the highest metric value is on top
-            uasort($label_metric_map, function ($a, $b) : int {
+            uasort($label_metric_map, function (array $a, array $b) : int {
                 return $b[1] <=> $a[1];
             });
 

--- a/tests/Phan/AST/ASTReverterTest.php
+++ b/tests/Phan/AST/ASTReverterTest.php
@@ -7,6 +7,8 @@ use Phan\Tests\BaseTest;
 use Phan\AST\ASTReverter;
 use Phan\Config;
 
+use AssertionError;
+
 final class ASTReverterTest extends BaseTest
 {
     /**
@@ -20,6 +22,9 @@ final class ASTReverterTest extends BaseTest
         $statements = \ast\parse_code($file_contents, Config::AST_VERSION);
         $this->assertSame(1, count($statements->children));
         $snippet_node = $statements->children[0];
+        if ($snippet_node === null) {
+            throw new AssertionError("invalid first statement in statement list");
+        }
 
         $reverter = new ASTReverter();
         $this->assertSame($expected, $reverter->toShortString($snippet_node));

--- a/tests/Phan/AST/TolerantASTConverter/ConversionTest.php
+++ b/tests/Phan/AST/TolerantASTConverter/ConversionTest.php
@@ -95,7 +95,10 @@ final class ConversionTest extends BaseTest
         return $tests;
     }
 
-    /** @return void */
+    /**
+     * @param ast\Node|int|string|float|null $node
+     * @return void
+     */
     private static function normalizeOriginalAST($node)
     {
         if ($node instanceof ast\Node) {

--- a/tests/Phan/AST/TolerantASTConverter/TolerantASTConverterWithNodeMappingTest.php
+++ b/tests/Phan/AST/TolerantASTConverter/TolerantASTConverterWithNodeMappingTest.php
@@ -42,6 +42,9 @@ final class TolerantASTConverterWithNodeMappingTest extends BaseTest
         $this->assertEquals($expected_node, $selected_node);
     }
 
+    /**
+     * @param Node|string|int|float|null $node
+     */
     private function findSelectedNode($node) : Node
     {
         $candidates = [];
@@ -51,6 +54,7 @@ final class TolerantASTConverterWithNodeMappingTest extends BaseTest
     }
 
     /**
+     * @param Node|int|string|float|null $node
      * @param array<int,Node> &$candidates
      * @return void
      * @suppress PhanUndeclaredProperty isSelected is dynamically added by Phan

--- a/tests/Phan/AbstractPhanFileTest.php
+++ b/tests/Phan/AbstractPhanFileTest.php
@@ -89,7 +89,7 @@ abstract class AbstractPhanFileTest extends BaseTest implements CodeBaseAwareTes
         $files = array_filter(
             array_filter(
                 scandir($source_dir),
-                function ($filename) : bool {
+                function (string $filename) : bool {
                     // Ignore directories and hidden files.
                     return !in_array($filename, ['.', '..'], true) && substr($filename, 0, 1) !== '.' && preg_match('@\.php$@', $filename);
                 }
@@ -108,7 +108,7 @@ abstract class AbstractPhanFileTest extends BaseTest implements CodeBaseAwareTes
         return array_combine(
             $files,
             array_map(
-                function ($filename) use ($source_dir, $expected_dir, $suffix) : array {
+                function (string $filename) use ($source_dir, $expected_dir, $suffix) : array {
                     return [
                         [self::getFileForPHPVersion($source_dir . DIRECTORY_SEPARATOR . $filename, $suffix)],
                         self::getFileForPHPVersion($expected_dir . DIRECTORY_SEPARATOR . $filename . self::EXPECTED_SUFFIX, $suffix),

--- a/tests/Phan/ForkPoolTest.php
+++ b/tests/Phan/ForkPoolTest.php
@@ -27,7 +27,11 @@ final class ForkPoolTest extends BaseTest
             /** @return void */
             function () {
             },
-            /** @return void */
+            /**
+             * @param int $unused_i
+             * @param array $data
+             * @return void
+             */
             function ($unused_i, $data) use (&$worker_data) {
                 $worker_data[] = $data;
             },

--- a/tests/Phan/ForkPoolTest.php
+++ b/tests/Phan/ForkPoolTest.php
@@ -47,11 +47,17 @@ final class ForkPoolTest extends BaseTest
         $did_startup = false;
         $pool = new ForkPool(
             [[1], [2], [3], [4]],
-            /** @return void */
+            /**
+             * @return void
+             */
             function () use (&$did_startup) {
                 $did_startup = true;
             },
-            /** @return void */
+            /**
+             * @param int $unused_i
+             * @param mixed $unused_data
+             * @return void
+             */
             function ($unused_i, $unused_data) {
             },
             function () use (&$did_startup) : array {

--- a/tests/Phan/Language/EmptyUnionTypeTest.php
+++ b/tests/Phan/Language/EmptyUnionTypeTest.php
@@ -159,9 +159,11 @@ final class EmptyUnionTypeTest extends BaseTest
                 ];
             case Closure::class:
                 return [
+                    /** @param mixed ...$unused_args */
                     function (...$unused_args) : bool {
                         return false;
                     },
+                    /** @param mixed ...$unused_args */
                     function (...$unused_args) : bool {
                         return true;
                     },

--- a/tests/Phan/Language/TypeTest.php
+++ b/tests/Phan/Language/TypeTest.php
@@ -515,7 +515,7 @@ final class TypeTest extends BaseTest
     /**
      * @dataProvider arrayShapeProvider
      */
-    public function testArrayShape($normalized_union_type_string, $type_string)
+    public function testArrayShape(string $normalized_union_type_string, string $type_string)
     {
         $this->assertTrue(\preg_match('@^' . Type::type_regex . '$@', $type_string) > 0, "Failed to parse '$type_string' with type_regex");
         $this->assertTrue(\preg_match('@^' . Type::type_regex_or_this . '$@', $type_string) > 0, "Failed to parse '$type_string' with type_regex_or_this");
@@ -583,7 +583,7 @@ final class TypeTest extends BaseTest
     }
 
     /** @dataProvider unparseableTypeProvider */
-    public function testUnparseableType($type_string)
+    public function testUnparseableType(string $type_string)
     {
         $this->assertFalse(\preg_match('@^' . Type::type_regex . '$@', $type_string) > 0, "Failed to parse '$type_string' with type_regex");
         $this->assertFalse(\preg_match('@^' . Type::type_regex_or_this . '$@', $type_string) > 0, "Failed to parse '$type_string' with type_regex_or_this");

--- a/tests/Phan/LanguageServer/LanguageServerIntegrationTest.php
+++ b/tests/Phan/LanguageServer/LanguageServerIntegrationTest.php
@@ -227,6 +227,7 @@ EOT;
 
     /**
      * @dataProvider hoverInOtherFileProvider
+     * @param ?string $expected_hover_markup
      */
     public function testHoverInOtherFile(string $new_file_contents, Position $position, $expected_hover_markup, string $requested_uri = null, bool $require_php71_or_newer = false)
     {

--- a/tests/Phan/PhanTestListener.php
+++ b/tests/Phan/PhanTestListener.php
@@ -50,7 +50,7 @@ final class PhanTestListener extends BaseTestListener
     }
 
     /**
-     * @param $time @phan-unused-param
+     * @param float $time @phan-unused-param
      */
     public function endTest(Test $test, $time)
     {


### PR DESCRIPTION
Phan continues to infer types of analyzed codebases in non-quick mode, but be consistent about annotating types in Phan's codebase itself