### PR TITLE
Fix incorrect PhanUnusedVariable for variable declared before break/continue

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,9 @@ New features:
   e.g. `@param (int|string)[] $paramName`, `@return (int|string)[]`
 + Support spaces after commas in array shapes (#1966)
 
+Bug fixes:
++ Fix false positive `PhanUnusedVariable` for variables declared before break/continue that are used after the loop. (#1985)
+
 25 Sep 2018, Phan 1.0.6
 -----------------------
 

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackingBranchScope.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackingBranchScope.php
@@ -39,6 +39,19 @@ class VariableTrackingBranchScope extends VariableTrackingScope
     }
 
     /**
+     * @return array<string,array<int,true>>
+     */
+    public function getDefinitionsRecursively()
+    {
+        $defs = $this->parent_scope->getDefinitionsRecursively();
+        foreach ($this->defs as $variable_name => $def) {
+            // TODO: Distinguish between being defined in *some* cases and being defined in *all* cases in this branch
+            $defs[$variable_name] = $def;
+        }
+        return $defs;
+    }
+
+    /**
      * Record a statement that was unreachable due to break/continue statements.
      *
      * @param VariableTrackingBranchScope $inner_scope @phan-unused-param

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackingScope.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackingScope.php
@@ -85,6 +85,14 @@ class VariableTrackingScope
         return $this->defs[$variable_name] ?? null;
     }
 
+    /**
+     * @return array<string,array<int,true>>
+     */
+    public function getDefinitionsRecursively()
+    {
+        return $this->defs;
+    }
+
     public function mergeInnerLoopScope(
         VariableTrackingLoopScope $scope,
         VariableGraph $graph
@@ -148,7 +156,7 @@ class VariableTrackingScope
         VariableTrackingBranchScope $scope,
         VariableGraph $graph
     ) {
-        foreach ($scope->defs as $variable_name => $defs) {
+        foreach ($scope->getDefinitionsRecursively() as $variable_name => $defs) {
             $defs_for_variable = $result->defs[$variable_name] ?? [];
             $loop_uses_of_own_variable = $scope->uses[$variable_name] ?? null;
 

--- a/tests/plugin_test/expected/051_loop_unused_defs.php.expected
+++ b/tests/plugin_test/expected/051_loop_unused_defs.php.expected
@@ -1,0 +1,1 @@
+src/051_loop_unused_defs.php:33 PhanUnusedVariable Unused definition of variable $b

--- a/tests/plugin_test/src/051_loop_unused_defs.php
+++ b/tests/plugin_test/src/051_loop_unused_defs.php
@@ -1,0 +1,50 @@
+<?php
+
+function foo51(int $value): bool {
+    do {
+        $a = true; // PhanUnusedVariable should not be emitted
+
+        if ($value == 1) {
+            break;
+        }
+
+        $a = false;
+    } while (false);
+
+    return $a;
+}
+
+function foo51b(): bool {
+    foreach (['a', 'b'] as $x) {
+        $a = true; // PhanUnusedVariable should not be emitted
+
+        if ($x === 'b') {
+            break;
+        }
+
+        $a = false;
+    }
+
+    return $a;
+}
+
+function foo51c(int $value): bool {
+    $a = true; // PhanUnusedVariable should not be emitted
+    $b = true; // PhanUnusedVariable should be emitted
+
+    do {
+        if ($value == 1) {
+            // TODO: Figure out why this would mark $b from the top as being used and implement a fix
+            // $b = 3;
+            // echo $b;
+            break;
+        }
+
+        $a = false;
+    } while (false);
+
+    return $a;
+}
+foo51(1);
+foo51b();
+foo51c(1);


### PR DESCRIPTION
This should not be emitted if the variables are used after the loop.

Fixes #1985