### PR TITLE
Improve line numbers for warnings about `@param` and `@return` annotations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@ New Features(Analysis)
 
   New issue types: `PhanCommentDuplicateMagicMethod`, `PhanCommentDuplicateMagicProperty`, `PhanCommentDuplicateParam`
 + Add basic support for `extract()` (#1978)
++ Improve line numbers for warnings about `@param` and `@return` annotations (#1369)
 
 Plugins:
 + Properly warn about code after `break` and `continue` in `UnreachableCodePlugin`.

--- a/src/Phan/Analysis/ReturnTypesAnalyzer.php
+++ b/src/Phan/Analysis/ReturnTypesAnalyzer.php
@@ -97,7 +97,7 @@ class ReturnTypesAnalyzer
                             $code_base,
                             $context,
                             Issue::TypeMismatchDeclaredReturn,
-                            $context->getLineNumberStart(),
+                            ParameterTypesAnalyzer::guessCommentReturnLineNumber($method) ?? $context->getLineNumberStart(),
                             $method->getName(),
                             $phpdoc_type->__toString(),
                             $real_return_type->__toString()
@@ -116,7 +116,7 @@ class ReturnTypesAnalyzer
                                 $code_base,
                                 $context,
                                 Issue::TypeMismatchDeclaredReturnNullable,
-                                $context->getLineNumberStart(),
+                                ParameterTypesAnalyzer::guessCommentReturnLineNumber($method) ?? $context->getLineNumberStart(),
                                 $method->getName(),
                                 $phpdoc_type->__toString(),
                                 $real_return_type->__toString()

--- a/src/Phan/Language/Element/Comment/Parameter.php
+++ b/src/Phan/Language/Element/Comment/Parameter.php
@@ -26,6 +26,12 @@ class Parameter
     private $type;
 
     /**
+     * @var int
+     * Get the line number.
+     */
+    private $lineno;
+
+    /**
      * @var bool
      * Whether or not the parameter is variadic (in the comment)
      */
@@ -53,12 +59,14 @@ class Parameter
     public function __construct(
         string $name,
         UnionType $type,
+        int $lineno = 0,
         bool $is_variadic = false,
         bool $has_default_value = false,
         bool $is_output_reference = false
     ) {
         $this->name = $name;
         $this->type = $type;
+        $this->lineno = $lineno;
         $this->is_variadic = $is_variadic;
         $this->has_default_value = $has_default_value;
         $this->is_output_reference = $is_output_reference;
@@ -117,6 +125,14 @@ class Parameter
         return $this->type;
     }
 
+    /**
+     * @return int
+     * The line number of the parameter
+     */
+    public function getLineno() : int
+    {
+        return $this->lineno;
+    }
     /**
      * @return bool
      * Whether or not the parameter is variadic

--- a/src/Phan/Language/Element/Comment/ReturnComment.php
+++ b/src/Phan/Language/Element/Comment/ReturnComment.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+namespace Phan\Language\Element\Comment;
+
+use Phan\Language\UnionType;
+
+/**
+ * The representation of an (at)return comment
+ */
+class ReturnComment
+{
+    /** @var UnionType the return type of the comment*/
+    private $type;
+
+    /** @var int the line number of the comment */
+    private $lineno;
+
+    public function __construct(UnionType $type, int $lineno)
+    {
+        $this->type = $type;
+        $this->lineno = $lineno;
+    }
+
+    public function getType() : UnionType
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return void
+     */
+    public function setType(UnionType $type)
+    {
+        $this->type = $type;
+    }
+
+    public function getLineno() : int
+    {
+        return $this->lineno;
+    }
+}

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -625,7 +625,7 @@ trait FunctionTrait
                     $code_base,
                     $context,
                     count($real_parameter_name_map) > 0 ? Issue::CommentParamWithoutRealParam : Issue::CommentParamOnEmptyParamList,
-                    $function->getFileRef()->getLineNumberStart(),
+                    $comment_parameter->getLineno(),
                     $comment_parameter_name,
                     (string)$function
                 );
@@ -680,7 +680,7 @@ trait FunctionTrait
                         $code_base,
                         $context,
                         $parameter->isVariadic() ? Issue::TypeMismatchVariadicParam : Issue::TypeMismatchVariadicComment,
-                        $function->getFileRef()->getLineNumberStart(),
+                        $comment_param->getLineno(),
                         $comment_param->__toString(),
                         $parameter->__toString()
                     );

