### PR TITLE
Improve documentation: Link to examples in documentation of issue types

### DIFF
--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -25,6 +25,8 @@ This issue comes up when there is an attempt to access a private class constant 
 Cannot access private class constant {CONST} defined at {FILE}:{LINE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0252_class_const_visibility.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0252_class_const_visibility.php#L17).
+
 ## PhanAccessClassConstantProtected
 
 This issue comes up when there is an attempt to access a protected class constant outside of the scope in which it's defined.
@@ -33,6 +35,7 @@ This issue comes up when there is an attempt to access a protected class constan
 Cannot access protected class constant {CONST} defined at {FILE}:{LINE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0252_class_const_visibility.php.expected#L3) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0252_class_const_visibility.php#L25).
 
 ## PhanAccessExtendsFinalClass
 
@@ -71,6 +74,8 @@ This issue comes up when there is an attempt to invoke a private method outside 
 Cannot access private method {METHOD} defined at {FILE}:{LINE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0175_priv_prot_methods.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0175_priv_prot_methods.php#L12).
+
 ## PhanAccessMethodPrivateWithCallMagicMethod
 
 This issue comes up when there is an attempt to invoke a private method outside of the scope in which it's defined, but the attempt would end up calling `__call` or `__callStatic` instead.
@@ -78,6 +83,8 @@ This issue comes up when there is an attempt to invoke a private method outside 
 ```
 Cannot access private method {METHOD} defined at {FILE}:{LINE} (if this call should be handled by __call, consider adding a @method tag to the class)
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0298_call_magic_method_accesses_inaccessible.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0298_call_magic_method_accesses_inaccessible.php#L74).
 
 ## PhanAccessMethodProtected
 
@@ -87,6 +94,8 @@ This issue comes up when there is an attempt to invoke a protected method outsid
 Cannot access protected method {METHOD} defined at {FILE}:{LINE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0351_protected_constructor.php.expected#L3) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0351_protected_constructor.php#L10).
+
 ## PhanAccessMethodProtectedWithCallMagicMethod
 
 This issue comes up when there is an attempt to invoke a protected method outside of the scope in which it's defined or an implementing child class, but the attempt would end up calling `__call` or `__callStatic` instead.
@@ -94,6 +103,8 @@ This issue comes up when there is an attempt to invoke a protected method outsid
 ```
 Cannot access protected method {METHOD} defined at {FILE}:{LINE} (if this call should be handled by __call, consider adding a @method tag to the class)
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0298_call_magic_method_accesses_inaccessible.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0298_call_magic_method_accesses_inaccessible.php#L80).
 
 ## PhanAccessNonStaticToStatic
 
@@ -103,11 +114,15 @@ This issue is emitted when a class redeclares an inherited instance method as a 
 Cannot make non static method {METHOD}() static
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0127_override_access.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0127_override_access.php#L8).
+
 ## PhanAccessNonStaticToStaticProperty
 
 ```
 Cannot make non static property {PROPERTY} into the static property {PROPERTY}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0492_class_constant_visibility.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0492_class_constant_visibility.php#L25).
 
 ## PhanAccessOverridesFinalMethod
 
@@ -117,6 +132,8 @@ This issue is emitted when a class attempts to override an inherited final metho
 Declaration of method {METHOD} overrides final method {METHOD} defined in {FILE}:{LINE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0319_override_parent_and_interface.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0319_override_parent_and_interface.php#L20).
+
 ## PhanAccessOverridesFinalMethodInternal
 
 This issue is emitted when a class attempts to override an inherited final method of an internal class.
@@ -124,6 +141,8 @@ This issue is emitted when a class attempts to override an inherited final metho
 ```
 Declaration of method {METHOD} overrides final internal method {METHOD}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0318_override_final_method.php.expected#L8) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0318_override_final_method.php#L70).
 
 ## PhanAccessOverridesFinalMethodPHPDoc
 
@@ -133,11 +152,15 @@ This issue is emitted when a class declares a PHPDoc `@method` tag, despite havi
 Declaration of phpdoc method {METHOD} is an unnecessary override of final method {METHOD} defined in {FILE}:{LINE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0318_override_final_method.php.expected#L6) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0318_override_final_method.php#L49).
+
 ## PhanAccessOwnConstructor
 
 ```
 Accessing own constructor directly via {CLASS}::__construct
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0310_self_construct.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0310_self_construct.php#L19).
 
 ## PhanAccessPropertyNonStaticAsStatic
 
@@ -205,6 +228,7 @@ $x = (new A())->prop;
 Access level to {METHOD} must be compatible with {METHOD} defined in {FILE}:{LINE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0181_override_access_level.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0181_override_access_level.php#L8).
 
 ## PhanAccessSignatureMismatchInternal
 
@@ -226,11 +250,15 @@ Cannot make static method {METHOD}() non static
 Cannot make static property {PROPERTY} into the non static property {PROPERTY}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0492_class_constant_visibility.php.expected#L3) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0492_class_constant_visibility.php#L26).
+
 ## PhanAccessWrongInheritanceCategory
 
 ```
 Attempting to inherit {CLASSLIKE} defined at {FILE}:{LINE} as if it were a {CLASSLIKE}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0316_incompatible_extend.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0316_incompatible_extend.php#L9).
 
 ## PhanAccessWrongInheritanceCategoryInternal
 
@@ -238,11 +266,15 @@ Attempting to inherit {CLASSLIKE} defined at {FILE}:{LINE} as if it were a {CLAS
 Attempting to inherit internal {CLASSLIKE} as if it were a {CLASSLIKE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0316_incompatible_extend.php.expected#L3) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0316_incompatible_extend.php#L11).
+
 ## PhanConstantAccessSignatureMismatch
 
 ```
 Access level to {CONST} must be compatible with {CONST} defined in {FILE}:{LINE}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0492_class_constant_visibility.php.expected#L5) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0492_class_constant_visibility.php#L34).
 
 ## PhanConstantAccessSignatureMismatchInternal
 
@@ -255,6 +287,8 @@ Access level to {CONST} must be compatible with internal {CONST}
 ```
 Access level to {PROPERTY} must be compatible with {PROPERTY} defined in {FILE}:{LINE}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0492_class_constant_visibility.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0492_class_constant_visibility.php#L23).
 
 ## PhanPropertyAccessSignatureMismatchInternal
 
@@ -276,6 +310,8 @@ Please do file an issue or otherwise get in touch if you get one of these (or an
 ```
 {CONST} is an invalid FQSEN for a constant
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/misc/fallback_test/expected/047_invalid_define.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/misc/fallback_test/src/047_invalid_define.php#L3).
 
 ## PhanUnanalyzable
 
@@ -339,6 +375,8 @@ Nullable type '{TYPE}' is not compatible with PHP 7.0
 ```
 Type '{TYPE}' refers to any object starting in PHP 7.2. In PHP 7.1 and earlier, it refers to a class/interface with the name 'object'
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0289_check_incorrect_soft_types.php.expected#L4) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0289_check_incorrect_soft_types.php#L14).
 
 ## PhanCompatiblePHP7
 
@@ -410,11 +448,15 @@ new parent;
 Cannot access {CLASS} when not in object context, but code is using callable {METHOD}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0370_callable_edge_cases.php.expected#L8) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0370_callable_edge_cases.php#L47).
+
 ## PhanContextNotObjectUsingSelf
 
 ```
 Cannot use {CLASS} as type when not in object context in {FUNCTION}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/misc/fallback_test/expected/034_function_return_self.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/misc/fallback_test/src/034_function_return_self.php#L3).
 
 # DeprecatedError
 
@@ -427,6 +469,8 @@ This category of issue comes up when you're accessing deprecated elements (as ma
 ```
 Call to deprecated class {CLASS} defined at {FILE}:{LINE}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0123_deprecated_class.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0123_deprecated_class.php#L12).
 
 ## PhanDeprecatedFunction
 
@@ -456,17 +500,23 @@ Call to deprecated function {FUNCTIONLIKE}()
 Using a deprecated interface {INTERFACE} defined at {FILE}:{LINE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0269_deprecated_interface.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0269_deprecated_interface.php#L7).
+
 ## PhanDeprecatedProperty
 
 ```
 Reference to deprecated property {PROPERTY} defined at {FILE}:{LINE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0171_deprecated_property.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0171_deprecated_property.php#L7).
+
 ## PhanDeprecatedTrait
 
 ```
 Using a deprecated trait {TRAIT} defined at {FILE}:{LINE}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0270_deprecated_trait.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0270_deprecated_trait.php#L7).
 
 # NOOPError
 
@@ -491,6 +541,8 @@ This will be emitted for the following code.
 ```
 Unused result of a binary '{OPERATOR}' operator
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0421_binary_operator.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0421_binary_operator.php#L4).
 
 ## PhanNoopClosure
 
@@ -527,11 +579,15 @@ C;
 Unused result of an encapsulated string literal
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0470_noop_scalar.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0470_noop_scalar.php#L4).
+
 ## PhanNoopNumericLiteral
 
 ```
 Unused result of a numeric literal {STRING_LITERAL} near this line
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/misc/fallback_test/expected/035_bad_switch_statement.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/misc/fallback_test/src/035_bad_switch_statement.php#L0).
 
 ## PhanNoopProperty
 
@@ -558,11 +614,15 @@ class C {
 Unused result of a string literal {STRING_LITERAL} near this line
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/misc/fallback_test/expected/051_invalid_function_node.php.expected#L3) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/misc/fallback_test/src/051_invalid_function_node.php#L3).
+
 ## PhanNoopUnaryOperator
 
 ```
 Unused result of a unary '{OPERATOR}' operator
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0422_unary_noop.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0422_unary_noop.php#L3).
 
 ## PhanNoopVariable
 
@@ -602,11 +662,15 @@ Possibly zero write references to protected property {PROPERTY}
 Possibly zero write references to public property {PROPERTY}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/expected/048_redundant_binary_op.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/src/048_redundant_binary_op.php#L5).
+
 ## PhanUnreachableCatch
 
 ```
 Catch statement for {CLASSLIKE} is unreachable. An earlier catch statement at line {LINE} caught the ancestor class/interface {CLASSLIKE}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0462_unreachable_catch.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0462_unreachable_catch.php#L9).
 
 ## PhanUnreferencedClass
 
@@ -643,17 +707,23 @@ YMMV.
 Possibly zero references to closure {FUNCTION}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/expected/017_unreferenced_closure.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/src/017_unreferenced_closure.php#L10).
+
 ## PhanUnreferencedConstant
 
 ```
 Possibly zero references to global constant {CONST}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/expected/001_dead_code.php.expected#L11) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/src/001_dead_code.php#L37).
+
 ## PhanUnreferencedFunction
 
 ```
 Possibly zero references to function {FUNCTION}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/expected/047_crash.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/src/047_crash.php#L11).
 
 ## PhanUnreferencedPrivateClassConstant
 
@@ -685,6 +755,8 @@ Possibly zero references to protected class constant {CONST}
 Possibly zero references to protected method {METHOD}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/expected/015_trait_method.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/src/015_trait_method.php#L9).
+
 ## PhanUnreferencedProtectedProperty
 
 ```
@@ -697,11 +769,15 @@ Possibly zero references to protected property {PROPERTY}
 Possibly zero references to public class constant {CONST}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/expected/021_param_default.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/src/021_param_default.php#L5).
+
 ## PhanUnreferencedPublicMethod
 
 ```
 Possibly zero references to public method {METHOD}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/expected/022_trait_method.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/src/022_trait_method.php#L5).
 
 ## PhanUnreferencedPublicProperty
 
@@ -709,11 +785,15 @@ Possibly zero references to public method {METHOD}
 Possibly zero references to public property {PROPERTY}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/expected/027_native_syntax_check.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/src/027_native_syntax_check.php#L3).
+
 ## PhanUnreferencedUseConstant
 
 ```
 Possibly zero references to use statement for constant {CONST} ({CONST})
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0268_group_use.php.expected#L5) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0268_group_use.php#L4).
 
 ## PhanUnreferencedUseFunction
 
@@ -721,11 +801,15 @@ Possibly zero references to use statement for constant {CONST} ({CONST})
 Possibly zero references to use statement for function {FUNCTION} ({FUNCTION})
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0268_group_use.php.expected#L3) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0268_group_use.php#L3).
+
 ## PhanUnreferencedUseNormal
 
 ```
 Possibly zero references to use statement for classlike/namespace {CLASSLIKE} ({CLASSLIKE})
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0268_group_use.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0268_group_use.php#L2).
 
 ## PhanUnusedClosureParameter
 
@@ -736,17 +820,23 @@ to detect if a variable or parameter is unused.
 Parameter ${PARAMETER} is never used
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/expected/006_preg_regex.php.expected#L3) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/src/006_preg_regex.php#L12).
+
 ## PhanUnusedClosureUseVariable
 
 ```
 Closure use variable ${VARIABLE} is never used
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0012_closures.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0012_closures.php#L13).
+
 ## PhanUnusedGlobalFunctionParameter
 
 ```
 Parameter ${PARAMETER} is never used
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/misc/fallback_test/expected/010_functions8.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/misc/fallback_test/src/010_functions8.php#L2).
 
 ## PhanUnusedPrivateFinalMethodParameter
 
@@ -760,6 +850,8 @@ Parameter ${PARAMETER} is never used
 Parameter ${PARAMETER} is never used
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0127_override_access.php.expected#L3) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0127_override_access.php#L12).
+
 ## PhanUnusedProtectedFinalMethodParameter
 
 ```
@@ -771,6 +863,8 @@ Parameter ${PARAMETER} is never used
 ```
 Parameter ${PARAMETER} is never used
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0056_aggressive_return_types.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0056_aggressive_return_types.php#L3).
 
 ## PhanUnusedPublicFinalMethodParameter
 
@@ -784,6 +878,8 @@ Parameter ${PARAMETER} is never used
 Parameter ${PARAMETER} is never used
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/expected/047_crash.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/src/047_crash.php#L6).
+
 ## PhanUnusedVariable
 
 Phan has various checks (See the `unused_variable_detection` config)
@@ -793,11 +889,15 @@ to detect if a variable or parameter is unused.
 Unused definition of variable ${VARIABLE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/misc/fallback_test/expected/037_assign_op.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/misc/fallback_test/src/037_assign_op.php#L3).
+
 ## PhanUnusedVariableCaughtException
 
 ```
 Unused definition of variable ${VARIABLE} as a caught exception
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/expected/054_shadowed_exception.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/src/054_shadowed_exception.php#L6).
 
 ## PhanUnusedVariableValueOfForeachWithKey
 
@@ -805,11 +905,15 @@ Unused definition of variable ${VARIABLE} as a caught exception
 Unused definition of variable ${VARIABLE} as the value of a foreach loop that included keys
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0480_array_access_iteration.php.expected#L3) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0480_array_access_iteration.php#L15).
+
 ## PhanWriteOnlyPrivateProperty
 
 ```
 Possibly zero read references to private property {PROPERTY}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/expected/024_strict_property_assignment.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/src/024_strict_property_assignment.php#L5).
 
 ## PhanWriteOnlyProtectedProperty
 
@@ -817,11 +921,15 @@ Possibly zero read references to private property {PROPERTY}
 Possibly zero read references to protected property {PROPERTY}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/expected/024_strict_property_assignment.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/src/024_strict_property_assignment.php#L8).
+
 ## PhanWriteOnlyPublicProperty
 
 ```
 Possibly zero read references to public property {PROPERTY}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/expected/024_strict_property_assignment.php.expected#L3) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/src/024_strict_property_assignment.php#L11).
 
 # ParamError
 
@@ -832,6 +940,8 @@ This category of error comes up when you're messing up your method or function p
 ```
 Redefinition of parameter {PARAMETER}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0183_redefined_parameter.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0183_redefined_parameter.php#L2).
 
 ## PhanParamReqAfterOpt
 
@@ -857,6 +967,8 @@ and warns if an overriding method's signature is incompatible with the overridde
 Declaration of {METHOD} should be compatible with {METHOD} defined in {FILE}:{LINE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0227_trait_class_interface.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0227_trait_class_interface.php#L13).
+
 ## PhanParamSignatureMismatchInternal
 
 This compares the param and return types inferred from phpdoc and real types (as well as documentation of internal methods),
@@ -866,6 +978,8 @@ For a check with much lower false positives and clearer issue messages, use the 
 ```
 Declaration of {METHOD} should be compatible with internal {METHOD}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0308_inheritdoc_incompatible.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0308_inheritdoc_incompatible.php#L7).
 
 ## PhanParamSignaturePHPDocMismatchHasNoParamType
 
@@ -878,6 +992,8 @@ Declaration of real/@method {METHOD} should be compatible with real/@method {MET
 ```
 Declaration of real/@method {METHOD} should be compatible with real/@method {METHOD} (parameter #{INDEX} has type '{TYPE}' which cannot replace original parameter with no type) defined in {FILE}:{LINE}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0531_magic_method_override.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0531_magic_method_override.php#L113).
 
 ## PhanParamSignaturePHPDocMismatchParamIsNotReference
 
@@ -903,6 +1019,8 @@ Declaration of real/@method {METHOD} should be compatible with real/@method {MET
 Declaration of real/@method {METHOD} should be compatible with real/@method {METHOD} (parameter #{INDEX} of type '{TYPE}' cannot replace original parameter of type '{TYPE}') defined in {FILE}:{LINE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0315_magic_method_compat.php.expected#L5) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0315_magic_method_compat.php#L15).
+
 ## PhanParamSignaturePHPDocMismatchParamVariadic
 
 ```
@@ -927,11 +1045,15 @@ Declaration of real/@method {METHOD} should be compatible with real/@method {MET
 Declaration of real/@method {METHOD} should be compatible with real/@method {METHOD} (the method override requires {COUNT} parameter(s), but the overridden method requires only {COUNT}) defined in {FILE}:{LINE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0315_magic_method_compat.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0315_magic_method_compat.php#L13).
+
 ## PhanParamSignatureRealMismatchHasNoParamType
 
 ```
 Declaration of {METHOD} should be compatible with {METHOD} (parameter #{INDEX} with no type cannot replace original parameter with type '{TYPE}') defined in {FILE}:{LINE}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0126_override_signature.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0126_override_signature.php#L12).
 
 ## PhanParamSignatureRealMismatchHasNoParamTypeInternal
 
@@ -945,6 +1067,8 @@ Declaration of {METHOD} should be compatible with internal {METHOD} (parameter #
 Declaration of {METHOD} should be compatible with {METHOD} (parameter #{INDEX} has type '{TYPE}' which cannot replace original parameter with no type) defined in {FILE}:{LINE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0374_compat.php.expected#L3) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0374_compat.php#L42).
+
 ## PhanParamSignatureRealMismatchHasParamTypeInternal
 
 ```
@@ -957,6 +1081,8 @@ Declaration of {METHOD} should be compatible with internal {METHOD} (parameter #
 Declaration of {METHOD} should be compatible with {METHOD} (parameter #{INDEX} is a non-reference parameter overriding a reference parameter) defined in {FILE}:{LINE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0124_override_signature.php.expected#L19) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0124_override_signature.php#L68).
+
 ## PhanParamSignatureRealMismatchParamIsNotReferenceInternal
 
 ```
@@ -968,6 +1094,8 @@ Declaration of {METHOD} should be compatible with internal {METHOD} (parameter #
 ```
 Declaration of {METHOD} should be compatible with {METHOD} (parameter #{INDEX} is a reference parameter overriding a non-reference parameter) defined in {FILE}:{LINE}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0124_override_signature.php.expected#L17) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0124_override_signature.php#L67).
 
 ## PhanParamSignatureRealMismatchParamIsReferenceInternal
 
@@ -993,6 +1121,8 @@ Declaration of {METHOD} should be compatible with internal {METHOD} (parameter #
 Declaration of {METHOD} should be compatible with {METHOD} (parameter #{INDEX} of type '{TYPE}' cannot replace original parameter of type '{TYPE}') defined in {FILE}:{LINE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0126_override_signature.php.expected#L3) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0126_override_signature.php#L16).
+
 ## PhanParamSignatureRealMismatchParamTypeInternal
 
 ```
@@ -1004,6 +1134,8 @@ Declaration of {METHOD} should be compatible with internal {METHOD} (parameter #
 ```
 Declaration of {METHOD} should be compatible with {METHOD} (parameter #{INDEX} is a variadic parameter replacing a non-variadic parameter) defined in {FILE}:{LINE}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0279_should_check_variadic_mismatch.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0279_should_check_variadic_mismatch.php#L21).
 
 ## PhanParamSignatureRealMismatchParamVariadicInternal
 
@@ -1017,6 +1149,8 @@ Declaration of {METHOD} should be compatible with internal {METHOD} (parameter #
 Declaration of {METHOD} should be compatible with {METHOD} (method returning '{TYPE}' cannot override method returning '{TYPE}') defined in {FILE}:{LINE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0278_should_differentiate_phpdoc_return_type.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0278_should_differentiate_phpdoc_return_type.php#L10).
+
 ## PhanParamSignatureRealMismatchReturnTypeInternal
 
 ```
@@ -1028,6 +1162,8 @@ Declaration of {METHOD} should be compatible with internal {METHOD} (method retu
 ```
 Declaration of {METHOD} should be compatible with {METHOD} (the method override accepts {COUNT} parameter(s), but the overridden method can accept {COUNT}) defined in {FILE}:{LINE}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0227_trait_class_interface.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0227_trait_class_interface.php#L13).
 
 ## PhanParamSignatureRealMismatchTooFewParametersInternal
 
@@ -1041,6 +1177,8 @@ Declaration of {METHOD} should be compatible with internal {METHOD} (the method 
 Declaration of {METHOD} should be compatible with {METHOD} (the method override requires {COUNT} parameter(s), but the overridden method requires only {COUNT}) defined in {FILE}:{LINE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0279_should_check_variadic_mismatch.php.expected#L4) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0279_should_check_variadic_mismatch.php#L23).
+
 ## PhanParamSignatureRealMismatchTooManyRequiredParametersInternal
 
 ```
@@ -1053,11 +1191,15 @@ Declaration of {METHOD} should be compatible with internal {METHOD} (the method 
 Argument {INDEX} ({PARAMETER}) is {TYPE} but {FUNCTIONLIKE}() takes {TYPE} when argument {INDEX} is {TYPE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0511_implode.php.expected#L3) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0511_implode.php#L8).
+
 ## PhanParamSpecial2
 
 ```
 Argument {INDEX} ({PARAMETER}) is {TYPE} but {FUNCTIONLIKE}() takes {TYPE} when passed only one argument
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0511_implode.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0511_implode.php#L4).
 
 ## PhanParamSpecial3
 
@@ -1065,17 +1207,23 @@ Argument {INDEX} ({PARAMETER}) is {TYPE} but {FUNCTIONLIKE}() takes {TYPE} when 
 The last argument to {FUNCTIONLIKE} must be of type {TYPE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0101_one_of_each.php.expected#L16) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0101_one_of_each.php#L57).
+
 ## PhanParamSpecial4
 
 ```
 The second to last argument to {FUNCTIONLIKE} must be of type {TYPE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0101_one_of_each.php.expected#L18) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0101_one_of_each.php#L60).
+
 ## PhanParamSuspiciousOrder
 
 ```
 Argument #{INDEX} of this call to {FUNCTIONLIKE} is typically a literal or constant but isn't, but argument #{INDEX} (which is typically a variable) is a literal or constant. The arguments may be in the wrong order.
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0381_wrong_order.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0381_wrong_order.php#L4).
 
 ## PhanParamTooFew
 
@@ -1097,6 +1245,8 @@ f6();
 ```
 Call with {COUNT} arg(s) to {FUNCTIONLIKE}() (as a provided callable) which requires {COUNT} arg(s) defined at {FILE}:{LINE}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/misc/fallback_test/expected/033_closure_crash.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/misc/fallback_test/src/033_closure_crash.php#L2).
 
 ## PhanParamTooFewInternal
 
@@ -1133,6 +1283,8 @@ f7(1, 2);
 Call with {COUNT} arg(s) to {FUNCTIONLIKE}() (As a provided callable) which only takes {COUNT} arg(s) defined at {FILE}:{LINE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0365_array_map_callable.php.expected#L8) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0365_array_map_callable.php#L53).
+
 ## PhanParamTooManyInternal
 
 This issue is emitted when you're passing more than the number of required and optional parameters than are defined for an internal method or function.
@@ -1153,6 +1305,8 @@ strlen('str', 42);
 Argument {INDEX} is {TYPE} but {FUNCTIONLIKE}() takes {TYPE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0364_extended_array_analyze.php.expected#L33) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0364_extended_array_analyze.php#L41).
+
 # RedefineError
 
 This category of issue come up when more than one thing of whatever type have the same name and namespace.
@@ -1168,6 +1322,8 @@ Declaration of {METHOD} must be compatible with {METHOD} in {FILE} on line {LINE
 ```
 {TRAIT} and {TRAIT} define the same property ({PROPERTY}) in the composition of {CLASS}. However, the definition differs and is considered incompatible. Class was composed in {FILE} on line {LINE}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0207_incompatible_composition.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0207_incompatible_composition.php#L10).
 
 ## PhanRedefineClass
 
@@ -1192,6 +1348,8 @@ If possible, exclude one of the files containing the conflicting definitions.
 ```
 {CLASS} aliased at {FILE}:{LINE} was previously defined as {CLASS} at {FILE}:{LINE}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0278_class_alias.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0278_class_alias.php#L36).
 
 ## PhanRedefineClassInternal
 
@@ -1242,17 +1400,23 @@ function strlen() {}
 {CLASS} extends {CLASS} declared at {FILE}:{LINE} which is also declared at {FILE}:{LINE}. This may lead to confusing errors.
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0493_inherit_redefined.php.expected#L5) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0493_inherit_redefined.php#L12).
+
 ## PhanRedefinedInheritedInterface
 
 ```
 {CLASS} inherits {INTERFACE} declared at {FILE}:{LINE} which is also declared at {FILE}:{LINE}. This may lead to confusing errors.
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0493_inherit_redefined.php.expected#L6) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0493_inherit_redefined.php#L12).
+
 ## PhanRedefinedUsedTrait
 
 ```
 {CLASS} uses {TRAIT} declared at {FILE}:{LINE} which is also declared at {FILE}:{LINE}. This may lead to confusing errors.
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0493_inherit_redefined.php.expected#L7) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0493_inherit_redefined.php#L12).
 
 # StaticCallError
 
@@ -1281,11 +1445,15 @@ This category of issue come from using incorrect types or types that cannot cast
 {PARAMETER} is variadic in comment, but not variadic in param ({PARAMETER})
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0258_variadic_comment_parsing.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0258_variadic_comment_parsing.php#L5).
+
 ## PhanMismatchVariadicParam
 
 ```
 {PARAMETER} is not variadic in comment, but variadic in param ({PARAMETER})
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0258_variadic_comment_parsing.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0258_variadic_comment_parsing.php#L6).
 
 ## PhanNonClassMethodCall
 
@@ -1319,6 +1487,8 @@ This issue may be emitted when `strict_param_checking` is true, when analyzing a
 Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE}() takes {TYPE} ({TYPE} is incompatible)
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/expected/025_strict_param_checks.php.expected#L3) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/src/025_strict_param_checks.php#L8).
+
 ## PhanPartialTypeMismatchProperty
 
 This issue (and similar issues) may be emitted when `strict_property_checking` is true
@@ -1326,6 +1496,8 @@ This issue (and similar issues) may be emitted when `strict_property_checking` i
 ```
 Assigning {TYPE} to property but {PROPERTY} is {TYPE} ({TYPE} is incompatible)
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/expected/024_strict_property_assignment.php.expected#L6) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/src/024_strict_property_assignment.php#L21).
 
 ## PhanPartialTypeMismatchReturn
 
@@ -1335,6 +1507,8 @@ This issue (and similar issues) may be emitted when `strict_return_checking` is 
 ```
 Returning type {TYPE} but {FUNCTIONLIKE}() is declared to return {TYPE} ({TYPE} is incompatible)
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/expected/026_strict_return_checks.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/src/026_strict_return_checks.php#L23).
 
 ## PhanPossiblyFalseTypeArgument
 
@@ -1352,11 +1526,15 @@ This issue may be emitted when `strict_param_checking` is true
 Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE}() takes {TYPE} ({TYPE} is incompatible)
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/expected/025_strict_param_checks.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/src/025_strict_param_checks.php#L4).
+
 ## PhanPossiblyFalseTypeMismatchProperty
 
 ```
 Assigning {TYPE} to property but {PROPERTY} is {TYPE} ({TYPE} is incompatible)
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/expected/024_strict_property_assignment.php.expected#L4) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/src/024_strict_property_assignment.php#L19).
 
 ## PhanPossiblyFalseTypeReturn
 
@@ -1365,6 +1543,8 @@ This issue may be emitted when `strict_return_checking` is true
 ```
 Returning type {TYPE} but {FUNCTIONLIKE}() is declared to return {TYPE} ({TYPE} is incompatible)
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/expected/026_strict_return_checks.php.expected#L3) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/src/026_strict_return_checks.php#L31).
 
 ## PhanPossiblyNullTypeArgument
 
@@ -1382,11 +1562,15 @@ This issue may be emitted when `strict_param_checking` is true
 Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE}() takes {TYPE} ({TYPE} is incompatible)
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/expected/025_strict_param_checks.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/src/025_strict_param_checks.php#L6).
+
 ## PhanPossiblyNullTypeMismatchProperty
 
 ```
 Assigning {TYPE} to property but {PROPERTY} is {TYPE} ({TYPE} is incompatible)
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/expected/024_strict_property_assignment.php.expected#L5) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/src/024_strict_property_assignment.php#L20).
 
 ## PhanPossiblyNullTypeReturn
 
@@ -1395,6 +1579,8 @@ This issue may be emitted when `strict_return_checking` is true
 ```
 Returning type {TYPE} but {FUNCTIONLIKE}() is declared to return {TYPE} ({TYPE} is incompatible)
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/expected/026_strict_return_checks.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/src/026_strict_return_checks.php#L16).
 
 ## PhanTypeArrayOperator
 
@@ -1422,11 +1608,15 @@ $a = false; if($a[1]) {}
 Suspicious array access to nullable {TYPE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0287_suspicious_nullable_array.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0287_suspicious_nullable_array.php#L3).
+
 ## PhanTypeArrayUnsetSuspicious
 
 ```
 Suspicious attempt to unset an offset of a value of type {TYPE}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0442_unset_suspicious.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0442_unset_suspicious.php#L4).
 
 ## PhanTypeComparisonFromArray
 
@@ -1462,6 +1652,8 @@ if (42 == [1, 2]) {}
 array to {TYPE} conversion
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0532_empty_array_element.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0532_empty_array_element.php#L2).
+
 ## PhanTypeExpectedObject
 
 ```
@@ -1474,11 +1666,15 @@ Expected an object instance but saw expression with type {TYPE}
 Expected an object instance or the name of a class but saw expression with type {TYPE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0521_misuse_closure_type.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0521_misuse_closure_type.php#L11).
+
 ## PhanTypeExpectedObjectOrClassNameInvalidName
 
 ```
 Expected an object instance or the name of a class but saw an invalid class name '{STRING_LITERAL}'
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0504_prop_assignment_fetch.php.expected#L7) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0504_prop_assignment_fetch.php#L19).
 
 ## PhanTypeExpectedObjectPropAccess
 
@@ -1486,17 +1682,23 @@ Expected an object instance or the name of a class but saw an invalid class name
 Expected an object instance when accessing an instance property, but saw an expression with type {TYPE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0379_bad_prop_access.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0379_bad_prop_access.php#L5).
+
 ## PhanTypeExpectedObjectPropAccessButGotNull
 
 ```
 Expected an object instance when accessing an instance property, but saw an expression with type {TYPE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0379_bad_prop_access.php.expected#L7) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0379_bad_prop_access.php#L28).
+
 ## PhanTypeExpectedObjectStaticPropAccess
 
 ```
 Expected an object instance or a class name when accessing a static property, but saw an expression with type {TYPE}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0379_bad_prop_access.php.expected#L3) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0379_bad_prop_access.php#L9).
 
 ## PhanTypeInstantiateAbstract
 
@@ -1540,11 +1742,15 @@ In a place where phan was expecting a callable, saw an array of size {COUNT}, bu
 Method name of callable must be a string, got {TYPE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0540_invalid_method_name.php.expected#L6) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0540_invalid_method_name.php#L9).
+
 ## PhanTypeInvalidCallableObjectOfMethod
 
 ```
 In a place where phan was expecting a callable, saw a two-element array with a class or expression with an unexpected type {TYPE} (expected a class type or string). Method name was {METHOD}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0521_misuse_closure_type.php.expected#L6) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0521_misuse_closure_type.php#L18).
 
 ## PhanTypeInvalidClosureScope
 
@@ -1552,11 +1758,15 @@ In a place where phan was expecting a callable, saw a two-element array with a c
 Invalid @phan-closure-scope: expected a class name, got {TYPE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0537_closure_scope.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0537_closure_scope.php#L8).
+
 ## PhanTypeInvalidDimOffset
 
 ```
 Invalid offset {SCALAR} of array type {TYPE}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0439_multi.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0439_multi.php#L4).
 
 ## PhanTypeInvalidDimOffsetArrayDestructuring
 
@@ -1564,11 +1774,15 @@ Invalid offset {SCALAR} of array type {TYPE}
 Invalid offset {SCALAR} of array type {TYPE} in an array destructuring assignment
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0402_array_destructuring.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0402_array_destructuring.php#L4).
+
 ## PhanTypeInvalidExpressionArrayDestructuring
 
 ```
 Invalid value of type {TYPE} in an array destructuring assignment, expected {TYPE}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0519_array_destructuring_expression.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0519_array_destructuring_expression.php#L4).
 
 ## PhanTypeInvalidInstanceof
 
@@ -1576,11 +1790,15 @@ Invalid value of type {TYPE} in an array destructuring assignment, expected {TYP
 Found an instanceof class name of type {TYPE}, but class name must be a valid object or a string
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0346_dynamic_instanceof.php.expected#L3) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0346_dynamic_instanceof.php#L24).
+
 ## PhanTypeInvalidLeftOperand
 
 ```
 Invalid operator: right operand is array and left is not
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0114_array_concatenation.php.expected#L3) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0114_array_concatenation.php#L12).
 
 ## PhanTypeInvalidLeftOperandOfAdd
 
@@ -1594,17 +1812,23 @@ Invalid operator: left operand is {TYPE} (expected array or number)
 Invalid operator: left operand is {TYPE} (expected number)
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0148_invalid_array.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0148_invalid_array.php#L15).
+
 ## PhanTypeInvalidMethodName
 
 ```
 Instance method name must be a string, got {TYPE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0540_invalid_method_name.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0540_invalid_method_name.php#L4).
+
 ## PhanTypeInvalidRightOperand
 
 ```
 Invalid operator: left operand is array and right is not
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/misc/fallback_test/expected/004_partial_arithmetic.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/misc/fallback_test/src/004_partial_arithmetic.php#L7).
 
 ## PhanTypeInvalidRightOperandOfAdd
 
@@ -1624,11 +1848,15 @@ Invalid operator: right operand is {TYPE} (expected number)
 Static method name must be a string, got {TYPE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0540_invalid_method_name.php.expected#L3) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0540_invalid_method_name.php#L6).
+
 ## PhanTypeInvalidThrowsIsInterface
 
 ```
 @throws annotation of {FUNCTIONLIKE} has suspicious interface type {TYPE} for an @throws annotation, expected class (PHP allows interfaces to be caught, so this might be intentional)
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0454_throws.php.expected#L10) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0454_throws.php#L57).
 
 ## PhanTypeInvalidThrowsIsTrait
 
@@ -1636,11 +1864,15 @@ Static method name must be a string, got {TYPE}
 @throws annotation of {FUNCTIONLIKE} has invalid trait type {TYPE}, expected a class
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0454_throws.php.expected#L11) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0454_throws.php#L60).
+
 ## PhanTypeInvalidThrowsNonObject
 
 ```
 @throws annotation of {FUNCTIONLIKE} has invalid non-object type {TYPE}, expected a class
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0454_throws.php.expected#L6) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0454_throws.php#L33).
 
 ## PhanTypeInvalidThrowsNonThrowable
 
@@ -1648,11 +1880,15 @@ Static method name must be a string, got {TYPE}
 @throws annotation of {FUNCTIONLIKE} has suspicious class type {TYPE}, which does not extend Error/Exception
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0454_throws.php.expected#L5) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0454_throws.php#L30).
+
 ## PhanTypeInvalidUnaryOperandBitwiseNot
 
 ```
 Invalid operator: unary operand of {STRING_LITERAL} is {TYPE} (expected number or string)
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0507_unary_op_warn.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0507_unary_op_warn.php#L2).
 
 ## PhanTypeInvalidUnaryOperandNumeric
 
@@ -1660,11 +1896,15 @@ Invalid operator: unary operand of {STRING_LITERAL} is {TYPE} (expected number o
 Invalid operator: unary operand of {STRING_LITERAL} is {TYPE} (expected number)
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0507_unary_op_warn.php.expected#L6) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0507_unary_op_warn.php#L8).
+
 ## PhanTypeInvalidYieldFrom
 
 ```
 Yield from statement was passed an invalid expression of type {TYPE} (expected Traversable/array)
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0475_analyze_yield_from.php.expected#L6) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0475_analyze_yield_from.php#L31).
 
 ## PhanTypeMagicVoidWithReturn
 
@@ -1710,11 +1950,15 @@ strlen(42);
 Attempting an array destructing assignment with a key of type {TYPE} but the only key types of the right hand side are of type {TYPE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0402_array_destructuring.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0402_array_destructuring.php#L4).
+
 ## PhanTypeMismatchDeclaredParam
 
 ```
 Doc-block of ${VARIABLE} in {METHOD} contains phpdoc param type {TYPE} which is incompatible with the param type {TYPE} declared in the signature
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0334_reject_bad_narrowing.php.expected#L6) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0334_reject_bad_narrowing.php#L25).
 
 ## PhanTypeMismatchDeclaredParamNullable
 
@@ -1722,11 +1966,15 @@ Doc-block of ${VARIABLE} in {METHOD} contains phpdoc param type {TYPE} which is 
 Doc-block of ${VARIABLE} in {METHOD} is phpdoc param type {TYPE} which is not a permitted replacement of the nullable param type {TYPE} declared in the signature ('?T' should be documented as 'T|null' or '?T')
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0005_compat.php.expected#L3) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0005_compat.php#L21).
+
 ## PhanTypeMismatchDeclaredReturn
 
 ```
 Doc-block of {METHOD} contains declared return type {TYPE} which is incompatible with the return type {TYPE} declared in the signature
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0486_crash_test.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0486_crash_test.php#L7).
 
 ## PhanTypeMismatchDeclaredReturnNullable
 
@@ -1734,11 +1982,15 @@ Doc-block of {METHOD} contains declared return type {TYPE} which is incompatible
 Doc-block of {METHOD} has declared return type {TYPE} which is not a permitted replacement of the nullable return type {TYPE} declared in the signature ('?T' should be documented as 'T|null' or '?T')
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0253_return_type_match.php.expected#L5) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0253_return_type_match.php#L46).
+
 ## PhanTypeMismatchDefault
 
 ```
 Default value for {TYPE} ${VARIABLE} can't be {TYPE}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0099_type_error.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0099_type_error.php#L4).
 
 ## PhanTypeMismatchDimAssignment
 
@@ -1746,11 +1998,15 @@ Default value for {TYPE} ${VARIABLE} can't be {TYPE}
 When appending to a value of type {TYPE}, found an array access index of type {TYPE}, but expected the index to be of type {TYPE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0354_string_index.php.expected#L6) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0354_string_index.php#L16).
+
 ## PhanTypeMismatchDimEmpty
 
 ```
 Assigning to an empty array index of a value of type {TYPE}, but expected the index to exist and be of type {TYPE}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0354_string_index.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0354_string_index.php#L10).
 
 ## PhanTypeMismatchDimFetch
 
@@ -1758,11 +2014,15 @@ Assigning to an empty array index of a value of type {TYPE}, but expected the in
 When fetching an array index from a value of type {TYPE}, found an array index of type {TYPE}, but expected the index to be of type {TYPE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0465_append_changes_shape.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0465_append_changes_shape.php#L5).
+
 ## PhanTypeMismatchDimFetchNullable
 
 ```
 When fetching an array index from a value of type {TYPE}, found an array index of type {TYPE}, but expected the index to be of the non-nullable type {TYPE}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0429_nullable_offsets.php.expected#L6) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0429_nullable_offsets.php#L16).
 
 ## PhanTypeMismatchForeach
 
@@ -1784,11 +2044,15 @@ foreach (null as $i) {}
 Yield statement has a key with type {TYPE} but {FUNCTIONLIKE}() is declared to yield keys of type {TYPE} in {TYPE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0475_analyze_yield_from.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0475_analyze_yield_from.php#L24).
+
 ## PhanTypeMismatchGeneratorYieldValue
 
 ```
 Yield statement has a value with type {TYPE} but {FUNCTIONLIKE}() is declared to yield values of type {TYPE} in {TYPE}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0475_analyze_yield_from.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0475_analyze_yield_from.php#L23).
 
 ## PhanTypeMismatchProperty
 
@@ -1820,11 +2084,15 @@ class G { function f() : int { return 'string'; } }
 When unpacking a value of type {TYPE}, the value's keys were of type {TYPE}, but the keys should be consecutive integers starting from 0
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0401_varargs.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0401_varargs.php#L13).
+
 ## PhanTypeMismatchUnpackValue
 
 ```
 Attempting to unpack a value of type {TYPE} which does not contain any subtypes of iterable (such as array or Traversable)
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0401_varargs.php.expected#L3) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0401_varargs.php#L15).
 
 ## PhanTypeMissingReturn
 
@@ -1856,11 +2124,15 @@ class F { static function f(&$v) {} } F::f('string');
 Must call parent::__construct() from {CLASS} which extends {CLASS}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0283_parent_constructor_called.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0283_parent_constructor_called.php#L6).
+
 ## PhanTypeSuspiciousEcho
 
 ```
 Suspicious argument {TYPE} for an echo/print statement
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0028_if_condition_assignment.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0028_if_condition_assignment.php#L3).
 
 ## PhanTypeSuspiciousIndirectVariable
 
@@ -1868,11 +2140,15 @@ Suspicious argument {TYPE} for an echo/print statement
 Indirect variable ${(expr)} has invalid inner expression type {TYPE}, expected string/integer
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0298_weird_variable_name.php.expected#L3) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0298_weird_variable_name.php#L10).
+
 ## PhanTypeSuspiciousStringExpression
 
 ```
 Suspicious type {TYPE} of a variable or expression encapsulated within a string. (Expected this to be able to cast to a string)
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0232_assignment_to_call.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0232_assignment_to_call.php#L5).
 
 ## PhanTypeVoidAssignment
 
@@ -1901,11 +2177,15 @@ You can ignore all errors of this category by passing in the command-line argume
 Trait alias {METHOD} has an ambiguous source method {METHOD} with more than one possible source trait. Possibilities: {TRAIT}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0297_ambiguous_trait_source.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0297_ambiguous_trait_source.php#L7).
+
 ## PhanClassContainsAbstractMethod
 
 ```
 non-abstract class {CLASS} contains abstract method {METHOD} declared at {FILE}:{LINE}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0493_inherit_redefined.php.expected#L4) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0493_inherit_redefined.php#L12).
 
 ## PhanClassContainsAbstractMethodInternal
 
@@ -1913,17 +2193,23 @@ non-abstract class {CLASS} contains abstract method {METHOD} declared at {FILE}:
 non-abstract class {CLASS} contains abstract internal method {METHOD}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0188_prop_array_access.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0188_prop_array_access.php#L2).
+
 ## PhanEmptyFQSENInCallable
 
 ```
 Possible call to a function '{FUNCTIONLIKE}' with an empty FQSEN.
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0467_name_not_empty.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0467_name_not_empty.php#L2).
+
 ## PhanEmptyFQSENInClasslike
 
 ```
 Possible use of a classlike '{CLASSLIKE}' with an empty FQSEN.
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/misc/fallback_test/expected/053_empty_fqsen.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/misc/fallback_test/src/053_empty_fqsen.php#L3).
 
 ## PhanEmptyFile
 
@@ -1990,17 +2276,23 @@ trait T { function f() { return parent::f(); } }
 Alias {METHOD} was defined for a method {METHOD} which does not exist in trait {TRAIT}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/misc/fallback_test/expected/013_traits12.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/misc/fallback_test/src/013_traits12.php#L3).
+
 ## PhanUndeclaredClass
 
 ```
 Reference to undeclared class {CLASS}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0504_prop_assignment_fetch.php.expected#L5) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0504_prop_assignment_fetch.php#L16).
+
 ## PhanUndeclaredClassAliasOriginal
 
 ```
 Reference to undeclared class {CLASS} for the original class of a class_alias for {CLASS}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0278_class_alias.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0278_class_alias.php#L34).
 
 ## PhanUndeclaredClassCatch
 
@@ -2022,11 +2314,15 @@ try {} catch (Undef $exception) {}
 Reference to constant {CONST} from undeclared class {CLASS}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0049_undefined_constant.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0049_undefined_constant.php#L2).
+
 ## PhanUndeclaredClassInCallable
 
 ```
 Reference to undeclared class {CLASS} in callable {METHOD}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0370_callable_edge_cases.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0370_callable_edge_cases.php#L33).
 
 ## PhanUndeclaredClassInstanceof
 
@@ -2059,6 +2355,8 @@ function g(Undef $v) { $v->f(); }
 Reference to instance property {PROPERTY} from undeclared class {CLASS}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0080_undefined_class.php.expected#L3) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0080_undefined_class.php#L4).
+
 ## PhanUndeclaredClassReference
 
 ```
@@ -2071,11 +2369,15 @@ Reference to undeclared class {CLASS}
 Reference to static property {PROPERTY} from undeclared class {CLASS}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0534_missing_static_property.php.expected#L3) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0534_missing_static_property.php#L8).
+
 ## PhanUndeclaredClosureScope
 
 ```
 Reference to undeclared class {CLASS} in @phan-closure-scope
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0264_closure_override_context.php.expected#L14) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0264_closure_override_context.php#L69).
 
 ## PhanUndeclaredConstant
 
@@ -2124,6 +2426,8 @@ some_missing_function();
 Call to undeclared function {FUNCTION} in callable
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/expected/016_dead_code_callable.php.expected#L5) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/src/016_dead_code_callable.php#L45).
+
 ## PhanUndeclaredInterface
 
 Implementing an interface that doesn't exist or otherwise can't be found will emit this issue.
@@ -2144,11 +2448,15 @@ class C17 implements UndeclaredInterface {}
 Call to undeclared method {METHOD}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0020_changing_types.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0020_changing_types.php#L16).
+
 ## PhanUndeclaredMethodInCallable
 
 ```
 Call to undeclared method {METHOD} in callable. Possible object type(s) for that method are {TYPE}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0521_misuse_closure_type.php.expected#L4) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0521_misuse_closure_type.php#L16).
 
 ## PhanUndeclaredProperty
 
@@ -2181,6 +2489,8 @@ C::staticMethod();
 Reference to undeclared static method {METHOD} in callable
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0370_callable_edge_cases.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0370_callable_edge_cases.php#L5).
+
 ## PhanUndeclaredStaticProperty
 
 Attempting to read a property that doesn't exist will result in this issue. You'll also see this issue if you write to an undeclared static property so long as `allow_missing_property` is false (which defaults to true).
@@ -2204,6 +2514,7 @@ If you attempt to use a trait that doesn't exist, you'll see this issue.
 Class uses undeclared trait {TRAIT}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0048_parent_class_exists.php.expected#L3) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0048_parent_class_exists.php#L9).
 
 ## PhanUndeclaredTypeParameter
 
@@ -2239,11 +2550,15 @@ class D { /** @var Undef */ public $p; }
 Return type of {METHOD} is undeclared type {TYPE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0226_internal_tostring_parameter_undeclared.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0226_internal_tostring_parameter_undeclared.php#L7).
+
 ## PhanUndeclaredTypeThrowsType
 
 ```
 @throws type of {METHOD} has undeclared type {TYPE}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0490_throws_suppress.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0490_throws_suppress.php#L11).
 
 ## PhanUndeclaredVariable
 
@@ -2253,17 +2568,23 @@ Trying to use a variable that hasn't been defined anywhere in scope will produce
 Variable ${VARIABLE} is undeclared
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/misc/fallback_test/expected/044_keys_in_lists.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/misc/fallback_test/src/044_keys_in_lists.php#L2).
+
 ## PhanUndeclaredVariableAssignOp
 
 ```
 Variable ${VARIABLE} was undeclared, but it is being used as the left hand side of an assignment operation
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0300_misc_types.php.expected#L11) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0300_misc_types.php#L21).
+
 ## PhanUndeclaredVariableDim
 
 ```
 Variable ${VARIABLE} was undeclared, but array fields are being added to it.
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0135_array_assignment_type.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0135_array_assignment_type.php#L5).
 
 # VarError
 
@@ -2282,6 +2603,8 @@ This category contains issues related to [Phan's generic type support](https://g
 ```
 Missing template parameters {PARAMETER} on constructor for generic class {CLASS}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0203_generic_errors.php.expected#L7) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0203_generic_errors.php#L27).
 
 ## PhanGenericGlobalVariable
 
@@ -2305,6 +2628,8 @@ This is emitted when a static method's PHPDoc contains a param/return type decla
 static method {METHOD} may not use template types
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0203_generic_errors.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0203_generic_errors.php#L16).
+
 ## PhanTemplateTypeStaticProperty
 
 This is emitted when a static property's PHPDoc contains an `@var` type declared in the class's phpdoc template annotations.
@@ -2313,7 +2638,7 @@ This is emitted when a static property's PHPDoc contains an `@var` type declared
 static property {PROPERTY} may not have a template type
 ```
 
-
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0203_generic_errors.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0203_generic_errors.php#L11).
 
 # Internal
 
@@ -2329,6 +2654,8 @@ This issue comes up when there is an attempt to access an `@internal` class cons
 Cannot access internal class constant {CONST} defined at {FILE}:{LINE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0278_internal_elements.php.expected#L20) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0278_internal_elements.php#L99).
+
 ## PhanAccessClassInternal
 
 This issue comes up when there is an attempt to access an `@internal` class constant outside of the namespace in which it's defined.
@@ -2336,6 +2663,8 @@ This issue comes up when there is an attempt to access an `@internal` class cons
 ```
 Cannot access internal {CLASS} defined at {FILE}:{LINE}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0278_internal_elements.php.expected#L24) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0278_internal_elements.php#L108).
 
 ## PhanAccessConstantInternal
 
@@ -2345,6 +2674,8 @@ This issue comes up when there is an attempt to access an `@internal` global con
 Cannot access internal constant {CONST} of namespace {NAMESPACE} defined at {FILE}:{LINE} from namespace {NAMESPACE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0278_internal_elements.php.expected#L16) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0278_internal_elements.php#L94).
+
 ## PhanAccessMethodInternal
 
 This issue comes up when there is an attempt to access an `@internal` method outside of the namespace in which it's defined.
@@ -2353,6 +2684,8 @@ This issue comes up when there is an attempt to access an `@internal` method out
 Cannot access internal method {METHOD} of namespace {NAMESPACE} defined at {FILE}:{LINE} from namespace {NAMESPACE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0278_internal_elements.php.expected#L14) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0278_internal_elements.php#L92).
+
 ## PhanAccessPropertyInternal
 
 This issue comes up when there is an attempt to access an `@internal` property outside of the namespace in which it's defined.
@@ -2360,6 +2693,8 @@ This issue comes up when there is an attempt to access an `@internal` property o
 ```
 Cannot access internal property {PROPERTY} of namespace {NAMESPACE} defined at {FILE}:{LINE} from namespace {NAMESPACE}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0278_internal_elements.php.expected#L18) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0278_internal_elements.php#L97).
 
 # CommentError
 
@@ -2371,11 +2706,15 @@ This is emitted for some (but not all) comments which Phan thinks are invalid or
 Comment {STRING_LITERAL} refers to {TYPE} instead of \Closure - Assuming \Closure
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0524_closure_ambiguous.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0524_closure_ambiguous.php#L18).
+
 ## PhanCommentDuplicateMagicMethod
 
 ```
 Comment declares @method {METHOD} multiple times
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0281_magic_method_support.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0281_magic_method_support.php#L19).
 
 ## PhanCommentDuplicateMagicProperty
 
@@ -2395,11 +2734,15 @@ Comment declares @param ${PARAMETER} multiple times
 Saw an @override annotation for class constant {CONST}, but could not find an overridden constant
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0332_override_complex.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0332_override_complex.php#L10).
+
 ## PhanCommentOverrideOnNonOverrideMethod
 
 ```
 Saw an @override annotation for method {METHOD}, but could not find an overridden method and it is not a magic method
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0355_namespace_relative.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0355_namespace_relative.php#L34).
 
 ## PhanCommentParamOnEmptyParamList
 
@@ -2413,11 +2756,15 @@ Saw an @param annotation for {VARIABLE}, but the param list of {FUNCTIONLIKE} is
 Expected @param annotation for {VARIABLE} to be before the @param annotation for {VARIABLE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0520_spaces_in_union_type.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0520_spaces_in_union_type.php#L5).
+
 ## PhanCommentParamWithoutRealParam
 
 ```
 Saw an @param annotation for {VARIABLE}, but it was not found in the param list of {FUNCTIONLIKE}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0373_reject_bad_type_narrowing.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0373_reject_bad_type_narrowing.php#L4).
 
 ## PhanInvalidCommentForDeclarationType
 
@@ -2425,11 +2772,15 @@ Saw an @param annotation for {VARIABLE}, but it was not found in the param list 
 The phpdoc comment for {COMMENT} cannot occur on a {TYPE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0432_phan_comment.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0432_phan_comment.php#L5).
+
 ## PhanMisspelledAnnotation
 
 ```
 Saw misspelled annotation {COMMENT}, should be one of {COMMENT}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0301_comment_checks.php.expected#L4) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0301_comment_checks.php#L7).
 
 ## PhanThrowTypeAbsent
 
@@ -2437,11 +2788,15 @@ Saw misspelled annotation {COMMENT}, should be one of {COMMENT}
 {METHOD}() can throw {TYPE} here, but has no '@throws' declarations for that class
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/expected/040_if_assign.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/src/040_if_assign.php#L4).
+
 ## PhanThrowTypeAbsentForCall
 
 ```
 {METHOD}() can throw {TYPE} because it calls {FUNCTIONLIKE}(), but has no '@throws' declarations for that class
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/expected/043_throws.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/src/043_throws.php#L22).
 
 ## PhanThrowTypeMismatch
 
@@ -2461,11 +2816,15 @@ Saw misspelled annotation {COMMENT}, should be one of {COMMENT}
 Saw unextractable annotation for comment '{COMMENT}'
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0285_nullable_generic_array.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0285_nullable_generic_array.php#L28).
+
 ## PhanUnextractableAnnotationElementName
 
 ```
 Saw possibly unextractable annotation for a fragment of comment '{COMMENT}': after {TYPE}, did not see an element name (will guess based on comment order)
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0284_non_empty_array_default.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0284_non_empty_array_default.php#L2).
 
 ## PhanUnextractableAnnotationPart
 
@@ -2473,11 +2832,15 @@ Saw possibly unextractable annotation for a fragment of comment '{COMMENT}': aft
 Saw unextractable annotation for a fragment of comment '{COMMENT}': '{COMMENT}'
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0301_comment_checks.php.expected#L5) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0301_comment_checks.php#L12).
+
 ## PhanUnextractableAnnotationSuffix
 
 ```
 Saw a token Phan may have failed to parse after '{COMMENT}': after {TYPE}, saw '{COMMENT}'
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0468_unparseable_param.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0468_unparseable_param.php#L4).
 
 # Syntax
 
@@ -2489,11 +2852,15 @@ Emitted for syntax errors.
 Constant expression contains invalid operations
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/misc/fallback_test/expected/015_class_const_declaration9.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/misc/fallback_test/src/015_class_const_declaration9.php#L3).
+
 ## PhanInvalidNode
 
 ```
 %s
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/misc/fallback_test/expected/026_invalid_assign.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/misc/fallback_test/src/026_invalid_assign.php#L2).
 
 ## PhanInvalidTraitUse
 
@@ -2501,13 +2868,19 @@ Constant expression contains invalid operations
 Invalid trait use: {DETAILS}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/misc/fallback_test/expected/056_trait_use.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/misc/fallback_test/src/056_trait_use.php#L11).
+
 ## PhanInvalidWriteToTemporaryExpression
 
 ```
 Cannot use temporary expression (of type {TYPE}) in write context
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0518_crash_assignment.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0518_crash_assignment.php#L4).
+
 ## PhanSyntaxError
 
 This emits warnings for unparsable PHP files (detected by `php-ast`).
 Note: This is not the same thing as running `php -l` on a file - PhanSyntaxError checks for syntax errors, but not semantics such as where certain expressions can occur (Which `php -l` would check for).
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/expected/028_parse_failure.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/src/028_parse_failure.php#L2).

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -2101,7 +2101,7 @@ Class extends undeclared class {CLASS}
 This issue will be emitted from the following code
 
 ```php
-class E extends Undef {}
+class E extends UndeclaredClass {}
 ```
 
 ## PhanUndeclaredFunction
@@ -2115,7 +2115,7 @@ Call to undeclared function {FUNCTION}
 This issue will be emitted for the code
 
 ```php
-f10();
+some_missing_function();
 ```
 
 ## PhanUndeclaredFunctionInCallable
@@ -2135,7 +2135,7 @@ Class implements undeclared interface {INTERFACE}
 The following code will express this issue.
 
 ```php
-class C17 implements C18 {}
+class C17 implements UndeclaredInterface {}
 ```
 
 ## PhanUndeclaredMethod
@@ -2204,11 +2204,6 @@ If you attempt to use a trait that doesn't exist, you'll see this issue.
 Class uses undeclared trait {TRAIT}
 ```
 
-An example would be
-
-```php
-class C20 { use T2; }
-```
 
 ## PhanUndeclaredTypeParameter
 
@@ -2256,12 +2251,6 @@ Trying to use a variable that hasn't been defined anywhere in scope will produce
 
 ```
 Variable ${VARIABLE} is undeclared
-```
-
-An example would be
-
-```php
-$v9 = $v10;
 ```
 
 ## PhanUndeclaredVariableAssignOp

--- a/internal/update_wiki_issue_types.php
+++ b/internal/update_wiki_issue_types.php
@@ -48,12 +48,17 @@ class WikiWriter
  */
 class WikiIssueTypeUpdater
 {
+    /**
+     * @var bool whether to print debugging messages to stderr
+     */
+    private static $verbose = false;
+
     private static function printUsageAndExit(int $exit_code = 1)
     {
         global $argv;
         $program = $argv[0];
         $help = <<<EOT
-Usage: $program
+Usage: $program [-v/--verbose]
 
 EOT;
         fwrite(STDERR, $help);
@@ -112,7 +117,11 @@ EOT;
     {
         global $argv;
         if (count($argv) !== 1) {
-            self::printUsageAndExit();
+            if (count($argv) === 2 && in_array($argv[1], ['-v', '--verbose'])) {
+                self::$verbose = true;
+            } else {
+                self::printUsageAndExit();
+            }
         }
         error_reporting(E_ALL);
 
@@ -129,34 +138,60 @@ EOT;
         foreach ($map as $issue) {
             // Print each new category as we see it.
             if ($category !== $issue->getCategory()) {
+                self::documentIssueCategorySection($writer, $issue, $old_text_for_section);
                 $category = $issue->getCategory();
-                if (!$category) {
-                    throw new InvalidArgumentException("Failed to find category for {$issue->getType()}");
-                }
-                $category_name = Issue::getNameForCategory($category);
-                if (!$category_name) {
-                    throw new InvalidArgumentException("Failed to find category name for category $category of {$issue->getType()}");
-                }
-
-                $header = '# ' . $category_name;
-                $writer->append($header . "\n");
-                if (array_key_exists($header, $old_text_for_section)) {
-                    $writer->append($old_text_for_section[$header]);
-                } else {
-                    $writer->append("\nTODO: Document issue category $category_name\n\n");
-                }
             }
-            // TODO: Print each severity as we see it?
-            $header = '## ' . $issue->getType();
-            // TODO: echo '## \[', $issue->getSeverityName(), '\] ', $issue->getType(), "\n";
-            if (array_key_exists($header, $old_text_for_section)) {
-                $writer->append($header . "\n");
+            self::documentIssue($writer, $issue, $old_text_for_section);
+        }
 
-                // Fill this in with the prior contents of the header
-                $writer->append(self::updateTextForSection($old_text_for_section[$header], $header));
-            } else {
-                $message = $issue->getTemplateRaw();
-                $placeholder = <<<EOT
+        // Get the new file contents, and normalize the whitespace at the end of the file.
+        $contents = rtrim($writer->getContents()) . "\n";
+
+        $wiki_filename_new = $wiki_filename . '.new';
+        self::debugLog(str_repeat('-', 80) . "\nSaving to '$wiki_filename_new'\n");
+        file_put_contents($wiki_filename_new, $contents);
+    }
+
+    /**
+     * Start documenting a brand new category of issues where the first issue in that category is $issue
+     * @param WikiWriter $writer
+     * @param Issue $issue
+     * @param array<string,string> $old_text_for_section
+     * @throws InvalidArgumentException
+     */
+    private static function documentIssueCategorySection(WikiWriter $writer, Issue $issue, array $old_text_for_section)
+    {
+        $category = $issue->getCategory();
+        if (!$category) {
+            throw new InvalidArgumentException("Failed to find category for {$issue->getType()}");
+        }
+        $category_name = Issue::getNameForCategory($category);
+        if (!$category_name) {
+            throw new InvalidArgumentException("Failed to find category name for category $category of {$issue->getType()}");
+        }
+
+        $header = '# ' . $category_name;
+        $writer->append($header . "\n");
+        if (array_key_exists($header, $old_text_for_section)) {
+            $writer->append($old_text_for_section[$header]);
+        } else {
+            $writer->append("\nTODO: Document issue category $category_name\n\n");
+        }
+    }
+
+    private static function documentIssue(WikiWriter $writer, Issue $issue, array $old_text_for_section)
+    {
+        // TODO: Print each severity as we see it?
+        $header = '## ' . $issue->getType();
+        // TODO: echo '## \[', $issue->getSeverityName(), '\] ', $issue->getType(), "\n";
+        if (array_key_exists($header, $old_text_for_section)) {
+            $writer->append($header . "\n");
+
+            // Fill this in with the prior contents of the header
+            $writer->append(self::updateTextForSection($old_text_for_section[$header], $header));
+        } else {
+            $message = $issue->getTemplateRaw();
+            $placeholder = <<<EOT
 
 ```
 $message
@@ -164,21 +199,22 @@ $message
 
 
 EOT;
-                // TODO: Fill this in with automatically generated contents
-                // TODO: uncomment
-                $writer->append($header . "\n");
-                $writer->append($placeholder);
-            }
+            $writer->append($header . "\n");
+            $writer->append($placeholder);
         }
-
-        // Get the new file contents, and normalize the whitespace at the end of the file.
-        $contents = rtrim($writer->getContents()) . "\n";
-
-        $wiki_filename_new = $wiki_filename . '.new';
-        fwrite(STDERR, str_repeat('-', 80) . "\nSaving to '$wiki_filename_new'\n");
-        file_put_contents($wiki_filename_new, $contents);
     }
 
+    private static function debugLog(string $message)
+    {
+        // Uncomment the below line to enable debugging
+        if (self::$verbose) {
+            fwrite(STDERR, $message);
+        }
+    }
+
+    /**
+     * Returns the section with an updated issue template string (if there already was an issue template)
+     */
     private static function updateTextForSection(string $text, string $header) : string
     {
         $issue_map = Issue::issueMap();
@@ -186,13 +222,126 @@ EOT;
         $issue = $issue_map[$issue_name] ?? null;
 
         if ($issue instanceof Issue) {
-            fwrite(STDERR, "Found $issue_name\n");
+            self::debugLog("Found $issue_name\n");
             /** @param array<int,string> $unused_match */
             $text = preg_replace_callback('@\n```\n[^\n]*\n```@', function ($unused_match) use ($issue) : string {
                 return "\n```\n{$issue->getTemplateRaw()}\n```";
             }, $text);
+            if (!preg_match('@```php|https?://@i', $text)) {
+                $example = self::findExamples()[$issue->getType()] ?? null;
+                if ($example) {
+                    $text = rtrim($text, "\n") . "\n\n" . self::textForExample($example);
+                }
+            }
         }
         return $text;
+    }
+
+    /**
+     * @param array{0:UnitTestRecord,1:int,2:int} $example
+     */
+    private static function textForExample(array $example) : string
+    {
+        list($record, $src_file_lineno, $expected_file_lineno) = $example;
+        $src_url = preg_replace('@.*/tests/@', 'https://github.com/phan/phan/tree/1.0.7/tests/', $record->src_filename);
+        $expected_url = preg_replace('@.*/tests/@', 'https://github.com/phan/phan/tree/1.0.7/tests/', $record->expected_filename);
+
+        return <<<EOT
+e.g. [this issue]($expected_url#L$expected_file_lineno) is emitted when analyzing [this PHP file]($src_url#L$src_file_lineno).
+
+
+EOT;
+    }
+
+    /** @var array|null */
+    private static $examples;
+
+    private static function findExamples() : array
+    {
+        return self::$examples ?? self::$examples = self::calculateExamples();
+    }
+
+    private static function calculateExamples() : array
+    {
+        $base = dirname(realpath(__DIR__));
+        $files = array_merge(
+            glob($base . '/tests/files/expected/*.php.expected'),
+            glob($base . '/tests/misc/fallback_test/expected/*.php.expected'),
+            glob($base . '/tests/plugin_test/expected/*.php.expected')
+        );
+        $records = [];
+        foreach ($files as $expected_filename) {
+            $src_filename = preg_replace('@/expected/(.*\.php)\.expected$@', '/src/\1', $expected_filename);
+            try {
+                $records[] = new UnitTestRecord($src_filename, $expected_filename);
+            } catch (RuntimeException $e) {
+                fwrite(STDERR, $e->getMessage());
+            }
+        }
+        // Put the longest files first, we overwrite issue names even if they were seen already
+        usort($records, function (UnitTestRecord $a, UnitTestRecord $b) : int {
+            return (strlen($b->src_contents) <=> strlen($a->src_contents)) ?: strcmp($a->src_filename, $b->src_filename);
+        });
+
+        $examples = [];
+        foreach ($records as $record) {
+            // Process these backwards so we use the first issue occurrence in a file as the finally chosen example.
+            $issues = $record->getIssues();
+            krsort($issues);
+            foreach ($issues as $expected_file_lineno => list($ref, $issue_name, $unused_description)) {
+                if (preg_match('/[0-9]+$/', $ref, $matches)) {
+                    $src_file_lineno = (int)$matches[0];
+                    $examples[$issue_name] = [$record, $src_file_lineno, $expected_file_lineno];
+                }
+            }
+        }
+        return $examples;
+    }
+}
+
+/**
+ * This represents a record of a unit test with a single source file and a single expectation file.
+ */
+class UnitTestRecord
+{
+    /** @var string the file name of the source of the unit test */
+    public $src_filename;
+    /** @var string the file name of the expected errors of the unit test */
+    public $expected_filename;
+    /** @var string the contents of the source of the unit test */
+    public $src_contents;
+    /** @var string the expected text errors of that unit test */
+    public $expected_contents;
+
+    public function __construct(string $src_filename, string $expected_filename)
+    {
+        $this->src_filename = $src_filename;
+        $this->expected_filename = $expected_filename;
+        $this->src_contents = self::getContents($src_filename);
+        $this->expected_contents = self::getContents($expected_filename);
+    }
+
+    public function getIssues() : array
+    {
+        $issues = [];
+        foreach (explode("\n", $this->expected_contents) as $i => $line) {
+            $line = trim($line);
+            if ($line === '') {
+                continue;
+            }
+            $lineno = $i + 1;
+            $issues[$lineno] = explode(' ', $line, 3);
+        }
+        return $issues;
+    }
+
+    private static function getContents(string $filename) : string
+    {
+        $contents = file_get_contents($filename);
+        if (!is_string($contents)) {
+            throw new RuntimeException("Failed to read $filename");
+        }
+        return $contents;
     }
 }
 WikiIssueTypeUpdater::main();


### PR DESCRIPTION
Many of these are automatically generated.

If there's nothing resembling an example (A link or a php code snippet), then this will insert a sentence linking to the test file causing an instance of that issue and the full issue message.

That sentence has the below format:

> e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0252_class_const_visibility.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0252_class_const_visibility.php#L17).