### PR TITLE
Make line number of UnusedPluginSuppression more accurate

### DIFF
--- a/.phan/plugins/UnusedSuppressionPlugin.php
+++ b/.phan/plugins/UnusedSuppressionPlugin.php
@@ -220,7 +220,7 @@ class UnusedSuppressionPlugin extends PluginV2 implements
         $plugin_successful_suppressions = $this->plugin_active_suppression_list[$plugin_class][$absolute_file_path] ?? null;
 
         foreach ($plugin_suppressions as $issue_type => $line_list) {
-            foreach ($line_list as $lineno) {
+            foreach ($line_list as $lineno => $lineno_of_comment) {
                 if (isset($plugin_successful_suppressions[$issue_type][$lineno])) {
                     continue;
                 }
@@ -228,19 +228,18 @@ class UnusedSuppressionPlugin extends PluginV2 implements
                 $issue_kind = 'UnusedPluginSuppression';
                 $message = 'Plugin {STRING_LITERAL} suppresses issue {ISSUETYPE} on this line but this suppression is unused or suppressed elsewhere';
                 if ($lineno === 0) {
-                    $lineno = 1;
                     $issue_kind = 'UnusedPluginFileSuppression';
                     $message = 'Plugin {STRING_LITERAL} suppresses issue {ISSUETYPE} in this file but this suppression is unused or suppressed elsewhere';
                 }
-                if (isset($plugin_suppressions['UnusedSuppression'][$lineno])) {
+                if (isset($plugin_suppressions['UnusedSuppression'][$lineno_of_comment])) {
                     continue;
                 }
-                if (isset($plugin_suppressions[$issue_kind][$lineno])) {
+                if (isset($plugin_suppressions[$issue_kind][$lineno_of_comment])) {
                     continue;
                 }
                 $this->emitIssue(
                     $code_base,
-                    (new Context())->withFile($relative_file_path)->withLineNumberStart($lineno),
+                    (new Context())->withFile($relative_file_path)->withLineNumberStart($lineno_of_comment),
                     $issue_kind,
                     $message,
                     [$plugin_name, $issue_type]

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@ Phan NEWS
 ?? ??? 2018, Phan 1.1.4 (dev)
 -----------------------
 
+Maintenance:
++ Emit `UnusedPluginSuppression` on `@phan-suppress-next-line` and `@phan-file-suppress`
+  on the same line as the comment declaring the suppression. (#2167, #1731)
+
 Bug fixes:
 + Fix a crash when analyzing a nullable parameter of type `self` in traits (#2163)
 + Properly parse closures/generic arrays/array shapes when inner types also contain commas (#2141)

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -36,7 +36,7 @@ class Config
      * New features increment minor versions, and bug fixes increment patch versions.
      * @suppress PhanUnreferencedPublicClassConstant
      */
-    const PHAN_PLUGIN_VERSION = '2.7.0';
+    const PHAN_PLUGIN_VERSION = '2.8.0';
 
     /**
      * @var string|null

--- a/src/Phan/Plugin/Internal/BuiltinSuppressionPlugin.php
+++ b/src/Phan/Plugin/Internal/BuiltinSuppressionPlugin.php
@@ -152,11 +152,12 @@ final class BuiltinSuppressionPlugin extends PluginV2 implements
         )) {
             $kind_list = array_map('trim', explode(',', $kind_list_text));
             foreach ($kind_list as $issue_kind) {
+                // Build a map where the line being suppressed is mapped to the line causing the suppression.
                 if ($comment_name === 'file-suppress') {
                     if (Config::getValue('disable_file_based_suppression')) {
                         continue;
                     }
-                    $suggestion_list[$issue_kind][0] = 0;
+                    $suggestion_list[$issue_kind][0] = $comment_start_line + substr_count($comment_text, "\n", 0, $comment_start_offset);
                     continue;
                 }
                 if (Config::getValue('disable_line_based_suppression')) {
@@ -172,7 +173,7 @@ final class BuiltinSuppressionPlugin extends PluginV2 implements
                 foreach ($kind_list as $issue_kind) {
                     // Store the suggestion for the issue kind.
                     // Make this an array set for easier lookup.
-                    $suggestion_list[$issue_kind][$line] = $line;
+                    $suggestion_list[$issue_kind][$line] = $comment_start_line;
                 }
             }
         }

--- a/src/Phan/PluginV2/SuppressionCapability.php
+++ b/src/Phan/PluginV2/SuppressionCapability.php
@@ -64,7 +64,8 @@ interface SuppressionCapability
      *
      * @param string $file_path the file to check for suppressions of
      *
-     * @return array<string,array<int,int>> Maps 0 or more issue types to a *list* of lines that this plugin is going to suppress.
+     * @return array<string,array<int,int>> Maps 0 or more issue types to a *map* of lines that this plugin is going to suppress.
+     * The keys of the map are the lines being suppressed, and the values are the lines *causing* the suppressions (if extracted from comments or nodes)
      *
      * An empty array can be returned if this is unknown.
      */

--- a/tests/plugin_test/expected/032_line_suppression.php.expected
+++ b/tests/plugin_test/expected/032_line_suppression.php.expected
@@ -1,12 +1,12 @@
-src/032_line_suppression.php:1 UnusedPluginFileSuppression Plugin BuiltinSuppressionPlugin suppresses issue MissingIssueType in this file but this suppression is unused or suppressed elsewhere
-src/032_line_suppression.php:1 UnusedPluginFileSuppression Plugin BuiltinSuppressionPlugin suppresses issue PhanParamTooMany in this file but this suppression is unused or suppressed elsewhere
 src/032_line_suppression.php:3 PhanInvalidCommentForDeclarationType The phpdoc comment for @property cannot occur on a function
 src/032_line_suppression.php:5 PhanInvalidCommentForDeclarationType The phpdoc comment for @property cannot occur on a function
 src/032_line_suppression.php:8 PhanInvalidCommentForDeclarationType The phpdoc comment for @property cannot occur on a function
+src/032_line_suppression.php:9 UnusedPluginFileSuppression Plugin BuiltinSuppressionPlugin suppresses issue MissingIssueType in this file but this suppression is unused or suppressed elsewhere
+src/032_line_suppression.php:9 UnusedPluginFileSuppression Plugin BuiltinSuppressionPlugin suppresses issue PhanParamTooMany in this file but this suppression is unused or suppressed elsewhere
 src/032_line_suppression.php:11 PhanUnreferencedFunction Possibly zero references to function \test_line_suppression()
 src/032_line_suppression.php:13 PhanUndeclaredVariable Variable $x is undeclared
 src/032_line_suppression.php:15 PhanUndeclaredVariable Variable $z is undeclared
 src/032_line_suppression.php:18 PhanUndeclaredFunction Call to undeclared function \call_undeclared_function_not_suppressed()
 src/032_line_suppression.php:18 PhanUnusedVariable Unused definition of variable $result
 src/032_line_suppression.php:20 UnusedPluginSuppression Plugin BuiltinSuppressionPlugin suppresses issue PhanUndeclaredVariable on this line but this suppression is unused or suppressed elsewhere
-src/032_line_suppression.php:30 UnusedPluginSuppression Plugin BuiltinSuppressionPlugin suppresses issue PhanUndeclaredVariable on this line but this suppression is unused or suppressed elsewhere
+src/032_line_suppression.php:29 UnusedPluginSuppression Plugin BuiltinSuppressionPlugin suppresses issue PhanUndeclaredVariable on this line but this suppression is unused or suppressed elsewhere


### PR DESCRIPTION
For `@phan-suppress-next-line`, `@phan-file-suppress`, emit
`UnusedPluginSuppression` on the same line as the comment.

Fixes #1731
Fixes #2167