### PR TITLE
Properly extract (int|string)[] in PHPDoc

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@ Phan NEWS
 -----------------------
 
 New features:
++ Support the `(int|string)[]` syntax of union types (union of multiple types converted to an array) in PHPDoc (#2008)
+
+  e.g. `@param (int|string)[] $paramName`, `@return (int|string)[]`
 + Support spaces after commas in array shapes (#1966)
 
 25 Sep 2018, Phan 1.0.6

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -267,7 +267,13 @@ class UnionType implements Serializable
             // Exclude empty type names
             // Exclude namespaces without type names (e.g. `\`, `\NS\`)
             if ($type_name !== '' && \preg_match('@\\\\[\[\]]*$@', $type_name) === 0) {
-                $parts[] = $type_name;
+                if (($type_name[0] ?? '') === '(' && \substr($type_name, -1) === ')') {
+                    foreach (self::extractTypePartsForStringInContext(\substr($type_name, 1, -1)) as $inner_type_name) {
+                        $parts[] = $inner_type_name;
+                    }
+                } else {
+                    $parts[] = $type_name;
+                }
             }
         }
         $cache[$type_string] = $parts;

--- a/tests/Phan/Language/UnionTypeTest.php
+++ b/tests/Phan/Language/UnionTypeTest.php
@@ -303,8 +303,11 @@ final class UnionTypeTest extends BaseTest
         )->asExpandedTypes(self::$code_base)->__toString();
     }
 
+    const VALID_UNION_TYPE_REGEX = '(^(' . UnionType::union_type_regex_or_this . ')$)';
+
     private static function makePHPDocUnionType(string $union_type_string) : UnionType
     {
+        self::assertTrue(preg_match(self::VALID_UNION_TYPE_REGEX, $union_type_string) > 0, "$union_type_string should be parsed by regex");
         return UnionType::fromStringInContext($union_type_string, new Context(), Type::FROM_PHPDOC);
     }
 
@@ -428,6 +431,15 @@ final class UnionTypeTest extends BaseTest
         $union_type = self::makePHPDocUnionType('array<int|string>');
         $this->assertSame('int[]|string[]', (string)$union_type);
         $this->assertSame(2, $union_type->typeCount());
+
+        // array keys are integers, values are strings
+        $union_type = self::makePHPDocUnionType('(int|string)[]');
+        $this->assertSame('int[]|string[]', (string)$union_type);
+        $this->assertSame(2, $union_type->typeCount());
+
+        $union_type = self::makePHPDocUnionType('((int)|(string))[]');
+        $this->assertSame('int[]|string[]', (string)$union_type);
+        $this->assertSame(2, $union_type->typeCount());
         $types = $union_type->getTypeSet();
         $type = reset($types);
 
@@ -448,6 +460,61 @@ final class UnionTypeTest extends BaseTest
         $this->assertSame($array_type($array_type($array_type(IntType::instance(false)))), $type);
         $type = next($types);
         $this->assertSame($array_type($array_type($array_type(StringType::instance(false)))), $type);
+    }
+
+    /**
+     * Assert values that should not be matched by the regular expression for a valid union type.
+     * This regular expression controls what can get passed to UnionType::from...()
+     *
+     * @dataProvider unparseableUnionTypeProvider
+     */
+    public function testUnparseableUnionType(string $type)
+    {
+        $this->assertSame(0, preg_match(self::VALID_UNION_TYPE_REGEX, $type), "'$type' should be unparseable");
+    }
+
+    public function unparseableUnionTypeProvider() : array
+    {
+        return [
+            ['()'],
+            ['()'],
+            [')('],
+            ['<>'],
+            ['[]'],
+            ['{}'],
+            ['?()'],
+            ['<=>'],
+            ['()[]'],
+            ['array<>'],
+            ['[(a|b)]'],
+            ['int|'],
+            ['|int'],
+            ['int|?'],
+            ['int|()'],
+            ['(int|)'],
+            ['array{'],
+            ['array{}}'],
+            ['(int){}'],
+        ];
+    }
+
+    public function testComplexUnionType()
+    {
+        // array keys are integers, values are strings
+        $union_type = self::makePHPDocUnionType('(int|string)|Closure():(int|stdClass)');
+        $this->assertSame('Closure():(\stdClass|int)|int|string', (string)$union_type);
+        $this->assertSame(3, $union_type->typeCount());
+    }
+
+    public function testNullableBasicArrayType()
+    {
+        // array keys are integers, values are strings
+        $union_type = self::makePHPDocUnionType('?(int|string)[]');
+        $this->assertSame('?int[]|?string[]', (string)$union_type);
+        $this->assertSame(2, $union_type->typeCount());
+        $union_type = self::makePHPDocUnionType('?((int|string))[]');
+        $this->assertSame('?int[]|?string[]', (string)$union_type);
+        $this->assertSame(2, $union_type->typeCount());
     }
 
     public function testNullableArrayType()

--- a/tests/files/expected/0536_array_doc_annotation.php.expected
+++ b/tests/files/expected/0536_array_doc_annotation.php.expected
@@ -1,0 +1,2 @@
+%s:11 PhanTypeMismatchReturn Returning type array{0:1,1:'x',2:false} but intAndStrings() is declared to return int[]|string[]
+%s:17 PhanTypeMismatchArgument Argument 1 (values) is array{0:array{}} but \intAndStrings() takes int[]|string[] defined at %s:7

--- a/tests/files/src/0536_array_doc_annotation.php
+++ b/tests/files/src/0536_array_doc_annotation.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @param (int|string)[] $values
+ * @return (int|string)[]
+ */
+function intAndStrings($values)
+{
+    var_export($values);
+    return [
+        1,
+        'x',
+        false,
+    ];
+}
+intAndStrings([2]);
+intAndStrings([[]]);


### PR DESCRIPTION
Update both regexes to support this syntax in `@param` and `@return`
(`@return` allows types to include `$this`)