### PR TITLE
Make property FQSENs in issue text more consistent.

### DIFF
--- a/.phan/plugins/HasPHPDocPlugin.php
+++ b/.phan/plugins/HasPHPDocPlugin.php
@@ -121,7 +121,7 @@ final class HasPHPDocPlugin extends PluginV2 implements
                 $property->getContext(),
                 "PhanPluginNoCommentOn${visibility_upper}Property",
                 "$visibility_upper property {PROPERTY} has no doc comment",
-                [$property->getFQSEN()]
+                [$property->getRepresentationForIssue()]
             );
             return;
         }
@@ -133,7 +133,7 @@ final class HasPHPDocPlugin extends PluginV2 implements
                 $property->getContext(),
                 "PhanPluginDescriptionlessCommentOn${visibility_upper}Property",
                 "$visibility_upper property {PROPERTY} has no readable description: {STRING_LITERAL}",
-                [$property->getFQSEN(), self::getDocCommentRepresentation($doc_comment)]
+                [$property->getRepresentationForIssue(), self::getDocCommentRepresentation($doc_comment)]
             );
             return;
         }

--- a/NEWS.md
+++ b/NEWS.md
@@ -26,8 +26,12 @@ New features(Analysis):
 + Properly warn about an undefined variable being passed to `array_shift` (it expects an array but undefined is converted to null) (related to fix for #2100)
 + Stop adding generic int/string to the type of a class property when the doc comment mentions only literal int/string values (#2102)
   (e.g. `@var 1|2`)
-+ Improve line number in warning about extra comma in arrays (i.e. empty array elements). (#2066)
++ Improve line number of warning about extra comma in arrays (i.e. empty array elements). (#2066)
 + Properly parse [flexible heredoc/nowdoc syntaxes](https://wiki.php.net/rfc/flexible_heredoc_nowdoc_syntaxes) that were added in PHP 7.3 (#1537)
+
+Maintenance:
++ Make issue messages more consistent in their syntax used to describe closures/functions (#1695)
++ Consistently refer to instance properties as `Class->propname` and static properties as `Class::$staticpropname` in issue messages.
 
 Bug fixes:
 + Properly type check `static::someMethodName()`.

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -1344,7 +1344,7 @@ class ContextNode
                         $this->context->getFile(),
                         $node->lineno ?? 0,
                         [
-                            (string)$property->getFQSEN(),
+                            $property->getRepresentationForIssue(),
                             $property->getFileRef()->getFile(),
                             $property->getFileRef()->getLineNumberStart(),
                         ]
@@ -1363,7 +1363,7 @@ class ContextNode
                         $this->context->getFile(),
                         $node->lineno ?? 0,
                         [
-                            (string)$property->getFQSEN(),
+                            $property->getRepresentationForIssue(),
                             $property->getElementNamespace(),
                             $property->getFileRef()->getFile(),
                             $property->getFileRef()->getLineNumberStart(),

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -777,7 +777,7 @@ class AssignmentVisitor extends AnalysisVisitor
             )) {
                 $this->addTypesToProperty($property, $node);
                 if (Config::get_strict_property_checking() && $this->right_type->typeCount() > 1) {
-                    $this->analyzePropertyAssignmentStrict($clazz, $property, $this->right_type, $node);
+                    $this->analyzePropertyAssignmentStrict($property, $this->right_type, $node);
                 }
             } elseif ($property_union_type->asExpandedTypes($this->code_base)->hasArrayAccess()) {
                 // Add any type if this is a subclass with array access.
@@ -799,12 +799,12 @@ class AssignmentVisitor extends AnalysisVisitor
                         Issue::TypeMismatchProperty,
                         $node->lineno ?? 0,
                         (string)$new_types,
-                        "{$clazz->getFQSEN()}::{$property->getName()}",
+                        $property->getRepresentationForIssue(),
                         (string)$property_union_type
                     );
                 } else {
                     if (Config::get_strict_property_checking() && $this->right_type->typeCount() > 1) {
-                        $this->analyzePropertyAssignmentStrict($clazz, $property, $this->right_type, $node);
+                        $this->analyzePropertyAssignmentStrict($property, $this->right_type, $node);
                     }
                     $this->right_type = $new_types;
                     $this->addTypesToProperty($property, $node);
@@ -830,14 +830,14 @@ class AssignmentVisitor extends AnalysisVisitor
                     Issue::TypeMismatchProperty,
                     $node->lineno ?? 0,
                     (string)$this->right_type,
-                    "{$clazz->getFQSEN()}::{$property->getName()}",
+                    $property->getRepresentationForIssue(),
                     (string)$property_union_type
                 );
                 return $this->context;
             }
 
             if (Config::get_strict_property_checking() && $this->right_type->typeCount() > 1) {
-                $this->analyzePropertyAssignmentStrict($clazz, $property, $this->right_type, $node);
+                $this->analyzePropertyAssignmentStrict($property, $this->right_type, $node);
             }
         }
 
@@ -871,7 +871,7 @@ class AssignmentVisitor extends AnalysisVisitor
         );
     }
 
-    private function analyzePropertyAssignmentStrict(Clazz $clazz, Property $property, UnionType $assignment_type, Node $node)
+    private function analyzePropertyAssignmentStrict(Property $property, UnionType $assignment_type, Node $node)
     {
         $type_set = $assignment_type->getTypeSet();
         if (\count($type_set) < 2) {
@@ -914,7 +914,7 @@ class AssignmentVisitor extends AnalysisVisitor
             self::getStrictIssueType($mismatch_type_set),
             $node->lineno ?? 0,
             (string)$this->right_type,
-            "{$clazz->getFQSEN()}::{$property->getName()}",
+            $property->getRepresentationForIssue(),
             (string)$property_union_type,
             (string)$mismatch_expanded_types
         );

--- a/src/Phan/Analysis/PropertyTypesAnalyzer.php
+++ b/src/Phan/Analysis/PropertyTypesAnalyzer.php
@@ -59,7 +59,7 @@ class PropertyTypesAnalyzer
                             $property->getContext(),
                             Issue::TemplateTypeStaticProperty,
                             $property->getFileRef()->getLineNumberStart(),
-                            (string)$property->getFQSEN()
+                            $property->asPropertyFQSENString()
                         );
                     }
                     continue;
@@ -80,7 +80,7 @@ class PropertyTypesAnalyzer
                         $property->getContext(),
                         Issue::UndeclaredTypeProperty,
                         $property->getFileRef()->getLineNumberStart(),
-                        [(string)$property->getFQSEN(), (string)$outer_type],
+                        [$property->asPropertyFQSENString(), (string)$outer_type],
                         IssueFixSuggester::suggestSimilarClass($code_base, $property->getContext(), $type_fqsen, null, 'Did you mean', IssueFixSuggester::CLASS_SUGGEST_CLASSES_AND_TYPES)
                     );
                 }

--- a/src/Phan/Analysis/ReferenceCountsAnalyzer.php
+++ b/src/Phan/Analysis/ReferenceCountsAnalyzer.php
@@ -372,7 +372,7 @@ class ReferenceCountsAnalyzer
             $element->getContext(),
             $issue_type,
             $element->getFileRef()->getLineNumberStart(),
-            (string)$element->getFQSEN()
+            $element->getRepresentationForIssue()
         );
     }
 
@@ -405,7 +405,7 @@ class ReferenceCountsAnalyzer
             $property->getContext(),
             $issue_type,
             $property->getFileRef()->getLineNumberStart(),
-            (string)$property->getFQSEN()
+            $property->getRepresentationForIssue()
         );
     }
 
@@ -434,7 +434,7 @@ class ReferenceCountsAnalyzer
             $property->getContext(),
             $issue_type,
             $property->getFileRef()->getLineNumberStart(),
-            (string)$property->getFQSEN()
+            $property->getRepresentationForIssue()
         );
     }
 

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -2302,7 +2302,7 @@ class Issue
                 self::UnreferencedClosure,
                 self::CATEGORY_NOOP,
                 self::SEVERITY_NORMAL,
-                "Possibly zero references to closure {FUNCTION}",
+                "Possibly zero references to {FUNCTION}",
                 self::REMEDIATION_B,
                 6010
             ),

--- a/src/Phan/Language/Element/AddressableElement.php
+++ b/src/Phan/Language/Element/AddressableElement.php
@@ -323,4 +323,14 @@ abstract class AddressableElement extends TypedElement implements AddressableEle
     {
         return $this->doc_comment;
     }
+
+    /**
+     * @return string the representation of this FQSEN for issue messages.
+     * Overridden in some subclasses
+     * @suppress PhanUnreferencedPublicMethod (inference error?)
+     */
+    public function getRepresentationForIssue() : string
+    {
+        return $this->getFQSEN()->__toString();
+    }
 }

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -995,7 +995,7 @@ class Clazz extends AddressableElement
                         Issue::fromType(Issue::AccessPropertyNonStaticAsStatic)(
                             $context->getFile(),
                             $context->getLineNumberStart(),
-                            [ "{$this->getFQSEN()}->\${$property->getName()}" ]
+                            [$property->asPropertyFQSENString()]
                         )
                     );
                 } else {
@@ -1003,7 +1003,7 @@ class Clazz extends AddressableElement
                         Issue::fromType(Issue::AccessPropertyStaticAsNonStatic)(
                             $context->getFile(),
                             $context->getLineNumberStart(),
-                            [ "{$this->getFQSEN()}::\${$property->getName()}" ]
+                            [$property->asPropertyFQSENString()]
                         )
                     );
                 }
@@ -1029,7 +1029,7 @@ class Clazz extends AddressableElement
                     Issue::fromType(Issue::AccessPropertyPrivate)(
                         $context->getFile(),
                         $context->getLineNumberStart(),
-                        [ (string)$property_fqsen, $method->getContext()->getFile(), $method->getContext()->getLineNumberStart() ]
+                        [$property->asPropertyFQSENString(), $method->getContext()->getFile(), $method->getContext()->getLineNumberStart() ]
                     )
                 );
             } elseif ($method->isProtected()) {
@@ -1037,7 +1037,7 @@ class Clazz extends AddressableElement
                     Issue::fromType(Issue::AccessPropertyProtected)(
                         $context->getFile(),
                         $context->getLineNumberStart(),
-                        [ (string)$property_fqsen, $method->getContext()->getFile(), $method->getContext()->getLineNumberStart() ]
+                        [$property->asPropertyFQSENString(), $method->getContext()->getFile(), $method->getContext()->getLineNumberStart() ]
                     )
                 );
             }
