### PR TITLE
Make issue output more consistent in references to closures/functions

### DIFF
--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -522,7 +522,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/1.1.1/tests/files/expected/0
 If a class, method, function, property or constant is marked in its comment as `@deprecated`, any references to them will emit a deprecated error.
 
 ```
-Call to deprecated function {FUNCTIONLIKE}() defined at {FILE}:{LINE}
+Call to deprecated function {FUNCTIONLIKE} defined at {FILE}:{LINE}
 ```
 
 This will be emitted for the following code.
@@ -536,7 +536,7 @@ f1();
 ## PhanDeprecatedFunctionInternal
 
 ```
-Call to deprecated function {FUNCTIONLIKE}()
+Call to deprecated function {FUNCTIONLIKE}
 ```
 
 ## PhanDeprecatedInterface
@@ -1275,7 +1275,7 @@ Declaration of {METHOD} should be compatible with internal {METHOD} (the method 
 ## PhanParamSpecial1
 
 ```
-Argument {INDEX} ({PARAMETER}) is {TYPE} but {FUNCTIONLIKE}() takes {TYPE} when argument {INDEX} is {TYPE}
+Argument {INDEX} ({PARAMETER}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} when argument {INDEX} is {TYPE}
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/1.1.1/tests/files/expected/0511_implode.php.expected#L3) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.1.1/tests/files/src/0511_implode.php#L8).
@@ -1283,7 +1283,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/1.1.1/tests/files/expected/0
 ## PhanParamSpecial2
 
 ```
-Argument {INDEX} ({PARAMETER}) is {TYPE} but {FUNCTIONLIKE}() takes {TYPE} when passed only one argument
+Argument {INDEX} ({PARAMETER}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} when passed only one argument
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/1.1.1/tests/files/expected/0511_implode.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.1.1/tests/files/src/0511_implode.php#L4).
@@ -1317,7 +1317,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/1.1.1/tests/files/expected/0
 This issue indicates that you're not passing in at least the number of required parameters to a function or method.
 
 ```
-Call with {COUNT} arg(s) to {FUNCTIONLIKE}() which requires {COUNT} arg(s) defined at {FILE}:{LINE}
+Call with {COUNT} arg(s) to {FUNCTIONLIKE} which requires {COUNT} arg(s) defined at {FILE}:{LINE}
 ```
 
 This will be emitted for the code
@@ -1330,7 +1330,7 @@ f6();
 ## PhanParamTooFewCallable
 
 ```
-Call with {COUNT} arg(s) to {FUNCTIONLIKE}() (as a provided callable) which requires {COUNT} arg(s) defined at {FILE}:{LINE}
+Call with {COUNT} arg(s) to {FUNCTIONLIKE} (as a provided callable) which requires {COUNT} arg(s) defined at {FILE}:{LINE}
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/1.1.1/tests/misc/fallback_test/expected/033_closure_crash.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.1.1/tests/misc/fallback_test/src/033_closure_crash.php#L2).
@@ -1340,7 +1340,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/1.1.1/tests/misc/fallback_te
 This issue indicates that you're not passing in at least the number of required parameters to an internal function or method.
 
 ```
-Call with {COUNT} arg(s) to {FUNCTIONLIKE}() which requires {COUNT} arg(s)
+Call with {COUNT} arg(s) to {FUNCTIONLIKE} which requires {COUNT} arg(s)
 ```
 
 This will be emitted for the code
@@ -1354,7 +1354,7 @@ strlen();
 This issue is emitted when you're passing more than the number of required and optional parameters than are defined for a method or function.
 
 ```
-Call with {COUNT} arg(s) to {FUNCTIONLIKE}() which only takes {COUNT} arg(s) defined at {FILE}:{LINE}
+Call with {COUNT} arg(s) to {FUNCTIONLIKE} which only takes {COUNT} arg(s) defined at {FILE}:{LINE}
 ```
 
 This will be emitted for the code
@@ -1367,7 +1367,7 @@ f7(1, 2);
 ## PhanParamTooManyCallable
 
 ```
-Call with {COUNT} arg(s) to {FUNCTIONLIKE}() (As a provided callable) which only takes {COUNT} arg(s) defined at {FILE}:{LINE}
+Call with {COUNT} arg(s) to {FUNCTIONLIKE} (As a provided callable) which only takes {COUNT} arg(s) defined at {FILE}:{LINE}
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/1.1.1/tests/files/expected/0365_array_map_callable.php.expected#L8) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.1.1/tests/files/src/0365_array_map_callable.php#L53).
@@ -1377,7 +1377,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/1.1.1/tests/files/expected/0
 This issue is emitted when you're passing more than the number of required and optional parameters than are defined for an internal method or function.
 
 ```
-Call with {COUNT} arg(s) to {FUNCTIONLIKE}() which only takes {COUNT} arg(s)
+Call with {COUNT} arg(s) to {FUNCTIONLIKE} which only takes {COUNT} arg(s)
 ```
 
 This will be emitted for the code
@@ -1389,7 +1389,7 @@ strlen('str', 42);
 ## PhanParamTypeMismatch
 
 ```
-Argument {INDEX} is {TYPE} but {FUNCTIONLIKE}() takes {TYPE}
+Argument {INDEX} is {TYPE} but {FUNCTIONLIKE} takes {TYPE}
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/1.1.1/tests/files/expected/0364_extended_array_analyze.php.expected#L33) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.1.1/tests/files/src/0364_extended_array_analyze.php#L41).
@@ -1563,7 +1563,7 @@ This issue (and similar issues) may be emitted when `strict_param_checking` is t
 (when some types of the argument's union type match, but not others.)
 
 ```
-Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE}() takes {TYPE} ({TYPE} is incompatible) defined at {FILE}:{LINE}
+Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} ({TYPE} is incompatible) defined at {FILE}:{LINE}
 ```
 
 ## PhanPartialTypeMismatchArgumentInternal
@@ -1571,7 +1571,7 @@ Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE}() takes {TYPE} ({TYPE
 This issue may be emitted when `strict_param_checking` is true, when analyzing an internal function.
 
 ```
-Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE}() takes {TYPE} ({TYPE} is incompatible)
+Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} ({TYPE} is incompatible)
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/1.1.1/tests/plugin_test/expected/025_strict_param_checks.php.expected#L3) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.1.1/tests/plugin_test/src/025_strict_param_checks.php#L8).
@@ -1592,7 +1592,7 @@ This issue (and similar issues) may be emitted when `strict_return_checking` is 
 (when some types of the return statement's union type match, but not others.)
 
 ```
-Returning type {TYPE} but {FUNCTIONLIKE}() is declared to return {TYPE} ({TYPE} is incompatible)
+Returning type {TYPE} but {FUNCTIONLIKE} is declared to return {TYPE} ({TYPE} is incompatible)
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/1.1.1/tests/plugin_test/expected/026_strict_return_checks.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.1.1/tests/plugin_test/src/026_strict_return_checks.php#L23).
@@ -1602,7 +1602,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/1.1.1/tests/plugin_test/expe
 This issue may be emitted when `strict_param_checking` is true
 
 ```
-Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE}() takes {TYPE} ({TYPE} is incompatible) defined at {FILE}:{LINE}
+Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} ({TYPE} is incompatible) defined at {FILE}:{LINE}
 ```
 
 ## PhanPossiblyFalseTypeArgumentInternal
@@ -1610,7 +1610,7 @@ Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE}() takes {TYPE} ({TYPE
 This issue may be emitted when `strict_param_checking` is true
 
 ```
-Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE}() takes {TYPE} ({TYPE} is incompatible)
+Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} ({TYPE} is incompatible)
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/1.1.1/tests/plugin_test/expected/025_strict_param_checks.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.1.1/tests/plugin_test/src/025_strict_param_checks.php#L4).
@@ -1628,7 +1628,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/1.1.1/tests/plugin_test/expe
 This issue may be emitted when `strict_return_checking` is true
 
 ```
-Returning type {TYPE} but {FUNCTIONLIKE}() is declared to return {TYPE} ({TYPE} is incompatible)
+Returning type {TYPE} but {FUNCTIONLIKE} is declared to return {TYPE} ({TYPE} is incompatible)
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/1.1.1/tests/plugin_test/expected/026_strict_return_checks.php.expected#L3) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.1.1/tests/plugin_test/src/026_strict_return_checks.php#L31).
@@ -1638,7 +1638,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/1.1.1/tests/plugin_test/expe
 This issue may be emitted when `strict_param_checking` is true
 
 ```
-Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE}() takes {TYPE} ({TYPE} is incompatible) defined at {FILE}:{LINE}
+Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} ({TYPE} is incompatible) defined at {FILE}:{LINE}
 ```
 
 ## PhanPossiblyNullTypeArgumentInternal
@@ -1646,7 +1646,7 @@ Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE}() takes {TYPE} ({TYPE
 This issue may be emitted when `strict_param_checking` is true
 
 ```
-Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE}() takes {TYPE} ({TYPE} is incompatible)
+Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} ({TYPE} is incompatible)
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/1.1.1/tests/plugin_test/expected/025_strict_param_checks.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.1.1/tests/plugin_test/src/025_strict_param_checks.php#L6).
@@ -1664,7 +1664,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/1.1.1/tests/plugin_test/expe
 This issue may be emitted when `strict_return_checking` is true
 
 ```
-Returning type {TYPE} but {FUNCTIONLIKE}() is declared to return {TYPE} ({TYPE} is incompatible)
+Returning type {TYPE} but {FUNCTIONLIKE} is declared to return {TYPE} ({TYPE} is incompatible)
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/1.1.1/tests/plugin_test/expected/026_strict_return_checks.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.1.1/tests/plugin_test/src/026_strict_return_checks.php#L16).
@@ -2061,7 +2061,7 @@ class A { public function __set() { return true; } }
 ## PhanTypeMismatchArgument
 
 ```
-Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE}() takes {TYPE} defined at {FILE}:{LINE}
+Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} defined at {FILE}:{LINE}
 ```
 
 This will be emitted for the code
@@ -2074,7 +2074,7 @@ f8('string');
 ## PhanTypeMismatchArgumentInternal
 
 ```
-Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE}() takes {TYPE}
+Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE}
 ```
 
 This will be emitted for the code
@@ -2180,7 +2180,7 @@ foreach (null as $i) {}
 ## PhanTypeMismatchGeneratorYieldKey
 
 ```
-Yield statement has a key with type {TYPE} but {FUNCTIONLIKE}() is declared to yield keys of type {TYPE} in {TYPE}
+Yield statement has a key with type {TYPE} but {FUNCTIONLIKE} is declared to yield keys of type {TYPE} in {TYPE}
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/1.1.1/tests/files/expected/0475_analyze_yield_from.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.1.1/tests/files/src/0475_analyze_yield_from.php#L24).
@@ -2188,7 +2188,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/1.1.1/tests/files/expected/0
 ## PhanTypeMismatchGeneratorYieldValue
 
 ```
-Yield statement has a value with type {TYPE} but {FUNCTIONLIKE}() is declared to yield values of type {TYPE} in {TYPE}
+Yield statement has a value with type {TYPE} but {FUNCTIONLIKE} is declared to yield values of type {TYPE} in {TYPE}
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/1.1.1/tests/files/expected/0475_analyze_yield_from.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.1.1/tests/files/src/0475_analyze_yield_from.php#L23).
@@ -2208,7 +2208,7 @@ function f(int $p = false) {}
 ## PhanTypeMismatchReturn
 
 ```
-Returning type {TYPE} but {FUNCTIONLIKE}() is declared to return {TYPE}
+Returning type {TYPE} but {FUNCTIONLIKE} is declared to return {TYPE}
 ```
 
 This issue is emitted from the following code
@@ -2266,7 +2266,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/1.1.1/tests/files/expected/0
 ## PhanTypeNonVarPassByRef
 
 ```
-Only variables can be passed by reference at argument {INDEX} of {FUNCTIONLIKE}()
+Only variables can be passed by reference at argument {INDEX} of {FUNCTIONLIKE}
 ```
 
 This issue is emitted from the following code
@@ -2980,7 +2980,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/1.1.1/tests/files/expected/0
 ## PhanThrowTypeAbsent
 
 ```
-{METHOD}() can throw {TYPE} here, but has no '@throws' declarations for that class
+{FUNCTIONLIKE} can throw {TYPE} here, but has no '@throws' declarations for that class
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/1.1.1/tests/plugin_test/expected/040_if_assign.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.1.1/tests/plugin_test/src/040_if_assign.php#L4).
@@ -2988,7 +2988,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/1.1.1/tests/plugin_test/expe
 ## PhanThrowTypeAbsentForCall
 
 ```
-{METHOD}() can throw {TYPE} because it calls {FUNCTIONLIKE}(), but has no '@throws' declarations for that class
+{FUNCTIONLIKE} can throw {TYPE} because it calls {FUNCTIONLIKE}, but has no '@throws' declarations for that class
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/1.1.1/tests/plugin_test/expected/043_throws.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.1.1/tests/plugin_test/src/043_throws.php#L22).
@@ -2996,13 +2996,13 @@ e.g. [this issue](https://github.com/phan/phan/tree/1.1.1/tests/plugin_test/expe
 ## PhanThrowTypeMismatch
 
 ```
-{METHOD}() throws {TYPE}, but it only has declarations of '@throws {TYPE}'
+{FUNCTIONLIKE} throws {TYPE}, but it only has declarations of '@throws {TYPE}'
 ```
 
 ## PhanThrowTypeMismatchForCall
 
 ```
-{METHOD}() throws {TYPE} because it calls {FUNCTIONLIKE}(), but it only has declarations of '@throws {TYPE}'
+{FUNCTIONLIKE} throws {TYPE} because it calls {FUNCTIONLIKE}, but it only has declarations of '@throws {TYPE}'
 ```
 
 ## PhanUnextractableAnnotation

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -2008,7 +2008,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/1.1.1/tests/files/expected/0
 ## PhanTypeInvalidTraitParam
 
 ```
