### PR TITLE
Fix name inferred for global constants define()d within a namespace

### DIFF
--- a/.phan/plugins/UnreachableCodePlugin.php
+++ b/.phan/plugins/UnreachableCodePlugin.php
@@ -68,7 +68,6 @@ final class UnreachableCodeVisitor extends PluginAwarePostAnalysisVisitor
     public function visitStmtList(Node $node)
     {
         $child_nodes = $node->children;
-        // Debug::printNode($node);
 
         $last_node_index = count($child_nodes) - 1;
         foreach ($child_nodes as $i => $node) {

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@ Phan NEWS
 New features(Analysis):
 + Add suggestions to `PhanUndeclaredFunction` for functions in other namespaces
   and similarly named functions in the same namespace.
++ Add issue types `PhanInvalidFQSENInCallable` and `PhanInvalidFQSENInClasslike`
 
 Maintenance:
 + Increase the default of the config setting `suggestion_check_limit` from 50 to 1000.
@@ -21,6 +22,8 @@ Bug fixes:
   replacing non-nullable param/return types in the real signature.
 + Infer the correct type for the result of the unary `+` operator.
   Improve inferences when `+`/`-` operators are used on string literals.
++ Fix name inferred for global constants `define()`d within a namespace (#2207).
+  This now properly treats the constant name as being fully qualified.
 
 29 Nov 2018, Phan 1.1.5
 -----------------------

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -2496,6 +2496,20 @@ This would be emitted if you have a file with the contents
 ```php
 ```
 
+## PhanInvalidFQSENInCallable
+
+```
+Possible call to a function '{FUNCTIONLIKE}' with an invalid FQSEN.
+```
+
+## PhanInvalidFQSENInClasslike
+
+```
+Possible use of a classlike '{CLASSLIKE}' with an invalid FQSEN.
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/misc/fallback_test/expected/063_invalid_fqsen.php.expected#L6) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/misc/fallback_test/src/063_invalid_fqsen.php#L7).
+
 ## PhanInvalidRequireFile
 
 ```

--- a/src/Phan/Analysis/BlockExitStatusChecker.php
+++ b/src/Phan/Analysis/BlockExitStatusChecker.php
@@ -446,7 +446,7 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
             }
         } else {
             if (!\is_string($expression)) {
-                return self::STATUS_PROCEED;  // Probably impossible.
+                return self::STATUS_THROW;  // Probably impossible.
             }
             $function_name = $expression;
         }

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -13,6 +13,8 @@ use Phan\AST\UnionTypeVisitor;
 use Phan\CodeBase;
 use Phan\Config;
 use Phan\Exception\CodeBaseException;
+use Phan\Exception\EmptyFQSENException;
+use Phan\Exception\FQSENException;
 use Phan\Exception\IssueException;
 use Phan\Exception\NodeException;
 use Phan\Exception\UnanalyzableException;
@@ -2003,7 +2005,16 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 $this->context,
                 $exception->getIssueInstance()
             );
