### PR TITLE
Improve Phan's unused variable detection (loops/conditionals/try-catch)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,9 @@ New features:
 
 Bug fixes:
 + Fix false positive `PhanUnusedVariable` for variables declared before break/continue that are used after the loop. (#1985)
-+ Emit `PhanUnusedVariable` for variables where definitions are shadowed by definitions in branches. (#2012)
++ Properly emit `PhanUnusedVariable` for variables where definitions are shadowed by definitions in branches and/or loops. (#2012)
++ Properly emit `PhanUnusedVariable` for variables which are redefined in a 'do while' loop.
++ Be more consistent about emitting `PhanUnusedVariableCaughtException` when exception variable names are reused later on.
 
 25 Sep 2018, Phan 1.0.6
 -----------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@ New features:
 
 Bug fixes:
 + Fix false positive `PhanUnusedVariable` for variables declared before break/continue that are used after the loop. (#1985)
++ Emit `PhanUnusedVariable` for variables where definitions are shadowed by definitions in branches. (#2012)
 
 25 Sep 2018, Phan 1.0.6
 -----------------------

--- a/src/Phan/AST/ASTSimplifier.php
+++ b/src/Phan/AST/ASTSimplifier.php
@@ -209,7 +209,6 @@ class ASTSimplifier
      */
     private function normalizeIfStatement(Node $original_node) : array
     {
-        $old_nodes = [];
         $nodes = [$original_node];
         // Repeatedly apply these rules
         do {

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -2012,7 +2012,7 @@ class UnionTypeVisitor extends AnalysisVisitor
                     }
 
                     return $union_type;
-                } catch (IssueException $exception) {
+                } catch (IssueException $_) {
                     return UnionType::empty();
                 }
             }
@@ -2410,7 +2410,6 @@ class UnionTypeVisitor extends AnalysisVisitor
         }
 
         // We're going to convert the class reference to a type
-        $type = null;
 
         // Check to see if the name is fully qualified
         if ($node->flags & \ast\flags\NAME_NOT_FQ) {

--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -100,11 +100,11 @@ class Analysis
         }
         try {
             $node = Parser::parseCode($code_base, $context, null, $file_path, $file_contents, $suppress_parse_errors);
-        } catch (ParseError $e) {
+        } catch (ParseError $_) {
             return $context;
-        } catch (CompileError $e) {
+        } catch (CompileError $_) {
             return $context;
-        } catch (ParseException $e) {
+        } catch (ParseException $_) {
             return $context;
         }
 

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -258,7 +258,6 @@ class AssignmentVisitor extends AnalysisVisitor
             // array element we're assigning to
             // TODO: Check key types are valid?
             $key_node = $child_node->children['key'];
-            $key_value = null;
 
             if ($key_node === null) {
                 $key_set[] = true;

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -1007,7 +1007,6 @@ class ParameterTypesAnalyzer
             ) {
                 $is_exclusively_narrowed = false;
                 if (!$method->checkHasSuppressIssueAndIncrementCount(Issue::TypeMismatchDeclaredParam)) {
-                    $param_name = $parameter->getName();
                     Issue::maybeEmit(
                         $code_base,
                         $context,

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -4,6 +4,7 @@ namespace Phan\Analysis;
 use AssertionError;
 use ast\flags;
 use ast\Node;
+use Exception;
 use Phan\AST\AnalysisVisitor;
 use Phan\AST\ContextNode;
 use Phan\AST\PhanAnnotationAdder;
@@ -757,7 +758,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 $context,
                 $exception->getIssueInstance()
             );
-        } catch (\Exception $_) {
+        } catch (Exception $_) {
             // Swallow any other types of exceptions. We'll log the errors
             // elsewhere.
         }
@@ -796,7 +797,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 $this->context,
                 $exception->getIssueInstance()
             );
-        } catch (\Exception $_) {
+        } catch (Exception $_) {
             // Swallow any other types of exceptions. We'll log the errors
             // elsewhere.
         }
@@ -1565,7 +1566,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 $this->context,
                 $exception->getIssueInstance()
             );
-        } catch (\Exception $_) {
+        } catch (Exception $_) {
             // If we can't figure out what kind of a call
             // this is, don't worry about it
             return $this->context;
@@ -1738,7 +1739,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 $this->context,
                 $exception->getIssueInstance()
             );
