### PR TITLE
Add the VarKeyword as public visibility token

### DIFF
--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -2419,6 +2419,9 @@ class TolerantASTConverter
         $ast_visibility = 0;
         foreach ($visibility as $token) {
             switch ($token->kind) {
+                case TokenKind::VarKeyword:
+                    $ast_visibility |= flags\MODIFIER_PUBLIC;
+                    break;
                 case TokenKind::PublicKeyword:
                     $ast_visibility |= flags\MODIFIER_PUBLIC;
                     break;


### PR DESCRIPTION
Phan fails to parse code that uses the "var" keyword for properties.

For example http://phpseclib.sourceforge.net still uses this.