### PR TITLE
Properly warn about undefined namespaced constants/functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,8 @@ New features(Analysis):
   New issue types: `PhanTypeInvalidBitwiseBinaryOperator`, `PhanTypeMismatchBitwiseBinaryOperands`
 + Indicate when warnings about too many arguments are caused only by argument unpacking. (#1324)
   New issue types: `PhanParamTooManyUnpack`, `PhanParamTooManyUnpackInternal`
++ Properly warn about undefined namespaced constants/functions from within a namespace (#2112)
+  Phan was failing to warn in some cases.
 
 Maintenance:
 + Make issue messages more consistent in their syntax used to describe closures/functions (#1695)

--- a/tests/files/expected/0288_use_relative_namespace_function.php.expected
+++ b/tests/files/expected/0288_use_relative_namespace_function.php.expected
@@ -1,4 +1,5 @@
 %s:19 PhanUndeclaredFunction Call to undeclared function \A510\inner\missingthisfn()
 %s:21 PhanUndeclaredFunction Call to undeclared function \A510\Inner\MissingGroupUseFn()
 %s:22 PhanUndeclaredFunction Call to undeclared function \mixedCaseFn()
+%s:23 PhanUndeclaredFunction Call to undeclared function \B510\A510\Inner\mixedCaseFn()
 %s:25 PhanUndeclaredFunction Call to undeclared function \A510\Inner\missingfn()

--- a/tests/files/expected/0467_name_not_empty.php.expected
+++ b/tests/files/expected/0467_name_not_empty.php.expected
@@ -1,7 +1,7 @@
 %s:2 PhanEmptyFQSENInCallable Possible call to a function '\' with an empty FQSEN.
 %s:3 PhanEmptyFQSENInCallable Possible call to a function '\' with an empty FQSEN.
-%s:4 PhanEmptyFQSENInCallable Possible call to a function '' with an empty FQSEN.
-%s:5 PhanEmptyFQSENInCallable Possible call to a function '' with an empty FQSEN.
+%s:4 PhanEmptyFQSENInCallable Possible call to a function '\' with an empty FQSEN.
+%s:5 PhanEmptyFQSENInCallable Possible call to a function '\' with an empty FQSEN.
 %s:6 PhanEmptyFQSENInClasslike Possible use of a classlike '\' with an empty FQSEN.
 %s:7 PhanEmptyFQSENInClasslike Possible use of a classlike '\' with an empty FQSEN.
 %s:8 PhanNonClassMethodCall Call to method foo on non-class type 1

--- a/tests/files/expected/0563_namespaced_functions_constants.php.expected
+++ b/tests/files/expected/0563_namespaced_functions_constants.php.expected
@@ -1,0 +1,8 @@
+%s:7 PhanUndeclaredFunction Call to undeclared function \MyNs\ast\parse_code()
+%s:8 PhanUndeclaredConstant Reference to undeclared constant \MyNs\ast\AST_UNPACK
+%s:9 PhanUndeclaredClassMethod Call to method __construct from undeclared class \MyNs\ast\Node (Did you mean class \ast\Node)
+%s:10 PhanUndeclaredFunction Call to undeclared function \MyNs\ast\parse_code()
+%s:11 PhanUndeclaredConstant Reference to undeclared constant \MyNs\ast\AST_UNPACK
+%s:12 PhanUndeclaredClassMethod Call to method __construct from undeclared class \MyNs\ast\Node (Did you mean class \ast\Node)
+%s:13 PhanUndeclaredFunction Call to undeclared function \MyNs\is_string()
+%s:14 PhanUndeclaredConstant Reference to undeclared constant \MyNs\PHP_VERSION

--- a/tests/files/expected/0564_global_namespace_functions_constants.php.expected
+++ b/tests/files/expected/0564_global_namespace_functions_constants.php.expected
@@ -1,0 +1,3 @@
+%s:21 PhanUndeclaredClassMethod Call to method __construct from undeclared class \a\Missing
+%s:22 PhanUndeclaredConstant Reference to undeclared constant \ast\MISSING_CONST
+%s:23 PhanUndeclaredFunction Call to undeclared function \ast\missing_function()

--- a/tests/files/src/0288_use_relative_namespace_function.php
+++ b/tests/files/src/0288_use_relative_namespace_function.php
@@ -20,8 +20,9 @@ namespace B510 {
         groupUseFn();  // fine
         MissingGroupUseFn();  // should report an error
         mixedCaseFn();  // should fail, this was not imported
-        A510\Inner\mixedCaseFn();
+        A510\Inner\mixedCaseFn();  // This should warn - This is \B510\A510\Inner\mixedCaseFn()
         Inner\mixedCaseFn();
         Inner\missingFn();  // should error
+        B510_Alias\Inner\mixedCaseFn();  // This should not warn
     }
 }

--- a/tests/files/src/0563_namespaced_functions_constants.php
+++ b/tests/files/src/0563_namespaced_functions_constants.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace MyNs;
+use ast as a;
+
+// Should warn
+var_export(ast\parse_code('', 50));
+var_export(ast\AST_UNPACK);
+var_export(new ast\Node());
+var_export(namespace\ast\parse_code('', 50));
+var_export(namespace\ast\AST_UNPACK);
+var_export(new namespace\ast\Node());
+var_export(namespace\is_string('a string'));
+var_export(namespace\PHP_VERSION);
+// Should not warn
+var_export(\ast\parse_code('', 50));
+var_export(\ast\AST_UNPACK);
+var_export(a\parse_code('', 50));
+var_export(a\AST_UNPACK);
+var_export(new a\Node());

--- a/tests/files/src/0564_global_namespace_functions_constants.php
+++ b/tests/files/src/0564_global_namespace_functions_constants.php
@@ -1,0 +1,23 @@
+<?php
+
+use ast as a;
+
+// Should not warn
+var_export(ast\parse_code('', 50));
+var_export(ast\AST_UNPACK);
+var_export(new ast\Node());
+var_export(namespace\ast\parse_code('', 50));
+var_export(namespace\ast\AST_UNPACK);
+var_export(new namespace\ast\Node());
+var_export(namespace\is_string('a string'));
+var_export(namespace\PHP_VERSION);
+// Also should not warn
+var_export(\ast\parse_code('', 50));
+var_export(\ast\AST_UNPACK);
+var_export(a\parse_code('', 50));
+var_export(a\AST_UNPACK);
+var_export(new a\Node());
+// Should warn
+var_export(new namespace\a\Missing());
+var_export(namespace\ast\MISSING_CONST);
+var_export(namespace\ast\missing_function());


### PR DESCRIPTION
And fix some more remaining edge cases when resolving constants and functions.
(Phan was failing to warn in some more cases)

Fixes #2112