### PR TITLE
Add .gitattributes for publishing releases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Files and directories with the attribute export-ignore won't be added to archive files
+# (such as zips/tarballs in GitHub Releases)
+/.appveyor.yml     export-ignore
+/.codeclimate.yml  export-ignore
+/.gitattributes    export-ignore
+/.gitignore        export-ignore
+/.github           export-ignore
+/.travis.yml       export-ignore
+/internal          export-ignore
+/phpcs.xml         export-ignore
+/phpdoc.dist.xml   export-ignore
+/phpunit.xml       export-ignore
+/plugins           export-ignore
+/tests             export-ignore

--- a/internal/publish_release
+++ b/internal/publish_release
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-# TODO: Add an option to use Github API to create the release
-# TODO: Check that ./phan --version is not a dev version
-function publish_release() {
-	git rm -r tests internal phpcs.xml phpdoc.dist.xml phpunit.xml plugins
-	git commit -m 'Remove files which should not be published from the release'
-}
-publish_release


### PR DESCRIPTION
And remove script that was previously used to delete those files
(prior to creating a git commit for the release)

Closes #1986