@@ -1062,7 +1062,7 @@ class Clazz extends AddressableElement
                     Issue::fromType(Issue::AccessPropertyPrivate)(
                         $context->getFile(),
                         $context->getLineNumberStart(),
-                        [ "{$this->getFQSEN()}::\${$property->getName()}", $property->getContext()->getFile(), $property->getContext()->getLineNumberStart() ]
+                        [$property->asPropertyFQSENString(), $property->getContext()->getFile(), $property->getContext()->getLineNumberStart() ]
                     )
                 );
             }
@@ -1071,7 +1071,7 @@ class Clazz extends AddressableElement
                     Issue::fromType(Issue::AccessPropertyProtected)(
                         $context->getFile(),
                         $context->getLineNumberStart(),
-                        [ "{$this->getFQSEN()}::\${$property->getName()}", $property->getContext()->getFile(), $property->getContext()->getLineNumberStart() ]
+                        [$property->asPropertyFQSENString(), $property->getContext()->getFile(), $property->getContext()->getLineNumberStart() ]
                     )
                 );
             }
@@ -1102,7 +1102,7 @@ class Clazz extends AddressableElement
             Issue::fromType(Issue::UndeclaredProperty)(
                 $context->getFile(),
                 $context->getLineNumberStart(),
-                [ "{$this->getFQSEN()}::\$$name}" ],
+                [$this->getFQSEN() . ($is_static ? '::$' : '->') . $name],
                 IssueFixSuggester::suggestSimilarProperty($code_base, $context, $this, $name, $is_static)
             )
         );

--- a/src/Phan/Language/Element/Func.php
+++ b/src/Phan/Language/Element/Func.php
@@ -414,6 +414,7 @@ class Func extends AddressableElement implements FunctionInterface
      * @return string
      * The fully-qualified structural element name of this
      * structural element (or something else for closures and callables)
