### PR TITLE
Added test for #2064

### DIFF
--- a/tests/plugin_test/src/060_array_intersect_key.php
+++ b/tests/plugin_test/src/060_array_intersect_key.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @return array<string,string>
+ */
+function test60(): array
+{
+    return array_intersect_key(
+        ["a" => "aa", "b" => "bb", "c" => "cc"],
+        ["a" => 1, "c" => new stdClass, "404" => true]
+    );
+}
+test60();


### PR DESCRIPTION
Currently, this test is failing and running `test.sh` shows:

```
> src/060_array_intersect_key.php:7 PhanPartialTypeMismatchReturn Returning type array<int,true>|array<string,\stdClass>|array<string,int>|array<string,string> but test60() is declared to return array<string,string> (array<string,int> is incompatible)
```