### PR TITLE
Add "defined at {FILE}:{LINE}" to warnings about property visibility

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@ Phan NEWS
 ?? ??? 2018, Phan 1.1.1 (dev)
 -----------------------
 
+New features(Analysis)
++ Add `defined at {FILE}:{LINE}` to warnings about property visibility.
+
 08 Oct 2018, Phan 1.1.0
 -----------------------
 

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -2511,7 +2511,7 @@ class Issue
                 self::AccessPropertyProtected,
                 self::CATEGORY_ACCESS,
                 self::SEVERITY_CRITICAL,
-                "Cannot access protected property {PROPERTY}",
+                "Cannot access protected property {PROPERTY} defined at {FILE}:{LINE}",
                 self::REMEDIATION_B,
                 1000
             ),
@@ -2519,7 +2519,7 @@ class Issue
                 self::AccessPropertyPrivate,
                 self::CATEGORY_ACCESS,
                 self::SEVERITY_CRITICAL,
-                "Cannot access private property {PROPERTY}",
+                "Cannot access private property {PROPERTY} defined at {FILE}:{LINE}",
                 self::REMEDIATION_B,
                 1001
             ),

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -1030,7 +1030,7 @@ class Clazz extends AddressableElement
                     Issue::fromType(Issue::AccessPropertyPrivate)(
                         $context->getFile(),
                         $context->getLineNumberStart(),
-                        [ (string)$property_fqsen ]
+                        [ (string)$property_fqsen, $method->getContext()->getFile(), $method->getContext()->getLineNumberStart() ]
                     )
                 );
             } elseif ($method->isProtected()) {
@@ -1038,7 +1038,7 @@ class Clazz extends AddressableElement
                     Issue::fromType(Issue::AccessPropertyProtected)(
                         $context->getFile(),
                         $context->getLineNumberStart(),
-                        [ (string)$property_fqsen ]
+                        [ (string)$property_fqsen, $method->getContext()->getFile(), $method->getContext()->getLineNumberStart() ]
                     )
                 );
             }
@@ -1064,7 +1064,7 @@ class Clazz extends AddressableElement
                     Issue::fromType(Issue::AccessPropertyPrivate)(
                         $context->getFile(),
                         $context->getLineNumberStart(),
-                        [ "{$this->getFQSEN()}::\${$property->getName()}" ]
+                        [ "{$this->getFQSEN()}::\${$property->getName()}", $property->getContext()->getFile(), $property->getContext()->getLineNumberStart() ]
                     )
                 );
             }
@@ -1073,7 +1073,7 @@ class Clazz extends AddressableElement
                     Issue::fromType(Issue::AccessPropertyProtected)(
                         $context->getFile(),
                         $context->getLineNumberStart(),
-                        [ "{$this->getFQSEN()}::\${$property->getName()}" ]
+                        [ "{$this->getFQSEN()}::\${$property->getName()}", $property->getContext()->getFile(), $property->getContext()->getLineNumberStart() ]
                     )
                 );
             }

--- a/tests/files/expected/0101_one_of_each.php.expected
+++ b/tests/files/expected/0101_one_of_each.php.expected
@@ -1,5 +1,5 @@
-%s:5 PhanAccessPropertyPrivate Cannot access private property \C1::$p
-%s:9 PhanAccessPropertyProtected Cannot access protected property \C2::$p
+%s:5 PhanAccessPropertyPrivate Cannot access private property \C1::$p defined at %s:4
+%s:9 PhanAccessPropertyProtected Cannot access protected property \C2::$p defined at %s:8
 %s:14 PhanCompatiblePHP7 Expression may not be PHP 7 compatible
 %s:14 PhanUndeclaredVariable Variable $v1 is undeclared
 %s:14 PhanUndeclaredVariable Variable $v2 is undeclared

--- a/tests/files/expected/0194_shared_base_class.php.expected
+++ b/tests/files/expected/0194_shared_base_class.php.expected
@@ -1,2 +1,2 @@
-%s:26 PhanAccessPropertyProtected Cannot access protected property \A::$var
+%s:26 PhanAccessPropertyProtected Cannot access protected property \A::$var defined at %s:4
 %s:27 PhanAccessMethodProtected Cannot access protected method \A::func defined at %s:6

--- a/tests/files/expected/0349_protected_method_from_trait.php.expected
+++ b/tests/files/expected/0349_protected_method_from_trait.php.expected
@@ -1,4 +1,4 @@
 %s:38 PhanUndeclaredProperty Reference to undeclared property \ExtendingClass->missingProp
 %s:47 PhanAccessMethodProtected Cannot access protected method \ExtendingClass::protectedAlias defined at %s:18
 %s:48 PhanAccessMethodProtected Cannot access protected method \ExtendingClass::foo3 defined at %s:15
