### PR TITLE
Improve extraction of summaries of elements (e.g. hover description)

### DIFF
--- a/.phan/plugins/DuplicateExpressionPlugin.php
+++ b/.phan/plugins/DuplicateExpressionPlugin.php
@@ -129,7 +129,7 @@ class RedundantNodeVisitor extends PluginAwarePostAnalysisVisitor
             );
             return;
         }
-        if ($cond_node->kind === ast\AST_ISSET) {
+        if ($cond_node instanceof Node && $cond_node->kind === ast\AST_ISSET) {
             if (ASTHasher::hash($cond_node->children['var']) === $true_node_hash) {
                 $this->emitPluginIssue(
                     $this->code_base,

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,11 +3,19 @@ Phan NEWS
 ?? ??? 2018, Phan 1.0.4 (dev)
 -----------------------
 
+Plugins:
++ Fix a crash in `DuplicateExpressionPlugin`.
+
 Language Server/Daemon mode:
-+ Support hover text for variables.
++ Support generating a hover description for variables.
 
   - For union types with a single non-nullable class/interface type, the hover text include the full summary description of that class-like.
   - For non-empty union types, this will just show the raw union type (e.g. `string|false`)
++ Improve extraction of summaries of elements (e.g. hover description)
+
+  - Support using `@return` as a summary for function-likes.
+  - Parse the lines after `@var` tag (before subsequent tags)
+    as an additional part of the summary for constants/properties.
 
 07 Sep 2018, Phan 1.0.3
 -----------------------

--- a/tests/Phan/Language/Element/MarkupDescriptionTest.php
+++ b/tests/Phan/Language/Element/MarkupDescriptionTest.php
@@ -32,19 +32,26 @@ final class MarkupDescriptionTest extends BaseTest
             [
                 '',
                 '/** @param T $x A parameter annotation goes here */',
+                Comment::ON_METHOD,
             ],
             [
                 '',
                 '/** @var T $x A local variable annotation of a function goes here*/',
-                Comment::ON_METHOD
+                Comment::ON_METHOD,
             ],
             [
                 '@var MyClass An annotation of a property goes here',
                 '/** @var MyClass An annotation of a property goes here */',
                 Comment::ON_PROPERTY,
             ],
+            // Allow the description of (at)var to be a summary for the property if there is no earlier summary
             [
-                '@var MyClass A annotation of a constant goes here',
+                <<<EOT
+@var MyClass A annotation of a constant goes here
+
+Rest of this comment
+EOT
+                ,
                 <<<EOT
 /**
  * @var MyClass A annotation of a constant goes here
@@ -55,6 +62,7 @@ EOT
                 ,
                 Comment::ON_CONST,
             ],
+            // Preserve leading whitespace when parsing the comment description
             [
                 <<<EOT
 A description goes here
@@ -75,6 +83,92 @@ EOT
  *    Rest of that list
  */
 EOT
+            ],
+            // Preserve leading whitespace when parsing markup after (at)return
+            [
+                <<<EOT
+@return int
+
+Rest of this description
+
+-  Example markup list
+   Rest of that list
+EOT
+                ,
+            <<<EOT
+/**
+ * @return int
+ *
+ * Rest of this description
+ *
+ * -  Example markup list
+ *    Rest of that list
+ *
+ * @internal
+ */
+EOT
+                ,
+                Comment::ON_METHOD
+            ],
+            // Only parse (at)return on comments of function-likes
+            [
+                ''
+                ,
+            <<<EOT
+/**
+ * @return int
+ *
+ * Rest of this description
+ */
+EOT
+                ,
+                Comment::ON_PROPERTY
+            ],
+            // Parse summaries on adjacent lines
+            [
+                <<<EOT
+@return int
+Rest of this description
+EOT
+                ,
+            <<<EOT
+/**
+ * @return int
+ * Rest of this description
+ *
+ * @internal
+ */
+EOT
+                ,
+                Comment::ON_FUNCTION
+            ],
+            // Treat informative (at)return as function-like summaries.
+            [
+                '@return int positive',
+            <<<EOT
+/**
+ * @return int positive
+ */
+EOT
+                ,
+                Comment::ON_FUNCTION
+            ],
+            // Treat informative single-line (at)return as function-like summaries.
+            [
+                '@return int positive',
+                '/**   @return int positive */',
+                Comment::ON_METHOD
+            ],
+            // Don't treat uninformative (at)return as function-like summaries.
+            [
+                '',
+            <<<EOT
+/**
+ * @return string|false
+ */
+EOT
+                ,
+                Comment::ON_FUNCTION
             ],
         ];
     }


### PR DESCRIPTION
- Support using `@return` as a summary for function-likes.
- Parse the lines after `@var` tag (before subsequent tags)
  as an additional part of the summary for constants/properties.

And fix a crash in DuplicateExpressionPlugin.