### PR TITLE
Update tests to account for alternate suggestions

### DIFF
--- a/internal/Phan-Config-Settings.md
+++ b/internal/Phan-Config-Settings.md
@@ -721,7 +721,7 @@ Phan will give up on suggesting a different name in issue messages
 if the number of candidates (for a given suggestion category) is greater than `suggestion_check_limit`.
 
 Set this to `0` to disable most suggestions for similar names, to other namespaces.
-Set this to `INT_MAX` (or other large value) to always suggesting similar names to other namespaces.
+Set this to `PHP_INT_MAX` (or other large value) to always suggesting similar names to other namespaces.
 (Phan will be a bit slower when this config setting is a larger value)
 
 (Default: `50`)

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -494,7 +494,7 @@ class Config
         // if the number of candidates (for a given suggestion category) is greater than `suggestion_check_limit`.
         //
         // Set this to `0` to disable most suggestions for similar names, to other namespaces.
-        // Set this to `INT_MAX` (or other large value) to always suggesting similar names to other namespaces.
+        // Set this to `PHP_INT_MAX` (or other large value) to always suggesting similar names to other namespaces.
         // (Phan will be a bit slower when this config setting is a larger value)
         'suggestion_check_limit' => 50,
 

--- a/tests/.phan_for_test/config.php
+++ b/tests/.phan_for_test/config.php
@@ -74,4 +74,12 @@ return [
         'PhanUnusedGlobalFunctionParameter',
         'PhanUnusedClosureParameter',
     ],
+
+    // Phan will give up on suggesting a different name in issue messages
+    // if the number of candidates (for a given suggestion category) is greater than `suggestion_check_limit`.
+    //
+    // Set this to `0` to disable most suggestions for similar names, to other namespaces.
+    // Set this to `PHP_INT_MAX` (or other large value) to always suggesting similar names to other namespaces.
+    // (Phan will be a bit slower when this config setting is a larger value)
+    'suggestion_check_limit' => PHP_INT_MAX,
 ];

--- a/tests/files/expected/0058_property_type_check.php.expected
+++ b/tests/files/expected/0058_property_type_check.php.expected
@@ -1,3 +1,3 @@
-%s:4 PhanUndeclaredTypeProperty Property \Test::client has undeclared type \Client
-%s:6 PhanUndeclaredTypeParameter Parameter of undeclared type \Client
-%s:8 PhanUndeclaredClassMethod Call to method test from undeclared class \Client
+%s:4 PhanUndeclaredTypeProperty Property \Test::client has undeclared type \ClientOfPropertyTypeCheck58
+%s:6 PhanUndeclaredTypeParameter Parameter of undeclared type \ClientOfPropertyTypeCheck58
+%s:8 PhanUndeclaredClassMethod Call to method test from undeclared class \ClientOfPropertyTypeCheck58

--- a/tests/files/expected/0241_nullable_71.php.expected
+++ b/tests/files/expected/0241_nullable_71.php.expected
@@ -2,5 +2,5 @@
 %s:4 PhanTypeMismatchReturn Returning type 42 but f241_1() is declared to return ?string
 %s:13 PhanTypeMismatchArgument Argument 1 (name) is 42 but \f241_3() takes ?string defined at %s:11
 %s:26 PhanTypeMismatchReturn Returning type 42 but f241_5() is declared to return ?string
-%s:41 PhanTypeMismatchReturn Returning type null but f241_10() is declared to return \Tuple<int,string>
-%s:41 PhanUndeclaredTypeReturnType Return type of f241_10 is undeclared type \Tuple<int,string>
+%s:41 PhanTypeMismatchReturn Returning type null but f241_10() is declared to return \TupleOfNullableTest241<int,string>
+%s:41 PhanUndeclaredTypeReturnType Return type of f241_10 is undeclared type \TupleOfNullableTest241<int,string>

--- a/tests/files/expected/0263_alias_outside_phpdoc.php.expected
+++ b/tests/files/expected/0263_alias_outside_phpdoc.php.expected
@@ -1,5 +1,5 @@
 %s:4 PhanUndeclaredTypeParameter Parameter of undeclared type \boolean
-%s:4 PhanUndeclaredTypeParameter Parameter of undeclared type \callback
+%s:4 PhanUndeclaredTypeParameter Parameter of undeclared type \callback%S
 %s:4 PhanUndeclaredTypeParameter Parameter of undeclared type \double
 %s:4 PhanUndeclaredTypeParameter Parameter of undeclared type \integer
 %s:4 PhanUndeclaredTypeParameter Parameter of undeclared type array<int,\double>

--- a/tests/files/expected/0289_check_incorrect_soft_types.php.expected
+++ b/tests/files/expected/0289_check_incorrect_soft_types.php.expected
@@ -1,4 +1,4 @@
-%s:3 PhanUndeclaredTypeParameter Parameter of undeclared type \resource
+%s:3 PhanUndeclaredTypeParameter Parameter of undeclared type \resource%S
 %s:4 PhanTypeMismatchArgumentInternal Argument 1 (fp) is \resource but \fread() takes resource
 %s:10 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is false|resource but \intdiv() takes int
 %s:14 PhanCompatibleNullableTypePHP71 Type 'object' refers to any object starting in PHP 7.2. In PHP 7.1 and earlier, it refers to a class/interface with the name 'object'