+     * @override
      */
     public function getRepresentationForIssue() : string
     {

--- a/src/Phan/Language/Element/Property.php
+++ b/src/Phan/Language/Element/Property.php
@@ -138,6 +138,15 @@ class Property extends ClassElement
     }
 
     /**
+     * @return string the representation of this FQSEN for issue messages.
+     * @override
+     */
+    public function getRepresentationForIssue() : string
+    {
+        return $this->asPropertyFQSENString();
+    }
+
+    /**
      * Override the default getter to fill in a future
      * union type if available.
      * @throws IssueException if getFutureUnionType fails.

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -511,7 +511,7 @@ class ParseVisitor extends ScopeVisitor
                         Issue::TypeMismatchProperty,
                         $child_node->lineno ?? 0,
                         (string)$original_union_type,
-                        (string)$property->getFQSEN(),
+                        $property->asPropertyFQSENString(),
                         (string)$variable->getUnionType()
                     );
                 }

--- a/tests/files/expected/0002_duplicate_class.php.expected
+++ b/tests/files/expected/0002_duplicate_class.php.expected
@@ -1,2 +1,1 @@
 %s:9 PhanRedefineClass Class \DuplicateClass defined at %s:9 was previously defined as Class \DuplicateClass at %s:3
-

--- a/tests/files/expected/0003_required_after_optional.php.expected
+++ b/tests/files/expected/0003_required_after_optional.php.expected
@@ -1,2 +1,1 @@
 %s:4 PhanParamReqAfterOpt Required argument follows optional
-

--- a/tests/files/expected/0006_property_types.php.expected
+++ b/tests/files/expected/0006_property_types.php.expected
@@ -1,2 +1,2 @@
-%s:6 PhanTypeMismatchProperty Assigning array{0:'alpha',1:'beta',2:'gamma'} to property but \A::property is \bad
-%s:6 PhanUndeclaredTypeProperty Property \A::property has undeclared type \bad
+%s:6 PhanTypeMismatchProperty Assigning array{0:'alpha',1:'beta',2:'gamma'} to property but \A->property is \bad
+%s:6 PhanUndeclaredTypeProperty Property \A->property has undeclared type \bad

--- a/tests/files/expected/0011_duplicate_function.php.expected
+++ b/tests/files/expected/0011_duplicate_function.php.expected
@@ -1,2 +1,1 @@
 %s:6 PhanRedefineFunction Function alpha defined at %s:6 was previously defined at %s:3
-

--- a/tests/files/expected/0014_parent_property.php.expected
+++ b/tests/files/expected/0014_parent_property.php.expected
@@ -1,1 +1,1 @@
-%s:11 PhanAccessPropertyNonStaticAsStatic Accessing non static property \A->$beta as static
+%s:11 PhanAccessPropertyNonStaticAsStatic Accessing non static property \A->beta as static

--- a/tests/files/expected/0015_null_method_call.php.expected
+++ b/tests/files/expected/0015_null_method_call.php.expected
@@ -1,2 +1,1 @@
 %s:11 PhanNonClassMethodCall Call to method f on non-class type null
-

--- a/tests/files/expected/0019_noop.php.expected
+++ b/tests/files/expected/0019_noop.php.expected
@@ -2,4 +2,3 @@
 %s:8 PhanNoopArray Unused array
 %s:11 PhanNoopClosure Unused closure
 %s:15 PhanNoopConstant Unused constant
-

--- a/tests/files/expected/0026_dim_types.php.expected
+++ b/tests/files/expected/0026_dim_types.php.expected
@@ -1,2 +1,1 @@
 %s:47 PhanTypeMismatchArgument Argument 1 (a) is string but \B::f() takes int defined at %s:22
-

--- a/tests/files/expected/0048_parent_class_exists.php.expected
+++ b/tests/files/expected/0048_parent_class_exists.php.expected
@@ -1,4 +1,3 @@
 %s:3 PhanUndeclaredExtendedClass Class extends undeclared class \A
 %s:6 PhanUndeclaredInterface Class implements undeclared interface \A
 %s:9 PhanUndeclaredTrait Class uses undeclared trait \A
-

--- a/tests/files/expected/0049_undefined_constant.php.expected
+++ b/tests/files/expected/0049_undefined_constant.php.expected
@@ -1,2 +1,1 @@
 %s:2 PhanUndeclaredClassConstant Reference to constant CONST from undeclared class \UndefinedClass
-

--- a/tests/files/expected/0050_parameter_dim_assignment.php.expected
+++ b/tests/files/expected/0050_parameter_dim_assignment.php.expected
@@ -1,2 +1,1 @@
 %s:21 PhanTypeMismatchReturn Returning type 'literalstring' but h() is declared to return int
-

--- a/tests/files/expected/0054_instanceof.php.expected
+++ b/tests/files/expected/0054_instanceof.php.expected
@@ -1,3 +1,2 @@
 %s:11 PhanUndeclaredClassInstanceof Checking instanceof against undeclared class \UndefClass
 %s:15 PhanUndeclaredClassInstanceof Checking instanceof against undeclared class \UndefClass
-

--- a/tests/files/expected/0057_nullable_required_typed_parameter.php.expected
+++ b/tests/files/expected/0057_nullable_required_typed_parameter.php.expected
@@ -1,2 +1,1 @@
 %s:8 PhanParamReqAfterOpt Required argument follows optional
-

--- a/tests/files/expected/0058_property_type_check.php.expected
+++ b/tests/files/expected/0058_property_type_check.php.expected
@@ -1,3 +1,3 @@
-%s:4 PhanUndeclaredTypeProperty Property \Test::client has undeclared type \ClientOfPropertyTypeCheck58
+%s:4 PhanUndeclaredTypeProperty Property \Test->client has undeclared type \ClientOfPropertyTypeCheck58
 %s:6 PhanUndeclaredTypeParameter Parameter $client has undeclared type \ClientOfPropertyTypeCheck58
 %s:8 PhanUndeclaredClassMethod Call to method test from undeclared class \ClientOfPropertyTypeCheck58

--- a/tests/files/expected/0062_new_method_type.php.expected
+++ b/tests/files/expected/0062_new_method_type.php.expected
@@ -1,2 +1,1 @@
 %s:9 PhanTypeMismatchArgument Argument 1 (i) is int but \g() takes string defined at %s:7
-

--- a/tests/files/expected/0065_tostring.php.expected
+++ b/tests/files/expected/0065_tostring.php.expected
@@ -1,2 +1,1 @@
 %s:16 PhanTypeMismatchArgument Argument 2 (arg) is \Stringular|string but \test() takes int defined at %s:10
-

--- a/tests/files/expected/0081_missing_property.php.expected
+++ b/tests/files/expected/0081_missing_property.php.expected
@@ -1,3 +1,2 @@
 %s:4 PhanUndeclaredProperty Reference to undeclared property \C->undef_prop_a
 %s:5 PhanUndeclaredProperty Reference to undeclared property \C->undef_prop_b
-

--- a/tests/files/expected/0082_no_op_property.php.expected
+++ b/tests/files/expected/0082_no_op_property.php.expected
@@ -1,3 +1,2 @@
 %s:6 PhanNoopProperty Unused property
 %s:13 PhanNoopProperty Unused property
-

--- a/tests/files/expected/0084_branch_scope.php.expected
+++ b/tests/files/expected/0084_branch_scope.php.expected
@@ -1,2 +1,1 @@
 %s:17 PhanTypeMismatchArgument Argument 1 (v) is 'str' but \f() takes int defined at %s:16
-

--- a/tests/files/expected/0086_conditional_instanceof_type.php.expected
+++ b/tests/files/expected/0086_conditional_instanceof_type.php.expected
@@ -1,2 +1,1 @@
 %s:8 PhanNonClassMethodCall Call to method f on non-class type null
-

--- a/tests/files/expected/0096_empty_file.php.expected
+++ b/tests/files/expected/0096_empty_file.php.expected
@@ -1,2 +1,1 @@
 %s:0 PhanEmptyFile Empty file %s
-

--- a/tests/files/expected/0098_undef.php.expected
+++ b/tests/files/expected/0098_undef.php.expected
@@ -2,7 +2,7 @@
 %s:9 PhanUndeclaredStaticMethod Static call to undeclared method \C98::staticMethod
 %s:13 PhanUndeclaredClassInstanceof Checking instanceof against undeclared class \Undef
 %s:16 PhanUndeclaredTypeParameter Parameter $p has undeclared type \Undef
-%s:19 PhanUndeclaredTypeProperty Property \D98::p has undeclared type \Undef
+%s:19 PhanUndeclaredTypeProperty Property \D98->p has undeclared type \Undef
 %s:22 PhanUndeclaredExtendedClass Class extends undeclared class \Undef
 %s:25 PhanParentlessClass Reference to parent of class \F98 that does not extend anything
 %s:25 PhanUnusedVariable Unused definition of variable $v

--- a/tests/files/expected/0099_type_error.php.expected
+++ b/tests/files/expected/0099_type_error.php.expected
@@ -1,6 +1,6 @@
 %s:4 PhanTypeMismatchDefault Default value for int $p can't be false
 %s:7 PhanTypeArraySuspicious Suspicious array access to false
-%s:10 PhanTypeMismatchProperty Assigning 'str' to property but \C::p is int
+%s:10 PhanTypeMismatchProperty Assigning 'str' to property but \C->p is int
 %s:13 PhanTypeInstantiateAbstract Instantiation of abstract class \D
 %s:16 PhanTypeInstantiateInterface Instantiation of interface \E
 %s:19 PhanTypeNonVarPassByRef Only variables can be passed by reference at argument 1 of \F::f()

--- a/tests/files/expected/0101_one_of_each.php.expected
+++ b/tests/files/expected/0101_one_of_each.php.expected
@@ -39,7 +39,7 @@
 %s:147 PhanTypeMissingReturn Method \C9::f is declared to return int but has no return value
 %s:150 PhanUndeclaredClassMethod Call to method f from undeclared class \F
 %s:155 PhanUndeclaredTypeParameter Parameter $p has undeclared type \Undef
-%s:158 PhanUndeclaredTypeProperty Property \C11::p has undeclared type \Undef
+%s:158 PhanUndeclaredTypeProperty Property \C11->p has undeclared type \Undef
 %s:161 PhanParentlessClass Reference to parent of class \C12 that does not extend anything
 %s:164 PhanTraitParentReference Reference to parent from trait \T1
 %s:172 PhanUndeclaredClassCatch Catching undeclared class \Undef

--- a/tests/files/expected/0113_uncaught_undef_class_const_exception.php.expected
+++ b/tests/files/expected/0113_uncaught_undef_class_const_exception.php.expected
@@ -1,2 +1,1 @@
 %s:5 PhanUndeclaredConstant Reference to undeclared constant \UndefClassConst::MY_CONST
-

--- a/tests/files/expected/0123_deprecated_class.php.expected
+++ b/tests/files/expected/0123_deprecated_class.php.expected
@@ -1,4 +1,3 @@
 %s:12 PhanDeprecatedClass Call to deprecated class \C defined at %s:5
 %s:13 PhanDeprecatedFunction Call to deprecated function \C::f() defined at %s:9
 %s:20 PhanDeprecatedFunction Call to deprecated function \f() defined at %s:18
-

--- a/tests/files/expected/0128_access.php.expected
+++ b/tests/files/expected/0128_access.php.expected
@@ -1,4 +1,3 @@
 %s:23 PhanAccessSignatureMismatch Access level to function pub() must be compatible with function pub() defined in %s:11
 %s:29 PhanAccessSignatureMismatch Access level to function pub() must be compatible with function pub() defined in %s:11
 %s:30 PhanAccessSignatureMismatch Access level to function prot() must be compatible with function prot() defined in %s:12
-

--- a/tests/files/expected/0171_deprecated_property.php.expected
+++ b/tests/files/expected/0171_deprecated_property.php.expected
@@ -1,1 +1,2 @@
-%s:7 PhanDeprecatedProperty Reference to deprecated property \C::p defined at %s:5
+%s:9 PhanDeprecatedProperty Reference to deprecated property \C->p defined at %s:5
+%s:10 PhanDeprecatedProperty Reference to deprecated property \C::$static_p defined at %s:7

--- a/tests/files/expected/0194_shared_base_class.php.expected
+++ b/tests/files/expected/0194_shared_base_class.php.expected
@@ -1,2 +1,2 @@
-%s:26 PhanAccessPropertyProtected Cannot access protected property \A::$var defined at %s:4
+%s:26 PhanAccessPropertyProtected Cannot access protected property \A->var defined at %s:4
 %s:27 PhanAccessMethodProtected Cannot access protected method \A::func defined at %s:6

--- a/tests/files/expected/0203_generic_errors.php.expected
+++ b/tests/files/expected/0203_generic_errors.php.expected
@@ -1,4 +1,4 @@
-%s:11 PhanTemplateTypeStaticProperty static property \C::p may not have a template type
+%s:11 PhanTemplateTypeStaticProperty static property \C::$p may not have a template type
 %s:16 PhanTemplateTypeStaticMethod static method \C::f may not use template types
 %s:21 PhanTemplateTypeStaticMethod static method \C::g may not use template types
 %s:21 PhanTypeMissingReturn Method \C::g is declared to return T but has no return value

--- a/tests/files/expected/0219_superglobal_type_check.php.expected
+++ b/tests/files/expected/0219_superglobal_type_check.php.expected
@@ -13,4 +13,3 @@
 %s:43 PhanUnusedVariable Unused definition of variable $http_response_headers
 %s:49 PhanUndeclaredVariable Variable $argc is undeclared
 %s:50 PhanUndeclaredVariable Variable $argv is undeclared
-

--- a/tests/files/expected/0236_assign_ref_analyzed.php.expected
+++ b/tests/files/expected/0236_assign_ref_analyzed.php.expected
@@ -1,2 +1,2 @@
-%s:10 PhanTypeMismatchProperty Assigning \A236 to property but \A236::badDoc is string
-%s:12 PhanTypeMismatchProperty Assigning \A236 to property but \A236::badDoc is string
+%s:10 PhanTypeMismatchProperty Assigning \A236 to property but \A236->badDoc is string
+%s:12 PhanTypeMismatchProperty Assigning \A236 to property but \A236->badDoc is string

--- a/tests/files/expected/0260_variadic_bug.php.expected
+++ b/tests/files/expected/0260_variadic_bug.php.expected
@@ -1,3 +1,2 @@
 %s:42 PhanTypeMismatchArgument Argument 3 (arguments) is array{0:2} but \VariadicBug::foo() takes int|string defined at %s:16
 %s:44 PhanTypeMismatchArgument Argument 3 (arguments) is array{0:2} but \variadic_bug_260() takes int|string defined at %s:31
-

--- a/tests/files/expected/0273_property_read_write_declarations.php.expected
+++ b/tests/files/expected/0273_property_read_write_declarations.php.expected
@@ -1,2 +1,2 @@
 %s:21 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \stdClass but \intdiv() takes int
-%s:22 PhanTypeMismatchProperty Assigning 2 to property but \A273::y is \stdClass
+%s:22 PhanTypeMismatchProperty Assigning 2 to property but \A273->y is \stdClass

--- a/tests/files/expected/0278_internal_elements.php.expected
+++ b/tests/files/expected/0278_internal_elements.php.expected
@@ -15,10 +15,10 @@
 %s:92 PhanTypeVoidAssignment Cannot assign void return value
 %s:94 PhanAccessConstantInternal Cannot access internal constant \NS278\A\CONST_INTERNAL of namespace \NS278\A defined at %s:8 from namespace \NS278\B
 %s:96 PhanAccessMethodInternal Cannot access internal method \NS278\A\C1::__construct() of namespace \NS278\A defined at %s:11 from namespace \NS278\B
-%s:97 PhanAccessPropertyInternal Cannot access internal property \NS278\A\C1::p of namespace \NS278\A defined at %s:13 from namespace \NS278\B
+%s:97 PhanAccessPropertyInternal Cannot access internal property \NS278\A\C1->p of namespace \NS278\A defined at %s:13 from namespace \NS278\B
 %s:98 PhanAccessMethodInternal Cannot access internal method \NS278\A\C1::f() of namespace \NS278\A defined at %s:14 from namespace \NS278\B
 %s:99 PhanAccessClassConstantInternal Cannot access internal class constant \NS278\A\C1::CONST_INTERNAL defined at %s:12
-%s:102 PhanAccessPropertyInternal Cannot access internal property \NS278\A\C2::p of namespace \NS278\A defined at %s:24 from namespace \NS278\B
+%s:102 PhanAccessPropertyInternal Cannot access internal property \NS278\A\C2->p of namespace \NS278\A defined at %s:24 from namespace \NS278\B
 %s:103 PhanAccessMethodInternal Cannot access internal method \NS278\A\C2::f() of namespace \NS278\A defined at %s:27 from namespace \NS278\B
 %s:106 PhanAccessClassConstantInternal Cannot access internal class constant \NS278\A\C2::CONST_INTERNAL defined at %s:21
 %s:108 PhanAccessClassInternal Cannot access internal Class \NS278\A\C1 defined at %s:11

--- a/tests/files/expected/0278_internal_elements.php.expected70
+++ b/tests/files/expected/0278_internal_elements.php.expected70
@@ -14,10 +14,10 @@
 %s:92 PhanAccessMethodInternal Cannot access internal method \NS278\A\f() of namespace \NS278\A defined at %s:33 from namespace \NS278\B
 %s:92 PhanTypeVoidAssignment Cannot assign void return value
 %s:96 PhanAccessMethodInternal Cannot access internal method \NS278\A\C1::__construct() of namespace \NS278\A defined at %s:11 from namespace \NS278\B
-%s:97 PhanAccessPropertyInternal Cannot access internal property \NS278\A\C1::p of namespace \NS278\A defined at %s:13 from namespace \NS278\B
+%s:97 PhanAccessPropertyInternal Cannot access internal property \NS278\A\C1->p of namespace \NS278\A defined at %s:13 from namespace \NS278\B
 %s:98 PhanAccessMethodInternal Cannot access internal method \NS278\A\C1::f() of namespace \NS278\A defined at %s:14 from namespace \NS278\B
 %s:99 PhanAccessClassConstantInternal Cannot access internal class constant \NS278\A\C1::CONST_INTERNAL defined at %s:12
-%s:102 PhanAccessPropertyInternal Cannot access internal property \NS278\A\C2::p of namespace \NS278\A defined at %s:24 from namespace \NS278\B
+%s:102 PhanAccessPropertyInternal Cannot access internal property \NS278\A\C2->p of namespace \NS278\A defined at %s:24 from namespace \NS278\B
 %s:103 PhanAccessMethodInternal Cannot access internal method \NS278\A\C2::f() of namespace \NS278\A defined at %s:27 from namespace \NS278\B
 %s:108 PhanAccessClassInternal Cannot access internal Class \NS278\A\C1 defined at %s:11
 %s:108 PhanAccessClassInternal Cannot access internal Interface \NS278\A\I2 defined at %s:53

--- a/tests/files/expected/0307_suppress_on_property.php.expected
+++ b/tests/files/expected/0307_suppress_on_property.php.expected
@@ -1,2 +1,2 @@
-%s:7 PhanTypeMismatchProperty Assigning array{} to property but \Foo307::x is \ArrayAccess
-%s:18 PhanTypeMismatchProperty Assigning array{key:'value'} to property but \Foo307::z is \ArrayAccess
+%s:7 PhanTypeMismatchProperty Assigning array{} to property but \Foo307->x is \ArrayAccess
+%s:18 PhanTypeMismatchProperty Assigning array{key:'value'} to property but \Foo307->z is \ArrayAccess

--- a/tests/files/expected/0311_condition_visitor_throw.php.expected
+++ b/tests/files/expected/0311_condition_visitor_throw.php.expected
@@ -16,4 +16,3 @@
 %s:36 PhanUndeclaredVariable Variable $c2 is undeclared
 %s:38 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is string but \intdiv() takes int
 %s:39 PhanUndeclaredVariable Variable $x3 is undeclared
-

--- a/tests/files/expected/0349_protected_method_from_trait.php.expected
+++ b/tests/files/expected/0349_protected_method_from_trait.php.expected
@@ -1,4 +1,4 @@
 %s:38 PhanUndeclaredProperty Reference to undeclared property \ExtendingClass->missingProp
 %s:47 PhanAccessMethodProtected Cannot access protected method \ExtendingClass::protectedAlias defined at %s:18
 %s:48 PhanAccessMethodProtected Cannot access protected method \ExtendingClass::foo3 defined at %s:15
-%s:50 PhanAccessPropertyProtected Cannot access protected property \ExtendingClass::$prop defined at %s:13
+%s:50 PhanAccessPropertyProtected Cannot access protected property \ExtendingClass->prop defined at %s:13

--- a/tests/files/expected/0354_string_index.php.expected
+++ b/tests/files/expected/0354_string_index.php.expected
@@ -1,6 +1,6 @@
 %s:9 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is string but \intdiv() takes int
 %s:10 PhanTypeMismatchDimEmpty Assigning to an empty array index of a value of type string, but expected the index to exist and be of type int
-%s:10 PhanTypeMismatchProperty Assigning array<int,string> to property but \A354::foo is string
+%s:10 PhanTypeMismatchProperty Assigning array<int,string> to property but \A354->foo is string
 %s:13 PhanTypeMismatchArgumentInternal Argument 1 (var) is 'aaa'|string but \count() takes \Countable|array
 %s:14 PhanTypeMismatchDimEmpty Assigning to an empty array index of a value of type 'aaa'|string, but expected the index to exist and be of type int
 %s:16 PhanTypeMismatchDimAssignment When appending to a value of type 'aaa', found an array access index of type 'offset', but expected the index to be of type int

--- a/tests/files/expected/0359_undeclared_class_in_prop.php.expected
+++ b/tests/files/expected/0359_undeclared_class_in_prop.php.expected
@@ -1,7 +1,7 @@
-%s:4 PhanUndeclaredTypeProperty Property \A359::missing4 has undeclared type \Missing359E
-%s:4 PhanUndeclaredTypeProperty Property \A359::missing4 has undeclared type \Missing359F[][]
+%s:4 PhanUndeclaredTypeProperty Property \A359->missing4 has undeclared type \Missing359E
+%s:4 PhanUndeclaredTypeProperty Property \A359->missing4 has undeclared type \Missing359F[][]
 %s:5 PhanUndeclaredTypeReturnType Return type of myInstanceMethod() is undeclared type \Missing359G
 %s:7 PhanUndeclaredTypeParameter Parameter $param1 has undeclared type \Missing359H[]
-%s:9 PhanUndeclaredTypeProperty Property \A359::missing1 has undeclared type \Missing359
-%s:9 PhanUndeclaredTypeProperty Property \A359::missing1 has undeclared type \Missing359B[][]
-%s:11 PhanUndeclaredTypeProperty Property \A359::missing2 has undeclared type ?\Missing359C
+%s:9 PhanUndeclaredTypeProperty Property \A359->missing1 has undeclared type \Missing359
+%s:9 PhanUndeclaredTypeProperty Property \A359->missing1 has undeclared type \Missing359B[][]
+%s:11 PhanUndeclaredTypeProperty Property \A359->missing2 has undeclared type ?\Missing359C

--- a/tests/files/expected/0360_undeclared_array_class_in_namespace.php.expected
+++ b/tests/files/expected/0360_undeclared_array_class_in_namespace.php.expected
@@ -1,4 +1,4 @@
 %s:12 PhanUndeclaredTypeParameter Parameter $x has undeclared type \Foo\Baz\MissingClass[][][]
 %s:12 PhanUndeclaredTypeReturnType Return type of myMethod() is undeclared type \Foo\Bat\OtherMissingClass[][]
-%s:18 PhanUndeclaredTypeProperty Property \Foo\Bar\MyClass::y has undeclared type \Foo\Bar\Closure[][] (Did you mean class \Closure)
-%s:22 PhanUndeclaredTypeProperty Property \Foo\Bar\MyClass::str has undeclared type \Foo\Bar\strong (Did you mean string)
+%s:18 PhanUndeclaredTypeProperty Property \Foo\Bar\MyClass::$y has undeclared type \Foo\Bar\Closure[][] (Did you mean class \Closure)
+%s:22 PhanUndeclaredTypeProperty Property \Foo\Bar\MyClass::$str has undeclared type \Foo\Bar\strong (Did you mean string)

--- a/tests/files/expected/0388_nullable_to_type_or_null.php.expected
+++ b/tests/files/expected/0388_nullable_to_type_or_null.php.expected
@@ -1,2 +1,2 @@
-%s:27 PhanTypeMismatchProperty Assigning ?int to property but \A388::prop2 is null|string
+%s:27 PhanTypeMismatchProperty Assigning ?int to property but \A388->prop2 is null|string
 %s:28 PhanTypeMismatchArgument Argument 2 (arg2) is ?int but \helper388() takes null|string defined at %s:16

--- a/tests/files/expected/0388_nullable_to_type_or_null.php.expected70
+++ b/tests/files/expected/0388_nullable_to_type_or_null.php.expected70
@@ -1,2 +1,2 @@
-%s:32 PhanTypeMismatchProperty Assigning ?int to property but \A388::prop2 is null|string
+%s:32 PhanTypeMismatchProperty Assigning ?int to property but \A388->prop2 is null|string
 %s:33 PhanTypeMismatchArgument Argument 2 (arg2) is ?int but \helper388() takes null|string defined at %s:16

--- a/tests/files/expected/0391_private_prop_of_this.php.expected
+++ b/tests/files/expected/0391_private_prop_of_this.php.expected
@@ -1,4 +1,4 @@
-%s:24 PhanAccessPropertyPrivate Cannot access private property \Subclass391::$_prop defined at %s:4
+%s:24 PhanAccessPropertyPrivate Cannot access private property \Subclass391->_prop defined at %s:4
 %s:25 PhanUndeclaredProperty Reference to undeclared property \Subclass391->_propOther
-%s:29 PhanAccessPropertyPrivate Cannot access private property \Subclass391::$_prop2 defined at %s:5
+%s:29 PhanAccessPropertyPrivate Cannot access private property \Subclass391->_prop2 defined at %s:5
 %s:29 PhanUndeclaredProperty Reference to undeclared property \Subclass391->_prop2Other

--- a/tests/files/expected/0392_protected_property_other_class.php.expected
+++ b/tests/files/expected/0392_protected_property_other_class.php.expected
@@ -1,4 +1,4 @@
-%s:18 PhanAccessPropertyProtected Cannot access protected property \A392::$prop1 defined at %s:9
-%s:19 PhanAccessPropertyPrivate Cannot access private property \A392::$prop2 defined at %s:10
-%s:21 PhanAccessPropertyProtected Cannot access protected property \A392::$prop1 defined at %s:9
-%s:22 PhanAccessPropertyPrivate Cannot access private property \A392::$prop2 defined at %s:10
+%s:18 PhanAccessPropertyProtected Cannot access protected property \A392->prop1 defined at %s:9
+%s:19 PhanAccessPropertyPrivate Cannot access private property \A392->prop2 defined at %s:10
+%s:21 PhanAccessPropertyProtected Cannot access protected property \A392->prop1 defined at %s:9
+%s:22 PhanAccessPropertyPrivate Cannot access private property \A392->prop2 defined at %s:10

--- a/tests/files/expected/0393_property_visibility_trait.php.expected
+++ b/tests/files/expected/0393_property_visibility_trait.php.expected
@@ -1,2 +1,2 @@
-%s:15 PhanAccessPropertyPrivate Cannot access private property \ExtendingClass393::$propPrivate defined at %s:9
+%s:15 PhanAccessPropertyPrivate Cannot access private property \ExtendingClass393->propPrivate defined at %s:9
 %s:16 PhanUndeclaredProperty Reference to undeclared property \ExtendingClass393->missingProp

--- a/tests/files/expected/0401_varargs.php.expected
+++ b/tests/files/expected/0401_varargs.php.expected
@@ -2,4 +2,3 @@
 %s:14 PhanTypeMismatchArgument Argument 1 (a1) is 2 but \test_varargs401() takes \stdClass defined at %s:3
 %s:15 PhanTypeMismatchUnpackValue Attempting to unpack a value of type 2 which does not contain any subtypes of iterable (such as array or Traversable)
 %s:16 PhanTypeMismatchUnpackValue Attempting to unpack a value of type \stdClass which does not contain any subtypes of iterable (such as array or Traversable)
-

--- a/tests/files/expected/0443_base_access_protected_subclass.php.expected
+++ b/tests/files/expected/0443_base_access_protected_subclass.php.expected
@@ -1,2 +1,2 @@
-%s:7 PhanAccessPropertyPrivate Cannot access private property \Subclass::$privateProp defined at %s:15
+%s:7 PhanAccessPropertyPrivate Cannot access private property \Subclass->privateProp defined at %s:15
 %s:9 PhanAccessMethodPrivate Cannot access private method \Subclass::privateMethod defined at %s:20

--- a/tests/files/expected/0487_alternate_suggestions.php.expected
+++ b/tests/files/expected/0487_alternate_suggestions.php.expected
@@ -1,4 +1,4 @@
-%s:21 PhanUndeclaredTypeProperty Property \A487::x has undeclared type \avoid (Did you mean class \Avid)
+%s:21 PhanUndeclaredTypeProperty Property \A487->x has undeclared type \avoid (Did you mean class \Avid)
 %s:28 PhanTypeMissingReturn Method \A487::test_suggestions is declared to return \avoid but has no return value
 %s:28 PhanUndeclaredTypeParameter Parameter $x has undeclared type \avoid (Did you mean class \Avid)
 %s:28 PhanUndeclaredTypeReturnType Return type of test_suggestions() is undeclared type \avoid (Did you mean class \Avid or void)

--- a/tests/files/expected/0496_callable_string.php.expected
+++ b/tests/files/expected/0496_callable_string.php.expected
@@ -2,4 +2,4 @@
 %s:20 PhanTypeMismatchArgumentInternal Argument 1 (var) is 'NS\\MyClass496' but \count() takes \Countable|array
 %s:23 PhanParamTooFew Call with 0 arg(s) to \NS\MyClass496::myStaticMethod() which requires 1 arg(s) defined at %s:8
 %s:25 PhanParamTooFew Call with 0 arg(s) to \NS\MyClass496::myInstanceMethod() which requires 1 arg(s) defined at %s:9
-%s:28 PhanAccessPropertyNonStaticAsStatic Accessing non static property \NS\MyClass496->$static_prop as static
+%s:28 PhanAccessPropertyNonStaticAsStatic Accessing non static property \NS\MyClass496->static_prop as static

--- a/tests/files/expected/0500_specific_property.php.expected
+++ b/tests/files/expected/0500_specific_property.php.expected
@@ -1,2 +1,2 @@
-%s:15 PhanTypeMismatchProperty Assigning array<int,int> to property but \Example500::propWithArrayDefault is string[]
-%s:19 PhanTypeMismatchProperty Assigning array<int,int> to property but \Example500::propSetInConstructor is string[]
+%s:15 PhanTypeMismatchProperty Assigning array<int,int> to property but \Example500->propWithArrayDefault is string[]
+%s:19 PhanTypeMismatchProperty Assigning array<int,int> to property but \Example500->propSetInConstructor is string[]

--- a/tests/files/expected/0501_less_specific_default.php.expected
+++ b/tests/files/expected/0501_less_specific_default.php.expected
@@ -1,3 +1,3 @@
-%s:11 PhanTypeMismatchProperty Assigning 2 to property but \Example501::propWithStringDefault is string
-%s:12 PhanTypeMismatchProperty Assigning \stdClass to property but \Example501::propWithStringDefault is string
-%s:14 PhanTypeMismatchProperty Assigning \stdClass to property but \Example501::propWithIntDefault is int
+%s:11 PhanTypeMismatchProperty Assigning 2 to property but \Example501->propWithStringDefault is string
+%s:12 PhanTypeMismatchProperty Assigning \stdClass to property but \Example501->propWithStringDefault is string
+%s:14 PhanTypeMismatchProperty Assigning \stdClass to property but \Example501->propWithIntDefault is int

--- a/tests/files/expected/0504_prop_assignment_fetch.php.expected
+++ b/tests/files/expected/0504_prop_assignment_fetch.php.expected
@@ -1,4 +1,4 @@
-%s:11 PhanTypeMismatchProperty Assigning 2 to property but \Test504::prop is array{0:2}|int[]
+%s:11 PhanTypeMismatchProperty Assigning 2 to property but \Test504::$prop is array{0:2}|int[]
 %s:12 PhanTypeConversionFromArray array to string conversion
 %s:13 PhanUndeclaredStaticProperty Static property 'propMissing' on \Test504 is undeclared
 %s:14 PhanUndeclaredStaticProperty Static property 'otherMissingProp' on \Test504 is undeclared

--- a/tests/files/expected/0541_unset.php.expected
+++ b/tests/files/expected/0541_unset.php.expected
@@ -2,6 +2,6 @@
 %s:8 PhanTypeObjectUnsetDeclaredProperty Suspicious attempt to unset class \A541's property myPrivateVar declared at %s:5 (This can be done, but is more commonly done for dynamic properties and Phan does not expect this)
 %s:9 PhanUndeclaredProperty Reference to undeclared property \A541->myDynamicVar
 %s:11 PhanTypeExpectedObjectPropAccess Expected an object instance when accessing an instance property, but saw an expression with type array{}
-%s:16 PhanAccessPropertyPrivate Cannot access private property \A541::$myPrivateVar defined at %s:5
+%s:16 PhanAccessPropertyPrivate Cannot access private property \A541->myPrivateVar defined at %s:5
 %s:16 PhanTypeObjectUnsetDeclaredProperty Suspicious attempt to unset class \A541's property myPrivateVar declared at %s:5 (This can be done, but is more commonly done for dynamic properties and Phan does not expect this)
 %s:17 PhanTypeObjectUnsetDeclaredProperty Suspicious attempt to unset class \A541's property myPublicVar declared at %s:4 (This can be done, but is more commonly done for dynamic properties and Phan does not expect this)

--- a/tests/files/expected/0556_literal_in_property.php.expected
+++ b/tests/files/expected/0556_literal_in_property.php.expected
@@ -1,6 +1,6 @@
-%s:13 PhanTypeMismatchProperty Assigning '1' to property but \Foo::x is -1|1
-%s:14 PhanTypeMismatchProperty Assigning 3 to property but \Foo::x is -1|1
-%s:15 PhanTypeMismatchProperty Assigning 'b' to property but \Foo::a is 'A'|'a'
-%s:17 PhanTypeMismatchProperty Assigning 'c' to property but \Foo::a is 'A'|'a'
-%s:18 PhanTypeMismatchProperty Assigning 1 to property but \Foo::maybeArray is 0|array
-%s:20 PhanTypeMismatchProperty Assigning 2 to property but \Foo::maybeArray is 0|array|array<string,int>
+%s:13 PhanTypeMismatchProperty Assigning '1' to property but \Foo->x is -1|1
+%s:14 PhanTypeMismatchProperty Assigning 3 to property but \Foo->x is -1|1
+%s:15 PhanTypeMismatchProperty Assigning 'b' to property but \Foo->a is 'A'|'a'
+%s:17 PhanTypeMismatchProperty Assigning 'c' to property but \Foo->a is 'A'|'a'
+%s:18 PhanTypeMismatchProperty Assigning 1 to property but \Foo->maybeArray is 0|array
+%s:20 PhanTypeMismatchProperty Assigning 2 to property but \Foo->maybeArray is 0|array|array<string,int>

--- a/tests/files/src/0171_deprecated_property.php
+++ b/tests/files/src/0171_deprecated_property.php
@@ -3,5 +3,8 @@
 class C {
     /** @deprecated */
     public $p = 'string';