-        } catch (\Exception $_) {
+        } catch (Exception $_) {
             // If we can't figure out the class for this method
             // call, cry YOLO and mark every method with that
             // name with a reference.
@@ -1848,7 +1849,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 $this->context,
                 $exception->getIssueInstance()
             );
-        } catch (\Exception $_) {
+        } catch (Exception $_) {
             // If we can't figure out the class for this method
             // call, cry YOLO and mark every method with that
             // name with a reference.
@@ -1895,7 +1896,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             try {
                 $class = $method->getClass($this->code_base);
                 $has_interface_class = $class->isInterface();
-            } catch (\Exception $_) {
+            } catch (Exception $_) {
             }
 
             if (!$method->isAbstract()
@@ -2183,7 +2184,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             $exception_or_null = $exception;
         } catch (NodeException $exception) {
             $exception_or_null = $exception;
-        } catch (\Exception $exception) {
+        } catch (Exception $_) {
             // Swallow any exceptions. We'll catch it later.
         }
 
@@ -2464,7 +2465,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                                 $context,
                                 $exception->getIssueInstance()
                             );
-                        } catch (\Exception $exception) {
+                        } catch (Exception $exception) {
                             // If we can't figure out what kind of a call
                             // this is, don't worry about it
                         }
@@ -2581,7 +2582,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                         $context,
                         $exception->getIssueInstance()
                     );
-                } catch (\Exception $_) {
+                } catch (Exception $_) {
                     // If we can't figure out what kind of a call
                     // this is, don't worry about it
                 }
@@ -2658,7 +2659,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             ))->getClosure();
 
             $method->addReference($inner_context);
-        } catch (\Exception $_) {
+        } catch (Exception $_) {
             // Swallow it
         }
     }

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -733,7 +733,6 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
             // array element we're assigning to
             // TODO: Check key types are valid?
             $key_node = $child_node->children['key'];
