### PR TITLE
Fix bugs in the language server

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,18 @@ New features(Analysis):
 Bug fixes:
 + Don't crash when parsing an invalid cast expression. Only the fallback/polyfill parsers were affected.
 
+Language Server/Daemon mode:
++ Fix bugs in the language server.
+
+  1. The language server was previously using the non-PCNTL fallback
+     implementation unconditionally due to an incorrect default configuration value.
+     After this fix, the language server properly uses PCNTL by default
+     if PCNTL is available.
+
+     This bug was introduced by PR #1743
+
+  2. Fix a bug causing the language server to eventually run out of memory when PCNTL was disabled.
+
 08 Oct 2018, Phan 1.1.0
 -----------------------
 

--- a/src/Phan/Bootstrap.php
+++ b/src/Phan/Bootstrap.php
@@ -82,6 +82,11 @@ function phan_error_handler($errno, $errstr, $errfile, $errline)
     if ($__no_echo_phan_errors) {
         return false;
     }
+    // php-src/ext/standard/streamsfuncs.c suggests that this is the only error caused by signal handlers and there are no translations
+    if ($errno === E_WARNING && preg_match('/^stream_select.*unable to select/', $errstr)) {
+        // Don't execute the PHP internal error handler
+        return true;
+    }
     error_log("$errfile:$errline [$errno] $errstr\n");
     if (class_exists(CodeBase::class, false)) {
         $most_recent_file = CodeBase::getMostRecentlyParsedOrAnalyzedFile();

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -807,8 +807,9 @@ class Config
         // Valid values: null, 'info'. Used when developing or debugging a language server client of Phan.
         'language_server_debug_level' => null,
 
-        // You can use the command line option `--language-server-require-pcntl` to set this to false for debugging.
-        'language_server_use_pcntl_fallback' => true,
+        // This should only be set by CLI (`--language-server-force-missing-pcntl` or `language-server-require-pcntl`), which will set this to true for debugging.
+        // When true, this will manually back up the state of the PHP process and restore it.
+        'language_server_use_pcntl_fallback' => false,
 
         // This should only be set via CLI (`--language-server-enable-go-to-definition`)
         // Affects "go to definition" and "go to type definition" of LSP.

--- a/src/Phan/LanguageServer/GoToDefinitionRequest.php
+++ b/src/Phan/LanguageServer/GoToDefinitionRequest.php
@@ -288,6 +288,25 @@ final class GoToDefinitionRequest extends NodeInfoRequest
         return array_values($this->locations);
     }
 
+    /**
+     * @return ?Hover
+     */
+    public function getHoverResponse()
+    {
+        return $this->hover_response;
+    }
+
+    /**
+     * @param ?Hover|?array $hover
+     */
+    public function setHoverResponse($hover)
+    {
+        if (is_array($hover)) {
+            $hover = Hover::fromArray($hover);
+        }
+        $this->hover_response = $hover;
+    }
+
     public function finalize()
     {
         $promise = $this->promise;

--- a/src/Phan/LanguageServer/Protocol/Hover.php
+++ b/src/Phan/LanguageServer/Protocol/Hover.php
@@ -25,4 +25,11 @@ class Hover
         $this->contents = $contents;
         $this->range = $range;
     }
+
+    public static function fromArray(array $data) : self {
+        return new self(
+            MarkupContent::fromArray($data['contents']),
+            isset($data['range']) ? Range::fromArray($data['range']) : null
+        );
+    }
 }

--- a/src/Phan/LanguageServer/Protocol/MarkupContent.php
+++ b/src/Phan/LanguageServer/Protocol/MarkupContent.php
@@ -49,4 +49,11 @@ class MarkupContent
         $this->kind = $kind;
         $this->value = $value;
     }
+
+    public static function fromArray(array $data) : self {
+        return new self(
+            $data['kind'],
+            $data['value']
+        );
+    }
 }

--- a/tests/Phan/LanguageServer/LanguageServerIntegrationTest.php
+++ b/tests/Phan/LanguageServer/LanguageServerIntegrationTest.php
@@ -1293,11 +1293,12 @@ EOT;
     {
         $requested_uri = $requested_uri ?? $this->getDefaultFileURI();
         $diagnostics_response = $this->awaitResponse($proc_out);
-        $this->assertSame('textDocument/publishDiagnostics', $diagnostics_response['method']);
+        $error_message = "Unexpected response: " . json_encode($diagnostics_response);
+        $this->assertSame('textDocument/publishDiagnostics', $diagnostics_response['method'] ?? null, $error_message);
         $uri = $diagnostics_response['params']['uri'];
-        $this->assertSame($uri, $requested_uri);
+        $this->assertSame($uri, $requested_uri, $error_message);
         $diagnostics = $diagnostics_response['params']['diagnostics'];
-        $this->assertSame([], $diagnostics);
+        $this->assertSame([], $diagnostics, $error_message);
     }
 
     /**


### PR DESCRIPTION
1. The language server was previously using the non-PCNTL fallback
   implementation unconditionally due to an incorrect default configuration.
   After this fix, the language server properly uses PCNTL by default
   if PCNTL is available.

   This bug was introduced by PR #1743
2. When PCNTL was disabled, reference cycles of PHP objects would accumulate
   (new objects were created when manually backing up the pre-analysis state
   of the program and restoring it later)

   This would lead to the Phan Language Server hitting out of memory
   errors, (sped up by requests (e.g. typing) and by analyzing large projects)

   Mitigate this by re-enabling the garbage collector when the language
   server is running and not using PCNTL.
3. When PCNTL is enabled, zombie processes would accumulate for the
   Language Server (but not the Daemon Mode).

   This was mitigated by properly calling `pcntl_waitpid()` and
   `pcntl_signal_dispatch()`,
   which Daemon Mode already was doing.

   (unreachable because of the first bug)
4. Properly serialize and unserialize the hover response from the worker process
   for requests for hover text.

   (unreachable because of the first bug)