### PR TITLE
Use dedicated PHPUnit assertions

### DIFF
--- a/tests/Phan/Language/TypeTest.php
+++ b/tests/Phan/Language/TypeTest.php
@@ -38,7 +38,7 @@ final class TypeTest extends BaseTest
 {
     private function makePHPDocType(string $type_string) : Type
     {
-        $this->assertTrue(\preg_match('@^' . Type::type_regex_or_this . '$@', $type_string) > 0, "Failed to parse '$type_string'");
+        $this->assertRegExp('@^' . Type::type_regex_or_this . '$@', $type_string, "Failed to parse '$type_string'");
         return Type::fromStringInContext($type_string, new Context(), Type::FROM_PHPDOC);
     }
 
@@ -53,7 +53,7 @@ final class TypeTest extends BaseTest
 
     public function assertParsesAsType(Type $expected_type, string $type_string)
     {
-        $this->assertTrue(\preg_match(self::DELIMITED_TYPE_REGEX_OR_THIS, $type_string) > 0, "Failed to parse '$type_string'");
+        $this->assertRegExp(self::DELIMITED_TYPE_REGEX_OR_THIS, $type_string, "Failed to parse '$type_string'");
         $this->assertSameType($expected_type, self::makePHPDocType($type_string));
     }
 
@@ -318,7 +318,7 @@ final class TypeTest extends BaseTest
 
     private function verifyClosureParam(FunctionLikeDeclarationType $expected_closure_type, string $union_type_string, string $normalized_type_string)
     {
-        $this->assertTrue(\preg_match(self::DELIMITED_TYPE_REGEX_OR_THIS, $union_type_string) > 0, "Failed to parse '$union_type_string'");
+        $this->assertRegExp(self::DELIMITED_TYPE_REGEX_OR_THIS, $union_type_string, "Failed to parse '$union_type_string'");
         $parsed_closure_type = self::makePHPDocType($union_type_string);
         $this->assertSame(get_class($expected_closure_type), get_class($parsed_closure_type), "expected closure/callable class for $normalized_type_string");
         $this->assertSame($normalized_type_string, (string)$parsed_closure_type, "failed parsing $union_type_string");
@@ -518,8 +518,8 @@ final class TypeTest extends BaseTest
      */
     public function testArrayShape(string $normalized_union_type_string, string $type_string)
     {
-        $this->assertTrue(\preg_match('@^' . Type::type_regex . '$@', $type_string) > 0, "Failed to parse '$type_string' with type_regex");
-        $this->assertTrue(\preg_match('@^' . Type::type_regex_or_this . '$@', $type_string) > 0, "Failed to parse '$type_string' with type_regex_or_this");
+        $this->assertRegExp('@^' . Type::type_regex . '$@', $type_string, "Failed to parse '$type_string' with type_regex");
+        $this->assertRegExp('@^' . Type::type_regex_or_this . '$@', $type_string, "Failed to parse '$type_string' with type_regex_or_this");
         $actual_type = self::makePHPDocType($type_string);
         $expected_flattened_type = UnionType::fromStringInContext($normalized_union_type_string, new Context(), Type::FROM_PHPDOC);
         if (!$actual_type instanceof ArrayShapeType) {
@@ -590,8 +590,8 @@ final class TypeTest extends BaseTest
     /** @dataProvider unparsableTypeProvider */
     public function testUnparsableType(string $type_string)
     {
-        $this->assertFalse(\preg_match('@^' . Type::type_regex . '$@', $type_string) > 0, "Failed to parse '$type_string' with type_regex");
-        $this->assertFalse(\preg_match('@^' . Type::type_regex_or_this . '$@', $type_string) > 0, "Failed to parse '$type_string' with type_regex_or_this");
+        $this->assertNotRegExp('@^' . Type::type_regex . '$@', $type_string, "Failed to parse '$type_string' with type_regex");
+        $this->assertNotRegExp('@^' . Type::type_regex_or_this . '$@', $type_string, "Failed to parse '$type_string' with type_regex_or_this");
     }
 
     public function unparsableTypeProvider() : array

--- a/tests/Phan/Language/UnionTypeTest.php
+++ b/tests/Phan/Language/UnionTypeTest.php
@@ -373,9 +373,9 @@ final class UnionTypeTest extends BaseTest
 
     public function testTemplateNullableTypes()
     {
-        $this->assertSame(1, preg_match('/^' . Type::type_regex . '$/', 'TypeTestClass<A1|null,B2|null>'), 'type_regex does not support nested pipes');
-        $this->assertSame(1, preg_match('/^' . Type::type_regex_or_this . '$/', 'TypeTestClass<A1|null>'), 'type_regex_or_this does not support nested pipes');
-        $this->assertSame(1, preg_match('/^' . Type::type_regex_or_this . '$/', 'TypeTestClass<A1|null,B2|null>'), 'type_regex_or_this does not support nested pipes');
+        $this->assertRegExp('/^' . Type::type_regex . '$/', 'TypeTestClass<A1|null,B2|null>', 'type_regex does not support nested pipes');
+        $this->assertRegExp('/^' . Type::type_regex_or_this . '$/', 'TypeTestClass<A1|null>', 'type_regex_or_this does not support nested pipes');
+        $this->assertRegExp('/^' . Type::type_regex_or_this . '$/', 'TypeTestClass<A1|null,B2|null>', 'type_regex_or_this does not support nested pipes');
         $union_type = self::makePHPDocUnionType('TypeTestClass<A1,B2|null>');
         $this->assertSame(1, $union_type->typeCount());
         $types = $union_type->getTypeSet();
@@ -471,7 +471,7 @@ final class UnionTypeTest extends BaseTest
      */
     public function testUnparseableUnionType(string $type)
     {
-        $this->assertSame(0, preg_match(self::VALID_UNION_TYPE_REGEX, $type), "'$type' should be unparseable");
+        $this->assertNotRegExp(self::VALID_UNION_TYPE_REGEX, $type, "'$type' should be unparseable");
     }
 
     public function unparseableUnionTypeProvider() : array


### PR DESCRIPTION
Using these dedicated PHPUnit assertions, we can simplify some logic and provide better error messages when a default one isn't set.