### PR TITLE
Don't warn about unsupported tags that are prefixed with known tags

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@ Phan NEWS
 Maintenance:
 + Emit `UnusedPluginSuppression` on `@phan-suppress-next-line` and `@phan-file-suppress`
   on the same line as the comment declaring the suppression. (#2167, #1731)
++ Don't emit `PhanInvalidCommentForDeclarationType` (or attempt to parse) unknown tags that have known tags as prefixes  (#2156)
+  (e.g. `@param-some-unknown-tag`)
 
 Bug fixes:
 + Fix a crash when analyzing a nullable parameter of type `self` in traits (#2163)

--- a/src/Phan/Language/Element/Comment/Builder.php
+++ b/src/Phan/Language/Element/Comment/Builder.php
@@ -310,7 +310,7 @@ final class Builder
     {
         // https://secure.php.net/manual/en/regexp.reference.internal-options.php
         // (?i) makes this case sensitive, (?-1) makes it case insensitive
-        if (\preg_match('/@((?i)param|var|return|throws|throw|returns|inherits|suppress|phan-[a-z0-9_-]*(?-i)|method|property|template|PhanClosureScope)\b/', $line, $matches)) {
+        if (\preg_match('/@((?i)param|var|return|throws|throw|returns|inherits|suppress|phan-[a-z0-9_-]*(?-i)|method|property|property-read|property-write|template|PhanClosureScope)(?:[^a-zA-Z0-9_\x7f-\xff-]|$)/', $line, $matches)) {
             $case_sensitive_type = $matches[1];
             $type = \strtolower($case_sensitive_type);
 
@@ -342,7 +342,7 @@ final class Builder
                 );
             } elseif ($type === 'suppress') {
                 $this->maybeParseSuppress($i, $line);
-            } elseif ($type === 'property') {
+            } elseif ($type === 'property' || $type === 'property-read' || $type === 'property-write') {
                 $this->maybeParseProperty($i, $line);
             } elseif ($type === 'method') {
                 $this->maybeParseMethod($i, $line);

--- a/tests/files/expected/0577_unknown_tags.php.expected
+++ b/tests/files/expected/0577_unknown_tags.php.expected
@@ -1,0 +1,2 @@
+%s:16 PhanInvalidCommentForDeclarationType The phpdoc comment for @template cannot occur on a method
+%s:21 PhanTypeMismatchArgumentInternal Argument 1 (string) is int but \strlen() takes string

--- a/tests/files/src/0577_unknown_tags.php
+++ b/tests/files/src/0577_unknown_tags.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @template-something-else Q
+ * @template T
+ */
+class TemplateClass577 {
+    /**
+     * @param T $v
+     */
+    public function __construct($v) {
+    }
+
+    /**
+     * @template-another-thing VV should not warn - this is an unsupported tag that might be used by other tools
+     * @template X should warn
+     * @param int $x
+     * @param-other-tag VV $x should not warn
+     */
+    public function test($x) {
+        echo strlen($x);
+    }
+}


### PR DESCRIPTION
E.g. don't warn about `@param-some-other-tag` being unparseable

Fixes #2156