### PR TITLE
Improve internal script to update documentation

### DIFF
--- a/internal/update_wiki_issue_types.php
+++ b/internal/update_wiki_issue_types.php
@@ -165,7 +165,8 @@ $message
 
 EOT;
             $writer->append($header . "\n");
-            $writer->append($placeholder);
+            // Append both the issue message and an example instance of that issue message (if possible)
+            $writer->append(self::updateTextForSection($placeholder, $header));
         }
     }
 


### PR DESCRIPTION
Make it append both the issue message and links to example instances
when initially creating the default.
(instead of just the issue message)