### PR TITLE
Warn about more invalid operands of the binary operators `^`,`/`,`&`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,9 @@ New features(Analysis):
   (e.g. `@var 1|2`)
 + Improve line number of warning about extra comma in arrays (i.e. empty array elements). (#2066)
 + Properly parse [flexible heredoc/nowdoc syntaxes](https://wiki.php.net/rfc/flexible_heredoc_nowdoc_syntaxes) that were added in PHP 7.3 (#1537)
++ Warn about more invalid operands of the binary operators `^`,`/`,`&` (#1825)
+  Also, fix cases where `PhanTypeArrayOperator` would not be emitted.
+  New issue types: `PhanTypeInvalidBitwiseBinaryOperator`, `PhanTypeMismatchBitwiseBinaryOperands`
 
 Maintenance:
 + Make issue messages more consistent in their syntax used to describe closures/functions (#1695)

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -749,7 +749,7 @@ YMMV.
 ## PhanUnreferencedClosure
 
 ```
-Possibly zero references to closure {FUNCTION}
+Possibly zero references to {FUNCTION}
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/1.1.1/tests/plugin_test/expected/017_unreferenced_closure.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.1.1/tests/plugin_test/src/017_unreferenced_closure.php#L10).
@@ -1684,8 +1684,10 @@ e.g. [this issue](https://github.com/phan/phan/tree/1.1.1/tests/files/expected/0
 ## PhanTypeArrayOperator
 
 ```
-Invalid array operator between types {TYPE} and {TYPE}
+Invalid array operand provided to operator '{OPERATOR}' between types {TYPE} and {TYPE}
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0561_bitwise_operands.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0561_bitwise_operands.php#L4).
 
 ## PhanTypeArraySuspicious
 
@@ -1822,6 +1824,14 @@ This issue will be emitted for the following code
 ```php
 interface E {} (new E);
 ```
+
+## PhanTypeInvalidBitwiseBinaryOperator
+
+```
+Invalid non-int/non-string operand provided to operator '{OPERATOR}' between types {TYPE} and {TYPE}
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0561_bitwise_operands.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0561_bitwise_operands.php#L3).
 
 ## PhanTypeInvalidCallableArrayKey
 
@@ -2090,6 +2100,14 @@ Attempting an array destructing assignment with a key of type {TYPE} but the onl
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/1.1.1/tests/files/expected/0402_array_destructuring.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.1.1/tests/files/src/0402_array_destructuring.php#L4).
+
+## PhanTypeMismatchBitwiseBinaryOperands
+
+```
+Unexpected mix of int and string operands provided to operator '{OPERATOR}' between types {TYPE} and {TYPE} (expected one type but not both)
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0561_bitwise_operands.php.expected#L8) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0561_bitwise_operands.php#L11).
 
 ## PhanTypeMismatchDeclaredParam
 

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -74,6 +74,8 @@ class Issue
     // Issue::CATEGORY_TYPE
     const NonClassMethodCall        = 'PhanNonClassMethodCall';
     const TypeArrayOperator         = 'PhanTypeArrayOperator';
+    const TypeInvalidBitwiseBinaryOperator = 'PhanTypeInvalidBitwiseBinaryOperator';
+    const TypeMismatchBitwiseBinaryOperands = 'PhanTypeMismatchBitwiseBinaryOperands';
     const TypeArraySuspicious       = 'PhanTypeArraySuspicious';
     const TypeArrayUnsetSuspicious  = 'PhanTypeArrayUnsetSuspicious';
     const TypeArraySuspiciousNullable = 'PhanTypeArraySuspiciousNullable';
@@ -1223,7 +1225,7 @@ class Issue
                 self::TypeArrayOperator,
                 self::CATEGORY_TYPE,
                 self::SEVERITY_NORMAL,
-                "Invalid array operator between types {TYPE} and {TYPE}",
+                "Invalid array operand provided to operator '{OPERATOR}' between types {TYPE} and {TYPE}",
                 self::REMEDIATION_B,
                 10008
             ),
@@ -1723,6 +1725,22 @@ class Issue
                 "{FUNCTIONLIKE} is declared to have a parameter \${PARAMETER} with a real type of trait {TYPE} (expected a class or interface or built-in type)",
                 self::REMEDIATION_B,
                 10090
+            ),
+            new Issue(
+                self::TypeInvalidBitwiseBinaryOperator,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                "Invalid non-int/non-string operand provided to operator '{OPERATOR}' between types {TYPE} and {TYPE}",
+                self::REMEDIATION_B,
+                10091
+            ),
+            new Issue(
+                self::TypeMismatchBitwiseBinaryOperands,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                "Unexpected mix of int and string operands provided to operator '{OPERATOR}' between types {TYPE} and {TYPE} (expected one type but not both)",
+                self::REMEDIATION_B,
+                10092
             ),
             // Issue::CATEGORY_VARIABLE
             new Issue(

--- a/src/Phan/Language/Element/Parameter.php
+++ b/src/Phan/Language/Element/Parameter.php
@@ -42,7 +42,7 @@ class Parameter extends Variable
 
     /**
      * @var UnionType|null
-     * The type of the default value if any
+     * The type of the default value, if any
      */
     private $default_value_type = null;
 

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -456,9 +456,17 @@ final class EmptyUnionType extends UnionType
     /**
      * @return bool
      * True if any types in this union are a printable scalar, or this is the empty union type
-     * @internal
      */
     public function hasPrintableScalar() : bool
+    {
+        return true;
+    }
+
+    /**
+     * @return bool
+     * True if any types in this union are a printable scalar, or this is the empty union type
+     */
+    public function hasValidBitwiseOperand() : bool
     {
         return true;
     }

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -1670,6 +1670,16 @@ class Type
 
     /**
      * @return bool
+     * True if this type is a valid operand for a bitwise operator ('|', '&', or '^').
+     * @internal
+     */
+    public function isValidBitwiseOperand() : bool
+    {
+        return false;  // Overridden in subclasses
+    }
+
+    /**
+     * @return bool
      * True if this type is a callable or a Closure.
      */
     public function isCallable() : bool

--- a/src/Phan/Language/Type/FloatType.php
+++ b/src/Phan/Language/Type/FloatType.php
@@ -1,6 +1,8 @@
 <?php declare(strict_types=1);
 namespace Phan\Language\Type;
 
+use Phan\Config;
+
 /**
  * Phan's representation of the type for `float`
  */
@@ -13,5 +15,10 @@ final class FloatType extends ScalarType
     public function getIsPossiblyNumeric() : bool
     {
         return true;
+    }
+
+    public function isValidBitwiseOperand() : bool
+    {
+        return Config::getValue('scalar_implicit_cast');
     }
 }

--- a/src/Phan/Language/Type/IterableType.php
+++ b/src/Phan/Language/Type/IterableType.php
@@ -20,6 +20,11 @@ class IterableType extends NativeType
         return false;
     }
 
+    public function isValidBitwiseOperand() : bool
+    {
+        return false;
+    }
+
     public function isPossiblyObject() : bool
     {
         return true;  // can be Traversable, which is an object

--- a/src/Phan/Language/Type/NullType.php
+++ b/src/Phan/Language/Type/NullType.php
@@ -130,6 +130,12 @@ final class NullType extends ScalarType
         return Config::get_null_casts_as_any_type();
     }
 
+    public function isValidBitwiseOperand() : bool
+    {
+        // Allow null in union types for bitwise operations if there are **other** valid types.
+        return Config::get_null_casts_as_any_type();
+    }
+
     public function isValidNumericOperand() : bool
     {
         return Config::get_null_casts_as_any_type();

--- a/src/Phan/Language/Type/ResourceType.php
+++ b/src/Phan/Language/Type/ResourceType.php
@@ -13,4 +13,9 @@ final class ResourceType extends NativeType
     {
         return false;
     }
+
+    public function isValidBitwiseOperand() : bool
+    {
+        return false;
+    }
 }

--- a/src/Phan/Language/Type/ScalarType.php
+++ b/src/Phan/Language/Type/ScalarType.php
@@ -23,6 +23,11 @@ abstract class ScalarType extends NativeType
         return true;  // Overridden in subclass BoolType
     }
 