-        } catch (Exception $_) {
+        } catch (Exception $e) {
+            if ($e instanceof FQSENException) {
+                Issue::maybeEmit(
+                    $this->code_base,
+                    $this->context,
+                    $e instanceof EmptyFQSENException ? Issue::EmptyFQSENInClasslike : Issue::InvalidFQSENInClasslike,
+                    $node->lineno,
+                    $e->getFQSEN()
+                );
+            }
             // We already checked for NonClassMethodCall
             if (Config::get_strict_method_checking()) {
                 $this->checkForPossibleNonObjectAndNonClassInMethod($node, $method_name);

--- a/src/Phan/Exception/EmptyFQSENException.php
+++ b/src/Phan/Exception/EmptyFQSENException.php
@@ -1,35 +1,9 @@
 <?php declare(strict_types=1);
 namespace Phan\Exception;
 
-use Exception;
-
 /**
  * Thrown to indicate that an empty FQSEN was used where a valid FQSEN was expected.
  */
-class EmptyFQSENException extends Exception
+class EmptyFQSENException extends FQSENException
 {
-    /** @var string the empty, unparseable FQSEN */
-    private $fqsen;
-
-    /**
-     * @param string $message
-     * The error message
-     * @param string $fqsen
-     * the empty, unparseable FQSEN
-     */
-    public function __construct(
-        string $message,
-        string $fqsen
-    ) {
-        parent::__construct($message);
-        $this->fqsen = $fqsen;
-    }
-
-    /**
-     * @return string the empty, unparseable FQSEN input that caused this exception
-     */
-    public function getFQSEN() : string
-    {
-        return $this->fqsen;
-    }
 }

--- a/src/Phan/Exception/FQSENException.php
+++ b/src/Phan/Exception/FQSENException.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+namespace Phan\Exception;
+
+use Exception;
+
+/**
+ * Thrown to indicate that an empty/invalid FQSEN was used where a valid FQSEN was expected.
+ * @see InvalidFQSENException
+ * @see EmptyFQSENException
+ */
+class FQSENException extends Exception
+{
+    /** @var string the empty/invalid, unparseable FQSEN */
+    private $fqsen;
+
+    /**
+     * @param string $message
+     * The error message
+     * @param string $fqsen
+     * the empty/invalid, unparseable FQSEN
+     */
+    public function __construct(
+        string $message,
+        string $fqsen
+    ) {
+        parent::__construct($message);
+        $this->fqsen = $fqsen;
+    }
+
+    /**
+     * @return string the empty, unparseable FQSEN input that caused this exception
+     */
+    public function getFQSEN() : string
+    {
+        return $this->fqsen;
+    }
+}

--- a/src/Phan/Exception/InvalidFQSENException.php
+++ b/src/Phan/Exception/InvalidFQSENException.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+namespace Phan\Exception;
+
+/**
+ * Thrown to indicate that an invalid FQSEN was used where a valid FQSEN was expected.
+ */
+class InvalidFQSENException extends FQSENException
+{
+}

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -69,7 +69,9 @@ class Issue
     const UndeclaredFunctionInCallable = 'PhanUndeclaredFunctionInCallable';
     const UndeclaredMethodInCallable = 'PhanUndeclaredMethodInCallable';
     const EmptyFQSENInCallable      = 'PhanEmptyFQSENInCallable';
+    const InvalidFQSENInCallable    = 'PhanInvalidFQSENInCallable';
     const EmptyFQSENInClasslike     = 'PhanEmptyFQSENInClasslike';
+    const InvalidFQSENInClasslike     = 'PhanInvalidFQSENInClasslike';
 
     // Issue::CATEGORY_TYPE
     const NonClassMethodCall        = 'PhanNonClassMethodCall';
@@ -978,6 +980,22 @@ class Issue
                 "Possible use of a classlike '{CLASSLIKE}' with an empty FQSEN.",
                 self::REMEDIATION_B,
                 11036
+            ),
+            new Issue(
+                self::InvalidFQSENInCallable,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_NORMAL,
+                "Possible call to a function '{FUNCTIONLIKE}' with an invalid FQSEN.",
+                self::REMEDIATION_B,
+                11042
+            ),
+            new Issue(
+                self::InvalidFQSENInClasslike,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_NORMAL,
+                "Possible use of a classlike '{CLASSLIKE}' with an invalid FQSEN.",
+                self::REMEDIATION_B,
+                11043
             ),
 
             // Issue::CATEGORY_ANALYSIS

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -9,6 +9,8 @@ use Phan\AST\UnionTypeVisitor;
 use Phan\CodeBase;
 use Phan\Config;
 use Phan\Exception\EmptyFQSENException;
+use Phan\Exception\FQSENException;
+use Phan\Exception\InvalidFQSENException;
 use Phan\Exception\IssueException;
 use Phan\Exception\RecursionDepthException;
 use Phan\Issue;
@@ -762,8 +764,11 @@ class Type
      * @param string $fully_qualified_string
      * A fully qualified type name
      *
+     *
      * @return Type
      * The type with that fully qualified type name (cached for efficiency)
+     *
+     * @throws FQSENException if the type name was the empty or invalid string
      */
     public static function fromFullyQualifiedString(
         string $fully_qualified_string
@@ -776,7 +781,7 @@ class Type
      * Extracts the parts of this Type from the passed in fully qualified type name.
      * Callers should ensure that the type regex accepts $fully_qualified_string
      *
-     * @throws EmptyFQSENException if the type name was the empty string
+     * @throws FQSENException if the type name was the empty or invalid string
      * @throws InvalidArgumentException if namespace is missing from something that should have a namespace
      * @suppress PhanPossiblyFalseTypeArgument, PhanPossiblyFalseTypeArgumentInternal
      */
@@ -861,7 +866,7 @@ class Type
             throw new EmptyFQSENException("Type was not fully qualified", $fully_qualified_string);
         }
         if ($namespace === '') {
-            throw new InvalidArgumentException("Type was not fully qualified");
+            throw new InvalidFQSENException("Type was not fully qualified", $fully_qualified_string);
         }
 
         return self::make(
@@ -1236,7 +1241,7 @@ class Type
         $context_namespace = $context->getNamespace();
         if ($context_namespace) {
             if ($namespace) {
-                $namespace = $context_namespace . '\\' . $namespace;
+                $namespace = \rtrim($context_namespace, '\\') . '\\' . $namespace;
             } else {
                 $namespace = $context_namespace;
             }

--- a/src/Phan/Plugin/Internal/MiscParamPlugin.php
+++ b/src/Phan/Plugin/Internal/MiscParamPlugin.php
@@ -574,7 +574,8 @@ final class MiscParamPlugin extends PluginV2 implements
                 $args[1],
                 0,
                 '',
-                false
+                false,
+                true
             );
         };
 

--- a/tests/files/expected/0467_name_not_empty.php.expected
+++ b/tests/files/expected/0467_name_not_empty.php.expected
@@ -3,6 +3,11 @@
 %s:4 PhanEmptyFQSENInCallable Possible call to a function '\' with an empty FQSEN.
 %s:5 PhanEmptyFQSENInCallable Possible call to a function '\' with an empty FQSEN.
 %s:6 PhanEmptyFQSENInClasslike Possible use of a classlike '\' with an empty FQSEN.
-%s:7 PhanEmptyFQSENInClasslike Possible use of a classlike '\' with an empty FQSEN.
-%s:8 PhanNonClassMethodCall Call to method foo on non-class type 1
-%s:9 PhanNonClassMethodCall Call to method foo on non-class type 0
+%s:7 PhanInvalidFQSENInClasslike Possible use of a classlike '\??' with an invalid FQSEN.
+%s:8 PhanInvalidFQSENInClasslike Possible use of a classlike '\,,' with an invalid FQSEN.
+%s:9 PhanEmptyFQSENInClasslike Possible use of a classlike '\' with an empty FQSEN.
+%s:10 PhanEmptyFQSENInClasslike Possible use of a classlike '\' with an empty FQSEN.
+%s:11 PhanInvalidFQSENInClasslike Possible use of a classlike '\a\\b' with an invalid FQSEN.
+%s:12 PhanInvalidFQSENInClasslike Possible use of a classlike '\a\\' with an invalid FQSEN.
+%s:13 PhanNonClassMethodCall Call to method foo on non-class type 1
+%s:14 PhanNonClassMethodCall Call to method foo on non-class type 0

--- a/tests/files/expected/0583_define_global_constant.php.expected
+++ b/tests/files/expected/0583_define_global_constant.php.expected
@@ -1,0 +1,7 @@
+%s:5 PhanUndeclaredConstant Reference to undeclared constant \test2207\TEST
+%s:7 PhanUndeclaredConstant Reference to undeclared constant \test2207\TEST
+%s:11 PhanTypeConversionFromArray array to string conversion
+%s:12 PhanUndeclaredConstant Reference to undeclared constant \test2207\TEST2
+%s:14 PhanInvalidConstantFQSEN '\' is an invalid FQSEN for a constant
+%s:15 PhanInvalidConstantFQSEN 'foo\\TEST3' is an invalid FQSEN for a constant
+%s:19 PhanUndeclaredConstant Reference to undeclared constant \test2207\TEST5

--- a/tests/files/src/0467_name_not_empty.php
+++ b/tests/files/src/0467_name_not_empty.php
@@ -2,8 +2,13 @@
 call_user_func_array('', []);
 call_user_func('\\', []);
 ''();
-'\\'();
+'\\'();  // Phan knows that ''() as a literal will definitely throw an error, so this warns about unreachable code. We don't bother checking for all cases because we already warn about the invalid FQSEN.
 ('')::foo();
+('??')::foo();
+(',,')::foo();
 '\\'::foo();
+'\\\\'::foo();
+'a\\\\b'::foo();
+'a\\\\'::foo();
 (1)::foo();
 (0)::foo();

--- a/tests/files/src/0583_define_global_constant.php
+++ b/tests/files/src/0583_define_global_constant.php
@@ -1,0 +1,27 @@
+<?php
+namespace test2207;
+define('TEST', 1);
+echo \TEST;  // should not warn
+echo \test2207\TEST;
+echo TEST;  // should not warn
+echo namespace\TEST;  // should warn
+
+$x = 'TEST2';
+define($x, []);
+echo TEST2;  // should not warn
+echo namespace\TEST2;  // should not warn
+
+define('\\', 'empty');
+define('foo\\\\TEST3', 'empty');  // should warn
+define('\\\\TEST4', 'empty');
+define('\\TEST5', 'empty');  // this is valid
+echo TEST5;
+echo namespace\TEST5;  // should warn
+
+/*
+// Note: Apparently, it does succeed if you actually do that (tested in PHP 7.0 and 7.3).
+// Still going to warn about it.
+php > define('foo\\\\\\TEST3', 'some value');
+php > var_export(constant('foo\\\\\\TEST3'));
+'some value'
+*/

--- a/tests/misc/fallback_test/expected/047_valid_define.php.expected
+++ b/tests/misc/fallback_test/expected/047_valid_define.php.expected
@@ -1,1 +1,2 @@
 src/047_valid_define.php:2 PhanInvalidConstantFQSEN ',,' is an invalid FQSEN for a constant
+src/047_valid_define.php:3 PhanInvalidConstantFQSEN '&&' is an invalid FQSEN for a constant

--- a/tests/misc/fallback_test/expected/063_invalid_fqsen.php.expected
+++ b/tests/misc/fallback_test/expected/063_invalid_fqsen.php.expected
@@ -1,0 +1,15 @@
+src/063_invalid_fqsen.php:2 PhanEmptyFQSENInCallable Possible call to a function '\' with an empty FQSEN.
+src/063_invalid_fqsen.php:3 PhanEmptyFQSENInCallable Possible call to a function '\' with an empty FQSEN.
+src/063_invalid_fqsen.php:4 PhanEmptyFQSENInCallable Possible call to a function '\' with an empty FQSEN.
+src/063_invalid_fqsen.php:5 PhanEmptyFQSENInCallable Possible call to a function '\' with an empty FQSEN.
+src/063_invalid_fqsen.php:6 PhanEmptyFQSENInClasslike Possible use of a classlike '\' with an empty FQSEN.
+src/063_invalid_fqsen.php:7 PhanInvalidFQSENInClasslike Possible use of a classlike '\??' with an invalid FQSEN.
+src/063_invalid_fqsen.php:8 PhanInvalidFQSENInClasslike Possible use of a classlike '\,,' with an invalid FQSEN.
+src/063_invalid_fqsen.php:9 PhanEmptyFQSENInClasslike Possible use of a classlike '\' with an empty FQSEN.
+src/063_invalid_fqsen.php:10 PhanEmptyFQSENInClasslike Possible use of a classlike '\' with an empty FQSEN.
+src/063_invalid_fqsen.php:11 PhanInvalidFQSENInClasslike Possible use of a classlike '\a\\b' with an invalid FQSEN.
+src/063_invalid_fqsen.php:12 PhanInvalidFQSENInClasslike Possible use of a classlike '\a\\' with an invalid FQSEN.
+src/063_invalid_fqsen.php:13 PhanNonClassMethodCall Call to method foo on non-class type 1
+src/063_invalid_fqsen.php:14 PhanNonClassMethodCall Call to method foo on non-class type 0
+src/063_invalid_fqsen.php:15 PhanInvalidFQSENInCallable Possible call to a function '\aaa\\b' with an invalid FQSEN.
+src/063_invalid_fqsen.php:16 PhanEmptyFQSENInCallable Possible call to a function '\aaa\' with an empty FQSEN.

--- a/tests/misc/fallback_test/src/047_valid_define.php
+++ b/tests/misc/fallback_test/src/047_valid_define.php
@@ -1,2 +1,3 @@
 <?php
 define(',,', 'value');
+define('&&', 'value');

--- a/tests/misc/fallback_test/src/063_invalid_fqsen.php
+++ b/tests/misc/fallback_test/src/063_invalid_fqsen.php
@@ -1,0 +1,16 @@
+<?php
+call_user_func_array('', []);
+call_user_func('\\', []);
+''();
+'\\'();
+('')::foo();
+('??')::foo();
+(',,')::foo();
+'\\'::foo();
+'\\\\'::foo();
+'a\\\\b'::foo();
+'a\\\\'::foo();
+(1)::foo();
+(0)::foo();
+call_user_func('aaa\\\\b', []);
+call_user_func('aaa\\', []);

--- a/tests/plugin_test/expected/062_strict_function_checking.php.expected
+++ b/tests/plugin_test/expected/062_strict_function_checking.php.expected
@@ -8,4 +8,5 @@ src/062_strict_function_checking.php:38 PhanTypePossiblyInvalidCallable Saw type
 src/062_strict_function_checking.php:39 PhanTypePossiblyInvalidCallable Saw type int|string which is possibly not a callable
 src/062_strict_function_checking.php:42 PhanTypeInvalidCallable Saw type array{key:string} which cannot be a callable
 src/062_strict_function_checking.php:44 PhanTypeInvalidCallable Saw type 2 which cannot be a callable
+src/062_strict_function_checking.php:45 PhanPluginUnreachableCode Unreachable statement detected
 src/062_strict_function_checking.php:45 PhanTypeInvalidCallable Saw type 2.3 which cannot be a callable


### PR DESCRIPTION
After the refactoring in #2135 (probably),
this unintentionally started treating calls to `define()` as passing a namespaced name.

This PR fixes that and treats the calls as being fully namespaced.

Fixes #2207

Make the way that Phan handles invalid FQSENs more consistent.
Add issue types `PhanInvalidFQSENInCallable` and
`PhanInvalidFQSENInClasslike`