--- a/tests/Phan/Language/Element/CommentTest.php
+++ b/tests/Phan/Language/Element/CommentTest.php
@@ -59,7 +59,7 @@ final class CommentTest extends BaseTest
         $this->assertFalse($comment->isDeprecated());
         $this->assertFalse($comment->isOverrideIntended());
         $this->assertFalse($comment->isNSInternal());
-        $this->assertSame('', (string)$comment->getReturnType());
+        $this->assertFalse($comment->hasReturnUnionType());
         $this->assertFalse($comment->hasReturnUnionType());
         $this->assertInstanceOf(None::class, $comment->getClosureScopeOption());
         $this->assertSame([], $comment->getParameterList());

--- a/tests/files/expected/0005_compat.php.expected
+++ b/tests/files/expected/0005_compat.php.expected
@@ -1,3 +1,3 @@
 %s:16 PhanTypeMismatchDefault Default value for int $b can't be false
 %s:16 PhanTypeMismatchDefault Default value for string $c can't be int
-%s:25 PhanTypeMismatchDeclaredParamNullable Doc-block of $categories in fromCategories is phpdoc param type \A which is not a permitted replacement of the nullable param type ?\A declared in the signature ('?T' should be documented as 'T|null' or '?T')
+%s:21 PhanTypeMismatchDeclaredParamNullable Doc-block of $categories in fromCategories is phpdoc param type \A which is not a permitted replacement of the nullable param type ?\A declared in the signature ('?T' should be documented as 'T|null' or '?T')

--- a/tests/files/expected/0253_keys_in_lists.php.expected
+++ b/tests/files/expected/0253_keys_in_lists.php.expected
@@ -10,4 +10,3 @@
 %s:42 PhanTypeInvalidDimOffsetArrayDestructuring Invalid offset 1 of array type array{k1:1,k2:'string'}|array{k1:2,k2:'string'} in an array destructuring assignment
 %s:42 PhanTypeMismatchArrayDestructuringKey Attempting an array destructing assignment with a key of type int but the only key types of the right hand side are of type string
 %s:46 PhanTypeInvalidDimOffsetArrayDestructuring Invalid offset "kMissing" of array type array{k1:1,k2:'string'}|array{k1:2,k2:'string'} in an array destructuring assignment
-

--- a/tests/files/expected/0253_return_type_match.php.expected
+++ b/tests/files/expected/0253_return_type_match.php.expected
@@ -1,8 +1,8 @@
-%s:4 PhanTypeMismatchDeclaredReturn Doc-block of f1 contains declared return type string which is incompatible with the return type int declared in the signature
-%s:21 PhanTypeMismatchDeclaredReturn Doc-block of a5 contains declared return type iterable which is incompatible with the return type array declared in the signature
-%s:33 PhanTypeMismatchDeclaredReturn Doc-block of a8 contains declared return type string which is incompatible with the return type iterable declared in the signature
-%s:42 PhanTypeMismatchDeclaredReturn Doc-block of a10 contains declared return type ?int which is incompatible with the return type int declared in the signature
-%s:47 PhanTypeMismatchDeclaredReturnNullable Doc-block of a11 has declared return type int which is not a permitted replacement of the nullable return type ?int declared in the signature ('?T' should be documented as 'T|null' or '?T')
-%s:57 PhanTypeMismatchDeclaredReturn Doc-block of f6 contains declared return type \C253_1 which is incompatible with the return type \C253_2 declared in the signature
-%s:61 PhanTypeMismatchDeclaredReturn Doc-block of f7 contains declared return type \C253_1 which is incompatible with the return type \C253_2 declared in the signature
-%s:69 PhanTypeMismatchDeclaredReturn Doc-block of h4 contains declared return type static which is incompatible with the return type iterable declared in the signature
+%s:3 PhanTypeMismatchDeclaredReturn Doc-block of f1 contains declared return type string which is incompatible with the return type int declared in the signature
+%s:20 PhanTypeMismatchDeclaredReturn Doc-block of a5 contains declared return type iterable which is incompatible with the return type array declared in the signature
+%s:32 PhanTypeMismatchDeclaredReturn Doc-block of a8 contains declared return type string which is incompatible with the return type iterable declared in the signature
+%s:41 PhanTypeMismatchDeclaredReturn Doc-block of a10 contains declared return type ?int which is incompatible with the return type int declared in the signature
+%s:46 PhanTypeMismatchDeclaredReturnNullable Doc-block of a11 has declared return type int which is not a permitted replacement of the nullable return type ?int declared in the signature ('?T' should be documented as 'T|null' or '?T')
+%s:56 PhanTypeMismatchDeclaredReturn Doc-block of f6 contains declared return type \C253_1 which is incompatible with the return type \C253_2 declared in the signature
+%s:60 PhanTypeMismatchDeclaredReturn Doc-block of f7 contains declared return type \C253_1 which is incompatible with the return type \C253_2 declared in the signature
+%s:68 PhanTypeMismatchDeclaredReturn Doc-block of h4 contains declared return type static which is incompatible with the return type iterable declared in the signature

