### PR TITLE
Add features to HasPHPDocPlugin; Add PHPDoc summaries of global functions/some methods

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -261,6 +261,12 @@ return [
         // TODO: Fix and remove suppression for this plugin
         'PhanPluginDescriptionlessCommentOnPrivateProperty',
         'PhanPluginDescriptionlessCommentOnProtectedProperty',
+
+        'PhanPluginNoCommentOnProtectedMethod',
+        'PhanPluginDescriptionlessCommentOnProtectedMethod',
+        'PhanPluginNoCommentOnPrivateMethod',
+        'PhanPluginDescriptionlessCommentOnPrivateMethod',
+        'PhanPluginNoCommentOnPublicMethod', // TODO: Maybe fix this issue type
     ],
 
     // If empty, no filter against issues types will be applied.

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -548,6 +548,9 @@ return [
         // The maximum number of `php --syntax-check` processes to run at any point in time (Minimum: 1).
         // This may be temporarily higher if php_native_syntax_check_binaries has more elements than this process count.
         'php_native_syntax_check_max_processes' => 4,
+
+        // blacklist of methods to warn about for HasPHPDocPlugin
+        'has_phpdoc_method_ignore_regex' => '@^Phan\\\\Tests\\\\.*::(test.*|.*Provider)$@',
     ],
 
     // A list of plugin files to execute

--- a/.phan/plugins/AlwaysReturnPlugin.php
+++ b/.phan/plugins/AlwaysReturnPlugin.php
@@ -161,5 +161,5 @@ final class AlwaysReturnPlugin extends PluginV2 implements
 }
 
 // Every plugin needs to return an instance of itself at the
-// end of the file in which its defined.
+// end of the file in which it's defined.
 return new AlwaysReturnPlugin();

--- a/.phan/plugins/DemoPlugin.php
+++ b/.phan/plugins/DemoPlugin.php
@@ -232,5 +232,5 @@ class DemoNodeVisitor extends PluginAwarePostAnalysisVisitor
 }
 
 // Every plugin needs to return an instance of itself at the
-// end of the file in which its defined.
+// end of the file in which it's defined.
 return new DemoPlugin();

--- a/.phan/plugins/DollarDollarPlugin.php
+++ b/.phan/plugins/DollarDollarPlugin.php
@@ -74,5 +74,5 @@ class DollarDollarVisitor extends PluginAwarePostAnalysisVisitor
 }
 
 // Every plugin needs to return an instance of itself at the
-// end of the file in which its defined.
+// end of the file in which it's defined.
 return new DollarDollarPlugin();

--- a/.phan/plugins/DuplicateArrayKeyPlugin.php
+++ b/.phan/plugins/DuplicateArrayKeyPlugin.php
@@ -204,5 +204,5 @@ class DuplicateArrayKeyVisitor extends PluginAwarePostAnalysisVisitor
 }
 
 // Every plugin needs to return an instance of itself at the
-// end of the file in which its defined.
+// end of the file in which it's defined.
 return new DuplicateArrayKeyPlugin();

--- a/.phan/plugins/DuplicateExpressionPlugin.php
+++ b/.phan/plugins/DuplicateExpressionPlugin.php
@@ -145,6 +145,6 @@ class RedundantNodeVisitor extends PluginAwarePostAnalysisVisitor
 }
 
 // Every plugin needs to return an instance of itself at the
-// end of the file in which its defined.
+// end of the file in which it's defined.
 
 return new DuplicateExpressionPlugin();

--- a/.phan/plugins/HasPHPDocPlugin.php
+++ b/.phan/plugins/HasPHPDocPlugin.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 
 use Phan\CodeBase;
+use Phan\Config;
 use Phan\Language\Element\Clazz;
 use Phan\Language\Element\Func;
 use Phan\Language\Element\MarkupDescription;
@@ -171,6 +172,14 @@ final class HasPHPDocPlugin extends PluginV2 implements
             // This reduces the number of false positives
             return;
         }
+        $method_filter = Config::getValue('plugin_config')['has_phpdoc_method_ignore_regex'] ?? null;
+        if (is_string($method_filter)) {
+            $fqsen_string = ltrim((string)$method->getFQSEN(), '\\');
+            if (preg_match($method_filter, $fqsen_string) > 0) {
+                return;
+            }
+        }
+
         $doc_comment = $method->getDocComment();
         if (!$doc_comment) {
             $visibility_upper = ucfirst($method->getVisibilityName());
@@ -178,7 +187,7 @@ final class HasPHPDocPlugin extends PluginV2 implements
                 $code_base,
                 $method->getContext(),
                 "PhanPluginNoCommentOn${visibility_upper}Method",
-                "$visibility_upper method {PROPERTY} has no doc comment",
+                "$visibility_upper method {METHOD} has no doc comment",
                 [$method->getFQSEN()]
             );
             return;
@@ -190,7 +199,7 @@ final class HasPHPDocPlugin extends PluginV2 implements
                 $code_base,
                 $method->getContext(),
                 "PhanPluginDescriptionlessCommentOn${visibility_upper}Method",
-                "$visibility_upper method {PROPERTY} has no readable description: {STRING_LITERAL}",
+                "$visibility_upper method {METHOD} has no readable description: {STRING_LITERAL}",
                 [$method->getFQSEN(), json_encode($method->getDocComment(), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)]
             );
             return;

--- a/.phan/plugins/HasPHPDocPlugin.php
+++ b/.phan/plugins/HasPHPDocPlugin.php
@@ -259,5 +259,5 @@ final class HasPHPDocPlugin extends PluginV2 implements
 }
 
 // Every plugin needs to return an instance of itself at the
-// end of the file in which its defined.
+// end of the file in which it's defined.
 return new HasPHPDocPlugin();

--- a/.phan/plugins/HasPHPDocPlugin.php
+++ b/.phan/plugins/HasPHPDocPlugin.php
@@ -217,6 +217,10 @@ final class HasPHPDocPlugin extends PluginV2 implements
             // This isn't user-defined, there's no reason to warn or way to change it.
             return;
         }
+        if ($function->isNSInternal($code_base)) {
+            // (at)internal are internal to the library, and there's less of a need to document them
+            return;
+        }
         if ($function->isClosure()) {
             // Probably not useful in many cases to document a short closure passed to array_map, etc.
             return;

--- a/.phan/plugins/InvokePHPNativeSyntaxCheckPlugin.php
+++ b/.phan/plugins/InvokePHPNativeSyntaxCheckPlugin.php
@@ -21,6 +21,8 @@ use Phan\PluginV2\FinalizeProcessCapability;
  *      This can replace the default binary (PHP_BINARY) with an array of absolute path or program names(in $PATH)
  *       E.g. have 'plugin_config' => ['php_native_syntax_check_binaries' => ['php72', 'php70', 'php56']]
  * Note: This may cause Phan to take over twice as long. This is recommended for use with `--processes N`.
+ *
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
 class InvokePHPNativeSyntaxCheckPlugin extends PluginV2 implements
     AfterAnalyzeFileCapability,

--- a/.phan/plugins/InvokePHPNativeSyntaxCheckPlugin.php
+++ b/.phan/plugins/InvokePHPNativeSyntaxCheckPlugin.php
@@ -355,5 +355,5 @@ class InvokeExecutionPromise
 }
 
 // Every plugin needs to return an instance of itself at the
-// end of the file in which its defined.
+// end of the file in which it's defined.
 return new InvokePHPNativeSyntaxCheckPlugin();

--- a/.phan/plugins/NoAssertPlugin.php
+++ b/.phan/plugins/NoAssertPlugin.php
@@ -80,5 +80,5 @@ class NoAssertVisitor extends PluginAwarePostAnalysisVisitor
 }
 
 // Every plugin needs to return an instance of itself at the
-// end of the file in which its defined.
+// end of the file in which it's defined.
 return new NoAssertPlugin();

--- a/.phan/plugins/PHPUnitNotDeadCodePlugin.php
+++ b/.phan/plugins/PHPUnitNotDeadCodePlugin.php
@@ -149,5 +149,5 @@ class PHPUnitNotDeadPluginVisitor extends PluginAwarePostAnalysisVisitor
 PHPUnitNotDeadPluginVisitor::init();
 
 // Every plugin needs to return an instance of itself at the
-// end of the file in which its defined.
+// end of the file in which it's defined.
 return new PHPUnitNotDeadCodePlugin();

--- a/.phan/plugins/PHPUnitNotDeadCodePlugin.php
+++ b/.phan/plugins/PHPUnitNotDeadCodePlugin.php
@@ -117,6 +117,11 @@ class PHPUnitNotDeadPluginVisitor extends PluginAwarePostAnalysisVisitor
             }
         }
     }
+
+
+    /**
+     * @return bool true if $method is a PHPUnit test case
+     */
     protected static function isTestCase(Method $method) : bool
     {
         if (!$method->isPublic()) {
@@ -132,6 +137,7 @@ class PHPUnitNotDeadPluginVisitor extends PluginAwarePostAnalysisVisitor
     }
 
     /**
+     * Static initializer for this plugin - Must be called before using methods.
      * @return void
      */
     public static function init()

--- a/.phan/plugins/PHPUnitNotDeadCodePlugin.php
+++ b/.phan/plugins/PHPUnitNotDeadCodePlugin.php
@@ -118,7 +118,6 @@ class PHPUnitNotDeadPluginVisitor extends PluginAwarePostAnalysisVisitor
         }
     }
 
-
     /**
      * @return bool true if $method is a PHPUnit test case
      */
@@ -137,7 +136,7 @@ class PHPUnitNotDeadPluginVisitor extends PluginAwarePostAnalysisVisitor
     }
 
     /**
-     * Static initializer for this plugin - Must be called before using methods.
+     * Static initializer for this plugin - Gets called below before any methods can be used
      * @return void
      */
     public static function init()

--- a/.phan/plugins/PregRegexCheckerPlugin.php
+++ b/.phan/plugins/PregRegexCheckerPlugin.php
@@ -167,5 +167,5 @@ class PregRegexCheckerPlugin extends PluginV2 implements AnalyzeFunctionCallCapa
 }
 
 // Every plugin needs to return an instance of itself at the
-// end of the file in which its defined.
+// end of the file in which it's defined.
 return new PregRegexCheckerPlugin();

--- a/.phan/plugins/README.md
+++ b/.phan/plugins/README.md
@@ -160,8 +160,23 @@ and that Phan can extract a plaintext summary/description from that comment.
 
 - **PhanPluginNoCommentOnClass**: `Class {CLASS} has no doc comment`
 - **PhanPluginDescriptionlessCommentOnClass**: `Class {CLASS} has no readable description: {STRING_LITERAL}`
+- **PhanPluginNoCommentOnFunction**: `Function {FUNCTION} has no doc comment`
+- **PhanPluginDescriptionlessCommentOnFunction**: `Function {FUNCTION} has no readable description: {STRING_LITERAL}`
 - **PhanPluginNoCommentOnPublicProperty**: `Public property {PROPERTY} has no doc comment` (Also exists for Private and Protected)
 - **PhanPluginDescriptionlessCommentOnPublicProperty**: `Public property {PROPERTY} has no readable description: {STRING_LITERAL}` (Also exists for Private and Protected)
+
+Warnings about method verbosity also exist, many categories may need to be completely disabled due to the large number of method declarations in a typical codebase:
+
+- Warnings are not emitted for `@internal` methods.
+- Warnings are not emitted for methods that override methods in the parent class.
+- Warnings can be suppressed based on the method FQSEN with `plugin_config => [..., 'has_phpdoc_method_ignore_regex' => (a PCRE regex)]`
+
+  (e.g. to suppress issues about tests, or about missing documentation about getters and setters, etc.)
+
+The warning types for methods are below:
+
+- **PhanPluginNoCommentOnPublicMethod**: `Public method {METHOD} has no doc comment` (Also exists for Private and Protected)
+- **PhanPluginDescriptionlessCommentOnPublicMethod**: `Public method {METHOD} has no readable description: {STRING_LITERAL}` (Also exists for Private and Protected)
 
 #### InvalidVariableIssetPlugin.php
 

--- a/.phan/plugins/SleepCheckerPlugin.php
+++ b/.phan/plugins/SleepCheckerPlugin.php
@@ -241,5 +241,5 @@ class SleepCheckerVisitor extends PluginAwarePostAnalysisVisitor
 }
 
 // Every plugin needs to return an instance of itself at the
-// end of the file in which its defined.
+// end of the file in which it's defined.
 return new SleepCheckerPlugin();

--- a/.phan/plugins/UnknownElementTypePlugin.php
+++ b/.phan/plugins/UnknownElementTypePlugin.php
@@ -141,5 +141,5 @@ class UnknownElementTypePlugin extends PluginV2 implements
 }
 
 // Every plugin needs to return an instance of itself at the
