### PR TITLE
Detect missing file paths passed to require/include{,_once}

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -230,6 +230,9 @@ return [
         'TypeError',
     ],
 
+    // Increase this to properly analyze require_once statements
+    'max_literal_string_type_length' => 1000,
+
     // Setting this to true makes the process assignment for file analysis
     // as predictable as possible, using consistent hashing.
     // Even if files are added or removed, or process counts change,
@@ -457,6 +460,18 @@ return [
     // can't be removed for whatever reason.
     // (e.g. '@Test\.php$@', or '@vendor/.*/(tests|Tests)/@')
     'exclude_file_regex' => '@^vendor/.*/(tests?|Tests?)/@',
+
+    // A list of include paths to check when checking if `require_once`, `include`, etc. are valid.
+    //
+    // To refer to the directory of the file being analyzed, use `'.'`
+    // To refer to the project root directory, you must use \Phan\Config::getProjectRootDirectory()
+    //
+    // (E.g. `['.', \Phan\Config::getProjectRootDirectory() . '/src/folder-added-to-include_path']`)
+    'include_paths' => ['.'],
+
+    // Enable this to warn about the use of relative paths in `require_once`, `include`, etc.
+    // Relative paths are harder to reason about, and opcache may have issues with relative paths in edge cases.
+    'warn_about_relative_include_statement' => true,
 
     // A file list that defines files that will be excluded
     // from parsing and analysis and will not be read at all.

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,11 @@ Phan NEWS
 New features(Analysis):
 + Add `defined at {FILE}:{LINE}` to warnings about property visibility.
 + Warn about missing references (`\n` or `$n`) in the replacement template string of `preg_replace()` (#2047)
++ Warn about missing/invalid files in `require`/`include`/`require_once`/`include_once` statements.
+
+  New issue types: `PhanRelativePathUsed`, `PhanTypeInvalidEval`, `PhanTypeInvalidRequire`, `PhanInvalidRequireFile`, `PhanMissingRequiredFile`
+
+  New config settings: `include_paths`, `warn_about_relative_include_statement`
 + Warn when attempting to unset a property that was declared (i.e. not a dynamic or magic property) (#569)
   New issue type: `PhanTypeObjectUnsetDeclaredProperty`
 
@@ -20,6 +25,7 @@ New features(Analysis):
 
 Maintenance:
 + Minor performance improvements.
++ Increase the default value of `max_literal_string_type_length` from 50 to 200.
 
 Bug fixes:
 + Don't crash when parsing an invalid cast expression. Only the fallback/polyfill parsers were affected.

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -1582,6 +1582,18 @@ Returning type {TYPE} but {FUNCTIONLIKE}() is declared to return {TYPE} ({TYPE} 
 
 e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/expected/026_strict_return_checks.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/plugin_test/src/026_strict_return_checks.php#L16).
 
+## PhanRelativePathUsed
+
+The config setting `warn_about_relative_include_statement` can be used to enable checks for this issue.
+
+Relative paths are harder to reason about, and opcache may have issues with relative paths in edge cases.
+
+```
+{FUNCTION}() statement was passed a relative path {STRING_LITERAL} instead of an absolute path
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0545_require_testing.php.expected#L5) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0545_require_testing.php#L5).
+
 ## PhanTypeArrayOperator
 
 ```
@@ -1776,6 +1788,14 @@ Invalid offset {SCALAR} of array type {TYPE} in an array destructuring assignmen
 
 e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0402_array_destructuring.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0402_array_destructuring.php#L4).
 
+## PhanTypeInvalidEval
+
+```
+Eval statement was passed an invalid expression of type {TYPE} (expected a string)
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0546_require_other_testing.php.expected#L6) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0546_require_other_testing.php#L7).
+
 ## PhanTypeInvalidExpressionArrayDestructuring
 
 ```
@@ -1821,6 +1841,14 @@ Instance method name must be a string, got {TYPE}
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0540_invalid_method_name.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0540_invalid_method_name.php#L4).
+
+## PhanTypeInvalidRequire
+
+```
+Require statement was passed an invalid expression of type {TYPE} (expected a string)
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0545_require_testing.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0545_require_testing.php#L2).
 
 ## PhanTypeInvalidRightOperand
 
@@ -2257,6 +2285,28 @@ This would be emitted if you have a file with the contents
 
 ```php
 ```
+
+## PhanInvalidRequireFile
+
+```
+Required file {FILE} is not a file
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0545_require_testing.php.expected#L4) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0545_require_testing.php#L5).
+
+## PhanMissingRequireFile
+
+This is emitted when a statement such as `require` or `include_once` refers to a path that doesn't exist.
+
+If this is warning about a relative include, then you may want to adjust the config settings for `include_paths` and optionally `warn_about_relative_include_paths`.
+
+Phan may fail to emit this issue when the resolved path length exceeds the config setting `max_literal_string_type_length` (which defaults to `200`)
+
+```
+Missing required file {FILE}
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/1.0.7/tests/files/expected/0545_require_testing.php.expected#L11) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.0.7/tests/files/src/0545_require_testing.php#L10).
 
 ## PhanParentlessClass
 

--- a/internal/Phan-Config-Settings.md
+++ b/internal/Phan-Config-Settings.md
@@ -313,6 +313,17 @@ globals that you have no hope of fixing.
 
 (Default: `false`)
 
+## include_paths
+
+A list of [include paths](https://secure.php.net/manual/en/ini.core.php#ini.include-path) to check when checking if `require_once`, `include`, etc. are pointing to valid files.
+
+To refer to the directory of the file being analyzed, use `'.'`
+To refer to the project root directory, use \Phan\Config::getProjectRootDirectory()
+
+(E.g. `['.', \Phan\Config::getProjectRootDirectory() . '/src/folder-added-to-include_path']`)
+
+(Default: `["."]`)
+
 ## inherit_phpdoc_types
 
 If enabled, inherit any missing phpdoc for types from
@@ -326,11 +337,11 @@ NOTE: This step will only be performed if [`analyze_signature_compatibility`](#a
 
 If a literal string type exceeds this length,
 then Phan converts it to a regular string type.
-This setting cannot be used to decrease the maximum.
+This setting cannot be less than 50.
 
-This setting can be used if users wish to store strings that are even longer than 50 bytes.
+This setting can be overridden if users wish to store strings that are even longer than 50 bytes.
 
-(Default: `50`)
+(Default: `200`)
 
 ## parent_constructor_required
 
@@ -503,6 +514,13 @@ E.g. rewrites `if ($a = value() && $a > 0) {...}`
 into `$a = value(); if ($a) { if ($a > 0) {...}}`
 
 (Default: `true`)
+
+## warn_about_relative_include_statement
+
+Enable this to warn about the use of relative paths in `require_once`, `include`, etc.
+Relative paths are harder to reason about, and opcache may have issues with relative paths in edge cases.
+
+(Default: `false`)
 
 ## warn_about_undocumented_throw_statements
 

--- a/internal/update_wiki_config_types.php
+++ b/internal/update_wiki_config_types.php
@@ -46,6 +46,8 @@ class ConfigEntry
         'analyzed_file_extensions' => self::CATEGORY_FILES,
         'exclude_file_regex' => self::CATEGORY_FILES,
         'exclude_file_list' => self::CATEGORY_FILES,
+        'include_paths' => self::CATEGORY_ANALYSIS,
+        'warn_about_relative_include_statement' => self::CATEGORY_ANALYSIS,
         'exclude_analysis_directory_list' => self::CATEGORY_FILES,
         'include_analysis_file_list' => self::CATEGORY_FILES,
         'backward_compatibility_checks' => self::CATEGORY_ANALYSIS,

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -2108,10 +2108,9 @@ class ContextNode
                 }
                 return $node;
             case ast\flags\MAGIC_DIR:
-                // TODO: Absolute directory?
-                return \dirname($context->getFile());
+                return \dirname(Config::projectPath($context->getFile()));
             case ast\flags\MAGIC_FILE:
-                return $context->getFile();
+                return Config::projectPath($context->getFile());
             case ast\flags\MAGIC_LINE:
                 return $node->lineno ?? $context->getLineNumberStart();
             case ast\flags\MAGIC_NAMESPACE:

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -394,10 +394,9 @@ class UnionTypeVisitor extends AnalysisVisitor
                 }
                 return StringType::instance(false)->asUnionType();
             case ast\flags\MAGIC_DIR:
-                // TODO: Absolute directory?
-                return self::literalStringUnionType(\dirname($this->context->getFile()));
+                return self::literalStringUnionType(\dirname(Config::projectPath($this->context->getFile())));
             case ast\flags\MAGIC_FILE:
-                return self::literalStringUnionType($this->context->getFile());
+                return self::literalStringUnionType(Config::projectPath($this->context->getFile()));
             case ast\flags\MAGIC_LINE:
                 return self::literalIntUnionType($node->lineno);
             case ast\flags\MAGIC_NAMESPACE:

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -33,6 +33,8 @@ class Issue
     const ClassContainsAbstractMethodInternal = 'PhanClassContainsAbstractMethodInternal';
     const ClassContainsAbstractMethod = 'PhanClassContainsAbstractMethod';
     const EmptyFile                 = 'PhanEmptyFile';
+    const MissingRequireFile        = 'PhanMissingRequireFile';
+    const InvalidRequireFile        = 'PhanInvalidRequireFile';
     const ParentlessClass           = 'PhanParentlessClass';
     const RequiredTraitNotAdded     = 'PhanRequiredTraitNotAdded';
     const TraitParentReference      = 'PhanTraitParentReference';
@@ -158,6 +160,9 @@ class Issue
     const TypeInvalidMethodName           = 'PhanTypeInvalidMethodName';
     const TypeInvalidStaticMethodName     = 'PhanTypeInvalidStaticMethodName';
     const TypeInvalidCallableMethodName   = 'PhanTypeInvalidCallableMethodName';
+    const TypeInvalidRequire              = 'PhanTypeInvalidRequire';
+    const TypeInvalidEval                 = 'PhanTypeInvalidEval';
+    const RelativePathUsed                = 'PhanRelativePathUsed';
 
     // Issue::CATEGORY_ANALYSIS
     const Unanalyzable              = 'PhanUnanalyzable';
@@ -621,6 +626,22 @@ class Issue
                 "Empty file {FILE}",
                 self::REMEDIATION_B,
                 11000
+            ),
+            new Issue(
+                self::MissingRequireFile,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_NORMAL,
+                "Missing required file {FILE}",
+                self::REMEDIATION_B,
+                11040
+            ),
+            new Issue(
+                self::InvalidRequireFile,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_NORMAL,
+                "Required file {FILE} is not a file",
+                self::REMEDIATION_B,
+                11041
             ),
             new Issue(
                 self::ParentlessClass,
@@ -1643,7 +1664,30 @@ class Issue
                 self::REMEDIATION_B,
                 10084
             ),
-
+            new Issue(
+                self::TypeInvalidRequire,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                "Require statement was passed an invalid expression of type {TYPE} (expected a string)",
+                self::REMEDIATION_B,
+                10085
+            ),
+            new Issue(
+                self::TypeInvalidEval,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                "Eval statement was passed an invalid expression of type {TYPE} (expected a string)",
+                self::REMEDIATION_B,
+                10086
+            ),
+            new Issue(
+                self::RelativePathUsed,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                "{FUNCTION}() statement was passed a relative path {STRING_LITERAL} instead of an absolute path",
+                self::REMEDIATION_B,
+                10087
+            ),
             // Issue::CATEGORY_VARIABLE
             new Issue(
                 self::VariableUseClause,

--- a/src/Phan/Library/Paths.php
+++ b/src/Phan/Library/Paths.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+namespace Phan\Library;
+
+/**
+ * Utilities for working with paths
+ */
+class Paths
+{
+    /**
+     * @return bool
+     * Is the passed in path already an absolute path?
+     */
+    public static function isAbsolutePath(string $path) : bool
+    {
+        // Make sure it's actually relative
+        if (\DIRECTORY_SEPARATOR === \substr($path, 0, 1)) {
+            return true;
+        }
+        // Check for absolute path in windows, e.g. C:\
+        if (\DIRECTORY_SEPARATOR === "\\" &&
+                \strlen($path) > 3 &&
+                \ctype_alpha($path[0]) &&
+                $path[1] === ':' &&
+                \strspn($path, '/\\', 2, 1)) {
+            return true;
+        }
+        return false;
+    }
+
+
+    /**
+     * Returns $path as an absolute path using $absolute_path as the starting folder.
+     * Returns $path unmodified if $path is already absolute.
+     *
+     * @param string $absolute_directory the path to use when converting $path from a relative path to an absolute path.
+     * @param string $path a relative or absolute path
+     */
+    public static function toAbsolutePath(string $absolute_directory, string $path) : string
+    {
+        if (Paths::isAbsolutePath($path)) {
+            return $path;
+        }
+        $path = \preg_replace('@^(\.[\\\\/]+)+@', '', $path);
+        if ($path === '.') {
+            return $absolute_directory;
+        }
+
+        return $absolute_directory . DIRECTORY_SEPARATOR .  $path;
+    }
+
+    public static function escapePathForIssue(string $path) : string
+    {
+        // If possible, use json_encode.
+        // If json_encode failed (e.g. invalid unicode), then use var_export
+        return json_encode($path, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: var_export($path, true);
+    }
+}

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -35,6 +35,7 @@ use Phan\Plugin\Internal\DependentReturnTypeOverridePlugin;
 use Phan\Plugin\Internal\MiscParamPlugin;
 use Phan\Plugin\Internal\NodeSelectionPlugin;
 use Phan\Plugin\Internal\NodeSelectionVisitor;
+use Phan\Plugin\Internal\RequireExistsPlugin;
 use Phan\Plugin\Internal\StringFunctionPlugin;
 use Phan\Plugin\Internal\ThrowAnalyzerPlugin;
 use Phan\Plugin\Internal\VariableTrackerPlugin;
@@ -747,6 +748,7 @@ final class ConfigPluginSet extends PluginV2 implements
             ];
             $plugin_set = array_merge($internal_return_type_plugins, $plugin_set);
         }
+        $plugin_set[] = new RequireExistsPlugin();
         if (Config::getValue('warn_about_undocumented_throw_statements')) {
             $plugin_set[] = new ThrowAnalyzerPlugin();
         }

--- a/src/Phan/Plugin/Internal/RequireExistsPlugin.php
+++ b/src/Phan/Plugin/Internal/RequireExistsPlugin.php
@@ -1,0 +1,140 @@
+<?php declare(strict_types=1);
+namespace Phan\Plugin\Internal;
+
+use ast;
+use ast\flags;
+use ast\Node;
+use Phan\AST\ContextNode;
+use Phan\AST\UnionTypeVisitor;
+use Phan\Config;
+use Phan\Issue;
+use Phan\Language\Type\StringType;
+use Phan\Library\Paths;
+use Phan\PluginV2;
+use Phan\PluginV2\PluginAwarePostAnalysisVisitor;
+use Phan\PluginV2\PostAnalyzeNodeCapability;
+
+use function file_exists;
+use function is_file;
+
+/**
+ * Analyzes require/include/require_once/include_once statements to check if the file exists
+ */
+class RequireExistsPlugin extends PluginV2 implements PostAnalyzeNodeCapability
+{
+    public static function getPostAnalyzeNodeVisitorClassName() : string
+    {
+        return RequireExistsVisitor::class;
+    }
+}
+
+/**
+ * Visits require/include/require_once/include_once statements to check if the file exists
+ */
+class RequireExistsVisitor extends PluginAwarePostAnalysisVisitor
+{
+    /**
+     * @return void
+     * @override
+     */
+    public function visitIncludeOrEval(Node $node)
+    {
+        if ($node->flags === ast\flags\EXEC_EVAL) {
+            $this->analyzeEval($node);
+            return;
+        }
+        $expr = $node->children['expr'];
+        if ($expr instanceof Node) {
+            $path = (new ContextNode($this->code_base, $this->context, $expr))->getEquivalentPHPScalarValue();
+        } else {
+            $path = $expr;
+        }
+
+        if (!is_string($path)) {
+            $type = UnionTypeVisitor::unionTypeFromNode($this->code_base, $this->context, $expr);
+            if (!$type->canCastToUnionType(StringType::instance(false)->asUnionType())) {
+                $this->emitIssue(
+                    Issue::TypeInvalidRequire,
+                    $expr->lineno ?? $node->lineno,
+                    $type
+                );
+            }
+            return;
+        }
+        $this->checkPathExistsInContext($node, $path);
+    }
+
+    private function analyzeEval(Node $node)
+    {
+        $expr = $node->children['expr'];
+        $type = UnionTypeVisitor::unionTypeFromNode($this->code_base, $this->context, $expr);
+        if (!$type->canCastToUnionType(StringType::instance(false)->asUnionType())) {
+            $this->emitIssue(
+                Issue::TypeInvalidEval,
+                $expr->lineno ?? $node->lineno,
+                $type
+            );
+        }
+    }
+
+    /**
+     * Check if the path provided to include()/require_once()/etc is valid.
+     */
+    private function checkPathExistsInContext(Node $node, string $relative_path)
+    {
+        $absolute_path = $this->getAbsolutePath($node, $relative_path);
+        if (!file_exists($absolute_path)) {
+            $this->emitIssue(
+                Issue::MissingRequireFile,
+                $node->children['expr']->lineno ?? $node->lineno,
+                Paths::escapePathForIssue($relative_path)
+            );
+            return;
+        }
+        if (!is_file($absolute_path)) {
+            $this->emitIssue(
+                Issue::InvalidRequireFile,
+                $node->children['expr']->lineno ?? $node->lineno,
+                Paths::escapePathForIssue($relative_path)
+            );
+            return;
+        }
+    }
+
+    const EXEC_NODE_FLAG_NAMES = [
+        flags\EXEC_EVAL => 'eval',
+        flags\EXEC_INCLUDE => 'include',
+        flags\EXEC_INCLUDE_ONCE => 'include_once',
+        flags\EXEC_REQUIRE => 'require',
+        flags\EXEC_REQUIRE_ONCE => 'require_once',
+    ];
+
+    private function getAbsolutePath(Node $node, string $relative_path) : string
+    {
+        if (Paths::isAbsolutePath($relative_path)) {
+            return $relative_path;
+        }
+
+        if (Config::getValue('warn_about_relative_include_statement')) {
+            $this->emitIssue(
+                Issue::RelativePathUsed,
+                $node->children['exec']->lineno ?? $node->lineno,
+                self::EXEC_NODE_FLAG_NAMES[$node->flags] ?? 'unknown',
+                Paths::escapePathForIssue($relative_path)
+            );
+        }
+
+        $first_absolute_path = '(unknown)';
+        foreach (Config::getValue('include_paths') ?: ['.'] as $include_path) {
+            if (!Paths::isAbsolutePath($include_path)) {
+                $include_path = Paths::toAbsolutePath(\dirname(Config::projectPath($this->context->getFile())), $include_path);
+            }
+            $absolute_path = Paths::toAbsolutePath($include_path, $relative_path);
+            if (file_exists($absolute_path)) {
+                return $absolute_path;
+            }
+            $first_absolute_path = $first_absolute_path ?? $absolute_path;
+        }
+        return $first_absolute_path;
+    }
+}

--- a/src/codebase.php
+++ b/src/codebase.php
@@ -7,10 +7,12 @@ $internal_trait_name_list = get_declared_traits();
 $internal_function_name_list = get_defined_functions()['internal'];
 
 if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
-  // This is the normal path when Phan is installed only in the scope of a project.
+    // This is the path to autoload.php when Phan is installed globally.
+    // @phan-suppress-next-line PhanMissingRequireFile
     require_once __DIR__ . '/../vendor/autoload.php';
 } else {
-  // This is the path to autoload.php when Phan is installed globally.
+    // This is the normal path when Phan is installed only in the scope of a project.
+    // @phan-suppress-next-line PhanMissingRequireFile
     require_once __DIR__ . '/../../../autoload.php';
 }
 

--- a/tests/.phan_for_test/config.php
+++ b/tests/.phan_for_test/config.php
@@ -82,4 +82,22 @@ return [
     // Set this to `PHP_INT_MAX` (or other large value) to always suggesting similar names to other namespaces.
     // (Phan will be a bit slower when this config setting is a larger value)
     'suggestion_check_limit' => PHP_INT_MAX,
+
+    // Increase the string length tracked in this test so that Phan can check dynamic require_once paths.
+    'max_literal_string_type_length' => 2000,
+
+    // A list of include paths to check when checking if `require_once`, `include`, etc. are valid.
+    //
+    // To refer to the directory of the file being analyzed, use `'.'`
+    // To refer to the project root directory, you must use \Phan\Config::getProjectRootDirectory()
+    //
+    // (E.g. `['.', \Phan\Config::getProjectRootDirectory() . '/src/folder-added-to-include_path']`)
+    'include_paths' => [
+        '.',
+        \Phan\Config::getProjectRootDirectory() . '/tests/files/include',
+    ],
+
+    // Enable this to warn about the use of relative paths in `require_once`, `include`, etc.
+    // Relative paths are harder to reason about, and opcache may have issues with relative paths in edge cases.
+    'warn_about_relative_include_statement' => true,
 ];

--- a/tests/files/expected/0338_magic_const_types.php.expected
+++ b/tests/files/expected/0338_magic_const_types.php.expected
@@ -3,7 +3,7 @@
 %s:16 PhanTypeMismatchArgument Argument 1 (x) is '%s' but \expect_int338() takes int defined at %s:3
 %s:17 PhanTypeMismatchArgument Argument 1 (x) is 17 but \expect_string338() takes string defined at %s:4
 %s:18 PhanTypeMismatchArgument Argument 1 (x) is '\\Test338' but \expect_int338() takes int defined at %s:3
-%s:19 PhanTypeMismatchArgument Argument 1 (x) is './tests/files/src' but \expect_int338() takes int defined at %s:3
+%s:19 PhanTypeMismatchArgument Argument 1 (x) is '%stests/files/src' but \expect_int338() takes int defined at %s:3
 %s:20 PhanTypeMismatchArgument Argument 1 (x) is 'test' but \expect_int338() takes int defined at %s:3
 %s:21 PhanTypeMismatchArgument Argument 1 (x) is 'Test338::test' but \expect_int338() takes int defined at %s:3
 %s:22 PhanTypeMismatchArgument Argument 1 (x) is '' but \expect_int338() takes int defined at %s:3

--- a/tests/files/expected/0545_require_testing.php.expected
+++ b/tests/files/expected/0545_require_testing.php.expected
@@ -1,0 +1,14 @@
+%s:2 PhanTypeInvalidRequire Require statement was passed an invalid expression of type array{} (expected a string)
+%s:3 PhanTypeInvalidRequire Require statement was passed an invalid expression of type \stdClass (expected a string)
+%s:4 PhanTypeInvalidRequire Require statement was passed an invalid expression of type 11 (expected a string)
+%s:5 PhanInvalidRequireFile Required file "" is not a file
+%s:5 PhanRelativePathUsed require_once() statement was passed a relative path "" instead of an absolute path
+%s:6 PhanInvalidRequireFile Required file "." is not a file
+%s:6 PhanRelativePathUsed include_once() statement was passed a relative path "." instead of an absolute path
+%s:7 PhanInvalidRequireFile Required file "%stests%sfiles%ssrc" is not a file
+%s:8 PhanInvalidRequireFile Required file "%stests%sfiles%ssrc/.." is not a file
+%s:9 PhanRelativePathUsed require_once() statement was passed a relative path "file_found_in_include_folder.php" instead of an absolute path
+%s:10 PhanMissingRequireFile Missing required file "file_missing_from_any_folder.php"
+%s:10 PhanRelativePathUsed require_once() statement was passed a relative path "file_missing_from_any_folder.php" instead of an absolute path
+%s:11 PhanMissingRequireFile Missing required file "%s/src/file_missing_from_any_folder.php"
+%s:12 PhanRelativePathUsed require_once() statement was passed a relative path "0101_one_of_each.php" instead of an absolute path

--- a/tests/files/expected/0546_require_other_testing.php.expected
+++ b/tests/files/expected/0546_require_other_testing.php.expected
@@ -1,0 +1,17 @@
+%s:2 PhanTypeInvalidRequire Require statement was passed an invalid expression of type array{} (expected a string)
+%s:3 PhanTypeInvalidRequire Require statement was passed an invalid expression of type array{} (expected a string)
+%s:4 PhanTypeInvalidRequire Require statement was passed an invalid expression of type array{} (expected a string)
+%s:5 PhanTypeInvalidRequire Require statement was passed an invalid expression of type array{} (expected a string)
+%s:6 PhanTypeInvalidRequire Require statement was passed an invalid expression of type \stdClass (expected a string)
+%s:7 PhanTypeInvalidEval Eval statement was passed an invalid expression of type array{} (expected a string)
+%s:8 PhanTypeInvalidRequire Require statement was passed an invalid expression of type false (expected a string)
+%s:9 PhanTypeInvalidRequire Require statement was passed an invalid expression of type float (expected a string)
+%s:11 PhanMissingRequireFile Missing required file "%stests%sfiles%ssrc%s0529_require_once.php"
+%s:12 PhanInvalidRequireFile Required file "" is not a file
+%s:12 PhanRelativePathUsed require_once() statement was passed a relative path "" instead of an absolute path
+%s:13 PhanInvalidRequireFile Required file "/" is not a file
+%s:14 PhanMissingRequireFile Missing required file "%stests%sfiles%ssrc%s0546_require_other_testing.php.missing"
+%s:15 PhanMissingRequireFile Missing required file "%stests%sfiles%ssrc%smissing"
+%s:16 PhanInvalidRequireFile Required file "%stests%sfiles%ssrc" is not a file
+%s:17 PhanMissingRequireFile Missing required file "file:///notarealpath"
+%s:17 PhanRelativePathUsed require_once() statement was passed a relative path "file:///notarealpath" instead of an absolute path

--- a/tests/files/include/file_found_in_include_folder.php
+++ b/tests/files/include/file_found_in_include_folder.php
@@ -1,0 +1,2 @@
+<?php
+// This is a placeholder for testing Phan's analysis of require() statements.

--- a/tests/files/src/0545_require_testing.php
+++ b/tests/files/src/0545_require_testing.php
@@ -1,0 +1,13 @@
+<?php
+require_once [];
+require_once (new stdClass());
+require_once 11;
+require_once '';
+include_once '.';
+require __DIR__;
+include __DIR__ . '/..';
+require_once 'file_found_in_include_folder.php';  // should not warn about missing file
+require_once 'file_missing_from_any_folder.php';
+require_once __DIR__ . '/file_missing_from_any_folder.php';
+require_once '0101_one_of_each.php';  // should not warn about missing file
+require_once __DIR__ . '/0101_one_of_each.php';  // should not warn about missing file

--- a/tests/files/src/0546_require_other_testing.php
+++ b/tests/files/src/0546_require_other_testing.php
@@ -1,0 +1,17 @@
+<?php
+require_once [];  // invalid
+include_once [];  // invalid
+include [];  // invalid
+require [];  // invalid
+require (new stdClass());  // invalid
+eval([]);  // invalid
+require_once false;  // invalid
+require_once 2.5;  // invalid
+require_once __FILE__;  // valid but questionable
+require_once __DIR__ . '/0529_require_once.php';  // valid but questionable
+require_once '';
+require_once '/';
+require_once __FILE__ . '.missing';  // valid but insane
+require_once __DIR__ . '/missing';  // valid but insane
+require_once __DIR__;  // valid but questionable
+require_once 'file:///notarealpath';  // Phan does not understand this, and treats it like a regular path

--- a/tests/multi_files/expected/321.php.expected
+++ b/tests/multi_files/expected/321.php.expected
@@ -1,0 +1,1 @@
+%s:3 PhanMissingRequireFile Missing required file "321.php"

--- a/tests/plugin_test/test.sh
+++ b/tests/plugin_test/test.sh
@@ -17,8 +17,8 @@ rm $ACTUAL_PATH -f || exit 1
 # We use the polyfill parser because it behaves consistently in all php versions.
 ../../phan --force-polyfill-parser --memory-limit 1G | tee $ACTUAL_PATH
 
-sed -i 's,\<closure_[0-9a-f]\{12\}\>,closure_%s,g' $ACTUAL_PATH
-sed -i 's,\<closure_[0-9a-f]\{12\}\>,closure_%s,g' $EXPECTED_PATH
+sed -i 's,\<closure_[0-9a-f]\{12\}\>,closure_%s,g' $ACTUAL_PATH $EXPECTED_PATH
+sed -i "s,[^\\']*plugin_test[/\\\\],,g" $ACTUAL_PATH $EXPECTED_PATH
 # php 7.3 compat
 sed -i 's,missing closing parenthesis,missing ),g' $ACTUAL_PATH
 


### PR DESCRIPTION
And warn when non-strings are passed to eval().

See NEWS.md for more details.