--- a/tests/files/expected/0253_return_type_match.php.expected70
+++ b/tests/files/expected/0253_return_type_match.php.expected70
@@ -1,6 +1,6 @@
-%s:4 PhanTypeMismatchDeclaredReturn Doc-block of f1 contains declared return type string which is incompatible with the return type int declared in the signature
-%s:21 PhanTypeMismatchDeclaredReturn Doc-block of a5 contains declared return type iterable which is incompatible with the return type array declared in the signature
-%s:34 PhanTypeMismatchDeclaredReturn Doc-block of a10 contains declared return type ?int which is incompatible with the return type int declared in the signature
-%s:50 PhanTypeMismatchDeclaredReturn Doc-block of f6 contains declared return type \C253_1 which is incompatible with the return type \C253_2 declared in the signature
-%s:54 PhanTypeMismatchDeclaredReturn Doc-block of f7 contains declared return type \C253_1 which is incompatible with the return type \C253_2 declared in the signature
-%s:62 PhanTypeMismatchDeclaredReturn Doc-block of h4 contains declared return type static which is incompatible with the return type \Traversable declared in the signature
+%s:3 PhanTypeMismatchDeclaredReturn Doc-block of f1 contains declared return type string which is incompatible with the return type int declared in the signature
+%s:20 PhanTypeMismatchDeclaredReturn Doc-block of a5 contains declared return type iterable which is incompatible with the return type array declared in the signature
+%s:33 PhanTypeMismatchDeclaredReturn Doc-block of a10 contains declared return type ?int which is incompatible with the return type int declared in the signature
+%s:49 PhanTypeMismatchDeclaredReturn Doc-block of f6 contains declared return type \C253_1 which is incompatible with the return type \C253_2 declared in the signature
+%s:53 PhanTypeMismatchDeclaredReturn Doc-block of f7 contains declared return type \C253_1 which is incompatible with the return type \C253_2 declared in the signature
+%s:61 PhanTypeMismatchDeclaredReturn Doc-block of h4 contains declared return type static which is incompatible with the return type \Traversable declared in the signature

--- a/tests/files/expected/0258_variadic_comment_parsing.php.expected
+++ b/tests/files/expected/0258_variadic_comment_parsing.php.expected
@@ -1,7 +1,7 @@
-%s:8 PhanMismatchVariadicComment int ...$x is variadic in comment, but not variadic in param ($x)
-%s:8 PhanMismatchVariadicParam array $y is not variadic in comment, but variadic in param (...$y)
-%s:16 PhanMismatchVariadicParam int $y is not variadic in comment, but variadic in param (...$y)
-%s:25 PhanMismatchVariadicComment int ...$x is variadic in comment, but not variadic in param ($x)
-%s:25 PhanMismatchVariadicParam array $y is not variadic in comment, but variadic in param (...$y)
-%s:32 PhanMismatchVariadicParam int $z is not variadic in comment, but variadic in param (...$z)
+%s:5 PhanMismatchVariadicComment int ...$x is variadic in comment, but not variadic in param ($x)
+%s:6 PhanMismatchVariadicParam array $y is not variadic in comment, but variadic in param (...$y)
+%s:14 PhanMismatchVariadicParam int $y is not variadic in comment, but variadic in param (...$y)
+%s:22 PhanMismatchVariadicComment int ...$x is variadic in comment, but not variadic in param ($x)
+%s:23 PhanMismatchVariadicParam array $y is not variadic in comment, but variadic in param (...$y)
+%s:30 PhanMismatchVariadicParam int $z is not variadic in comment, but variadic in param (...$z)
 %s:36 PhanTypeMismatchArgument Argument 3 (y) is array{} but \badvariadic258b() takes int defined at %s:16

