### PR TITLE
Fix analysis of !empty($x), various coding style changes in Phan itself 

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -269,9 +269,6 @@ return [
     // here to inhibit them from being reported
     'suppress_issue_types' => [
         'PhanUnreferencedClosure',  // False positives seen with closures in arrays, TODO: move closure checks closer to what is done by unused variable plugin
-        // TODO: Fix and remove suppression for this plugin
-        'PhanPluginDescriptionlessCommentOnPrivateProperty',
-
         'PhanPluginNoCommentOnProtectedMethod',
         'PhanPluginDescriptionlessCommentOnProtectedMethod',
         'PhanPluginNoCommentOnPrivateMethod',

--- a/.phan/plugins/DemoPlugin.php
+++ b/.phan/plugins/DemoPlugin.php
@@ -216,7 +216,7 @@ class DemoNodeVisitor extends PluginAwarePostAnalysisVisitor
 
         // If we can't figure out the name of the class,  don't
         // bother continuing.
-        if (empty($class_name)) {
+        if (!$class_name) {
             return;
         }
 

--- a/.phan/plugins/NoAssertPlugin.php
+++ b/.phan/plugins/NoAssertPlugin.php
@@ -73,6 +73,7 @@ class NoAssertVisitor extends PluginAwarePostAnalysisVisitor
             $this->code_base,
             $this->context,
             'PhanPluginNoAssert',
+            // phpcs:ignore Generic.Files.LineLength.MaxExceeded
             'assert() is discouraged. Although phan supports using assert() for type annotations, PHP\'s documentation recommends assertions only for debugging, and assert() has surprising behaviors.',
             []
         );

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@ Phan NEWS
 ?? Dec 2018, Phan 1.1.6 (dev)
 -----------------------
 
+Bug fixes:
++ Infer more accurate types after asserting `!empty($x)`
+
 29 Nov 2018, Phan 1.1.5
 -----------------------
 

--- a/internal/PHP_CodeSniffer/composer.lock
+++ b/internal/PHP_CodeSniffer/composer.lock
@@ -12,17 +12,17 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "af1aeb948cc7abb67bbd318947966539e353bb86"
+                "reference": "f6fd0f1f92c5433c52190e05ef6d339693f3115b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/af1aeb948cc7abb67bbd318947966539e353bb86",
-                "reference": "af1aeb948cc7abb67bbd318947966539e353bb86",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/f6fd0f1f92c5433c52190e05ef6d339693f3115b",
+                "reference": "f6fd0f1f92c5433c52190e05ef6d339693f3115b",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1",
-                "squizlabs/php_codesniffer": "^3.3.0"
+                "squizlabs/php_codesniffer": "^3.3.1"
             },
             "require-dev": {
                 "jakub-onderka/php-parallel-lint": "1.0.0",
@@ -43,7 +43,7 @@
                 "MIT"
             ],
             "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
-            "time": "2018-09-21T18:58:45+00:00"
+            "time": "2018-11-27T18:57:46+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -51,12 +51,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "632c8f395b16bf8ceeaab8b16a500a70fac7473b"
+                "reference": "b53f64e10e41aa754ffa7c11999af1881e6c1780"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/632c8f395b16bf8ceeaab8b16a500a70fac7473b",
-                "reference": "632c8f395b16bf8ceeaab8b16a500a70fac7473b",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/b53f64e10e41aa754ffa7c11999af1881e6c1780",
+                "reference": "b53f64e10e41aa754ffa7c11999af1881e6c1780",
                 "shasum": ""
             },
             "require": {
@@ -94,7 +94,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-09-07T15:14:24+00:00"
+            "time": "2018-11-27T02:04:54+00:00"
         }
     ],
     "packages-dev": [],

--- a/internal/update_wiki_issue_types.php
+++ b/internal/update_wiki_issue_types.php
@@ -18,6 +18,9 @@ class WikiIssueTypeUpdater
      */
     private static $verbose = false;
 
