### PR TITLE
Properly detect code after `break` or `continue` in UnreachableCodePlugin

### DIFF
--- a/.phan/plugins/UnreachableCodePlugin.php
+++ b/.phan/plugins/UnreachableCodePlugin.php
@@ -81,7 +81,7 @@ final class UnreachableCodeVisitor extends PluginAwarePostAnalysisVisitor
             if (!($node instanceof Node)) {
                 continue;
             }
-            if (!BlockExitStatusChecker::willUnconditionallyThrowOrReturn($node)) {
+            if (!BlockExitStatusChecker::willUnconditionallySkipRemainingStatements($node)) {
                 continue;
             }
             // Skip over empty statements and scalar statements.

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@ Phan NEWS
 ?? ??? 2018, Phan 1.0.5 (dev)
 -----------------------
 
+Plugins:
++ Properly warn about code after `break` and `continue` in `UnreachableCodePlugin`.
+  Previously, Phan only warned about code after `throw` and `return`.
+
 Bug fixes:
 + Don't infer bad types for variables when analyzing `array_push` using expressions containing those variables. (#1955)
   (also fixes other `array_*` functions taking references)

--- a/tests/plugin_test/expected/050_unreachable_code.php.expected
+++ b/tests/plugin_test/expected/050_unreachable_code.php.expected
@@ -1,0 +1,4 @@
+src/050_unreachable_code.php:11 PhanPluginUnreachableCode Unreachable statement detected
+src/050_unreachable_code.php:14 PhanPluginUnreachableCode Unreachable statement detected
+src/050_unreachable_code.php:17 PhanPluginUnreachableCode Unreachable statement detected
+src/050_unreachable_code.php:20 PhanPluginUnreachableCode Unreachable statement detected

--- a/tests/plugin_test/src/050_unreachable_code.php
+++ b/tests/plugin_test/src/050_unreachable_code.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @return void
+ * @throws Exception
+ */
+function test50(int $x) {
+    switch ($x) {
+        case 2:
+            break;
+            echo $x;
+        case 3:
+            continue;
+            break;
+        case 4:
+            return;
+            break;
+        default:
+            throw new Exception("fail");
+            break;
+    }
+}
+test50(5);


### PR DESCRIPTION
Previously, it only checked for `throw` and `return`