-Method {METHOD} is declared to have a parameter ${PARAMETER} with a real type of trait {TYPE} (expected a class or interface or built-in type)
+{FUNCTIONLIKE} is declared to have a parameter ${PARAMETER} with a real type of trait {TYPE} (expected a class or interface or built-in type)
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0560_trait_in_param_return.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0560_trait_in_param_return.php#L8).
@@ -2016,7 +2016,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/
 ## PhanTypeInvalidTraitReturn
 
 ```
-Expected a class or interface (or built-in type) to be the real return type of method {METHOD} but got trait {TRAIT}
+Expected a class or interface (or built-in type) to be the real return type of {FUNCTIONLIKE} but got trait {TRAIT}
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0560_trait_in_param_return.php.expected#L3) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0560_trait_in_param_return.php#L8).

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -119,7 +119,7 @@ class ParameterTypesAnalyzer
                         $method->getContext(),
                         Issue::TypeInvalidTraitParam,
                         $parameter->getFileRef()->getLineNumberStart(),
-                        $method->getName(),
+                        $method->getNameForIssue(),
                         $parameter->getName(),
                         $type_fqsen->__toString()
                     );

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -963,7 +963,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                         Issue::TypeMismatchReturn,
                         $lineno,
                         (string)$expression_type,
-                        $method->getName(),
+                        $method->getNameForIssue(),
                         (string)$method_return_type
                     );
                 } elseif (Config::get_strict_return_checking() && $expression_type->typeCount() > 1) {
@@ -1017,7 +1017,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                     Issue::TypeMismatchReturn,
                     $lineno,
                     (string)$expression_type,
-                    $method->getName(),
+                    $method->getNameForIssue(),
                     (string)$expected_return_type
                 );
             } elseif (Config::get_strict_return_checking() && $expression_type->typeCount() > 1) {
@@ -1075,7 +1075,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 Issue::TypeMismatchGeneratorYieldValue,
                 $node->lineno,
                 (string)$yield_value_type,
-                $method->getName(),
+                $method->getNameForIssue(),
                 (string)$expected_value_type,
                 '\Generator<' . implode(',', $template_type_list) . '>'
             );
@@ -1095,7 +1095,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                     Issue::TypeMismatchGeneratorYieldKey,
                     $node->lineno,
                     (string)$yield_key_type,
-                    $method->getName(),
+                    $method->getNameForIssue(),
                     (string)$expected_key_type,
                     '\Generator<' . implode(',', $template_type_list) . '>'
                 );
@@ -1175,7 +1175,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 Issue::TypeMismatchGeneratorYieldValue,
                 $node->lineno,
                 (string)$yield_value_type,
-                $method->getName(),
+                $method->getNameForIssue(),
                 (string)$expected_value_type,
                 '\Generator<' . implode(',', $template_type_list) . '>'
             );
@@ -1190,7 +1190,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                     Issue::TypeMismatchGeneratorYieldKey,
                     $node->lineno,
                     (string)$yield_key_type,
-                    $method->getName(),
+                    $method->getNameForIssue(),
                     (string)$expected_key_type,
                     '\Generator<' . implode(',', $template_type_list) . '>'
                 );
@@ -1271,7 +1271,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             self::getStrictIssueType($mismatch_type_set),
             $lineno,
             (string)$expression_type,
-            $method->getName(),
+            $method->getNameForIssue(),
             (string)$method_return_type,
             $mismatch_expanded_types
         );

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -541,7 +541,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
                     Issue::TypeMismatchReturn,
                     $node->lineno ?? 0,
                     '\\Generator',
-                    $func->getName(),
+                    $func->getNameForIssue(),
                     (string)$func_return_type
                 );
             }

--- a/src/Phan/Analysis/ReturnTypesAnalyzer.php
+++ b/src/Phan/Analysis/ReturnTypesAnalyzer.php
@@ -76,7 +76,7 @@ class ReturnTypesAnalyzer
                     $method->getContext(),
                     Issue::UndeclaredTypeReturnType,
                     $method->getFileRef()->getLineNumberStart(),
-                    [$method->getName(), (string)$outer_type],
+                    [$method->getNameForIssue(), (string)$outer_type],
                     IssueFixSuggester::suggestSimilarClass($code_base, $method->getContext(), $type_fqsen, null, 'Did you mean', IssueFixSuggester::CLASS_SUGGEST_CLASSES_AND_TYPES_AND_VOID)
                 );
             }
@@ -144,7 +144,7 @@ class ReturnTypesAnalyzer
                     $context,
                     Issue::TypeInvalidTraitReturn,
                     $method->getFileRef()->getLineNumberStart(),
-                    $method->getName(),
+                    $method->getNameForIssue(),
                     $type_fqsen->__toString()
                 );
             }

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -1712,7 +1712,7 @@ class Issue
                 self::TypeInvalidTraitReturn,
                 self::CATEGORY_TYPE,
                 self::SEVERITY_NORMAL,
-                "Expected a class or interface (or built-in type) to be the real return type of method {METHOD} but got trait {TRAIT}",
+                "Expected a class or interface (or built-in type) to be the real return type of {FUNCTIONLIKE} but got trait {TRAIT}",
                 self::REMEDIATION_B,
                 10089
             ),
@@ -1720,7 +1720,7 @@ class Issue
                 self::TypeInvalidTraitParam,
                 self::CATEGORY_TYPE,
                 self::SEVERITY_NORMAL,
-                "Method {METHOD} is declared to have a parameter \${PARAMETER} with a real type of trait {TYPE} (expected a class or interface or built-in type)",
+                "{FUNCTIONLIKE} is declared to have a parameter \${PARAMETER} with a real type of trait {TYPE} (expected a class or interface or built-in type)",
                 self::REMEDIATION_B,
                 10090
             ),

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -1055,7 +1055,7 @@ class Issue
                 self::TypeMismatchArgument,
                 self::CATEGORY_TYPE,
                 self::SEVERITY_NORMAL,
-                "Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE}() takes {TYPE} defined at {FILE}:{LINE}",
+                "Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} defined at {FILE}:{LINE}",
                 self::REMEDIATION_B,
                 10003
             ),
@@ -1063,7 +1063,7 @@ class Issue
                 self::TypeMismatchArgumentInternal,
                 self::CATEGORY_TYPE,
                 self::SEVERITY_NORMAL,
-                "Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE}() takes {TYPE}",
+                "Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE}",
                 self::REMEDIATION_B,
                 10004
             ),
@@ -1071,7 +1071,7 @@ class Issue
                 self::TypeMismatchGeneratorYieldValue,
                 self::CATEGORY_TYPE,
                 self::SEVERITY_NORMAL,
-                "Yield statement has a value with type {TYPE} but {FUNCTIONLIKE}() is declared to yield values of type {TYPE} in {TYPE}",
+                "Yield statement has a value with type {TYPE} but {FUNCTIONLIKE} is declared to yield values of type {TYPE} in {TYPE}",
                 self::REMEDIATION_B,
                 10067
             ),
@@ -1079,7 +1079,7 @@ class Issue
                 self::TypeMismatchGeneratorYieldKey,
                 self::CATEGORY_TYPE,
                 self::SEVERITY_NORMAL,
-                "Yield statement has a key with type {TYPE} but {FUNCTIONLIKE}() is declared to yield keys of type {TYPE} in {TYPE}",
+                "Yield statement has a key with type {TYPE} but {FUNCTIONLIKE} is declared to yield keys of type {TYPE} in {TYPE}",
                 self::REMEDIATION_B,
                 10068
             ),
@@ -1095,7 +1095,7 @@ class Issue
                 self::PartialTypeMismatchArgument,
                 self::CATEGORY_TYPE,
                 self::SEVERITY_NORMAL,
-                "Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE}() takes {TYPE} ({TYPE} is incompatible) defined at {FILE}:{LINE}",
+                "Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} ({TYPE} is incompatible) defined at {FILE}:{LINE}",
                 self::REMEDIATION_B,
                 10054
             ),
@@ -1103,7 +1103,7 @@ class Issue
                 self::PartialTypeMismatchArgumentInternal,
                 self::CATEGORY_TYPE,
                 self::SEVERITY_NORMAL,
-                "Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE}() takes {TYPE} ({TYPE} is incompatible)",
+                "Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} ({TYPE} is incompatible)",
                 self::REMEDIATION_B,
                 10055
             ),
@@ -1111,7 +1111,7 @@ class Issue
                 self::PossiblyNullTypeArgument,
                 self::CATEGORY_TYPE,
                 self::SEVERITY_NORMAL,
-                "Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE}() takes {TYPE} ({TYPE} is incompatible) defined at {FILE}:{LINE}",
+                "Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} ({TYPE} is incompatible) defined at {FILE}:{LINE}",
                 self::REMEDIATION_B,
                 10056
             ),
@@ -1119,7 +1119,7 @@ class Issue
                 self::PossiblyNullTypeArgumentInternal,
                 self::CATEGORY_TYPE,
                 self::SEVERITY_NORMAL,
-                "Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE}() takes {TYPE} ({TYPE} is incompatible)",
+                "Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} ({TYPE} is incompatible)",
                 self::REMEDIATION_B,
                 10057
             ),
@@ -1127,7 +1127,7 @@ class Issue
                 self::PossiblyFalseTypeArgument,
                 self::CATEGORY_TYPE,
                 self::SEVERITY_NORMAL,
-                "Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE}() takes {TYPE} ({TYPE} is incompatible) defined at {FILE}:{LINE}",
+                "Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} ({TYPE} is incompatible) defined at {FILE}:{LINE}",
                 self::REMEDIATION_B,
                 10058
             ),
@@ -1135,7 +1135,7 @@ class Issue
                 self::PossiblyFalseTypeArgumentInternal,
                 self::CATEGORY_TYPE,
                 self::SEVERITY_NORMAL,
-                "Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE}() takes {TYPE} ({TYPE} is incompatible)",
+                "Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} ({TYPE} is incompatible)",
                 self::REMEDIATION_B,
                 10059
             ),
@@ -1143,7 +1143,7 @@ class Issue
                 self::TypeMismatchReturn,
                 self::CATEGORY_TYPE,
                 self::SEVERITY_NORMAL,
-                "Returning type {TYPE} but {FUNCTIONLIKE}() is declared to return {TYPE}",
+                "Returning type {TYPE} but {FUNCTIONLIKE} is declared to return {TYPE}",
                 self::REMEDIATION_B,
                 10005
             ),
@@ -1151,7 +1151,7 @@ class Issue
                 self::PartialTypeMismatchReturn,
                 self::CATEGORY_TYPE,
                 self::SEVERITY_NORMAL,
-                "Returning type {TYPE} but {FUNCTIONLIKE}() is declared to return {TYPE} ({TYPE} is incompatible)",
+                "Returning type {TYPE} but {FUNCTIONLIKE} is declared to return {TYPE} ({TYPE} is incompatible)",
                 self::REMEDIATION_B,
                 10060
             ),
@@ -1159,7 +1159,7 @@ class Issue
                 self::PossiblyNullTypeReturn,
                 self::CATEGORY_TYPE,
                 self::SEVERITY_NORMAL,
-                "Returning type {TYPE} but {FUNCTIONLIKE}() is declared to return {TYPE} ({TYPE} is incompatible)",
+                "Returning type {TYPE} but {FUNCTIONLIKE} is declared to return {TYPE} ({TYPE} is incompatible)",
                 self::REMEDIATION_B,
                 10061
             ),
@@ -1167,7 +1167,7 @@ class Issue
                 self::PossiblyFalseTypeReturn,
                 self::CATEGORY_TYPE,
                 self::SEVERITY_NORMAL,
-                "Returning type {TYPE} but {FUNCTIONLIKE}() is declared to return {TYPE} ({TYPE} is incompatible)",
+                "Returning type {TYPE} but {FUNCTIONLIKE} is declared to return {TYPE} ({TYPE} is incompatible)",
                 self::REMEDIATION_B,
                 10062
             ),
@@ -1367,7 +1367,7 @@ class Issue
                 self::TypeNonVarPassByRef,
                 self::CATEGORY_TYPE,
                 self::SEVERITY_NORMAL,
-                "Only variables can be passed by reference at argument {INDEX} of {FUNCTIONLIKE}()",
+                "Only variables can be passed by reference at argument {INDEX} of {FUNCTIONLIKE}",
                 self::REMEDIATION_B,
                 10018
             ),
@@ -1775,7 +1775,7 @@ class Issue
                 self::DeprecatedFunction,
                 self::CATEGORY_DEPRECATED,
                 self::SEVERITY_NORMAL,
-                "Call to deprecated function {FUNCTIONLIKE}() defined at {FILE}:{LINE}",
+                "Call to deprecated function {FUNCTIONLIKE} defined at {FILE}:{LINE}",
                 self::REMEDIATION_B,
                 5000
             ),
@@ -1783,7 +1783,7 @@ class Issue
                 self::DeprecatedFunctionInternal,
                 self::CATEGORY_DEPRECATED,
                 self::SEVERITY_NORMAL,
-                "Call to deprecated function {FUNCTIONLIKE}()",
+                "Call to deprecated function {FUNCTIONLIKE}",
                 self::REMEDIATION_B,
                 5005
             ),
@@ -1833,7 +1833,7 @@ class Issue
                 self::ParamTooMany,
                 self::CATEGORY_PARAMETER,
                 self::SEVERITY_LOW,
-                "Call with {COUNT} arg(s) to {FUNCTIONLIKE}() which only takes {COUNT} arg(s) defined at {FILE}:{LINE}",
+                "Call with {COUNT} arg(s) to {FUNCTIONLIKE} which only takes {COUNT} arg(s) defined at {FILE}:{LINE}",
                 self::REMEDIATION_B,
                 7001
             ),
@@ -1841,7 +1841,7 @@ class Issue
                 self::ParamTooManyInternal,
                 self::CATEGORY_PARAMETER,
                 self::SEVERITY_LOW,
-                "Call with {COUNT} arg(s) to {FUNCTIONLIKE}() which only takes {COUNT} arg(s)",
+                "Call with {COUNT} arg(s) to {FUNCTIONLIKE} which only takes {COUNT} arg(s)",
                 self::REMEDIATION_B,
                 7002
             ),
@@ -1849,7 +1849,7 @@ class Issue
                 self::ParamTooManyCallable,
                 self::CATEGORY_PARAMETER,
                 self::SEVERITY_LOW,
-                "Call with {COUNT} arg(s) to {FUNCTIONLIKE}() (As a provided callable) which only takes {COUNT} arg(s) defined at {FILE}:{LINE}",
+                "Call with {COUNT} arg(s) to {FUNCTIONLIKE} (As a provided callable) which only takes {COUNT} arg(s) defined at {FILE}:{LINE}",
                 self::REMEDIATION_B,
                 7043
             ),
@@ -1857,7 +1857,7 @@ class Issue
                 self::ParamTooFew,
                 self::CATEGORY_PARAMETER,
                 self::SEVERITY_CRITICAL,
-                "Call with {COUNT} arg(s) to {FUNCTIONLIKE}() which requires {COUNT} arg(s) defined at {FILE}:{LINE}",
+                "Call with {COUNT} arg(s) to {FUNCTIONLIKE} which requires {COUNT} arg(s) defined at {FILE}:{LINE}",
                 self::REMEDIATION_B,
                 7003
             ),
@@ -1865,7 +1865,7 @@ class Issue
                 self::ParamTooFewInternal,
                 self::CATEGORY_PARAMETER,
                 self::SEVERITY_CRITICAL,
-                "Call with {COUNT} arg(s) to {FUNCTIONLIKE}() which requires {COUNT} arg(s)",
+                "Call with {COUNT} arg(s) to {FUNCTIONLIKE} which requires {COUNT} arg(s)",
                 self::REMEDIATION_B,
                 7004
             ),
@@ -1873,7 +1873,7 @@ class Issue
                 self::ParamTooFewCallable,
                 self::CATEGORY_PARAMETER,
                 self::SEVERITY_CRITICAL,
-                "Call with {COUNT} arg(s) to {FUNCTIONLIKE}() (as a provided callable) which requires {COUNT} arg(s) defined at {FILE}:{LINE}",
+                "Call with {COUNT} arg(s) to {FUNCTIONLIKE} (as a provided callable) which requires {COUNT} arg(s) defined at {FILE}:{LINE}",
                 self::REMEDIATION_B,
                 7044
             ),
@@ -1881,7 +1881,7 @@ class Issue
                 self::ParamSpecial1,
                 self::CATEGORY_PARAMETER,
                 self::SEVERITY_NORMAL,
-                "Argument {INDEX} ({PARAMETER}) is {TYPE} but {FUNCTIONLIKE}() takes {TYPE} when argument {INDEX} is {TYPE}",
+                "Argument {INDEX} ({PARAMETER}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} when argument {INDEX} is {TYPE}",
                 self::REMEDIATION_B,
                 7005
             ),
@@ -1889,7 +1889,7 @@ class Issue
                 self::ParamSpecial2,
                 self::CATEGORY_PARAMETER,
                 self::SEVERITY_NORMAL,
-                "Argument {INDEX} ({PARAMETER}) is {TYPE} but {FUNCTIONLIKE}() takes {TYPE} when passed only one argument",
+                "Argument {INDEX} ({PARAMETER}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} when passed only one argument",
                 self::REMEDIATION_B,
                 7006
             ),
@@ -1913,7 +1913,7 @@ class Issue
                 self::ParamTypeMismatch,
                 self::CATEGORY_PARAMETER,
                 self::SEVERITY_NORMAL,
-                "Argument {INDEX} is {TYPE} but {FUNCTIONLIKE}() takes {TYPE}",
+                "Argument {INDEX} is {TYPE} but {FUNCTIONLIKE} takes {TYPE}",
                 self::REMEDIATION_B,
                 7009
             ),
@@ -3210,7 +3210,7 @@ class Issue
                 self::ThrowTypeAbsent,
                 self::CATEGORY_COMMENT,
                 self::SEVERITY_LOW,
-                "{METHOD}() can throw {TYPE} here, but has no '@throws' declarations for that class",
+                "{FUNCTIONLIKE} can throw {TYPE} here, but has no '@throws' declarations for that class",
                 self::REMEDIATION_A,
                 16011
             ),
@@ -3218,7 +3218,7 @@ class Issue
                 self::ThrowTypeAbsentForCall,
                 self::CATEGORY_COMMENT,
                 self::SEVERITY_LOW,
-                "{METHOD}() can throw {TYPE} because it calls {FUNCTIONLIKE}(), but has no '@throws' declarations for that class",
+                "{FUNCTIONLIKE} can throw {TYPE} because it calls {FUNCTIONLIKE}, but has no '@throws' declarations for that class",
                 self::REMEDIATION_A,
                 16012
             ),
@@ -3226,7 +3226,7 @@ class Issue
                 self::ThrowTypeMismatch,
                 self::CATEGORY_COMMENT,
                 self::SEVERITY_LOW,
-                "{METHOD}() throws {TYPE}, but it only has declarations of '@throws {TYPE}'",
+                "{FUNCTIONLIKE} throws {TYPE}, but it only has declarations of '@throws {TYPE}'",
                 self::REMEDIATION_A,
                 16013
             ),
@@ -3234,7 +3234,7 @@ class Issue
                 self::ThrowTypeMismatchForCall,
                 self::CATEGORY_COMMENT,
                 self::SEVERITY_LOW,
-                "{METHOD}() throws {TYPE} because it calls {FUNCTIONLIKE}(), but it only has declarations of '@throws {TYPE}'",
+                "{FUNCTIONLIKE} throws {TYPE} because it calls {FUNCTIONLIKE}, but it only has declarations of '@throws {TYPE}'",
                 self::REMEDIATION_A,
                 16014
             ),

--- a/src/Phan/Language/Element/FunctionInterface.php
+++ b/src/Phan/Language/Element/FunctionInterface.php
@@ -38,6 +38,13 @@ interface FunctionInterface extends AddressableElementInterface
     public function getRepresentationForIssue() : string;
 
     /**
+     * @return string
+     * The name of this structural element (without namespace/class),
+     * or a string for FunctionLikeDeclarationType (or a closure) which lacks a real FQSEN
+     */
+    public function getNameForIssue() : string;
+
+    /**
      * Sets the scope within this function-like element's body,
      * for tracking variables within the function-like.
      * @return void

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -73,7 +73,18 @@ trait FunctionTrait
      */
     public function getRepresentationForIssue() : string
     {
-        return $this->getFQSEN()->__toString();
+        return $this->getFQSEN()->__toString() . '()';
+    }
+
+    /**
+     * @return string
+     * The name of this structural element (without namespace/class),
+     * or a string for FunctionLikeDeclarationType which lacks a real FQSEN
+     * @suppress PhanUnreferencedPublicMethod bad inference?
+     */
+    public function getNameForIssue() : string
+    {
+        return $this->getName() . '()';
     }
 
     /**

--- a/src/Phan/Language/Type/FunctionLikeDeclarationType.php
+++ b/src/Phan/Language/Type/FunctionLikeDeclarationType.php
@@ -345,6 +345,13 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
     }
 
     /** @override */
+    public function getNameForIssue() : string
+    {
+        // Represent this as "Closure(int):void" in issue messages instead of \closure_phpdoc_abcd123456Df
+        return $this->__toString();
+    }
+
+    /** @override */
     public function getHasReturn() : bool
     {
         return true;

--- a/src/Phan/Plugin/Internal/MiscParamPlugin.php
+++ b/src/Phan/Plugin/Internal/MiscParamPlugin.php
@@ -67,7 +67,7 @@ final class MiscParamPlugin extends PluginV2 implements
                         1,
                         'values',
                         (string)$node_type,
-                        $function->getName(),
+                        $function->getRepresentationForIssue(),
                         'array'
                         ]
                     );
@@ -98,7 +98,7 @@ final class MiscParamPlugin extends PluginV2 implements
                         $context->getFile(),
                         $context->getLineNumberStart(),
                         [
-                        (string)$function->getFQSEN(),
+                        $function->getRepresentationForIssue(),
                         'callable'
                         ]
                     );
@@ -119,7 +119,7 @@ final class MiscParamPlugin extends PluginV2 implements
                             [
                             ($i + 1),
                             (string)$node_type,
-                            (string)$function->getFQSEN(),
+                            $function->getRepresentationForIssue(),
                             'array'
                             ]
                         );
@@ -157,7 +157,7 @@ final class MiscParamPlugin extends PluginV2 implements
                                 1,
                                 'pieces',
                                 $node_type->asNonLiteralType(),
-                                (string)$function->getFQSEN(),
+                                $function->getRepresentationForIssue(),
                                 'string[]'
                             ]
                         );
@@ -190,7 +190,7 @@ final class MiscParamPlugin extends PluginV2 implements
                             2,
                             'glue',
                             (string)$arg2_type->asNonLiteralType(),
-                            (string)$function->getRepresentationForIssue(),
+                            $function->getRepresentationForIssue(),
                             'string',
                             1,
                             'array'
@@ -222,7 +222,7 @@ final class MiscParamPlugin extends PluginV2 implements
                             2,
                             'pieces',
                             (string)$arg2_type->asNonLiteralType(),
-                            (string)$function->getFQSEN(),
+                            $function->getRepresentationForIssue(),
                             'string[]',
                             1,
                             'string'
@@ -271,7 +271,7 @@ final class MiscParamPlugin extends PluginV2 implements
                         $context->getFile(),
                         $context->getLineNumberStart(),
                         [
-                        (string)$function->getFQSEN(),
+                        $function->getRepresentationForIssue(),
                         'callable'
                         ]
                     );
@@ -289,7 +289,7 @@ final class MiscParamPlugin extends PluginV2 implements
                         $context->getFile(),
                         $context->getLineNumberStart(),
                         [
-                        (string)$function->getFQSEN(),
+                        $function->getRepresentationForIssue(),
                         'callable'
                         ]
                     );
@@ -310,7 +310,7 @@ final class MiscParamPlugin extends PluginV2 implements
                             [
                             ($i + 1),
                             (string)$node_type,
-                            (string)$function->getFQSEN(),
+                            $function->getRepresentationForIssue(),
                             'array'
                             ]
                         );

--- a/tests/files/expected/0044_closure_types.php.expected
+++ b/tests/files/expected/0044_closure_types.php.expected
@@ -1,2 +1,2 @@
-%s:6 PhanTypeMismatchArgument Argument 1 (i) is 'string' but \closure_%s() takes int defined at %s:3
-%s:7 PhanTypeMismatchArgument Argument 1 (s) is 42 but \closure_%s() takes string defined at %s:4
+%s:6 PhanTypeMismatchArgument Argument 1 (i) is 'string' but Closure(int $i) : int takes int defined at %s:3
+%s:7 PhanTypeMismatchArgument Argument 1 (s) is 42 but Closure(string $s) : string takes string defined at %s:4

--- a/tests/files/expected/0098_undef.php.expected
+++ b/tests/files/expected/0098_undef.php.expected
@@ -13,5 +13,5 @@
 %s:37 PhanTraitParentReference Reference to parent from trait \T98
 %s:40 PhanParentlessClass Reference to parent of class \G98 that does not extend anything
 %s:43 PhanUndeclaredExtendedClass Class extends undeclared class \Undef
-%s:46 PhanUndeclaredTypeReturnType Return type of j is undeclared type \Undef
-%s:49 PhanUndeclaredTypeReturnType Return type of k is undeclared type \self
+%s:46 PhanUndeclaredTypeReturnType Return type of j() is undeclared type \Undef
+%s:49 PhanUndeclaredTypeReturnType Return type of k() is undeclared type \self

--- a/tests/files/expected/0101_one_of_each.php.expected
+++ b/tests/files/expected/0101_one_of_each.php.expected
@@ -13,9 +13,9 @@
 %s:48 PhanParamReqAfterOpt Required argument follows optional
 %s:51 PhanParamSpecial1 Argument 2 (pieces) is string but \join() takes string[] when argument 1 is string
 %s:54 PhanParamSpecial2 Argument 1 (pieces) is string but \join() takes string[] when passed only one argument
-%s:57 PhanParamSpecial3 The last argument to \array_udiff must be of type callable
+%s:57 PhanParamSpecial3 The last argument to \array_udiff() must be of type callable
 %s:57 PhanTypeConversionFromArray array to string conversion
-%s:60 PhanParamSpecial4 The second to last argument to \array_uintersect_uassoc must be of type callable
+%s:60 PhanParamSpecial4 The second to last argument to \array_uintersect_uassoc() must be of type callable
 %s:60 PhanTypeConversionFromArray array to string conversion
 %s:64 PhanParamTooFew Call with 0 arg(s) to \f6() which requires 1 arg(s) defined at %s:63
 %s:71 PhanParamTooMany Call with 2 arg(s) to \f7() which only takes 1 arg(s) defined at %s:70

--- a/tests/files/expected/0223_generator_closure_return_type.php.expected
+++ b/tests/files/expected/0223_generator_closure_return_type.php.expected
@@ -1,4 +1,4 @@
-%s:5 PhanTypeMismatchReturn Returning type 1 but {closure}() is declared to return \Generator
-%s:9 PhanTypeMismatchReturn Returning type 1 but {closure}() is declared to return \Iterator
-%s:13 PhanTypeMismatchReturn Returning type 1 but {closure}() is declared to return \Traversable
-%s:17 PhanTypeMismatchReturn Returning type \Generator but {closure}() is declared to return int
+%s:5 PhanTypeMismatchReturn Returning type 1 but Closure() : \Generator is declared to return \Generator
+%s:9 PhanTypeMismatchReturn Returning type 1 but Closure() : \Iterator is declared to return \Iterator
+%s:13 PhanTypeMismatchReturn Returning type 1 but Closure() : \Traversable is declared to return \Traversable
+%s:17 PhanTypeMismatchReturn Returning type \Generator but Closure() is declared to return int

--- a/tests/files/expected/0226_internal_tostring_parameter_undeclared.php.expected
+++ b/tests/files/expected/0226_internal_tostring_parameter_undeclared.php.expected
@@ -1,2 +1,2 @@
-%s:7 PhanUndeclaredTypeReturnType Return type of foo is undeclared type \urlstring
+%s:7 PhanUndeclaredTypeReturnType Return type of foo() is undeclared type \urlstring
 %s:9 PhanTypeMismatchArgumentInternal Argument 1 (message) is \urlstring but \error_log() takes string

--- a/tests/files/expected/0241_nullable_71.php.expected
+++ b/tests/files/expected/0241_nullable_71.php.expected
@@ -3,4 +3,4 @@
 %s:13 PhanTypeMismatchArgument Argument 1 (name) is 42 but \f241_3() takes ?string defined at %s:11
 %s:26 PhanTypeMismatchReturn Returning type 42 but f241_5() is declared to return ?string
 %s:41 PhanTypeMismatchReturn Returning type null but f241_10() is declared to return \TupleOfNullableTest241<int,string>
-%s:41 PhanUndeclaredTypeReturnType Return type of f241_10 is undeclared type \TupleOfNullableTest241<int,string>
+%s:41 PhanUndeclaredTypeReturnType Return type of f241_10() is undeclared type \TupleOfNullableTest241<int,string>

--- a/tests/files/expected/0241_nullable_71.php.expected70
+++ b/tests/files/expected/0241_nullable_71.php.expected70
@@ -1,3 +1,3 @@
-%s70:12 PhanTypeMismatchReturn Returning type 42 but f241_5() is declared to return ?string
-%s70:27 PhanTypeMismatchReturn Returning type null but f241_10() is declared to return \Tuple<int,string>
-%s70:27 PhanUndeclaredTypeReturnType Return type of f241_10 is undeclared type \Tuple<int,string>
+%s:12 PhanTypeMismatchReturn Returning type 42 but f241_5() is declared to return ?string
+%s:27 PhanTypeMismatchReturn Returning type null but f241_10() is declared to return \Tuple<int,string>
+%s:27 PhanUndeclaredTypeReturnType Return type of f241_10() is undeclared type \Tuple<int,string>

--- a/tests/files/expected/0262_obj_cast_to_specific_obj.php.expected
+++ b/tests/files/expected/0262_obj_cast_to_specific_obj.php.expected
@@ -1,2 +1,2 @@
-%s:18 PhanUndeclaredTypeReturnType Return type of returns_nullable_class is undeclared type \NullableClass
+%s:18 PhanUndeclaredTypeReturnType Return type of returns_nullable_class() is undeclared type \NullableClass
 %s:26 PhanTypeMismatchReturn Returning type object but returns_array() is declared to return array

--- a/tests/files/expected/0263_alias_outside_phpdoc.php.expected
+++ b/tests/files/expected/0263_alias_outside_phpdoc.php.expected
@@ -3,7 +3,7 @@
 %s:4 PhanUndeclaredTypeParameter Parameter $c has undeclared type \callback
 %s:4 PhanUndeclaredTypeParameter Parameter $d has undeclared type \double
 %s:4 PhanUndeclaredTypeParameter Parameter $e has undeclared type array<int,\double>
-%s:4 PhanUndeclaredTypeReturnType Return type of foo263 is undeclared type \boolean
+%s:4 PhanUndeclaredTypeReturnType Return type of foo263() is undeclared type \boolean
 %s:5 PhanTypeMismatchReturn Returning type false but foo263() is declared to return \boolean
 %s:7 PhanTypeMismatchArgument Argument 1 (a) is false but \foo263() takes \boolean defined at %s:4
 %s:7 PhanTypeMismatchArgument Argument 2 (b) is 2 but \foo263() takes \integer defined at %s:4

--- a/tests/files/expected/0278_internal_elements.php.expected
+++ b/tests/files/expected/0278_internal_elements.php.expected
@@ -11,15 +11,15 @@
 %s:73 PhanUnusedVariable Unused definition of variable $v23
 %s:74 PhanUnusedVariable Unused definition of variable $v24
 %s:75 PhanUnusedVariable Unused definition of variable $v25
-%s:92 PhanAccessMethodInternal Cannot access internal method \NS278\A\f of namespace \NS278\A defined at %s:33 from namespace \NS278\B
+%s:92 PhanAccessMethodInternal Cannot access internal method \NS278\A\f() of namespace \NS278\A defined at %s:33 from namespace \NS278\B
 %s:92 PhanTypeVoidAssignment Cannot assign void return value
 %s:94 PhanAccessConstantInternal Cannot access internal constant \NS278\A\CONST_INTERNAL of namespace \NS278\A defined at %s:8 from namespace \NS278\B
-%s:96 PhanAccessMethodInternal Cannot access internal method \NS278\A\C1::__construct of namespace \NS278\A defined at %s:11 from namespace \NS278\B
+%s:96 PhanAccessMethodInternal Cannot access internal method \NS278\A\C1::__construct() of namespace \NS278\A defined at %s:11 from namespace \NS278\B
 %s:97 PhanAccessPropertyInternal Cannot access internal property \NS278\A\C1::p of namespace \NS278\A defined at %s:13 from namespace \NS278\B
-%s:98 PhanAccessMethodInternal Cannot access internal method \NS278\A\C1::f of namespace \NS278\A defined at %s:14 from namespace \NS278\B
+%s:98 PhanAccessMethodInternal Cannot access internal method \NS278\A\C1::f() of namespace \NS278\A defined at %s:14 from namespace \NS278\B
 %s:99 PhanAccessClassConstantInternal Cannot access internal class constant \NS278\A\C1::CONST_INTERNAL defined at %s:12
 %s:102 PhanAccessPropertyInternal Cannot access internal property \NS278\A\C2::p of namespace \NS278\A defined at %s:24 from namespace \NS278\B
-%s:103 PhanAccessMethodInternal Cannot access internal method \NS278\A\C2::f of namespace \NS278\A defined at %s:27 from namespace \NS278\B
+%s:103 PhanAccessMethodInternal Cannot access internal method \NS278\A\C2::f() of namespace \NS278\A defined at %s:27 from namespace \NS278\B
 %s:106 PhanAccessClassConstantInternal Cannot access internal class constant \NS278\A\C2::CONST_INTERNAL defined at %s:21
 %s:108 PhanAccessClassInternal Cannot access internal Class \NS278\A\C1 defined at %s:11
 %s:108 PhanAccessClassInternal Cannot access internal Interface \NS278\A\I2 defined at %s:53

--- a/tests/files/expected/0278_internal_elements.php.expected70
+++ b/tests/files/expected/0278_internal_elements.php.expected70
@@ -11,14 +11,14 @@
 %s:73 PhanUnusedVariable Unused definition of variable $v23
 %s:74 PhanUnusedVariable Unused definition of variable $v24
 %s:75 PhanUnusedVariable Unused definition of variable $v25
-%s:92 PhanAccessMethodInternal Cannot access internal method \NS278\A\f of namespace \NS278\A defined at %s:33 from namespace \NS278\B
+%s:92 PhanAccessMethodInternal Cannot access internal method \NS278\A\f() of namespace \NS278\A defined at %s:33 from namespace \NS278\B
 %s:92 PhanTypeVoidAssignment Cannot assign void return value
-%s:96 PhanAccessMethodInternal Cannot access internal method \NS278\A\C1::__construct of namespace \NS278\A defined at %s:11 from namespace \NS278\B
+%s:96 PhanAccessMethodInternal Cannot access internal method \NS278\A\C1::__construct() of namespace \NS278\A defined at %s:11 from namespace \NS278\B
 %s:97 PhanAccessPropertyInternal Cannot access internal property \NS278\A\C1::p of namespace \NS278\A defined at %s:13 from namespace \NS278\B
-%s:98 PhanAccessMethodInternal Cannot access internal method \NS278\A\C1::f of namespace \NS278\A defined at %s:14 from namespace \NS278\B
+%s:98 PhanAccessMethodInternal Cannot access internal method \NS278\A\C1::f() of namespace \NS278\A defined at %s:14 from namespace \NS278\B
 %s:99 PhanAccessClassConstantInternal Cannot access internal class constant \NS278\A\C1::CONST_INTERNAL defined at %s:12
 %s:102 PhanAccessPropertyInternal Cannot access internal property \NS278\A\C2::p of namespace \NS278\A defined at %s:24 from namespace \NS278\B
-%s:103 PhanAccessMethodInternal Cannot access internal method \NS278\A\C2::f of namespace \NS278\A defined at %s:27 from namespace \NS278\B
+%s:103 PhanAccessMethodInternal Cannot access internal method \NS278\A\C2::f() of namespace \NS278\A defined at %s:27 from namespace \NS278\B
 %s:108 PhanAccessClassInternal Cannot access internal Class \NS278\A\C1 defined at %s:11
 %s:108 PhanAccessClassInternal Cannot access internal Interface \NS278\A\I2 defined at %s:53
 %s:108 PhanAccessClassInternal Cannot access internal Trait \NS278\A\T2 defined at %s:56

--- a/tests/files/expected/0333_closure_return_types.php.expected
+++ b/tests/files/expected/0333_closure_return_types.php.expected
@@ -1,4 +1,4 @@
 %s:4 PhanTypeMismatchReturn Returning type \stdClass but f333() is declared to return int
-%s:6 PhanTypeMismatchArgument Argument 1 (arg) is 'notanint' but \closure_%s() takes int defined at %s:4
-%s:14 PhanParamTooFew Call with 0 arg(s) to \closure_%s() which requires 1 arg(s) defined at %s:11
+%s:6 PhanTypeMismatchArgument Argument 1 (arg) is 'notanint' but Closure(int $arg) : \stdClass takes int defined at %s:4
+%s:14 PhanParamTooFew Call with 0 arg(s) to Closure(int $arg) : \stdClass which requires 1 arg(s) defined at %s:11
 %s:15 PhanTypeMismatchReturn Returning type \stdClass but g333() is declared to return int

--- a/tests/files/expected/0358_undeclared_class_in_generic_array.php.expected
+++ b/tests/files/expected/0358_undeclared_class_in_generic_array.php.expected
@@ -1,4 +1,4 @@
 %s:9 PhanUndeclaredTypeParameter Parameter $a has undeclared type \UndefClass357A[]
 %s:9 PhanUndeclaredTypeParameter Parameter $b has undeclared type \UndefClass357B[][][]
 %s:9 PhanUndeclaredTypeParameter Parameter $c has undeclared type \UndefClass357C
-%s:9 PhanUndeclaredTypeReturnType Return type of test358 is undeclared type \UndefClass357D[]
+%s:9 PhanUndeclaredTypeReturnType Return type of test358() is undeclared type \UndefClass357D[]

--- a/tests/files/expected/0359_undeclared_class_in_prop.php.expected
+++ b/tests/files/expected/0359_undeclared_class_in_prop.php.expected
@@ -1,6 +1,6 @@
 %s:4 PhanUndeclaredTypeProperty Property \A359::missing4 has undeclared type \Missing359E
 %s:4 PhanUndeclaredTypeProperty Property \A359::missing4 has undeclared type \Missing359F[][]
-%s:5 PhanUndeclaredTypeReturnType Return type of myInstanceMethod is undeclared type \Missing359G
+%s:5 PhanUndeclaredTypeReturnType Return type of myInstanceMethod() is undeclared type \Missing359G
 %s:7 PhanUndeclaredTypeParameter Parameter $param1 has undeclared type \Missing359H[]
 %s:9 PhanUndeclaredTypeProperty Property \A359::missing1 has undeclared type \Missing359
 %s:9 PhanUndeclaredTypeProperty Property \A359::missing1 has undeclared type \Missing359B[][]

--- a/tests/files/expected/0360_undeclared_array_class_in_namespace.php.expected
+++ b/tests/files/expected/0360_undeclared_array_class_in_namespace.php.expected
@@ -1,4 +1,4 @@
 %s:12 PhanUndeclaredTypeParameter Parameter $x has undeclared type \Foo\Baz\MissingClass[][][]
-%s:12 PhanUndeclaredTypeReturnType Return type of myMethod is undeclared type \Foo\Bat\OtherMissingClass[][]
+%s:12 PhanUndeclaredTypeReturnType Return type of myMethod() is undeclared type \Foo\Bat\OtherMissingClass[][]
 %s:18 PhanUndeclaredTypeProperty Property \Foo\Bar\MyClass::y has undeclared type \Foo\Bar\Closure[][] (Did you mean class \Closure)
 %s:22 PhanUndeclaredTypeProperty Property \Foo\Bar\MyClass::str has undeclared type \Foo\Bar\strong (Did you mean string)

--- a/tests/files/expected/0365_array_map_callable.php.expected
+++ b/tests/files/expected/0365_array_map_callable.php.expected
@@ -1,4 +1,4 @@
-%s:7 PhanTypeMismatchArgument Argument 1 (x) is 'x' but \closure_%s() takes int defined at %s:7
+%s:7 PhanTypeMismatchArgument Argument 1 (x) is 'x' but Closure(int $x) : int takes int defined at %s:7
 %s:7 PhanTypeMismatchReturn Returning type array<int,int> but test365A() is declared to return string[]
 %s:13 PhanTypeMismatchReturn Returning type array<int,int> but test365B() is declared to return string[]
 %s:32 PhanTypeMismatchReturn Returning type array<int,\stdClass> but test365C() is declared to return string[]

--- a/tests/files/expected/0366_array_map_types.php.expected
+++ b/tests/files/expected/0366_array_map_types.php.expected
@@ -1,4 +1,4 @@
-%s:6 PhanTypeMismatchArgument Argument 1 (x) is \stdClass but \closure_%s() takes string defined at %s:6
+%s:6 PhanTypeMismatchArgument Argument 1 (x) is \stdClass but Closure(string $x) : bool takes string defined at %s:6
 %s:6 PhanTypeMismatchReturn Returning type array<int,\stdClass> but test366() is declared to return int[]
 %s:14 PhanTypeMismatchReturn Returning type array<int,int> but test366B() is declared to return string[]
-%s:16 PhanTypeMismatchArgument Argument 1 (x) is \stdClass but \closure_%s() takes string defined at %s:14
+%s:16 PhanTypeMismatchArgument Argument 1 (x) is \stdClass but Closure(string $x) : int takes string defined at %s:14

--- a/tests/files/expected/0382_closure.php.expected
+++ b/tests/files/expected/0382_closure.php.expected
@@ -1,3 +1,3 @@
-%s:7 PhanParamTooFew Call with 0 arg(s) to \closure_%s() which requires 1 arg(s) defined at %s:6
+%s:7 PhanParamTooFew Call with 0 arg(s) to Closure(int $x) : bool which requires 1 arg(s) defined at %s:6
 %s:8 PhanTypeMismatchArgumentInternal Argument 1 (var) is bool but \count() takes \Countable|array
-%s:11 PhanParamTooMany Call with 1 arg(s) to \closure_%s() which only takes 0 arg(s) defined at %s:10
+%s:11 PhanParamTooMany Call with 1 arg(s) to Closure() : string which only takes 0 arg(s) defined at %s:10

--- a/tests/files/expected/0454_throws.php.expected
+++ b/tests/files/expected/0454_throws.php.expected
@@ -1,5 +1,5 @@
 %s:15 PhanTypeMissingReturn Method \MyNs\example1 is declared to return \MyNs\MissingType but has no return value
-%s:15 PhanUndeclaredTypeReturnType Return type of example1 is undeclared type \MyNs\MissingType
+%s:15 PhanUndeclaredTypeReturnType Return type of example1() is undeclared type \MyNs\MissingType
 %s:21 PhanUndeclaredTypeThrowsType @throws type of example3 has undeclared type \MyNs\MissingException
 %s:23 PhanMisspelledAnnotation Saw misspelled annotation @throw, should be one of @throws
 %s:30 PhanTypeInvalidThrowsNonThrowable @throws annotation of a has suspicious class type \stdClass, which does not extend Error/Exception

--- a/tests/files/expected/0455_closure_type_cast.php.expected
+++ b/tests/files/expected/0455_closure_type_cast.php.expected
@@ -1,15 +1,15 @@
 %s:8 PhanTypeSuspiciousEcho Suspicious argument Closure(int):void for an echo/print statement
-%s:9 PhanTypeMismatchArgument Argument 1 (p0) is \stdClass but Closure(int):void() takes int defined at %s:6
-%s:10 PhanParamTooFew Call with 0 arg(s) to Closure(int):void() which requires 1 arg(s) defined at %s:6
+%s:9 PhanTypeMismatchArgument Argument 1 (p0) is \stdClass but Closure(int):void takes int defined at %s:6
+%s:10 PhanParamTooFew Call with 0 arg(s) to Closure(int):void which requires 1 arg(s) defined at %s:6
 %s:15 PhanTypeMismatchArgument Argument 1 (fn) is Closure(int,string):void but \expects_int_param() takes Closure(int):void defined at %s:6
 %s:17 PhanTypeMismatchArgument Argument 1 (fn) is Closure(int&):void but \expects_int_param() takes Closure(int):void defined at %s:6
-%s:24 PhanTypeMismatchArgument Argument 1 (p0) is \stdClass but Closure(int=):void() takes int defined at %s:22
-%s:26 PhanTypeMismatchArgument Argument 1 (p0) is null but Closure(int=):void() takes int defined at %s:22
+%s:24 PhanTypeMismatchArgument Argument 1 (p0) is \stdClass but Closure(int=):void takes int defined at %s:22
+%s:26 PhanTypeMismatchArgument Argument 1 (p0) is null but Closure(int=):void takes int defined at %s:22
 %s:28 PhanTypeMismatchArgument Argument 1 (fn) is Closure(int):void but \expects_optional_int_param() takes Closure(int=):void defined at %s:22
 %s:31 PhanTypeMismatchArgument Argument 1 (fn) is Closure(int,string):void but \expects_optional_int_param() takes Closure(int=):void defined at %s:22
 %s:32 PhanTypeMismatchArgument Argument 1 (fn) is Closure():void but \expects_optional_int_param() takes Closure(int=):void defined at %s:22
 %s:33 PhanTypeMismatchArgument Argument 1 (fn) is Closure(int&=):void but \expects_optional_int_param() takes Closure(int=):void defined at %s:22
-%s:41 PhanParamTooMany Call with 1 arg(s) to Closure():int() which only takes 0 arg(s) defined at %s:40
+%s:41 PhanParamTooMany Call with 1 arg(s) to Closure():int which only takes 0 arg(s) defined at %s:40
 %s:42 PhanTypeMismatchReturn Returning type int but expects_int_return() is declared to return \stdClass
 %s:48 PhanTypeMismatchArgument Argument 1 (fn) is Closure():array but \expects_int_return() takes Closure():int defined at %s:40
 %s:49 PhanTypeMismatchArgument Argument 1 (fn) is Closure(array):int but \expects_int_return() takes Closure():int defined at %s:40
@@ -20,6 +20,6 @@
 %s:67 PhanTypeMismatchArgument Argument 1 (fn) is Closure(mixed):void but \expects_void() takes Closure():void defined at %s:56
 %s:68 PhanTypeMismatchArgument Argument 1 (fn) is Closure():int but \expects_void() takes Closure():void defined at %s:56
 %s:69 PhanTypeMismatchArgument Argument 1 (fn) is Closure(int):void but \expects_void() takes Closure():void defined at %s:56
-%s:77 PhanTypeMismatchArgument Argument 1 (p0) is array{0:'arg'} but Closure(string...):void() takes string defined at %s:74
+%s:77 PhanTypeMismatchArgument Argument 1 (p0) is array{0:'arg'} but Closure(string...):void takes string defined at %s:74
 %s:80 PhanTypeMismatchArgument Argument 1 (fn) is Closure(int...):void but \expects_void_variadic() takes Closure(string...):void defined at %s:74
 %s:82 PhanTypeMismatchArgument Argument 1 (fn) is Closure(string):void but \expects_void_variadic() takes Closure(string...):void defined at %s:74

--- a/tests/files/expected/0457_callable_type_cast.php.expected
+++ b/tests/files/expected/0457_callable_type_cast.php.expected
@@ -1,15 +1,15 @@
 %s:8 PhanTypeSuspiciousEcho Suspicious argument callable(int):void for an echo/print statement
-%s:9 PhanTypeMismatchArgument Argument 1 (p0) is \stdClass but callable(int):void() takes int defined at %s:6
-%s:10 PhanParamTooFew Call with 0 arg(s) to callable(int):void() which requires 1 arg(s) defined at %s:6
+%s:9 PhanTypeMismatchArgument Argument 1 (p0) is \stdClass but callable(int):void takes int defined at %s:6
+%s:10 PhanParamTooFew Call with 0 arg(s) to callable(int):void which requires 1 arg(s) defined at %s:6
 %s:15 PhanTypeMismatchArgument Argument 1 (fn) is Closure(int,string):void but \expects_cb_int_param() takes callable(int):void defined at %s:6
 %s:17 PhanTypeMismatchArgument Argument 1 (fn) is Closure(int&):void but \expects_cb_int_param() takes callable(int):void defined at %s:6
-%s:24 PhanTypeMismatchArgument Argument 1 (p0) is \stdClass but callable(int=):void() takes int defined at %s:22
-%s:26 PhanTypeMismatchArgument Argument 1 (p0) is null but callable(int=):void() takes int defined at %s:22
+%s:24 PhanTypeMismatchArgument Argument 1 (p0) is \stdClass but callable(int=):void takes int defined at %s:22
+%s:26 PhanTypeMismatchArgument Argument 1 (p0) is null but callable(int=):void takes int defined at %s:22
 %s:28 PhanTypeMismatchArgument Argument 1 (fn) is Closure(int):void but \expects_cb_optional_int_param() takes callable(int=):void defined at %s:22
 %s:31 PhanTypeMismatchArgument Argument 1 (fn) is Closure(int,string):void but \expects_cb_optional_int_param() takes callable(int=):void defined at %s:22
 %s:32 PhanTypeMismatchArgument Argument 1 (fn) is Closure():void but \expects_cb_optional_int_param() takes callable(int=):void defined at %s:22
 %s:33 PhanTypeMismatchArgument Argument 1 (fn) is Closure(int&=):void but \expects_cb_optional_int_param() takes callable(int=):void defined at %s:22
-%s:41 PhanParamTooMany Call with 1 arg(s) to callable():int() which only takes 0 arg(s) defined at %s:40
+%s:41 PhanParamTooMany Call with 1 arg(s) to callable():int which only takes 0 arg(s) defined at %s:40
 %s:42 PhanTypeMismatchReturn Returning type int but expects_cb_int_return() is declared to return \stdClass
 %s:48 PhanTypeMismatchArgument Argument 1 (fn) is Closure():array but \expects_cb_int_return() takes callable():int defined at %s:40
 %s:49 PhanTypeMismatchArgument Argument 1 (fn) is Closure(array):int but \expects_cb_int_return() takes callable():int defined at %s:40
@@ -20,6 +20,6 @@
 %s:65 PhanTypeMismatchArgument Argument 1 (fn) is Closure(mixed):void but \expects_cb_void() takes callable():void defined at %s:54
 %s:66 PhanTypeMismatchArgument Argument 1 (fn) is Closure():int but \expects_cb_void() takes callable():void defined at %s:54
 %s:67 PhanTypeMismatchArgument Argument 1 (fn) is Closure(int):void but \expects_cb_void() takes callable():void defined at %s:54
-%s:75 PhanTypeMismatchArgument Argument 1 (p0) is array{0:'arg'} but callable(string...):void() takes string defined at %s:72
+%s:75 PhanTypeMismatchArgument Argument 1 (p0) is array{0:'arg'} but callable(string...):void takes string defined at %s:72
 %s:78 PhanTypeMismatchArgument Argument 1 (fn) is Closure(int...):void but \expects_cb_void_variadic() takes callable(string...):void defined at %s:72
 %s:80 PhanTypeMismatchArgument Argument 1 (fn) is Closure(string):void but \expects_cb_void_variadic() takes callable(string...):void defined at %s:72

--- a/tests/files/expected/0487_alternate_suggestions.php.expected
+++ b/tests/files/expected/0487_alternate_suggestions.php.expected
@@ -1,8 +1,8 @@
 %s:21 PhanUndeclaredTypeProperty Property \A487::x has undeclared type \avoid (Did you mean class \Avid)
 %s:28 PhanTypeMissingReturn Method \A487::test_suggestions is declared to return \avoid but has no return value
 %s:28 PhanUndeclaredTypeParameter Parameter $x has undeclared type \avoid (Did you mean class \Avid)
-%s:28 PhanUndeclaredTypeReturnType Return type of test_suggestions is undeclared type \avoid (Did you mean class \Avid or void)
+%s:28 PhanUndeclaredTypeReturnType Return type of test_suggestions() is undeclared type \avoid (Did you mean class \Avid or void)
 %s:28 PhanUndeclaredTypeThrowsType @throws type of test_suggestions has undeclared type \avoid (Did you mean class \Avid)
 %s:40 PhanUndeclaredTypeParameter Parameter $x has undeclared type array<string,\imt>[] (Did you mean trait \Ime or class \Imf or class \Img or interface \Imi or interface \Imj or int)
-%s:40 PhanUndeclaredTypeReturnType Return type of test_throw_suggestions is undeclared type array<string,\imt>[] (Did you mean trait \Ime or class \Imf or class \Img or interface \Imi or interface \Imj or int)
+%s:40 PhanUndeclaredTypeReturnType Return type of test_throw_suggestions() is undeclared type array<string,\imt>[] (Did you mean trait \Ime or class \Imf or class \Img or interface \Imi or interface \Imj or int)
 %s:40 PhanUndeclaredTypeThrowsType @throws type of test_throw_suggestions has undeclared type \imt (Did you mean class \Imf or interface \Imi)

--- a/tests/files/expected/0499_indirect_variable.php.expected
+++ b/tests/files/expected/0499_indirect_variable.php.expected
@@ -1,2 +1,2 @@
 %s:5 PhanTypeMismatchArgumentInternal Argument 1 (var) is 'x' but \count() takes \Countable|array
-%s:7 PhanTypeMismatchReturn Returning type 2 but {closure}() is declared to return \stdClass
+%s:7 PhanTypeMismatchReturn Returning type 2 but Closure() : \stdClass is declared to return \stdClass

--- a/tests/files/expected/0520_spaces_in_union_type.php.expected
+++ b/tests/files/expected/0520_spaces_in_union_type.php.expected
@@ -1,3 +1,3 @@
 %s:5 PhanCommentParamOutOfOrder Expected @param annotation for x to be before the @param annotation for y
 %s:10 PhanTypeMismatchArgumentInternal Argument 1 (var) is int|string but \count() takes \Countable|array
-%s:10 PhanTypeMismatchReturn Returning type int but {closure}() is declared to return array|object
+%s:10 PhanTypeMismatchReturn Returning type int but Closure($x, $y) is declared to return array|object

--- a/tests/files/expected/0558_static_binding_in_trait.php.expected
+++ b/tests/files/expected/0558_static_binding_in_trait.php.expected
@@ -1,1 +1,1 @@
-%s:27 PhanTypeInvalidTraitReturn Expected a class or interface (or built-in type) to be the real return type of method getC1AsT but got trait \T
+%s:27 PhanTypeInvalidTraitReturn Expected a class or interface (or built-in type) to be the real return type of getC1AsT() but got trait \T

--- a/tests/files/expected/0560_trait_in_param_return.php.expected
+++ b/tests/files/expected/0560_trait_in_param_return.php.expected
@@ -1,3 +1,3 @@
-%s:8 PhanTypeInvalidTraitParam Method getC1AsT is declared to have a parameter $other with a real type of trait \T (expected a class or interface or built-in type)
-%s:8 PhanTypeInvalidTraitParam Method getC1AsT is declared to have a parameter $x with a real type of trait \T (expected a class or interface or built-in type)
-%s:8 PhanTypeInvalidTraitReturn Expected a class or interface (or built-in type) to be the real return type of method getC1AsT but got trait \T
+%s:8 PhanTypeInvalidTraitParam getC1AsT() is declared to have a parameter $other with a real type of trait \T (expected a class or interface or built-in type)
+%s:8 PhanTypeInvalidTraitParam getC1AsT() is declared to have a parameter $x with a real type of trait \T (expected a class or interface or built-in type)
+%s:8 PhanTypeInvalidTraitReturn Expected a class or interface (or built-in type) to be the real return type of getC1AsT() but got trait \T

--- a/tests/rasmus_files/expected/0026_closure.php.expected
+++ b/tests/rasmus_files/expected/0026_closure.php.expected
@@ -1,4 +1,3 @@
-%s:4 PhanTypeMismatchReturn Returning type string but {closure}() is declared to return array
+%s:4 PhanTypeMismatchReturn Returning type string but Closure(string $arg) : array is declared to return array
 %s:4 PhanUndeclaredVariable Variable $undefined is undeclared
-%s:5 PhanParamTooFew Call with 0 arg(s) to \closure_%s() which requires 1 arg(s) defined at %s:4
-
+%s:5 PhanParamTooFew Call with 0 arg(s) to Closure(string $arg) : array which requires 1 arg(s) defined at %s:4


### PR DESCRIPTION
This generally uses the name for warnings within the function-like,
and FQSENs for warnings outside of the function-like.

Fixes #1695
