### PR TITLE
Catch an uncaught exception extracting the URL in hover

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,9 @@ Bug fixes:
   (also fixes other `array_*` functions taking references)
 + Fix false negatives in PHP5 backwards compatibility heuristic checks (#1939)
 
+Language Server/Daemon mode:
++ Fix an uncaught exception when extracting a URL with an unexpected scheme (not `file:/...`) (#1960)
+
 10 Sep 2018, Phan 1.0.4
 -----------------------
 

--- a/src/Phan/LanguageServer/Logger.php
+++ b/src/Phan/LanguageServer/Logger.php
@@ -47,6 +47,13 @@ class Logger
         fwrite($file, $msg . "\n");
     }
 
+    /** @return void */
+    public static function logError(string $msg)
+    {
+        $file = self::getLogFile();
+        fwrite($file, $msg . "\n");
+    }
+
     /**
      * @return resource the log file handle
      */


### PR DESCRIPTION
Not sure why VS Code is sending "git:/" URLs to the language server
in the first place, it seems like a bug in VS Code

Fixes #1960