### PR TITLE
 Support the upcoming php-ast 1.0.0 release

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,15 @@
 Phan NEWS
 
-?? ??? 2018, Phan 1.0.8 (dev)
+?? ??? 2018, Phan 1.1.0 (dev)
 -----------------------
+
+Maintenance:
++ Work on making this compatible with `php-ast` 1.0.0dev. (#2038)
+  (Phan continues to support php-ast 0.1.5 and newer)
+
+  Remove dead code (such as helper functions and references to constants) that aren't needed when using AST version 50 (which Phan uses).
+
+  Some plugins may be affected if they call these helper methods or use those constants when the shim is used.
 
 Bug fixes:
 + Fix a crash parsing an empty `shell\_exec` shorthand string when using the fallback parser

--- a/composer.lock
+++ b/composer.lock
@@ -497,16 +497,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v3.4.15",
+            "version": "v3.4.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "6b217594552b9323bcdcfc14f8a0ce126e84cd73"
+                "reference": "3b2b415d4c48fbefca7dc742aa0a0171bfae4e0b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/6b217594552b9323bcdcfc14f8a0ce126e84cd73",
-                "reference": "6b217594552b9323bcdcfc14f8a0ce126e84cd73",
+                "url": "https://api.github.com/repos/symfony/console/zipball/3b2b415d4c48fbefca7dc742aa0a0171bfae4e0b",
+                "reference": "3b2b415d4c48fbefca7dc742aa0a0171bfae4e0b",
                 "shasum": ""
             },
             "require": {
@@ -562,20 +562,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2018-07-26T11:19:56+00:00"
+            "time": "2018-10-02T16:33:53+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v3.4.15",
+            "version": "v3.4.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "c4625e75341e4fb309ce0c049cbf7fb84b8897cd"
+                "reference": "0a612e9dfbd2ccce03eb174365f31ecdca930ff6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/c4625e75341e4fb309ce0c049cbf7fb84b8897cd",
-                "reference": "c4625e75341e4fb309ce0c049cbf7fb84b8897cd",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/0a612e9dfbd2ccce03eb174365f31ecdca930ff6",
+                "reference": "0a612e9dfbd2ccce03eb174365f31ecdca930ff6",
                 "shasum": ""
             },
             "require": {
@@ -618,7 +618,7 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2018-08-03T10:42:44+00:00"
+            "time": "2018-10-02T16:33:53+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -79,6 +79,7 @@ class TolerantASTConverter
     const AST_VERSION = 50;
 
     // The versions that this supports
+    // TODO: Also enable support for version 60 once there is a stable 1.0.0 release. (Issue #2038)
     const SUPPORTED_AST_VERSIONS = [self::AST_VERSION];
 
     const _IGNORED_STRING_TOKEN_KIND_SET = [

--- a/src/Phan/AST/TolerantASTConverter/ast_shim.php
+++ b/src/Phan/AST/TolerantASTConverter/ast_shim.php
@@ -55,12 +55,9 @@ const AST_TYPE = 1;
 const AST_VAR = 256;
 const AST_CONST = 257;
 const AST_UNPACK = 258;
-const AST_UNARY_PLUS = 259;
-const AST_UNARY_MINUS = 260;
 const AST_CAST = 261;
 const AST_EMPTY = 262;
 const AST_ISSET = 263;
-const AST_SILENCE = 264;
 const AST_SHELL_EXEC = 265;
 const AST_CLONE = 266;
 const AST_EXIT = 267;
@@ -92,15 +89,10 @@ const AST_ASSIGN = 517;
 const AST_ASSIGN_REF = 518;
 const AST_ASSIGN_OP = 519;
 const AST_BINARY_OP = 520;
-const AST_GREATER = 521;
-const AST_GREATER_EQUAL = 522;
-const AST_AND = 523;
-const AST_OR = 524;
 const AST_ARRAY_ELEM = 525;
 const AST_NEW = 526;
 const AST_INSTANCEOF = 527;
 const AST_YIELD = 528;
-const AST_COALESCE = 529;
 const AST_STATIC = 530;
 const AST_WHILE = 531;
 const AST_DO_WHILE = 532;
@@ -141,6 +133,9 @@ const MODIFIER_ABSTRACT = 2;
 const MODIFIER_FINAL = 4;
 const RETURNS_REF = 67108864;
 const FUNC_RETURNS_REF = 67108864;
+const FUNC_GENERATOR = 4194304;  // NOTE: Not set in all PHP versions.
+const ARRAY_ELEM_REF = 1;
+const CLOSURE_USE_REF = 1;
 const CLASS_ABSTRACT = 32;
 const CLASS_FINAL = 4;
 const CLASS_TRAIT = 128;
@@ -188,18 +183,6 @@ const BINARY_IS_GREATER = 256;
 const BINARY_IS_GREATER_OR_EQUAL = 257;
 const BINARY_SPACESHIP = 170;
 const BINARY_COALESCE = 260;
-const ASSIGN_BITWISE_OR = 31;
-const ASSIGN_BITWISE_AND = 32;
-const ASSIGN_BITWISE_XOR = 33;
-const ASSIGN_CONCAT = 30;
-const ASSIGN_ADD = 23;
-const ASSIGN_SUB = 24;
-const ASSIGN_MUL = 25;
-const ASSIGN_DIV = 26;
-const ASSIGN_MOD = 27;
-const ASSIGN_POW = 167;
-const ASSIGN_SHIFT_LEFT = 28;
-const ASSIGN_SHIFT_RIGHT = 29;
 const EXEC_EVAL = 1;
 const EXEC_INCLUDE = 2;
 const EXEC_INCLUDE_ONCE = 4;
@@ -223,10 +206,13 @@ const ARRAY_SYNTAX_SHORT = 3;
 
 namespace ast;
 
+// The parse_file(), parse_code(), get_kind_name(), and kind_uses_flags() are deliberately omitted from this stub.
+// Use Phan\Debug and Phan\AST\Parser instead.
+
 if (!class_exists('\ast\Node')) {
     /**
      * This class describes a single node in a PHP AST.
-     * @suppress PhanRedefineClassInternal TODO: why isn't this warning?
+     * @suppress PhanRedefineClassInternal
      */
     class Node
     {
@@ -257,5 +243,39 @@ if (!class_exists('\ast\Node')) {
             $this->children = $children;
             $this->lineno = $lineno;
         }
+    }
+
+    /**
+     * Metadata entry for a single AST kind, as returned by ast\get_metadata().
+     * @suppress PhanRedefineClassInternal
+     * @suppress PhanUnreferencedClass
+     */
+    class Metadata
+    {
+        /**
+         * @var int AST node kind (one of the ast\AST_* constants).
+         * @suppress PhanUnreferencedPublicProperty
+         */
+        public $kind;
+
+        /**
+         * @var string Name of the node kind (e.g. "AST_NAME").
+         * @suppress PhanUnreferencedPublicProperty
+         */
+        public $name;
+
+        /**
+         * @var array<int,string> Array of supported flags. The flags are given as names of constants, such as
+         *                        "ast\flags\TYPE_STRING".
+         * @suppress PhanUnreferencedPublicProperty
+         */
+        public $flags;
+
+        /**
+         * @var bool Whether the flags are exclusive or combinable. Exclusive flags should be checked
+         *           using ===, while combinable flags should be checked using &.
+         * @suppress PhanUnreferencedPublicProperty
+         */
+        public $flagsCombinable;
     }
 }

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1001,38 +1001,6 @@ class UnionTypeVisitor extends AnalysisVisitor
     }
 
     /**
-     * Visit a node with kind `\ast\AST_GREATER`
-     *
-     * @param Node $node
-     * A node of the type indicated by the method name that we'd
-     * like to figure out the type that it produces.
-     *
-     * @return UnionType
-     * The set of types that are possibly produced by the
-     * given node
-     */
-    public function visitGreater(Node $node) : UnionType
-    {
-        return $this->visitBinaryOp($node);
-    }
-
-    /**
-     * Visit a node with kind `\ast\AST_GREATER_EQUAL`
-     *
-     * @param Node $node
-     * A node of the type indicated by the method name that we'd
-     * like to figure out the type that it produces.
-     *
-     * @return UnionType
-     * The set of types that are possibly produced by the
-     * given node
-     */
-    public function visitGreaterEqual(Node $node) : UnionType
-    {
-        return $this->visitBinaryOp($node);
-    }
-
-    /**
      * Visit a node with kind `\ast\AST_CAST`
      *
      * @param Node $node

--- a/src/Phan/AST/Visitor/Element.php
+++ b/src/Phan/AST/Visitor/Element.php
@@ -55,7 +55,6 @@ class Element
         ast\AST_CLOSURE            => 'visitClosure',
         ast\AST_CLOSURE_USES       => 'visitClosureUses',
         ast\AST_CLOSURE_VAR        => 'visitClosureVar',
-        ast\AST_COALESCE           => 'visitCoalesce',
         ast\AST_CONST              => 'visitConst',
         ast\AST_CONST_DECL         => 'visitConstDecl',
         ast\AST_CONST_ELEM         => 'visitConstElem',
@@ -71,8 +70,6 @@ class Element
         ast\AST_FUNC_DECL          => 'visitFuncDecl',
         ast\AST_ISSET              => 'visitIsset',
         ast\AST_GLOBAL             => 'visitGlobal',
-        ast\AST_GREATER            => 'visitGreater',
-        ast\AST_GREATER_EQUAL      => 'visitGreaterEqual',
         ast\AST_GROUP_USE          => 'visitGroupUse',
         ast\AST_IF                 => 'visitIf',
         ast\AST_IF_ELEM            => 'visitIfElem',
@@ -100,14 +97,12 @@ class Element
         ast\AST_SWITCH_LIST        => 'visitSwitchList',
         ast\AST_TYPE               => 'visitType',
         ast\AST_NULLABLE_TYPE      => 'visitNullableType',
-        ast\AST_UNARY_MINUS        => 'visitUnaryMinus',
         ast\AST_UNARY_OP           => 'visitUnaryOp',
         ast\AST_USE                => 'visitUse',
         ast\AST_USE_ELEM           => 'visitUseElem',
         ast\AST_USE_TRAIT          => 'visitUseTrait',
         ast\AST_VAR                => 'visitVar',
         ast\AST_WHILE              => 'visitWhile',
-        ast\AST_AND                => 'visitAnd',
         ast\AST_CATCH_LIST         => 'visitCatchList',
         ast\AST_CLONE              => 'visitClone',
         ast\AST_CONDITIONAL        => 'visitConditional',
@@ -119,19 +114,16 @@ class Element
         ast\AST_LABEL              => 'visitLabel',
         ast\AST_METHOD_REFERENCE   => 'visitMethodReference',
         ast\AST_NAME_LIST          => 'visitNameList',
-        ast\AST_OR                 => 'visitOr',
         ast\AST_POST_DEC           => 'visitPostDec',
         ast\AST_POST_INC           => 'visitPostInc',
         ast\AST_PRE_DEC            => 'visitPreDec',
         ast\AST_REF                => 'visitRef',
         ast\AST_SHELL_EXEC         => 'visitShellExec',
-        ast\AST_SILENCE            => 'visitSilence',
         ast\AST_THROW              => 'visitThrow',
         ast\AST_TRAIT_ADAPTATIONS  => 'visitTraitAdaptations',
         ast\AST_TRAIT_ALIAS        => 'visitTraitAlias',
         ast\AST_TRAIT_PRECEDENCE   => 'visitTraitPrecedence',
         ast\AST_TRY                => 'visitTry',
-        ast\AST_UNARY_PLUS         => 'visitUnaryPlus',
         ast\AST_UNPACK             => 'visitUnpack',
         ast\AST_UNSET              => 'visitUnset',
         ast\AST_YIELD              => 'visitYield',
@@ -294,10 +286,6 @@ class Element
                 return $visitor->visitUnaryBitwiseNot($this->node);
             case flags\UNARY_BOOL_NOT:
                 return $visitor->visitUnaryBoolNot($this->node);
-            case flags\UNARY_MINUS:
-                return $visitor->visitUnaryMinus($this->node);
-            case flags\UNARY_PLUS:
-                return $visitor->visitUnaryPlus($this->node);
             case flags\UNARY_SILENCE:
                 return $visitor->visitUnarySilence($this->node);
             default:

--- a/src/Phan/AST/Visitor/FlagVisitorImplementation.php
+++ b/src/Phan/AST/Visitor/FlagVisitorImplementation.php
@@ -338,16 +338,25 @@ abstract class FlagVisitorImplementation implements FlagVisitor
         return $this->visit($node);
     }
 
+    /**
+     * Visit a node with kind `ast\AST_UNARY_OP` and flags `ast\flags\UNARY_MINUS`
+     */
     public function visitUnaryMinus(Node $node)
     {
         return $this->visit($node);
     }
 
+    /**
+     * Visit a node with kind `ast\AST_UNARY_OP` and flags `ast\flags\UNARY_PLUS`
+     */
     public function visitUnaryPlus(Node $node)
     {
         return $this->visit($node);
     }
 
+    /**
+     * Visit a node with kind `ast\AST_UNARY_OP` and flags `ast\flags\UNARY_SILENCE`
+     */
     public function visitUnarySilence(Node $node)
     {
         return $this->visit($node);

--- a/src/Phan/AST/Visitor/KindVisitor.php
+++ b/src/Phan/AST/Visitor/KindVisitor.php
@@ -96,11 +96,6 @@ interface KindVisitor
     public function visitClosureVar(Node $node);
 
     /**
-     * Visit a node with kind `\ast\AST_COALESCE`
-     */
-    public function visitCoalesce(Node $node);
-
-    /**
      * Visit a node with kind `\ast\AST_CONST`
      */
     public function visitConst(Node $node);
@@ -174,16 +169,6 @@ interface KindVisitor
      * Visit a node with kind `\ast\AST_GLOBAL`
      */
     public function visitGlobal(Node $node);
-
-    /**
-     * Visit a node with kind `\ast\AST_GREATER`
-     */
-    public function visitGreater(Node $node);
-
-    /**
-     * Visit a node with kind `\ast\AST_GREATER_EQUAL`
-     */
-    public function visitGreaterEqual(Node $node);
 
     /**
      * Visit a node with kind `\ast\AST_GROUP_USE`
@@ -321,11 +306,6 @@ interface KindVisitor
     public function visitNullableType(Node $node);
 
     /**
-     * Visit a node with kind `\ast\AST_UNARY_MINUS`
-     */
-    public function visitUnaryMinus(Node $node);
-
-    /**
      * Visit a node with kind `\ast\AST_UNARY_OP`
      */
     public function visitUnaryOp(Node $node);
@@ -354,11 +334,6 @@ interface KindVisitor
      * Visit a node with kind `\ast\AST_WHILE`
      */
     public function visitWhile(Node $node);
-
-    /**
-     * Visit a node with kind `\ast\AST_AND`
-     */
-    public function visitAnd(Node $node);
 
     /**
      * Visit a node with kind `\ast\AST_CATCH_LIST`
@@ -416,11 +391,6 @@ interface KindVisitor
     public function visitNameList(Node $node);
 
     /**
-     * Visit a node with kind `\ast\AST_OR`
-     */
-    public function visitOr(Node $node);
-
-    /**
      * Visit a node with kind `\ast\AST_POST_DEC`
      */
     public function visitPostDec(Node $node);
@@ -446,11 +416,6 @@ interface KindVisitor
     public function visitShellExec(Node $node);
 
     /**
-     * Visit a node with kind `\ast\AST_SILENCE`
-     */
-    public function visitSilence(Node $node);
-
-    /**
      * Visit a node with kind `\ast\AST_THROW`
      */
     public function visitThrow(Node $node);
@@ -474,11 +439,6 @@ interface KindVisitor
      * Visit a node with kind `\ast\AST_TRY`
      */
     public function visitTry(Node $node);
-
-    /**
-     * Visit a node with kind `\ast\AST_UNARY_PLUS`
-     */
-    public function visitUnaryPlus(Node $node);
 
     /**
      * Visit a node with kind `\ast\AST_UNPACK`

--- a/src/Phan/AST/Visitor/KindVisitorImplementation.php
+++ b/src/Phan/AST/Visitor/KindVisitorImplementation.php
@@ -121,11 +121,6 @@ abstract class KindVisitorImplementation implements KindVisitor
         return $this->visit($node);
     }
 
-    public function visitCoalesce(Node $node)
-    {
-        return $this->visit($node);
-    }
-
     public function visitConst(Node $node)
     {
         return $this->visit($node);
@@ -197,16 +192,6 @@ abstract class KindVisitorImplementation implements KindVisitor
     }
 
     public function visitGlobal(Node $node)
-    {
-        return $this->visit($node);
-    }
-
-    public function visitGreater(Node $node)
-    {
-        return $this->visit($node);
-    }
-
-    public function visitGreaterEqual(Node $node)
     {
         return $this->visit($node);
     }
@@ -346,11 +331,6 @@ abstract class KindVisitorImplementation implements KindVisitor
         return $this->visit($node);
     }
 
-    public function visitUnaryMinus(Node $node)
-    {
-        return $this->visit($node);
-    }
-
     public function visitUnaryOp(Node $node)
     {
         return $this->visit($node);
@@ -377,12 +357,6 @@ abstract class KindVisitorImplementation implements KindVisitor
     }
 
     public function visitWhile(Node $node)
-    {
-        return $this->visit($node);
-    }
-
-
-    public function visitAnd(Node $node)
     {
         return $this->visit($node);
     }
@@ -442,11 +416,6 @@ abstract class KindVisitorImplementation implements KindVisitor
         return $this->visit($node);
     }
 
-    public function visitOr(Node $node)
-    {
-        return $this->visit($node);
-    }
-
     public function visitPostDec(Node $node)
     {
         return $this->visit($node);
@@ -472,11 +441,6 @@ abstract class KindVisitorImplementation implements KindVisitor
         return $this->visit($node);
     }
 
-    public function visitSilence(Node $node)
-    {
-        return $this->visit($node);
-    }
-
     public function visitThrow(Node $node)
     {
         return $this->visit($node);
@@ -498,11 +462,6 @@ abstract class KindVisitorImplementation implements KindVisitor
     }
 
     public function visitTry(Node $node)
-    {
-        return $this->visit($node);
-    }
-
-    public function visitUnaryPlus(Node $node)
     {
         return $this->visit($node);
     }

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -191,32 +191,6 @@ class ConditionVisitor extends KindVisitorImplementation
     }
 
     /**
-     * @param Node $node
-     * A node to parse
-     *
-     * @return Context
-     * A new or an unchanged context resulting from
-     * parsing the node
-     */
-    public function visitAnd(Node $node) : Context
-    {
-        return $this->analyzeShortCircuitingAnd($node->children['left'], $node->children['right']);
-    }
-
-    /**
-     * @param Node $node
-     * A node to parse
-     *
-     * @return Context
-     * A new or an unchanged context resulting from
-     * parsing the node
-     */
-    public function visitOr(Node $node) : Context
-    {
-        return $this->analyzeShortCircuitingOr($node->children['left'], $node->children['right']);
-    }
-
-    /**
      * Helper method
      * @param Node|mixed $left
      * a Node or non-node to parse (possibly an AST literal)
@@ -306,20 +280,6 @@ class ConditionVisitor extends KindVisitorImplementation
         if ($expr_node instanceof Node) {
             return (new NegatedConditionVisitor($this->code_base, $this->context))->__invoke($expr_node);
         }
-        return $this->context;
-    }
-
-    /**
-     * @param Node $node
-     * A node to parse
-     *
-     * @return Context
-     * A new or an unchanged context resulting from
-     * parsing the node
-     */
-    public function visitCoalesce(Node $node) : Context
-    {
-        $this->checkVariablesDefined($node);
         return $this->context;
     }
 

--- a/src/Phan/Analysis/NegatedConditionVisitor.php
+++ b/src/Phan/Analysis/NegatedConditionVisitor.php
@@ -130,19 +130,6 @@ class NegatedConditionVisitor extends KindVisitorImplementation
     }
 
     /**
-     * @param Node $node
-     * A node to parse
-     *
-     * @return Context
-     * A new or an unchanged context resulting from
-     * parsing the node
-     */
-    public function visitOr(Node $node) : Context
-    {
-        return $this->analyzeShortCircuitingOr($node->children['left'], $node->children['right']);
-    }
-
-    /**
      * Helper method
      * @param Node|mixed $left
      * a Node or non-node to parse (possibly an AST literal)
@@ -623,20 +610,6 @@ class NegatedConditionVisitor extends KindVisitorImplementation
             'is_scalar' => $remove_scalar_callback,
             'is_string' => $make_basic_negated_assertion_callback(StringType::class),
         ];
-    }
-
-    /**
-     * @param Node $node
-     * A node to parse
-     *
-     * @return Context
-     * A new or an unchanged context resulting from
-     * parsing the node
-     */
-    public function visitCoalesce(Node $node) : Context
-    {
-        $this->checkVariablesDefined($node);
-        return $this->context;
     }
 
     /**

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -651,13 +651,13 @@ class BlockAnalysisVisitor extends AnalysisVisitor
         );
 
         // NOTE: This is different from other analysis visitors because analyzing 'cond' with `||` has side effects
-        // after supporting visitAnd() and visitOr() in BlockAnalysisVisitor
+        // after supporting `BlockAnalysisVisitor->visitBinaryOp()`
         // TODO: Calling analyzeAndGetUpdatedContext before preOrderAnalyze is a hack.
 
         // TODO: This is redundant and has worse knowledge of the specific types of blocks than ConditionVisitor does.
         // TODO: Implement a hybrid BlockAnalysisVisitor+ConditionVisitor that will do a better job of inferences and reducing false positives? (and reduce the redundant work)
 
-        // E.g. the below code would update the context of BlockAnalysisVisitor in BlockAnalysisVisitor->visitOr()
+        // E.g. the below code would update the context of BlockAnalysisVisitor in BlockAnalysisVisitor->visitBinaryOp()
         //
         //     if (!(is_string($x) || $x === null)) {}
         //
@@ -1106,9 +1106,9 @@ class BlockAnalysisVisitor extends AnalysisVisitor
     {
         $flags = $node->flags;
         if ($flags === \ast\flags\BINARY_BOOL_AND) {
-            return $this->visitAnd($node);
+            return $this->analyzeBinaryBoolAnd($node);
         } elseif ($flags === \ast\flags\BINARY_BOOL_OR) {
-            return $this->visitOr($node);
+            return $this->analyzeBinaryBoolOr($node);
         }
         return $this->visit($node);
     }
@@ -1121,7 +1121,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitAnd(Node $node) : Context
+    public function analyzeBinaryBoolAnd(Node $node) : Context
     {
         $context = $this->context->withLineNumberStart(
             $node->lineno ?? 0
@@ -1180,7 +1180,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitOr(Node $node) : Context
+    public function analyzeBinaryBoolOr(Node $node) : Context
     {
         $context = $this->context->withLineNumberStart(
             $node->lineno ?? 0

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -20,6 +20,8 @@ class Config
      * The version of the AST (defined in php-ast) that we're using.
      * Other versions are likely to have edge cases we no longer support,
      * and version 50 got rid of Decl.
+     *
+     * TODO: Also enable support for version 60 once there is a stable php-ast 1.0.0 release. (Issue #2038)
      */
     const AST_VERSION = 50;
 
@@ -32,7 +34,7 @@ class Config
      * New features increment minor versions, and bug fixes increment patch versions.
      * @suppress PhanUnreferencedPublicClassConstant
      */
-    const PHAN_PLUGIN_VERSION = '2.5.0';
+    const PHAN_PLUGIN_VERSION = '2.6.0';
 
     /**
      * @var string|null

--- a/src/Phan/Debug.php
+++ b/src/Phan/Debug.php
@@ -381,21 +381,7 @@ class Debug
                 flags\BINARY_SPACESHIP => 'BINARY_SPACESHIP',
                 flags\BINARY_COALESCE => 'BINARY_COALESCE',
             ],
-            \ast\AST_ASSIGN_OP => $shared_binary_ops + [
-                // Old version 10 flags
-                flags\ASSIGN_BITWISE_OR => 'ASSIGN_BITWISE_OR',
-                flags\ASSIGN_BITWISE_AND => 'ASSIGN_BITWISE_AND',
-                flags\ASSIGN_BITWISE_XOR => 'ASSIGN_BITWISE_XOR',
-                flags\ASSIGN_CONCAT => 'ASSIGN_CONCAT',
-                flags\ASSIGN_ADD => 'ASSIGN_ADD',
-                flags\ASSIGN_SUB => 'ASSIGN_SUB',
-                flags\ASSIGN_MUL => 'ASSIGN_MUL',
-                flags\ASSIGN_DIV => 'ASSIGN_DIV',
-                flags\ASSIGN_MOD => 'ASSIGN_MOD',
-                flags\ASSIGN_POW => 'ASSIGN_POW',
-                flags\ASSIGN_SHIFT_LEFT => 'ASSIGN_SHIFT_LEFT',
-                flags\ASSIGN_SHIFT_RIGHT => 'ASSIGN_SHIFT_RIGHT',
-            ],
+            \ast\AST_ASSIGN_OP => $shared_binary_ops,
             \ast\AST_MAGIC_CONST => [
                 flags\MAGIC_LINE => 'MAGIC_LINE',
                 flags\MAGIC_FILE => 'MAGIC_FILE',

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -1299,7 +1299,6 @@ class ParseVisitor extends ScopeVisitor
         ast\AST_ARRAY => true,
         ast\AST_BINARY_OP => true,
         ast\AST_CLASS_CONST => true,
-        ast\AST_COALESCE => true,
         ast\AST_CONDITIONAL => true,
         ast\AST_CONST => true,
         ast\AST_DIM => true,


### PR DESCRIPTION
For #2038

Get rid of constants that are no longer used by AST version 50.
Get rid of the unused helper methods that unnecessarily
handled those constants in Phan's visitors.

Tests now pass both in php-ast 0.1.5 (and newer) and 1.0.0dev

I didn't encounter any issues setting Config::AST_VERSION to version 60,
but will wait until 1.0.0 is stable before finalizing that change.
