### PR TITLE
Be more strict about self-analysis of `@throws` annotations

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -228,17 +228,25 @@ return [
     // If enabled (and warn_about_undocumented_throw_statements is enabled),
     // warn about function/closure/method calls that have (at)throws
     // without the invoking method documenting that exception.
-    // TODO: Enable for self-analysis
-    'warn_about_undocumented_exceptions_thrown_by_invoked_functions' => false,
+    'warn_about_undocumented_exceptions_thrown_by_invoked_functions' => true,
 
     // If this is a list, Phan will not warn about lack of documentation of (at)throws
     // for any of the listed classes or their subclasses.
     // This setting only matters when warn_about_undocumented_throw_statements is true.
     // The default is the empty array (Warn about every kind of Throwable)
     'exception_classes_with_optional_throws_phpdoc' => [
+        'LogicException',
         'RuntimeException',
+        'InvalidArgumentException',
         'AssertionError',
         'TypeError',
+        'Phan\Exception\IssueException',  // TODO: Make Phan aware that some arguments suppress certain issues
+        'Phan\AST\TolerantASTConverter\InvalidNodeException',  // This is used internally in TolerantASTConverter
+
+        // TODO: Undo the suppressions for the below categories of issues:
+        'Phan\Exception\CodeBaseException',
+        'Phan\Exception\FQSENException',  // Especially for this
+
     ],
 
     // Increase this to properly analyze require_once statements

--- a/.phan/plugins/PHPUnitNotDeadCodePlugin.php
+++ b/.phan/plugins/PHPUnitNotDeadCodePlugin.php
@@ -69,6 +69,7 @@ class PHPUnitNotDeadPluginVisitor extends PluginAwarePostAnalysisVisitor
         }
         // This assumes PreOrderAnalysisVisitor->visitClass is called first.
         $context = $this->context;
