### PR TITLE
Mention when too many argument warnings are caused by unpacking

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,8 @@ New features(Analysis):
 + Warn about more invalid operands of the binary operators `^`,`/`,`&` (#1825)
   Also, fix cases where `PhanTypeArrayOperator` would not be emitted.
   New issue types: `PhanTypeInvalidBitwiseBinaryOperator`, `PhanTypeMismatchBitwiseBinaryOperands`
++ Indicate when warnings about too many arguments are caused only by argument unpacking. (#1324)
+  New issue types: `PhanParamTooManyUnpack`, `PhanParamTooManyUnpackInternal`
 
 Maintenance:
 + Make issue messages more consistent in their syntax used to describe closures/functions (#1695)

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -1386,6 +1386,20 @@ This will be emitted for the code
 strlen('str', 42);
 ```
 
+## PhanParamTooManyUnpack
+
+```
+Call with {COUNT} or more args to {FUNCTIONLIKE} which only takes {COUNT} arg(s) defined at {FILE}:{LINE} (argument unpacking was used)
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0562_unpack_too_many.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0562_unpack_too_many.php#L7).
+
+## PhanParamTooManyUnpackInternal
+
+```
+Call with {COUNT} or more args to {FUNCTIONLIKE} which only takes {COUNT} arg(s) (argument unpacking was used)
+```
+
 ## PhanParamTypeMismatch
 
 ```

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -203,7 +203,9 @@ class Issue
     const ParamTooFewInternal       = 'PhanParamTooFewInternal';
     const ParamTooFewCallable       = 'PhanParamTooFewCallable';
     const ParamTooMany              = 'PhanParamTooMany';
+    const ParamTooManyUnpack        = 'PhanParamTooManyUnpack';
     const ParamTooManyInternal      = 'PhanParamTooManyInternal';
+    const ParamTooManyUnpackInternal = 'PhanParamTooManyUnpackInternal';
     const ParamTooManyCallable      = 'PhanParamTooManyCallable';
     const ParamTypeMismatch         = 'PhanParamTypeMismatch';
     const ParamSignatureMismatch    = 'PhanParamSignatureMismatch';
@@ -2209,6 +2211,22 @@ class Issue
                 "Argument #{INDEX} of this call to {FUNCTIONLIKE} is typically a literal or constant but isn't, but argument #{INDEX} (which is typically a variable) is a literal or constant. The arguments may be in the wrong order.",
                 self::REMEDIATION_B,
                 7045
+            ),
+            new Issue(
+                self::ParamTooManyUnpack,
+                self::CATEGORY_PARAMETER,
+                self::SEVERITY_LOW,
+                "Call with {COUNT} or more args to {FUNCTIONLIKE} which only takes {COUNT} arg(s) defined at {FILE}:{LINE} (argument unpacking was used)",
+                self::REMEDIATION_B,
+                7046
+            ),
+            new Issue(
+                self::ParamTooManyUnpackInternal,
+                self::CATEGORY_PARAMETER,
+                self::SEVERITY_LOW,
+                "Call with {COUNT} or more args to {FUNCTIONLIKE} which only takes {COUNT} arg(s) (argument unpacking was used)",
+                self::REMEDIATION_B,
+                7047
             ),
 
             // Issue::CATEGORY_NOOP

--- a/tests/files/expected/0562_unpack_too_many.php.expected
+++ b/tests/files/expected/0562_unpack_too_many.php.expected
@@ -1,0 +1,2 @@
+%s:7 PhanParamTooManyUnpack Call with 0 or more args to \Example::__construct() which only takes 0 arg(s) defined at %s:4 (argument unpacking was used)
+%s:10 PhanParamTooMany Call with 2 arg(s) to \Example::__construct() which only takes 0 arg(s) defined at %s:4

--- a/tests/files/src/0562_unpack_too_many.php
+++ b/tests/files/src/0562_unpack_too_many.php
@@ -1,0 +1,12 @@
+<?php
+
+class Example {
+    public function __construct() {
+    }
+    public static function make(...$args) {
+        return new self(...$args);
+    }
+    public static function make2(...$args) {
+        return new self('extra', ...$args);
+    }
+}


### PR DESCRIPTION
Fixes #1324