### PR TITLE
Properly resolve self type in traits; warn about traits in signatures

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,8 @@ New features(Analysis):
 
   By default, this will only warn about use statements made from the global namespace, of elements also in the global namespace.
   To also warn about redundant **namespaced** uses of classes/namespaces (e.g. `namespace Foo; use Foo\MyClass;`), enable `warn_about_redundant_use_namespaced_class`
++ Warn when using a trait as a real param/return type of a method-like (#2007)
+  New issue types: `PhanTypeInvalidTraitParam`, `PhanTypeInvalidTraitReturn`
 + Improve the polyfill/fallback parser's heredoc and nowdoc lexing (#1537)
 + Properly warn about an undefined variable being passed to `array_shift` (it expects an array but undefined is converted to null) (related to fix for #2100)
 + Stop adding generic int/string to the type of a class property when the doc comment mentions only literal int/string values (#2102)
@@ -30,6 +32,7 @@ Bug fixes:
 + Properly type check `static::someMethodName()`.
   Previously, Phan would fail to infer types for the results of those method calls.
 + Improve handling of `array_shift`. Don't warn when it's used on a global or superglobal (#2100)
++ Infer that `self` and `static` in a trait refer to the methods of that trait. (#2006)
 
 22 Oct 2018, Phan 1.1.1
 -----------------------

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -2005,6 +2005,22 @@ e.g. [this issue](https://github.com/phan/phan/tree/1.1.1/tests/files/expected/0
 
 e.g. [this issue](https://github.com/phan/phan/tree/1.1.1/tests/files/expected/0454_throws.php.expected#L5) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.1.1/tests/files/src/0454_throws.php#L30).
 
+## PhanTypeInvalidTraitParam
+
+```
+Method {METHOD} is declared to have a parameter ${PARAMETER} with a real type of trait {TYPE} (expected a class or interface or built-in type)
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0560_trait_in_param_return.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0560_trait_in_param_return.php#L8).
+
+## PhanTypeInvalidTraitReturn
+
+```
+Expected a class or interface (or built-in type) to be the real return type of method {METHOD} but got trait {TRAIT}
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0560_trait_in_param_return.php.expected#L3) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0560_trait_in_param_return.php#L8).
+
 ## PhanTypeInvalidUnaryOperandBitwiseNot
 
 ```
@@ -2700,7 +2716,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/1.1.1/tests/files/expected/0
 If you have a parameter on a function or method of a type that is not defined, you'll see this issue.
 
 ```
-Parameter of undeclared type {TYPE}
+Parameter ${PARAMETER} has undeclared type {TYPE}
 ```
 
 This issue will be emitted from the following code

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -918,7 +918,6 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             $is_trait = $clazz->isTrait();
         }
 
-
         // Get the method/function/closure we're in
         $method = $context->getFunctionLikeInScope($code_base);
 
@@ -930,7 +929,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
 
         // Figure out what we intend to return
         // (For traits, lower the false positive rate by comparing against the real return type instead of the phpdoc type (#800))
-        $method_return_type = $is_trait ? $method->getRealReturnType() : $method->getUnionType();
+        $method_return_type = $is_trait ? $method->getRealReturnType()->withAddedClassForResolvedSelf($method->getContext()) : $method->getUnionType();
 
         // This leaves functions which aren't syntactically generators.
 
@@ -2895,6 +2894,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
 
         $original_method_scope = $method->getInternalScope();
         $method->setInternalScope(clone($original_method_scope));
+        $method_context = $method->getContext();
 
         try {
             // Even though we don't modify the parameter list, we still need to know the types
@@ -2972,7 +2972,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             // Now that we know something about the parameters used
             // to call the method, we can reanalyze the method with
             // the types of the parameter
-            $method->analyzeWithNewParams($method->getContext(), $this->code_base, $parameter_list);
+            $method->analyzeWithNewParams($method_context, $this->code_base, $parameter_list);
         } finally {
             $method->setInternalScope($original_method_scope);
         }

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -163,6 +163,8 @@ class Issue
     const TypeInvalidRequire              = 'PhanTypeInvalidRequire';
     const TypeInvalidEval                 = 'PhanTypeInvalidEval';
     const RelativePathUsed                = 'PhanRelativePathUsed';
+    const TypeInvalidTraitReturn          = 'PhanTypeInvalidTraitReturn';
+    const TypeInvalidTraitParam           = 'PhanTypeInvalidTraitParam';
 
     // Issue::CATEGORY_ANALYSIS
     const Unanalyzable              = 'PhanUnanalyzable';
@@ -817,7 +819,7 @@ class Issue
                 self::UndeclaredTypeParameter,
                 self::CATEGORY_UNDEFINED,
                 self::SEVERITY_NORMAL,
-                "Parameter of undeclared type {TYPE}",
+                "Parameter \${PARAMETER} has undeclared type {TYPE}",
                 self::REMEDIATION_B,
                 11019
             ),
@@ -1705,6 +1707,22 @@ class Issue
                 "Expected an object to be passed to clone() but got {TYPE}",
                 self::REMEDIATION_B,
                 10088
+            ),
+            new Issue(
+                self::TypeInvalidTraitReturn,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                "Expected a class or interface (or built-in type) to be the real return type of method {METHOD} but got trait {TRAIT}",
+                self::REMEDIATION_B,
+                10089
+            ),
+            new Issue(
+                self::TypeInvalidTraitParam,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                "Method {METHOD} is declared to have a parameter \${PARAMETER} with a real type of trait {TYPE} (expected a class or interface or built-in type)",
+                self::REMEDIATION_B,
+                10090
             ),
             // Issue::CATEGORY_VARIABLE
             new Issue(

--- a/src/Phan/Language/Element/Func.php
+++ b/src/Phan/Language/Element/Func.php
@@ -406,4 +406,9 @@ class Func extends AddressableElement implements FunctionInterface
         $namespace = ltrim($fqsen->getNamespace(), '\\');
         return [$namespace, $stub];
     }
+
+    public function getUnionTypeWithUnmodifiedStatic() : UnionType
+    {
+        return $this->getUnionType();
+    }
 }

--- a/src/Phan/Language/Element/FunctionInterface.php
+++ b/src/Phan/Language/Element/FunctionInterface.php
@@ -382,4 +382,6 @@ interface FunctionInterface extends AddressableElementInterface
      * Converts Generator|array<int,stdClass> to Generator<int,stdClass>, etc.
      */
     public function getReturnTypeAsGeneratorTemplateType() : Type;
+
+    public function getUnionTypeWithUnmodifiedStatic() : UnionType;
 }

--- a/src/Phan/Language/Element/Parameter.php
+++ b/src/Phan/Language/Element/Parameter.php
@@ -276,11 +276,7 @@ class Parameter extends Variable
     ) : Parameter {
         // Get the type of the parameter
         $type_node = $node->children['type'];
-        $union_type = UnionTypeVisitor::unionTypeFromNode(
-            $code_base,
-            $context,
-            $type_node
-        );
+        $union_type = $type_node ? (new UnionTypeVisitor($code_base, $context))->fromTypeInSignature($type_node) : UnionType::empty();
 
         // Create the skeleton parameter from what we know so far
         $parameter = Parameter::create(

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -193,11 +193,43 @@ final class EmptyUnionType extends UnionType
     }
 
     /**
+     * @return bool
+     * True if this type has a type referencing the
+     * class context 'static' or 'self'.
+     */
+    public function hasStaticOrSelfType() : bool
+    {
+        return false;
+    }
+
+    /**
      * @return UnionType
      * A new UnionType with any references to 'static' resolved
      * in the given context.
      */
     public function withStaticResolvedInContext(
+        Context $context
+    ) : UnionType {
+        return $this;
+    }
+
+    /**
+     * @return UnionType
+     * A new UnionType *plus* any references to 'self' (but not 'static') resolved
+     * in the given context.
+     */
+    public function withAddedClassForResolvedSelf(
+        Context $context
+    ) : UnionType {
+        return $this;
+    }
+
+    /**
+     * @return UnionType
+     * A new UnionType with any references to 'self' (but not 'static') resolved
+     * in the given context. (the type of 'self' is replaced)
+     */
+    public function withSelfResolvedInContext(
         Context $context
     ) : UnionType {
         return $this;

--- a/src/Phan/Language/Scope.php
+++ b/src/Phan/Language/Scope.php
@@ -129,6 +129,20 @@ abstract class Scope
         return ($this->flags & self::IN_CLASS_LIKE_SCOPE) !== 0;
     }
 
+    public function isInTraitScope() : bool
+    {
+        return ($this->flags & self::IN_TRAIT_SCOPE) !== 0;
+    }
+
+    /**
+     * Checks if we're in an interface's scope.
+     * @suppress PhanUnreferencedPublicMethod
+     */
+    public function isInInterfaceScope() : bool
+    {
+        return ($this->flags & self::IN_INTERFACE_SCOPE) !== 0;
+    }
+
     /**
      * Returns true if we're in an element scope (i.e. not in the global scope)
      */

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -38,6 +38,7 @@ use Phan\Language\Type\ObjectType;
 use Phan\Language\Type\ResourceType;
 use Phan\Language\Type\ScalarRawType;
 use Phan\Language\Type\ScalarType;
+use Phan\Language\Type\SelfType;
 use Phan\Language\Type\StaticType;
 use Phan\Language\Type\StringType;
 use Phan\Language\Type\TrueType;
@@ -403,7 +404,7 @@ class Type
 
         if ($template_parameter_type_list) {
             $key .= '<' . \implode(',', \array_map(function (UnionType $union_type) : string {
-                return (string)$union_type;
+                return $union_type->__toString();
             }, $template_parameter_type_list)) . '>';
         }
 
@@ -750,7 +751,7 @@ class Type
     ) : Type {
 
         return self::fromStringInContext(
-            (string)$reflection_type,
+            $reflection_type->__toString(),
             new Context(),
             Type::FROM_NODE
         );
@@ -1196,7 +1197,7 @@ class Type
                 $element_type = self::maybeFindParentType($non_generic_array_type_name[0] === '?', $context, $code_base);
             } else {
                 $element_type = static::fromFullyQualifiedString(
-                    (string)$context->getClassFQSEN()
+                    $context->getClassFQSEN()->__toString()
                 );
             }
 
@@ -1216,8 +1217,11 @@ class Type
                 // Will throw if $code_base is null or there is no parent type
                 return self::maybeFindParentType($is_nullable, $context, $code_base);
             }
+            if ($source === self::FROM_PHPDOC && $context->getScope()->isInTraitScope()) {
+                return SelfType::instance($is_nullable);
+            }
             return static::fromFullyQualifiedString(
-                (string)$context->getClassFQSEN()
+                $context->getClassFQSEN()->__toString()
             )->withIsNullable($is_nullable);
         }
 
@@ -1584,6 +1588,7 @@ class Type
      */
     public function isSelfType() : bool
     {
+        // TODO: Ensure that this is always a SelfType instance
         return $this->namespace === '\\' && self::isSelfTypeString($this->name);
     }
 
@@ -1595,6 +1600,20 @@ class Type
      */
     public function isStaticType() : bool
     {
+        return false;
+    }
+
+    public function hasStaticOrSelfTypesRecursive(CodeBase $code_base) : bool
+    {
+        $union_type = $this->iterableValueUnionType($code_base);
+        if (!$union_type) {
+            return false;
+        }
+        foreach ($union_type->getTypeSet() as $type) {
+            if ($type->hasStaticOrSelfTypesRecursive($code_base)) {
+                return true;
+            }
+        }
         return false;
     }
 
@@ -1795,6 +1814,8 @@ class Type
 
     /**
      * @return ?UnionType returns the iterable value's union type if this is a subtype of iterable, null otherwise.
+     *
+     * This is overridden by the array subclasses
      */
     public function iterableValueUnionType(CodeBase $unused_code_base)
     {
@@ -2246,23 +2267,9 @@ class Type
      * Either this or 'static' resolved in the given context.
      */
     public function withStaticResolvedInContext(
-        Context $context
+        Context $_
     ) : Type {
-        // TODO: Create SelfType, to go along with StaticType
-        if (\strcasecmp($this->name, 'self') !== 0) {
-            return $this;
-        }
-
-        // If the context isn't in a class scope, there's nothing
-        // we can do
-        if (!$context->isInClassScope()) {
-            return $this;
-        }
-        $type = $context->getClassFQSEN()->asType();
-        if ($this->getIsNullable()) {
-            return $type->withIsNullable(true);
-        }
-        return $type;
+        return $this;
     }
 
     /**

--- a/src/Phan/Language/Type/ArrayShapeType.php
+++ b/src/Phan/Language/Type/ArrayShapeType.php
@@ -181,6 +181,7 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
 
     /**
      * @return UnionType
+     * @override
      */
     public function iterableValueUnionType(CodeBase $unused_code_base)
     {

--- a/src/Phan/Language/Type/FunctionLikeDeclarationType.php
+++ b/src/Phan/Language/Type/FunctionLikeDeclarationType.php
@@ -570,6 +570,11 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
         return $this->return_type;
     }
 
+    public function getUnionTypeWithUnmodifiedStatic() : UnionType
+    {
+        return $this->return_type;
+    }
+
     public function getSuppressIssueList() : array
     {
         // TODO: Inherit suppress issue list from phpdoc declaring this?

--- a/src/Phan/Language/Type/SelfType.php
+++ b/src/Phan/Language/Type/SelfType.php
@@ -1,24 +1,27 @@
 <?php declare(strict_types=1);
 namespace Phan\Language\Type;
 
-use AssertionError;
 use Phan\CodeBase;
 use Phan\Language\Context;
 use Phan\Language\Type;
 use Phan\Language\UnionType;
 
 /**
- * Represents the PHPDoc type `static`.
+ * Represents the PHPDoc type `self`.
  * This is converted to a real class when necessary.
  * @see $this->withStaticResolvedInContext()
  */
-final class StaticType extends StaticOrSelfType
+final class SelfType extends StaticOrSelfType
 {
     /** Not an override */
-    const NAME = 'static';
+    const NAME = 'self';
 
+    protected function __construct(bool $is_nullable)
+    {
+        parent::__construct('\\', self::NAME, [], $is_nullable);
+    }
     /**
-     * Returns a nullable/non-nullable instance of this StaticType
+     * Returns a nullable/non-nullable instance of this SelfType
      *
      * @param bool $is_nullable
      * An optional parameter, which if true returns a
@@ -32,22 +35,16 @@ final class StaticType extends StaticOrSelfType
             static $nullable_instance = null;
 
             if ($nullable_instance === null) {
-                $nullable_instance = static::make('\\', static::NAME, [], true, Type::FROM_TYPE);
+                $nullable_instance = new self(true);
             }
 
-            if (!($nullable_instance instanceof static)) {
-                throw new AssertionError('Expected StaticType::make to return StaticType');
-            }
             return $nullable_instance;
         }
 
         static $instance;
 
         if (!$instance) {
-            $instance = static::make('\\', static::NAME, [], false, Type::FROM_TYPE);
-            if (!($instance instanceof static)) {
-                throw new AssertionError('Expected StaticType::make to return StaticType');
-            }
+            $instance = new self(false);
         }
         return $instance;
     }
@@ -57,12 +54,12 @@ final class StaticType extends StaticOrSelfType
         return false;
     }
 
-    public function isSelfType() : bool
+    public function isStaticType() : bool
     {
         return false;
     }
 
-    public function isStaticType() : bool
+    public function isSelfType() : bool
     {
         return true;
     }
@@ -80,7 +77,7 @@ final class StaticType extends StaticOrSelfType
 
     /**
      * @return Type
-     * Either this or 'static' resolved in the given context.
+     * Either this or 'self' resolved in the given context.
      */
     public function withStaticResolvedInContext(
         Context $context

--- a/src/Phan/Language/Type/StaticOrSelfType.php
+++ b/src/Phan/Language/Type/StaticOrSelfType.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+namespace Phan\Language\Type;
+
+use Phan\CodeBase;
+use Phan\Language\Type;
+
+/**
+ * Represents the PHPDoc type `self` or `static`.
+ * This is converted to a real class when necessary.
+ * @see $this->withStaticResolvedInContext()
+ */
+class StaticOrSelfType extends Type
+{
+    public function hasStaticOrSelfTypesRecursive(CodeBase $_) : bool
+    {
+        return true;
+    }
+}

--- a/src/Phan/LanguageServer/GoToDefinitionRequest.php
+++ b/src/Phan/LanguageServer/GoToDefinitionRequest.php
@@ -14,6 +14,7 @@ use Phan\Language\FQSEN;
 use Phan\Language\FQSEN\FullyQualifiedClassName;
 use Phan\Language\FQSEN\FullyQualifiedFunctionName;
 use Phan\Language\FQSEN\FullyQualifiedMethodName;
+use Phan\Language\Type\StaticOrSelfType;
 use Phan\Language\Type\TemplateType;
 use Phan\Language\UnionType;
 use Phan\LanguageServer\Protocol\Hover;
@@ -135,7 +136,7 @@ final class GoToDefinitionRequest extends NodeInfoRequest
             if ($type instanceof TemplateType) {
                 continue;
             }
-            if ($type->isSelfType() || $type->isStaticType()) {
+            if ($type instanceof StaticOrSelfType) {
                 if (!$context->isInClassScope()) {
                     // Phan already warns elsewhere
                     continue;
@@ -188,7 +189,7 @@ final class GoToDefinitionRequest extends NodeInfoRequest
             if ($type instanceof TemplateType) {
                 continue;
             }
-            if ($type->isSelfType() || $type->isStaticType()) {
+            if ($type instanceof StaticOrSelfType) {
                 if (!$context->isInClassScope()) {
                     // Phan already warns elsewhere
                     continue;

--- a/tests/files/expected/0058_property_type_check.php.expected
+++ b/tests/files/expected/0058_property_type_check.php.expected
@@ -1,3 +1,3 @@
 %s:4 PhanUndeclaredTypeProperty Property \Test::client has undeclared type \ClientOfPropertyTypeCheck58
-%s:6 PhanUndeclaredTypeParameter Parameter of undeclared type \ClientOfPropertyTypeCheck58
+%s:6 PhanUndeclaredTypeParameter Parameter $client has undeclared type \ClientOfPropertyTypeCheck58
 %s:8 PhanUndeclaredClassMethod Call to method test from undeclared class \ClientOfPropertyTypeCheck58

--- a/tests/files/expected/0070_closure_type.php.expected
+++ b/tests/files/expected/0070_closure_type.php.expected
@@ -1,3 +1,3 @@
-%s:3 PhanUndeclaredTypeParameter Parameter of undeclared type \A\Closure (Did you mean class \Closure)
+%s:3 PhanUndeclaredTypeParameter Parameter $c has undeclared type \A\Closure (Did you mean class \Closure)
 %s:4 PhanTypeMismatchArgument Argument 1 (c) is Closure():void but \A\f() takes \A\Closure defined at %s:3
 %s:14 PhanTypeMismatchArgument Argument 1 (c) is callable but \C\f() takes \Closure defined at %s:13

--- a/tests/files/expected/0098_undef.php.expected
+++ b/tests/files/expected/0098_undef.php.expected
@@ -1,7 +1,7 @@
 %s:6 PhanUndeclaredClassCatch Catching undeclared class \Undef
 %s:9 PhanUndeclaredStaticMethod Static call to undeclared method \C98::staticMethod
 %s:13 PhanUndeclaredClassInstanceof Checking instanceof against undeclared class \Undef
-%s:16 PhanUndeclaredTypeParameter Parameter of undeclared type \Undef
+%s:16 PhanUndeclaredTypeParameter Parameter $p has undeclared type \Undef
 %s:19 PhanUndeclaredTypeProperty Property \D98::p has undeclared type \Undef
 %s:22 PhanUndeclaredExtendedClass Class extends undeclared class \Undef
 %s:25 PhanParentlessClass Reference to parent of class \F98 that does not extend anything
@@ -9,7 +9,7 @@
 %s:28 PhanUndeclaredProperty Reference to undeclared property \C98->undef
 %s:31 PhanUndeclaredProperty Reference to undeclared property \C98->undef
 %s:34 PhanUndeclaredClassMethod Call to method f from undeclared class \Undef
-%s:34 PhanUndeclaredTypeParameter Parameter of undeclared type \Undef
+%s:34 PhanUndeclaredTypeParameter Parameter $v has undeclared type \Undef
 %s:37 PhanTraitParentReference Reference to parent from trait \T98
 %s:40 PhanParentlessClass Reference to parent of class \G98 that does not extend anything
 %s:43 PhanUndeclaredExtendedClass Class extends undeclared class \Undef

--- a/tests/files/expected/0101_one_of_each.php.expected
+++ b/tests/files/expected/0101_one_of_each.php.expected
@@ -38,7 +38,7 @@
 %s:144 PhanTypeMismatchReturn Returning type 'string' but f() is declared to return int
 %s:147 PhanTypeMissingReturn Method \C9::f is declared to return int but has no return value
 %s:150 PhanUndeclaredClassMethod Call to method f from undeclared class \F
-%s:155 PhanUndeclaredTypeParameter Parameter of undeclared type \Undef
+%s:155 PhanUndeclaredTypeParameter Parameter $p has undeclared type \Undef
 %s:158 PhanUndeclaredTypeProperty Property \C11::p has undeclared type \Undef
 %s:161 PhanParentlessClass Reference to parent of class \C12 that does not extend anything
 %s:164 PhanTraitParentReference Reference to parent from trait \T1
@@ -46,7 +46,7 @@
 %s:176 PhanUndeclaredConstant Reference to undeclared constant \C16::C
 %s:180 PhanUndeclaredClassInstanceof Checking instanceof against undeclared class \Undef
 %s:183 PhanUndeclaredClassMethod Call to method f5 from undeclared class \Undef
-%s:183 PhanUndeclaredTypeParameter Parameter of undeclared type \Undef
+%s:183 PhanUndeclaredTypeParameter Parameter $p has undeclared type \Undef
 %s:192 PhanUndeclaredExtendedClass Class extends undeclared class \Undef
 %s:195 PhanUndeclaredFunction Call to undeclared function \f10()
 %s:198 PhanUndeclaredInterface Class implements undeclared interface \C18

--- a/tests/files/expected/0203_generic_errors.php.expected
+++ b/tests/files/expected/0203_generic_errors.php.expected
@@ -5,7 +5,7 @@
 %s:24 PhanUnextractableAnnotationElementName Saw possibly unextractable annotation for a fragment of comment '* @param int': after int, did not see an element name (will guess based on comment order)
 %s:25 PhanUnextractableAnnotationElementName Saw possibly unextractable annotation for a fragment of comment '* @param X': after X, did not see an element name (will guess based on comment order)
 %s:27 PhanGenericConstructorTypes Missing template parameters T on constructor for generic class \C
-%s:27 PhanUndeclaredTypeParameter Parameter of undeclared type \X (Did you mean class \C)
+%s:27 PhanUndeclaredTypeParameter Parameter $p2 has undeclared type \X (Did you mean class \C)
 %s:30 PhanParamTooFew Call with 0 arg(s) to \C::__construct() which requires 2 arg(s) defined at %s:27
 %s:36 PhanUnextractableAnnotationElementName Saw possibly unextractable annotation for a fragment of comment '* @param int': after int, did not see an element name (will guess based on comment order)
 %s:37 PhanUnextractableAnnotationElementName Saw possibly unextractable annotation for a fragment of comment '* @param T': after T, did not see an element name (will guess based on comment order)

--- a/tests/files/expected/0204_generic_inheritance.php.expected
+++ b/tests/files/expected/0204_generic_inheritance.php.expected
@@ -5,4 +5,4 @@
 %s:50 PhanTypeMismatchArgument Argument 1 (p) is 42 but \f() takes bool defined at %s:3
 %s:55 PhanUndeclaredExtendedClass Class extends undeclared class \NotFound
 %s:58 PhanUndeclaredClass Reference to undeclared class \NotFound
-%s:67 PhanUndeclaredTypeParameter Parameter of undeclared type \NotFound
+%s:67 PhanUndeclaredTypeParameter Parameter $p has undeclared type \NotFound

--- a/tests/files/expected/0263_alias_outside_phpdoc.php.expected
+++ b/tests/files/expected/0263_alias_outside_phpdoc.php.expected
@@ -1,8 +1,8 @@
-%s:4 PhanUndeclaredTypeParameter Parameter of undeclared type \boolean
-%s:4 PhanUndeclaredTypeParameter Parameter of undeclared type \callback%S
-%s:4 PhanUndeclaredTypeParameter Parameter of undeclared type \double
-%s:4 PhanUndeclaredTypeParameter Parameter of undeclared type \integer
-%s:4 PhanUndeclaredTypeParameter Parameter of undeclared type array<int,\double>
+%s:4 PhanUndeclaredTypeParameter Parameter $a has undeclared type \boolean
+%s:4 PhanUndeclaredTypeParameter Parameter $b has undeclared type \integer
+%s:4 PhanUndeclaredTypeParameter Parameter $c has undeclared type \callback
+%s:4 PhanUndeclaredTypeParameter Parameter $d has undeclared type \double
+%s:4 PhanUndeclaredTypeParameter Parameter $e has undeclared type array<int,\double>
 %s:4 PhanUndeclaredTypeReturnType Return type of foo263 is undeclared type \boolean
 %s:5 PhanTypeMismatchReturn Returning type false but foo263() is declared to return \boolean
 %s:7 PhanTypeMismatchArgument Argument 1 (a) is false but \foo263() takes \boolean defined at %s:4
@@ -10,4 +10,3 @@
 %s:7 PhanTypeMismatchArgument Argument 3 (c) is Closure():void but \foo263() takes \callback defined at %s:4
 %s:7 PhanTypeMismatchArgument Argument 4 (d) is float but \foo263() takes \double defined at %s:4
 %s:7 PhanTypeMismatchArgument Argument 5 (e) is float but \foo263() takes \double defined at %s:4
-

--- a/tests/files/expected/0289_check_incorrect_soft_types.php.expected
+++ b/tests/files/expected/0289_check_incorrect_soft_types.php.expected
@@ -1,5 +1,5 @@
-%s:3 PhanUndeclaredTypeParameter Parameter of undeclared type \resource%S
+%s:3 PhanUndeclaredTypeParameter Parameter $x has undeclared type \resource
 %s:4 PhanTypeMismatchArgumentInternal Argument 1 (fp) is \resource but \fread() takes resource
 %s:10 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is false|resource but \intdiv() takes int
 %s:14 PhanCompatibleNullableTypePHP71 Type 'object' refers to any object starting in PHP 7.2. In PHP 7.1 and earlier, it refers to a class/interface with the name 'object'
-%s:18 PhanUndeclaredTypeParameter Parameter of undeclared type \mixed
+%s:18 PhanUndeclaredTypeParameter Parameter $x has undeclared type \mixed

--- a/tests/files/expected/0358_undeclared_class_in_generic_array.php.expected
+++ b/tests/files/expected/0358_undeclared_class_in_generic_array.php.expected
@@ -1,4 +1,4 @@
-%s:9 PhanUndeclaredTypeParameter Parameter of undeclared type \UndefClass357A[]
-%s:9 PhanUndeclaredTypeParameter Parameter of undeclared type \UndefClass357B[][][]
-%s:9 PhanUndeclaredTypeParameter Parameter of undeclared type \UndefClass357C
+%s:9 PhanUndeclaredTypeParameter Parameter $a has undeclared type \UndefClass357A[]
+%s:9 PhanUndeclaredTypeParameter Parameter $b has undeclared type \UndefClass357B[][][]
+%s:9 PhanUndeclaredTypeParameter Parameter $c has undeclared type \UndefClass357C
 %s:9 PhanUndeclaredTypeReturnType Return type of test358 is undeclared type \UndefClass357D[]

--- a/tests/files/expected/0359_undeclared_class_in_prop.php.expected
+++ b/tests/files/expected/0359_undeclared_class_in_prop.php.expected
@@ -1,7 +1,7 @@
 %s:4 PhanUndeclaredTypeProperty Property \A359::missing4 has undeclared type \Missing359E
 %s:4 PhanUndeclaredTypeProperty Property \A359::missing4 has undeclared type \Missing359F[][]
-%s:5 PhanUndeclaredTypeParameter Parameter of undeclared type \Missing359H[]
 %s:5 PhanUndeclaredTypeReturnType Return type of myInstanceMethod is undeclared type \Missing359G
+%s:7 PhanUndeclaredTypeParameter Parameter $param1 has undeclared type \Missing359H[]
 %s:9 PhanUndeclaredTypeProperty Property \A359::missing1 has undeclared type \Missing359
 %s:9 PhanUndeclaredTypeProperty Property \A359::missing1 has undeclared type \Missing359B[][]
 %s:11 PhanUndeclaredTypeProperty Property \A359::missing2 has undeclared type ?\Missing359C

--- a/tests/files/expected/0360_undeclared_array_class_in_namespace.php.expected
+++ b/tests/files/expected/0360_undeclared_array_class_in_namespace.php.expected
@@ -1,4 +1,4 @@
-%s:12 PhanUndeclaredTypeParameter Parameter of undeclared type \Foo\Baz\MissingClass[][][]
+%s:12 PhanUndeclaredTypeParameter Parameter $x has undeclared type \Foo\Baz\MissingClass[][][]
 %s:12 PhanUndeclaredTypeReturnType Return type of myMethod is undeclared type \Foo\Bat\OtherMissingClass[][]
 %s:18 PhanUndeclaredTypeProperty Property \Foo\Bar\MyClass::y has undeclared type \Foo\Bar\Closure[][] (Did you mean class \Closure)
-%s:22 PhanUndeclaredTypeProperty Property \Foo\Bar\MyClass::str has undeclared type \Foo\Bar\strong (Did you mean %Sstring%S)
+%s:22 PhanUndeclaredTypeProperty Property \Foo\Bar\MyClass::str has undeclared type \Foo\Bar\strong (Did you mean string)

--- a/tests/files/expected/0487_alternate_suggestions.php.expected
+++ b/tests/files/expected/0487_alternate_suggestions.php.expected
@@ -1,8 +1,8 @@
 %s:21 PhanUndeclaredTypeProperty Property \A487::x has undeclared type \avoid (Did you mean class \Avid)
 %s:28 PhanTypeMissingReturn Method \A487::test_suggestions is declared to return \avoid but has no return value
-%s:28 PhanUndeclaredTypeParameter Parameter of undeclared type \avoid (Did you mean class \Avid)
+%s:28 PhanUndeclaredTypeParameter Parameter $x has undeclared type \avoid (Did you mean class \Avid)
 %s:28 PhanUndeclaredTypeReturnType Return type of test_suggestions is undeclared type \avoid (Did you mean class \Avid or void)
 %s:28 PhanUndeclaredTypeThrowsType @throws type of test_suggestions has undeclared type \avoid (Did you mean class \Avid)
-%s:40 PhanUndeclaredTypeParameter Parameter of undeclared type array<string,\imt>[] (Did you mean trait \Ime or class \Imf or class \Img or interface \Imi or interface \Imj or int)
+%s:40 PhanUndeclaredTypeParameter Parameter $x has undeclared type array<string,\imt>[] (Did you mean trait \Ime or class \Imf or class \Img or interface \Imi or interface \Imj or int)
 %s:40 PhanUndeclaredTypeReturnType Return type of test_throw_suggestions is undeclared type array<string,\imt>[] (Did you mean trait \Ime or class \Imf or class \Img or interface \Imi or interface \Imj or int)
 %s:40 PhanUndeclaredTypeThrowsType @throws type of test_throw_suggestions has undeclared type \imt (Did you mean class \Imf or interface \Imi)

--- a/tests/files/expected/0531_magic_method_override.php.expected
+++ b/tests/files/expected/0531_magic_method_override.php.expected
@@ -1,4 +1,4 @@
-%s:113 PhanParamSignatureMismatch Declaration of function addItem(\ScalarType531 $item) : array should be compatible with function addItem(mixed $item) : \Collection531|static defined in %s:41
+%s:113 PhanParamSignatureMismatch Declaration of function addItem(\ScalarType531 $item) : array should be compatible with function addItem(mixed $item) : static defined in %s:41
 %s:113 PhanParamSignaturePHPDocMismatchHasParamType Declaration of real/@method function addItem(\ScalarType531 $item) should be compatible with real/@method function addItem($item) (parameter #1 has type '\ScalarType531' which cannot replace original parameter with no type) defined in %s:41
-%s:114 PhanParamSignatureMismatch Declaration of function setItems(\ScalarType531[] $item) : array should be compatible with function setItems(array $items) : \Collection531|static defined in %s:31
+%s:114 PhanParamSignatureMismatch Declaration of function setItems(\ScalarType531[] $item) : array should be compatible with function setItems(array $items) : static defined in %s:31
 %s:114 PhanParamSignaturePHPDocMismatchParamType Declaration of real/@method function setItems(\ScalarType531[] $item) should be compatible with real/@method function setItems(array $items) (parameter #1 of type '\ScalarType531[]' cannot replace original parameter of type 'array') defined in %s:31

--- a/tests/files/expected/0539_method_param_line_warning.php.expected
+++ b/tests/files/expected/0539_method_param_line_warning.php.expected
@@ -1,1 +1,1 @@
-%s:31 PhanUndeclaredTypeParameter Parameter of undeclared type \stdClas (Did you mean class \stdClass)
+%s:33 PhanUndeclaredTypeParameter Parameter $param4 has undeclared type \stdClas (Did you mean class \stdClass)

--- a/tests/files/expected/0557_static_binding_in_trait_param.php.expected
+++ b/tests/files/expected/0557_static_binding_in_trait_param.php.expected
@@ -1,0 +1,2 @@
+%s:34 PhanTypeMismatchArgument Argument 1 (x) is \C2|\T but \C1::handleSelf() takes \C1 defined at %s:12
+%s:36 PhanTypeMismatchArgument Argument 1 (x) is \C2|\T but \C1::handleStatic() takes \C1|static defined at %s:23

--- a/tests/files/expected/0558_static_binding_in_trait.php.expected
+++ b/tests/files/expected/0558_static_binding_in_trait.php.expected
@@ -1,0 +1,1 @@
+%s:27 PhanTypeInvalidTraitReturn Expected a class or interface (or built-in type) to be the real return type of method getC1AsT but got trait \T

--- a/tests/files/expected/0560_trait_in_param_return.php.expected
+++ b/tests/files/expected/0560_trait_in_param_return.php.expected
@@ -1,0 +1,3 @@
+%s:8 PhanTypeInvalidTraitParam Method getC1AsT is declared to have a parameter $other with a real type of trait \T (expected a class or interface or built-in type)
+%s:8 PhanTypeInvalidTraitParam Method getC1AsT is declared to have a parameter $x with a real type of trait \T (expected a class or interface or built-in type)
+%s:8 PhanTypeInvalidTraitReturn Expected a class or interface (or built-in type) to be the real return type of method getC1AsT but got trait \T

--- a/tests/files/expected/0801_trait_analyze_method_body.php.expected
+++ b/tests/files/expected/0801_trait_analyze_method_body.php.expected
@@ -1,2 +1,2 @@
 %s:4 PhanTypeMismatchReturn Returning type 'a' but f2() is declared to return int
-%s:10 PhanTypeMismatchReturn Returning type array{} but f() is declared to return \U301
+%s:10 PhanTypeMismatchReturn Returning type array{} but f() is declared to return \U301|self

--- a/tests/files/src/0557_static_binding_in_trait_param.php
+++ b/tests/files/src/0557_static_binding_in_trait_param.php
@@ -1,0 +1,36 @@
+<?php
+
+class C1 {
+    use T;
+}
+
+class C2 {
+    use T;
+}
+
+trait T {
+    public function handleSelf(self $x) : self
+    {
+        if (rand() % 2 > 0) {
+            return $this;
+        }
+        return $x;  // should not warn
+    }
+
+    /**
+     * @param static $x neither return should warn
+     */
+    public function handleStatic($x) : self
+    {
+        if (rand() % 2 > 0) {
+            return $this;
+        }
+        return $x;
+    }
+}
+$c1 = new C1();
+$c2 = new C2();
+var_export($c1->handleSelf($c1));
+var_export($c1->handleSelf($c2));  // should warn
+var_export($c1->handleStatic($c1));
+var_export($c1->handleStatic($c2));  // should warn

--- a/tests/files/src/0558_static_binding_in_trait.php
+++ b/tests/files/src/0558_static_binding_in_trait.php
@@ -1,0 +1,36 @@
+<?php
+
+class C1 {
+    use T;
+}
+
+class C2 {
+    use T;
+}
+
+trait T {
+    public function getC1() : self
+    {
+        return new C1();
+    }
+
+    public function getC2() : self
+    {
+        return new C2();  // This is a fatal error when called on an instance of C1
+    }
+
+    public function getSelf() : self
+    {
+        return $this;  // Should not warn
+    }
+
+    public function getC1AsT() : T
+    {
+        // You can't have instances of traits. You can have instances of classes using traits.
+        return new C1();  // A return type of T is something Phan should warn about - This return statement would trigger : Uncaught TypeError: Return value of C1::getC1AsT() must be an instance of T, instance of C1 returned in /path/to/phan/trait_binding.php:lineno
+    }
+
+}
+$c1 = new C1();
+var_export($c1->getC1());
+var_export($c1->getC2());

--- a/tests/files/src/0559_static_binding_false_positive.php
+++ b/tests/files/src/0559_static_binding_false_positive.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+class SomeClass
+{
+    use SomeTrait;
+
+    protected $param;
+
+    /**
+     * Set some param
+     *
+     * @param string $param
+     *
+     * @return $this
+     */
+    public function setSomeParam($param)
+    {
+        $this->param = $param;
+        return $this;
+    }
+}
+
+trait SomeTrait
+{
+    protected $traitParam;
+
+    /**
+     * Get some param
+     *
+     * @param string $traitParam
+     *
+     * @return self
+     */
+    public function setSomeTraitParam($traitParam) : self
+    {
+        printf('Class: %-13s | get_class(): %-13s | get_called_class(): %-13s%s', __CLASS__, get_class(), get_called_class(), PHP_EOL);
+        $this->traitParam = $traitParam;
+        return $this;
+    }
+}
+
+$obj = new SomeClass();
+
+$obj->setSomeParam('some value')
+    ->setSomeTraitParam('some value')
+    ->setSomeParam('some value');

--- a/tests/files/src/0560_trait_in_param_return.php
+++ b/tests/files/src/0560_trait_in_param_return.php
@@ -1,0 +1,15 @@
+<?php
+class C1 {
+    use T;
+}
+
+trait T {
+
+    public function getC1AsT(T $x, T $other) : T {
+        if (rand(0, 1) > 0) {
+            return $other;
+        }
+        // You can't have instances of traits. You can have instances of classes using traits.
+        return $x;  // A return type of T is something Phan should warn about - This return statement would trigger Uncaught TypeError: Return value of C1::getC1AsT() must be an instance of T, instance of C1 returned in /path/to/phan/trait_binding.php:lineno
+    }
+}

--- a/tests/misc/rewriting_test/expected/001_phpdoc_rewriting_test.php.expected
+++ b/tests/misc/rewriting_test/expected/001_phpdoc_rewriting_test.php.expected
@@ -1,2 +1,2 @@
-src/001_phpdoc_rewriting_test.php:8 PhanUndeclaredTypeParameter Parameter of undeclared type \missingClass
+src/001_phpdoc_rewriting_test.php:8 PhanUndeclaredTypeParameter Parameter $z has undeclared type \missingClass
 src/001_phpdoc_rewriting_test.php:9 PhanTypeMismatchArgumentInternal Argument 1 (string) is float|int but \strlen() takes string


### PR DESCRIPTION
Continue implementing trait checks

Fixes #2007
Fixes #2006

Don't emit a false positive seen for `self` in trait param

This is because it's no longer immediately converted to the trait

Warn about using traits as real param/return types.
That will crash at runtime when using that method.

Add parameter name to error message for undeclared types