+    /** @deprecated */
+    public static $static_p = 's_string';
 }
 $v2 = (new C)->p;
+$v3 = C::$static_p;

--- a/tests/php70_files/expected/000_getopt.php.expected
+++ b/tests/php70_files/expected/000_getopt.php.expected
@@ -1,2 +1,1 @@
 %s:4 PhanParamTooManyInternal Call with 3 arg(s) to \getopt() which only takes 2 arg(s)
-

--- a/tests/php70_files/expected/001_hash_init.php.expected
+++ b/tests/php70_files/expected/001_hash_init.php.expected
@@ -1,2 +1,1 @@
 %s:7 PhanTypeMismatchArgumentInternal Argument 1 (obj) is resource but \spl_object_hash() takes object
-

--- a/tests/php70_files/expected/002_object_hint.php.expected
+++ b/tests/php70_files/expected/002_object_hint.php.expected
@@ -1,3 +1,2 @@
 %s:3 PhanCompatibleNullableTypePHP71 Type 'object' refers to any object starting in PHP 7.2. In PHP 7.1 and earlier, it refers to a class/interface with the name 'object'
 %s:18 PhanCompatibleNullableTypePHP71 Type 'object' refers to any object starting in PHP 7.2. In PHP 7.1 and earlier, it refers to a class/interface with the name 'object'