-// end of the file in which its defined.
+// end of the file in which it's defined.
 return new UnknownElementTypePlugin();

--- a/.phan/plugins/UnreachableCodePlugin.php
+++ b/.phan/plugins/UnreachableCodePlugin.php
@@ -116,5 +116,5 @@ final class UnreachableCodeVisitor extends PluginAwarePostAnalysisVisitor
     }
 }
 // Every plugin needs to return an instance of itself at the
-// end of the file in which its defined.
+// end of the file in which it's defined.
 return new UnreachableCodePlugin();

--- a/.phan/plugins/UnusedSuppressionPlugin.php
+++ b/.phan/plugins/UnusedSuppressionPlugin.php
@@ -279,5 +279,5 @@ class UnusedSuppressionPlugin extends PluginV2 implements
 }
 
 // Every plugin needs to return an instance of itself at the
-// end of the file in which its defined.
+// end of the file in which it's defined.
 return new UnusedSuppressionPlugin();

--- a/.phan/plugins/UnusedSuppressionPlugin.php
+++ b/.phan/plugins/UnusedSuppressionPlugin.php
@@ -261,6 +261,8 @@ class UnusedSuppressionPlugin extends PluginV2 implements
     }
 
     /**
+     * Record the fact that $plugin caused suppressions in $file_path for issue $issue_path due to an annotation around $line
+     *
      * @return void
      * @internal
      */

--- a/.phan/plugins/UnusedSuppressionPlugin.php
+++ b/.phan/plugins/UnusedSuppressionPlugin.php
@@ -261,7 +261,7 @@ class UnusedSuppressionPlugin extends PluginV2 implements
     }
 
     /**
-     * Record the fact that $plugin caused suppressions in $file_path for issue $issue_path due to an annotation around $line
+     * Record the fact that $plugin caused suppressions in $file_path for issue $issue_type due to an annotation around $line
      *
      * @return void
      * @internal

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,11 +3,16 @@ Phan NEWS
 ?? ??? 2018, Phan 1.0.7 (dev)
 -----------------------
 
-New features:
+New features(Analysis):
 + Support the `(int|string)[]` syntax of union types (union of multiple types converted to an array) in PHPDoc (#2008)
 
   e.g. `@param (int|string)[] $paramName`, `@return (int|string)[]`
 + Support spaces after commas in array shapes (#1966)
+
+Plugins:
++ In HasPHPDocPlugin, warn about global functions without extractable PHPDoc summaries.
+
+  New issue types: `PhanPluginNoCommentOnFunction`, `PhanPluginDescriptionlessCommentOnFunction`
 
 Bug fixes:
 + Fix false positive `PhanUnusedVariable` for variables declared before break/continue that are used after the loop. (#1985)
@@ -15,7 +20,7 @@ Bug fixes:
 25 Sep 2018, Phan 1.0.6
 -----------------------
 
-New features:
+New features(Analysis):
 + Be more consistent about warning about undeclared properties in some edge cases.
   New issue types: `PhanUndeclaredClassProperty`, `PhanUndeclaredClassStaticProperty`
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,12 @@ Plugins:
 + In HasPHPDocPlugin, warn about global functions without extractable PHPDoc summaries.
 
   New issue types: `PhanPluginNoCommentOnFunction`, `PhanPluginDescriptionlessCommentOnFunction`
++ In HasPHPDocPlugin, warn about methods without extractable PHPDoc summaries.
+
+  New issue types: `PhanPluginNoCommentOn*Method`, `PhanPluginDescriptionlessCommentOn*Method`
+
+  These can be suppressed based on the method FQSEN with `plugin_config => [..., 'has_phpdoc_method_ignore_regex' => (a PCRE regex)]`
+  (e.g. to suppress issues about tests, or about missing documentation about getters and setters, etc.)
 
 Bug fixes:
 + Fix false positive `PhanUnusedVariable` for variables declared before break/continue that are used after the loop. (#1985)

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Phan is able to perform the following kinds of analysis.
 * Supports checking that phpdoc type annotations are a narrowed form (E.g. subclasses/subtypes) of the real type signatures
 * Supports inferring types from [assert() statements](https://github.com/phan/phan/wiki/Annotating-Your-Source-Code) and conditionals in if elements/loops.
 * Supports [`@deprecated` annotation](https://github.com/phan/phan/wiki/Annotating-Your-Source-Code#deprecated) for deprecating classes, methods and functions
-* Supports [`@internal` annotation](https://github.com/phan/phan/wiki/Annotating-Your-Source-Code#internal) for elements (such as a constant, function, class, class constant, property or method) as internal to the package in which its defined.
+* Supports [`@internal` annotation](https://github.com/phan/phan/wiki/Annotating-Your-Source-Code#internal) for elements (such as a constant, function, class, class constant, property or method) as internal to the package in which it's defined.
 * Supports `@suppress <ISSUE_TYPE>` annotations for [suppressing issues](https://github.com/phan/phan/wiki/Annotating-Your-Source-Code#suppress).
 * Supports [magic @property annotations](https://github.com/phan/phan/wiki/Annotating-Your-Source-Code#property) (partial) (`@property <union_type> <variable_name>`)
 * Supports [magic @method annotations](https://github.com/phan/phan/wiki/Annotating-Your-Source-Code#method) (`@method <union_type> <method_name>(<union_type> <param1_name>)`)

--- a/internal/dump_fallback_ast.php
+++ b/internal/dump_fallback_ast.php
@@ -35,7 +35,7 @@ use Microsoft\PhpParser\Parser;
 dump_main();
 
 /**
- * Dumps a snippet provided on stdin.
+ * Dumps a snippet provided as a command line argument
  * @return void
  */
 function dump_main()

--- a/internal/dump_fallback_ast.php
+++ b/internal/dump_fallback_ast.php
@@ -34,7 +34,10 @@ use Microsoft\PhpParser\Parser;
 
 dump_main();
 
-// Dumps a snippet provided on stdin.
+/**
+ * Dumps a snippet provided on stdin.
+ * @return void
+ */
 function dump_main()
 {
     error_reporting(E_ALL);
@@ -75,11 +78,20 @@ EOB;
     }
 }
 
+/**
+ * Parses $expr and echoes the compact AST representation to stdout.
+ * @return void
+ */
 function dump_expr_as_ast(string $expr)
 {
     $ast_data = (new \Phan\AST\TolerantASTConverter\TolerantASTConverter())->parseCodeAsPHPAST($expr, 50);
     echo \Phan\Debug::nodeToString($ast_data);
 }
+
+/**
+ * Parses $expr and echoes the tolerant-php-parser AST to stdout.
+ * @return void
+ */
 function dump_expr(string $expr)
 {
     // Instantiate new parser instance

--- a/internal/internalsignatures.php
+++ b/internal/internalsignatures.php
@@ -27,6 +27,8 @@ define('ORIGINAL_SIGNATURE_PATH', dirname(__DIR__) . '/src/Phan/Language/Interna
  * - Compare the signatures against Phan's to report incomplete or inaccurate signatures of Phan itself (or the external signature)
  *
  * TODO: could extend this to properties (the use of properties in extensions is rare).
+ *
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
 abstract class IncompatibleSignatureDetectorBase
 {

--- a/internal/reflection_completeness_check.php
+++ b/internal/reflection_completeness_check.php
@@ -1,11 +1,12 @@
 #!/usr/bin/env php
 <?php
 declare(strict_types = 1);
-// @phan-file-suppress PhanNativePHPSyntaxCheckPlugin
 /**
  * This checks that the function signatures are complete.
  * TODO: Expand to checking classes (methods, and properties)
  * TODO: Refactor the scripts in internal/ to reuse more code.
+ * @phan-file-suppress PhanNativePHPSyntaxCheckPlugin
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
 require_once dirname(__DIR__) . '/vendor/autoload.php';
 

--- a/internal/sanitycheck.php
+++ b/internal/sanitycheck.php
@@ -120,7 +120,7 @@ class PhanParameterInfo
 }
 
 /**
- * Extracts a list of representations of parameters from the compact array descriptions in FunctionSignatureMap.php
+ * Extracts a list of representations of parameters from the compact array description ($fields) from FunctionSignatureMap.php
  *
  * @param string[] $fields
  * @phan-param array{0:string}|array<string,string> $fields

--- a/internal/sanitycheck.php
+++ b/internal/sanitycheck.php
@@ -3,6 +3,8 @@
 declare(strict_types = 1);
 // @phan-file-suppress PhanNativePHPSyntaxCheckPlugin
 /**
+ * Loads the ReflectionFunction or ReflectionMethod for the given function or method name.
+ * Method names must use '::' to separate the class and method names.
  * @throws ReflectionException
  */
 function load_internal_function(string $function_name) : ReflectionFunctionAbstract
@@ -17,6 +19,11 @@ function load_internal_function(string $function_name) : ReflectionFunctionAbstr
 }
 
 /**
+ * Returns the number of required and optional parameters from Phan's internal signature map entry for some function.
+ * as well as whether that map entry has the mistake of putting a required parameter after an optional parameter
+ *
+ * @param array<int|string,string> $fields - E.g. `['returnType', 'paramNameWithAnnotations'=>'paramType']`
+ * @return array{0:int,1:int,2:bool} [int $num_required, int $num_optional, bool $saw_optional_after_required]
  * @throws InvalidArgumentException for invalid fields
  */
 function getParametersCountsFromPhan(array $fields) : array
@@ -46,7 +53,12 @@ function getParametersCountsFromPhan(array $fields) : array
     return [$num_required, $num_optional, $saw_optional_after_required];
 }
 /**
+ * Gets the number of required and actual parameters from reflection.
+ *
+ * Variadic functions are treated as if they have 10000 optional parameters.
+ *
  * @param ReflectionParameter[] $args
+ * @return array{0:int,1:int} [$num_required, $num_optional]
  */
 function getParameterCountsFromReflection(array $args) : array
 {
@@ -108,11 +120,13 @@ class PhanParameterInfo
 }
 
 /**
+ * Extracts a list of representations of parameters from the compact array descriptions in FunctionSignatureMap.php
+ *
  * @param string[] $fields
  * @phan-param array{0:string}|array<string,string> $fields
  * @return array<int,PhanParameterInfo>
  */
-function get_parameters_from_phan($fields)
+function get_parameters_from_phan($fields) : array
 {
     unset($fields[0]);
     $result = [];
@@ -123,9 +137,17 @@ function get_parameters_from_phan($fields)
 }
 
 /**
+ * Check if Phan's function signature map has any contradictions with PHP's function signature map.
+ *
+ * This may either be a bug in Phan's signature map or in the reflection info.
+ *
+ * Note that certain bugs in the reflection info may be backwards incompatible changes
+ * (e.g. making an optional method parameter required, changing real param/return types in certain ways, etc.
+ * may be backwards incompatible for classes that subclass a class,
+ * and would have to wait for the next PHP major version (8.0))
+ *
  * @return void
  * @throws InvalidArgumentException for invalid return types
- * TODO: consistent naming
  */
 function check_fields(string $function_name, array $fields, array $signatures)
 {
@@ -281,6 +303,9 @@ function check_fields(string $function_name, array $fields, array $signatures)
     }
 }
 
+/**
+ * Load Phan's function signatures and check that they are compatible with Reflection's real function/method signatures
+ */
 function main_check_fields()
 {
     error_reporting(E_ALL);

--- a/internal/update_wiki_issue_types.php
+++ b/internal/update_wiki_issue_types.php
@@ -22,7 +22,10 @@ class WikiWriter
         $this->print_to_stdout = $print_to_stdout;
     }
 
-    /** @return void */
+    /**
+     * Append $text to the buffer of text to save.
+     * @return void
+     */
     public function append(string $text)
     {
         $this->contents .= $text;

--- a/internal/update_wiki_issue_types.php
+++ b/internal/update_wiki_issue_types.php
@@ -97,6 +97,8 @@ EOT;
     }
 
     /**
+     * Updates the markdown document of issue types with minimal documentation of missing issue types.
+     *
      * @return void
      * @throws InvalidArgumentException (uncaught) if the documented issue types can't be found.
      */

--- a/src/Phan/AST/ASTReverter.php
+++ b/src/Phan/AST/ASTReverter.php
@@ -35,6 +35,10 @@ class ASTReverter
     }
 
     /**
+     * Convert $node to a short PHP string representing $node.
+     *
+     * This does not work for all node kinds, and may be ambiguous.
+     *
      * @param Node|string|int|float $node
      * @return string
      */
