### PR TITLE
Fix false positives analyzing define()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@ Phan NEWS
 ?? ??? 2018, Phan 1.1.3 (dev)
 -----------------------
 
-New features (CLI)
+New features(CLI)
 + Warn when calling method on union types that are definitely partially invalid. (#1885)
   New config setting: `--strict-method-checking` (enabled as part of `--strict-type-checking`)
   New issue type: `PhanPossiblyNonClassMethodCall`
@@ -16,15 +16,17 @@ New features (CLI)
 Plugins:
 + Add `BeforeAnalyzeCapability`, which will be executed once before starting the analysis phase. (#2086)
 
-New features (Analysis)
-
+New features(Analysis):
 + Add a heuristic check to detect potential infinite recursion in a functionlike calling itself (i.e. stack overflows)
   New issue types: `PhanInfiniteRecursion`
+
+Bug fixes:
++ Fix false positives analyzing `define()` (#2128)
 
 05 Nov 2018, Phan 1.1.2
 -----------------------
 
-New features(CLI)
+New features(CLI):
 + Make `phan --progress-bar` fit within narrower console widths. (#2096)
   (Make the old width into the new **maximum** width)
   Additionally, use a gradient of shades for the progress bar.

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -31,6 +31,10 @@
     <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes.IncorrectStrictTypesFormat" />
   </rule>
   <rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints" />
+  <rule ref="PSR1.Classes.ClassDeclaration.MissingNamespace">
+    <exclude-pattern>*/.phan/plugins/*</exclude-pattern>
+    <exclude-pattern>/internal/*</exclude-pattern>
+  </rule>
   <!-- <rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalFunctions" /> doesn't account for 'use function...' statements, don't use that -->
   <!-- TODO: Look into SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing once PSR-12 is back into review -->
 

--- a/src/Phan/Language/Element/ElementFutureUnionType.php
+++ b/src/Phan/Language/Element/ElementFutureUnionType.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 namespace Phan\Language\Element;
 
+use Phan\Exception\IssueException;
 use Phan\Language\FutureUnionType;
 use Phan\Language\Type\NullType;
 use Phan\Language\UnionType;
@@ -75,7 +76,11 @@ trait ElementFutureUnionType
         $future_union_type = $this->future_union_type;
         $this->future_union_type = null;
 
-        $union_type = $future_union_type->get();
+        try {
+            $union_type = $future_union_type->get();
+        } catch (IssueException $_) {
+            $union_type = UnionType::empty();
+        }
 
         // Don't set 'null' as the type if that's the default
         // given that its the default.

--- a/src/Phan/Language/Element/GlobalConstant.php
+++ b/src/Phan/Language/Element/GlobalConstant.php
@@ -23,7 +23,7 @@ class GlobalConstant extends AddressableElement implements ConstantInterface
     public function getUnionType() : UnionType
     {
         if (null !== ($union_type = $this->getFutureUnionType())) {
-            $this->setUnionType($this->getUnionType()->withUnionType($union_type));
+            $this->setUnionType(parent::getUnionType()->withUnionType($union_type));
         }
 
         return parent::getUnionType();

--- a/src/Phan/Language/FileRef.php
+++ b/src/Phan/Language/FileRef.php
@@ -96,6 +96,15 @@ class FileRef implements \Serializable
     }
 
     /**
+     * @return bool
+     * True if this object refers to the same file and line number.
+     */
+    public function equals(FileRef $other) : bool
+    {
+        return $this->getLineNumberStart() === $other->getLineNumberStart() && $this->getFile() === $other->getFile();
+    }
+
+    /**
      * @var int $line_number
      * The starting line number of the element within the file
      *

--- a/tests/files/expected/0567_invalid_constants.php.expected
+++ b/tests/files/expected/0567_invalid_constants.php.expected
@@ -1,0 +1,9 @@
+%s:14 PhanUndeclaredVariable Variable $undError is undeclared
+%s:15 PhanParamTooFewInternal Call with 1 arg(s) to \define() which requires 2 arg(s)
+%s:17 PhanUndeclaredConstant Reference to undeclared constant \cons2128Error2
+%s:18 PhanParamTooFewInternal Call with 1 arg(s) to \define() which requires 2 arg(s)
+%s:18 PhanUndeclaredVariable Variable $undefVar is undeclared
+%s:20 PhanInvalidConstantFQSEN '' is an invalid FQSEN for a constant
+%s:25 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is 'a' but \intdiv() takes int
+%s:33 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is 'a' but \intdiv() takes int
+%s:38 PhanTypeMismatchArgumentInternal Argument 1 (string) is int but \strlen() takes string

--- a/tests/files/src/0567_invalid_constants.php
+++ b/tests/files/src/0567_invalid_constants.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Tests for https://github.com/phan/phan/issues/2128
+ *
+ * Note that the order in which Phan parses define() still has edge cases.
+ * Putting files with constants first in `directory_list` is recommended.
+ */
+declare(strict_types=1);
+
+function exampleConstantDefs() {
+    $str2und = 'a';
+    define('cons2128', $str2und);
+    unset($str2und);
+    define('cons2128Error', $undError);  // should warn, this is undefined
+    define('cons2128Error2');
+    echo strlen(cons2128Error);
+    echo cons2128Error2;  // Should warn - This constant does not exist - the declaration will fail with only 1 arg
+    define($undefVar);  // Should emit undefined variable warnings and PhanParamTooFewInternal
+    $invalid = '';
+    define($invalid, 'x');  // Should emit PhanInvalidConstantFQSEN
+}
+
+exampleConstantDefs();
+
+echo intdiv(cons2128, 2);  // should warn - cons2128 should have type 'string'
+var_dump(strpos(cons2128, 'b'));  // should not warn
+
+$str2int = 'a';
+define('cons21282', $str2int);
+$str2int = 0;
+
+var_dump(strpos(cons21282, 'b'));
+var_dump(intdiv(cons21282, 4));
+
+$cons21283 = 'cons21283';
+define($cons21283, count($_SERVER));
+echo cons21283;  // should not warn
+echo strlen(cons21283);  // should warn

--- a/tests/misc/fallback_test/expected/047_invalid_define.php.expected
+++ b/tests/misc/fallback_test/expected/047_invalid_define.php.expected
@@ -1,4 +1,3 @@
-src/047_invalid_define.php:3 PhanInvalidConstantFQSEN ', ' is an invalid FQSEN for a constant
 src/047_invalid_define.php:3 PhanNoopConstant Unused constant
 src/047_invalid_define.php:3 PhanNoopStringLiteral Unused result of a string literal ");\nconst CON2 = " near this line
 src/047_invalid_define.php:3 PhanParamTooFewInternal Call with 1 arg(s) to \define() which requires 2 arg(s)

--- a/tests/misc/fallback_test/expected/047_valid_define.php.expected
+++ b/tests/misc/fallback_test/expected/047_valid_define.php.expected
@@ -1,0 +1,1 @@
+src/047_valid_define.php:2 PhanInvalidConstantFQSEN ',,' is an invalid FQSEN for a constant

--- a/tests/misc/fallback_test/src/047_valid_define.php
+++ b/tests/misc/fallback_test/src/047_valid_define.php
@@ -1,0 +1,2 @@
+<?php
+define(',,', 'value');

--- a/tests/plugin_test/expected/001_dead_code.php.expected
+++ b/tests/plugin_test/expected/001_dead_code.php.expected
@@ -1,4 +1,5 @@
 src/001_dead_code.php:8 PhanUnreferencedFunction Possibly zero references to function \duplicateFnB()
+src/001_dead_code.php:13 PhanUnreferencedConstant Possibly zero references to global constant \Const1B
 src/001_dead_code.php:18 PhanReadOnlyPublicProperty Possibly zero write references to public property \DuplicateClass001::$static_prop1
 src/001_dead_code.php:19 PhanUnreferencedPublicProperty Possibly zero references to public property \DuplicateClass001::$static_prop2
 src/001_dead_code.php:21 PhanReadOnlyPublicProperty Possibly zero write references to public property \DuplicateClass001->instance_prop1
@@ -8,7 +9,6 @@ src/001_dead_code.php:26 PhanUnreferencedPublicMethod Possibly zero references t
 src/001_dead_code.php:29 PhanRedefineFunction Function duplicateFnA defined at src/001_dead_code.php:29 was previously defined at src/001_dead_code.php:4
 src/001_dead_code.php:33 PhanRedefineFunction Function duplicateFnB defined at src/001_dead_code.php:33 was previously defined at src/001_dead_code.php:8
 src/001_dead_code.php:33 PhanUnreferencedFunction Possibly zero references to function \duplicateFnB,1()
-src/001_dead_code.php:37 PhanUnreferencedConstant Possibly zero references to global constant \Const1B
 src/001_dead_code.php:39 PhanRedefineClass Class \DuplicateClass001 defined at src/001_dead_code.php:39 was previously defined as Class \DuplicateClass001 at src/001_dead_code.php:15
 src/001_dead_code.php:41 PhanUnreferencedPublicClassConstant Possibly zero references to public class constant \DuplicateClass001,1::D
 src/001_dead_code.php:44 PhanUnreferencedPublicProperty Possibly zero references to public property \DuplicateClass001,1::$static_prop2

--- a/tests/plugin_test/src/001_dead_code.php
+++ b/tests/plugin_test/src/001_dead_code.php
@@ -10,7 +10,7 @@ if (rand() % 2 == 1) {
     }
 
     define('Const1A', 'x');
-    define('Const1B', 1);
+    define('Const1B', 1);  // NOTE: Phan tracks only the first definition of a constant it parses.
 
     class DuplicateClass001 {
         const C = true;


### PR DESCRIPTION
Fixes #2128 

Change the way Phan tracks global constants. Track only the first constant declaration, not the last.