--- a/tests/files/expected/0360_undeclared_array_class_in_namespace.php.expected
+++ b/tests/files/expected/0360_undeclared_array_class_in_namespace.php.expected
@@ -1,4 +1,4 @@
 %s:12 PhanUndeclaredTypeParameter Parameter of undeclared type \Foo\Baz\MissingClass[][][]
 %s:12 PhanUndeclaredTypeReturnType Return type of myMethod is undeclared type \Foo\Bat\OtherMissingClass[][]
 %s:18 PhanUndeclaredTypeProperty Property \Foo\Bar\MyClass::y has undeclared type \Foo\Bar\Closure[][] (Did you mean class \Closure)
-%s:22 PhanUndeclaredTypeProperty Property \Foo\Bar\MyClass::str has undeclared type \Foo\Bar\strong (Did you mean string)
+%s:22 PhanUndeclaredTypeProperty Property \Foo\Bar\MyClass::str has undeclared type \Foo\Bar\strong (Did you mean %Sstring%S)

--- a/tests/files/expected/0478_undeclared_classlike_suggestions.php.expected
+++ b/tests/files/expected/0478_undeclared_classlike_suggestions.php.expected
@@ -4,5 +4,5 @@
 %s:7 PhanUndeclaredInterface Class implements undeclared interface \ExampleInterface (Did you mean interface \NS2\ExampleInterface)
 %s:7 PhanUndeclaredTrait Class uses undeclared trait \ExampleTrait (Did you mean trait \NS2\ExampleTrait)
 %s:16 PhanUndeclaredClassConstant Reference to constant class from undeclared class \NS3\ClassWithRepeatedName (Did you mean class \ClassWithRepeatedName or class \NS2\ClassWithRepeatedName)
-%s:23 PhanUndeclaredClassCatch Catching undeclared class \NS2\Exception (Did you mean class \Exception)
-%s:26 PhanUndeclaredClassInstanceof Checking instanceof against undeclared class \NS2\InvalidArgumentException (Did you mean class \InvalidArgumentException)
+%s:23 PhanUndeclaredClassCatch Catching undeclared class \NS2\Exception (Did you mean %Sclass \Exception%S)
+%s:26 PhanUndeclaredClassInstanceof Checking instanceof against undeclared class \NS2\InvalidArgumentException (Did you mean %Sclass \InvalidArgumentException%S)

--- a/tests/files/src/0058_property_type_check.php
+++ b/tests/files/src/0058_property_type_check.php
@@ -1,9 +1,9 @@
 <?php
 class Test {
-    /** @var Client */
+    /** @var ClientOfPropertyTypeCheck58 */
     public $client;
 
-    function fn(Client $client) {
+    function fn(ClientOfPropertyTypeCheck58 $client) {
         $this->client = $client;
         $this->client->test();
     }

--- a/tests/files/src/0241_nullable_71.php
+++ b/tests/files/src/0241_nullable_71.php
@@ -37,5 +37,5 @@ function f241_8() { return []; }
 /** @return ?string[] */
 function f241_9() { return null; }
 
-/** @return Tuple<int,string> */
+/** @return TupleOfNullableTest241<int,string> */
 function f241_10() { return null; }

--- a/tests/files/src/0263_alias_outside_phpdoc.php
+++ b/tests/files/src/0263_alias_outside_phpdoc.php
@@ -4,4 +4,4 @@
 function foo263(boolean $a, integer $b, callback $c, double $d, double ...$e) : boolean {
     return false;
 }
-foo263(false, 2, function() {}, 1.2345, 3.14);
+foo263(false, 2, function () {}, 1.2345, 3.14);

--- a/tests/php72_files/expected/0001_objecthint.php.expected
+++ b/tests/php72_files/expected/0001_objecthint.php.expected
@@ -3,4 +3,4 @@
 %s:14 PhanTypeMismatchArgument Argument 1 (x) is array{} but \object_test() takes object defined at %s:3
 %s:14 PhanTypeMismatchArgument Argument 2 (y) is array{} but \object_test() takes ?object defined at %s:3
 %s:26 PhanTypeMismatchReturn Returning type 'invalid' but nullableobject_test() is declared to return ?object
-%s:29 PhanUndeclaredClassMethod Call to method __construct from undeclared class \object
+%s:29 PhanUndeclaredClassMethod Call to method __construct from undeclared class \object%S


### PR DESCRIPTION
Alternate suggestions may have been generated depending on what PHP
modules were installed with the PHP binary used to run the unit tests.

- Rename some classes to avoid this ambiguity
- Increase the suggestion check limit so that test results will include all
  suggestions
- Add `%S` where suggestions might go
  (a wildcard with 0 or more characters)

For #2041