### PR TITLE
Check for the existence of pcntl_signal before calling it

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@ Phan NEWS
 ?? ??? 2018, Phan 1.1.5 (dev)
 -----------------------
 
+Language Server
++ Fix a crash in the Language Server when pcntl is not installed or enabled (e.g. on Windows) (#2186)
+
 27 Nov 2018, Phan 1.1.4
 -----------------------
 

--- a/src/Phan/Daemon.php
+++ b/src/Phan/Daemon.php
@@ -53,19 +53,21 @@ class Daemon
         try {
             $got_signal = false;
 
-            pcntl_signal(
-                SIGCHLD,
-                /**
-                 * @param int $signo
-                 * @param int|null $status
-                 * @param int|null $pid
-                 * @return void
-                 */
-                function ($signo, $status = null, $pid = null) use (&$got_signal) {
-                    $got_signal = true;
-                    Request::childSignalHandler($signo, $status, $pid);
-                }
-            );
+            if (function_exists('pcntl_signal')) {
+                pcntl_signal(
+                    SIGCHLD,
+                    /**
+                     * @param int $signo
+                     * @param int|null $status
+                     * @param int|null $pid
+                     * @return void
+                     */
+                    function ($signo, $status = null, $pid = null) use (&$got_signal) {
+                        $got_signal = true;
+                        Request::childSignalHandler($signo, $status, $pid);
+                    }
+                );
+            }
             while (true) {
                 $got_signal = false;  // reset this.
                 // We get an error from stream_socket_accept. After the RuntimeException is thrown, pcntl_signal is called.


### PR DESCRIPTION
Fixes #2186

Tested with a php build configured with `--disable-pcntl`
and running the tests with PHAN_RUN_INTEGRATION_TEST=1