### PR TITLE
Make variable and static property completions compatible with VS Code

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@ Language Server/Daemon mode:
 + Add `--output-mode <mode>` to `phan_client`. (#1568)
   Supported formats: `phan_client` (default), `text`, `json`, `csv`, `codeclimate`, `checkstyle`, or `pylint`
 + Add `--color` to `phan_client` (e.g. for use with `--output-mode text`)
++ Add `--language-server-completion-vscode`. This is a workaround to make completion of variables and static properties work in [the Phan plugin for VS Code](https://github.com/tysonandre/vscode-php-phan)
 
 Plugins:
 + Add a new issue type to `DuplicateExpressionPlugin`: `PhanPluginBothLiteralsBinaryOp`. (#2297)

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -87,6 +87,7 @@ class CLI
         'language-server-enable-go-to-definition',
         'language-server-enable-hover',
         'language-server-enable-completion',
+        'language-server-completion-vscode',
         'markdown-issue-messages',
         'memory-limit:',
         'minimum-severity:',
@@ -501,8 +502,13 @@ class CLI
                 case 'language-server-enable-hover':
                     Config::setValue('language_server_enable_hover', true);
                     break;
+                case 'language-server-completion-vscode':
+                    break;
                 case 'language-server-enable-completion':
-                    Config::setValue('language_server_enable_completion', true);
+                    Config::setValue(
+                        'language_server_enable_completion',
+                        isset($opts['language-server-completion-vscode']) ? Config::COMPLETION_VSCODE : true
+                    );
                     break;
                 case 'language-server-verbose':
                     Config::setValue('language_server_debug_level', 'info');
@@ -956,6 +962,10 @@ Extended help:
  --language-server-enable-completion
   Enables support for "Completion" in the Phan Language Server.
   Disabled by default.
+
+ --language-server-completion-vscode
+  Adds a workaround to make completion of variables and static properties
+  that are compatible with language clients such as VS Code.
 
  --language-server-verbose
   Emit verbose logging messages related to the language server implementation to stderr.

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -903,6 +903,8 @@ class Config
         ],
     ];
 
+    const COMPLETION_VSCODE = 'vscode';
+
     /**
      * Disallow the constructor.
      */

--- a/src/Phan/LanguageServer/CompletionResolver.php
+++ b/src/Phan/LanguageServer/CompletionResolver.php
@@ -353,6 +353,7 @@ class CompletionResolver
         string $incomplete_variable_name
     ) {
         $variable_candidates = $context->getScope()->getVariableMap();
+        $prefix = CompletionRequest::useVSCodeCompletion() ? '$' : '';
         // TODO: Use the alias map
         // TODO: Remove the namespace
         foreach ($variable_candidates as $suggested_variable_name => $variable) {
@@ -363,7 +364,7 @@ class CompletionResolver
             $request->recordCompletionElement(
                 $code_base,
                 $variable,
-                $suggested_variable_name
+                $prefix . $incomplete_variable_name
             );
         }
         $superglobal_names = array_merge(array_keys(Variable::_BUILTIN_SUPERGLOBAL_TYPES), Config::getValue('runkit_superglobals'));
@@ -379,7 +380,7 @@ class CompletionResolver
                     Variable::getUnionTypeOfHardcodedGlobalVariableWithName($superglobal_name),
                     0
                 ),
-                $superglobal_name
+                $prefix . $incomplete_variable_name
             );
         }
     }


### PR DESCRIPTION
NOTE:

- The old code works in LanguageClient-neovim.
- The new code works in vscode-php-phan.

I assume this is because of differences in the ways they identify the
current token being completed (vim doesn't include the `$`, VS Code does)

- A short term solution is to add client-specific workarounds instead

TODO: Look into implementing textEdit;
hopefully client support is better with textEdit in both.