+        // @phan-suppress-next-line PhanThrowTypeAbsentForCall definitely in class scope in visitClass
         $class = $context->getClassInScope($code_base);
         if (!$class->getFQSEN()->asType()->asExpandedTypes($code_base)->hasType(self::$phpunit_test_case_type)) {
             // This isn't a phpunit test case.
@@ -113,6 +114,7 @@ class PHPUnitNotDeadPluginVisitor extends PluginAwarePostAnalysisVisitor
         if (preg_match('/@dataProvider\s+' . self::WORD_REGEX . '/', $method->getNode()->children['docComment'] ?? '', $match)) {
             $data_provider_name = $match[1];
             if ($class->hasMethodWithName($this->code_base, $data_provider_name)) {
+                // @phan-suppress-next-line PhanThrowTypeAbsentForCall checked for existence
                 $class->getMethodByName($this->code_base, $data_provider_name)->addReference($this->context);
             }
         }
@@ -138,6 +140,7 @@ class PHPUnitNotDeadPluginVisitor extends PluginAwarePostAnalysisVisitor
     /**
      * Static initializer for this plugin - Gets called below before any methods can be used
      * @return void
+     * @suppress PhanThrowTypeAbsentForCall this FQSEN is valid
      */
     public static function init()
     {

--- a/.phan/plugins/PrintfCheckerPlugin.php
+++ b/.phan/plugins/PrintfCheckerPlugin.php
@@ -477,6 +477,7 @@ class PrintfCheckerPlugin extends PluginV2 implements AnalyzeFunctionCallCapabil
                 }
                 $expected_union_type = new UnionType();
                 foreach ($expected_set as $type_name => $_) {
+                    // @phan-suppress-next-line PhanThrowTypeAbsentForCall getExpectedUnionTypeName should only return valid union types
                     $expected_union_type = $expected_union_type->withType(Type::fromFullyQualifiedString($type_name));
                 }
                 if ($actual_union_type->canCastToUnionType($expected_union_type)) {

--- a/.phan/plugins/SleepCheckerPlugin.php
+++ b/.phan/plugins/SleepCheckerPlugin.php
@@ -73,6 +73,7 @@ class SleepCheckerVisitor extends PluginAwarePostAnalysisVisitor
             // Give up, failed to extract property names
             return;
         }
+        // @phan-suppress-next-line PhanThrowTypeAbsentForCall we're in class scope
         $class = $this->context->getClassInScope($this->code_base);
         $class_fqsen = $class->getFQSEN();
         foreach ($class->getPropertyMap($this->code_base) as $property_name => $property) {
@@ -187,6 +188,7 @@ class SleepCheckerVisitor extends PluginAwarePostAnalysisVisitor
         if (!is_array($value)) {
             return;
         }
+        // @phan-suppress-next-line PhanThrowTypeAbsentForCall we're in class scope
         $class = $context->getClassInScope($code_base);
 
         foreach ($value as $prop_name) {

--- a/internal/dump_fallback_ast.php
+++ b/internal/dump_fallback_ast.php
@@ -36,6 +36,7 @@ dump_main();
 /**
  * Dumps a snippet provided as a command line argument
  * @return void
+ * @throws Exception if it can't render the AST
  */
 function dump_main()
 {
@@ -100,6 +101,7 @@ function dump_expr_as_ast(string $expr, bool $with_placeholders)
 /**
  * Parses $expr and echoes the tolerant-php-parser AST to stdout.
  * @return void
+ * @throws Exception
  */
 function dump_expr(string $expr)
 {

--- a/internal/internalsignatures.php
+++ b/internal/internalsignatures.php
@@ -5,6 +5,7 @@
 use Phan\Analysis;
 use Phan\CodeBase;
 use Phan\Config;
+use Phan\Exception\FQSENException;
 use Phan\Language\Element\Func;
 use Phan\Language\Element\Method;
 use Phan\Language\FQSEN\FullyQualifiedClassName;
@@ -1151,6 +1152,7 @@ class IncompatibleStubsSignatureDetector extends IncompatibleSignatureDetectorBa
 
     /**
      * @return ?array
+     * @throws FQSENException if signature map is invalid
      */
     public function parseMethodSignature(string $class_name, string $method_name)
     {
@@ -1179,6 +1181,7 @@ class IncompatibleStubsSignatureDetector extends IncompatibleSignatureDetectorBa
 
     /**
      * @return ?array
+     * @throws FQSENException if $function_name is invalid
      */
     public function parseFunctionSignature(string $function_name)
     {

--- a/internal/reflection_completeness_check.php
+++ b/internal/reflection_completeness_check.php
@@ -10,6 +10,7 @@ declare(strict_types = 1);
  */
 require_once dirname(__DIR__) . '/vendor/autoload.php';
 
+use Exception;
 use Phan\Config;
 use Phan\Language\FQSEN\FullyQualifiedFunctionName;
 use Phan\Language\FQSEN\FullyQualifiedMethodName;
@@ -49,7 +50,12 @@ class ReflectionCompletenessCheck
                 if (array_key_exists($function_name, self::EXCLUDED_FUNCTIONS)) {
                     continue;
                 }
-                $fqsen = FullyQualifiedFunctionName::fromFullyQualifiedString($function_name);
+                try {
+                    $fqsen = FullyQualifiedFunctionName::fromFullyQualifiedString($function_name);
+                } catch (Exception $e) {
+                    echo "Obtained invalid reflection function '$function_name' from reflection, ignoring: " . $e->getMessage() . "\n";
+                    continue;
+                }
                 $map_list = UnionType::internalFunctionSignatureMapForFQSEN($fqsen);
                 if (!$map_list) {
                     $stub_signature = self::stubSignatureToString(self::createStubSignature($reflection_function));

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -156,6 +156,7 @@ class ContextNode
                 return null;
             }
         }
+        // @phan-suppress-next-line PhanThrowTypeAbsentForCall hopefully impossible to parse an invalid FQSEN
         return FullyQualifiedClassName::fromStringInContext(
             $trait_fqsen_string,
             $this->context
@@ -427,7 +428,8 @@ class ContextNode
     }
 
     /**
-     * @return UnionType the union type of the class for this class node. (Should have just one Type)
+     * @return UnionType the union type of the class for this class node. (Typically has just one Type)
+     * @throws FQSENException if class union type is invalid
      */
     public function getClassUnionType() : UnionType
     {
@@ -445,6 +447,7 @@ class ContextNode
 
     /**
      * @return array{0:UnionType,1:Clazz[]}
+     * @throws CodeBaseException if $ignore_missing_classes == false
      */
     public function getClassListInner(bool $ignore_missing_classes)
     {
@@ -1562,13 +1565,6 @@ class ContextNode
      * Get the (non-class) constant associated with this node
      * in this context
      *
-     * @throws NodeException
-     * An exception is thrown if we can't understand the node
-     *
-     * @throws CodeBaseException
-     * An exception is thrown if we can't find the given
-     * global constant
-     *
      * @throws IssueException
      * should be emitted by the caller if caught.
      */
@@ -1585,10 +1581,7 @@ class ContextNode
 
         $constant_name = $node->children['name']->children['name'] ?? null;
         if (!\is_string($constant_name)) {
-            throw new NodeException(
-                $node,
-                "Can't determine constant name"
-            );
+            throw new AssertionError("Can't determine constant name");
         }
 
         $code_base = $this->code_base;

--- a/src/Phan/AST/TolerantASTConverter/NodeDumper.php
+++ b/src/Phan/AST/TolerantASTConverter/NodeDumper.php
@@ -2,6 +2,7 @@
 
 namespace Phan\AST\TolerantASTConverter;
 
+use Exception;
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Token;
 
@@ -106,7 +107,7 @@ class NodeDumper
      * @param Node|Token|null $ast_node
      * @param string $padding (to be echoed before the current node
      * @return string
-     * @throws \InvalidArgumentException for invalid $ast_node values
+     * @throws Exception for invalid $ast_node values
      */
     public function dumpTreeAsString($ast_node, string $key = '', string $padding = '') : string
     {
@@ -147,6 +148,7 @@ class NodeDumper
      * @param Node|Token $ast_node
      * @param string $padding (to be echoed before the current node
      * @return void
+     * @throws Exception for invalid $ast_node values
      * @suppress PhanUnreferencedPublicMethod
      */
     public function dumpTree($ast_node, string $key = '', string $padding = '')

--- a/src/Phan/AST/TolerantASTConverter/StringUtil.php
+++ b/src/Phan/AST/TolerantASTConverter/StringUtil.php
@@ -2,7 +2,6 @@
 
 namespace Phan\AST\TolerantASTConverter;
 
-use Error;
 use function chr;
 use function hexdec;
 use function is_string;
@@ -135,6 +134,7 @@ final class StringUtil
      * @param null|string $quote Quote type
      *
      * @return string String with escape sequences parsed
+     * @throws InvalidNodeException for invalid code points
      */
     public static function parseEscapeSequences($str, $quote) : string
     {
@@ -176,7 +176,7 @@ final class StringUtil
      *
      * @return string UTF-8 representation of code point
      *
-     * @throws \Error for invalid code points
+     * @throws InvalidNodeException for invalid code points
      */
     private static function codePointToUtf8(int $num) : string
     {
@@ -193,6 +193,6 @@ final class StringUtil
             return chr(($num >> 18) + 0xF0) . chr((($num >> 12) & 0x3F) + 0x80)
                  . chr((($num >> 6) & 0x3F) + 0x80) . chr(($num & 0x3F) + 0x80);
         }
-        throw new Error('Invalid UTF-8 codepoint escape sequence: Codepoint too large');
+        throw new InvalidNodeException('Invalid UTF-8 codepoint escape sequence: Codepoint too large');
     }
 }

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -5,6 +5,7 @@ namespace Phan\AST\TolerantASTConverter;
 use AssertionError;
 use ast;
 use ast\flags;
+use Exception;
 use Error;
 use InvalidArgumentException;
 use Microsoft\PhpParser;
@@ -227,7 +228,10 @@ class TolerantASTConverter
         self::$file_contents = $file_contents;
     }
 
-    /** @param null|bool|int|string|PhpParser\Node|Token|(PhpParser\Node|Token)[] $n */
+    /**
+     * @param null|bool|int|string|PhpParser\Node|Token|(PhpParser\Node|Token)[] $n
+     * @throws Exception if node is invalid
+     */
     protected static function debugDumpNodeOrToken($n) : string
     {
         if (\is_scalar($n)) {
@@ -251,7 +255,8 @@ class TolerantASTConverter
      * @param ?int $lineno
      * @param bool $return_null_on_empty (return null if non-array (E.g. semicolon is seen))
      * @return ?ast\Node
-     * @throws RuntimeException if the statement list is invalid
+     * Throws RuntimeException|Exception if the statement list is invalid
+     * @suppress PhanThrowTypeAbsentForCall|PhanThrowTypeMismatchForCall
      */
     private static function phpParserStmtlistToAstNode($parser_nodes, $lineno, bool $return_null_on_empty = false)
     {
@@ -361,12 +366,14 @@ class TolerantASTConverter
              */
             $fallback_closure = function ($n, int $unused_start_line) {
                 if (!($n instanceof PhpParser\Node) && !($n instanceof Token)) {
+                    // @phan-suppress-next-line PhanThrowTypeMismatchForCall debugDumpNodeOrToken can throw
                     throw new \InvalidArgumentException("Invalid type for node: " . (\is_object($n) ? \get_class($n) : \gettype($n)) . ": " . static::debugDumpNodeOrToken($n));
                 }
                 return static::astStub($n);
             };
         }
         $callback = $callback_map[\get_class($n)] ?? $fallback_closure;
+        // @phan-suppress-next-line PhanThrowTypeMismatch, PhanThrowTypeAbsentForCall
         return $callback($n, self::getStartLine($n));
     }
 
@@ -400,7 +407,7 @@ class TolerantASTConverter
             /**
              * @param PhpParser\Node|Token $n
              * @return ast\Node - Not a real node, but a node indicating the TODO
-             * @throws InvalidArgumentException for invalid node classes
+             * @throws InvalidArgumentException|Exception for invalid node classes
              * @throws Error if the environment variable AST_THROW_INVALID is set to debug.
              */
             $fallback_closure = function ($n, int $unused_start_line) {
@@ -412,6 +419,7 @@ class TolerantASTConverter
             };
         }
         $callback = $callback_map[\get_class($n)] ?? $fallback_closure;
+        // @phan-suppress-next-line PhanThrowTypeAbsent
         $result = $callback($n, self::$file_position_map->getStartLine($n));
         if (($result instanceof ast\Node) && $result->kind === ast\AST_NAME) {
             return new ast\Node(ast\AST_CONST, 0, ['name' => $result], $result->lineno);
@@ -765,6 +773,7 @@ class TolerantASTConverter
                 }
             },
             'Microsoft\PhpParser\Node\Expression\ScriptInclusionExpression' => function (PhpParser\Node\Expression\ScriptInclusionExpression $n, int $start_line) : ast\Node {
+                // @phan-suppress-next-line PhanThrowTypeAbsentForCall should not happen
                 $flags = static::phpParserIncludeTokenToAstIncludeFlags($n->requireOrIncludeKeyword);
                 return new ast\Node(
                     ast\AST_INCLUDE_OR_EVAL,
@@ -992,6 +1001,7 @@ class TolerantASTConverter
             },
             /**
              * @return ast\Node|string
+             * @throws Exception if the tokens of the string literal are invalid, etc.
              */
             'Microsoft\PhpParser\Node\StringLiteral' => function (PhpParser\Node\StringLiteral $n, int $start_line) {
                 $children = $n->children;
@@ -2384,6 +2394,7 @@ class TolerantASTConverter
                 'default' => null,
             ];
         } else {
+            // @phan-suppress-next-line PhanThrowTypeMismatchForCall debugDumpNodeOrToken can throw
             throw new \InvalidArgumentException("Unexpected class for property element: Expected Variable or AssignmentExpression, got: " . static::debugDumpNodeOrToken($n));
         }
 
@@ -2715,6 +2726,9 @@ class TolerantASTConverter
         return StringUtil::parse($str);
     }
 
+    /**
+     * @throws Exception if node is invalid
+     */
     private static function parseQuotedString(PhpParser\Node\StringLiteral $n) : string
     {
         $start = $n->getStart();

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverterWithNodeMapping.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverterWithNodeMapping.php
@@ -187,6 +187,7 @@ class TolerantASTConverterWithNodeMapping extends TolerantASTConverter
                 }
             }
             if ($node_or_token instanceof PhpParser\Node) {
+                // @phan-suppress-next-line PhanThrowTypeAbsentForCall shouldn't happen for generated ASTs
                 $end_position = $node_or_token->getEndPosition();
                 // fprintf(STDERR, "Scanning over Node %s %d-%d\n", get_class($node_or_token), $node_or_token->getStart(), $end_position);
                 if ($end_position < $offset) {
@@ -340,6 +341,7 @@ class TolerantASTConverterWithNodeMapping extends TolerantASTConverter
             /**
              * @param PhpParser\Node|Token $n
              * @throws InvalidArgumentException for invalid token classes
+             * @suppress PhanThrowTypeMismatchForCall can throw if debugDumpNodeOrToken fails
              */
             $fallback_closure = function ($n, int $unused_start_line) : ast\Node {
                 if (!($n instanceof PhpParser\Node) && !($n instanceof Token)) {
@@ -382,6 +384,7 @@ class TolerantASTConverterWithNodeMapping extends TolerantASTConverter
              */
             $fallback_closure = function ($n, int $unused_start_line) : ast\Node {
                 if (!($n instanceof PhpParser\Node) && !($n instanceof Token)) {
+                    // @phan-suppress-next-line PhanThrowTypeMismatchForCall debugDumpNodeOrToken can throw
                     throw new InvalidArgumentException("Invalid type for node: " . (\is_object($n) ? \get_class($n) : \gettype($n)) . ": " . static::debugDumpNodeOrToken($n));
                 }
                 return static::astStub($n);

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -9,6 +9,7 @@ use Phan\AST\UnionTypeVisitor;
 use Phan\AST\Visitor\KindVisitorImplementation;
 use Phan\BlockAnalysisVisitor;
 use Phan\CodeBase;
+use Phan\Exception\FQSENException;
 use Phan\Exception\IssueException;
 use Phan\Issue;
 use Phan\Language\Context;
@@ -643,8 +644,8 @@ class ConditionVisitor extends KindVisitorImplementation implements ConditionVis
                 return;
             }
             try {
-                $fqsen = FullyQualifiedClassName::fromFullyQualifiedUserProvidedString($class_name);
-            } catch (\InvalidArgumentException $_) {
+                $fqsen = FullyQualifiedClassName::fromFullyQualifiedString($class_name);
+            } catch (FQSENException $_) {
                 throw new IssueException(Issue::fromType(Issue::TypeComparisonToInvalidClass)(
                     $context->getFile(),
                     $context->getLineNumberStart(),

--- a/src/Phan/Analysis/ConditionVisitorUtil.php
+++ b/src/Phan/Analysis/ConditionVisitorUtil.php
@@ -3,7 +3,6 @@ namespace Phan\Analysis;
 
 use ast;
 use ast\Node;
-use InvalidArgumentException;
 use Phan\Analysis\ConditionVisitor\BinaryCondition;
 use Phan\Analysis\ConditionVisitor\ComparisonCondition;
 use Phan\Analysis\ConditionVisitor\IdenticalCondition;
@@ -14,6 +13,7 @@ use Phan\BlockAnalysisVisitor;
 use Phan\CodeBase;
 use Phan\Config;
 use Phan\Exception\IssueException;
+use Phan\Exception\FQSENException;
 use Phan\Issue;
 use Phan\IssueFixSuggester;
 use Phan\Language\Context;
@@ -540,8 +540,8 @@ trait ConditionVisitorUtil
         }
         $fqsen_string = '\\' . $expr_value;
         try {
-            $fqsen = FullyQualifiedClassName::fromFullyQualifiedUserProvidedString($fqsen_string);
-        } catch (InvalidArgumentException $_) {
+            $fqsen = FullyQualifiedClassName::fromFullyQualifiedString($fqsen_string);
+        } catch (FQSENException $_) {
             Issue::maybeEmit(
                 $this->code_base,
                 $this->context,

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -17,7 +17,6 @@ use Phan\Exception\EmptyFQSENException;
 use Phan\Exception\FQSENException;
 use Phan\Exception\IssueException;
 use Phan\Exception\NodeException;
-use Phan\Exception\UnanalyzableException;
 use Phan\Issue;
 use Phan\IssueFixSuggester;
 use Phan\Language\Context;
@@ -3280,8 +3279,10 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 ))->getProperty(
                     true
                 );
-            } catch (UnanalyzableException $_) {
-                // Ignore it. There's nothing we can do. (E.g. the class name for the static property fetch couldn't be determined.
+            } catch (IssueException $_) {
+                // Hopefully caught elsewhere
+            } catch (NodeException $_) {
+                // Hopefully caught elsewhere
             }
         }
 

--- a/src/Phan/Daemon.php
+++ b/src/Phan/Daemon.php
@@ -3,6 +3,7 @@ namespace Phan;
 
 use AssertionError;
 use Closure;
+use Exception;
 use InvalidArgumentException;
 use Phan\Daemon\ExitException;
 use Phan\Daemon\Request;
@@ -31,6 +32,8 @@ class Daemon
      *
      * @return Request|null - A writable request, which has been fully read from.
      * Callers should close after they are finished writing.
+     *
+     * @throws Exception if analysis fails unexpectedly
      */
     public static function run(CodeBase $code_base, Closure $file_path_lister)
     {
@@ -124,6 +127,8 @@ class Daemon
     /**
      * @return void - A writable request, which has been fully read from.
      * Callers should close after they are finished writing.
+     *
+     * @throws Exception if analysis failed in an unexpected way
      */
     private static function runWithoutPcntl(CodeBase $code_base, Closure $file_path_lister)
     {
@@ -193,6 +198,7 @@ class Daemon
 
     /**
      * @return void
+     * @throws Exception if analysis throws
      */
     private static function analyzeDaemonRequestOnMainThread(CodeBase $code_base, Request $request)
     {

--- a/src/Phan/Exception/FQSENException.php
+++ b/src/Phan/Exception/FQSENException.php
@@ -23,7 +23,7 @@ class FQSENException extends Exception
         string $message,
         string $fqsen
     ) {
-        parent::__construct($message);
+        parent::__construct($message . " for FQSEN '$fqsen'");
         $this->fqsen = $fqsen;
     }
 

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -2,6 +2,7 @@
 namespace Phan\Language\Element;
 
 use Closure;
+use LogicException;
 use Phan\Analysis\AbstractMethodAnalyzer;
 use Phan\Analysis\ClassInheritanceAnalyzer;
 use Phan\Analysis\CompositionAnalyzer;
@@ -33,6 +34,7 @@ use Phan\Library\Option;
 use Phan\Library\Some;
 use Phan\Memoize;
 use Phan\Plugin\ConfigPluginSet;
+use RuntimeException;
 
 /**
  * Clazz represents the information Phan knows about a class, trait, or interface,
@@ -438,7 +440,7 @@ class Clazz extends AddressableElement
      * @return FullyQualifiedClassName
      * The parent class of this class if one exists
      *
-     * @throws \Exception
+     * @throws LogicException
      * An exception is thrown if this class has no parent
      */
     public function getParentClassFQSEN() : FullyQualifiedClassName
@@ -446,7 +448,7 @@ class Clazz extends AddressableElement
         $parent_type_option = $this->getParentTypeOption();
 
         if (!$parent_type_option->isDefined()) {
-            throw new \Exception("Class $this has no parent");
+            throw new LogicException("Class $this has no parent");
         }
 
         return FullyQualifiedClassName::fromType($parent_type_option->get());
@@ -456,7 +458,7 @@ class Clazz extends AddressableElement
      * @return Clazz
      * The parent class of this class if defined
      *
-     * @throws \Exception
+     * @throws LogicException|RuntimeException
      * An exception is thrown if this class has no parent
      */
     public function getParentClass(CodeBase $code_base) : Clazz
@@ -464,14 +466,14 @@ class Clazz extends AddressableElement
         $parent_type_option = $this->getParentTypeOption();
 
         if (!$parent_type_option->isDefined()) {
-            throw new \Exception("Class $this has no parent");
+            throw new LogicException("Class $this has no parent");
         }
 
         $parent_fqsen = FullyQualifiedClassName::fromType($parent_type_option->get());
 
         // invoking hasClassWithFQSEN also has the side effect of lazily loading the parent class definition.
         if (!$code_base->hasClassWithFQSEN($parent_fqsen)) {
-            throw new \Exception("Failed to load parent Class $parent_fqsen of Class $this");
+            throw new RuntimeException("Failed to load parent Class $parent_fqsen of Class $this");
         }
 
         return $code_base->getClassByFQSEN(
@@ -483,7 +485,7 @@ class Clazz extends AddressableElement
      * @return Clazz
      * The parent class of this class if defined
      *
-     * @throws \Exception
+     * @throws LogicException|RuntimeException
      * An exception is thrown if this class has no parent
      */
     private function getParentClassWithoutHydrating(CodeBase $code_base) : Clazz
@@ -491,14 +493,14 @@ class Clazz extends AddressableElement
         $parent_type_option = $this->getParentTypeOption();
 
         if (!$parent_type_option->isDefined()) {
-            throw new \Exception("Class $this has no parent");
+            throw new LogicException("Class $this has no parent");
         }
 
         $parent_fqsen = FullyQualifiedClassName::fromType($parent_type_option->get());
 
         // invoking hasClassWithFQSEN also has the side effect of lazily loading the parent class definition.
         if (!$code_base->hasClassWithFQSEN($parent_fqsen)) {
-            throw new \Exception("Failed to load parent Class $parent_fqsen of Class $this");
+            throw new RuntimeException("Failed to load parent Class $parent_fqsen of Class $this");
         }
 
         return $code_base->getClassByFQSENWithoutHydrating(

--- a/src/Phan/Language/FQSEN/FullyQualifiedClassName.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedClassName.php
@@ -1,7 +1,7 @@
 <?php declare(strict_types=1);
 namespace Phan\Language\FQSEN;
 
-use InvalidArgumentException;
+use Phan\Exception\FQSENException;
 use Phan\Language\Type;
 use Phan\Language\UnionType;
 use Phan\Memoize;
@@ -53,6 +53,7 @@ class FullyQualifiedClassName extends FullyQualifiedGlobalStructuralElement
     /**
      * Asserts that something is a valid class FQSEN in PHPDoc.
      * Use this for FQSENs passed in from the analyzed code.
+     * @suppress PhanUnreferencedPublicMethod
      */
     public static function isValidClassFQSEN(string $type) : bool
     {
@@ -67,13 +68,12 @@ class FullyQualifiedClassName extends FullyQualifiedGlobalStructuralElement
      *
      * @return static
      *
-     * @throws InvalidArgumentException on failure.
+     * @throws FQSENException on failure.
+     * @deprecated use self::fromFullyQualifiedString()
+     * @suppress PhanUnreferencedPublicMethod
      */
     public static function fromFullyQualifiedUserProvidedString(string $fully_qualified_string) : FullyQualifiedClassName
     {
-        if (!self::isValidClassFQSEN($fully_qualified_string)) {
-            throw new InvalidArgumentException("Invalid class FQSEN '$fully_qualified_string'");
-        }
         return self::fromFullyQualifiedString($fully_qualified_string);
     }
 
@@ -83,6 +83,7 @@ class FullyQualifiedClassName extends FullyQualifiedGlobalStructuralElement
      */
     public function asType() : Type
     {
+        // @phan-suppress-next-line PhanThrowTypeAbsentForCall the creation of FullyQualifiedClassName checks for FQSENException.
         return Type::fromFullyQualifiedString(
             $this->__toString()
         );
@@ -104,6 +105,7 @@ class FullyQualifiedClassName extends FullyQualifiedGlobalStructuralElement
     public static function getStdClassFQSEN() : FullyQualifiedClassName
     {
         return self::memoizeStatic(__METHOD__, function () : FullyQualifiedClassName {
+            // @phan-suppress-next-line PhanThrowTypeAbsentForCall
             return self::fromFullyQualifiedString("\stdClass");
         });
     }

--- a/src/Phan/Language/FQSEN/FullyQualifiedFunctionName.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedFunctionName.php
@@ -3,6 +3,7 @@ namespace Phan\Language\FQSEN;
 
 use ast\Node;
 use Phan\Exception\EmptyFQSENException;
+use Phan\Exception\FQSENException;
 use Phan\Language\Context;
 
 /**
@@ -39,8 +40,8 @@ class FullyQualifiedFunctionName extends FullyQualifiedGlobalStructuralElement i
      * @param Context $context
      * The context in which the FQSEN string was found
      *
-     * @throws EmptyFQSENException
-     * if $fqsen_string has an empty name component.
+     * @throws FQSENException
+     * if $fqsen_string has an empty/invalid name component.
      */
     public static function fromStringInContext(
         string $fqsen_string,
@@ -98,6 +99,7 @@ class FullyQualifiedFunctionName extends FullyQualifiedGlobalStructuralElement i
 
         $name = 'closure_' . substr(md5($hash_material), 0, 12);
 
+        // @phan-suppress-next-line PhanThrowTypeAbsentForCall this is valid
         return static::fromStringInContext(
             $name,
             $context

--- a/src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php
@@ -207,8 +207,13 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN
                 }
 
                 $namespace = '\\' . \implode('\\', $parts);
-                if ($namespace !== '\\' && !preg_match(self::VALID_STRUCTURAL_ELEMENT_REGEX, $namespace)) {
-                    throw new InvalidFQSENException("The namespace $namespace is invalid", $fqsen_string);
+                if ($namespace !== '\\') {
+                    if (!preg_match(self::VALID_STRUCTURAL_ELEMENT_REGEX, $namespace)) {
+                        throw new InvalidFQSENException("The namespace $namespace is invalid", $fqsen_string);
+                    }
+                } elseif (\count($parts) > 0) {
+                    // E.g. from `\\stdClass` with two backslashes
+                    throw new InvalidFQSENException("The namespace cannot have empty parts", $fqsen_string);
                 }
 
                 return static::make(

--- a/src/Phan/LanguageServer/LanguageServer.php
+++ b/src/Phan/LanguageServer/LanguageServer.php
@@ -4,6 +4,7 @@ namespace Phan\LanguageServer;
 use AdvancedJsonRpc;
 use AssertionError;
 use Closure;
+use Exception;
 use Phan\CodeBase;
 use Phan\Config;
 use Phan\Daemon\ExitException;
@@ -569,6 +570,7 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
         }
 
         if (Config::getValue('language_server_use_pcntl_fallback')) {
+            // @phan-suppress-next-line PhanThrowTypeAbsentForCall
             $this->finishAnalyzingURIsWithoutPcntl($uris_to_analyze);
             return;
         }
@@ -643,6 +645,8 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
     /**
      * @param array<string,string> $uris_to_analyze
      * @return void
+     *
+     * @throws Exception if analysis throws an exception
      *
      * @suppress PhanAccessMethodInternal
      */

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -13,6 +13,7 @@ use Phan\Config;
 use Phan\Daemon;
 use Phan\Exception\FQSENException;
 use Phan\Exception\IssueException;
+use Phan\Exception\UnanalyzableException;
 use Phan\Issue;
 use Phan\Language\Context;
 use Phan\Language\Element\ClassConstant;
@@ -210,11 +211,11 @@ class ParseVisitor extends ScopeVisitor
                             ));
                     } else {
                         $parent_class_name =
-                            $this->context->getNamespace() . '\\' . $parent_class_name;
+                            \rtrim($this->context->getNamespace(), '\\') . '\\' . $parent_class_name;
                     }
                 } elseif ($extends_node->flags & \ast\flags\NAME_RELATIVE) {
                     $parent_class_name =
-                        $this->context->getNamespace() . '\\' . $parent_class_name;
+                        \rtrim($this->context->getNamespace(), '\\') . '\\' . $parent_class_name;
                 }
                 // $extends_node->flags is 0 when it is fully qualified?
 
@@ -272,6 +273,8 @@ class ParseVisitor extends ScopeVisitor
      * @return Context
      * A new or an unchanged context resulting from
      * parsing the node
+     *
+     * @throws UnanalyzableException if saw an invalid AST node (e.g. from polyfill)
      */
     public function visitUseTrait(Node $node) : Context
     {

--- a/src/Phan/Phan.php
+++ b/src/Phan/Phan.php
@@ -90,6 +90,8 @@ class Phan implements IgnoredFilesFilterInterface
      * true if issues were found.
      *
      * @see \Phan\CodeBase
+     *
+     * @throws Exception if analysis fails unrecoverably or in an unexpected way
      */
     public static function analyzeFileList(
         CodeBase $code_base,

--- a/tests/Phan/AST/TolerantASTConverter/ErrorTolerantConversionTest.php
+++ b/tests/Phan/AST/TolerantASTConverter/ErrorTolerantConversionTest.php
@@ -359,6 +359,7 @@ EOT;
             $dumper = new NodeDumper($incomplete_contents);
             $dumper->setIncludeTokenKind(true);
             $dumper->setIncludeOffset(true);
+            // @phan-suppress-next-line PhanThrowTypeAbsentForCall should not happen and unit test would fail
             $dump = $dumper->dumpTreeAsString($php_parser_node);
             $original_ast_dump = Debug::nodeToString($ast);
             $modified_ast_dump = Debug::nodeToString($fallback_ast);

--- a/tests/Phan/AST/TolerantASTConverter/TolerantASTConverterWithNodeMappingTest.php
+++ b/tests/Phan/AST/TolerantASTConverter/TolerantASTConverterWithNodeMappingTest.php
@@ -83,6 +83,7 @@ final class TolerantASTConverterWithNodeMappingTest extends BaseTest
     {
         $converter = new TolerantASTConverterWithNodeMapping($byte_offset);
         $errors = [];
+        // @phan-suppress-next-line PhanThrowTypeAbsentForCall don't care in unit test
         $ast = $converter->parseCodeAsPHPAST($file_contents, TolerantASTConverter::AST_VERSION, $errors);
         if (count($errors) > 0) {
             throw new InvalidArgumentException("Unexpected errors: " . json_encode($errors));

--- a/tests/Phan/AbstractPhanFileTest.php
+++ b/tests/Phan/AbstractPhanFileTest.php
@@ -175,6 +175,7 @@ abstract class AbstractPhanFileTest extends BaseTest implements CodeBaseAwareTes
         Phan::setPrinter($printer);
         Phan::setIssueCollector(new BufferingCollector());
 
+        // @phan-suppress-next-line PhanThrowTypeAbsentForCall should not throw Exception for any passing tests
         Phan::analyzeFileList($this->code_base, function () use ($test_file_list) : array {
             return $test_file_list;
         });

--- a/tests/files/expected/0583_define_global_constant.php.expected
+++ b/tests/files/expected/0583_define_global_constant.php.expected
@@ -4,4 +4,5 @@
 %s:12 PhanUndeclaredConstant Reference to undeclared constant \test2207\TEST2
 %s:14 PhanInvalidConstantFQSEN '\' is an invalid FQSEN for a constant
 %s:15 PhanInvalidConstantFQSEN 'foo\\TEST3' is an invalid FQSEN for a constant
+%s:16 PhanInvalidConstantFQSEN '\\TEST4' is an invalid FQSEN for a constant
 %s:19 PhanUndeclaredConstant Reference to undeclared constant \test2207\TEST5


### PR DESCRIPTION
More work will be done in the future.

Also, warn about `'\\fqsen'` being invalid in define(), etc.