+    public function isValidBitwiseOperand() : bool
+    {
+        return true;
+    }
+
     public function isSelfType() : bool
     {
         return false;

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -1564,7 +1564,6 @@ class UnionType implements Serializable
     /**
      * @return bool
      * True if any types in this union are a printable scalar, or this is the empty union type
-     * @internal
      */
     public function hasPrintableScalar() : bool
     {
@@ -1574,6 +1573,21 @@ class UnionType implements Serializable
 
         return $this->hasTypeMatchingCallback(function (Type $type) : bool {
             return $type->isPrintableScalar();
+        });
+    }
+
+    /**
+     * @return bool
+     * True if any types in this union are a valid operand for a bitwise operator ('|', '&', or '^').
+     */
+    public function hasValidBitwiseOperand() : bool
+    {
+        if ($this->isEmpty()) {
+            return true;
+        }
+
+        return $this->hasTypeMatchingCallback(function (Type $type) : bool {
+            return $type->isValidBitwiseOperand();
         });
     }
 

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -521,7 +521,7 @@ class ParseVisitor extends ScopeVisitor
                 if ($variable_type->hasGenericArray() && !$original_property_type->hasTypeMatchingCallback(function (Type $type) : bool {
                     return \get_class($type) !== ArrayType::class;
                 })) {
-                    // Don't convert `/** @var T[] */ public $x = []` to union type `string[]|array`
+                    // Don't convert `/** @var T[] */ public $x = []` to union type `T[]|array`
                     $property->setUnionType($variable_type);
                 } else {
                     // Set the declared type to the doc-comment type and add

--- a/src/Phan/Phan.php
+++ b/src/Phan/Phan.php
@@ -301,7 +301,7 @@ class Phan implements IgnoredFilesFilterInterface
                 $code_base->resolveClassAliases();
             }
 
-            // Take a pass over all functions verifying
+            // Take a pass over all classes verifying
             // various states now that we have the whole
             // state in memory
             Analysis::analyzeClasses($code_base, $path_filter);

--- a/tests/files/expected/0561_bitwise_operands.php.expected
+++ b/tests/files/expected/0561_bitwise_operands.php.expected
@@ -1,0 +1,10 @@
+%s:3 PhanTypeInvalidBitwiseBinaryOperator Invalid non-int/non-string operand provided to operator '|' between types int and iterable
+%s:4 PhanTypeArrayOperator Invalid array operand provided to operator '|' between types array and iterable
+%s:5 PhanTypeArrayOperator Invalid array operand provided to operator '|' between types int and array
+%s:6 PhanTypeArrayOperator Invalid array operand provided to operator '|' between types int and array{}
+%s:7 PhanTypeInvalidBitwiseBinaryOperator Invalid non-int/non-string operand provided to operator '|' between types int and resource
+%s:8 PhanTypeInvalidBitwiseBinaryOperator Invalid non-int/non-string operand provided to operator '|' between types int and float
+%s:9 PhanTypeInvalidBitwiseBinaryOperator Invalid non-int/non-string operand provided to operator '|' between types int and \stdClass
+%s:11 PhanTypeMismatchBitwiseBinaryOperands Unexpected mix of int and string operands provided to operator '|' between types int and string (expected one type but not both)
+%s:12 PhanTypeMismatchBitwiseBinaryOperands Unexpected mix of int and string operands provided to operator '^' between types int and string (expected one type but not both)
+%s:13 PhanTypeMismatchBitwiseBinaryOperands Unexpected mix of int and string operands provided to operator '&' between types int and string (expected one type but not both)

--- a/tests/files/src/0561_bitwise_operands.php
+++ b/tests/files/src/0561_bitwise_operands.php
@@ -1,0 +1,14 @@
+<?php
+call_user_func(function (int $a, string $b, array $x, iterable $i) {
+    var_export($a | $i);
+    var_export($x | $i);
+    var_export($a | $x);
+    var_export($a | []);
+    var_export($a | STDIN);
+    var_export($a | 2.3);
+    var_export($a | (new stdClass()));
+    var_export($a | false);
+    var_export($a | $b);
+    var_export($a ^ $b);
+    var_export($a & $b);
+}, 2, 'x', [2], [2]);


### PR DESCRIPTION
Warn if one side is an int and the other is a string.

Warn about more invalid types (including non-arrays such as objects)

Fixes #1825