### PR TITLE
Fix a bug analyzing nullable phpdoc on non-nullable elements

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@ Plugins
 
 Bug fixes:
 + Infer more accurate types after asserting `!empty($x)`
++ Fix a bug causing Phan to fail to warn about nullable phpdoc types
+  replacing non-nullable param/return types in the real signature.
 + Infer the correct type for the result of the unary `+` operator.
   Improve inferences when `+`/`-` operators are used on string literals.
 

--- a/src/Phan/Analysis/ArgumentType.php
+++ b/src/Phan/Analysis/ArgumentType.php
@@ -255,7 +255,7 @@ final class ArgumentType
      * @param CodeBase $code_base
      * The global code base
      *
-     * @param ?\Closure $get_argument_type (Node|string|int $node, int $i) -> UnionType
+     * @param \Closure $get_argument_type (Node|string|int $node, int $i) -> UnionType
      * Fetches the types of individual arguments.
      */
     public static function analyzeForCallback(

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -2333,6 +2333,9 @@ class Type
         if ($union_type->hasType($this)) {
             return true;
         }
+        if ($this->getIsNullable() && !$union_type->containsNullable()) {
+            return false;
+        }
         $this_resolved = $this->withStaticResolvedInContext($context);
         // TODO: Allow casting MyClass<TemplateType> to MyClass (Without the template?
 

--- a/src/Phan/Language/Type/ClosureType.php
+++ b/src/Phan/Language/Type/ClosureType.php
@@ -147,9 +147,12 @@ final class ClosureType extends Type
     {
         $func = $this->func;
         if ($func) {
-            return $func->asFunctionLikeDeclarationType()->__toString();
+            $result = $func->asFunctionLikeDeclarationType()->__toString();
+        } else {
+            $result = '\Closure';
         }
-        return '\Closure';
+
+        return $this->is_nullable ? "?$result" : $result;
     }
 
     /**

--- a/src/Phan/LanguageServer/Server/TextDocument.php
+++ b/src/Phan/LanguageServer/Server/TextDocument.php
@@ -184,7 +184,7 @@ class TextDocument
      * @return ?Promise <Location|Location[]|null>
      * @suppress PhanUnreferencedPublicMethod called by client via AdvancedJsonRpc
      */
-    public function definition(TextDocumentIdentifier $textDocument, Position $position) : Promise
+    public function definition(TextDocumentIdentifier $textDocument, Position $position)
     {
         Logger::logInfo("Called textDocument/definition, uri={$textDocument->uri} position={$position->line}:{$position->character}");
         try {
@@ -205,7 +205,7 @@ class TextDocument
      * @return ?Promise <Location|Location[]|null>
      * @suppress PhanUnreferencedPublicMethod called by client via AdvancedJsonRpc
      */
-    public function typeDefinition(TextDocumentIdentifier $textDocument, Position $position) : Promise
+    public function typeDefinition(TextDocumentIdentifier $textDocument, Position $position)
     {
         Logger::logInfo("Called textDocument/typeDefinition, uri={$textDocument->uri} position={$position->line}:{$position->character}");
         try {

--- a/tests/files/expected/0582_declared_nullable_return.php.expected
+++ b/tests/files/expected/0582_declared_nullable_return.php.expected
@@ -1,0 +1,2 @@
+%s:6 PhanTypeMismatchDeclaredReturn Doc-block of getNullable contains declared return type ?\stdClass which is incompatible with the return type \stdClass declared in the signature
+%s:13 PhanTypeMismatchDeclaredReturn Doc-block of getFalseable contains declared return type false which is incompatible with the return type \stdClass declared in the signature

--- a/tests/files/src/0582_declared_nullable_return.php
+++ b/tests/files/src/0582_declared_nullable_return.php
@@ -1,0 +1,18 @@
+<?php
+
+class Foo582 {
+    /**
+     * Should emit PhanTypeMismatchDeclaredReturn
+     * @return ?stdClass some description
+     */
+    public function getNullable() : stdClass {
+        return new stdClass();
+    }
+    /**
+     * Should emit PhanTypeMismatchDeclaredReturn
+     * @return stdClass|false some description
+     */
+    public function getFalseable() : stdClass {
+        return new stdClass();
+    }
+}


### PR DESCRIPTION
Phan failed to warn about nullable phpdoc types
replacing non-nullable param/return types in the real signature.

It would also analyze those as if they really were nullable.

Fixes #2198