-

--- a/tests/php70_files/expected/003_short_array.php.expected
+++ b/tests/php70_files/expected/003_short_array.php.expected
@@ -6,4 +6,3 @@
 %s:17 PhanTypeMismatchArgumentInternal Argument 1 (string) is array{0:2} but \strlen() takes string
 %s:21 PhanCompatibleKeyedArrayAssignPHP70 Using array keys in an array destructuring assignment is not compatible with PHP 7.0
 %s:24 PhanTypeMismatchArgumentInternal Argument 1 (string) is array{0:3} but \strlen() takes string
-

--- a/tests/php70_files/expected/004_void.php.expected
+++ b/tests/php70_files/expected/004_void.php.expected
@@ -1,2 +1,1 @@
 %s:4 PhanCompatibleVoidTypePHP70 Return type 'void' means the absence of a return value starting in PHP 7.1. In PHP 7.0, void refers to a class/interface with the name 'void'
-

--- a/tests/php70_files/expected/005_nullable.php.expected
+++ b/tests/php70_files/expected/005_nullable.php.expected
@@ -2,4 +2,3 @@
 %s:5 PhanCompatibleNullableTypePHP70 Nullable type '?int' is not compatible with PHP 7.0
 %s:9 PhanCompatibleNullableTypePHP70 Nullable type '?int' is not compatible with PHP 7.0
 %s:17 PhanCompatibleNullableTypePHP70 Nullable type '?int' is not compatible with PHP 7.0