--- a/tests/files/expected/0291_word_regex_ignores_nonword.php.expected
+++ b/tests/files/expected/0291_word_regex_ignores_nonword.php.expected
@@ -1,3 +1,3 @@
-%s:7 PhanCommentParamOutOfOrder Expected @param annotation for x to be before the @param annotation for y
+%s:4 PhanCommentParamOutOfOrder Expected @param annotation for x to be before the @param annotation for y
 %s:8 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is array but \intdiv() takes int
 %s:9 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is string but \intdiv() takes int

--- a/tests/files/expected/0314_param_type_match.php.expected
+++ b/tests/files/expected/0314_param_type_match.php.expected
@@ -1,11 +1,11 @@
-%s:4 PhanTypeMismatchDeclaredParam Doc-block of $arg1 in f1 contains phpdoc param type string which is incompatible with the param type int declared in the signature
-%s:15 PhanTypeMismatchDeclaredParam Doc-block of $arg1 in f4 contains phpdoc param type iterable which is incompatible with the param type array declared in the signature
-%s:18 PhanTypeMismatchDeclaredParam Doc-block of $arg1 in f5 contains phpdoc param type iterable which is incompatible with the param type array declared in the signature
-%s:24 PhanTypeMismatchDeclaredParam Doc-block of $arg2 in f6 contains phpdoc param type iterable which is incompatible with the param type array declared in the signature
-%s:24 PhanTypeMismatchDeclaredParam Doc-block of $arg2 in f6 contains phpdoc param type string which is incompatible with the param type array declared in the signature
-%s:33 PhanTypeMismatchDeclaredParam Doc-block of $arg1 in f9 contains phpdoc param type string which is incompatible with the param type iterable declared in the signature
-%s:37 PhanTypeMismatchDeclaredParam Doc-block of $arg1 in a10 contains phpdoc param type ?int which is incompatible with the param type int declared in the signature
+%s:3 PhanTypeMismatchDeclaredParam Doc-block of $arg1 in f1 contains phpdoc param type string which is incompatible with the param type int declared in the signature
+%s:14 PhanTypeMismatchDeclaredParam Doc-block of $arg1 in f4 contains phpdoc param type iterable which is incompatible with the param type array declared in the signature
+%s:17 PhanTypeMismatchDeclaredParam Doc-block of $arg1 in f5 contains phpdoc param type iterable which is incompatible with the param type array declared in the signature
+%s:22 PhanTypeMismatchDeclaredParam Doc-block of $arg2 in f6 contains phpdoc param type iterable which is incompatible with the param type array declared in the signature
+%s:22 PhanTypeMismatchDeclaredParam Doc-block of $arg2 in f6 contains phpdoc param type string which is incompatible with the param type array declared in the signature
+%s:32 PhanTypeMismatchDeclaredParam Doc-block of $arg1 in f9 contains phpdoc param type string which is incompatible with the param type iterable declared in the signature
+%s:36 PhanTypeMismatchDeclaredParam Doc-block of $arg1 in a10 contains phpdoc param type ?int which is incompatible with the param type int declared in the signature
 %s:58 PhanTypeMismatchReturn Returning type array<int,int> but a13() is declared to return int
-%s:75 PhanTypeMismatchDeclaredParam Doc-block of $arg1 in g2 contains phpdoc param type \C314_1 which is incompatible with the param type \C314_2 declared in the signature
-%s:79 PhanTypeMismatchDeclaredParam Doc-block of $arg1 in g3 contains phpdoc param type \C314_1 which is incompatible with the param type \C314_2 declared in the signature
+%s:74 PhanTypeMismatchDeclaredParam Doc-block of $arg1 in g2 contains phpdoc param type \C314_1 which is incompatible with the param type \C314_2 declared in the signature
+%s:78 PhanTypeMismatchDeclaredParam Doc-block of $arg1 in g3 contains phpdoc param type \C314_1 which is incompatible with the param type \C314_2 declared in the signature
 %s:84 PhanTypeMismatchArgumentInternal Argument 1 (string) is int[] but \strlen() takes string

