### PR TITLE
Update plugin to support detecting properties accidentally left out of __sleep()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,17 @@ Bug fixes
 + Fix a crash analyzing comparison with variable assignment expression (#1940)
   (e.g. `if (1 + 1 > ($var = 1))`)
 
+Plugins:
++ Update `SleepCheckerPlugin` to warn about properties that aren't returned in `__sleep()`
+  that don't have a doc comment annotation of `@phan-transient` or `@transient`.
+  (This is not an officially specified annotation)
+
+  New issue type: `SleepCheckerPropertyMissingTransient`
+
+  New setting: `$config['plugin_config']['sleep_transient_warning_blacklist_regex']`
+  can be used to prevent Phan from warning about certain properties missing `@phan-transient`
+
+
 06 Sep 2018, Phan 1.0.2
 -----------------------
 

--- a/tests/plugin_test/expected/031_sleep.php.expected
+++ b/tests/plugin_test/expected/031_sleep.php.expected
@@ -6,6 +6,7 @@ src/031_sleep.php:17 SleepCheckerInvalidPropName __sleep is returning an array t
 src/031_sleep.php:17 SleepCheckerMagicPropName __sleep is returning an array that includes z, which is a magic property
 src/031_sleep.php:19 SleepCheckerInvalidPropName __sleep is returning an array that includes _Z, which cannot be found
 src/031_sleep.php:22 PhanUnusedPublicMethodParameter Parameter $x is never used
+src/031_sleep.php:28 SleepCheckerPropertyMissingTransient Property public $_myProp that is not serialized by __sleep should be annotated with @transient or @phan-transient
 src/031_sleep.php:35 SleepCheckerInvalidReturnStatement __sleep must return an array of strings. This is definitely not an array.
 src/031_sleep.php:37 SleepCheckerInvalidReturnStatement __sleep must return an array of strings. This is definitely not an array.
 src/031_sleep.php:39 SleepCheckerInvalidPropName __sleep is returning an array that includes _myprop, which cannot be found


### PR DESCRIPTION
Update SleepCheckerPlugin

Add warning about missing `@phan-transient` or `@transient` in __sleep