+    /** @var array<string,array>|null an example for a subset of the issue types */
+    private static $examples;
+
     private static function printUsageAndExit(int $exit_code = 1)
     {
         global $argv;
@@ -227,14 +230,14 @@ e.g. [this issue]($expected_url#L$expected_file_lineno) is emitted when analyzin
 EOT;
     }
 
-    /** @var array|null */
-    private static $examples;
-
     private static function findExamples() : array
     {
         return self::$examples ?? self::$examples = self::calculateExamples();
     }
 
+    /**
+     * @return array<string,array>
+     */
     private static function calculateExamples() : array
     {
         // @phan-suppress-next-line PhanPossiblyFalseTypeArgumentInternal

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -8,9 +8,7 @@
   <config name="installed_paths" value="../../slevomat/coding-standard"/>
   <rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference" />
   <rule ref="SlevomatCodingStandard.Commenting.EmptyComment" />
-  <!-- TODO: Enable
   <rule ref="SlevomatCodingStandard.ControlStructures.DisallowEmpty" />
-  -->
   <rule ref="SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash" />
   <rule ref="SlevomatCodingStandard.Namespaces.UselessAlias" />
   <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses">

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -684,7 +684,7 @@ class ContextNode
         // If there were no classes on the left-type, figure
         // out what we were trying to call the method on
         // and send out an error.
-        if (empty($class_list)) {
+        if (\count($class_list) === 0) {
             $union_type = UnionTypeVisitor::unionTypeFromClassNode(
                 $this->code_base,
                 $this->context,
@@ -1834,7 +1834,7 @@ class ContextNode
             return;
         }
 
-        if (!($this->node instanceof Node) || empty($this->node->children['expr'])) {
+        if (!($this->node instanceof Node) || !($this->node->children['expr'] ?? false)) {
             return;
         }
 
@@ -1918,8 +1918,7 @@ class ContextNode
                 )
                 ||
                 (
-                    !empty($lnode->children['class'])
-                    && $lnode->children['class'] instanceof Node
+                    ($lnode->children['class'] ?? null) instanceof Node
                     && (
                         $lnode->children['class']->kind == ast\AST_VAR
                         || $lnode->children['class']->kind == ast\AST_NAME
@@ -1927,8 +1926,7 @@ class ContextNode
                 )
                 ||
                 (
-                    !empty($lnode->children['expr'])
-                    && $lnode->children['expr'] instanceof Node
+                    ($lnode->children['expr'] ?? null) instanceof Node
                     && (
                         $lnode->children['expr']->kind == ast\AST_VAR
                         || $lnode->children['expr']->kind == ast\AST_NAME

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverterWithNodeMapping.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverterWithNodeMapping.php
@@ -108,6 +108,7 @@ class TolerantASTConverterWithNodeMapping extends TolerantASTConverter
         try {
             $parser_node = static::phpParserParse($file_contents, $errors);
             self::findNodeAtOffset($parser_node, $byte_offset);
+            // phpcs:ignore Generic.Files.LineLength.MaxExceeded
             // fwrite(STDERR, "Seeking node: " . json_encode(self::$closest_node_or_token, JSON_PRETTY_PRINT) . "nearby: " . json_encode(self::$closest_node_or_token_symbol, JSON_PRETTY_PRINT) . "\n");
             return $this->phpParserToPhpast($parser_node, $version, $file_contents);
         } catch (Throwable $e) {

--- a/src/Phan/AST/TolerantASTConverter/ast_shim.php
+++ b/src/Phan/AST/TolerantASTConverter/ast_shim.php
@@ -278,6 +278,7 @@ if (!class_exists('ast\Metadata')) {
          *           using ===, while combinable flags should be checked using &.
          * @suppress PhanUnreferencedPublicProperty
          */
+        // phpcs:ignore Phan.NamingConventions.ValidUnderscoreVariableName.MemberVarNotUnderscore
         public $flagsCombinable;
     }
 }

--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -117,7 +117,7 @@ class Analysis
             return $context;
         }
 
-        if (empty($node)) {
+        if (!$node) {
             // php-ast would return an empty node for 0 byte files in older releases.
             Issue::maybeEmit(
                 $code_base,
@@ -510,7 +510,7 @@ class Analysis
         }
 
         // Ensure we have some content
-        if (empty($node)) {
+        if (!$node) {
             Issue::maybeEmit(
                 $code_base,
                 $context,

--- a/src/Phan/Analysis/Analyzable.php
+++ b/src/Phan/Analysis/Analyzable.php
@@ -60,7 +60,7 @@ trait Analyzable
      */
     public function hasNode() : bool
     {
-        return !empty($this->node);
+        return $this->node !== null;
     }
 
     /**
@@ -103,7 +103,7 @@ trait Analyzable
         if ($definition_node->kind === \ast\AST_CLOSURE) {
             // TODO: Pick up 'uses' when this is a closure invoked inline (e.g. array_map(function($x) use($localVar) {...}, args
             // TODO: Investigate replacing the types of these with 'mixed' for quick mode re-analysis, or checking if the type will never vary.
-            if (!empty($definition_node->children['uses'])) {
+            if (isset($definition_node->children['uses'])) {
                 return $context;
             }
         }

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -734,7 +734,7 @@ class AssignmentVisitor extends AnalysisVisitor
             } catch (\Exception $_) {
                 // swallow it
             }
-        } elseif (!empty($class_list)) {
+        } elseif (\count($class_list) > 0) {
             $first_class = $class_list[0];
             $this->emitIssueWithSuggestion(
                 Issue::UndeclaredProperty,
@@ -1049,7 +1049,7 @@ class AssignmentVisitor extends AnalysisVisitor
             return $this->analyzePropAssignment($clazz, $property, $node);
         }
 
-        if (!empty($class_list)) {
+        if (\count($class_list) > 0) {
             $this->emitIssue(
                 Issue::UndeclaredStaticProperty,
                 $node->lineno ?? 0,

--- a/src/Phan/Analysis/ConditionVisitor/ComparisonCondition.php
+++ b/src/Phan/Analysis/ConditionVisitor/ComparisonCondition.php
@@ -10,7 +10,7 @@ use Phan\Language\Context;
  */
 class ComparisonCondition implements BinaryCondition
 {
-    /** @var int */
+    /** @var int the value of ast\Node->flags */
     private $flags;
 
     public function __construct(int $flags)

--- a/src/Phan/Analysis/ConditionVisitorUtil.php
+++ b/src/Phan/Analysis/ConditionVisitorUtil.php
@@ -57,7 +57,7 @@ trait ConditionVisitorUtil
      * Note that Phan can't know some scalars are not an int/string/float, since 0/""/"0"/0.0/[] are empty.
      * (Remove arrays anyway)
      */
-    protected final function removeTruthyFromVariable(Node $var_node, Context $context, bool $suppress_issues) : Context
+    final protected function removeTruthyFromVariable(Node $var_node, Context $context, bool $suppress_issues) : Context
     {
         return $this->updateVariableWithConditionalFilter(
             $var_node,
@@ -73,7 +73,7 @@ trait ConditionVisitorUtil
     }
 
     // Remove any types which are definitely falsey from that variable (NullType, FalseType)
-    protected final function removeFalseyFromVariable(Node $var_node, Context $context, bool $suppress_issues) : Context
+    final protected function removeFalseyFromVariable(Node $var_node, Context $context, bool $suppress_issues) : Context
     {
         return $this->updateVariableWithConditionalFilter(
             $var_node,
@@ -89,7 +89,7 @@ trait ConditionVisitorUtil
     }
 
 
-    protected final function removeNullFromVariable(Node $var_node, Context $context, bool $suppress_issues) : Context
+    final protected function removeNullFromVariable(Node $var_node, Context $context, bool $suppress_issues) : Context
     {
         return $this->updateVariableWithConditionalFilter(
             $var_node,
@@ -104,7 +104,7 @@ trait ConditionVisitorUtil
         );
     }
 
-    protected final function removeFalseFromVariable(Node $var_node, Context $context) : Context
+    final protected function removeFalseFromVariable(Node $var_node, Context $context) : Context
     {
         return $this->updateVariableWithConditionalFilter(
             $var_node,
@@ -119,7 +119,7 @@ trait ConditionVisitorUtil
         );
     }
 
-    protected final function removeTrueFromVariable(Node $var_node, Context $context) : Context
+    final protected function removeTrueFromVariable(Node $var_node, Context $context) : Context
     {
         return $this->updateVariableWithConditionalFilter(
             $var_node,
@@ -142,7 +142,7 @@ trait ConditionVisitorUtil
      *
      * Note: It's expected that $should_filter_cb returns false on the new UnionType of that variable.
      */
-    protected final function updateVariableWithConditionalFilter(
+    final protected function updateVariableWithConditionalFilter(
         Node $var_node,
         Context $context,
         \Closure $should_filter_cb,
@@ -183,7 +183,7 @@ trait ConditionVisitorUtil
         return $context;
     }
 
-    protected final function updateVariableWithNewType(
+    final protected function updateVariableWithNewType(
         Node $var_node,
         Context $context,
         UnionType $new_union_type,
@@ -224,7 +224,7 @@ trait ConditionVisitorUtil
      * @return Context - Constant after inferring type from an expression such as `if ($x === 'literal')`
      * @suppress PhanUnreferencedPublicMethod referenced in ConditionVisitorInterface
      */
-    public final function updateVariableToBeIdentical(
+    final public function updateVariableToBeIdentical(
         Node $var_node,
         $expr,
         Context $context = null
@@ -269,7 +269,7 @@ trait ConditionVisitorUtil
      * @return Context - Constant after inferring type from an expression such as `if ($x === 'literal')`
      * @suppress PhanUnreferencedPublicMethod referenced in ConditionVisitorInterface
      */
-    public final function updateVariableToBeCompared(
+    final public function updateVariableToBeCompared(
         Node $var_node,
         $expr,
         int $flags
@@ -331,7 +331,7 @@ trait ConditionVisitorUtil
      * @return Context - Constant after inferring type from an expression such as `if ($x !== 'literal')`
      * @suppress PhanUnreferencedPublicMethod referenced in ConditionVisitorInterface
      */
-    public final function updateVariableToBeNotIdentical(
+    final public function updateVariableToBeNotIdentical(
         Node $var_node,
         $expr,
         Context $context = null
@@ -368,7 +368,7 @@ trait ConditionVisitorUtil
      * @return Context - Constant after inferring type from an expression such as `if ($x !== 'literal')`
      * @suppress PhanUnreferencedPublicMethod referenced in ConditionVisitorInterface
      */
-    public final function updateVariableToBeNotEqual(
+    final public function updateVariableToBeNotEqual(
         Node $var_node,
         $expr,
         Context $context = null
@@ -617,7 +617,7 @@ trait ConditionVisitorUtil
      *
      * TODO: support assertions on superglobals, within the current file scope?
      */
-    public final function getVariableFromScope(Node $var_node, Context $context)
+    final public function getVariableFromScope(Node $var_node, Context $context)
     {
         if ($var_node->kind !== ast\AST_VAR) {
             return null;
@@ -673,7 +673,7 @@ trait ConditionVisitorUtil
         );
     }
 
-    protected static final function isArgumentListWithVarAsFirstArgument(array $args) : bool
+    final protected static function isArgumentListWithVarAsFirstArgument(array $args) : bool
     {
         if (\count($args) >= 1) {
             $arg = $args[0];
@@ -686,7 +686,7 @@ trait ConditionVisitorUtil
      * Fetches the function name. Does not check for function uses or namespaces.
      * @return ?string (null if function name could not be found)
      */
-    protected static final function getFunctionName(Node $node)
+    final protected static function getFunctionName(Node $node)
     {
         $expr = $node->children['expr'];
         if (!($expr instanceof Node)) {

--- a/src/Phan/Analysis/NegatedConditionVisitor.php
+++ b/src/Phan/Analysis/NegatedConditionVisitor.php
@@ -768,12 +768,6 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
                         $var_node->flags ?? 0
                     )));
                 }
-                $context->setScope($context->getScope()->withVariable(new Variable(
-                    $context->withLineNumberStart($var_node->lineno ?? 0),
-                    $var_name,
-                    UnionType::empty(),
-                    $var_node->flags ?? 0
-                )));
                 return $this->removeFalseyFromVariable($var_node, $context, true);
             }
         } else {

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -1842,7 +1842,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                     $node->children['class']
                 ))->getClassList();
 
-                if (!empty($class_list)) {
+                if (\count($class_list) > 0) {
                     $class = \array_values($class_list)[0];
 
                     $this->emitIssue(

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -87,9 +87,8 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
             $class_name = (string)$node->children['name'];
         }
 
-        if (empty($class_name)) {
+        if (!$class_name) {
             // Should only occur with --use-fallback-parser
-            // Class name
             throw new UnanalyzableException($node, "Class name cannot be empty");
         }
 
@@ -402,9 +401,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
         // Make the closure reachable by FQSEN from anywhere
         $code_base->addFunction($func);
 
-        if (!empty($node->children['uses'])
-            && $node->children['uses']->kind == \ast\AST_CLOSURE_USES
-        ) {
+        if (($node->children['uses']->kind ?? null) == \ast\AST_CLOSURE_USES) {
             $uses = $node->children['uses'];
             foreach ($uses->children as $use) {
                 if (!($use instanceof Node) || $use->kind != \ast\AST_CLOSURE_VAR) {
@@ -421,7 +418,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
                     $use->children['name']
                 ))->getVariableName();
 
-                if (empty($variable_name)) {
+                if (!$variable_name) {
                     continue;
                 }
 
@@ -1007,7 +1004,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
             $node->children['var']
         ))->getVariableName();
 
-        if (!empty($variable_name)) {
+        if ($variable_name) {
             $variable = Variable::fromNodeInContext(
                 $node->children['var'],
                 $this->context,

--- a/src/Phan/Analysis/ReachabilityChecker.php
+++ b/src/Phan/Analysis/ReachabilityChecker.php
@@ -14,7 +14,7 @@ use Phan\AST\Visitor\KindVisitorImplementation;
  */
 final class ReachabilityChecker extends KindVisitorImplementation
 {
-    /** @var Node */
+    /** @var Node the node we're checking for reachability. */
     private $inner;
 
     public function __construct(Node $inner)

--- a/src/Phan/Analysis/ScopeVisitor.php
+++ b/src/Phan/Analysis/ScopeVisitor.php
@@ -258,14 +258,14 @@ abstract class ScopeVisitor extends AnalysisVisitor
         foreach ($node->children as $child_node) {
             $target = $child_node->children['name'];
 
-            if (empty($child_node->children['alias'])) {
+            if (isset($child_node->children['alias'])) {
+                $alias = $child_node->children['alias'];
+            } else {
                 if (($pos = \strrpos($target, '\\')) !== false) {
                     $alias = \substr($target, $pos + 1);
                 } else {
                     $alias = $target;
                 }
-            } else {
-                $alias = $child_node->children['alias'];
             }
             if (!\is_string($alias)) {
                 // Should be impossible

--- a/src/Phan/Bootstrap.php
+++ b/src/Phan/Bootstrap.php
@@ -132,6 +132,7 @@ if (!class_exists(CompileError::class)) {
      *
      * @suppress PhanRedefineClassInternal
      */
+    // phpcs:ignore PSR1.Classes.ClassDeclaration.MissingNamespace
     class CompileError extends Error
     {
     }

--- a/src/Phan/CodeBase/ClassMap.php
+++ b/src/Phan/CodeBase/ClassMap.php
@@ -44,7 +44,7 @@ class ClassMap
      */
     public function hasClassConstantWithName(string $name) : bool
     {
-        return !empty($this->class_constant_map[$name]);
+        return isset($this->class_constant_map[$name]);
     }
 
     public function getClassConstantByName(string $name) : ClassConstant
@@ -75,7 +75,7 @@ class ClassMap
      */
     public function hasPropertyWithName(string $name) : bool
     {
-        return !empty($this->property_map[$name]);
+        return isset($this->property_map[$name]);
     }
 
     /**

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -588,7 +588,7 @@ class Issue
     {
         static $error_map;
 
-        if (!empty($error_map)) {
+        if (\is_array($error_map)) {
             return $error_map;
         }
 
@@ -3552,7 +3552,7 @@ class Issue
     {
         $error_map = self::issueMap();
 
-        if (empty($error_map[$type])) {
+        if (!isset($error_map[$type])) {
             throw new InvalidArgumentException("Undefined error type $type");
         }
 

--- a/src/Phan/Language/Element/Comment/Builder.php
+++ b/src/Phan/Language/Element/Comment/Builder.php
@@ -66,7 +66,12 @@ final class Builder
     /** @var UnionType the union type of the set of (at)throws annotations */
     public $throw_union_type;
 
-    /** @var array<int,array{0:string,1:int,2:array<int,mixed>}> */
+    /**
+     * A list of issues detected in the comment being built.
+     * This is stored instead of immediately emitting the issue because later lines might suppress these issues.
+     *
+     * @var array<int,array{0:string,1:int,2:array<int,mixed>}>
+     */
     private $issues = [];
 
     public function __construct(

--- a/src/Phan/Language/Element/Comment/Builder.php
+++ b/src/Phan/Language/Element/Comment/Builder.php
@@ -315,6 +315,7 @@ final class Builder
     {
         // https://secure.php.net/manual/en/regexp.reference.internal-options.php
         // (?i) makes this case sensitive, (?-1) makes it case insensitive
+        // phpcs:ignore Generic.Files.LineLength.MaxExceeded
         if (\preg_match('/@((?i)param|var|return|throws|throw|returns|inherits|suppress|phan-[a-z0-9_-]*(?-i)|method|property|property-read|property-write|template|PhanClosureScope)(?:[^a-zA-Z0-9_\x7f-\xff-]|$)/', $line, $matches)) {
             $case_sensitive_type = $matches[1];
             $type = \strtolower($case_sensitive_type);

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -64,7 +64,7 @@ trait FunctionTrait
      * The fully-qualified structural element name of this
      * structural element
      */
-    public abstract function getFQSEN();
+    abstract public function getFQSEN();
 
     /**
      * @return string
@@ -902,17 +902,17 @@ trait FunctionTrait
         return $this->analyze($context, $code_base);
     }
 
-    public abstract function analyze(Context $context, CodeBase $code_base) : Context;
+    abstract public function analyze(Context $context, CodeBase $code_base) : Context;
 
-    public abstract function getRecursionDepth() : int;
+    abstract public function getRecursionDepth() : int;
 
     /** @return Node|null */
-    public abstract function getNode();
+    abstract public function getNode();
 
     /** @return Context */
-    public abstract function getContext() : Context;
+    abstract public function getContext() : Context;
 
-    public abstract function getFileRef() : FileRef;
+    abstract public function getFileRef() : FileRef;
 
     /**
      * Returns true if the return type depends on the argument, and a plugin makes Phan aware of that.
@@ -1027,12 +1027,12 @@ trait FunctionTrait
     }
 
     /** @return void */
-    public abstract function memoizeFlushAll();
+    abstract public function memoizeFlushAll();
 
-    public abstract function getUnionType() : UnionType;
+    abstract public function getUnionType() : UnionType;
 
     /** @return void */
-    public abstract function setUnionType(UnionType $type);
+    abstract public function setUnionType(UnionType $type);
 
     /**
      * Creates a callback that can restore this element to the state it had before parsing.
@@ -1088,7 +1088,7 @@ trait FunctionTrait
         return $this->as_closure_declaration_type ?? ($this->as_closure_declaration_type = $this->createFunctionLikeDeclarationType());
     }
 
-    public abstract function returnsRef() : bool;
+    abstract public function returnsRef() : bool;
 
     private function createFunctionLikeDeclarationType() : FunctionLikeDeclarationType
     {

--- a/src/Phan/Language/FQSEN/FullyQualifiedClassName.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedClassName.php
@@ -47,7 +47,8 @@ class FullyQualifiedClassName extends FullyQualifiedGlobalStructuralElement
         );
     }
 
-    const valid_class_regex = '/^\\\\?[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*(\\\\[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)*$/';
+    /** @internal */
+    const VALID_CLASS_REGEX = '/^\\\\?[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*(\\\\[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)*$/';
 
     /**
      * Asserts that something is a valid class FQSEN in PHPDoc.
@@ -55,7 +56,7 @@ class FullyQualifiedClassName extends FullyQualifiedGlobalStructuralElement
      */
     public static function isValidClassFQSEN(string $type) : bool
     {
-        return preg_match(self::valid_class_regex, $type) > 0;
+        return preg_match(self::VALID_CLASS_REGEX, $type) > 0;
     }
 
     /**

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -316,13 +316,13 @@ class Type
     public function __wakeup()
     {
         debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
-        throw new Error("Cannot unserialize Type");
+        throw new Error("Cannot unserialize Type '$this'");
     }
 
     /** @throws Error this should not be called accidentally */
     public function __clone()
     {
-        throw new Error("Cannot clone Type");
+        throw new Error("Cannot clone Type '$this'");
     }
 
     /**

--- a/src/Phan/Language/Type/FunctionLikeDeclarationType.php
+++ b/src/Phan/Language/Type/FunctionLikeDeclarationType.php
@@ -25,16 +25,31 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
     // Subclasses will override this
     const NAME = '';
 
-    /** @var FileRef */
+    /**
+     * The file and location where this function-like Type was declared.
+     * (e.g. in a doc comment, as a closure, etc).
+     * @var FileRef
+     */
     private $file_ref;
 
-    /** @var array<int,ClosureDeclarationParameter> */
+    /**
+     * Describes information that was parsed about the parameters of this function-like Type.
+     * (Name and UnionType)
+     * @var array<int,ClosureDeclarationParameter>
+     */
     private $params;
 
-    /** @var UnionType */
+    /**
+     * The return type of this function-like Type.
+     * @var UnionType
+     */
     private $return_type;
 
-    /** @var bool */
+    /**
+     * Does this function-like type return a reference?
+     * Currently only possible for real closures, not for callable declarations declared in phpdoc.
+     * @var bool
+     */
     private $returns_reference;
 
     // computed properties
@@ -45,7 +60,10 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
     /** @var int see FunctionTrait */
     private $optional_param_count;
 
-    /** @var bool */
+    /**
+     * Is this a function declaration variadic?
+     * @var bool
+     */
     private $is_variadic;
     // end computed properties
 

--- a/src/Phan/Language/Type/GenericIterableType.php
+++ b/src/Phan/Language/Type/GenericIterableType.php
@@ -16,12 +16,12 @@ final class GenericIterableType extends IterableType
     const NAME = 'iterable';
 
     /**
-     * @var UnionType
+     * @var UnionType the union type of the keys of this iterable.
      */
     private $key_union_type;
 
     /**
-     * @var UnionType
+     * @var UnionType the union type of the elements of this iterable.
      */
     private $element_union_type;
 

--- a/src/Phan/Language/Type/GenericMultiArrayType.php
+++ b/src/Phan/Language/Type/GenericMultiArrayType.php
@@ -141,7 +141,9 @@ final class GenericMultiArrayType extends ArrayType implements MultiType, Generi
         return true;
     }
 
-    /** @var ?UnionType */
+    /**
+     * @var ?UnionType the normalized element union type. Computed from `$this->element_types`.
+     */
     private $element_types_union_type;
 
     /**

--- a/src/Phan/Language/Type/LiteralIntType.php
+++ b/src/Phan/Language/Type/LiteralIntType.php
@@ -55,9 +55,9 @@ final class LiteralIntType extends IntType implements LiteralTypeInterface
         return (string)$this->value;
     }
 
-    /** @var IntType */
+    /** @var IntType the non-nullable int type instance. */
     private static $non_nullable_int_type;
-    /** @var IntType */
+    /** @var IntType the nullable int type instance. */
     private static $nullable_int_type;
 
     public static function init()

--- a/src/Phan/Language/Type/LiteralStringType.php
+++ b/src/Phan/Language/Type/LiteralStringType.php
@@ -137,20 +137,20 @@ final class LiteralStringType extends StringType implements LiteralTypeInterface
         return self::instanceForValue($escaped_string, $is_nullable);
     }
 
-    /** @var StringType */
-    private static $non_nullable_int_type;
-    /** @var StringType */
-    private static $nullable_int_type;
+    /** @var StringType the non-nullable string type instance. */
+    private static $non_nullable_string_type;
+    /** @var StringType the nullable string type instance. */
+    private static $nullable_string_type;
 
     public static function init()
     {
-        self::$non_nullable_int_type = StringType::instance(false);
-        self::$nullable_int_type = StringType::instance(true);
+        self::$non_nullable_string_type = StringType::instance(false);
+        self::$nullable_string_type = StringType::instance(true);
     }
 
     public function asNonLiteralType() : Type
     {
-        return $this->is_nullable ? self::$nullable_int_type : self::$non_nullable_int_type;
+        return $this->is_nullable ? self::$nullable_string_type : self::$non_nullable_string_type;
     }
 
     /**
@@ -159,7 +159,7 @@ final class LiteralStringType extends StringType implements LiteralTypeInterface
      */
     public function withFlattenedArrayShapeOrLiteralTypeInstances() : array
     {
-        return [$this->is_nullable ? self::$nullable_int_type : self::$non_nullable_int_type];
+        return [$this->is_nullable ? self::$nullable_string_type : self::$non_nullable_string_type];
     }
 
     public function hasArrayShapeOrLiteralTypeInstances() : bool

--- a/src/Phan/Language/Type/TemplateType.php
+++ b/src/Phan/Language/Type/TemplateType.php
@@ -9,7 +9,7 @@ use Phan\Language\Type;
  */
 final class TemplateType extends Type
 {
-    /** @var string */
+    /** @var string an identifier for the template type. */
     private $template_type_identifier;
 
     /**

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -128,7 +128,7 @@ class UnionType implements Serializable
         }
     }
 
-    /** @var EmptyUnionType */
+    /** @var EmptyUnionType an empty union type - Cached here for quick access. */
     private static $empty_instance;
 
     /**

--- a/src/Phan/Language/UnionTypeBuilder.php
+++ b/src/Phan/Language/UnionTypeBuilder.php
@@ -12,7 +12,7 @@ namespace Phan\Language;
  */
 final class UnionTypeBuilder
 {
-    /** @var array<int,Type> */
+    /** @var array<int,Type> the list of unique types in this builder instance. */
     private $type_set;
 
     /** @param array<int,Type> $type_set (must be unique) */

--- a/src/Phan/LanguageServer/Client/TextDocument.php
+++ b/src/Phan/LanguageServer/Client/TextDocument.php
@@ -16,6 +16,8 @@ use Sabre\Event\Promise;
 class TextDocument
 {
     /**
+     * Used to send `textDocument/*` notifications and requests to the language server client of the Phan Language Server.
+     *
      * @var ClientHandler
      */
     private $handler;

--- a/src/Phan/LanguageServer/ClientHandler.php
+++ b/src/Phan/LanguageServer/ClientHandler.php
@@ -7,6 +7,8 @@ use AdvancedJsonRpc;
 use Sabre\Event\Promise;
 
 /**
+ * Used to send notifications and requests to the language server client of the Phan Language Server.
+ *
  * Source: https://github.com/felixfbecker/php-language-server/tree/master/src/ClientHandler.php
  * See ../../../LICENSE.LANGUAGE_SERVER
  */

--- a/src/Phan/LanguageServer/CompletionRequest.php
+++ b/src/Phan/LanguageServer/CompletionRequest.php
@@ -32,23 +32,21 @@ use Phan\LanguageServer\Protocol\Position;
 final class CompletionRequest extends NodeInfoRequest
 {
     /**
-     * @var CompletionContext|null
-     * @suppress PhanWriteOnlyPrivateProperty may use this later when the implementation of code completion is finished
-     */
-    private $completion_context;
-
-    /**
      * @var array<string,CompletionItem> the list of completion items.
      */
     private $completions = [];
 
+    /**
+     * Construct a CompletionRequest from the parameters provided by the language server client.
+     *
+     * @suppress PhanUnusedPublicFinalMethodParameter
+     */
     public function __construct(
         string $uri,
         Position $position,
         CompletionContext $completion_context = null
     ) {
         parent::__construct($uri, $position);
-        $this->completion_context = $completion_context;
     }
 
     /**

--- a/src/Phan/LanguageServer/ProtocolStreamReader.php
+++ b/src/Phan/LanguageServer/ProtocolStreamReader.php
@@ -17,23 +17,24 @@ class ProtocolStreamReader extends Emitter implements ProtocolReader
     const PARSE_HEADERS = 1;
     const PARSE_BODY = 2;
 
-    /** @var resource */
+    /** @var resource the input stream resource for data from the client. */
     private $input;
+
     /**
      * This is checked by ProtocolStreamReader so that it will stop reading from streams in the forked process.
      * There could be buffered bytes in stdin/over TCP, those would be processed by TCP if it were not for this check.
      * @var bool
      */
     private $is_accepting_new_requests = true;
-    /** @var int */
+    /** @var int (self::PARSE_*) the state of the parsing state machine */
     private $parsing_mode = self::PARSE_HEADERS;
-    /** @var string */
+    /** @var string the intermediate state of the buffer */
     private $buffer = '';
-    /** @var string[] */
+    /** @var string[] the headers that were parsed during the PARSE_HEADERS phase */
     private $headers = [];
-    /** @var int */
+    /** @var int the content-length that we are expecting */
     private $content_length;
-    /** @var bool */
+    /** @var bool was a close notification sent to the listeners already? */
     private $did_emit_close = false;
 
     /**

--- a/src/Phan/Library/RAII.php
+++ b/src/Phan/Library/RAII.php
@@ -15,7 +15,7 @@ use Closure;
  */
 class RAII
 {
-    /** @var null|Closure():void */
+    /** @var null|Closure():void this is called exactly once, either during __destruct (when the variable goes out of scope) or manually */
     private $finalizer;
 
     /**

--- a/src/Phan/Library/Set.php
+++ b/src/Phan/Library/Set.php
@@ -2,6 +2,7 @@
 namespace Phan\Library;
 
 use Closure;
+use TypeError;
 
 /**
  * A set of objects supporting union and
@@ -60,11 +61,15 @@ class Set extends \SplObjectStorage
      */
     public static function intersectAll(array $set_list) : Set
     {
-        if (empty($set_list)) {
+        if (\count($set_list) === 0) {
             return new Set();
         }
 
         $intersected_set = \array_shift($set_list);
+        if (!$intersected_set instanceof Set) {
+            // impossible
+            throw new TypeError('Saw non-Set in $set_list');
+        }
         foreach ($set_list as $set) {
             $intersected_set = $intersected_set->intersect($set);
         }
@@ -101,11 +106,15 @@ class Set extends \SplObjectStorage
      */
     public static function unionAll(array $set_list) : Set
     {
-        if (empty($set_list)) {
+        if (\count($set_list) === 0) {
             return new Set();
         }
 
         $union_set = \array_shift($set_list);
+        if (!$union_set instanceof Set) {
+            // impossible
+            throw new TypeError('Saw non-Set in $set_list');
+        }
         foreach ($set_list as $set) {
             $union_set = $union_set->union($set);
         }

--- a/src/Phan/Library/Some.php
+++ b/src/Phan/Library/Some.php
@@ -13,7 +13,7 @@ namespace Phan\Library;
  */
 class Some extends Option
 {
-    /** @var T */
+    /** @var T the value wrapped by this Some<T>*/
     private $_;
 
     /**

--- a/src/Phan/Ordering.php
+++ b/src/Phan/Ordering.php
@@ -12,13 +12,15 @@ use Phan\Library\Hasher\Sequential;
  */
 class Ordering
 {
-    /** @var CodeBase */
+    /**
+     * @var CodeBase
+     * The entire code base. Used to choose a file analysis ordering.
+     */
     private $code_base;
 
     /**
      * @param CodeBase $code_base
-     * The entire code base used to choose a file
-     * analysis ordering.
+     * The entire code base. Used to choose a file analysis ordering.
      */
     public function __construct(CodeBase $code_base)
     {

--- a/src/Phan/Ordering.php
+++ b/src/Phan/Ordering.php
@@ -104,7 +104,7 @@ class Ordering
             $hierarchy_root = $class->getHierarchyRootFQSEN($this->code_base);
 
             // Create a bucket for this root if it doesn't exist
-            if (empty($root_fqsen_list[(string)$hierarchy_root])) {
+            if (!isset($root_fqsen_list[(string)$hierarchy_root])) {
                 $root_fqsen_list[(string)$hierarchy_root] = [];
             }
 

--- a/src/Phan/Output/Collector/BufferingCollector.php
+++ b/src/Phan/Output/Collector/BufferingCollector.php
@@ -15,7 +15,7 @@ final class BufferingCollector implements IssueCollectorInterface
     /** @var array<string,IssueInstance> the issues that were collected */
     private $issues = [];
 
-    /** @var IssueFilterInterface */
+    /** @var IssueFilterInterface used to prevent some issues from being output (based on config and CLI options) */
     private $filter;
 
     /**

--- a/src/Phan/Output/Collector/ParallelChildCollector.php
+++ b/src/Phan/Output/Collector/ParallelChildCollector.php
@@ -14,7 +14,7 @@ use Phan\Output\IssueCollectorInterface;
 class ParallelChildCollector implements IssueCollectorInterface
 {
     /**
-     * @var resource
+     * @var resource a message queue used to receive messages from the child processes in the worker group.
      */
     private $message_queue_resource;
 

--- a/src/Phan/Output/Filter/ChainedIssueFilter.php
+++ b/src/Phan/Output/Filter/ChainedIssueFilter.php
@@ -11,7 +11,11 @@ use Phan\Output\IssueFilterInterface;
 final class ChainedIssueFilter implements IssueFilterInterface
 {
 
-    /** @var IssueFilterInterface[] */
+    /**
+     * 0 or more filters. If any of these reject an IssueInstance,
+     * then this ChainedIssueFilter will reject the instance.
+     * @var IssueFilterInterface[]
+     */
     private $filters = [];
 
     /**

--- a/src/Phan/Output/Filter/FileIssueFilter.php
+++ b/src/Phan/Output/Filter/FileIssueFilter.php
@@ -11,7 +11,7 @@ use Phan\Output\IssueFilterInterface;
 final class FileIssueFilter implements IssueFilterInterface
 {
 
-    /** @var IgnoredFilesFilterInterface */
+    /** @var IgnoredFilesFilterInterface used to check if issues in a file name should be ignored. */
     private $ignored_files_filter;
 
     /**

--- a/src/Phan/Output/Printer/CheckstylePrinter.php
+++ b/src/Phan/Output/Printer/CheckstylePrinter.php
@@ -11,10 +11,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 final class CheckstylePrinter implements BufferedPrinterInterface
 {
 
-    /** @var OutputInterface */
+    /** @var OutputInterface an output that XML can be written to. */
     private $output;
 
-    /** @var array<string,array<int,array>> */
+    /** @var array<string,array<int,array>> maps files with issues to the list of those issues */
     private $files = [];
 
     /** @param IssueInstance $instance */

--- a/src/Phan/Output/Printer/CheckstylePrinter.php
+++ b/src/Phan/Output/Printer/CheckstylePrinter.php
@@ -20,7 +20,7 @@ final class CheckstylePrinter implements BufferedPrinterInterface
     /** @param IssueInstance $instance */
     public function print(IssueInstance $instance)
     {
-        if (empty($this->files[$instance->getFile()])) {
+        if (!isset($this->files[$instance->getFile()])) {
             $this->files[$instance->getFile()] = [];
         }
 

--- a/src/Phan/Output/Printer/CodeClimatePrinter.php
+++ b/src/Phan/Output/Printer/CodeClimatePrinter.php
@@ -17,10 +17,10 @@ final class CodeClimatePrinter implements BufferedPrinterInterface
     const CODECLIMATE_SEVERITY_CRITICAL = 'critical';
     const CODECLIMATE_SEVERITY_NORMAL = 'normal';
 
-    /** @var OutputInterface */
+    /** @var OutputInterface an output that zero byte separated JSON can be written to.  */
     private $output;
 
-    /** @var array<int,array> */
+    /** @var array<int,array> a list of associative arrays with codeclimate issue fields. */
     private $messages = [];
 
     /** @param IssueInstance $instance */

--- a/src/Phan/Output/Printer/JSONPrinter.php
+++ b/src/Phan/Output/Printer/JSONPrinter.php
@@ -14,10 +14,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 final class JSONPrinter implements BufferedPrinterInterface
 {
 
-    /** @var OutputInterface */
+    /** @var OutputInterface an output that JSON encoded can be written to. */
     private $output;
 
-    /** @var array<int,array<string,mixed>> */
+    /** @var array<int,array<string,mixed>> the issue data to be JSON encoded. */
     private $messages = [];
 
     /** @param IssueInstance $instance */

--- a/src/Phan/Output/Printer/PlainTextPrinter.php
+++ b/src/Phan/Output/Printer/PlainTextPrinter.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 final class PlainTextPrinter implements IssuePrinterInterface
 {
 
-    /** @var OutputInterface */
+    /** @var OutputInterface an output that plaintext formatted issues can be written to. */
     private $output;
 
     /**

--- a/src/Phan/Output/Printer/PylintPrinter.php
+++ b/src/Phan/Output/Printer/PylintPrinter.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class PylintPrinter implements IssuePrinterInterface
 {
-    /** @var OutputInterface */
+    /** @var OutputInterface an output that pylint formatted issues can be written to. */
     private $output;
 
     /** @param IssueInstance $instance */

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -98,7 +98,7 @@ class ParseVisitor extends ScopeVisitor
 
         // This happens now and then and I have no idea
         // why.
-        if (empty($class_name)) {
+        if (!$class_name) {
             return $this->context;
         }
 
@@ -240,7 +240,7 @@ class ParseVisitor extends ScopeVisitor
             }
 
             // Add any implemented interfaces
-            if (!empty($node->children['implements'])) {
+            if (isset($node->children['implements'])) {
                 $interface_list = (new ContextNode(
                     $this->code_base,
                     $this->context,

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -600,7 +600,7 @@ final class ConfigPluginSet extends PluginV2 implements
         return $result;
     }
 
-    /** @var ?NodeSelectionPlugin */
+    /** @var ?NodeSelectionPlugin - If the language server requests more information about a node, this may be set (e.g. for "Go To Definition") */
     private $node_selection_plugin;
 
     /**

--- a/src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php
@@ -200,6 +200,11 @@ final class DependentReturnTypeOverridePlugin extends PluginV2 implements
             }
             return $string_or_false;
         };
+        $parse_url_handler = $make_arg_existence_dependent_type_method(
+            1,
+            'string|int|null|false',
+            'array{scheme?:string,host?:string,port?:int,user?:string,pass?:string,path?:string,query?:string,fragment?:string}|false'
+        );
 
         return [
             // commonly used functions where the return type depends on a passed in boolean
@@ -216,7 +221,7 @@ final class DependentReturnTypeOverridePlugin extends PluginV2 implements
             'getenv'                      => $getenv_handler,
             'version_compare'             => $make_arg_existence_dependent_type_method(2, 'bool', 'int'),
             'pathinfo'                    => $make_arg_existence_dependent_type_method(1, 'string', 'array{dirname:string,basename:string,extension?:string,filename:string}'),
-            'parse_url'                   => $make_arg_existence_dependent_type_method(1, 'string|int|null|false', 'array{scheme?:string,host?:string,port?:int,user?:string,pass?:string,path?:string,query?:string,fragment?:string}|false'),
+            'parse_url'                   => $parse_url_handler,
             'substr'                      => $substr_handler,
         ];
     }

--- a/src/Phan/Profile.php
+++ b/src/Phan/Profile.php
@@ -8,6 +8,7 @@ trait Profile
 {
     /**
      * @var array<string,array<int,float>>
+     * Maps each phase of Phan analysis to a list of 1 or more durations (in seconds) spent in that phase.
      */
     private static $label_delta_map = [];
 

--- a/tests/Phan/AbstractPhanFileTest.php
+++ b/tests/Phan/AbstractPhanFileTest.php
@@ -20,7 +20,7 @@ abstract class AbstractPhanFileTest extends BaseTest implements CodeBaseAwareTes
 {
     const EXPECTED_SUFFIX = '.expected';
 
-    /** @var CodeBase */
+    /** @var CodeBase represents the known state of the test code base we're analyzing. */
     private $code_base;
 
     /**

--- a/tests/Phan/AnalyzerTest.php
+++ b/tests/Phan/AnalyzerTest.php
@@ -20,7 +20,7 @@ use Phan\Language\FQSEN\FullyQualifiedClassName;
 final class AnalyzerTest extends BaseTest
 {
     /**
-     * @var CodeBase
+     * @var CodeBase represents the known state of the test code base we're analyzing.
      */
     private $code_base;
 

--- a/tests/Phan/BaseTest.php
+++ b/tests/Phan/BaseTest.php
@@ -40,8 +40,8 @@ abstract class BaseTest extends TestCase
             'non_nullable_int_type',
         ],
         'Phan\Language\Type\LiteralStringType' => [
-            'nullable_int_type',
-            'non_nullable_int_type',
+            'nullable_string_type',
+            'non_nullable_string_type',
         ],
         'Phan\Language\UnionType' => [
             'empty_instance',

--- a/tests/Phan/Language/UnionTypeTest.php
+++ b/tests/Phan/Language/UnionTypeTest.php
@@ -64,8 +64,8 @@ final class UnionTypeTest extends BaseTest
             'non_nullable_int_type',
         ],
         'Phan\Language\Type\LiteralStringType' => [
-            'nullable_int_type',
-            'non_nullable_int_type',
+            'nullable_string_type',
+            'non_nullable_string_type',
         ],
         'Phan\Language\UnionType' => [
             'empty_instance',

--- a/tests/Phan/LanguageServer/LanguageServerIntegrationTest.php
+++ b/tests/Phan/LanguageServer/LanguageServerIntegrationTest.php
@@ -956,7 +956,13 @@ EOT
 
             $cur_line = explode("\n", $new_file_contents)[$position->line] ?? '';
 
-            $message = "Unexpected type definition for {$position->line}:{$position->character} (0-based) on line " . json_encode($cur_line) . ' at "' . substr($cur_line, $position->character, 10) . '"';
+            $message = sprintf(
+                "Unexpected type definition for %d:%d (0-based) on line %s at \"%s\"",
+                $position->line,
+                $position->character,
+                (string)json_encode($cur_line),
+                (string)substr($cur_line, $position->character, 10)
+            );
             $this->assertEquals($expected_definition_response, $definition_response, $message);  // slightly better diff view than assertSame
             $this->assertSame($expected_definition_response, $definition_response, $message);
 
@@ -1034,7 +1040,13 @@ EOT
 
             $cur_line = explode("\n", $new_file_contents)[$position->line] ?? '';
 
-            $message = "Unexpected hover response for {$position->line}:{$position->character} (0-based) on line " . json_encode($cur_line) . ' at "' . substr($cur_line, $position->character, 10) . '"';
+            $message = sprintf(
+                "Unexpected hover response for %d:%d (0-based) on line %s at \"%s\"",
+                $position->line,
+                $position->character,
+                (string)json_encode($cur_line),
+                (string)substr($cur_line, $position->character, 10)
+            );
             $this->assertEquals($expected_hover_response, $hover_response, $message);  // slightly better diff view than assertSame
             $this->assertSame($expected_hover_response, $hover_response, $message);
 

--- a/tests/Phan/Plugin/Internal/MethodSearcherPluginTest.php
+++ b/tests/Phan/Plugin/Internal/MethodSearcherPluginTest.php
@@ -34,8 +34,8 @@ final class MethodSearcherPluginTest extends BaseTest
             'non_nullable_int_type',
         ],
         'Phan\Language\Type\LiteralStringType' => [
-            'nullable_int_type',
-            'non_nullable_int_type',
+            'nullable_string_type',
+            'non_nullable_string_type',
         ],
         'Phan\Language\UnionType' => [
             'empty_instance',

--- a/tests/files/expected/0341_negated_condition_visitor.php.expected
+++ b/tests/files/expected/0341_negated_condition_visitor.php.expected
@@ -4,6 +4,7 @@
 %s:23 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is null but \intdiv() takes int
 %s:27 PhanTypeMismatchArgumentInternal Argument 1 (string) is int but \strlen() takes string
 %s:33 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is ?int but \intdiv() takes int
+%s:35 PhanTypeMismatchArgumentInternal Argument 1 (string) is int but \strlen() takes string
 %s:44 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is string but \intdiv() takes int
 %s:45 PhanTypeMismatchArgumentInternal Argument 1 (string) is int but \strlen() takes string
 %s:53 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is string but \intdiv() takes int

--- a/tests/files/src/0341_negated_condition_visitor.php
+++ b/tests/files/src/0341_negated_condition_visitor.php
@@ -32,7 +32,7 @@ function testNegate341C(?int $x) {
     if (empty($x)) {
         intdiv($x, 2);  // wrong if it's null, can be null or 0 (?int)
     } else {
-        echo strlen($x);  // should infer $x is int and warn
+        echo strlen($x);  // infers that $x is int and warns
     }
 }
 

--- a/tool/make_stubs
+++ b/tool/make_stubs
@@ -166,7 +166,7 @@ StubsGenerator::main();
  * A representation of the collection of stubs for elements of a PHP module(a.k.a. extension).
  */
 class StubCollection {
-    /** @var CodeBase */
+    /** @var CodeBase represents the known state of the code base we're extracting the stubs from. */
     private $code_base;
 
     public function __construct(CodeBase $code_base) {


### PR DESCRIPTION
Document other private properties of Phan's classes

Update php_codesniffer version used for self-analysis and fix code style issues. Stop using empty() within phan itself.