### PR TITLE
Add phpdoc descriptions to public properties of Phan, fix minor bugs

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -560,7 +560,7 @@ return [
         // TODO: warn about the usage of assert() for Phan's self-analysis. See https://github.com/phan/phan/issues/288
         'NoAssertPlugin',
 
-        // 'HasPHPDocPlugin',
+        'HasPHPDocPlugin',
 
         ////////////////////////////////////////////////////////////////////////
         // End plugins for Phan's self-analysis

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -257,6 +257,9 @@ return [
         'PhanPossiblyFalseTypeArgumentInternal',
         'PhanPossiblyNullTypeArgument',
         'PhanPossiblyNullTypeArgumentInternal',
+        // TODO: Fix and remove suppression for this plugin
+        'PhanPluginDescriptionlessCommentOnPrivateProperty',
+        'PhanPluginDescriptionlessCommentOnProtectedProperty',
     ],
 
     // If empty, no filter against issues types will be applied.

--- a/.phan/plugins/DemoPlugin.php
+++ b/.phan/plugins/DemoPlugin.php
@@ -160,7 +160,7 @@ class DemoPlugin extends PluginV2 implements
      * The code base in which the function exists
      *
      * @param Property $property
-     * A function being analyzed
+     * A property being analyzed
      *
      * @return void
      *

--- a/.phan/plugins/DemoPlugin.php
+++ b/.phan/plugins/DemoPlugin.php
@@ -157,7 +157,7 @@ class DemoPlugin extends PluginV2 implements
 
     /**
      * @param CodeBase $code_base
-     * The code base in which the function exists
+     * The code base in which the property exists
      *
      * @param Property $property
      * A property being analyzed

--- a/.phan/plugins/InvokePHPNativeSyntaxCheckPlugin.php
+++ b/.phan/plugins/InvokePHPNativeSyntaxCheckPlugin.php
@@ -30,7 +30,11 @@ class InvokePHPNativeSyntaxCheckPlugin extends PluginV2 implements
     const LINE_NUMBER_REGEX = "@ on line ([1-9][0-9]*)$@";
     const STDIN_FILENAME_REGEX = "@ in (Standard input code|-)@";
 
-    /** @var array<int,InvokeExecutionPromise> */
+    /**
+     * @var array<int,InvokeExecutionPromise>
+     * A list of invoked processes that this plugin created.
+     * This plugin is waiting for execution of those processes to finish.
+     */
     private $processes = [];
 
     /**
@@ -159,22 +163,22 @@ class InvokeExecutionPromise
     /** @var string path to the php binary invoked */
     private $binary;
 
-    /** @var bool */
+    /** @var bool is the process finished executing */
     private $done = false;
 
-    /** @var resource */
+    /** @var resource result of proc_open() */
     private $process;
 
     /** @var array{0:resource,1:resource,2:resource} */
     private $pipes;
 
-    /** @var ?string */
+    /** @var ?string an error message */
     private $error = null;
 
-    /** @var string */
+    /** @var string the raw bytes from stdout with serialized data */
     private $raw_stdout = '';
 
-    /** @var Context */
+    /** @var Context has the file name being analyzed */
     private $context;
 
     public function __construct(string $binary, string $file_contents, Context $context)

--- a/.phan/plugins/InvokePHPNativeSyntaxCheckPlugin.php
+++ b/.phan/plugins/InvokePHPNativeSyntaxCheckPlugin.php
@@ -33,7 +33,8 @@ class InvokePHPNativeSyntaxCheckPlugin extends PluginV2 implements
     /**
      * @var array<int,InvokeExecutionPromise>
      * A list of invoked processes that this plugin created.
-     * This plugin is waiting for execution of those processes to finish.
+     * This plugin creates a processes(up to a maximum number can run at a time)
+     * and then waits for the execution of those processes to finish.
      */
     private $processes = [];
 

--- a/.phan/plugins/PHPUnitNotDeadCodePlugin.php
+++ b/.phan/plugins/PHPUnitNotDeadCodePlugin.php
@@ -47,6 +47,7 @@ class PHPUnitNotDeadPluginVisitor extends PluginAwarePostAnalysisVisitor
     /** @var Type */
     private static $phpunit_test_case_type;
 
+    /** @var bool */
     private static $did_warn_unused = false;
 
     /**

--- a/.phan/plugins/UnknownElementTypePlugin.php
+++ b/.phan/plugins/UnknownElementTypePlugin.php
@@ -112,10 +112,10 @@ class UnknownElementTypePlugin extends PluginV2 implements
 
     /**
      * @param CodeBase $code_base
-     * The code base in which the function exists
+     * The code base in which the property exists
      *
      * @param Property $property
-     * A function being analyzed
+     * A property being analyzed
      *
      * @return void
      *

--- a/.phan/plugins/UnusedSuppressionPlugin.php
+++ b/.phan/plugins/UnusedSuppressionPlugin.php
@@ -62,7 +62,7 @@ class UnusedSuppressionPlugin extends PluginV2 implements
 
     /**
      * @param CodeBase $code_base
-     * The code base in which the function exists
+     * The code base in which the element exists
      *
      * @param AddressableElement $element
      * Any element such as function, method, class
@@ -159,7 +159,7 @@ class UnusedSuppressionPlugin extends PluginV2 implements
 
     /**
      * @param CodeBase $unused_code_base
-     * The code base in which the function exists
+     * The code base in which the property exists
      *
      * @param Property $property
      * A property being analyzed

--- a/.phan/plugins/UnusedSuppressionPlugin.php
+++ b/.phan/plugins/UnusedSuppressionPlugin.php
@@ -45,6 +45,10 @@ class UnusedSuppressionPlugin extends PluginV2 implements
      */
     private $elements_for_postponed_analysis = [];
 
+    /**
+     * @var string[] a list of files where checks for unused suppressions was postponed
+     * (Because of non-quick mode, we may emit issues in a file after analysis has run on that file)
+     */
     private $files_for_postponed_analysis = [];
 
     /**

--- a/internal/internalsignatures.php
+++ b/internal/internalsignatures.php
@@ -965,6 +965,7 @@ class IncompatibleStubsSignatureDetector extends IncompatibleSignatureDetectorBa
         return 0;
     }
 
+    /** @var bool */
     private $initialized = false;
 
     private function getFileList() : array

--- a/internal/reflection_completeness_check.php
+++ b/internal/reflection_completeness_check.php
@@ -12,6 +12,11 @@ use Phan\Language\FQSEN\FullyQualifiedMethodName;
 use Phan\Language\FQSEN\FullyQualifiedFunctionName;
 use Phan\Language\UnionType;
 
+/**
+ * Checks if Phan has internal signatures for all elements of PHP modules
+ * (e.g. php-ast, redis)
+ * that the running PHP binary has Reflection information for.
+ */
 class ReflectionCompletenessCheck
 {
     const EXCLUDED_FUNCTIONS = [

--- a/internal/sanitycheck.php
+++ b/internal/sanitycheck.php
@@ -65,7 +65,7 @@ function getParameterCountsFromReflection(array $args) : array
 /**
  * This represents an entry in Phan's internal function signatures for a function/method parameter.
  *
- * (e.g. `'args...' => 'string|int'`)
+ * (e.g. `'...args' => 'string|int'`)
  */
 class PhanParameterInfo
 {
@@ -73,7 +73,7 @@ class PhanParameterInfo
     public $name;
 
     /**
-     * @var string the original spec string, e.g. `'...string'`
+     * @var string the original spec string, e.g. `'...args'`
      * @suppress PhanWriteOnlyPublicProperty may use this in the future, e.g. for warnings
      */
     public $original_name_spec;

--- a/internal/sanitycheck.php
+++ b/internal/sanitycheck.php
@@ -69,22 +69,25 @@ function getParameterCountsFromReflection(array $args) : array
  */
 class PhanParameterInfo
 {
-    /** @var string */
+    /** @var string the parameter name */
     public $name;
+
     /**
-     * @var string
+     * @var string the original spec string, e.g. `'...string'`
      * @suppress PhanWriteOnlyPublicProperty may use this in the future, e.g. for warnings
      */
     public $original_name_spec;
 
-    /** @var bool */
+    /** @var bool is this parameter optional */
     public $is_optional;
-    /** @var bool */
+
+    /** @var bool is this parameter passed by reference */
     public $is_by_reference;
-    /** @var bool */
+
+    /** @var bool is this parameter variadic */
     public $is_variadic;
 
-    /** @var string */
+    /** @var string the union type string */
     public $value;
 
     public function __construct(string $original_name_spec, string $value_spec)

--- a/phan_client
+++ b/phan_client
@@ -283,10 +283,10 @@ class PhanPHPLinterOpts
     /** @var string[]|null - optional, maps original files to temporary file path to use as a substitute. */
     public $temporary_file_map = null;
 
-    /** @var bool - unused. */
+    /** @var bool if true, enable verbose output. */
     public $verbose = false;
 
-    /** @var bool */
+    /** @var bool should this client request analysis from the Phan server when the file has syntax errors */
     public $use_fallback_parser;
 
     /** @var bool */

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -107,7 +107,7 @@ class CLI
     ];
 
     /**
-     * @var OutputInterface
+     * @var OutputInterface used for outputting the formatted issue messages.
      */
     private $output;
 

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -168,7 +168,10 @@ class CodeBase
     private $undo_tracker;
 
     /**
-     * @var bool
+     * @var bool is the undo tracker currently enabled?
+     *
+     * If the Phan Language Server or Daemon Mode is enabled,
+     * the undo tracker will be enabled prior to the analysis phase, and disabled afterwards.
      */
     private $has_enabled_undo_tracker = false;
 

--- a/src/Phan/Daemon/Request.php
+++ b/src/Phan/Daemon/Request.php
@@ -54,8 +54,16 @@ class Request
     /** @var array<int,string>|null */
     private $files = null;
 
+    /**
+     * A set of process ids of child processes
+     * @var array<int,true>
+     */
     private static $child_pids = [];
 
+    /**
+     * A set of process ids of child processes
+     * @var array<int,int>
+     */
     private static $exited_pid_status = [];
 
 
@@ -480,7 +488,6 @@ class Request
 
             // TODO: Use http://php.net/manual/en/book.inotify.php if available, watch all directories if available.
             // Daemon continues to execute.
-            self::$child_pids[] = $fork_result;
             Daemon::debugf("Created a child pid %d", $fork_result);
         }
         return null;

--- a/src/Phan/Daemon/Request.php
+++ b/src/Phan/Daemon/Request.php
@@ -67,9 +67,21 @@ class Request
     private static $exited_pid_status = [];
 
 
-    /** @var ?GoToDefinitionRequest */
+    /**
+     * The most recent Language Server Protocol request to look up what an element is
+     * (e.g. "go to definition", "go to type definition", "hover")
+     *
+     * @var ?GoToDefinitionRequest
+     */
     private $most_recent_definition_request;
-    /** @var bool */
+
+    /**
+     * If true, this process will exit() after finishing.
+     * If false, this class will instead throw ExitException to be caught by the caller
+     * (E.g. if pcntl is unavailable)
+     *
+     * @var bool
+     */
     private $should_exit;
 
     /**

--- a/src/Phan/Daemon/Transport/StreamResponder.php
+++ b/src/Phan/Daemon/Transport/StreamResponder.php
@@ -16,6 +16,7 @@ class StreamResponder implements Responder
     /** @var ?array the request data */
     private $request_data;
 
+    /** @var bool did this process already finish reading the data of the request? */
     private $did_read_request_data = false;
 
     /** @param resource $connection a stream */

--- a/src/Phan/Language/Element/Comment/Builder.php
+++ b/src/Phan/Language/Element/Comment/Builder.php
@@ -25,44 +25,45 @@ use Phan\Library\Some;
  */
 final class Builder
 {
-    /** @var array<int,string> */
+    /** @var array<int,string> the list of lines of the doc comment */
     public $lines;
-    /** @var int */
+    /** @var int count($this->lines) */
     public $comment_lines_count;
-    /** @var CodeBase */
+    /** @var CodeBase The code base within which we're operating. */
     public $code_base;
-    /** @var Context */
+    /** @var Context the context of the parser at the comment we're reading */
     public $context;
-    /** @var int */
+    /** @var int the line number of the element this doc comment belongs to */
     public $lineno;
-    /** @var int */
+    /** @var int an enum value from Comment::ON_* */
     public $comment_type;
-    /** @var array<int,Parameter> */
+    /** @var array<int,Parameter> the list of extracted (at)var annotations*/
     public $variable_list = [];
-    /** @var array<int,Parameter> */
+    /** @var array<int,Parameter> the list of extracted (at)param annotations */
     public $parameter_list = [];
-    /** @var array<int,TemplateType> */
+    /** @var array<int,TemplateType> the list of extracted (at)template annotations */
     public $template_type_list = [];
-    /** @var Option<Type> */
+    /** @var Option<Type> the (at)inherits annotation */
     public $inherited_type;
-    /** @var UnionType */
+    // TODO: Warn about multiple (at)returns
+    /** @var UnionType the (at)return annotation types*/
     public $return_union_type;
     /**
      * @var array<int,string>
      * @suppress PhanReadOnlyPublicProperty FIXME: array_push doesn't count as a write-reference
      */
     public $suppress_issue_list = [];
-    /** @var array<int,Property> */
+    /** @var array<int,Property> the list of (at)property annotations (and property-read, property-write) */
     public $magic_property_list = [];
-    /** @var array<int,Method> */
+    /** @var array<int,Method> the list of (at)method annotations */
     public $magic_method_list = [];
-    /** @var Option */
+    /** @var Option<Type> the type a closure will be bound to */
     public $closure_scope;
-    /** @var int */
+    /** @var int combination of flags from \Phan\Flags */
     public $comment_flags = 0;
-    /** @var array<string,mixed> */
+    /** @var array<string,mixed> annotations for Phan that override the standardized version of those annotations. Used for compatibility with other tools. */
     public $phan_overrides = [];
-    /** @var UnionType */
+    /** @var UnionType the union type of the set of (at)throws annotations */
     public $throw_union_type;
 
     public function __construct(

--- a/src/Phan/Language/Element/Comment/Builder.php
+++ b/src/Phan/Language/Element/Comment/Builder.php
@@ -49,7 +49,7 @@ final class Builder
     /** @var UnionType the (at)return annotation types*/
     public $return_union_type;
     /**
-     * @var array<int,string>
+     * @var array<int,string> the list of issue names from (at)suppress annotations
      * @suppress PhanReadOnlyPublicProperty FIXME: array_push doesn't count as a write-reference
      */
     public $suppress_issue_list = [];

--- a/src/Phan/Language/Element/MarkupDescription.php
+++ b/src/Phan/Language/Element/MarkupDescription.php
@@ -49,7 +49,11 @@ class MarkupDescription
      */
     public static function extractDocComment(string $doc_comment, int $comment_category = null) : string
     {
-        $doc_comment = preg_replace('@(^/\*\*)|(\*/$)@', '', $doc_comment);
+        // Trim the start and the end of the doc comment.
+        //
+        // We leave in the second `*` of `/**` so that every single non-empty line
+        // of a typical doc comment will begin with a `*`
+        $doc_comment = preg_replace('@(^/\*)|(\*/$)@', '', $doc_comment);
 
         $results = [];
         $lines = explode("\n", $doc_comment);

--- a/src/Phan/Language/Element/Property.php
+++ b/src/Phan/Language/Element/Property.php
@@ -84,7 +84,7 @@ class Property extends ClassElement
         return $this->real_defining_fqsen ?? $this->getDefiningFQSEN();
     }
 
-    private function getVisibilityName() : string
+    public function getVisibilityName() : string
     {
         if ($this->isPrivate()) {
             return 'private';

--- a/src/Phan/Language/FQSEN.php
+++ b/src/Phan/Language/FQSEN.php
@@ -2,7 +2,7 @@
 namespace Phan\Language;
 
 /**
- * A Fully-Qualified Name
+ * A Fully-Qualified Structural Element Name
  */
 interface FQSEN
 {

--- a/src/Phan/Language/NamespaceMapEntry.php
+++ b/src/Phan/Language/NamespaceMapEntry.php
@@ -4,12 +4,12 @@ namespace Phan\Language;
 use Phan\Language\FQSEN\FullyQualifiedGlobalStructuralElement;
 
 /**
- * Tracks a `use Foo\Bar;` statement at the top of a class.
+ * Tracks a `use Foo\Bar;` statement inside of a namespace.
  */
 class NamespaceMapEntry implements \Serializable
 {
     /**
-     * @var FullyQualifiedGlobalStructuralElement
+     * @var FullyQualifiedGlobalStructuralElement the FQSEN of the
      */
     public $fqsen;
 
@@ -24,7 +24,7 @@ class NamespaceMapEntry implements \Serializable
     public $lineno;
 
     /**
-     * @var bool
+     * @var bool has this use statement been referenced during the parse/analysis phase?
      */
     public $is_used = false;
 

--- a/src/Phan/LanguageServer/ClientHandler.php
+++ b/src/Phan/LanguageServer/ClientHandler.php
@@ -13,17 +13,17 @@ use Sabre\Event\Promise;
 class ClientHandler
 {
     /**
-     * @var ProtocolReader
+     * @var ProtocolReader used to read notifications, requests, and responses from the LSP client
      */
     public $protocolReader;
 
     /**
-     * @var ProtocolWriter
+     * @var ProtocolWriter used to send notifications, requests, and responses to the LSP client
      */
     public $protocolWriter;
 
     /**
-     * @var IdGenerator
+     * @var IdGenerator used to generate ids when sending requests to the client.
      */
     public $idGenerator;
 

--- a/src/Phan/LanguageServer/IdGenerator.php
+++ b/src/Phan/LanguageServer/IdGenerator.php
@@ -12,7 +12,7 @@ namespace Phan\LanguageServer;
 class IdGenerator
 {
     /**
-     * @var int
+     * @var int an incrementing counter for generating unique request IDs
      */
     public $counter = 1;
 

--- a/src/Phan/LanguageServer/Logger.php
+++ b/src/Phan/LanguageServer/Logger.php
@@ -11,7 +11,7 @@ use Phan\Config;
  */
 class Logger
 {
-    /** @var resource|false */
+    /** @var resource|false the log file handle */
     public static $file = false;
 
     public static function shouldLog() : bool
@@ -48,7 +48,7 @@ class Logger
     }
 
     /**
-     * @return resource
+     * @return resource the log file handle
      */
     private static function getLogFile()
     {

--- a/src/Phan/LanguageServer/Protocol/Location.php
+++ b/src/Phan/LanguageServer/Protocol/Location.php
@@ -16,12 +16,12 @@ use Phan\LanguageServer\Utils;
 class Location
 {
     /**
-     * @var string|null
+     * @var string|null the URI of the location
      */
     public $uri;
 
     /**
-     * @var Range|null
+     * @var Range|null the byte range of the location
      */
     public $range;
 

--- a/src/Phan/LanguageServer/Protocol/Message.php
+++ b/src/Phan/LanguageServer/Protocol/Message.php
@@ -6,17 +6,20 @@ namespace Phan\LanguageServer\Protocol;
 use AdvancedJsonRpc\Message as MessageBody;
 
 /**
+ * This represents a notification, request, or response from the Language Server Protocol,
+ * which uses JSON-RPC 2.
+ *
  * Source: https://github.com/felixfbecker/php-language-server/tree/master/src/Protocol/Message.php
  */
 class Message
 {
     /**
-     * @var ?\AdvancedJsonRpc\Message
+     * @var ?\AdvancedJsonRpc\Message the optional decoded message body for this message
      */
     public $body;
 
     /**
-     * @var array<string,string>
+     * @var array<string,string> the headers associated with this message (e.g. Content-Length)
      */
     public $headers;
 

--- a/src/Phan/LanguageServer/Server/Workspace.php
+++ b/src/Phan/LanguageServer/Server/Workspace.php
@@ -19,17 +19,19 @@ use Phan\LanguageServer\Utils;
 class Workspace
 {
     /**
-     * @var LanguageClient
+     * @var LanguageClient represents the client of this language server.
      */
     public $client;
 
     /**
-     * @var LanguageServer
+     * @var LanguageServer represents the LSP related functionality of the Phan Language Server.
      */
     public $server;
 
     /**
-     * @var FileMapping
+     * @var FileMapping this tracks the state of files opened and edited in the client.
+     *
+     * Any entries in this object should override the state of the files on disk.
      */
     public $file_mapping;
 

--- a/src/Phan/Library/Tuple1.php
+++ b/src/Phan/Library/Tuple1.php
@@ -13,7 +13,7 @@ class Tuple1 extends Tuple
     /** @var int */
     const ARITY = 1;
 
-    /** @var T0 */
+    /** @var T0 element 0 of this tuple (0-based index) */
     public $_0;
 
     /**

--- a/src/Phan/Library/Tuple2.php
+++ b/src/Phan/Library/Tuple2.php
@@ -18,7 +18,7 @@ class Tuple2 extends Tuple1
     /** @var int */
     const ARITY = 2;
 
-    /** @var T1 */
+    /** @var T1 element 1 of this tuple (0-based index) */
     public $_1;
 
     /**

--- a/src/Phan/Library/Tuple3.php
+++ b/src/Phan/Library/Tuple3.php
@@ -22,7 +22,7 @@ class Tuple3 extends Tuple2
     /** @var int */
     const ARITY = 3;
 
-    /** @var T2 */
+    /** @var T2 element 2 of this tuple (0-based index) */
     public $_2;
 
     /**

--- a/src/Phan/Library/Tuple4.php
+++ b/src/Phan/Library/Tuple4.php
@@ -25,7 +25,7 @@ class Tuple4 extends Tuple3
     /** @var int */
     const ARITY = 4;
 
-    /** @var T3 */
+    /** @var T3 element 3 of this tuple (0-based index) */
     public $_3;
 
     /**

--- a/src/Phan/Library/Tuple5.php
+++ b/src/Phan/Library/Tuple5.php
@@ -28,7 +28,7 @@ class Tuple5 extends Tuple4
     /** @var int */
     const ARITY = 4;
 
-    /** @var T4 */
+    /** @var T4 element 4 of this tuple (0-based index) */
     public $_4;
 
     /**

--- a/src/Phan/Output/Filter/MinimumSeverityFilter.php
+++ b/src/Phan/Output/Filter/MinimumSeverityFilter.php
@@ -12,7 +12,7 @@ use Phan\Output\IssueFilterInterface;
 final class MinimumSeverityFilter implements IssueFilterInterface
 {
 
-    /** @var int */
+    /** @var int the provided minimum severity */
     private $minimum_severity;
 
     /**

--- a/src/Phan/Output/Printer/CSVPrinter.php
+++ b/src/Phan/Output/Printer/CSVPrinter.php
@@ -14,10 +14,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 final class CSVPrinter implements BufferedPrinterInterface
 {
 
-    /** @var OutputInterface */
+    /** @var OutputInterface for writing comma separated values to */
     private $output;
 
-    /** @var resource */
+    /** @var resource in-memory stream for fputcsv() */
     private $stream;
 
     /** @param IssueInstance $instance */

--- a/src/Phan/Phan.php
+++ b/src/Phan/Phan.php
@@ -28,10 +28,10 @@ use InvalidArgumentException;
  */
 class Phan implements IgnoredFilesFilterInterface
 {
-    /** @var IssuePrinterInterface */
+    /** @var IssuePrinterInterface used to print formatted issues. */
     public static $printer;
 
-    /** @var IssueCollectorInterface */
+    /** @var IssueCollectorInterface used to gather issues to be printed (or used) once analysis is finished */
     private static $issue_collector;
 
     /**

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
@@ -26,11 +26,19 @@ use function is_string;
 final class VariableTrackerVisitor extends AnalysisVisitor
 {
     /**
+     * This shared graph instance maps definitions of variables (in a function-like context)
+     * to the uses of that variable.
+     *
      * @var VariableGraph
      */
     public static $variable_graph;
 
-    /** @var VariableTrackingScope */
+    /**
+     * This represents the status of variables in the current scope
+     * (e.g. which variable definitions are available to be used, etc.)
+     *
+     * @var VariableTrackingScope
+     */
     private $scope;
 
     public function __construct(VariableTrackingScope $scope)

--- a/tests/Phan/Language/Element/MarkupDescriptionTest.php
+++ b/tests/Phan/Language/Element/MarkupDescriptionTest.php
@@ -159,6 +159,11 @@ EOT
                 '/**   @return int positive */',
                 Comment::ON_METHOD
             ],
+            [
+                '@return int self::MY_ENUM_* description',
+                '/**   @return int self::MY_ENUM_* description */',
+                Comment::ON_METHOD
+            ],
             // Don't treat uninformative (at)return as function-like summaries.
             [
                 '',

--- a/tests/Phan/LanguageServer/LanguageServerIntegrationTest.php
+++ b/tests/Phan/LanguageServer/LanguageServerIntegrationTest.php
@@ -38,8 +38,11 @@ final class LanguageServerIntegrationTest extends BaseTest
         return self::getLSPFolder() . '/src/example.php';
     }
 
-    // Incrementing message id for language client requests.
-    // Each test case has its own instance property $this->messageId
+    /**
+     * Incrementing message id for language client requests.
+     * Each test case has its own instance property $this->messageId
+     * @var int
+     */
     private $messageId = 0;
 
     /**

--- a/tool/make_stubs
+++ b/tool/make_stubs
@@ -166,15 +166,16 @@ StubsGenerator::main();
 class StubCollection {
     /** @var CodeBase */
     private $code_base;
+
     public function __construct(CodeBase $code_base) {
         $this->code_base = $code_base;
     }
 
-    /** @var string[][] */
+    /** @var string[][] a list of class stubs for a PHP module */
     public $class_stubs = [];
-    /** @var string[][] */
+    /** @var string[][] a list of function stubs for a PHP module */
     public $function_stubs = [];
-    /** @var string[][] */
+    /** @var string[][] a list of global constant stubs for a PHP module */
     public $global_constant_stubs = [];
 
     /** @return void */

--- a/tool/make_stubs
+++ b/tool/make_stubs
@@ -160,6 +160,9 @@ EOT;
 
 StubsGenerator::main();
 
+/**
+ * A representation of the collection of stubs for elements of a PHP module(a.k.a. extension).
+ */
 class StubCollection {
     /** @var CodeBase */
     private $code_base;


### PR DESCRIPTION
- Fix a minor bug in the Phan daemon mode
- Fix a minor bug extracting markup descriptions from single-line comments (parts before `*` within the comment were removed)