-%s:50 PhanAccessPropertyProtected Cannot access protected property \ExtendingClass::$prop
+%s:50 PhanAccessPropertyProtected Cannot access protected property \ExtendingClass::$prop defined at %s:13

--- a/tests/files/expected/0391_private_prop_of_this.php.expected
+++ b/tests/files/expected/0391_private_prop_of_this.php.expected
@@ -1,4 +1,4 @@
-%s:24 PhanAccessPropertyPrivate Cannot access private property \Subclass391::$_prop
+%s:24 PhanAccessPropertyPrivate Cannot access private property \Subclass391::$_prop defined at %s:4
 %s:25 PhanUndeclaredProperty Reference to undeclared property \Subclass391->_propOther
-%s:29 PhanAccessPropertyPrivate Cannot access private property \Subclass391::$_prop2
+%s:29 PhanAccessPropertyPrivate Cannot access private property \Subclass391::$_prop2 defined at %s:5
 %s:29 PhanUndeclaredProperty Reference to undeclared property \Subclass391->_prop2Other

--- a/tests/files/expected/0392_protected_property_other_class.php.expected
+++ b/tests/files/expected/0392_protected_property_other_class.php.expected
@@ -1,4 +1,4 @@
-%s:18 PhanAccessPropertyProtected Cannot access protected property \A392::$prop1
-%s:19 PhanAccessPropertyPrivate Cannot access private property \A392::$prop2
-%s:21 PhanAccessPropertyProtected Cannot access protected property \A392::$prop1
-%s:22 PhanAccessPropertyPrivate Cannot access private property \A392::$prop2
+%s:18 PhanAccessPropertyProtected Cannot access protected property \A392::$prop1 defined at %s:9
+%s:19 PhanAccessPropertyPrivate Cannot access private property \A392::$prop2 defined at %s:10
+%s:21 PhanAccessPropertyProtected Cannot access protected property \A392::$prop1 defined at %s:9
+%s:22 PhanAccessPropertyPrivate Cannot access private property \A392::$prop2 defined at %s:10

--- a/tests/files/expected/0393_property_visibility_trait.php.expected
+++ b/tests/files/expected/0393_property_visibility_trait.php.expected
@@ -1,2 +1,2 @@
-%s:15 PhanAccessPropertyPrivate Cannot access private property \ExtendingClass393::$propPrivate
+%s:15 PhanAccessPropertyPrivate Cannot access private property \ExtendingClass393::$propPrivate defined at %s:9
 %s:16 PhanUndeclaredProperty Reference to undeclared property \ExtendingClass393->missingProp

--- a/tests/files/expected/0443_base_access_protected_subclass.php.expected
+++ b/tests/files/expected/0443_base_access_protected_subclass.php.expected
@@ -1,2 +1,2 @@
-%s:7 PhanAccessPropertyPrivate Cannot access private property \Subclass::$privateProp
+%s:7 PhanAccessPropertyPrivate Cannot access private property \Subclass::$privateProp defined at %s:15
 %s:9 PhanAccessMethodPrivate Cannot access private method \Subclass::privateMethod defined at %s:20

--- a/tests/rasmus_files/expected/0036_properties.php.expected
+++ b/tests/rasmus_files/expected/0036_properties.php.expected
@@ -2,5 +2,5 @@
 %s:8 PhanTypeMismatchProperty Assigning string to property but \A::num is int
 %s:11 PhanUndeclaredProperty Reference to undeclared property \A->str
 %s:12 PhanTypeMismatchProperty Assigning array{} to property but \A::text is int|string
-%s:18 PhanAccessPropertyProtected Cannot access protected property \A::$foo
+%s:18 PhanAccessPropertyProtected Cannot access protected property \A::$foo defined at %s:8
 %s:19 PhanUndeclaredProperty Reference to undeclared property \A->bar

--- a/tests/rasmus_files/expected/0037_properties2.php.expected
+++ b/tests/rasmus_files/expected/0037_properties2.php.expected
@@ -1,3 +1,3 @@
 %s:13 PhanTypeMismatchProperty Assigning array<int,int> to property but \B::text is string
-%s:20 PhanAccessPropertyProtected Cannot access protected property \B::$text
+%s:20 PhanAccessPropertyProtected Cannot access protected property \B::$text defined at %s:4
 %s:30 PhanTypeMismatchProperty Assigning array{} to property but \B::text is string


### PR DESCRIPTION
Fixes #1375