### PR TITLE
Properly type check `static::someMethodName()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,10 @@ New features(Analysis):
 
   New annotations: `@phan-read-only` and `@phan-write-only` (on its own line) in the doc comment of a real property.
 
+Bug fixes:
++ Properly type check `static::someMethodName()`.
+  Previously, Phan would fail to infer types for the results of those method calls.
+
 22 Oct 2018, Phan 1.1.1
 -----------------------
 

--- a/internal/internalsignatures.php
+++ b/internal/internalsignatures.php
@@ -89,7 +89,7 @@ EOT;
     }
 
     /**
-     * @return array|null
+     * @return array
      */
     private function updateSignature(string $function_like_name, array $arguments_from_phan)
     {

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -71,6 +71,13 @@ if (!class_exists('ast\Node')) {
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
+ *
+ * NOTE: EchoExpression can get converted to multiple `ast\Node`s (e.g. for `echo 'first', 'second';`, which is why this has so many partial mismatches.
+ * The current version of tolerant-php-parser prevents EchoExpression (and UnsetIntrinsicExpression) from being anything other than a top-level statement.
+ *
+ * @phan-file-suppress PhanPartialTypeMismatchReturn
+ * @phan-file-suppress PhanPartialTypeMismatchArgument
+ * @phan-file-suppress PhanPartialTypeMismatchArgumentInternal
  */
 class TolerantASTConverter
 {
@@ -279,7 +286,7 @@ class TolerantASTConverter
                 continue;
             }
             if (\is_array($child_node)) {
-                // Echo_ returns multiple children.
+                // EchoExpression returns multiple children.
                 foreach ($child_node as $child_node_part) {
                     $children[] = $child_node_part;
                 }
@@ -309,7 +316,7 @@ class TolerantASTConverter
             }
             $child_node = static::phpParserNodeToAstNode($expr);
             if (\is_array($child_node)) {
-                // Echo_ returns multiple children in php-ast
+                // EchoExpression returns multiple children in php-ast
                 foreach ($child_node as $child_node_part) {
                     $children[] = $child_node_part;
                 }
@@ -362,7 +369,7 @@ class TolerantASTConverter
 
     /**
      * @param PhpParser\Node|Token $n - The node from PHP-Parser
-     * @return ast\Node|ast\Node[]|string|int|float|bool - whatever ast\parse_code would return as the equivalent.
+     * @return ast\Node|ast\Node[]|string|int|float|bool|null - whatever ast\parse_code would return as the equivalent.
      * @throws InvalidNodeException when self::$should_add_placeholders is false, like many of these methods.
      */
     protected static function phpParserNodeToAstNodeOrPlaceholderExpr($n)
@@ -1021,7 +1028,7 @@ class TolerantASTConverter
                 foreach ($n->statements as $parser_node) {
                     $child_node = static::phpParserNodeToAstNode($parser_node);
                     if (\is_array($child_node)) {
-                        // Echo_ returns multiple children.
+                        // EchoExpression returns multiple children.
                         foreach ($child_node as $child_node_part) {
                             $children[] = $child_node_part;
                         }

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverterWithNodeMapping.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverterWithNodeMapping.php
@@ -233,7 +233,7 @@ class TolerantASTConverterWithNodeMapping extends TolerantASTConverter
 
     /**
      * @param PhpParser\Node|Token $n - The node from PHP-Parser
-     * @return ast\Node|ast\Node[]|string|int|float|bool - whatever ast\parse_code would return as the equivalent.
+     * @return ast\Node|ast\Node[]|string|int|float|bool|null - whatever ast\parse_code would return as the equivalent.
      * @throws InvalidNodeException when self::$should_add_placeholders is false, like many of these methods.
      * @override
      */

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -2443,7 +2443,7 @@ class UnionTypeVisitor extends AnalysisVisitor
             $this->code_base,
             $this->context,
             $node
-        );
+        )->withStaticResolvedInContext($this->context);
 
         // Iterate over each viable class type to see if any
         // have the constant we're looking for

--- a/tests/files/expected/0552_test_static.php.expected
+++ b/tests/files/expected/0552_test_static.php.expected
@@ -1,0 +1,2 @@
+%s:34 PhanTypeSuspiciousEcho Suspicious argument \Subclass552 for an echo/print statement
+%s:38 PhanTypeSuspiciousEcho Suspicious argument \Subclass552 for an echo/print statement

--- a/tests/files/src/0552_test_static.php
+++ b/tests/files/src/0552_test_static.php
@@ -1,0 +1,40 @@
+<?php
+
+abstract class Base552 {
+    /** @return Base552 */
+    public abstract static function foo() : Base552;
+
+    /** @param int $x not using parameter type widening for real parameters - that was added in 7.2 */
+    public function test($x) {
+        var_export($x);
+    }
+}
+
+class Subclass552 extends Base552 {
+    /**
+     * @return static this subclass should take priority over the declared return type.
+     */
+    public static function foo() : Base552 {
+        return new static();
+    }
+
+    public function methodOfSubclass() {
+        echo "in method\n";
+    }
+
+    /** @param mixed $x */
+    public function test($x) {
+        var_export($x);
+    }
+
+    public static function main() {
+        $s = static::foo();
+        $s->methodOfSubclass();
+        $s->test('str');
+        echo $s;
+        $s2 = (new static())->foo();
+        $s2->methodOfSubclass();
+        $s2->test('str');
+        echo $s2;
+    }
+}


### PR DESCRIPTION
Previously, Phan would fail to infer types for the results of those
method calls.