-            $key_value = null;
 
             if ($key_node === null) {
                 $key_set[] = true;

--- a/src/Phan/Daemon.php
+++ b/src/Phan/Daemon.php
@@ -221,7 +221,6 @@ class Daemon
      */
     private static function createDaemonStreamSocketServer()
     {
-        $listen_url = null;
         if (Config::getValue('daemonize_socket')) {
             $listen_url = 'unix://' . Config::getValue('daemonize_socket');
         } elseif (Config::getValue('daemonize_tcp')) {

--- a/src/Phan/Language/Element/Comment/Builder.php
+++ b/src/Phan/Language/Element/Comment/Builder.php
@@ -136,7 +136,6 @@ final class Builder
             // If the type looks like a variable name, make it an
             // empty type so that other stuff can match it. We can't
             // just skip it or we'd mess up the parameter order.
-            $union_type = null;
             if (0 !== \strpos($type, '$')) {
                 $union_type =
                     UnionType::fromStringInContext(

--- a/src/Phan/Language/Element/Comment/Builder.php
+++ b/src/Phan/Language/Element/Comment/Builder.php
@@ -569,7 +569,6 @@ final class Builder
         // Search up to 10 lines before $lineno_search
         $lineno_stop = \max(1, $lineno_search - 9);
         $lines_array = $entry->getLines();
-        $j = $i;
 
         $line = $this->lines[$i];
         for ($check_lineno = $lineno_search; $check_lineno >= $lineno_stop; $check_lineno--) {

--- a/src/Phan/LanguageServer/ProtocolStreamReader.php
+++ b/src/Phan/LanguageServer/ProtocolStreamReader.php
@@ -72,7 +72,6 @@ class ProtocolStreamReader extends Emitter implements ProtocolReader
      */
     private function readMessages() : int
     {
-        $c = '';
         $emitted_messages = 0;
         while (($c = fgetc($this->input)) !== false && $c !== '') {
             $this->buffer .= $c;

--- a/src/Phan/Ordering.php
+++ b/src/Phan/Ordering.php
@@ -51,10 +51,9 @@ class Ordering
 
         if (Config::getValue('randomize_file_order')) {
             $random_proc_file_map = [];
-            $i = 0;
             shuffle($analysis_file_list);
             foreach ($analysis_file_list as $i => $file) {
-                $random_proc_file_map[$i++ % $process_count][] = $file;
+                $random_proc_file_map[$i % $process_count][] = $file;
             }
             return $random_proc_file_map;
         }

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -688,7 +688,6 @@ class ParseVisitor extends ScopeVisitor
 
         // Hunt for an un-taken alternate ID
         $alternate_id = 0;
-        $function_fqsen = null;
         do {
             $function_fqsen =
                 FullyQualifiedFunctionName::fromStringInContext(

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
@@ -578,7 +578,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
     }
 
     /**
-     * @param Node $node a node of kind AST_CATCH_LIST
+     * @param Node $node a node of kind AST_TRY
      * Analyzes catch statement lists.
      * @return VariableTrackingScope
      *
@@ -599,7 +599,10 @@ final class VariableTrackerVisitor extends AnalysisVisitor
 
         $catch_node_list = $node->children['catches']->children;
         if (count($catch_node_list) > 0) {
-            $main_scope = $this->analyze($main_scope, $node->children['catches']);
+            $catches_scope = new VariableTrackingBranchScope($main_scope);
+            $catches_scope = $this->analyze($catches_scope, $node->children['catches']);
+            // @phan-suppress-next-line PhanTypeMismatchArgument
+            $main_scope = $main_scope->mergeBranchScopeList([$catches_scope], true, []);
         }
         $finally_node = $node->children['finally'];
         if ($finally_node !== null) {

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
@@ -433,10 +433,12 @@ final class VariableTrackerVisitor extends AnalysisVisitor
 
         $inner_scope = new VariableTrackingLoopScope($outer_scope);
         $inner_scope = $this->analyze($inner_scope, $node->children['stmts']);
+        $inner_scope = $this->analyzeWhenValidNode($inner_scope, $node->children['cond']);
 
         // Merge inner scope into outer scope
         // @phan-suppress-next-line PhanTypeMismatchArgument
         $outer_scope = $outer_scope->mergeInnerLoopScope($inner_scope, self::$variable_graph);
+        // @phan-suppress-next-line PhanTypeMismatchArgument
         return $outer_scope_unbranched->mergeWithSingleBranchScope($outer_scope);
     }
 

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
@@ -418,7 +418,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
         $outer_scope = $outer_scope->mergeInnerLoopScope($inner_scope, self::$variable_graph);
 
         // @phan-suppress-next-line PhanTypeMismatchArgument
-        return $outer_scope_unbranched->mergeBranchScopeList([$outer_scope], true, []);
+        return $outer_scope_unbranched->mergeWithSingleBranchScope($outer_scope);
     }
 
     /**
@@ -437,7 +437,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
         // Merge inner scope into outer scope
         // @phan-suppress-next-line PhanTypeMismatchArgument
         $outer_scope = $outer_scope->mergeInnerLoopScope($inner_scope, self::$variable_graph);
-        return $outer_scope_unbranched->mergeBranchScopeList([$outer_scope], true, []);
+        return $outer_scope_unbranched->mergeWithSingleBranchScope($outer_scope);
     }
 
     /**
@@ -476,7 +476,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
         if ($loop_node instanceof Node) {
             $loop_scope = $this->analyze(new VariableTrackingBranchScope($inner_scope), $loop_node);
             // @phan-suppress-next-line PhanTypeMismatchArgument
-            $inner_scope = $inner_scope->mergeBranchScopeList([$loop_scope], true, []);
+            $inner_scope = $inner_scope->mergeWithSingleBranchScope($loop_scope);
         }
         // TODO: If the graph analysis is improved, look into making this stop analyzing 'loop' twice
         $inner_scope = $this->analyzeWhenValidNode($inner_scope, $node->children['cond']);
@@ -484,14 +484,14 @@ final class VariableTrackerVisitor extends AnalysisVisitor
         if ($loop_node instanceof Node) {
             $loop_scope = $this->analyze(new VariableTrackingBranchScope($inner_scope), $loop_node);
             // @phan-suppress-next-line PhanTypeMismatchArgument
-            $inner_scope = $inner_scope->mergeBranchScopeList([$loop_scope], true, []);
+            $inner_scope = $inner_scope->mergeWithSingleBranchScope($loop_scope);
         }
 
         // Merge inner scope into outer scope
         // @phan-suppress-next-line PhanTypeMismatchArgument
         $outer_scope = $outer_scope->mergeInnerLoopScope($inner_scope, self::$variable_graph);
         // @phan-suppress-next-line PhanTypeMismatchArgument
-        return $outer_scope_unbranched->mergeBranchScopeList([$outer_scope], true, []);
+        return $outer_scope_unbranched->mergeWithSingleBranchScope($outer_scope);
     }
 
     /**
@@ -620,14 +620,14 @@ final class VariableTrackerVisitor extends AnalysisVisitor
 
         // TODO: Use BlockExitStatusChecker, like BlockAnalysisVisitor
         // TODO: Optimize
-        $main_scope = $outer_scope->mergeBranchScopeList([$try_scope], true, []);
+        $main_scope = $outer_scope->mergeWithSingleBranchScope($try_scope);
 
         $catch_node_list = $node->children['catches']->children;
         if (count($catch_node_list) > 0) {
             $catches_scope = new VariableTrackingBranchScope($main_scope);
             $catches_scope = $this->analyze($catches_scope, $node->children['catches']);
             // @phan-suppress-next-line PhanTypeMismatchArgument
-            $main_scope = $main_scope->mergeBranchScopeList([$catches_scope], true, []);
+            $main_scope = $main_scope->mergeWithSingleBranchScope($catches_scope);
         }
         $finally_node = $node->children['finally'];
         if ($finally_node !== null) {

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackingBranchScope.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackingBranchScope.php
@@ -38,6 +38,18 @@ class VariableTrackingBranchScope extends VariableTrackingScope
     }
 
     /**
+     * @return ?array<int,true>
+     * @override
+     */
+    public function getDefinitionUpToScope(string $variable_name, VariableTrackingScope $forbidden_scope)
+    {
+        if ($this === $forbidden_scope) {
+            return null;
+        }
+        return $this->defs[$variable_name] ?? $this->parent_scope->getDefinitionUpToScope($variable_name, $forbidden_scope);
+    }
+
+    /**
      * @return array<string,array<int,true>>
      */
     public function getDefinitionsRecursively()

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackingBranchScope.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackingBranchScope.php
@@ -26,15 +26,14 @@ class VariableTrackingBranchScope extends VariableTrackingScope
      */
     public function getDefinition(string $variable_name)
     {
-        $parent_definitions = $this->parent_scope->getDefinition($variable_name);
         $definitions = $this->defs[$variable_name] ?? null;
-        if ($parent_definitions === null) {
-            return $definitions;
-        }
         if ($definitions === null) {
+            $parent_definitions = $this->parent_scope->getDefinition($variable_name);
+            if (is_array($parent_definitions)) {
+                $this->defs[$variable_name] = $parent_definitions;
+            }
             return $parent_definitions;
         }
-        $definitions += $parent_definitions;
         return $definitions;
     }
 

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackingScope.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackingScope.php
@@ -209,29 +209,16 @@ class VariableTrackingScope
             // TODO: Make this properly recurse until it reaches the right depth (unnecessary right now)
             $result->mergeUses($scope->uses);
         }
-        if ($merge_parent_scope) {
-            $is_redefined_in_all_scopes = function (string $variable_name) use ($branch_scopes) : bool {
-                foreach ($branch_scopes as $scope) {
-                    if (isset($scope->defs[$variable_name])) {
-                        return false;
-                    }
-                }
-                return true;
-            };
-        } else {
-            $is_redefined_in_all_scopes = function (string $unused_variable_name) : bool {
-                return false;
-            };
-        }
+
         foreach ($def_key_set as $variable_name => $_) {
-            if ($is_redefined_in_all_scopes($variable_name)) {
-                $defs_for_variable = [];
+            if ($merge_parent_scope) {
+                $defs_for_variable = $result->getDefinition($variable_name) ?? [];
             } else {
-                $defs_for_variable = $result->defs[$variable_name] ?? [];
+                $defs_for_variable = [];
             }
 
             foreach ($branch_scopes as $scope) {
-                foreach ($scope->defs[$variable_name] ?? [] as $def_id => $_) {
+                foreach ($scope->getDefinition($variable_name) ?? [] as $def_id => $_) {
                     $defs_for_variable[$def_id] = true;
                 }
             }

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackingScope.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackingScope.php
@@ -227,7 +227,6 @@ class VariableTrackingScope
      * Equivalent to mergeBranchScopeList([$scope], true, [])
      *
      * @param VariableTrackingBranchScope $scope
-     * @param array<int,VariableTrackingBranchScope> $inner_exiting_scope_list
      */
     public function mergeWithSingleBranchScope(
         VariableTrackingBranchScope $scope

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackingScope.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackingScope.php
@@ -157,7 +157,7 @@ class VariableTrackingScope
         VariableGraph $graph
     ) {
         foreach ($scope->getDefinitionsRecursively() as $variable_name => $defs) {
-            $defs_for_variable = $result->defs[$variable_name] ?? [];
+            $defs_for_variable = $result->getDefinition($variable_name) ?? [];
             $loop_uses_of_own_variable = $scope->uses[$variable_name] ?? null;
 
             foreach ($defs as $def_id => $_) {

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackingScope.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackingScope.php
@@ -7,7 +7,7 @@ use function spl_object_id;
 
 /**
  * This will represent a variable scope, similar to \Phan\Language\Scope.
- * Instead of tracking the union types for variable names, this will instead track definitions of variable names.
+ * Instead of tracking the union types for variable names, this will instead track definitions and uses of variable names.
  *
  * @see ContextMergeVisitor for something similar for union types.
  */
@@ -32,6 +32,8 @@ class VariableTrackingScope
     protected $uses = [];
 
     /**
+     * Record that $variable_name had a definition that was created by the Node $node
+     *
      * @return void
      */
     public function recordDefinition(string $variable_name, Node $node)
@@ -42,6 +44,8 @@ class VariableTrackingScope
     }
 
     /**
+     * Record that $variable_name had a definition that was created by the Node $node where spl_object_id($node) is $node_id
+     *
      * @return void
      */
     public function recordDefinitionById(string $variable_name, int $node_id)
@@ -52,6 +56,10 @@ class VariableTrackingScope
     }
 
     /**
+     * Record the fact that $node is a usage of $variable_name.
+     *
+     * If it is already a definition of $variable_name, then don't record that.
+     *
      * @suppress PhanUnreferencedPublicMethod used by reference
      * @return void
      */
@@ -66,6 +74,10 @@ class VariableTrackingScope
     }
 
     /**
+     * Record the fact that a node is a usage of $variable_name.
+     *
+     * Equivalent to $this->recordUsage($variable_name, spl_object_id($node))
+     *
      * @return void
      */
     public function recordUsageById(string $variable_name, int $node_id)
@@ -77,8 +89,11 @@ class VariableTrackingScope
     }
 
     /**
-     * Overridden by subclasses
-     * @return ?array<int,true>
+     * Gets the definitions of $variable_name in this scope.
+     *
+     * This is overridden by subclasses, some of which will modify $this->defs
+     *
+     * @return ?array<int,true> the Nodes which defined $variable_name
      */
     public function getDefinition(string $variable_name)
     {
@@ -86,6 +101,23 @@ class VariableTrackingScope
     }
 
     /**
+     * Gets the definitions of $variable_name in this scope.
+     *
+     * This is overridden by subclasses
+     *
+     * @return ?array<int,true> the Nodes which defined $variable_name
+     */
+    public function getDefinitionUpToScope(string $variable_name, VariableTrackingScope $forbidden_scope)
+    {
+        if ($this === $forbidden_scope) {
+            return null;
+        }
+        return $this->defs[$variable_name] ?? null;
+    }
+
+    /**
+     * Recursively finds the accessible definitions of various variable names
+     *
      * @return array<string,array<int,true>>
      */
     public function getDefinitionsRecursively()
@@ -93,19 +125,24 @@ class VariableTrackingScope
         return $this->defs;
     }
 
+    /**
+     * This creates a new scope where the definitions both inside and outside of the loop are accounted for.
+     *
+     * Additionally, it will mark references to variables at the beginning of the inner body of the loop as being uses of variables defined at the end of the loop.
+     */
     public function mergeInnerLoopScope(
-        VariableTrackingLoopScope $scope,
+        VariableTrackingLoopScope $inner_loop_scope,
         VariableGraph $graph
     ) : VariableTrackingScope {
         $result = clone($this);
         // TODO: Can this be optimized for common use cases?
-        foreach ($scope->skipped_loop_scopes as $alternate_scope) {
-            $this->flattenScopeToMergedLoopResult($scope, $alternate_scope, $graph);
+        foreach ($inner_loop_scope->skipped_loop_scopes as $alternate_scope) {
+            $this->flattenScopeToMergedLoopResult($inner_loop_scope, $alternate_scope, $graph);
         }
-        foreach ($scope->skipped_exiting_loop_scopes as $alternate_scope) {
-            $this->flattenUsesFromScopeToMergedLoopResult($scope, $alternate_scope, $graph);
+        foreach ($inner_loop_scope->skipped_exiting_loop_scopes as $alternate_scope) {
+            $this->flattenUsesFromScopeToMergedLoopResult($inner_loop_scope, $alternate_scope, $graph);
         }
-        $this->addScopeToMergedLoopResult($result, $scope, $graph);
+        $this->addScopeToMergedLoopResult($result, $inner_loop_scope, $graph);
         return $result;
     }
 
@@ -113,7 +150,7 @@ class VariableTrackingScope
      * @return void
      */
     protected function flattenScopeToMergedLoopResult(
-        VariableTrackingLoopScope $scope,
+        VariableTrackingLoopScope $inner_loop_scope,
         VariableTrackingBranchScope $alternate_scope,
         VariableGraph $graph
     ) {
@@ -123,17 +160,17 @@ class VariableTrackingScope
         $parent_scope = $alternate_scope->parent_scope;
         if (!($parent_scope instanceof VariableTrackingLoopScope)) {
             '@phan-var VariableTrackingBranchScope $parent_scope';
-            $this->flattenScopeToMergedLoopResult($scope, $parent_scope, $graph);
+            $this->flattenScopeToMergedLoopResult($inner_loop_scope, $parent_scope, $graph);
         }
-        $this->addScopeToMergedLoopResult($scope, $alternate_scope, $graph);
-        $scope->mergeUses($alternate_scope->uses);
+        $this->addScopeToMergedLoopResult($inner_loop_scope, $alternate_scope, $graph);
+        $inner_loop_scope->mergeUses($alternate_scope->uses);
     }
 
     /**
      * @return void
      */
     protected function flattenUsesFromScopeToMergedLoopResult(
-        VariableTrackingLoopScope $scope,
+        VariableTrackingLoopScope $inner_loop_scope,
         VariableTrackingBranchScope $alternate_scope,
         VariableGraph $graph
     ) {
@@ -143,9 +180,9 @@ class VariableTrackingScope
         $parent_scope = $alternate_scope->parent_scope;
         if (!($parent_scope instanceof VariableTrackingLoopScope)) {
             '@phan-var VariableTrackingBranchScope $parent_scope';
-            $this->flattenScopeToMergedLoopResult($scope, $parent_scope, $graph);
+            $this->flattenScopeToMergedLoopResult($inner_loop_scope, $parent_scope, $graph);
         }
-        $scope->mergeUses($alternate_scope->uses);
+        $inner_loop_scope->mergeUses($alternate_scope->uses);
     }
 
     /**
@@ -157,7 +194,8 @@ class VariableTrackingScope
         VariableGraph $graph
     ) {
         foreach ($scope->getDefinitionsRecursively() as $variable_name => $defs) {
-            $defs_for_variable = $result->getDefinition($variable_name) ?? [];
+            // @phan-suppress-next-line PhanUndeclaredProperty
+            $defs_for_variable = $result->getDefinitionUpToScope($variable_name, $result->parent_scope ?? $result) ?? [];
             $loop_uses_of_own_variable = $scope->uses[$variable_name] ?? null;
 
             foreach ($defs as $def_id => $_) {
@@ -183,6 +221,31 @@ class VariableTrackingScope
             }
             $this->uses[$variable_name] += $def_id_set;
         }
+    }
+
+    /**
+     * Equivalent to mergeBranchScopeList([$scope], true, [])
+     *
+     * @param VariableTrackingBranchScope $scope
+     * @param array<int,VariableTrackingBranchScope> $inner_exiting_scope_list
+     */
+    public function mergeWithSingleBranchScope(
+        VariableTrackingBranchScope $scope
+    ) : VariableTrackingScope {
+        $result = clone($this);
+        $def_key_set = $scope->defs;
+        // Anything which is used within a branch is used within the parent
+        $result->mergeUses($scope->uses);
+
+        foreach ($def_key_set as $variable_name => $_) {
+            $defs_for_variable = $result->getDefinition($variable_name) ?? [];
+
+            foreach ($scope->getDefinition($variable_name) ?? [] as $def_id => $_) {
+                $defs_for_variable[$def_id] = true;
+            }
+            $result->defs[$variable_name] = $defs_for_variable;
+        }
+        return $result;
     }
 
     /**

--- a/tests/Phan/LanguageServer/LanguageServerIntegrationTest.php
+++ b/tests/Phan/LanguageServer/LanguageServerIntegrationTest.php
@@ -1595,7 +1595,6 @@ EOT;
         $content_length = 0;
         $headers = [];
         '@phan-var array<string,string> $headers';
-        $c = false;
         $parsing_mode = ProtocolStreamReader::PARSE_HEADERS;
         while (($c = fgetc($proc_out)) !== false && $c !== '') {
             $buffer .= $c;

--- a/tests/files/expected/0451_switch_cases.php.expected
+++ b/tests/files/expected/0451_switch_cases.php.expected
@@ -1,1 +1,2 @@
+%s:4 PhanUnusedVariable Unused definition of variable $x
 %s:13 PhanTypeMismatchArgumentInternal Argument 1 (var) is ?array{} but \count() takes \Countable|array

--- a/tests/files/expected/0452_switch_cases.php.expected
+++ b/tests/files/expected/0452_switch_cases.php.expected
@@ -1,2 +1,4 @@
+%s:4 PhanUnusedVariable Unused definition of variable $val
 %s:11 PhanTypeMismatchArgumentInternal Argument 1 (var) is false but \count() takes \Countable|array
+%s:13 PhanUnusedVariable Unused definition of variable $v2
 %s:24 PhanTypeMismatchArgumentInternal Argument 1 (var) is \stdClass|float but \count() takes \Countable|array

--- a/tests/plugin_test/expected/046_unused_exception.php.expected
+++ b/tests/plugin_test/expected/046_unused_exception.php.expected
@@ -1,1 +1,2 @@
+src/046_unused_exception.php:3 PhanUnusedVariable Unused definition of variable $e
 src/046_unused_exception.php:12 PhanUnusedVariableCaughtException Unused definition of variable $e2 as a caught exception

--- a/tests/plugin_test/expected/052_shadowed_def.php.expected
+++ b/tests/plugin_test/expected/052_shadowed_def.php.expected
@@ -1,0 +1,2 @@
+src/052_shadowed_def.php:4 PhanUnusedVariable Unused definition of variable $a
+src/052_shadowed_def.php:22 PhanUnusedVariable Unused definition of variable $a

--- a/tests/plugin_test/expected/053_shadowed_loop_def.php.expected
+++ b/tests/plugin_test/expected/053_shadowed_loop_def.php.expected
@@ -1,0 +1,1 @@
+src/053_shadowed_loop_def.php:3 PhanUnusedVariable Unused definition of variable $a

--- a/tests/plugin_test/expected/054_shadowed_exception.php.expected
+++ b/tests/plugin_test/expected/054_shadowed_exception.php.expected
@@ -1,0 +1,1 @@
+src/054_shadowed_exception.php:6 PhanUnusedVariableCaughtException Unused definition of variable $e as a caught exception

--- a/tests/plugin_test/expected/056_while_loop.php.expected
+++ b/tests/plugin_test/expected/056_while_loop.php.expected
@@ -1,0 +1,1 @@
+src/056_while_loop.php:6 PhanUnusedVariable Unused definition of variable $c

--- a/tests/plugin_test/src/051_loop_unused_defs.php
+++ b/tests/plugin_test/src/051_loop_unused_defs.php
@@ -28,8 +28,8 @@ function foo51b(): bool {
     return $a;
 }
 
-function foo51c(int $value): bool {
-    $a = true; // PhanUnusedVariable should not be emitted
+
+function foo51c(int $value) {
     $b = true; // PhanUnusedVariable should be emitted
 
     do {
@@ -38,11 +38,7 @@ function foo51c(int $value): bool {
             echo $b;
             break;
         }
-
-        $a = false;
     } while (false);
-
-    return $a;
 }
 foo51(1);
 foo51b();

--- a/tests/plugin_test/src/051_loop_unused_defs.php
+++ b/tests/plugin_test/src/051_loop_unused_defs.php
@@ -34,9 +34,8 @@ function foo51c(int $value): bool {
 
     do {
         if ($value == 1) {
-            // TODO: Figure out why this would mark $b from the top as being used and implement a fix
-            // $b = 3;
-            // echo $b;
+            $b = 'a string';
+            echo $b;
             break;
         }
 

--- a/tests/plugin_test/src/052_shadowed_def.php
+++ b/tests/plugin_test/src/052_shadowed_def.php
@@ -1,0 +1,31 @@
+<?php
+
+call_user_func(function () {
+    $a = true;  // PhanUnusedVariable should be emitted
+    if (rand(0, 1) > 0) {
+        $a = true;
+        var_export($a);
+    }
+});
+
+call_user_func(function () {
+    $a = true;  // PhanUnusedVariable should not be emitted
+    if (rand(0, 1) > 0) {
+        if (rand(0, 1) > 0) {
+            $a = true;
+        }
+        var_export($a);
+    }
+});
+
+call_user_func(function () {
+    $a = true;  // PhanUnusedVariable should be emitted
+    if (rand(0, 1) > 0) {
+        if (rand(0, 1) > 0) {
+            $a = true;
+        } else {
+            $a = 'x';
+        }
+        var_export($a);
+    }
+});

--- a/tests/plugin_test/src/053_shadowed_loop_def.php
+++ b/tests/plugin_test/src/053_shadowed_loop_def.php
@@ -1,0 +1,54 @@
+<?php
+call_user_func(function () {
+    $a = null;  // Should warn about unused $a
+    do {
+        $a = rand(0, 1);
+    } while ($a > 0);
+});
+// should not warn about unused variables
+call_user_func(function () {
+    try {
+        $a = intdiv(2,1);
+    } catch (Exception $e) {
+        $a = $e->getCode();
+    }
+    var_export($a);
+});
+// should not warn about unused variables
+call_user_func(function (array $data) {
+    $a = null;
+    if (rand(0, 1) > 0) {
+        foreach ($data as $x) {
+            $a = $x;
+        }
+    } else {
+        $a = 2;
+    }
+    return $a;
+}, []);
+
+// should not warn about unused variables
+call_user_func(function (int $n) {
+    $a = null;
+    if (rand(0, 1) > 0) {
+        for ($i = 0; $i < $n; $i++) {
+            $a = $n;
+        }
+    } else {
+        $a = 2;
+    }
+    return $a;
+}, -1);
+
+// should not warn about unused variables (This is unrealistic, but all definitions can be used)
+call_user_func(function (int $n) {
+    $a = null;
+    if (rand(0, 1) > 0) {
+        while (rand(0, 1) > 0) {
+            $a = $n;
+        }
+    } else {
+        $a = 2;
+    }
+    return $a;
+}, -1);

--- a/tests/plugin_test/src/054_shadowed_exception.php
+++ b/tests/plugin_test/src/054_shadowed_exception.php
@@ -1,0 +1,13 @@
+<?php
+
+call_user_func(function () {
+    try {
+        throw new Exception('first test');
+    } catch (Exception $e) {  // Should warn
+    }
+    try {
+        throw new Exception('test');
+    } catch (Exception $e) {
+        echo $e->getMessage();
+    }
+});

--- a/tests/plugin_test/src/055_loop_false_positive.php
+++ b/tests/plugin_test/src/055_loop_false_positive.php
@@ -1,0 +1,19 @@
+<?php
+call_user_func(function () {
+    $i = 0;  // TODO: Phan should not warn about this being unused
+    for (;;$i = rand(0,10)) {
+        if ($i === 2) {
+            break;
+        }
+        echo $i;
+    }
+
+    // TODO: Phan should not warn about this being unused
+    for ($j = 0;
+        ; $j = rand(0,10)) {
+        if ($j === 2) {
+            break;
+        }
+        echo $j;
+    }
+});

--- a/tests/plugin_test/src/056_while_loop.php
+++ b/tests/plugin_test/src/056_while_loop.php
@@ -1,0 +1,8 @@
+<?php
+call_user_func(function (int $a) {
+    $b = rand(0, $a);
+    while ($a != $b) {
+        $b = rand(0, $a + 1);  // should not emit PhanUnusedVariable
+        $c = $a;
+    }
+}, 2);


### PR DESCRIPTION
See NEWS.md for more details.

This fixes #2012 

Also fix unused variables that were detected in Phan's codebase (These definitions were often needed due to limitations of earlier versions of Phan)