--- a/tests/files/expected/0314_param_type_match.php.expected70
+++ b/tests/files/expected/0314_param_type_match.php.expected70
@@ -1,10 +1,10 @@
-%s:4 PhanTypeMismatchDeclaredParam Doc-block of $arg1 in f1 contains phpdoc param type string which is incompatible with the param type int declared in the signature
-%s:15 PhanTypeMismatchDeclaredParam Doc-block of $arg1 in f4 contains phpdoc param type iterable which is incompatible with the param type array declared in the signature
-%s:18 PhanTypeMismatchDeclaredParam Doc-block of $arg1 in f5 contains phpdoc param type iterable which is incompatible with the param type array declared in the signature
-%s:24 PhanTypeMismatchDeclaredParam Doc-block of $arg2 in f6 contains phpdoc param type iterable which is incompatible with the param type array declared in the signature
-%s:24 PhanTypeMismatchDeclaredParam Doc-block of $arg2 in f6 contains phpdoc param type string which is incompatible with the param type array declared in the signature
-%s:37 PhanTypeMismatchDeclaredParam Doc-block of $arg1 in a10 contains phpdoc param type ?int which is incompatible with the param type int declared in the signature
+%s:3 PhanTypeMismatchDeclaredParam Doc-block of $arg1 in f1 contains phpdoc param type string which is incompatible with the param type int declared in the signature
+%s:14 PhanTypeMismatchDeclaredParam Doc-block of $arg1 in f4 contains phpdoc param type iterable which is incompatible with the param type array declared in the signature
+%s:17 PhanTypeMismatchDeclaredParam Doc-block of $arg1 in f5 contains phpdoc param type iterable which is incompatible with the param type array declared in the signature
+%s:22 PhanTypeMismatchDeclaredParam Doc-block of $arg2 in f6 contains phpdoc param type iterable which is incompatible with the param type array declared in the signature
+%s:22 PhanTypeMismatchDeclaredParam Doc-block of $arg2 in f6 contains phpdoc param type string which is incompatible with the param type array declared in the signature
+%s:36 PhanTypeMismatchDeclaredParam Doc-block of $arg1 in a10 contains phpdoc param type ?int which is incompatible with the param type int declared in the signature
 %s:58 PhanTypeMismatchReturn Returning type array<int,int> but a13() is declared to return int
-%s:75 PhanTypeMismatchDeclaredParam Doc-block of $arg1 in g2 contains phpdoc param type \C314_1 which is incompatible with the param type \C314_2 declared in the signature
-%s:79 PhanTypeMismatchDeclaredParam Doc-block of $arg1 in g3 contains phpdoc param type \C314_1 which is incompatible with the param type \C314_2 declared in the signature
+%s:74 PhanTypeMismatchDeclaredParam Doc-block of $arg1 in g2 contains phpdoc param type \C314_1 which is incompatible with the param type \C314_2 declared in the signature
+%s:78 PhanTypeMismatchDeclaredParam Doc-block of $arg1 in g3 contains phpdoc param type \C314_1 which is incompatible with the param type \C314_2 declared in the signature
 %s:84 PhanTypeMismatchArgumentInternal Argument 1 (string) is int[] but \strlen() takes string

--- a/tests/files/expected/0334_reject_bad_narrowing.php.expected
+++ b/tests/files/expected/0334_reject_bad_narrowing.php.expected
@@ -1,11 +1,11 @@
-%s:7 PhanCommentParamWithoutRealParam Saw an @param annotation for w, but it was not found in the param list of function badNarrowing334(?\DateTime $x = null);
-%s:7 PhanTypeMismatchDeclaredParamNullable Doc-block of $x in badNarrowing334 is phpdoc param type \DateTime which is not a permitted replacement of the nullable param type ?\DateTime declared in the signature ('?T' should be documented as 'T|null' or '?T')
+%s:4 PhanTypeMismatchDeclaredParamNullable Doc-block of $x in badNarrowing334 is phpdoc param type \DateTime which is not a permitted replacement of the nullable param type ?\DateTime declared in the signature ('?T' should be documented as 'T|null' or '?T')
+%s:5 PhanCommentParamWithoutRealParam Saw an @param annotation for w, but it was not found in the param list of function badNarrowing334(?\DateTime $x = null);
 %s:12 PhanTypeMismatchArgument Argument 1 (x) is 442 but \badNarrowing334() takes ?\DateTime defined at %s:7
