### PR TITLE
Fix a crash when analyzing an anonymous class created with 0 args

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,8 @@ Plugins:
 
 Bug fixes:
 + Infer more accurate types after asserting `!empty($x)`
++ Fix a crash seen when analyzing anonymous class with 0 args
+  when checking if PhanInfiniteRecursion should be emitted (#2206)
 + Fix a bug causing Phan to fail to warn about nullable phpdoc types
   replacing non-nullable param/return types in the real signature.
 + Infer the correct type for the result of the unary `+` operator.

--- a/src/Phan/Analysis/ReachabilityChecker.php
+++ b/src/Phan/Analysis/ReachabilityChecker.php
@@ -166,7 +166,7 @@ final class ReachabilityChecker extends KindVisitorImplementation
      */
     public function visitClass(Node $node)
     {
-        $args = $node->children['args'];
+        $args = $node->children['args'] ?? null;
         if (!$args instanceof Node) {
             return null;
         }

--- a/tests/files/expected/0585_reachability_anonymous_class_arg.php.expected
+++ b/tests/files/expected/0585_reachability_anonymous_class_arg.php.expected
@@ -1,0 +1,1 @@
+%s:9 PhanInfiniteRecursion my_recursive_function_bad() is calling itself in a way that may cause infinite recursion.

--- a/tests/files/src/0584_reachability_crash.php
+++ b/tests/files/src/0584_reachability_crash.php
@@ -1,0 +1,28 @@
+<?php
+interface SomeInterface
+{
+    public function removed();
+}
+
+class Test2206 {
+    private function removeData(bool $runAgain = true): bool
+    {
+        $responder = new class() implements \SomeInterface
+        {
+            public $removed = false;
+
+            public function removed()
+            {
+                $this->removed = true;
+            }
+        };
+
+        $dataRemoved = $responder->removed;
+
+        if ($runAgain) {
+            $dataRemoved = $dataRemoved || $this->removeData(false);
+        }
+
+        return $dataRemoved;
+    }
+}

--- a/tests/files/src/0585_reachability_anonymous_class_arg.php
+++ b/tests/files/src/0585_reachability_anonymous_class_arg.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * PhanInfiniteRecursion should be emitted - this is calling my_recursive_function without ever returning or creating the class.
+ *
+ * @return object
+ */
+function my_recursive_function_bad(int $x) {
+    return (new class(my_recursive_function_bad($x - 1)) {
+        public $value;
+
+        public function __construct($value) {
+            var_export($value);
+            $this->value = $value;
+        }
+    });
+}
+
+/**
+ * PhanInfiniteRecursion should be emitted - this is calling my_recursive_function without ever returning or creating the class.
+ *
+ * @return object
+ */
+function my_recursive_function_good(int $x) {
+    if ($x <= 0) {
+        return new stdClass();
+    }
+    return (new class(my_recursive_function_good($x - 1)) {
+        public $value;
+
+        /**
+         * @param object $value
+         */
+        public function __construct($value) {
+            var_export($value);
+            $this->value = $value;
+        }
+    });
+}


### PR DESCRIPTION
This crash happens in functions/methods that calls themself,
due to a bug in the check for PhanInfiniteRecursion.

Fixes #2206