-

--- a/tests/php70_files/expected/006_iterable.php.expected
+++ b/tests/php70_files/expected/006_iterable.php.expected
@@ -1,3 +1,2 @@
 %s:3 PhanCompatibleIterableTypePHP70 Return type 'iterable' means a Traversable/array value starting in PHP 7.1. In PHP 7.0, iterable refers to a class/interface with the name 'iterable'
 %s:6 PhanCompatibleIterableTypePHP70 Return type 'iterable' means a Traversable/array value starting in PHP 7.1. In PHP 7.0, iterable refers to a class/interface with the name 'iterable'
-

--- a/tests/php70_files/expected/008_catch_multiple_exceptions.php.expected
+++ b/tests/php70_files/expected/008_catch_multiple_exceptions.php.expected
@@ -1,2 +1,1 @@
 %s:5 PhanCompatibleMultiExceptionCatchPHP70 Catching multiple exceptions is not supported before PHP 7.1
-

--- a/tests/php70_files/expected/009_negative_string_offset.php.expected
+++ b/tests/php70_files/expected/009_negative_string_offset.php.expected
@@ -2,4 +2,3 @@
 %s:6 PhanCompatibleNegativeStringOffset Using negative string offsets is not supported before PHP 7.1 (emits an 'Uninitialized string offset' notice)
 %s:8 PhanCompatibleNegativeStringOffset Using negative string offsets is not supported before PHP 7.1 (emits an 'Uninitialized string offset' notice)
 %s:11 PhanCompatibleNegativeStringOffset Using negative string offsets is not supported before PHP 7.1 (emits an 'Uninitialized string offset' notice)
-

--- a/tests/plugin_test/expected/000_plugins.php.expected
+++ b/tests/plugin_test/expected/000_plugins.php.expected
@@ -12,7 +12,7 @@ src/000_plugins.php:40 PhanPluginNonBoolBranch Non bool value of type array|arra
 src/000_plugins.php:47 PhanPluginNumericalComparison non numerical values compared by the operators '==' or '!='
 src/000_plugins.php:49 PhanPluginNumericalComparison numerical values compared by the operators '===' or '!=='
 src/000_plugins.php:55 UnusedSuppression Element \testUnusedSuppressionPlugin suppresses issue PhanParamTooFew but does not use it
-src/000_plugins.php:61 PhanUnreferencedFunction Possibly zero references to function \testUnreferencedFunction
+src/000_plugins.php:61 PhanUnreferencedFunction Possibly zero references to function \testUnreferencedFunction()
 src/000_plugins.php:64 PhanUnusedGlobalFunctionParameter Parameter $className is never used
 src/000_plugins.php:66 PhanUnreferencedClass Possibly zero references to class \__autoload
 src/000_plugins.php:67 PhanUnreferencedConstant Possibly zero references to global constant \__autoload
@@ -24,4 +24,4 @@ src/000_plugins.php:114 PhanUnusedVariable Unused definition of variable $x
 src/000_plugins.php:127 PhanTypeMismatchArgumentInternal Argument 1 (string) is int but \strlen() takes string
 src/000_plugins.php:138 DemoPluginMethodName Method \TestDemoPlugin::function cannot be called `function`
 src/000_plugins.php:139 DemoPluginPropertyName Property \TestDemoPlugin::property should not be called `property`
-src/000_plugins.php:139 PhanReadOnlyPublicProperty Possibly zero write references to public property \TestDemoPlugin::property
+src/000_plugins.php:139 PhanReadOnlyPublicProperty Possibly zero write references to public property \TestDemoPlugin->property

--- a/tests/plugin_test/expected/001_dead_code.php.expected
+++ b/tests/plugin_test/expected/001_dead_code.php.expected
@@ -1,17 +1,17 @@
-src/001_dead_code.php:8 PhanUnreferencedFunction Possibly zero references to function \duplicateFnB
-src/001_dead_code.php:18 PhanReadOnlyPublicProperty Possibly zero write references to public property \DuplicateClass001::static_prop1
-src/001_dead_code.php:19 PhanUnreferencedPublicProperty Possibly zero references to public property \DuplicateClass001::static_prop2
-src/001_dead_code.php:21 PhanReadOnlyPublicProperty Possibly zero write references to public property \DuplicateClass001::instance_prop1
-src/001_dead_code.php:22 PhanUnreferencedPublicProperty Possibly zero references to public property \DuplicateClass001::instance_prop2
-src/001_dead_code.php:25 PhanUnreferencedPublicMethod Possibly zero references to public method \DuplicateClass001::f2
-src/001_dead_code.php:26 PhanUnreferencedPublicMethod Possibly zero references to public method \DuplicateClass001::f3
+src/001_dead_code.php:8 PhanUnreferencedFunction Possibly zero references to function \duplicateFnB()
+src/001_dead_code.php:18 PhanReadOnlyPublicProperty Possibly zero write references to public property \DuplicateClass001::$static_prop1
+src/001_dead_code.php:19 PhanUnreferencedPublicProperty Possibly zero references to public property \DuplicateClass001::$static_prop2
+src/001_dead_code.php:21 PhanReadOnlyPublicProperty Possibly zero write references to public property \DuplicateClass001->instance_prop1
+src/001_dead_code.php:22 PhanUnreferencedPublicProperty Possibly zero references to public property \DuplicateClass001->instance_prop2
+src/001_dead_code.php:25 PhanUnreferencedPublicMethod Possibly zero references to public method \DuplicateClass001::f2()
+src/001_dead_code.php:26 PhanUnreferencedPublicMethod Possibly zero references to public method \DuplicateClass001::f3()
 src/001_dead_code.php:29 PhanRedefineFunction Function duplicateFnA defined at src/001_dead_code.php:29 was previously defined at src/001_dead_code.php:4
 src/001_dead_code.php:33 PhanRedefineFunction Function duplicateFnB defined at src/001_dead_code.php:33 was previously defined at src/001_dead_code.php:8
-src/001_dead_code.php:33 PhanUnreferencedFunction Possibly zero references to function \duplicateFnB,1
+src/001_dead_code.php:33 PhanUnreferencedFunction Possibly zero references to function \duplicateFnB,1()
 src/001_dead_code.php:37 PhanUnreferencedConstant Possibly zero references to global constant \Const1B
 src/001_dead_code.php:39 PhanRedefineClass Class \DuplicateClass001 defined at src/001_dead_code.php:39 was previously defined as Class \DuplicateClass001 at src/001_dead_code.php:15
 src/001_dead_code.php:41 PhanUnreferencedPublicClassConstant Possibly zero references to public class constant \DuplicateClass001,1::D
-src/001_dead_code.php:44 PhanUnreferencedPublicProperty Possibly zero references to public property \DuplicateClass001,1::static_prop2
-src/001_dead_code.php:47 PhanUnreferencedPublicProperty Possibly zero references to public property \DuplicateClass001,1::instance_prop2
-src/001_dead_code.php:50 PhanUnreferencedPublicMethod Possibly zero references to public method \DuplicateClass001,1::f2
-src/001_dead_code.php:51 PhanUnreferencedPublicMethod Possibly zero references to public method \DuplicateClass001,1::f4
+src/001_dead_code.php:44 PhanUnreferencedPublicProperty Possibly zero references to public property \DuplicateClass001,1::$static_prop2
+src/001_dead_code.php:47 PhanUnreferencedPublicProperty Possibly zero references to public property \DuplicateClass001,1->instance_prop2
+src/001_dead_code.php:50 PhanUnreferencedPublicMethod Possibly zero references to public method \DuplicateClass001,1::f2()
+src/001_dead_code.php:51 PhanUnreferencedPublicMethod Possibly zero references to public method \DuplicateClass001,1::f4()

--- a/tests/plugin_test/expected/003_suppress_on_property.php.expected
+++ b/tests/plugin_test/expected/003_suppress_on_property.php.expected
@@ -1,3 +1,3 @@
-src/003_suppress_on_property.php:7 PhanReadOnlyPublicProperty Possibly zero write references to public property \A3::x
+src/003_suppress_on_property.php:7 PhanReadOnlyPublicProperty Possibly zero write references to public property \A3->x
 src/003_suppress_on_property.php:10 PhanPluginMixedKeyNoKey Should not mix array entries of the form [key => value,] with entries of the form [value,].
 src/003_suppress_on_property.php:19 PhanPluginDuplicateArrayKey Duplicate/Equivalent array key value('key') detected in array - the earlier entry will be ignored.

--- a/tests/plugin_test/expected/014_unreferenced_constant.php.expected
+++ b/tests/plugin_test/expected/014_unreferenced_constant.php.expected
@@ -1,3 +1,3 @@
 src/014_unreferenced_constant.php:6 PhanUnreferencedPublicClassConstant Possibly zero references to public class constant \A14::unreferencedconst
-src/014_unreferenced_constant.php:10 PhanUnreferencedPublicProperty Possibly zero references to public property \A14::prop2
-src/014_unreferenced_constant.php:12 PhanUnreferencedPublicMethod Possibly zero references to public method \A14::foo_unused
+src/014_unreferenced_constant.php:10 PhanUnreferencedPublicProperty Possibly zero references to public property \A14::$prop2
+src/014_unreferenced_constant.php:12 PhanUnreferencedPublicMethod Possibly zero references to public method \A14::foo_unused()

--- a/tests/plugin_test/expected/015_trait_method.php.expected
+++ b/tests/plugin_test/expected/015_trait_method.php.expected
@@ -1,5 +1,5 @@
-src/015_trait_method.php:9 PhanUnreferencedProtectedMethod Possibly zero references to protected method \T15::fn2
+src/015_trait_method.php:9 PhanUnreferencedProtectedMethod Possibly zero references to protected method \T15::fn2()
 src/015_trait_method.php:19 PhanUnreferencedPublicClassConstant Possibly zero references to public class constant \I15::CI2
-src/015_trait_method.php:31 PhanUnreferencedPublicMethod Possibly zero references to public method \Base15::baseInstanceMethod2
+src/015_trait_method.php:31 PhanUnreferencedPublicMethod Possibly zero references to public method \Base15::baseInstanceMethod2()
 src/015_trait_method.php:35 PhanUnreferencedPublicClassConstant Possibly zero references to public class constant \Base15::C2