-%s:17 PhanTypeMismatchDeclaredParamNullable Doc-block of $x in badNarrowingAsNull334 is phpdoc param type null which is not a permitted replacement of the nullable param type ?int declared in the signature ('?T' should be documented as 'T|null' or '?T')
+%s:15 PhanTypeMismatchDeclaredParamNullable Doc-block of $x in badNarrowingAsNull334 is phpdoc param type null which is not a permitted replacement of the nullable param type ?int declared in the signature ('?T' should be documented as 'T|null' or '?T')
 %s:22 PhanTypeMismatchArgument Argument 1 (x) is '42' but \badNarrowingAsNull334() takes ?int defined at %s:17
-%s:28 PhanTypeMismatchDeclaredParam Doc-block of $x in badNarrowingAsNullComposite334 contains phpdoc param type int which is incompatible with the param type ?string declared in the signature
-%s:28 PhanTypeMismatchDeclaredParam Doc-block of $y in badNarrowingAsNullComposite334 contains phpdoc param type ?int which is incompatible with the param type ?string declared in the signature
+%s:25 PhanTypeMismatchDeclaredParam Doc-block of $x in badNarrowingAsNullComposite334 contains phpdoc param type int which is incompatible with the param type ?string declared in the signature
+%s:26 PhanTypeMismatchDeclaredParam Doc-block of $y in badNarrowingAsNullComposite334 contains phpdoc param type ?int which is incompatible with the param type ?string declared in the signature
 %s:32 PhanTypeMismatchArgument Argument 1 (x) is 2 but \badNarrowingAsNullComposite334() takes ?string defined at %s:28
 %s:32 PhanTypeMismatchArgument Argument 2 (y) is 3 but \badNarrowingAsNullComposite334() takes ?string defined at %s:28
-%s:38 PhanTypeMismatchDeclaredParam Doc-block of $x in badNarrowingAsNullComposite334B contains phpdoc param type int which is incompatible with the param type ?string declared in the signature
-%s:38 PhanTypeMismatchDeclaredParam Doc-block of $y in badNarrowingAsNullComposite334B contains phpdoc param type ?int which is incompatible with the param type ?string declared in the signature
+%s:35 PhanTypeMismatchDeclaredParam Doc-block of $x in badNarrowingAsNullComposite334B contains phpdoc param type int which is incompatible with the param type ?string declared in the signature
+%s:36 PhanTypeMismatchDeclaredParam Doc-block of $y in badNarrowingAsNullComposite334B contains phpdoc param type ?int which is incompatible with the param type ?string declared in the signature

--- a/tests/files/expected/0373_reject_bad_type_narrowing.php.expected
+++ b/tests/files/expected/0373_reject_bad_type_narrowing.php.expected
@@ -1,1 +1,1 @@
-%s:6 PhanCommentParamWithoutRealParam Saw an @param annotation for notX, but it was not found in the param list of function badNarrowingNoType373($x);
+%s:4 PhanCommentParamWithoutRealParam Saw an @param annotation for notX, but it was not found in the param list of function badNarrowingNoType373($x);

--- a/tests/files/expected/0486_crash_test.php.expected
+++ b/tests/files/expected/0486_crash_test.php.expected
@@ -1,2 +1,2 @@
-%s:8 PhanTypeMismatchDeclaredReturn Doc-block of g contains declared return type iterable<int> which is incompatible with the return type \Traversable declared in the signature
-%s:11 PhanTypeMismatchDeclaredReturn Doc-block of h contains declared return type iterable<int> which is incompatible with the return type int declared in the signature
+%s:7 PhanTypeMismatchDeclaredReturn Doc-block of g contains declared return type iterable<int> which is incompatible with the return type \Traversable declared in the signature
+%s:10 PhanTypeMismatchDeclaredReturn Doc-block of h contains declared return type iterable<int> which is incompatible with the return type int declared in the signature

--- a/tests/files/expected/0520_spaces_in_union_type.php.expected
+++ b/tests/files/expected/0520_spaces_in_union_type.php.expected
@@ -1,3 +1,3 @@
-%s:9 PhanCommentParamOutOfOrder Expected @param annotation for x to be before the @param annotation for y
+%s:5 PhanCommentParamOutOfOrder Expected @param annotation for x to be before the @param annotation for y
 %s:10 PhanTypeMismatchArgumentInternal Argument 1 (var) is int|string but \count() takes \Countable|array
 %s:10 PhanTypeMismatchReturn Returning type int but {closure}() is declared to return array|object


### PR DESCRIPTION
Fixes #1369