@@ -48,6 +52,8 @@ class ASTReverter
     }
 
     /**
+     * Static initializer.
+     *
      * @return void
      */
     public static function init()

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -567,7 +567,7 @@ class ContextNode
                         $type_value = $type->getValue();
                         if (\preg_match('/^\\\\?[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff\\\]*$/', $type_value)) {
                             // TODO: warn about invalid types and unparsable types
-                            $fqsen = FullyQualifiedClassName::makeFromExtractedNamespaceAndName($type_value);
+                            $fqsen = FullyQualifiedClassName::fromFullyQualifiedString($type_value);
                             if ($this->code_base->hasClassWithFQSEN($fqsen)) {
                                 $class_list[] = $this->code_base->getClassByFQSEN($fqsen);
                             } else {

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -51,6 +51,7 @@ if (!\function_exists('spl_object_id')) {
 /**
  * Methods for an AST node in context
  * @phan-file-suppress PhanPartialTypeMismatchArgument
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
 class ContextNode
 {

--- a/src/Phan/AST/PhanAnnotationAdder.php
+++ b/src/Phan/AST/PhanAnnotationAdder.php
@@ -23,6 +23,7 @@ use Closure;
  *    Same for $x in $x ?? null, empty($x['offset']), and so on.
  * 2. Mark $x and $x['key'] in "$x['key'] = $y" as being acceptable to be null or undefined.
  *    and so on (e.g. ['key' => $x[0]] = $y)
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
 class PhanAnnotationAdder
 {

--- a/src/Phan/AST/TolerantASTConverter/NodeDumper.php
+++ b/src/Phan/AST/TolerantASTConverter/NodeDumper.php
@@ -31,6 +31,7 @@ use function substr;
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
 class NodeDumper
 {

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -70,6 +70,7 @@ if (!class_exists('ast\Node')) {
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
 class TolerantASTConverter
 {

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -2275,7 +2275,7 @@ class UnionTypeVisitor extends AnalysisVisitor
                     continue;
                 }
                 // TODO: warn about invalid types and unparsable types
-                $fqsen = FullyQualifiedClassName::makeFromExtractedNamespaceAndName($value);
+                $fqsen = FullyQualifiedClassName::fromFullyQualifiedString($value);
                 if (!$this->code_base->hasClassWithFQSEN($fqsen)) {
                     $is_valid = false;
                     continue;
@@ -2675,7 +2675,7 @@ class UnionTypeVisitor extends AnalysisVisitor
                 return $class->getParentClassFQSEN();  // may or may not exist.
             default:
                 // TODO: Reject invalid/empty class names earlier
-                return FullyQualifiedClassName::makeFromExtractedNamespaceAndName($class_name);
+                return FullyQualifiedClassName::fromFullyQualifiedString($class_name);
         }
     }
 

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -63,6 +63,7 @@ use function is_string;
  *
  * @phan-file-suppress PhanPartialTypeMismatchArgument node is complicated
  * @phan-file-suppress PhanPartialTypeMismatchArgumentInternal node is complicated
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
 class UnionTypeVisitor extends AnalysisVisitor
 {

--- a/src/Phan/AST/Visitor/KindVisitorImplementation.php
+++ b/src/Phan/AST/Visitor/KindVisitorImplementation.php
@@ -10,6 +10,7 @@ use Phan\Debug;
  * A visitor of AST nodes based on the node's kind value
  * which does nothing upon visiting a node of any kind
  * @phan-file-suppress PhanPluginUnknownMethodReturnType - TODO: Make this and FlagVisitorImplementation use Phan templates?
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
 abstract class KindVisitorImplementation implements KindVisitor
 {

--- a/src/Phan/Analysis/Analyzable.php
+++ b/src/Phan/Analysis/Analyzable.php
@@ -37,9 +37,10 @@ trait Analyzable
     private static $recursion_depth = 0;
 
     /**
+     * Keep a reference to the Node which declared this analyzable object so that we can use it later.
+     *
      * @param Node $node
      * The AST Node defining this object.
-     * We keep a reference to this so that we can use it later.
      * @return void
      */
     public function setNode(Node $node)

--- a/src/Phan/Analysis/ArgumentType.php
+++ b/src/Phan/Analysis/ArgumentType.php
@@ -26,6 +26,7 @@ use Phan\PluginV2\StopParamAnalysisException;
  * and emits issues for incorrect argument types.
  *
  * @phan-file-suppress PhanPartialTypeMismatchArgument
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
 final class ArgumentType
 {

--- a/src/Phan/Analysis/ContextMergeVisitor.php
+++ b/src/Phan/Analysis/ContextMergeVisitor.php
@@ -256,6 +256,8 @@ class ContextMergeVisitor extends KindVisitorImplementation
     }
 
     /**
+     * Returns a new scope which combines the parent scope with a list of 2 or more child scopes
+     * (one of those scopes is permitted to be the parent scope)
      * @param array<int,Scope> $scope_list
      */
     public function combineScopeList(array $scope_list) : Context

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -1072,6 +1072,9 @@ class ParameterTypesAnalyzer
     }
 
     /**
+     * Guesses the return number of a method's PHPDoc's (at)return statement.
+     * Returns null if that could not be found.
+     *
      * @return ?int
      * @internal
      */

--- a/src/Phan/Analysis/ReferenceCountsAnalyzer.php
+++ b/src/Phan/Analysis/ReferenceCountsAnalyzer.php
@@ -429,6 +429,9 @@ class ReferenceCountsAnalyzer
     }
 
     /**
+     * Find Elements with FQSENs that are the same as $element's FQSEN,
+     * apart from the alternate id.
+     * (i.e. duplicate declarations)
      * @return ?AddressableElement
      */
     public static function findAlternateReferencedElementDeclaration(

--- a/src/Phan/Bootstrap.php
+++ b/src/Phan/Bootstrap.php
@@ -44,7 +44,14 @@ set_exception_handler(function (Throwable $throwable) {
 });
 
 /**
+ * Executes $closure with Phan's default error handler disabled.
+ *
+ * This is useful in cases where PHP notices are unavoidable,
+ * e.g. notices in preg_match() when checking if a regex is valid
+ * and you don't want the default behavior of terminating the program.
+ *
  * @return mixed
+ * @see PregRegexCheckerPlugin
  */
 function with_disabled_phan_error_handler(Closure $closure)
 {

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Output\StreamOutput;
  * for the analyzed project.
  *
  * @phan-file-suppress PhanPartialTypeMismatchArgumentInternal
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
 class CLI
 {

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -64,6 +64,7 @@ use function strtolower;
  * for a background daemon analyzing single files. (Phan\CodeBase\UndoTracker)
  *
  * @phan-file-suppress PhanPartialTypeMismatchReturn the way generic objects is type hinted is inadequate, etc.
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
 class CodeBase
 {

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -305,8 +305,9 @@ class CodeBase
     }
 
     /**
+     * Returns the most recently parsed or analyzed file.
      * @return ?string
-     * @internal - For use only by the phan error handler
+     * @internal - For use only by the phan error handler, to help with debugging crashes
      */
     public static function getMostRecentlyParsedOrAnalyzedFile()
     {

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -439,7 +439,7 @@ class CodeBase
     private function addInternalFunctionsByNames(array $internal_function_name_list)
     {
         foreach ($internal_function_name_list as $function_name) {
-            $this->internal_function_fqsen_set->attach(FullyQualifiedFunctionName::makeFromExtractedNamespaceAndName($function_name));
+            $this->internal_function_fqsen_set->attach(FullyQualifiedFunctionName::fromFullyQualifiedString($function_name));
         }
     }
 

--- a/src/Phan/CodeBase/ClassMap.php
+++ b/src/Phan/CodeBase/ClassMap.php
@@ -7,6 +7,7 @@ use Phan\Language\Element\Property;
 
 /**
  * Maps for elements associated with an individual class
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
 class ClassMap
 {

--- a/src/Phan/CodeBase/UndoTracker.php
+++ b/src/Phan/CodeBase/UndoTracker.php
@@ -17,6 +17,7 @@ use Phan\Phan;
  *
  * (We don't garbage collect reference cycles, so this attempts to work in a way that avoids cycles.
  *  Haven't verified that it does that as expected, yet)
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
 class UndoTracker
 {

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -905,6 +905,7 @@ class Config
     }
 
     /**
+     * Resets the configuration to the initial state, prior to parsing config files and CLI arguments.
      * @return void
      * @internal - this should only be used in unit tests.
      */

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -12,6 +12,7 @@ namespace Phan;
  *
  * For efficiency, all of these methods are static methods.
  * Configuration is fetched frequently, and static methods were much faster than magic __get().
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
 class Config
 {

--- a/src/Phan/Config/Initializer.php
+++ b/src/Phan/Config/Initializer.php
@@ -14,6 +14,7 @@ use TypeError;
 
 /**
  * This class is used by 'phan --init' to generate a phan config for a composer project.
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
 class Initializer
 {

--- a/src/Phan/Daemon/Request.php
+++ b/src/Phan/Daemon/Request.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Output\BufferedOutput;
 
 /**
  * Represents the state of a client request to a daemon, and contains methods for sending formatted responses.
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
 class Request
 {

--- a/src/Phan/Daemon/Transport/CapturerResponder.php
+++ b/src/Phan/Daemon/Transport/CapturerResponder.php
@@ -41,7 +41,7 @@ class CapturerResponder implements Responder
     }
 
     /**
-     * @return ?array
+     * @return ?array the raw response data that the analysis would have sent back serialized if this was actually a fork.
      */
     public function getResponseData()
     {

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -14,6 +14,7 @@ use Phan\Plugin\ConfigPluginSet;
 
 /**
  * An issue emitted during the course of analysis
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
 class Issue
 {

--- a/src/Phan/IssueFixSuggester.php
+++ b/src/Phan/IssueFixSuggester.php
@@ -25,6 +25,7 @@ use function strtolower;
  * self::suggestSimilarMethod(CodeBase, Context, Clazz, string $wanted_method_name, bool $is_static)
  * self::suggestSimilarProperty(CodeBase, Context, Clazz, string $wanted_property_name, bool $is_static)
  * self::suggestSimilarClassConstant(CodeBase, Context, FullyQualifiedClassConstantName)
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
 class IssueFixSuggester
 {

--- a/src/Phan/IssueInstance.php
+++ b/src/Phan/IssueInstance.php
@@ -13,6 +13,7 @@ use Phan\Output\Colorizing;
  *
  * @see Issue for how these are emitted. Visitors and plugins often have helper methods to emit issues.
  * @see OutputPrinter for how this is converted to various output formats
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
 class IssueInstance
 {

--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -23,6 +23,7 @@ use RuntimeException;
 /**
  * An object representing the context in which any
  * structural element (such as a class or method) lives.
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
 class Context extends FileRef
 {

--- a/src/Phan/Language/Element/AddressableElement.php
+++ b/src/Phan/Language/Element/AddressableElement.php
@@ -15,6 +15,7 @@ use Phan\Memoize;
 /**
  * An addressable element is a TypedElement with an FQSEN.
  * (E.g. a class, property, function, method, etc.)
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
 abstract class AddressableElement extends TypedElement implements AddressableElementInterface
 {
@@ -294,7 +295,8 @@ abstract class AddressableElement extends TypedElement implements AddressableEle
     }
 
     /**
-     * @internal - Used by daemon mode to restore an element to the state it had before parsing.
+     * Used by daemon mode to restore an element to the state it had before parsing.
+     * @internal
      * @return ?Closure
      */
     abstract public function createRestoreCallback();

--- a/src/Phan/Language/Element/AddressableElementInterface.php
+++ b/src/Phan/Language/Element/AddressableElementInterface.php
@@ -20,10 +20,8 @@ interface AddressableElementInterface extends TypedElementInterface
     public function getFQSEN();
 
     /**
+     * Sets the fully qualified structural element name of this element.
      * @param FQSEN $fqsen
-     * A fully qualified structural element name to set on
-     * this element
-     *
      * @return void
      */
     public function setFQSEN(FQSEN $fqsen);
@@ -53,10 +51,10 @@ interface AddressableElementInterface extends TypedElementInterface
     public function isPrivate() : bool;
 
     /**
-     * @param FileRef $file_ref
-     * A reference to a location in which this typed structural
-     * element is referenced.
+     * Track a location $file_ref in which this typed structural element
+     * is referenced.
      *
+     * @param FileRef $file_ref
      * @return void
      */
     public function addReference(FileRef $file_ref);
@@ -102,16 +100,18 @@ interface AddressableElementInterface extends TypedElementInterface
     public function isDeprecated() : bool;
 
     /**
+     * Set this element as deprecated or not deprecated
+     *
      * @param bool $is_deprecated
-     * Set this element as deprecated
      *
      * @return void
      */
     public function setIsDeprecated(bool $is_deprecated);
 
     /**
+     * Set the set of issue names ($suppress_issue_list) to suppress
+     *
      * @param array<int,string> $suppress_issue_list
-     * Set the set of issue names to suppress
      *
      * @return void
      */

--- a/src/Phan/Language/Element/ClassConstant.php
+++ b/src/Phan/Language/Element/ClassConstant.php
@@ -106,7 +106,8 @@ class ClassConstant extends ClassElement implements ConstantInterface
     }
 
     /**
-     * @param bool $is_override_intended - True if this class constant is intended to be an override of another class constant (contains (at)override)
+     * Records whether or not this class constant is intended to be an override of another class constant (contains (at)override in PHPDoc)
+     * @param bool $is_override_intended
 
      * @return void
      */
@@ -137,7 +138,7 @@ class ClassConstant extends ClassElement implements ConstantInterface
         return $string;
     }
 
-    private function getVisibilityName() : string
+    public function getVisibilityName() : string
     {
         if ($this->isPrivate()) {
             return 'private';

--- a/src/Phan/Language/Element/ClassElement.php
+++ b/src/Phan/Language/Element/ClassElement.php
@@ -96,9 +96,10 @@ abstract class ClassElement extends AddressableElement
     }
 
     /**
+     * Sets the FQSEN of the class element in the location in which
+     * the element was originally defined.
+     *
      * @param FullyQualifiedClassElement $defining_fqsen
-     * The FQSEN of this class element in the location in which
-     * it was originally defined
      * @return void
      */
     public function setDefiningFQSEN(
@@ -171,6 +172,8 @@ abstract class ClassElement extends AddressableElement
     }
 
     /**
+     * Sets whether this method overrides another method
+     *
      * @param bool $is_override
      * True if this method overrides another method
      *
@@ -219,6 +222,7 @@ abstract class ClassElement extends AddressableElement
      * @param CodeBase $code_base used for access checks to protected properties
      * @param ?FullyQualifiedClassName $accessing_class_fqsen the class FQSEN of the current scope.
      *                                    null if in the global scope.
+     * @return bool true if this can be accessed from the scope of $accessing_class_fqsen
      */
     public function isAccessibleFromClass(CodeBase $code_base, $accessing_class_fqsen) : bool
     {

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -2856,7 +2856,7 @@ class Clazz extends AddressableElement
     }
 
     /**
-     * @internal - Used by daemon mode to restore an element to the state it had before parsing.
+     * Used by daemon mode to restore an element to the state it had before parsing.
      * @return Closure
      */
     public function createRestoreCallback()

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -42,6 +42,7 @@ use Phan\Plugin\ConfigPluginSet;
  * @see CodeBase for the data structures used for looking up classes or elements of classes (properties, methods, constants, etc)
  *
  * @phan-file-suppress PhanPartialTypeMismatchArgument
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
 class Clazz extends AddressableElement
 {
@@ -601,10 +602,10 @@ class Clazz extends AddressableElement
     }
 
     /**
-     * @param FQSEN $fqsen
      * Add the given FQSEN to the list of implemented
-     * interfaces for this class
+     * interfaces for this class.
      *
+     * @param FQSEN $fqsen
      * @return void
      */
     public function addInterfaceClassFQSEN(FQSEN $fqsen)
@@ -619,8 +620,8 @@ class Clazz extends AddressableElement
     }
 
     /**
-     * @return array<int,FullyQualifiedClassName>
      * Get the list of interfaces implemented by this class
+     * @return array<int,FullyQualifiedClassName>
      */
     public function getInterfaceFQSENList() : array
     {

--- a/src/Phan/Language/Element/ClosedScopeElement.php
+++ b/src/Phan/Language/Element/ClosedScopeElement.php
@@ -16,6 +16,7 @@ trait ClosedScopeElement
     private $internal_scope;
 
     /**
+     * Sets the internal scope of this closed scope element.
      * @return void
      */
     public function setInternalScope(ClosedScope $internal_scope)

--- a/src/Phan/Language/Element/Comment.php
+++ b/src/Phan/Language/Element/Comment.php
@@ -496,7 +496,7 @@ class Comment
 
     /**
      * @return Option<Type>
-     * An optional Type defined by a (at)PhanClosureScope
+     * An optional Type defined by a (at)phan-closure-scope
      * directive specifying a single type.
      *
      * @suppress PhanPartialTypeMismatchReturn (Null)
@@ -633,7 +633,7 @@ class Comment
     }
 
     /**
-     * @return array<int,CommentParameter>
+     * @return array<int,CommentParameter> the list of (at)var annotations
      */
     public function getVariableList() : array
     {

--- a/src/Phan/Language/Element/Comment/Builder.php
+++ b/src/Phan/Language/Element/Comment/Builder.php
@@ -467,7 +467,7 @@ final class Builder
     private function maybeParsePhanClosureScope(int $i, string $line)
     {
         // TODO: different type for closures
-        $this->checkCompatible('@PhanClosureScope', Comment::FUNCTION_LIKE, $i);
+        $this->checkCompatible('@phan-closure-scope', Comment::FUNCTION_LIKE, $i);
         $this->closure_scope = $this->getPhanClosureScopeFromCommentLine($line, $i);
     }
 

--- a/src/Phan/Language/Element/Comment/ReturnComment.php
+++ b/src/Phan/Language/Element/Comment/ReturnComment.php
@@ -27,6 +27,7 @@ class ReturnComment
     }
 
     /**
+     * Sets the type of this (at)return comment
      * @return void
      */
     public function setType(UnionType $type)

--- a/src/Phan/Language/Element/ConstantInterface.php
+++ b/src/Phan/Language/Element/ConstantInterface.php
@@ -12,11 +12,12 @@ interface ConstantInterface
 {
 
     /**
+     * Sets a value that can be used to resolve the union type of this constant later.
+     * Used if it cannot be resolved immediately while parsing.
+     *
      * @return void
      */
-    public function setFutureUnionType(
-        FutureUnionType $future_union_type
-    );
+    public function setFutureUnionType(FutureUnionType $future_union_type);
 
     /**
      * Sets the node with the AST representing the value of this constant.

--- a/src/Phan/Language/Element/ConstantTrait.php
+++ b/src/Phan/Language/Element/ConstantTrait.php
@@ -50,7 +50,8 @@ trait ConstantTrait
     }
 
     /**
-     * @internal - Used by daemon mode to restore an element to the state it had before parsing.
+     * Used by daemon mode to restore an element to the state it had before parsing.
+     * @internal
      * @return ?Closure
      */
     public function createRestoreCallback()

--- a/src/Phan/Language/Element/ElementFutureUnionType.php
+++ b/src/Phan/Language/Element/ElementFutureUnionType.php
@@ -26,14 +26,17 @@ trait ElementFutureUnionType
     protected $future_union_type = null;
 
     /**
-     * @param UnionType $type
      * Set the type of this element
+     * @param UnionType $type
      *
      * @return void
      */
     abstract public function setUnionType(UnionType $type);
 
     /**
+     * Sets a value that can be used once parsing/hydration is completed,
+     * to resolve the union type of this element.
+     *
      * @return void
      */
     public function setFutureUnionType(

--- a/src/Phan/Language/Element/ElementFutureUnionType.php
+++ b/src/Phan/Language/Element/ElementFutureUnionType.php
@@ -46,8 +46,8 @@ trait ElementFutureUnionType
      * @return bool
      * Returns true if this element has an unresolved union type.
      *
-     * @internal - Mostly useful for Phan internals
-     *             (e.g. a property with an unresolved future union type can't have a template type)
+     * @internal because this is mostly useful for Phan internals
+     *           (e.g. a property with an unresolved future union type can't have a template type)
      */
     public function hasUnresolvedFutureUnionType() : bool
     {

--- a/src/Phan/Language/Element/Func.php
+++ b/src/Phan/Language/Element/Func.php
@@ -362,6 +362,7 @@ class Func extends AddressableElement implements FunctionInterface
     }
 
     /**
+     * Returns a string that can be used as a stand-alone PHP stub for this global function.
      * @suppress PhanUnreferencedPublicMethod (toStubInfo is used by callers for more flexibility)
      */
     public function toStub() : string

--- a/src/Phan/Language/Element/Func.php
+++ b/src/Phan/Language/Element/Func.php
@@ -354,6 +354,14 @@ class Func extends AddressableElement implements FunctionInterface
     }
 
     /**
+     * True if this is a closure
+     */
+    public function isClosure() : bool
+    {
+        return $this->getFQSEN()->isClosure();
+    }
+
+    /**
      * @suppress PhanUnreferencedPublicMethod (toStubInfo is used by callers for more flexibility)
      */
     public function toStub() : string

--- a/src/Phan/Language/Element/FunctionFactory.php
+++ b/src/Phan/Language/Element/FunctionFactory.php
@@ -82,7 +82,8 @@ class FunctionFactory
     }
 
     /**
-     * @return array<int,Method>
+     * @return array<int,Method> a list of 1 or more method signatures from a ReflectionMethod
+     * and Phan's alternate signatures for that method's FQSEN in FunctionSignatureMap.
      */
     public static function methodListFromReflectionClassAndMethod(
         Context $context,

--- a/src/Phan/Language/Element/FunctionInterface.php
+++ b/src/Phan/Language/Element/FunctionInterface.php
@@ -12,8 +12,8 @@ use Phan\Language\Type\FunctionLikeDeclarationType;
 use Phan\Language\UnionType;
 
 /**
- * Interface defining the behavior of both Methods
- *  and Functions
+ * Interface defining the behavior of both Methods and Functions
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
 interface FunctionInterface extends AddressableElementInterface
 {
@@ -38,6 +38,8 @@ interface FunctionInterface extends AddressableElementInterface
     public function getRepresentationForIssue() : string;
 
     /**
+     * Sets the scope within this function-like element's body,
+     * for tracking variables within the function-like.
      * @return void
      */
     public function setInternalScope(ClosedScope $internal_scope);
@@ -107,10 +109,12 @@ interface FunctionInterface extends AddressableElementInterface
     public function isReturnTypeUndefined() : bool;
 
     /**
-     * @param bool $is_return_type_undefined
-     * True if this method had no return type defined when it
+     * Sets whether this method had no return type defined when it
      * was defined (either in the signature itself or in the
      * docblock).
+     *
+     * @param bool $is_return_type_undefined
+     * True if it was undefined
      *
      * @return void
      */

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -27,6 +27,7 @@ use Phan\Language\UnionType;
 /**
  * This contains functionality common to global functions, closures, and methods
  * @see FunctionInterface - Classes using this trait use that interface
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
 trait FunctionTrait
 {

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -1020,7 +1020,8 @@ trait FunctionTrait
     public abstract function setUnionType(UnionType $type);
 
     /**
-     * @internal - Used by daemon mode to restore an element to the state it had before parsing.
+     * Creates a callback that can restore this element to the state it had before parsing.
+     * @internal - Used by daemon mode
      * @return Closure
      */
     public function createRestoreCallback()

--- a/src/Phan/Language/Element/GlobalConstant.php
+++ b/src/Phan/Language/Element/GlobalConstant.php
@@ -73,6 +73,7 @@ class GlobalConstant extends AddressableElement implements ConstantInterface
     }
 
     /**
+     * Returns a standalone stub of PHP code for this global constant.
      * @suppress PhanUnreferencedPublicMethod toStubInfo is used by callers instead
      */
     public function toStub() : string

--- a/src/Phan/Language/Element/MarkupDescription.php
+++ b/src/Phan/Language/Element/MarkupDescription.php
@@ -25,7 +25,6 @@ class MarkupDescription
      * Extracts a plaintext description of the element from the doc comment of an element.
      *
      * @return ?string
-     * @internal
      */
     public static function extractDescriptionFromDocComment(AddressableElementInterface $element)
     {
@@ -38,6 +37,8 @@ class MarkupDescription
             $comment_category = Comment::ON_PROPERTY;
         } elseif ($element instanceof ConstantInterface) {
             $comment_category = Comment::ON_CONST;
+        } elseif ($element instanceof FunctionInterface) {
+            $comment_category = Comment::ON_FUNCTION;
         }
         $extracted_doc_comment = self::extractDocComment($doc_comment, $comment_category);
         return $extracted_doc_comment ?: null;
@@ -57,9 +58,11 @@ class MarkupDescription
 
         $results = [];
         $lines = explode("\n", $doc_comment);
+        $saw_phpdoc_tag = false;
         foreach ($lines as $i => $line) {
             $line = self::trimLine($line);
             if (!is_string($line) || preg_match('/^\s*@/', $line) > 0) {
+                $saw_phpdoc_tag = true;
                 if (count($results) === 0) {
                     // Special cases:
                     if (\in_array($comment_category, [Comment::ON_PROPERTY, Comment::ON_CONST])) {
@@ -71,13 +74,14 @@ class MarkupDescription
                     } elseif (\in_array($comment_category, Comment::FUNCTION_LIKE)) {
                         // Treat `@return T description of return value` as a valid single-line comment of closures, functions, and methods.
                         // Variables don't currently have associated comments
-                        if (preg_match('/^\s*@return\s/', $line) > 0) {
+                        if (preg_match('/^\s*@return(\s|$)/', $line) > 0) {
                             $results = array_merge($results, self::extractTagSummary($lines, $i));
                         }
                     }
                 }
-                // Assume that the description stopped after the first phpdoc tag.
-                break;
+            }
+            if ($saw_phpdoc_tag) {
+                continue;
             }
             if (\trim($line) === '') {
                 $line = '';
@@ -109,8 +113,9 @@ class MarkupDescription
      * @param array<int,string> $lines
      * @param int $i the offset of the tag in $lines
      * @return array<int,string> the trimmed lines
+     * @internal
      */
-    private static function extractTagSummary(array $lines, int $i): array
+    public static function extractTagSummary(array $lines, int $i): array
     {
         $summary = [];
         $summary[] = self::trimLine($lines[$i]);

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -99,7 +99,8 @@ class Method extends ClassElement implements FunctionInterface
     }
 
     /**
-     * @param bool $from_phpdoc - True if this is a magic phpdoc method (declared via (at)method on class declaration phpdoc)
+     * Sets whether this is a magic phpdoc method (declared via (at)method on class declaration phpdoc)
+     * @param bool $from_phpdoc - True if this is a magic phpdoc method
      * @return void
      */
     public function setIsFromPHPDoc(bool $from_phpdoc)
@@ -123,7 +124,8 @@ class Method extends ClassElement implements FunctionInterface
     }
 
     /**
-     * @param bool $is_override_intended - True if this method is intended to be an override of another method (contains (at)override)
+     * Sets whether this method is intended to be an override of another method (contains (at)override)
+     * @param bool $is_override_intended
 
      * @return void
      */

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -680,18 +680,23 @@ class Method extends ClassElement implements FunctionInterface
         return $string;
     }
 
+    public function getVisibilityName() : string
+    {
+        if ($this->isPrivate()) {
+            return 'private';
+        } elseif ($this->isProtected()) {
+            return 'protected';
+        } else {
+            return 'public';
+        }
+    }
+
     public function toStub(bool $class_is_interface = false) : string
     {
         $string = '    ';
         // It's an error to have visibility or abstract in an interface's stub (e.g. JsonSerializable)
         if (!$class_is_interface) {
-            if ($this->isPrivate()) {
-                $string .= 'private ';
-            } elseif ($this->isProtected()) {
-                $string .= 'protected ';
-            } else {
-                $string .= 'public ';
-            }
+            $string .= $this->getVisibilityName() . ' ';
 
             if ($this->isAbstract()) {
                 $string .= 'abstract ';

--- a/src/Phan/Language/Element/Parameter.php
+++ b/src/Phan/Language/Element/Parameter.php
@@ -30,6 +30,7 @@ use Phan\Parse\ParseVisitor;
  * (e.g. of a function, closure, method, a PHPDoc closure/callable signature such as `Closure(MyClass=):void`, or phpdoc method.
  *
  * @phan-file-suppress PhanPartialTypeMismatchArgument
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
 class Parameter extends Variable
 {

--- a/src/Phan/Language/Element/Property.php
+++ b/src/Phan/Language/Element/Property.php
@@ -189,7 +189,8 @@ class Property extends ClassElement
     }
 
     /**
-     * @internal - Used by daemon mode to restore an element to the state it had before parsing.
+     * Used by daemon mode to restore an element to the state it had before parsing.
+     * @internal
      * @return ?Closure
      */
     public function createRestoreCallback()

--- a/src/Phan/Language/Element/Property.php
+++ b/src/Phan/Language/Element/Property.php
@@ -11,6 +11,7 @@ use TypeError;
 
 /**
  * Phan's representation of a class/trait/interface's property (including magic and dynamic properties)
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
 class Property extends ClassElement
 {

--- a/src/Phan/Language/Element/TypedElement.php
+++ b/src/Phan/Language/Element/TypedElement.php
@@ -10,6 +10,7 @@ use Phan\Language\UnionType;
  * Any PHP structural element that also has a type and is
  * addressable such as a class, method, closure, property,
  * constant, variable, ...
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
 abstract class TypedElement implements TypedElementInterface
 {

--- a/src/Phan/Language/Element/TypedElementInterface.php
+++ b/src/Phan/Language/Element/TypedElementInterface.php
@@ -24,8 +24,8 @@ interface TypedElementInterface
     public function getUnionType() : UnionType;
 
     /**
-     * @param UnionType $type
      * Set the type of this element
+     * @param UnionType $type
      *
      * @return void
      */

--- a/src/Phan/Language/Element/UnaddressableTypedElement.php
+++ b/src/Phan/Language/Element/UnaddressableTypedElement.php
@@ -7,6 +7,7 @@ use Phan\Language\UnionType;
 /**
  * Any PHP structural element that also has a type and is
  * does not store a reference to its context (such as a variable).
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
 abstract class UnaddressableTypedElement
 {

--- a/src/Phan/Language/FQSEN.php
+++ b/src/Phan/Language/FQSEN.php
@@ -8,9 +8,12 @@ interface FQSEN
 {
 
     /**
-     * @param string $fully_qualified_string
-     * An FQSEN string like '\Namespace\Class::method' or
+     * Constructs an FQSEN from a FQSEN string such as '\Namespace\Class::method' or
      * 'Class' or 'Class::method'.
+     *
+     * The case depends on the case of the first FQSEN string this was called with.
+     *
+     * @param string $fully_qualified_string
      *
      * @return static
      */
@@ -19,9 +22,10 @@ interface FQSEN
     );
 
     /**
+     * Constructs an FQSEN from an FQSEN string such as '\Namespace\Class::method' or
+     * 'Class' or 'Class::method', using namespace uses from the current context.
+     *
      * @param string $fqsen_string
-     * An FQSEN string like '\Namespace\Class::method' or
-     * 'Class' or 'Class::method'.
      *
      * @param Context $context
      * The context in which the FQSEN string was found

--- a/src/Phan/Language/FQSEN/FullyQualifiedClassElement.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedClassElement.php
@@ -46,6 +46,10 @@ abstract class FullyQualifiedClassElement extends AbstractFQSEN
     }
 
     /**
+     * Construct a fully-qualified class element from the class,
+     * the element name in the class.
+     * (and an alternate id to account for duplicate element definitions)
+     *
      * @param FullyQualifiedClassName $fully_qualified_class_name
      * The fully qualified class name of the class in which
      * this element exists

--- a/src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php
@@ -64,10 +64,15 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN
     }
 
     /**
+     * Construct a fully-qualified global structural element from a namespace and name
+     * (such as 'is_string', '\is_int', 'stdClass', 'PHP_VERSION_ID', 'ast\parse_code', etc.)
+     *
      * @param string $name
      * The name of this structural element, may contain a namespace.
      *
      * @return static
+     *
+     * @deprecated - use fromFullyQualifiedString
      */
     public static function makeFromExtractedNamespaceAndName(string $name)
     {
@@ -81,11 +86,13 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN
     }
 
     /**
+     * Construct a fully-qualified global structural element from a namespace and name.
+     *
      * @param string $namespace
      * The namespace in this element's scope
      *
      * @param string $name
-     * The name of this structural element
+     * The name of this structural element (additional namespace prefixes here are properly handled)
      *
      * @param int $alternate_id
      * An alternate ID for the element for use when
@@ -262,7 +269,7 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN
     }
 
     /**
-     * @return static
+     * @return static a copy of this global structural element with a different namespace
      */
     public function withNamespace(
         string $namespace

--- a/src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php
@@ -73,6 +73,7 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN
      * @return static
      *
      * @deprecated - use fromFullyQualifiedString
+     * @suppress PhanUnreferencedPublicMethod
      */
     public static function makeFromExtractedNamespaceAndName(string $name)
     {

--- a/src/Phan/Language/FutureUnionType.php
+++ b/src/Phan/Language/FutureUnionType.php
@@ -60,6 +60,8 @@ class FutureUnionType
     }
 
     /**
+     * Gets the codebase singleton which created this FutureUnionType.
+     * (used to resolve class references, constants, etc.)
      * @internal (May rethink exposing the codebase in the future)
      */
     public function getCodebase() : CodeBase
@@ -68,6 +70,8 @@ class FutureUnionType
     }
 
     /**
+     * Gets the context in which this FutureUnionType was created
+     * (used to resolve class references, constants, etc.)
      * @internal (May rethink exposing the codebase in the future)
      */
     public function getContext() : Context

--- a/src/Phan/Language/Scope.php
+++ b/src/Phan/Language/Scope.php
@@ -87,7 +87,8 @@ abstract class Scope
     }
 
     /**
-     * @return FQSEN
+     * @return FQSEN in which this scope was declared
+     * (e.g. a FullyQualifiedFunctionName, FullyQualifiedClassName, etc.)
      * @suppress PhanPossiblyNullTypeReturn callers should call hasFQSEN
      */
     public function getFQSEN()
@@ -175,7 +176,8 @@ abstract class Scope
     }
 
     /**
-     * @return Variable
+     * Locates the variable with name $name.
+     * Callers should check $this->hasVariableWithName() first.
      */
     public function getVariableByName(string $name) : Variable
     {
@@ -195,7 +197,7 @@ abstract class Scope
      * @param Variable $variable
      * A variable to add to the local scope
      *
-     * @return Scope
+     * @return Scope a clone of this scope with $variable added
      */
     public function withVariable(Variable $variable) : Scope
     {
@@ -235,6 +237,9 @@ abstract class Scope
     }
 
     /**
+     * Add $variable to the current scope.
+     *
+     * @see $this->withVariable() for creating a clone of a scope with $variable instead
      * @return void
      */
     public function addVariable(Variable $variable)
@@ -249,6 +254,8 @@ abstract class Scope
     }
 
     /**
+     * Add $variable to the set of global variables
+     *
      * @param Variable $variable
      * A variable to add to the set of global variables
      *
@@ -336,6 +343,11 @@ abstract class Scope
     }
 
     /**
+     * Adds a template type to the current scope.
+     *
+     * The TemplateType is resolved during analysis based on the passed in union types
+     * for the parameters (e.g. of __construct()) using those template types
+     *
      * @param TemplateType $template_type
      * A template type parameterizing the generic class in scope
      *

--- a/src/Phan/Language/Scope/ClosureScope.php
+++ b/src/Phan/Language/Scope/ClosureScope.php
@@ -17,6 +17,7 @@ class ClosureScope extends FunctionLikeScope
     private $override_class_fqsen = null;
 
     /**
+     * Override the class FQSEN inside this closure's scope (with an (at)phan-closure-scope annotation).
      * @return void
      */
     public function overrideClassFQSEN(FullyQualifiedClassName $fqsen = null)

--- a/src/Phan/Language/Scope/ClosureScope.php
+++ b/src/Phan/Language/Scope/ClosureScope.php
@@ -27,6 +27,8 @@ class ClosureScope extends FunctionLikeScope
 
     /**
      * @return FullyQualifiedClassName|null
+     * If the (at)phan-closure-scope annotation is used, returns the corresponding override class FQSEN.
+     * Returns the class FQSEN inside this closure's scope (with an (at)phan-closure-scope annotation).
      */
     public function getOverrideClassFQSEN()
     {
@@ -35,7 +37,7 @@ class ClosureScope extends FunctionLikeScope
 
     /**
      * @return bool
-     * True if we're in a class scope
+     * True if this closure should be analyzed as if we're in a class scope
      */
     public function isInClassScope() : bool
     {

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -462,6 +462,9 @@ class Type
 
 
     /**
+     * Constructs a type based on the input type and the provided mapping
+     * from template type identifiers to concrete union types.
+     *
      * @param Type $type
      * The base type of this generic type referencing a
      * generic class
@@ -759,6 +762,7 @@ class Type
      * A fully qualified type name
      *
      * @return Type
+     * The type with that fully qualified type name (cached for efficiency)
      */
     public static function fromFullyQualifiedString(
         string $fully_qualified_string
@@ -768,10 +772,13 @@ class Type
     }
 
     /**
+     * Extracts the parts of this Type from the passed in fully qualified type name.
+     * Callers should ensure that the type regex accepts $fully_qualified_string
+     *
      * @throws EmptyFQSENException if the type name was the empty string
      * @throws InvalidArgumentException if namespace is missing from something that should have a namespace
      */
-    public static function fromFullyQualifiedStringInner(
+    protected static function fromFullyQualifiedStringInner(
         string $fully_qualified_string
     ) : Type {
         if ($fully_qualified_string === '') {
@@ -2581,6 +2588,12 @@ class Type
     }
 
     /**
+     * Converts this type to one where array shapes are flattened to generic arrays, and literal scalars are converted to the general type for that scalar.
+     *
+     * E.g. converts the type `array{0:2}` to `array<int,int>`
+     *
+     * This is overridden by subclasses.
+     *
      * @return Type[]
      */
     public function withFlattenedArrayShapeOrLiteralTypeInstances() : array

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -2570,7 +2570,9 @@ class Type
     }
 
     /**
-     * @internal - Used to check for quick mode
+     * Used to check if this type can be replaced by more specific types, for non-quick mode
+     *
+     * @internal
      */
     public function shouldBeReplacedBySpecificTypes() : bool
     {

--- a/src/Phan/Language/Type/ArrayShapeType.php
+++ b/src/Phan/Language/Type/ArrayShapeType.php
@@ -73,6 +73,8 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
     }
 
     /**
+     * Returns an immutable array shape type instance without $field_key.
+     *
      * @param int|string|float|bool $field_key
      */
     public function withoutField($field_key) : ArrayShapeType

--- a/src/Phan/Language/Type/ClosureDeclarationParameter.php
+++ b/src/Phan/Language/Type/ClosureDeclarationParameter.php
@@ -31,6 +31,9 @@ final class ClosureDeclarationParameter
     }
 
     /**
+     * Gets the non-variadic type of this parameter.
+     * (i.e. the type of individual arguments the closure expects to be passed in by the caller)
+     *
      * @suppress PhanUnreferencedPublicMethod
      */
     public function getNonVariadicUnionType() : UnionType
@@ -70,6 +73,9 @@ final class ClosureDeclarationParameter
     }
 
     /**
+     * Checks if this parameter can be used as an equivalent or more permissive form of the parameter $other.
+     * This is used to check if closure/callable types can be cast to other closure/callable types.
+     *
      * @see \Phan\Analysis\ParameterTypesAnalyzer::analyzeOverrideSignatureForOverriddenMethod() - Similar logic using LSP
      */
     public function canCastToParameterIgnoringVariadic(ClosureDeclarationParameter $other) : bool

--- a/src/Phan/Language/Type/ClosureType.php
+++ b/src/Phan/Language/Type/ClosureType.php
@@ -97,7 +97,7 @@ final class ClosureType extends Type
      * @param bool $is_nullable
      * If true, returns a nullable instance of this closure type
      *
-     * @return static
+     * @return static an instance of this closure type with appropriate nullability
      */
     public static function instance(bool $is_nullable)
     {

--- a/src/Phan/Language/Type/FunctionLikeDeclarationType.php
+++ b/src/Phan/Language/Type/FunctionLikeDeclarationType.php
@@ -115,7 +115,7 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
     }
 
     /**
-     * @return ?ClosureDeclarationParameter
+     * @return ?ClosureDeclarationParameter the parameter which the argument at the index $i would be passed in as
      */
     public function getClosureParameterForArgument(int $i)
     {

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -394,7 +394,7 @@ final class GenericArrayType extends ArrayType implements GenericArrayInterface
     const CONVERT_KEY_MIXED_TO_INT_OR_STRING_UNION_TYPE = 1;
 
     /**
-     * @return UnionType
+     * @return UnionType a union type corresponding to $key_type
      */
     public static function unionTypeForKeyType(int $key_type, int $behavior = self::CONVERT_KEY_MIXED_TO_INT_OR_STRING_UNION_TYPE) : UnionType
     {

--- a/src/Phan/Language/Type/GenericMultiArrayType.php
+++ b/src/Phan/Language/Type/GenericMultiArrayType.php
@@ -9,9 +9,11 @@ use Phan\Language\UnionType;
 use Phan\Language\UnionTypeBuilder;
 
 /**
+ * A temporary representation of `array<KeyType, T1|T2...>`
+ *
  * Callers should split this up into multiple GenericArrayType instances.
  *
- * This is generated from phpdoc array<int, T1|T2> where callers expect a subclass of Type.
+ * This is generated from phpdoc `array<int, T1|T2>` where callers expect a subclass of Type.
  */
 final class GenericMultiArrayType extends ArrayType implements MultiType, GenericArrayInterface
 {
@@ -89,8 +91,11 @@ final class GenericMultiArrayType extends ArrayType implements MultiType, Generi
     }
 
     /**
+     * Public creator of GenericMultiArrayType instances
+     *
      * @param array<int,Type> $element_types
      * @param bool $is_nullable
+     * @param int $key_type
      * @return GenericMultiArrayType
      */
     public static function fromElementTypes(

--- a/src/Phan/Language/Type/LiteralIntType.php
+++ b/src/Phan/Language/Type/LiteralIntType.php
@@ -30,7 +30,7 @@ final class LiteralIntType extends IntType implements LiteralTypeInterface
     }
 
     /**
-     * @return LiteralIntType
+     * @return LiteralIntType a unique LiteralIntType for $value (and the nullability)
      */
     public static function instanceForValue(int $value, bool $is_nullable)
     {

--- a/src/Phan/Language/Type/LiteralIntType.php
+++ b/src/Phan/Language/Type/LiteralIntType.php
@@ -20,7 +20,8 @@ final class LiteralIntType extends IntType implements LiteralTypeInterface
     }
 
     /**
-     * @internal - Only exists to prevent accidentally calling this
+     * Only exists to prevent accidentally calling this
+     * @internal - do not call
      * @deprecated
      */
     public static function instance(bool $unused_is_nullable)

--- a/src/Phan/Language/Type/LiteralStringType.php
+++ b/src/Phan/Language/Type/LiteralStringType.php
@@ -35,7 +35,11 @@ final class LiteralStringType extends StringType implements LiteralTypeInterface
     }
 
     /**
-     * @return StringType|LiteralStringType
+     * @return StringType|LiteralStringType a StringType for $value
+     * This will construct an StringType instead if the value is longer than the longest supported string type
+     *
+     * - This avoids making error messages excessively long
+     * - This avoids running out of memory tracking string representations when analyzing code that may build up long strings.
      */
     public static function instanceForValue(string $value, bool $is_nullable)
     {

--- a/src/Phan/Language/Type/LiteralStringType.php
+++ b/src/Phan/Language/Type/LiteralStringType.php
@@ -24,7 +24,8 @@ final class LiteralStringType extends StringType implements LiteralTypeInterface
     }
 
     /**
-     * @internal - Only exists to prevent accidentally calling this on the parent class
+     * Only exists to prevent accidentally calling this on the parent class
+     * @internal
      * @deprecated
      * @throws RuntimeException to prevent this from being called
      */

--- a/src/Phan/Language/Type/MultiType.php
+++ b/src/Phan/Language/Type/MultiType.php
@@ -10,6 +10,7 @@ interface MultiType
 {
     /**
      * @return array<int,Type>
+     * A list of 2 or more types that this MultiType represents
      */
     public function asIndividualTypeInstances() : array;
 }

--- a/src/Phan/Language/Type/NativeType.php
+++ b/src/Phan/Language/Type/NativeType.php
@@ -23,6 +23,7 @@ abstract class NativeType extends Type
      * If true, returns a nullable instance of this native type
      *
      * @return static
+     * Returns a nullable/non-nullable instance of this native type (possibly unchanged)
      */
     public static function instance(bool $is_nullable)
     {

--- a/src/Phan/Language/Type/StaticType.php
+++ b/src/Phan/Language/Type/StaticType.php
@@ -18,6 +18,8 @@ final class StaticType extends Type
     const NAME = 'static';
 
     /**
+     * Returns a nullable/non-nullable instance of this StaticType
+     *
      * @param bool $is_nullable
      * An optional parameter, which if true returns a
      * nullable instance of this native type

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -54,6 +54,7 @@ if (!\function_exists('spl_object_id')) {
  * > or a union of any other types such as string|int|null|DateTime|DateTime[],
  * > and many other types
  *
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod TODO: Document the public methods
  */
 class UnionType implements Serializable
 {

--- a/src/Phan/Language/UnionTypeBuilder.php
+++ b/src/Phan/Language/UnionTypeBuilder.php
@@ -8,6 +8,7 @@ namespace Phan\Language;
  *
  * @see UnionType->withType()
  * @see UnionType->withoutType()
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
 final class UnionTypeBuilder
 {

--- a/src/Phan/LanguageServer/CompletionRequest.php
+++ b/src/Phan/LanguageServer/CompletionRequest.php
@@ -28,6 +28,7 @@ use Phan\LanguageServer\Protocol\Position;
  * @see \Phan\AST\TolerantASTConverter\TolerantASTConverterWithNodeMapping for how isSelected is set
  *
  * @phan-file-suppress PhanUnusedPublicMethodParameter
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
 final class CompletionRequest extends NodeInfoRequest
 {

--- a/src/Phan/LanguageServer/CompletionResolver.php
+++ b/src/Phan/LanguageServer/CompletionResolver.php
@@ -20,6 +20,7 @@ use Phan\Language\FQSEN\FullyQualifiedClassName;
 /**
  * This implements closures for finding completions for valid/invalid nodes where isSelected is set
  * @phan-file-suppress PhanUnusedPublicMethodParameter
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
 class CompletionResolver
 {

--- a/src/Phan/LanguageServer/DefinitionResolver.php
+++ b/src/Phan/LanguageServer/DefinitionResolver.php
@@ -22,6 +22,7 @@ use Phan\Language\UnionType;
 
 /**
  * This implements closures for finding definitions for nodes where isSelected is set
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
 class DefinitionResolver
 {
@@ -101,6 +102,8 @@ class DefinitionResolver
     }
 
     /**
+     * Record information about this definition, to send back to the language client after all possible definitions were found.
+     *
      * @return void
      */
     public static function locateClassDefinition(

--- a/src/Phan/LanguageServer/FileMapping.php
+++ b/src/Phan/LanguageServer/FileMapping.php
@@ -8,6 +8,8 @@ namespace Phan\LanguageServer;
  *
  * TODO: remove all overrides when a language client disconnects.
  * (Right now, we only have a single client, and shut down when the client disconnects)
+ *
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod TODO: Document
  */
 class FileMapping
 {

--- a/src/Phan/LanguageServer/GoToDefinitionRequest.php
+++ b/src/Phan/LanguageServer/GoToDefinitionRequest.php
@@ -32,6 +32,8 @@ use Phan\LanguageServer\Protocol\Position;
  * @see \Phan\LanguageServer\DefinitionResolver for how this maps the found node to the type in the context.
  * @see \Phan\Plugin\Internal\NodeSelectionPlugin for how the node is found
  * @see \Phan\AST\TolerantASTConverter\TolerantASTConverterWithNodeMapping for how isSelected is set
+ *
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
 final class GoToDefinitionRequest extends NodeInfoRequest
 {

--- a/src/Phan/LanguageServer/LanguageServer.php
+++ b/src/Phan/LanguageServer/LanguageServer.php
@@ -751,6 +751,7 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
     /**
      * @param int $severity
      * @return int
+     * A DiagnosticSeverity constant used by the language server protocol.
      */
     public static function diagnosticSeverityFromPhanSeverity($severity) : int
     {
@@ -886,7 +887,12 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
     }
 
     /**
-     * @suppress PhanUnreferencedPublicMethod this is called by the client through AdvancedJsonRpc
+     * Currently a no-op.
+     *
+     * The initialized notification is sent from the client to the server after the client received the result of the initialize request
+     * but before the client is sending any other request or notification to the server.
+     *
+     * @suppress PhanUnreferencedPublicMethod
      * @return void
      */
     public function initialized()

--- a/src/Phan/LanguageServer/Logger.php
+++ b/src/Phan/LanguageServer/Logger.php
@@ -7,7 +7,7 @@ use Phan\Config;
 
 /**
  * A logger used by Phan for developing or debugging the language server.
- * Logs to stderr.
+ * Logs to stderr by default.
  */
 class Logger
 {
@@ -19,7 +19,10 @@ class Logger
         return Config::getValue('language_server_debug_level') === 'info';
     }
 
-    /** @return void */
+    /**
+     * Logs a request received from the client
+     * @return void
+     */
     public static function logRequest(array $headers, string $buffer)
     {
         if (!self::shouldLog()) {
@@ -28,7 +31,10 @@ class Logger
         self::logInfo(sprintf("Request:\n%s\nData:\n%s\n\n", json_encode($headers), $buffer));
     }
 
-    /** @return void */
+    /**
+     * Logs a response this is about to send back to the client
+     * @return void
+     */
     public static function logResponse(array $headers, string $buffer)
     {
         if (!self::shouldLog()) {
@@ -37,7 +43,15 @@ class Logger
         self::logInfo(sprintf("Response:\n%s\nData:\n%s\n\n", json_encode($headers), $buffer));
     }
 
-    /** @return void */
+    /**
+     * Logs an info message to a configured file (defaults to STDERR),
+     * if debugging is turned on.
+     *
+     * This is used by code related to the language server.
+     * Phan is slower when verbose logging is enabled.
+     *
+     * @return void
+     */
     public static function logInfo(string $msg)
     {
         if (!self::shouldLog()) {
@@ -47,7 +61,11 @@ class Logger
         fwrite($file, $msg . "\n");
     }
 
-    /** @return void */
+    /**
+     * Logs an error related to the language server protocol
+     * to the configured log file (defaults to STDERR)
+     * @return void
+     */
     public static function logError(string $msg)
     {
         $file = self::getLogFile();
@@ -55,7 +73,7 @@ class Logger
     }
 
     /**
-     * @return resource the log file handle
+     * @return resource the log file handle (defaults to STDERR)
      */
     private static function getLogFile()
     {
@@ -67,6 +85,7 @@ class Logger
     }
 
     /**
+     * Overrides the log file to a different one
      * @param resource $newFile
      * @return void
      * @suppress PhanUnreferencedPublicMethod this is made available for debugging issues
@@ -80,8 +99,9 @@ class Logger
             if (self::$file === $newFile) {
                 return;
             }
-            fclose(self::$file);
-            self::$file = false;
+            if (self::$file !== STDERR) {
+                fclose(self::$file);
+            }
         }
         self::$file = $newFile;
     }

--- a/src/Phan/LanguageServer/NodeInfoRequest.php
+++ b/src/Phan/LanguageServer/NodeInfoRequest.php
@@ -10,6 +10,7 @@ use Sabre\Event\Promise;
  * @see \Phan\LanguageServer\DefinitionResolver for how this maps the found node to the type in the context.
  * @see \Phan\Plugin\Internal\NodeSelectionPlugin for how the node is found
  * @see \Phan\AST\TolerantASTConverter\TolerantASTConverterWithNodeMapping for how isSelected is set
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
 abstract class NodeInfoRequest
 {

--- a/src/Phan/LanguageServer/ProtocolReader.php
+++ b/src/Phan/LanguageServer/ProtocolReader.php
@@ -13,6 +13,7 @@ use Sabre\Event\EmitterInterface;
  *
  * Source: https://github.com/felixfbecker/php-language-server/tree/master/src/ProtocolReader.php
  * See ../../../LICENSE.LANGUAGE_SERVER
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
 interface ProtocolReader extends EmitterInterface
 {

--- a/src/Phan/LanguageServer/Utils.php
+++ b/src/Phan/LanguageServer/Utils.php
@@ -18,6 +18,10 @@ use Throwable;
 class Utils
 {
     /**
+     * Causes the sabre event loop to crash, for debugging.
+     *
+     * E.g. this is called if there is an unrecoverable error elsewhere.
+     *
      * @return void
      * @suppress PhanUnreferencedPublicMethod
      */

--- a/src/Phan/Library/FileCache.php
+++ b/src/Phan/Library/FileCache.php
@@ -1,6 +1,8 @@
 <?php declare(strict_types=1);
 namespace Phan\Library;
 
+use RuntimeException;
+
 /**
  * An LRU cache for the contents of files (FileCacheEntry), and data structures derived from contents of files.
  */
@@ -26,6 +28,9 @@ final class FileCache
     }
 
     /**
+     * Adds an entry recording that $file_name has contents $file_contents,
+     * overwriting any previous entries
+     *
      * @return FileCacheEntry
      */
     public static function addEntry(string $file_name, string $contents) : FileCacheEntry
@@ -49,7 +54,8 @@ final class FileCache
     }
 
     /**
-     * @return ?FileCacheEntry
+     * @return ?FileCacheEntry if the entry exists in cache, return it.
+     * Otherwise, return null.
      */
     public static function getEntry(string $file_name)
     {
@@ -64,8 +70,9 @@ final class FileCache
     }
 
     /**
-     * @throws \RuntimeException if the file could not be loaded
-     * @return FileCacheEntry
+     * @param string $file_name an absolute path to a file on disk
+     * @return FileCacheEntry This will load the file from the filesystem if it could not be found.
+     * @throws RuntimeException if the file could not be loaded
      */
     public static function getOrReadEntry(string $file_name) : FileCacheEntry
     {
@@ -74,14 +81,14 @@ final class FileCache
             return $entry;
         }
         if (!\file_exists($file_name)) {
-            throw new \RuntimeException("FileCache::getOrReadEntry: unable to find '$file_name'\n");
+            throw new RuntimeException("FileCache::getOrReadEntry: unable to find '$file_name'\n");
         }
         if (!\is_readable($file_name)) {
-            throw new \RuntimeException("FileCache::getOrReadEntry: unable to read '$file_name'\n");
+            throw new RuntimeException("FileCache::getOrReadEntry: unable to read '$file_name'\n");
         }
         $contents = file_get_contents($file_name);
         if (!\is_string($contents)) {
-            throw new \RuntimeException("FileCache::getOrReadEntry: file_get_contents failed for '$file_name'\n");
+            throw new RuntimeException("FileCache::getOrReadEntry: file_get_contents failed for '$file_name'\n");
         }
         $entry = self::addEntry($file_name, $contents);
         return $entry;

--- a/src/Phan/Library/Hasher/Consistent.php
+++ b/src/Phan/Library/Hasher/Consistent.php
@@ -10,8 +10,10 @@ use Phan\Library\Hasher;
  */
 class Consistent implements Hasher
 {
-    const VIRTUAL_COPY_COUNT = 16;  // Larger number means a more balanced distribution.
-    const MAX = 0x40000000;  // i.e. (1 << 30)
+    /** A larger number means a more balanced distribution. */
+    const VIRTUAL_COPY_COUNT = 16;
+    /** i.e. (1 << 30) */
+    const MAX = 0x40000000;
     /** @var array<int,int> - Sorted list of hash values, for binary search. */
     protected $hash_ring_ids;
     /** @var array<int,int> - Groups corresponding to hash values in hash_ring_ids */
@@ -81,7 +83,7 @@ class Consistent implements Hasher
     }
 
     /**
-     * @return array<int,int>
+     * @return array<int,int> A list of VIRTUAL_COPY_COUNT hashes for group $i in the consistent hash ring.
      */
     public static function getHashesForGroup(int $group) : array
     {

--- a/src/Phan/Library/Option.php
+++ b/src/Phan/Library/Option.php
@@ -15,17 +15,24 @@ namespace Phan\Library;
 abstract class Option
 {
     /**
+     * If this has a value, return that value.
+     * Otherwise, return $else
+     *
      * @param T $else
      * @return T
      */
     abstract public function getOrElse($else);
 
     /**
-     * @return bool
+     * @return bool true if this is defined (i.e. this is an instance of Some)
      */
     abstract public function isDefined() : bool;
 
     /**
+     * Gets the value, or throws if this was an instance of None.
+     *
+     * The caller should check if $this->isDefined()
+     *
      * @return T
      */
     abstract public function get();

--- a/src/Phan/Library/RAII.php
+++ b/src/Phan/Library/RAII.php
@@ -5,14 +5,17 @@ use Closure;
 
 /**
  * Implements Resource Acquisition Is Initialization.
- * An unused variable in the local scope can be used to call this.
+ * An defined but unused variable in a function/method scope can be used to create this,
+ * and the passed in finalizer closure will be called when that function/method returns.
  *
  * Note: This assumes that the garbage collector eagerly calls __destruct.
  * This may not be the case in alternate PHP implementations.
+ *
+ * @see https://en.wikipedia.org/wiki/Resource_acquisition_is_initialization
  */
 class RAII
 {
-    /** @var Closure():void */
+    /** @var null|Closure():void */
     private $finalizer;
 
     /**
@@ -24,6 +27,7 @@ class RAII
     }
 
     /**
+     * Calls the finalizer, unless it has already been called.
      * @return void
      */
     public function callFinalizerOnce()
@@ -31,6 +35,7 @@ class RAII
         $finalizer = $this->finalizer;
         if ($finalizer) {
             $finalizer();
+            $this->finalizer = null;
         }
     }
 

--- a/src/Phan/Library/RegexKeyExtractor.php
+++ b/src/Phan/Library/RegexKeyExtractor.php
@@ -33,7 +33,7 @@ class RegexKeyExtractor
 
     /**
      * @param string|mixed $regex
-     * @return array<string|int,true>
+     * @return array<string|int,true> the best guess at the keys that would be parsed into $matches by preg_match, based on the regex and flags passed to preg_match
      * @throws InvalidArgumentException if the regex could not be parsed by these heuristics
      */
     public static function getKeys($regex) : array

--- a/src/Phan/Output/Collector/BufferingCollector.php
+++ b/src/Phan/Output/Collector/BufferingCollector.php
@@ -67,6 +67,10 @@ final class BufferingCollector implements IssueCollectorInterface
     }
 
     /**
+     * Clear the array of issues without outputting anything.
+     *
+     * Called after analysis ends.
+     *
      * @return void
      */
     public function flush()

--- a/src/Phan/Output/Collector/ParallelChildCollector.php
+++ b/src/Phan/Output/Collector/ParallelChildCollector.php
@@ -35,6 +35,7 @@ class ParallelChildCollector implements IssueCollectorInterface
     }
 
     /**
+     * Assert that the dependencies needed for communicating with the child or parent process are available.
      * @throws AssertionError if PHP modules needed for shared communication aren't loaded
      * @internal
      */

--- a/src/Phan/Output/Collector/ParallelParentCollector.php
+++ b/src/Phan/Output/Collector/ParallelParentCollector.php
@@ -82,13 +82,12 @@ class ParallelParentCollector implements IssueCollectorInterface
     }
 
     /**
+     * Read the entire queue and write all issues to the
+     * base collector
      * @return void
      */
     public function readQueuedIssues()
     {
-        // Read the entire queue and write all issues to the
-        // base collector
-
         // Get the status of the queue
         $status = msg_stat_queue(
             $this->message_queue_resource

--- a/src/Phan/Output/Colorizing.php
+++ b/src/Phan/Output/Colorizing.php
@@ -103,6 +103,10 @@ class Colorizing
     private static $color_scheme = null;
 
     /**
+     * Returns a version of $template where template strings (e.g. `{FILE}`
+     * are replaced with printf conversion specifiers (e.g. `%s`)
+     * and color control codes are inserted before/after those conversion specifiers.
+     *
      * @param string $template
      * @param array<int,int|string|float|FQSEN|Type|UnionType> $template_parameters
      */

--- a/src/Phan/Output/IssueCollectorInterface.php
+++ b/src/Phan/Output/IssueCollectorInterface.php
@@ -19,9 +19,9 @@ interface IssueCollectorInterface
     public function collectIssue(IssueInstance $issue);
 
     /**
-     * @return array<int,IssueInstance>
+     * @return array<int,IssueInstance> the list of collected issues from calls to collectIssue()
      */
-    public function getCollectedIssues():array;
+    public function getCollectedIssues(): array;
 
     /**
      * Remove all collected issues (from the parse phase) for the given file paths.

--- a/src/Phan/Output/IssuePrinterInterface.php
+++ b/src/Phan/Output/IssuePrinterInterface.php
@@ -11,12 +11,16 @@ interface IssuePrinterInterface
 {
 
     /**
+     * Emit an issue to the configured OutputInterface
+     *
      * @param IssueInstance $instance
      * @return void
      */
     public function print(IssueInstance $instance);
 
     /**
+     * Sets the OutputInterface instance that issues will be printed to.
+     *
      * @param OutputInterface $output
      * @return void
      */

--- a/src/Phan/Output/PrinterFactory.php
+++ b/src/Phan/Output/PrinterFactory.php
@@ -17,7 +17,7 @@ class PrinterFactory
 {
 
     /**
-     * @return array<int,string>
+     * @return array<int,string> the supported types of Printers
      */
     public function getTypes():array
     {
@@ -25,7 +25,8 @@ class PrinterFactory
     }
 
     /**
-     * @param ?string $type
+     * Return an IssuePrinterInterface of type $type that outputs issues to $output
+     * @param ?string $type the configured type of printer
      */
     public function getPrinter($type, OutputInterface $output):IssuePrinterInterface
     {

--- a/src/Phan/Phan.php
+++ b/src/Phan/Phan.php
@@ -34,7 +34,7 @@ class Phan implements IgnoredFilesFilterInterface
     private static $issue_collector;
 
     /**
-     * @return IssueCollectorInterface
+     * @return IssueCollectorInterface used to gather issues to be printed (or used) once analysis is finished
      */
     public static function getIssueCollector() : IssueCollectorInterface
     {
@@ -42,6 +42,7 @@ class Phan implements IgnoredFilesFilterInterface
     }
 
     /**
+     * Set the IssueCollectorInterface used to gather issues to be printed (or used) once analysis is finished
      * @param IssueCollectorInterface $issue_collector
      *
      * @return void
@@ -236,6 +237,9 @@ class Phan implements IgnoredFilesFilterInterface
     }
 
     /**
+     * Finish analyzing any files that need to be analyzed
+     * (for full analysis, or a limited number of files for daemon mode, etc.)
+     *
      * @param CodeBase $code_base
      * A code base needs to be passed in because we require
      * it to be initialized before any classes or files are
@@ -553,6 +557,7 @@ class Phan implements IgnoredFilesFilterInterface
     }
 
     /**
+     * Set the printer to use to emit issues to.
      * @return void
      */
     public static function setPrinter(

--- a/src/Phan/Plugin/ClosuresForKind.php
+++ b/src/Phan/Plugin/ClosuresForKind.php
@@ -28,6 +28,8 @@ class ClosuresForKind
     }
 
     /**
+     * Record the fact that the resulting closure for Node kind $kind should invoke $c
+     *
      * @param int $kind - A valid value of a node kind
      * @param Closure $c
      * @return void
@@ -45,7 +47,7 @@ class ClosuresForKind
     }
 
     /**
-     * Record the fact that a Closure needs to be the given subset of values of node->kind
+     * Record the fact that the resulting Closure needs to call $c for the given subset of values of node->kind
      *
      * @param array<int,int> $kinds - A list of unique values of node kinds
      * @param Closure $c - The closure to execute on each of those kinds

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -66,6 +66,8 @@ use function is_null;
  *
  * (Note: This is called almost once per each AST node being analyzed.
  * Speed is preferred over using Phan\Memoize.)
+ *
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod TODO: Document
  */
 final class ConfigPluginSet extends PluginV2 implements
     AfterAnalyzeFileCapability,
@@ -182,6 +184,9 @@ final class ConfigPluginSet extends PluginV2 implements
     }
 
     /**
+     * Resets this set of plugins to the state it had before any user-defined or internal plugins were added,
+     * then re-initialize plugins based on the current configuration.
+     *
      * @suppress PhanDeprecatedInterface
      * @internal - Used only for testing
      */

--- a/src/Phan/Plugin/Internal/ClosureReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ClosureReturnTypeOverridePlugin.php
@@ -258,7 +258,11 @@ final class ClosureReturnTypeOverridePlugin extends PluginV2 implements
     }
 
     /**
-     * @phan-return Closure(mixed,int):UnionType
+     * This caches the arguments inferred as the union types of arguments passed to function calls.
+     * This is used in case there are multiple function-likes that need to be analyzed
+     *
+     * TODO: Is this still needed?
+     * @return Closure(mixed,int):UnionType
      */
     public static function createNormalArgumentCache(CodeBase $code_base, Context $context) : Closure
     {

--- a/src/Phan/Plugin/Internal/NodeSelectionPlugin.php
+++ b/src/Phan/Plugin/Internal/NodeSelectionPlugin.php
@@ -48,6 +48,7 @@ class NodeSelectionVisitor extends PluginAwarePostAnalysisVisitor
     // A plugin's visitors should not override visit() unless they need to.
 
     /**
+     * This is the catch-all for Nodes with kinds that don't have specialized methods
      * @param Node $node
      * A node to check
      *

--- a/src/Phan/Plugin/Internal/NodeSelectionPlugin.php
+++ b/src/Phan/Plugin/Internal/NodeSelectionPlugin.php
@@ -71,5 +71,5 @@ class NodeSelectionVisitor extends PluginAwarePostAnalysisVisitor
 }
 
 // Every plugin needs to return an instance of itself at the
-// end of the file in which its defined.
+// end of the file in which it's defined.
 return new NodeSelectionPlugin();

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableGraph.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableGraph.php
@@ -6,6 +6,7 @@ use function spl_object_id;
 
 /**
  * This represents a summary of all of the definitions and uses of all variable within a scope.
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
 final class VariableGraph
 {
@@ -55,6 +56,7 @@ final class VariableGraph
     }
 
     /**
+     * Record the fact that $node is a definition of the variable with name $name in the scope $scope
      * @return void
      */
     public function recordVariableDefinition(string $name, Node $node, VariableTrackingScope $scope)

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackingLoopScope.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackingLoopScope.php
@@ -40,6 +40,9 @@ final class VariableTrackingLoopScope extends VariableTrackingBranchScope
     }
 
     /**
+     * Account for the definitions and uses of the child scopes with `break`/`continue` inside of this switch statement,
+     * using these to update the definition and uses of the outer scope of the `switch` node
+     *
      * @return void
      */
     public function flattenSwitchCaseScopes(VariableGraph $graph)

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackingScope.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackingScope.php
@@ -10,6 +10,7 @@ use function spl_object_id;
  * Instead of tracking the union types for variable names, this will instead track definitions of variable names.
  *
  * @see ContextMergeVisitor for something similar for union types.
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
 class VariableTrackingScope
 {

--- a/src/Phan/PluginV2/AfterAnalyzeFileCapability.php
+++ b/src/Phan/PluginV2/AfterAnalyzeFileCapability.php
@@ -12,6 +12,8 @@ use Phan\Language\Context;
 interface AfterAnalyzeFileCapability
 {
     /**
+     * This method is called after Phan analyzes a file.
+     *
      * @param CodeBase $code_base
      * The code base in which the node exists
      *

--- a/src/Phan/PluginV2/BeforeAnalyzeFileCapability.php
+++ b/src/Phan/PluginV2/BeforeAnalyzeFileCapability.php
@@ -12,6 +12,8 @@ use Phan\Language\Context;
 interface BeforeAnalyzeFileCapability
 {
     /**
+     * This method is called before analyzing a file.
+     *
      * @param CodeBase $code_base
      * The code base in which the node exists
      *

--- a/src/Phan/PluginV2/PluginAwareBaseAnalysisVisitor.php
+++ b/src/Phan/PluginV2/PluginAwareBaseAnalysisVisitor.php
@@ -26,6 +26,9 @@ abstract class PluginAwareBaseAnalysisVisitor extends AnalysisVisitor
     }
 
     /**
+     * Emit an issue with the provided arguments,
+     * unless that issue is suppressed.
+     *
      * @param string $issue_type
      * A name for the type of issue such as 'PhanPluginMyIssue'
      *

--- a/tests/Phan/AST/TolerantASTConverter/ConversionTest.php
+++ b/tests/Phan/AST/TolerantASTConverter/ConversionTest.php
@@ -41,7 +41,7 @@ final class ConversionTest extends BaseTest
     }
 
     /**
-     * @return bool
+     * @return bool does php-ast support $ast_version
      */
     public static function hasNativeASTSupport(int $ast_version)
     {

--- a/tests/Phan/CodeBaseAwareTestInterface.php
+++ b/tests/Phan/CodeBaseAwareTestInterface.php
@@ -14,6 +14,9 @@ interface CodeBaseAwareTestInterface
 {
 
     /**
+     * Sets the codebase used by this unit test to a valid codebase (before the test),
+     * or to null (to free up memory after the test is complete)
+     *
      * @param ?CodeBase $code_base
      * @return void
      */

--- a/tests/Phan/Language/Element/MarkupDescriptionTest.php
+++ b/tests/Phan/Language/Element/MarkupDescriptionTest.php
@@ -46,13 +46,13 @@ final class MarkupDescriptionTest extends BaseTest
             ],
             // Allow the description of (at)var to be a summary for the property if there is no earlier summary
             [
-                <<<EOT
+                <<<'EOT'
 @var MyClass A annotation of a constant goes here
 
 Rest of this comment
 EOT
                 ,
-                <<<EOT
+                <<<'EOT'
 /**
  * @var MyClass A annotation of a constant goes here
  *
@@ -64,7 +64,7 @@ EOT
             ],
             // Preserve leading whitespace when parsing the comment description
             [
-                <<<EOT
+                <<<'EOT'
 A description goes here
 
 Rest of this description
@@ -73,7 +73,7 @@ Rest of this description
    Rest of that list
 EOT
                 ,
-            <<<EOT
+            <<<'EOT'
 /**
  * A description goes here
  *
@@ -86,7 +86,7 @@ EOT
             ],
             // Preserve leading whitespace when parsing markup after (at)return
             [
-                <<<EOT
+                <<<'EOT'
 @return int
 
 Rest of this description
@@ -95,7 +95,7 @@ Rest of this description
    Rest of that list
 EOT
                 ,
-            <<<EOT
+            <<<'EOT'
 /**
  * @return int
  *
@@ -114,7 +114,7 @@ EOT
             [
                 ''
                 ,
-            <<<EOT
+            <<<'EOT'
 /**
  * @return int
  *
@@ -126,12 +126,12 @@ EOT
             ],
             // Parse summaries on adjacent lines
             [
-                <<<EOT
+                <<<'EOT'
 @return int
 Rest of this description
 EOT
                 ,
-            <<<EOT
+            <<<'EOT'
 /**
  * @return int
  * Rest of this description
@@ -145,7 +145,7 @@ EOT
             // Treat informative (at)return as function-like summaries.
             [
                 '@return int positive',
-            <<<EOT
+            <<<'EOT'
 /**
  * @return int positive
  */
@@ -160,6 +160,34 @@ EOT
                 Comment::ON_METHOD
             ],
             [
+                "@return float\npositive value",
+                <<<'EOT'
+/**
+ * @param int $x
+ * @return float
+ * positive value
+ */
+EOT
+                ,
+                Comment::ON_METHOD
+            ],
+            // Check that it does not fail completely for invalid phpdoc with multiple `(at)return` statements
+            [
+                "@return float\npositive value.",
+                <<<'EOT'
+/**
+ * @param int $x
+ * @return float
+ * positive value.
+ * @internal
+ * @return false
+ * on failure.
+ */
+EOT
+                ,
+                Comment::ON_METHOD
+            ],
+            [
                 '@return int self::MY_ENUM_* description',
                 '/**   @return int self::MY_ENUM_* description */',
                 Comment::ON_METHOD
@@ -167,7 +195,7 @@ EOT
             // Don't treat uninformative (at)return as function-like summaries.
             [
                 '',
-            <<<EOT
+            <<<'EOT'
 /**
  * @return string|false
  */

--- a/tests/Phan/Language/TypeTest.php
+++ b/tests/Phan/Language/TypeTest.php
@@ -32,6 +32,7 @@ use Phan\Tests\BaseTest;
 
 /**
  * Unit tests of Type
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
 final class TypeTest extends BaseTest
 {

--- a/tests/Phan/LanguageServer/LanguageServerIntegrationTest.php
+++ b/tests/Phan/LanguageServer/LanguageServerIntegrationTest.php
@@ -22,6 +22,7 @@ use stdClass;
  * (integration test timeouts weren't implemented or tested yet).
  *
  * @phan-file-suppress PhanThrowTypeAbsent, PhanThrowTypeAbsentForCall it's a test
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
 final class LanguageServerIntegrationTest extends BaseTest
 {

--- a/tests/Phan/Library/RegexKeyExtractorTest.php
+++ b/tests/Phan/Library/RegexKeyExtractorTest.php
@@ -10,6 +10,8 @@ use Phan\Tests\BaseTest;
 final class RegexKeyExtractorTest extends BaseTest
 {
     /**
+     * Test that $expected_keys are extracted from $regex
+     *
      * @param string $regex a regular expression for preg_match
      * @param array<int,int|string> $expected_keys
      * @return void

--- a/tests/files/expected/0537_closure_scope.php.expected
+++ b/tests/files/expected/0537_closure_scope.php.expected
@@ -1,0 +1,1 @@
+%s:8 PhanTypeInvalidClosureScope Invalid @phan-closure-scope: expected a class name, got int

--- a/tests/files/src/0537_closure_scope.php
+++ b/tests/files/src/0537_closure_scope.php
@@ -1,0 +1,11 @@
+<?php
+
+class C537 {
+    function test () {
+        /**
+         * @phan-closure-scope int should warn
+         */
+        $f = function () { return $this; };
+        return $f;
+    }
+}

--- a/tool/make_stubs
+++ b/tool/make_stubs
@@ -26,6 +26,7 @@ if (!class_exists('\ast\Node')) {
  * These are regular PHP files stubbing PHP modules, containing empty method implementations, etc.
  *
  * Configured stubs can be used in IDEs, analysis, etc. where extensions aren't installed or enabled (e.g. xdebug)
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
 class StubsGenerator {
 


### PR DESCRIPTION
Update code that was looked at, deprecate a method that duplicated functionality of another methods, and fix incorrect code.

Start working on ensuring that new public methods in Phan's codebase have PHPDoc comments.

Improve extraction of summaries from doc comments (Fix a bug where Phan wouldn't extract annotations if that annotation wasn't the first annotation)