-src/015_trait_method.php:37 PhanUnreferencedPublicProperty Possibly zero references to public property \Base15::p2
+src/015_trait_method.php:37 PhanUnreferencedPublicProperty Possibly zero references to public property \Base15::$p2

--- a/tests/plugin_test/expected/016_dead_code_callable.php.expected
+++ b/tests/plugin_test/expected/016_dead_code_callable.php.expected
@@ -1,5 +1,5 @@
-src/016_dead_code_callable.php:7 PhanUnreferencedFunction Possibly zero references to function \myfunc16unused
-src/016_dead_code_callable.php:12 PhanUnreferencedFunction Possibly zero references to function \double16unused
-src/016_dead_code_callable.php:20 PhanUnreferencedPublicMethod Possibly zero references to public method \MyClass16::static_func_unused
-src/016_dead_code_callable.php:26 PhanUnreferencedPublicMethod Possibly zero references to public method \MyClass16::instanceFuncUnused
+src/016_dead_code_callable.php:7 PhanUnreferencedFunction Possibly zero references to function \myfunc16unused()
+src/016_dead_code_callable.php:12 PhanUnreferencedFunction Possibly zero references to function \double16unused()
+src/016_dead_code_callable.php:20 PhanUnreferencedPublicMethod Possibly zero references to public method \MyClass16::static_func_unused()
+src/016_dead_code_callable.php:26 PhanUnreferencedPublicMethod Possibly zero references to public method \MyClass16::instanceFuncUnused()
 src/016_dead_code_callable.php:45 PhanUndeclaredFunctionInCallable Call to undeclared function undeclared_func_16 in callable

--- a/tests/plugin_test/expected/016_dead_code_fromCallbale.php.expected
+++ b/tests/plugin_test/expected/016_dead_code_fromCallbale.php.expected
@@ -1,1 +1,1 @@
-src/016_dead_code_fromCallable.php:4 PhanUnreferencedFunction Possibly zero references to function \callable16bUnused
+src/016_dead_code_fromCallable.php:4 PhanUnreferencedFunction Possibly zero references to function \callable16bUnused()

--- a/tests/plugin_test/expected/017_unreferenced_closure.php.expected
+++ b/tests/plugin_test/expected/017_unreferenced_closure.php.expected
@@ -1,1 +1,1 @@
-src/017_unreferenced_closure.php:10 PhanUnreferencedClosure Possibly zero references to closure \closure_%s
+src/017_unreferenced_closure.php:10 PhanUnreferencedClosure Possibly zero references to Closure(string $x)

--- a/tests/plugin_test/expected/022_trait_method.php.expected
+++ b/tests/plugin_test/expected/022_trait_method.php.expected
@@ -1,1 +1,1 @@
-src/022_trait_method.php:5 PhanUnreferencedPublicMethod Possibly zero references to public method \T22::myUnusedFunction
+src/022_trait_method.php:5 PhanUnreferencedPublicMethod Possibly zero references to public method \T22::myUnusedFunction()

--- a/tests/plugin_test/expected/023_write_only_property.php.expected
+++ b/tests/plugin_test/expected/023_write_only_property.php.expected
@@ -1,6 +1,6 @@
-src/023_write_only_property.php:4 PhanWriteOnlyPublicProperty Possibly zero read references to public property \MyClass23::a
-src/023_write_only_property.php:5 PhanWriteOnlyProtectedProperty Possibly zero read references to protected property \MyClass23::b
-src/023_write_only_property.php:6 PhanWriteOnlyPrivateProperty Possibly zero read references to private property \MyClass23::c
-src/023_write_only_property.php:15 PhanUnreferencedPublicProperty Possibly zero references to public property \MyClass23::g
-src/023_write_only_property.php:34 PhanWriteOnlyPublicProperty Possibly zero read references to public property \OtherClass::subclassProp
-src/023_write_only_property.php:35 PhanUnreferencedPublicProperty Possibly zero references to public property \OtherClass::subclassPropUnused
+src/023_write_only_property.php:4 PhanWriteOnlyPublicProperty Possibly zero read references to public property \MyClass23->a
+src/023_write_only_property.php:5 PhanWriteOnlyProtectedProperty Possibly zero read references to protected property \MyClass23->b
+src/023_write_only_property.php:6 PhanWriteOnlyPrivateProperty Possibly zero read references to private property \MyClass23->c
+src/023_write_only_property.php:15 PhanUnreferencedPublicProperty Possibly zero references to public property \MyClass23->g
+src/023_write_only_property.php:34 PhanWriteOnlyPublicProperty Possibly zero read references to public property \OtherClass->subclassProp
+src/023_write_only_property.php:35 PhanUnreferencedPublicProperty Possibly zero references to public property \OtherClass->subclassPropUnused

--- a/tests/plugin_test/expected/024_strict_property_assignment.php.expected
+++ b/tests/plugin_test/expected/024_strict_property_assignment.php.expected
@@ -1,6 +1,6 @@
-src/024_strict_property_assignment.php:5 PhanWriteOnlyPrivateProperty Possibly zero read references to private property \MyClass24::a
-src/024_strict_property_assignment.php:8 PhanWriteOnlyProtectedProperty Possibly zero read references to protected property \MyClass24::b
-src/024_strict_property_assignment.php:11 PhanWriteOnlyPublicProperty Possibly zero read references to public property \MyClass24::c
-src/024_strict_property_assignment.php:19 PhanPossiblyFalseTypeMismatchProperty Assigning false|int to property but \MyClass24::a is int (false is incompatible)
-src/024_strict_property_assignment.php:20 PhanPossiblyNullTypeMismatchProperty Assigning \stdClass|null to property but \MyClass24::b is \stdClass (null is incompatible)
-src/024_strict_property_assignment.php:21 PhanPartialTypeMismatchProperty Assigning \MyClass24|\Traversable to property but \MyClass24::c is \MyClass24 (\Traversable|iterable is incompatible)
+src/024_strict_property_assignment.php:5 PhanWriteOnlyPrivateProperty Possibly zero read references to private property \MyClass24->a
+src/024_strict_property_assignment.php:8 PhanWriteOnlyProtectedProperty Possibly zero read references to protected property \MyClass24->b
+src/024_strict_property_assignment.php:11 PhanWriteOnlyPublicProperty Possibly zero read references to public property \MyClass24->c
+src/024_strict_property_assignment.php:19 PhanPossiblyFalseTypeMismatchProperty Assigning false|int to property but \MyClass24->a is int (false is incompatible)
+src/024_strict_property_assignment.php:20 PhanPossiblyNullTypeMismatchProperty Assigning \stdClass|null to property but \MyClass24->b is \stdClass (null is incompatible)
+src/024_strict_property_assignment.php:21 PhanPartialTypeMismatchProperty Assigning \MyClass24|\Traversable to property but \MyClass24->c is \MyClass24 (\Traversable|iterable is incompatible)

--- a/tests/plugin_test/expected/027_native_syntax_check.php.expected
+++ b/tests/plugin_test/expected/027_native_syntax_check.php.expected
@@ -1,5 +1,5 @@
 src/027_native_syntax_check.php:2 PhanUnreferencedClass Possibly zero references to class \X
-src/027_native_syntax_check.php:3 PhanUnreferencedPublicProperty Possibly zero references to public property \X::y
+src/027_native_syntax_check.php:3 PhanUnreferencedPublicProperty Possibly zero references to public property \X->y
 src/027_native_syntax_check.php:4 PhanNativePHPSyntaxCheckPlugin Saw error or notice for php --syntax-check: "Fatal error: Constant expression contains invalid operations"
 src/027_native_syntax_check.php:4 PhanUndeclaredVariable Variable $y is undeclared
-src/027_native_syntax_check.php:4 PhanUnreferencedPublicProperty Possibly zero references to public property \X::x
+src/027_native_syntax_check.php:4 PhanUnreferencedPublicProperty Possibly zero references to public property \X->x

--- a/tests/plugin_test/expected/032_line_suppression.php.expected
+++ b/tests/plugin_test/expected/032_line_suppression.php.expected
@@ -3,7 +3,7 @@ src/032_line_suppression.php:1 UnusedPluginFileSuppression Plugin BuiltinSuppres
 src/032_line_suppression.php:3 PhanInvalidCommentForDeclarationType The phpdoc comment for @property cannot occur on a function
 src/032_line_suppression.php:5 PhanInvalidCommentForDeclarationType The phpdoc comment for @property cannot occur on a function
 src/032_line_suppression.php:8 PhanInvalidCommentForDeclarationType The phpdoc comment for @property cannot occur on a function
-src/032_line_suppression.php:11 PhanUnreferencedFunction Possibly zero references to function \test_line_suppression
+src/032_line_suppression.php:11 PhanUnreferencedFunction Possibly zero references to function \test_line_suppression()
 src/032_line_suppression.php:13 PhanUndeclaredVariable Variable $x is undeclared
 src/032_line_suppression.php:15 PhanUndeclaredVariable Variable $z is undeclared
 src/032_line_suppression.php:18 PhanUndeclaredFunction Call to undeclared function \call_undeclared_function_not_suppressed()

--- a/tests/plugin_test/expected/034_loop_checks.php.expected
+++ b/tests/plugin_test/expected/034_loop_checks.php.expected
@@ -1,1 +1,1 @@
-src/034_loop_checks.php:5 PhanReadOnlyPublicProperty Possibly zero write references to public property \Example34::array
+src/034_loop_checks.php:5 PhanReadOnlyPublicProperty Possibly zero write references to public property \Example34->array

--- a/tests/plugin_test/expected/047_crash.php.expected
+++ b/tests/plugin_test/expected/047_crash.php.expected
@@ -1,3 +1,3 @@
 src/047_crash.php:6 PhanUnusedPublicMethodParameter Parameter $arg is never used
-src/047_crash.php:11 PhanUnreferencedFunction Possibly zero references to function \example
+src/047_crash.php:11 PhanUnreferencedFunction Possibly zero references to function \example()
 src/047_crash.php:12 PhanTypeMismatchArgument Argument 1 (arg) is 'my arg' but \X47::myMethod() takes int defined at src/047_crash.php:6

