### PR TITLE
Fix sorting of code completion lists alphabetically

### DIFF
--- a/src/Phan/LanguageServer/CompletionRequest.php
+++ b/src/Phan/LanguageServer/CompletionRequest.php
@@ -153,10 +153,10 @@ final class CompletionRequest extends NodeInfoRequest
     {
         $promise = $this->promise;
         if ($promise) {
-            $result = $this->completions ? array_values($this->completions) : null;
+            $result = $this->completions ?: null;
             if ($result !== null) {
                 uksort($result, 'strcasecmp');
-                $result_list = new CompletionList($result);
+                $result_list = new CompletionList(array_values($result));
             } else {
                 $result_list = null;
             }

--- a/tests/Phan/LanguageServer/LanguageServerIntegrationTest.php
+++ b/tests/Phan/LanguageServer/LanguageServerIntegrationTest.php
@@ -330,7 +330,7 @@ EOT;
             'filterText' => null,
             'insertText' => null,
         ];
-        $methodCompletionItem = [
+        $myStaticFunctionItem = [
             'label' => 'my_static_function',
             'kind' => CompletionItemKind::METHOD,
             'detail' => 'mixed',
@@ -375,6 +375,7 @@ EOT;
             'filterText' => null,
             'insertText' => null,
         ];
+        // These completions are returned to the language client in alphabetical order
         $staticPropertyCompletions = [
             $propertyCompletionItem,
         ];
@@ -382,16 +383,16 @@ EOT;
             array_merge($propertyCompletionItem, ['insertText' => 'Var']),
         ];
         $allStaticCompletions = [
-            $propertyCompletionItem,
-            $myClassConstantItem,
             $myClassClassItem,
-            $methodCompletionItem,
+            $myClassConstantItem,
+            $myStaticFunctionItem,
+            $propertyCompletionItem,
         ];
         $allConstantCompletions = [
-            $myGlobalConstantItem,
-            $myOtherGlobalConstantItem,
             $myClassItem,
+            $myGlobalConstantItem,
             $myGlobalFunctionItem,
+            $myOtherGlobalConstantItem,
         ];
 
         return [
@@ -531,17 +532,16 @@ EOT;
             'insertText' => null,
         ];
         $publicM9OtherCompletions = [
-            $otherPublicVarPropertyItem,
             $otherPublicPropertyItem,
+            $otherPublicVarPropertyItem,
         ];
         $publicM9MyCompletions = [
+            $myOtherStaticMethodItem,
+            $myStaticMethodItem,
+            $myInstanceMethodItem,
             $myMagicPropertyItem,
             $myPublicVarItem,
-            $myInstanceMethodItem,
-            $myStaticMethodItem,
-            $myOtherStaticMethodItem,
         ];
-
 
         $myLocalVarItem = [
             'label' => 'myLocalVar',


### PR DESCRIPTION
The sort was done in the wrong order.

This also fixes a bug returning lists of 10 or more values.