### PR TITLE
Improve incompatible expression detection for PHP5

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@ Phan NEWS
 Bug fixes:
 + Don't infer bad types for variables when analyzing `array_push` using expressions containing those variables. (#1955)
   (also fixes other `array_*` functions taking references)
++ Fix false negatives in PHP5 backwards compatibility heuristic checks (#1939)
 
 10 Sep 2018, Phan 1.0.4
 -----------------------

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -1701,6 +1701,8 @@ class ContextNode
      * This ignores union types, and can be run in the parse phase.
      * (It often should, because outside quick mode, it may be run multiple times per node)
      *
+     * TODO: This is repetitive, move these checks into ParseVisitor?
+     *
      * @return void
      */
     public function analyzeBackwardCompatibility()
@@ -1820,8 +1822,8 @@ class ContextNode
             $line = $cache_entry->getLine($this->node->lineno) ?? '';
             unset($cache_entry);
             if (strpos($line, '}[') === false
-                || strpos($line, ']}') === false
-                || strpos($line, '>{') === false
+                && strpos($line, ']}') === false
+                && strpos($line, '>{') === false
             ) {
                 Issue::maybeEmit(
                     $this->code_base,

--- a/tests/files/expected/0528_backwards_compatibility.php.expected
+++ b/tests/files/expected/0528_backwards_compatibility.php.expected
@@ -1,0 +1,3 @@
+%s:10 PhanCompatiblePHP7 Expression may not be PHP 7 compatible
+%s:22 PhanCompatiblePHP7 Expression may not be PHP 7 compatible
+%s:31 PhanCompatiblePHP7 Expression may not be PHP 7 compatible

--- a/tests/files/src/0528_backwards_compatibility.php
+++ b/tests/files/src/0528_backwards_compatibility.php
@@ -1,0 +1,32 @@
+<?php
+class PHP5Class {
+	public $arr = [
+		'key' => 'value',
+	];
+};
+$class = new PHP5Class();
+
+$var = 'arr';
+echo $class->$var['key'], PHP_EOL;  // This behaves differently in PHP 5, Phan should warn
+echo $class->{$var}['key'], PHP_EOL;  // This behaves the same way in PHP 5 and 7, Phan should not warn
+
+/**
+ * Phan should detect PHP5 incompatible expressions within a class function argument
+ */
+class PHP5Class2 {
+	public function func($var) {
+		return $var;
+	}
+}
+$class2 = new PHP5Class2();
+echo $class2->func($class->$var['key']), PHP_EOL;
+echo $class2->func($class->{$var}['key']), PHP_EOL;
+
+/**
+ * Phan should detect PHP5 incompatible expressions within an array key
+ */
+$arr = [
+	'value' => 'value2',
+];
+echo $arr[$class->$var['key']], PHP_EOL;
+echo $arr[$class->{$var}['key']], PHP_EOL;


### PR DESCRIPTION
These were not being emitted consistently depending on where the
expression was.

Fixes #1939