### PR TITLE
Avoid recursion when checking if the element in scope exists

### DIFF
--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -389,6 +389,7 @@ class Context extends FileRef
      * @return bool
      * True if this context is currently within a property
      * scope, else false.
+     * @suppress PhanUnreferencedPublicMethod
      */
     public function isInPropertyScope() : bool
     {
@@ -418,7 +419,7 @@ class Context extends FileRef
      */
     public function getClassInScope(CodeBase $code_base) : Clazz
     {
-        if (!$this->isInClassScope()) {
+        if (!$this->scope->isInClassScope()) {
             throw new AssertionError("Must be in class scope to get class");
         }
 
@@ -447,7 +448,7 @@ class Context extends FileRef
      */
     public function getPropertyInScope(CodeBase $code_base) : Property
     {
-        if (!$this->isInPropertyScope()) {
+        if (!$this->scope->isInPropertyScope()) {
             throw new AssertionError("Must be in property scope to get property");
         }
 
@@ -480,10 +481,7 @@ class Context extends FileRef
      */
     public function isInMethodScope() : bool
     {
-        return (
-            $this->isInClassScope()
-            && $this->isInFunctionLikeScope()
-        );
+        return $this->scope->isInMethodLikeScope();
     }
 
     /**
@@ -534,13 +532,11 @@ class Context extends FileRef
      * True if we're within the scope of a class, method,
      * function or closure. False if we're in the global
      * scope
+     * @suppress PhanUnreferencedPublicMethod
      */
     public function isInElementScope() : bool
     {
-        return (
-            $this->isInFunctionLikeScope()
-            || $this->isInClassScope()  // isInPropertyScope implies isInClassScope
-        );
+        return $this->scope->isInElementScope();
     }
 
     /**
@@ -550,7 +546,7 @@ class Context extends FileRef
      */
     public function isInGlobalScope() : bool
     {
-        return !$this->isInElementScope();
+        return !$this->scope->isInElementScope();
     }
 
     /**
@@ -567,11 +563,11 @@ class Context extends FileRef
      */
     public function getElementInScope(CodeBase $code_base) : TypedElement
     {
-        if ($this->isInFunctionLikeScope()) {
+        if ($this->scope->isInFunctionLikeScope()) {
             return $this->getFunctionLikeInScope($code_base);
-        } elseif ($this->isInPropertyScope()) {
+        } elseif ($this->scope->isInPropertyScope()) {
             return $this->getPropertyInScope($code_base);
-        } elseif ($this->isInClassScope()) {
+        } elseif ($this->scope->isInClassScope()) {
             return $this->getClassInScope($code_base);
         }
 
@@ -597,7 +593,7 @@ class Context extends FileRef
         if ($code_base->hasFileLevelSuppression($this->getFile(), $issue_name)) {
             return true;
         }
-        if (!$this->isInElementScope()) {
+        if (!$this->scope->isInElementScope()) {
             return false;
         }
 

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -136,7 +136,8 @@ class Clazz extends AddressableElement
 
         $this->setInternalScope(new ClassScope(
             $context->getScope(),
-            $fqsen
+            $fqsen,
+            $flags
         ));
     }
 
@@ -202,6 +203,8 @@ class Clazz extends AddressableElement
             $clazz->addAdditionalType(IterableType::instance(false));
         }
 
+        $class_scope = new ClassScope(new GlobalScope(), $class_fqsen, $flags);
+
         // Note: If there are multiple calls to Clazz->addProperty(),
         // the UnionType from the first one will be used, subsequent calls to addProperty()
         // will have no effect.
@@ -217,9 +220,7 @@ class Clazz extends AddressableElement
                 continue;
             }
 
-            $property_context = $context->withScope(
-                new ClassScope(new GlobalScope(), $clazz->getFQSEN())
-            );
+            $property_context = $context->withScope($class_scope);
 
             $property_type =
                 UnionType::fromStringInContext(
@@ -251,9 +252,7 @@ class Clazz extends AddressableElement
         //       `$class->getStaticProperties()`.
 
         foreach ($class->getDefaultProperties() as $name => $value) {
-            $property_context = $context->withScope(
-                new ClassScope(new GlobalScope(), $clazz->getFQSEN())
-            );
+            $property_context = $context->withScope($class_scope);
 
             $property_fqsen = FullyQualifiedPropertyName::make(
                 $clazz->getFQSEN(),
@@ -308,9 +307,7 @@ class Clazz extends AddressableElement
         }
 
         foreach ($class->getMethods() as $reflection_method) {
-            $method_context = $context->withScope(
-                new ClassScope(new GlobalScope(), $clazz->getFQSEN())
-            );
+            $method_context = $context->withScope($class_scope);
 
             $method_list =
                 FunctionFactory::methodListFromReflectionClassAndMethod(

--- a/src/Phan/Language/Scope/BranchScope.php
+++ b/src/Phan/Language/Scope/BranchScope.php
@@ -13,6 +13,10 @@ use Phan\Language\Scope;
  */
 class BranchScope extends Scope
 {
+    public function __construct(Scope $scope)
+    {
+        parent::__construct($scope, null, $scope->flags);
+    }
 
     /**
      * @return bool
@@ -50,15 +54,6 @@ class BranchScope extends Scope
     }
 
     /**
-     * @return bool
-     * True if we're in a class scope
-     */
-    public function isInClassScope() : bool
-    {
-        return $this->parent_scope->isInClassScope();
-    }
-
-    /**
      * @return FullyQualifiedClassName
      * Crawl the scope hierarchy to get a class FQSEN.
      */
@@ -84,14 +79,5 @@ class BranchScope extends Scope
     public function getFunctionLikeFQSEN()
     {
         return $this->parent_scope->getFunctionLikeFQSEN();
-    }
-
-    /**
-     * @return bool
-     * True if we're in a class scope
-     */
-    public function isInFunctionLikeScope() : bool
-    {
-        return $this->parent_scope->isInFunctionLikeScope();
     }
 }

--- a/src/Phan/Language/Scope/ClassScope.php
+++ b/src/Phan/Language/Scope/ClassScope.php
@@ -3,12 +3,30 @@ namespace Phan\Language\Scope;
 
 use AssertionError;
 use Phan\Language\FQSEN\FullyQualifiedClassName;
+use Phan\Language\Scope;
 
 /**
  * Phan's representation of the scope within a class declaration.
  */
 class ClassScope extends ClosedScope
 {
+    const IN_CLASS_OR_PROPERTY_SCOPE = Scope::IN_CLASS_LIKE_SCOPE | Scope::IN_PROPERTY_SCOPE;
+
+    public function __construct(
+        Scope $parent_scope,
+        FullyQualifiedClassName $fqsen,
+        int $ast_flags
+    ) {
+        $this->parent_scope = $parent_scope;
+        $this->fqsen = $fqsen;
+        $flags = ($parent_scope->flags & ~self::IN_CLASS_OR_PROPERTY_SCOPE) | Scope::IN_CLASS_SCOPE;
+        if ($ast_flags & \ast\flags\CLASS_TRAIT) {
+            $flags |= Scope::IN_TRAIT_SCOPE;
+        } elseif ($ast_flags & \ast\flags\CLASS_INTERFACE) {
+            $flags |= Scope::IN_INTERFACE_SCOPE;
+        }
+        $this->flags = $flags;
+    }
 
     /**
      * @return bool

--- a/src/Phan/Language/Scope/ClosureScope.php
+++ b/src/Phan/Language/Scope/ClosureScope.php
@@ -2,6 +2,8 @@
 namespace Phan\Language\Scope;
 
 use Phan\Language\FQSEN\FullyQualifiedClassName;
+use Phan\Language\FQSEN\FullyQualifiedFunctionName;
+use Phan\Language\Scope;
 
 /**
  * Represents the Scope of a closure declaration, used by a Closure's Context.
@@ -10,6 +12,15 @@ use Phan\Language\FQSEN\FullyQualifiedClassName;
  */
 class ClosureScope extends FunctionLikeScope
 {
+    public function __construct(
+        Scope $parent_scope,
+        FullyQualifiedFunctionName $fqsen
+    ) {
+        $this->parent_scope = $parent_scope;
+        $this->fqsen = $fqsen;
+        $this->flags = $parent_scope->flags | Scope::IN_FUNCTION_LIKE_SCOPE;
+    }
+
     /**
      * The optional FQSEN of an (at)phan-closure-scope annotation. (an annotation used for closures that will be bound to a different class)
      * @var FullyQualifiedClassName|null
@@ -22,6 +33,7 @@ class ClosureScope extends FunctionLikeScope
      */
     public function overrideClassFQSEN(FullyQualifiedClassName $fqsen = null)
     {
+        $this->flags |= Scope::IN_CLASS_SCOPE;
         $this->override_class_fqsen = $fqsen;
     }
 
@@ -33,18 +45,6 @@ class ClosureScope extends FunctionLikeScope
     public function getOverrideClassFQSEN()
     {
         return $this->override_class_fqsen;
-    }
-
-    /**
-     * @return bool
-     * True if this closure should be analyzed as if we're in a class scope
-     */
-    public function isInClassScope() : bool
-    {
-        if ($this->override_class_fqsen !== null) {
-            return true;
-        }
-        return parent::isInClassScope();
     }
 
     /**

--- a/src/Phan/Language/Scope/FunctionLikeScope.php
+++ b/src/Phan/Language/Scope/FunctionLikeScope.php
@@ -1,9 +1,11 @@
 <?php declare(strict_types=1);
 namespace Phan\Language\Scope;
 
+use Phan\Language\FQSEN;
 use Phan\Language\FQSEN\FullyQualifiedClassName;
 use Phan\Language\FQSEN\FullyQualifiedFunctionName;
 use Phan\Language\FQSEN\FullyQualifiedMethodName;
+use Phan\Language\Scope;
 
 /**
  * The scope of a function, method, or closure.
@@ -11,13 +13,13 @@ use Phan\Language\FQSEN\FullyQualifiedMethodName;
  */
 class FunctionLikeScope extends ClosedScope
 {
-    /**
-     * @return bool
-     * True if we're in a class scope
-     */
-    public function isInClassScope() : bool
-    {
-        return $this->parent_scope->isInClassScope();
+    public function __construct(
+        Scope $parent_scope,
+        FQSEN $fqsen
+    ) {
+        $this->parent_scope = $parent_scope;
+        $this->fqsen = $fqsen;
+        $this->flags = $parent_scope->flags | Scope::IN_FUNCTION_LIKE_SCOPE;
     }
 
     /**
@@ -55,6 +57,15 @@ class FunctionLikeScope extends ClosedScope
     public function isInPropertyScope() : bool
     {
         return false;
+    }
+
+    /**
+     * @return bool
+     * True if we're in a class-like scope
+     */
+    public function isInMethodLikeScope() : bool
+    {
+        return ($this->flags & self::IN_CLASS_LIKE_SCOPE) !== 0;
     }
 
     /**

--- a/src/Phan/Language/Scope/GlobalScope.php
+++ b/src/Phan/Language/Scope/GlobalScope.php
@@ -1,7 +1,10 @@
 <?php declare(strict_types=1);
 namespace Phan\Language\Scope;
 
+use AssertionError;
 use Phan\Language\Element\Variable;
+use Phan\Language\FQSEN\FullyQualifiedClassName;
+use Phan\Language\FQSEN\FullyQualifiedPropertyName;
 use Phan\Language\Scope;
 
 /**
@@ -9,6 +12,12 @@ use Phan\Language\Scope;
  */
 class GlobalScope extends Scope
 {
+    /**
+     * Deliberate no-op
+     */
+    public function __construct()
+    {
+    }
 
     /**
      * @var array<string,Variable>
@@ -33,6 +42,26 @@ class GlobalScope extends Scope
     public function isInFunctionLikeScope() : bool
     {
         return false;
+    }
+
+    public function isInElementScope() : bool
+    {
+        return false;
+    }
+
+    public function isInMethodLikeScope() : bool
+    {
+        return false;
+    }
+
+    public function hasAnyTemplateType() : bool
+    {
+        return false;
+    }
+
+    public function getTemplateTypeMap() : array
+    {
+        return [];
     }
 
     /**
@@ -116,5 +145,53 @@ class GlobalScope extends Scope
     public function getGlobalVariableByName(string $name) : Variable
     {
         return $this->getVariableByName($name);
+    }
+
+    /**
+     * @return bool
+     * True if this scope has a parent scope
+     */
+    public function hasParentScope() : bool
+    {
+        return false;
+    }
+
+    /**
+     * @return Scope
+     * Get the parent scope of this scope
+     * @suppress PhanPossiblyNullTypeReturn callers should call hasParentScope
+     */
+    public function getParentScope() : Scope
+    {
+        throw new AssertionError("Global scope has no parent scope");
+    }
+
+    public function getClassFQSEN() : FullyQualifiedClassName
+    {
+        throw new AssertionError("Cannot get class FQSEN on scope");
+    }
+
+    public function getPropertyFQSEN() : FullyQualifiedPropertyName
+    {
+        throw new AssertionError("Cannot get class FQSEN on scope");
+    }
+
+    /**
+     * @return null
+     */
+    public function getClassFQSENOrNull()
+    {
+        return null;
+    }
+
+    public function getFunctionLikeFQSEN()
+    {
+        throw new AssertionError("Cannot get method/function/closure FQSEN on scope");
+    }
+
+    public function hasTemplateType(
+        string $unused_template_type_identifier
+    ) : bool {
+        return false;
     }
 }

--- a/src/Phan/Language/Scope/PropertyScope.php
+++ b/src/Phan/Language/Scope/PropertyScope.php
@@ -3,12 +3,21 @@ namespace Phan\Language\Scope;
 
 use Phan\Language\FQSEN\FullyQualifiedClassName;
 use Phan\Language\FQSEN\FullyQualifiedPropertyName;
+use Phan\Language\Scope;
 
 /**
  * Represents the Scope of the Context of a class's property declaration.
  */
 class PropertyScope extends ClosedScope
 {
+    public function __construct(
+        Scope $parent_scope,
+        FullyQualifiedPropertyName $fqsen
+    ) {
+        $this->parent_scope = $parent_scope;
+        $this->fqsen = $fqsen;
+        $this->flags = $parent_scope->flags;
+    }
 
     /**
      * @return bool

--- a/tests/Phan/Language/ContextTest.php
+++ b/tests/Phan/Language/ContextTest.php
@@ -41,10 +41,12 @@ final class ContextTest extends BaseTest
         $context_namespace =
             $context->withNamespace('\A');
 
+        $class_fqsen = FullyQualifiedClassName::fromFullyQualifiedString('\\A\\B');
         $context_class = $context_namespace->withScope(
             new ClassScope(
                 $context_namespace->getScope(),
-                FullyQualifiedClassName::fromFullyQualifiedString('\\A\\B')
+                $class_fqsen,
+                0
             )
         );
 


### PR DESCRIPTION
This also allows Phan to start tracking information about the context in a
bitmask (e.g. trait vs interface vs class)