--- a/tests/plugin_test/expected/048_redundant_binary_op.php.expected
+++ b/tests/plugin_test/expected/048_redundant_binary_op.php.expected
@@ -1,4 +1,4 @@
-src/048_redundant_binary_op.php:5 PhanReadOnlyPublicProperty Possibly zero write references to public property \A48::prop
+src/048_redundant_binary_op.php:5 PhanReadOnlyPublicProperty Possibly zero write references to public property \A48::$prop
 src/048_redundant_binary_op.php:8 PhanPluginDuplicateExpressionBinaryOp Both sides of the binary operator > are the same: (2 + 2)
 src/048_redundant_binary_op.php:9 PhanPluginDuplicateExpressionBinaryOp Both sides of the binary operator == are the same: $x->prop
 src/048_redundant_binary_op.php:10 PhanPluginDuplicateExpressionBinaryOp Both sides of the binary operator != are the same: A48::$prop

--- a/tests/rasmus_files/expected/0002_dangling_var.php.expected
+++ b/tests/rasmus_files/expected/0002_dangling_var.php.expected
@@ -1,2 +1,1 @@
 %s:2 PhanNoopVariable Unused variable
-

--- a/tests/rasmus_files/expected/0004_number_of_args.php.expected
+++ b/tests/rasmus_files/expected/0004_number_of_args.php.expected
@@ -1,4 +1,3 @@
 %s:5 PhanParamTooFew Call with 0 arg(s) to \test() which requires 2 arg(s) defined at %s:2
 %s:6 PhanParamTooFew Call with 1 arg(s) to \test() which requires 2 arg(s) defined at %s:2
 %s:9 PhanParamTooMany Call with 4 arg(s) to \test() which only takes 3 arg(s) defined at %s:2
-

--- a/tests/rasmus_files/expected/0006_var_combo.php.expected
+++ b/tests/rasmus_files/expected/0006_var_combo.php.expected
@@ -3,4 +3,3 @@
 %s:5 PhanStaticCallToNonStatic Static call to non-static method \A::func() defined at %s:3
 %s:6 PhanStaticCallToNonStatic Static call to non-static method \A::func() defined at %s:3
 %s:6 PhanTypeMismatchArgument Argument 1 (arg) is array but \A::func() takes int defined at %s:3
-

--- a/tests/rasmus_files/expected/0009_method_call.php.expected
+++ b/tests/rasmus_files/expected/0009_method_call.php.expected
@@ -1,2 +1,1 @@
 %s:7 PhanParamTooFew Call with 1 arg(s) to \A::test() which requires 2 arg(s) defined at %s:3
-

--- a/tests/rasmus_files/expected/0010_this_method_call.php.expected
+++ b/tests/rasmus_files/expected/0010_this_method_call.php.expected
@@ -1,2 +1,1 @@
 %s:9 PhanParamTooFew Call with 0 arg(s) to \B::testA() which requires 1 arg(s) defined at %s:3
-

--- a/tests/rasmus_files/expected/0012_redef_interface_class.php.expected
+++ b/tests/rasmus_files/expected/0012_redef_interface_class.php.expected
@@ -1,3 +1,2 @@
 %s:7 PhanRedefineClass Trait \Test defined at %s:7 was previously defined as Interface \Test at %s:2
 %s:12 PhanRedefineClass Class \Test defined at %s:12 was previously defined as Interface \Test at %s:2
-

--- a/tests/rasmus_files/expected/0014_varargs_internal.php.expected
+++ b/tests/rasmus_files/expected/0014_varargs_internal.php.expected
@@ -1,2 +1,1 @@
 %s:2 PhanParamTooFewInternal Call with 0 arg(s) to \max() which requires 1 arg(s)
-

--- a/tests/rasmus_files/expected/0015_variadic_call.php.expected
+++ b/tests/rasmus_files/expected/0015_variadic_call.php.expected
@@ -1,2 +1,1 @@
 %s:5 PhanParamTooFew Call with 0 arg(s) to \test() which requires 1 arg(s) defined at %s:2
-

--- a/tests/rasmus_files/expected/0018_return_var.php.expected
+++ b/tests/rasmus_files/expected/0018_return_var.php.expected
@@ -1,2 +1,1 @@
 %s:3 PhanTypeMismatchReturn Returning type string but test() is declared to return int
-

--- a/tests/rasmus_files/expected/0019_static_var.php.expected
+++ b/tests/rasmus_files/expected/0019_static_var.php.expected
@@ -1,2 +1,1 @@
 %s:7 PhanTypeMismatchArgument Argument 1 (arg) is float but \test2() takes int defined at %s:6
-

--- a/tests/rasmus_files/expected/0021_foreach.php.expected
+++ b/tests/rasmus_files/expected/0021_foreach.php.expected
@@ -1,2 +1,1 @@
 %s:8 PhanTypeConversionFromArray array to string conversion
-

--- a/tests/rasmus_files/expected/0022_ref_params.php.expected
+++ b/tests/rasmus_files/expected/0022_ref_params.php.expected
@@ -1,2 +1,1 @@
 %s:15 PhanTypeMismatchArgument Argument 1 (farg2) is float but \B::test2() takes int defined at %s:8
-

--- a/tests/rasmus_files/expected/0028_construct.php.expected
+++ b/tests/rasmus_files/expected/0028_construct.php.expected
@@ -1,2 +1,1 @@
 %s:7 PhanTypeMismatchArgument Argument 1 (arg) is 'wrong' but \A::__construct() takes int defined at %s:3
-

--- a/tests/rasmus_files/expected/0029_internal_method.php.expected
+++ b/tests/rasmus_files/expected/0029_internal_method.php.expected
@@ -1,2 +1,1 @@
 %s:3 PhanTypeMismatchArgumentInternal Argument 1 (format) is 1 but \DateTime::format() takes string
-

--- a/tests/rasmus_files/expected/0030_def_arg_type.php.expected
+++ b/tests/rasmus_files/expected/0030_def_arg_type.php.expected
@@ -1,2 +1,1 @@
 %s:4 PhanTypeMismatchDefault Default value for int $arg2 can't be float
-

--- a/tests/rasmus_files/expected/0036_properties.php.expected
+++ b/tests/rasmus_files/expected/0036_properties.php.expected
@@ -1,6 +1,6 @@
-%s:8 PhanTypeMismatchProperty Assigning int to property but \A::text is string
-%s:8 PhanTypeMismatchProperty Assigning string to property but \A::num is int
+%s:8 PhanTypeMismatchProperty Assigning int to property but \A->text is string
+%s:8 PhanTypeMismatchProperty Assigning string to property but \A->num is int
 %s:11 PhanUndeclaredProperty Reference to undeclared property \A->str
-%s:12 PhanTypeMismatchProperty Assigning array{} to property but \A::text is int|string
-%s:18 PhanAccessPropertyProtected Cannot access protected property \A::$foo defined at %s:8
+%s:12 PhanTypeMismatchProperty Assigning array{} to property but \A->text is int|string
+%s:18 PhanAccessPropertyProtected Cannot access protected property \A->foo defined at %s:8
 %s:19 PhanUndeclaredProperty Reference to undeclared property \A->bar

--- a/tests/rasmus_files/expected/0037_properties2.php.expected
+++ b/tests/rasmus_files/expected/0037_properties2.php.expected
@@ -1,3 +1,4 @@
-%s:13 PhanTypeMismatchProperty Assigning array<int,int> to property but \B::text is string
-%s:20 PhanAccessPropertyProtected Cannot access protected property \B::$text defined at %s:4
-%s:30 PhanTypeMismatchProperty Assigning array{} to property but \B::text is string
+%s:13 PhanTypeMismatchProperty Assigning array<int,int> to property but \B->text is string
+%s:20 PhanAccessPropertyProtected Cannot access protected property \B->text defined at %s:4
+%s:30 PhanTypeMismatchProperty Assigning array{} to property but \B->text is string
+

--- a/tests/rasmus_files/expected/0037_properties2.php.expected
+++ b/tests/rasmus_files/expected/0037_properties2.php.expected
@@ -1,4 +1,3 @@
 %s:13 PhanTypeMismatchProperty Assigning array<int,int> to property but \B->text is string
 %s:20 PhanAccessPropertyProtected Cannot access protected property \B->text defined at %s:4
 %s:30 PhanTypeMismatchProperty Assigning array{} to property but \B->text is string
-

--- a/tests/rasmus_files/expected/0038_properties3.php.expected
+++ b/tests/rasmus_files/expected/0038_properties3.php.expected
@@ -1,2 +1,2 @@
-%s:9 PhanTypeMismatchProperty Assigning array<int,string> to property but \A::prop is int[]
-%s:10 PhanTypeMismatchProperty Assigning 1 to property but \A::prop is int[]
+%s:9 PhanTypeMismatchProperty Assigning array<int,string> to property but \A->prop is int[]
+%s:10 PhanTypeMismatchProperty Assigning 1 to property but \A->prop is int[]

--- a/tests/rasmus_files/expected/0039_static_property_ref.php.expected
+++ b/tests/rasmus_files/expected/0039_static_property_ref.php.expected
@@ -1,2 +1,1 @@
 %s:10 PhanTypeMismatchArgument Argument 1 (arg) is 'abc' but \test3() takes array defined at %s:7
-

--- a/tests/rasmus_files/expected/0040_deprecated.php.expected
+++ b/tests/rasmus_files/expected/0040_deprecated.php.expected
@@ -1,2 +1,1 @@
 %s:7 PhanDeprecatedFunction Call to deprecated function \test() defined at %s:5
-

--- a/tests/rasmus_files/expected/0041_array_comp.php.expected
+++ b/tests/rasmus_files/expected/0041_array_comp.php.expected
@@ -1,3 +1,2 @@
 %s:3 PhanTypeComparisonFromArray array to int comparison
 %s:4 PhanTypeComparisonFromArray array to int comparison
-

--- a/tests/rasmus_files/expected/0043_array_access_object.php.expected
+++ b/tests/rasmus_files/expected/0043_array_access_object.php.expected
@@ -1,2 +1,1 @@
 %s:4 PhanTypeArraySuspicious Suspicious array access to \A
-


### PR DESCRIPTION
Consistently show static properties one way,
and instance properties a different way.

This affects a large number of test cases.

Also, normalize whitespace in the expected output text