### PR TITLE
Analyze assertions on get_class($var)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,10 @@ New features(CLI)
   `/path/phan/tool/phoogle 'string -> array -> string`
 + Make Phan infer union types of variables from switch statements on variables (#1291)
   (including literal int and string types)
++ Analyze simple assertions on `get_class($var)` (#1977)
+  e.g.  `assert(get_class($x) === 'someClass')`
+  or `if (get_class($x) === someClass::class)`.
+  Note that `switch(get_class($var))` is not supported yet.
 
 Plugins:
 + Add `BeforeAnalyzeCapability`, which will be executed once before starting the analysis phase. (#2086)

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -1780,6 +1780,22 @@ An example would be
 if (42 == [1, 2]) {}
 ```
 
+## PhanTypeComparisonToInvalidClass
+
+```
+Saw code asserting that an expression has a class, but that class is an invalid/impossible FQSEN {STRING_LITERAL}
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0568_get_class_assert.php.expected#L6) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0568_get_class_assert.php#L21).
+
+## PhanTypeComparisonToInvalidClassType
+
+```
+Saw code asserting that an expression has a class, but saw an invalid/impossible union type {TYPE} (expected {TYPE})
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0568_get_class_assert.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0568_get_class_assert.php#L6).
+
 ## PhanTypeConversionFromArray
 
 ```

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -33,7 +33,7 @@ use ReflectionMethod;
  *
  * @phan-file-suppress PhanUnusedClosureParameter
  */
-class ConditionVisitor extends KindVisitorImplementation
+class ConditionVisitor extends KindVisitorImplementation implements ConditionVisitorInterface
 {
     use ConditionVisitorUtil;
 

--- a/src/Phan/Analysis/ConditionVisitor/BinaryCondition.php
+++ b/src/Phan/Analysis/ConditionVisitor/BinaryCondition.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+namespace Phan\Analysis\ConditionVisitor;
+
+use ast\Node;
+use Phan\Analysis\ConditionVisitorInterface;
+use Phan\Language\Context;
+
+/**
+ * This represents an assertion implementation acting on two sides of a condition (!=, ==, ===, etc)
+ */
+interface BinaryCondition
+{
+    /**
+     * Assert that this condition applies to the variable $var (i.e. $var OPERATION $expr)
+     *
+     * @param Node $var
+     * @param Node|int|string|float $expr
+     * @return Context
+     */
+    public function analyzeVar(ConditionVisitorInterface $visitor, Node $var, $expr) : Context;
+
+    /**
+     * Assert that this condition applies to the variable $object (i.e. get_class($object) OPERATION $expr)
+     *
+     * @param Node|int|string|float $object
+     * @param Node|int|string|float $expr
+     * @return Context
+     */
+    public function analyzeClassCheck(ConditionVisitorInterface $visitor, $object, $expr) : Context;
+}

--- a/src/Phan/Analysis/ConditionVisitor/IdenticalCondition.php
+++ b/src/Phan/Analysis/ConditionVisitor/IdenticalCondition.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+namespace Phan\Analysis\ConditionVisitor;
+
+use ast\Node;
+use Phan\Analysis\ConditionVisitorInterface;
+use Phan\Language\Context;
+
+/**
+ * This represents an identical/equals assertion implementation acting on two sides of a condition (===)
+ */
+class IdenticalCondition implements BinaryCondition
+{
+    /**
+     * Assert that this condition applies to the variable $var (i.e. $var === $expr)
+     *
+     * @param Node $var
+     * @param Node|int|string|float $expr
+     * @return Context
+     * @override
+     */
+    public function analyzeVar(ConditionVisitorInterface $visitor, Node $var, $expr) : Context
+    {
+        return $visitor->updateVariableToBeIdentical($var, $expr);
+    }
+
+    /**
+     * Assert that this condition applies to the variable $object (i.e. get_class($object) === $expr)
+     *
+     * @param Node|int|string|float $object
+     * @param Node|int|string|float $expr
+     * @return Context
+     * @suppress PhanUnusedPublicMethodParameter
+     */
+    public function analyzeClassCheck(ConditionVisitorInterface $visitor, $object, $expr) : Context
+    {
+        return $visitor->analyzeClassAssertion($object, $expr) ?? $visitor->getContext();
+    }
+}

--- a/src/Phan/Analysis/ConditionVisitor/NotEqualsCondition.php
+++ b/src/Phan/Analysis/ConditionVisitor/NotEqualsCondition.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+namespace Phan\Analysis\ConditionVisitor;
+
+use ast\Node;
+use Phan\Analysis\ConditionVisitorInterface;
+use Phan\Language\Context;
+
+/**
+ * This represents a not equals assertion implementation acting on two sides of a condition (!=)
+ */
+class NotEqualsCondition implements BinaryCondition
+{
+    /**
+     * Assert that this condition applies to the variable $var (i.e. $var != $expr)
+     *
+     * @param Node $var
+     * @param Node|int|string|float $expr
+     * @return Context
+     * @override
+     */
+    public function analyzeVar(ConditionVisitorInterface $visitor, Node $var, $expr) : Context
+    {
+        return $visitor->updateVariableToBeNotEqual($var, $expr);
+    }
+
+    /**
+     * Assert that this condition applies to the variable $object (i.e. get_class($object) != $expr)
+     *
+     * @param Node $object
+     * @param Node|int|string|float $expr
+     * @return Context
+     * @override
+     * @suppress PhanUnusedPublicMethodParameter
+     */
+    public function analyzeClassCheck(ConditionVisitorInterface $visitor, $object, $expr) : Context
+    {
+        return $visitor->getContext();
+    }
+}

--- a/src/Phan/Analysis/ConditionVisitor/NotIdenticalCondition.php
+++ b/src/Phan/Analysis/ConditionVisitor/NotIdenticalCondition.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+namespace Phan\Analysis\ConditionVisitor;
+
+use ast\Node;
+use Phan\Analysis\ConditionVisitorInterface;
+use Phan\Language\Context;
+
+/**
+ * This represents a not identical assertion implementation acting on two sides of a condition (!==)
+ */
+class NotIdenticalCondition implements BinaryCondition
+{
+    /**
+     * Assert that this condition applies to the variable $var (i.e. $var !== $expr)
+     *
+     * @param Node $var
+     * @param Node|int|string|float $expr
+     * @return Context
+     * @override
+     */
+    public function analyzeVar(ConditionVisitorInterface $visitor, Node $var, $expr) : Context
+    {
+        return $visitor->updateVariableToBeNotIdentical($var, $expr);
+    }
+
+    /**
+     * Assert that this condition applies to the variable $object (i.e. get_class($object) !== $expr)
+     *
+     * @param Node $object
+     * @param Node|int|string|float $expr
+     * @return Context
+     * @suppress PhanUnusedPublicMethodParameter
+     */
+    public function analyzeClassCheck(ConditionVisitorInterface $visitor, $object, $expr) : Context
+    {
+        return $visitor->getContext();
+    }
+}

--- a/src/Phan/Analysis/ConditionVisitorInterface.php
+++ b/src/Phan/Analysis/ConditionVisitorInterface.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+namespace Phan\Analysis;
+
+use ast\Node;
+use Phan\Language\Context;
+
+/**
+ * This implements common functionality to update variables based on checks within a conditional (of an if/elseif/else/while/for/assert(), etc.)
+ *
+ * Classes using ConditionVisitorUtil must implement this trait.
+ */
+interface ConditionVisitorInterface
+{
+    public function getContext() : Context;
+
+    /**
+     * @param Node $var_node
+     * @param Node|int|float|string $expr
+     * @return Context - Constant after inferring type from an expression such as `if ($x === 'literal')`
+     */
+    public function updateVariableToBeIdentical(
+        Node $var_node,
+        $expr,
+        Context $context = null
+    ) : Context;
+
+    /**
+     * @param Node $var_node
+     * @param Node|int|float|string $expr
+     * @return Context - Constant after inferring type from an expression such as `if ($x == 'literal')`
+     */
+    public function updateVariableToBeNotIdentical(
+        Node $var_node,
+        $expr,
+        Context $context = null
+    ) : Context;
+
+    /**
+     * @param Node $var_node
+     * @param Node|int|float|string $expr
+     * @return Context - Constant after inferring type from an expression such as `if ($x != 'literal')`
+     */
+    public function updateVariableToBeNotEqual(
+        Node $var_node,
+        $expr,
+        Context $context = null
+    ) : Context;
+
+    /**
+     * Returns a context where the variable for $object_node has the class found in $expr_node
+     *
+     * @param Node|string|int|float $object_node
+     * @param Node|string|int|float $expr_node
+     * @return ?Context
+     */
+    public function analyzeClassAssertion($object_node, $expr_node);
+}

--- a/src/Phan/Analysis/NegatedConditionVisitor.php
+++ b/src/Phan/Analysis/NegatedConditionVisitor.php
@@ -30,7 +30,7 @@ use Phan\Language\UnionTypeBuilder;
  * TODO: Make $x > 0, $x < 0, $x >= 50, etc.  remove FalseType and NullType from $x
  * TODO: if (a || b || c || d) might get really slow, due to creating both ConditionVisitor and NegatedConditionVisitor
  */
-class NegatedConditionVisitor extends KindVisitorImplementation
+class NegatedConditionVisitor extends KindVisitorImplementation implements ConditionVisitorInterface
 {
     use ConditionVisitorUtil;
 

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -810,6 +810,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
             if ($cond_node !== null) {
                 if ($switch_variable) {
                     // Add the variable type from the above case statements, if it was possible for it to fall through
+                    // TODO: Also support switch(get_class($variable))
                     $visitor = new ConditionVisitor($this->code_base, $child_context);
                     $child_context = $visitor->updateVariableToBeIdentical($switch_case_node, $cond_node, $child_context);
                     if ($previous_child_context !== null) {

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -171,6 +171,8 @@ class Issue
     const TypeInvalidTraitReturn          = 'PhanTypeInvalidTraitReturn';
     const TypeInvalidTraitParam           = 'PhanTypeInvalidTraitParam';
     const InfiniteRecursion               = 'PhanInfiniteRecursion';
+    const TypeComparisonToInvalidClass    = 'PhanTypeComparisonToInvalidClass';
+    const TypeComparisonToInvalidClassType = 'PhanTypeComparisonToInvalidClassType';
 
     // Issue::CATEGORY_ANALYSIS
     const Unanalyzable              = 'PhanUnanalyzable';
@@ -1779,6 +1781,22 @@ class Issue
                 'Saw type {TYPE} which is possibly not a callable',
                 self::REMEDIATION_B,
                 10096
+            ),
+            new Issue(
+                self::TypeComparisonToInvalidClass,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                'Saw code asserting that an expression has a class, but that class is an invalid/impossible FQSEN {STRING_LITERAL}',
+                self::REMEDIATION_B,
+                10097
+            ),
+            new Issue(
+                self::TypeComparisonToInvalidClassType,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                'Saw code asserting that an expression has a class, but saw an invalid/impossible union type {TYPE} (expected {TYPE})',
+                self::REMEDIATION_B,
+                10098
             ),
             // Issue::CATEGORY_VARIABLE
             new Issue(

--- a/src/Phan/Language/FQSEN/FullyQualifiedClassName.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedClassName.php
@@ -1,9 +1,12 @@
 <?php declare(strict_types=1);
 namespace Phan\Language\FQSEN;
 
+use InvalidArgumentException;
 use Phan\Language\Type;
 use Phan\Language\UnionType;
 use Phan\Memoize;
+
+use function preg_match;
 
 /**
  * A Fully-Qualified Class Name
@@ -42,6 +45,35 @@ class FullyQualifiedClassName extends FullyQualifiedGlobalStructuralElement
         return self::fromFullyQualifiedString(
             $type->asFQSENString()
         );
+    }
+
+    const valid_class_regex = '/^\\\\?[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*(\\\\[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)*$/';
+
+    /**
+     * Asserts that something is a valid class FQSEN in PHPDoc.
+     * Use this for FQSENs passed in from the analyzed code.
+     */
+    public static function isValidClassFQSEN(string $type) : bool
+    {
+        return preg_match(self::valid_class_regex, $type) > 0;
+    }
+
+    /**
+     * Parses a FQSEN from a string
+     *
+     * @param $fully_qualified_string
+     * An fully qualified string like '\Namespace\Class'
+     *
+     * @return static
+     *
+     * @throws InvalidArgumentException on failure.
+     */
+    public static function fromFullyQualifiedUserProvidedString(string $fully_qualified_string) : FullyQualifiedClassName
+    {
+        if (!self::isValidClassFQSEN($fully_qualified_string)) {
+            throw new InvalidArgumentException("Invalid class FQSEN '$fully_qualified_string'");
+        }
+        return self::fromFullyQualifiedString($fully_qualified_string);
     }
 
     /**

--- a/tests/files/expected/0568_get_class_assert.php.expected
+++ b/tests/files/expected/0568_get_class_assert.php.expected
@@ -1,0 +1,11 @@
+%s:6 PhanTypeComparisonToInvalidClassType Saw code asserting that an expression has a class, but saw an invalid/impossible union type 2 (expected false|string)
+%s:9 PhanTypeComparisonToInvalidClassType Saw code asserting that an expression has a class, but saw an invalid/impossible union type \stdClass (expected false|string)
+%s:13 PhanUndeclaredMethod Call to undeclared method \stdClass::method
+%s:16 PhanUndeclaredMethod Call to undeclared method \stdClass::method
+%s:18 PhanUndeclaredClassConstant Reference to constant class from undeclared class \Foo\stdClass (Did you mean class \stdClass)
+%s:21 PhanTypeComparisonToInvalidClass Saw code asserting that an expression has a class, but that class is an invalid/impossible FQSEN 'A|B'
+%s:26 PhanTypeComparisonToInvalidClass Saw code asserting that an expression has a class, but that class is an invalid/impossible FQSEN ','
+%s:29 PhanTypeComparisonToInvalidClass Saw code asserting that an expression has a class, but that class is an invalid/impossible FQSEN '\\stdClass'
+%s:33 PhanUndeclaredClassMethod Call to method method from undeclared class \int
+%s:38 PhanTypeComparisonToInvalidClassType Saw code asserting that an expression has a class, but saw an invalid/impossible union type true (expected false|string)
+%s:41 PhanTypeComparisonToInvalidClass Saw code asserting that an expression has a class, but that class is an invalid/impossible FQSEN 'Traversable<T>'

--- a/tests/files/src/0568_get_class_assert.php
+++ b/tests/files/src/0568_get_class_assert.php
@@ -1,0 +1,47 @@
+<?php
+namespace Foo;
+
+// TODO: Add support for assertions on switch(get_class($x)) { case 'stdClass': }
+function test_class_assert($a, $b, $c, $d, $e) {
+    if (get_class($a) === 2) {  // Phan should warn
+        echo $a->method();
+    }
+    if (get_class($a) === new \stdClass()) {  // Phan should warn
+        echo $a->method();
+    }
+    if (get_class($b) === 'stdClass') {
+        echo $b->method();  // Phan should warn
+    }
+    if (get_class($c) == \stdClass::class) {
+        echo $c->method();  // Phan should warn
+    }
+    if (get_class($d) == stdClass::class) {
+        echo $d->method();  // Phan should warn
+    }
+    if (get_class($e) == 'A|B') {
+        echo $e->method();  // Phan should warn
+    }
+}
+function test_class_assert2($a, $b, $c, $d, $e) {
+    if (get_class($a) === ',') {  // TODO: Phan should warn
+        echo $a->method();
+    }
+    if (get_class($b) === '\stdClass') {  // Phan should warn
+        echo $b->method();
+    }
+    if (get_class($c) == 'int') {
+        echo $c->method();  // Phan should warn
+    }
+    if (get_class($d) == false) {
+        echo $d->method();  // TODO: Phan should warn
+    }
+    if (get_class($d) == true) {  // Phan should warn
+        echo $d->method();
+    }
+    if (get_class($e) == 'Traversable<T>') {  // Phan should warn
+        echo $e->method();
+    }
+    if (get_class() == 'stdClass') {  // TODO: Should affect assertions on $this (e.g. in closures) and fail in global functions - Not urgent
+        echo "impossible\n";
+    }
+}


### PR DESCRIPTION
This supports assertions such as
`assert(get_class($x) === 'someClass')`
or `if (get_class($x) === someClass::class)`

For #1977

Note that `switch(get_class($var))` is not supported yet