### PR TITLE
 Improve Phan's analysis of generics/templates in classes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@ Phan NEWS
 ?? ??? 201?, Phan 1.1.8 (dev)
 -----------------------
 
+New features(Analysis):
++ Infer more accurate types for return values/expected arguments of methods of template classes.
++ Support template types in magic methods and properties. (related to #497)
+
 08 Dec 2018, Phan 1.1.7
 -----------------------
 

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -762,10 +762,17 @@ class ContextNode
         // looking for
         foreach ($class_list as $class) {
             if ($class->hasMethodWithName($this->code_base, $method_name, $is_direct)) {
-                return $class->getMethodByName(
+                $method = $class->getMethodByName(
                     $this->code_base,
                     $method_name
                 );
+                if ($method->hasTemplateType()) {
+                    return $method->resolveTemplateType(
+                        $this->code_base,
+                        UnionTypeVisitor::unionTypeFromNode($this->code_base, $this->context, $node->children['expr'] ?? $node->children['class'])
+                    );
+                }
+                return $method;
             } elseif (!$is_static && $class->allowsCallingUndeclaredInstanceMethod($this->code_base)) {
                 return $class->getCallMethod($this->code_base);
             } elseif ($is_static && $class->allowsCallingUndeclaredStaticMethod($this->code_base)) {

--- a/src/Phan/Analysis/ArgumentType.php
+++ b/src/Phan/Analysis/ArgumentType.php
@@ -542,6 +542,17 @@ final class ArgumentType
             // We resolve them if possible in ContextNode->getMethod()
             return;
         }
+        if ($parameter_type->hasTemplateParameterTypes()) {
+            // TODO: Make the check for templates recursive
+            $argument_type_expanded_templates = $argument_type->asExpandedTypesPreservingTemplate($code_base);
+            if ($argument_type_expanded_templates->canCastToUnionTypeHandlingTemplates($parameter_type, $code_base)) {
+                // - can cast MyClass<\stdClass> to MyClass<mixed>
+                // - can cast Some<\stdClass> to Option<\stdClass>
+                // - cannot cast Some<\SomeOtherClass> to Option<\stdClass>
+                return;
+            }
+            // echo "Debug: $argument_type $argument_type_expanded_templates cannot cast to $parameter_type\n";
+        }
 
         if ($method->isPHPInternal()) {
             // If we are not in strict mode and we accept a string parameter

--- a/src/Phan/Analysis/ArgumentType.php
+++ b/src/Phan/Analysis/ArgumentType.php
@@ -3,6 +3,7 @@ namespace Phan\Analysis;
 
 use AssertionError;
 use ast\Node;
+use Closure;
 use Phan\AST\ContextNode;
 use Phan\AST\UnionTypeVisitor;
 use Phan\CodeBase;
@@ -255,7 +256,7 @@ final class ArgumentType
      * @param CodeBase $code_base
      * The global code base
      *
-     * @param \Closure $get_argument_type (Node|string|int $node, int $i) -> UnionType
+     * @param Closure $get_argument_type (Node|string|int $node, int $i) -> UnionType
      * Fetches the types of individual arguments.
      */
     public static function analyzeForCallback(
@@ -263,7 +264,7 @@ final class ArgumentType
         array $arg_nodes,
         Context $context,
         CodeBase $code_base,
-        \Closure $get_argument_type
+        Closure $get_argument_type
     ) {
         // Special common cases where we want slightly
         // better multi-signature error messages
@@ -346,7 +347,7 @@ final class ArgumentType
      * @param Context $context
      * The context in which we see the call
      *
-     * @param \Closure $get_argument_type (Node|string|int $node, int $i) -> UnionType
+     * @param Closure $get_argument_type (Node|string|int $node, int $i) -> UnionType
      *
      * @return void
      */
@@ -355,7 +356,7 @@ final class ArgumentType
         FunctionInterface $method,
         array $arg_nodes,
         Context $context,
-        \Closure $get_argument_type
+        Closure $get_argument_type
     ) {
         // There's nothing reasonable we can do here
         if ($method instanceof Method) {
@@ -537,7 +538,8 @@ final class ArgumentType
         $parameter_type = $alternate_parameter->getNonVariadicUnionType();
 
         if ($parameter_type->hasTemplateType()) {
-            // Don't worry about template types
+            // Don't worry about **unresolved** template types.
+            // We resolve them if possible in ContextNode->getMethod()
             return;
         }
 

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -1286,8 +1286,10 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
     private function checkCanCastToReturnType(CodeBase $code_base, UnionType $expression_type, UnionType $method_return_type) : bool
     {
         if ($method_return_type->hasTemplateParameterTypes()) {
-            // TODO: Better casting logic for template types (E.g. should be able to cast None to Option<MyClass>, but not Some<int> to Option<MyClass>
-            return $expression_type->canCastToExpandedUnionType($method_return_type, $code_base);
+            // Perform a check that does a better job understanding rules of templates.
+            // (E.g. should be able to cast None to Option<MyClass>, but not Some<int> to Option<MyClass>
+            return $expression_type->asExpandedTypesPreservingTemplate($code_base)->canCastToUnionTypeHandlingTemplates($method_return_type, $code_base) ||
+                $expression_type->canCastToUnionTypeHandlingTemplates($method_return_type->asExpandedTypesPreservingTemplate($code_base), $code_base);
         }
         // We allow base classes to cast to subclasses, and subclasses to cast to base classes,
         // but don't allow subclasses to cast to subclasses on a separate branch of the inheritance tree

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -125,7 +125,7 @@ class CodeBase
     private $internal_function_fqsen_set;
 
     /**
-     * @var Set<FullyQualifiedMethodName>
+     * @var Set<Method>
      * The set of all methods
      */
     private $method_set;
@@ -209,9 +209,6 @@ class CodeBase
         $this->class_fqsen_class_map_map = new Map();
         $this->method_set = new Set();
         $this->internal_function_fqsen_set = new Set();
-        if (false) {
-            $this->internal_function_fqsen_set->attach(new \stdClass());
-        }
 
         // Add any pre-defined internal classes, interfaces,
         // constants, traits and functions

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -73,7 +73,7 @@ use function strtolower;
 class CodeBase
 {
     /**
-     * @var Map
+     * @var Map<FullyQualifiedClassName,Clazz>
      * A map from FQSEN to an internal or user defined class
      *
      * TODO: Improve Phan's self-analysis, allow the shorthand array access set syntax to be used without making bad inferences
@@ -82,56 +82,56 @@ class CodeBase
     private $fqsen_class_map;
 
     /**
-     * @var Map
+     * @var Map<FullyQualifiedClassName,Clazz>
      * A map from FQSEN to a user defined class
      */
     private $fqsen_class_map_user_defined;
 
     /**
-     * @var Map
+     * @var Map<FullyQualifiedClassName,Clazz>
      * A map from FQSEN to an internal class
      */
     private $fqsen_class_map_internal;
 
     /**
-     * @var Map
+     * @var Map<FullyQualifiedClassName,ReflectionClass>
      * A map from FQSEN to a ReflectionClass
      */
     private $fqsen_class_map_reflection;
 
     /**
-     * @var Map
+     * @var Map<FullyQualifiedClassName,ClassAliasRecord>
      * A map from FQSEN to set of ClassAliasRecord objects
      */
     private $fqsen_alias_map;
 
     /**
-     * @var Map
+     * @var Map<FullyQualifiedGlobalConstantName,GlobalConstant>
      * A map from FQSEN to a global constant
      */
     private $fqsen_global_constant_map;
 
     /**
-     * @var Map
+     * @var Map<FullyQualifiedFunctionName,Func>
      * A map from FQSEN to function
      */
     private $fqsen_func_map;
 
     /**
-     * @var Set
+     * @var Set<FullyQualifiedFunctionName>
      * A set of internal function FQSENs to lazily initialize.
      * Entries are removed as new entries get added to fqsen_func_map.
      */
     private $internal_function_fqsen_set;
 
     /**
-     * @var Set
+     * @var Set<FullyQualifiedMethodName>
      * The set of all methods
      */
     private $method_set;
 
     /**
-     * @var Map
+     * @var Map<FullyQualifiedClassName,ClassMap>
      * A map from FullyQualifiedClassName to a ClassMap,
      * an object that holds properties, methods and class
      * constants.
@@ -139,7 +139,7 @@ class CodeBase
     private $class_fqsen_class_map_map;
 
     /**
-     * @var array<string,Set>
+     * @var array<string,Set<Method>>
      * A map from a string method name to a Set of
      * Methods
      */
@@ -209,6 +209,9 @@ class CodeBase
         $this->class_fqsen_class_map_map = new Map();
         $this->method_set = new Set();
         $this->internal_function_fqsen_set = new Set();
+        if (false) {
+            $this->internal_function_fqsen_set->attach(new \stdClass());
+        }
 
         // Add any pre-defined internal classes, interfaces,
         // constants, traits and functions
@@ -924,7 +927,7 @@ class CodeBase
 
 
     /**
-     * @return Map
+     * @return Map<FullyQualifiedClassName,Clazz>
      * A map from FQSENs to classes which are internal.
      */
     public function getUserDefinedClassMap() : Map
@@ -933,7 +936,7 @@ class CodeBase
     }
 
     /**
-     * @return Map
+     * @return Map<FullyQualifiedClassName,Clazz>
      * A list of all classes which are internal.
      */
     public function getInternalClassMap() : Map
@@ -1015,7 +1018,7 @@ class CodeBase
     }
 
     /**
-     * @return Method[]
+     * @return array<string,Method>
      * The set of methods associated with the given class
      */
     public function getMethodMapByFullyQualifiedClassName(
@@ -1027,7 +1030,7 @@ class CodeBase
     }
 
     /**
-     * @return Set
+     * @return Set<Method>
      * A set of all known methods with the given name
      */
     public function getMethodSetByName(string $name) : Set
@@ -1043,7 +1046,7 @@ class CodeBase
     }
 
     /**
-     * @return Set
+     * @return Set<Func|Method>
      * The set of all methods and functions
      *
      * This is slow and should be used only for debugging.
@@ -1058,7 +1061,7 @@ class CodeBase
     }
 
     /**
-     * @return Set
+     * @return Set<Method>
      * The set of all methods that Phan is tracking.
      */
     public function getMethodSet() : Set
@@ -1157,7 +1160,7 @@ class CodeBase
     }
 
     /**
-     * @return Map
+     * @return Map<FullyQualifiedFunctionName,Func>
      */
     public function getFunctionMap() : Map
     {
@@ -1260,7 +1263,7 @@ class CodeBase
     }
 
     /**
-     * @return Map
+     * @return Map<FullyQualifiedGlobalConstantName,GlobalConstant>
      */
     public function getGlobalConstantMap() : Map
     {
@@ -1355,7 +1358,7 @@ class CodeBase
     }
 
     /**
-     * @return Map
+     * @return Map<FullyQualifiedClassName,ClassMap>
      */
     public function getClassMapMap() : Map
     {

--- a/src/Phan/Language/Element/Comment/Method.php
+++ b/src/Phan/Language/Element/Comment/Method.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 namespace Phan\Language\Element\Comment;
 
+use Phan\Language\Type\TemplateType;
 use Phan\Language\UnionType;
 
 /**
@@ -162,5 +163,19 @@ class Method
         }
 
         return $string;
+    }
+
+    /**
+     * Replace the resolved reference to class T (possibly namespaced) with a regular template type, in this (at)method annotation.
+     *
+     * @param array<string,TemplateType> $template_types maps the incorrectly resolved name to the template type
+     * @return void
+     */
+    public function convertTypesToTemplateTypes(array $template_types)
+    {
+        $this->type = $this->type->withConvertTypesToTemplateTypes($template_types);
+        foreach ($this->parameters as $parameter) {
+            $parameter->convertTypesToTemplateTypes($template_types);
+        }
     }
 }

--- a/src/Phan/Language/Element/Comment/Parameter.php
+++ b/src/Phan/Language/Element/Comment/Parameter.php
@@ -4,6 +4,7 @@ namespace Phan\Language\Element\Comment;
 
 use Phan\Language\Context;
 use Phan\Language\Element\Variable;
+use Phan\Language\Type\TemplateType;
 use Phan\Language\UnionType;
 
 /**
@@ -196,5 +197,16 @@ class Parameter
         }
 
         return $string;
+    }
+
+    /**
+     * Replace the resolved reference to class T (possibly namespaced) with a regular template type.
+     *
+     * @param array<string,TemplateType> $template_fix_map maps the incorrectly resolved name to the template type
+     * @return void
+     */
+    public function convertTypesToTemplateTypes(array $template_fix_map)
+    {
+        $this->type = $this->type->withConvertTypesToTemplateTypes($template_fix_map);
     }
 }

--- a/src/Phan/Language/Element/Comment/Property.php
+++ b/src/Phan/Language/Element/Comment/Property.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 namespace Phan\Language\Element\Comment;
 
+use Phan\Language\Type\TemplateType;
 use Phan\Language\UnionType;
 
 /**
@@ -103,5 +104,16 @@ class Property
         $string .= '$' . $this->name;
 
         return $string;
+    }
+
+    /**
+     * Replace the resolved reference to class T (possibly namespaced) with a regular template type.
+     *
+     * @param array<string,TemplateType> $template_fix_map maps the incorrectly resolved name to the template type
+     * @return void
+     */
+    public function convertTypesToTemplateTypes(array $template_fix_map)
+    {
+        $this->type = $this->type->withConvertTypesToTemplateTypes($template_fix_map);
     }
 }

--- a/src/Phan/Language/Element/Flags.php
+++ b/src/Phan/Language/Element/Flags.php
@@ -47,6 +47,7 @@ class Flags
     const IS_READ_ONLY = (1 << 21);
     const IS_WRITE_ONLY = (1 << 22);
     const HAS_STATIC_UNION_TYPE = (1 << 23);
+    const HAS_TEMPLATE_TYPE = (1 << 24);
 
     /**
      * Either enable or disable the given flag on

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -657,6 +657,9 @@ trait FunctionTrait
             }
         }
         $function->setPHPDocParameterTypeMap($valid_comment_parameter_type_map);
+        if ($function instanceof Method) {
+            $function->checkForTemplateTypes();
+        }
         // Special, for libraries which use this for to document variadic param lists.
     }
 

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -452,6 +452,13 @@ final class EmptyUnionType extends UnionType
         return true;  // Empty can cast to anything. See parent implementation.
     }
 
+    public function canCastToUnionTypeHandlingTemplates(
+        UnionType $target,
+        CodeBase $code_base
+    ) : bool {
+        return true;
+    }
+
     /**
      * @return bool
      * True if all types in this union are scalars
@@ -924,6 +931,36 @@ final class EmptyUnionType extends UnionType
         int $recursion_depth = 0
     ) : UnionType {
         return $this;
+    }
+
+    /**
+     * @param CodeBase $code_base
+     * The code base to use in order to find super classes, etc.
+     *
+     * @param int $recursion_depth
+     * This thing has a tendency to run-away on me. This tracks
+     * how bad I messed up by seeing how far the expanded types
+     * go
+     *
+     * @return UnionType
+     * Expands all class types to all inherited classes returning
+     * a superset of this type.
+     */
+    public function asExpandedTypesPreservingTemplate(
+        CodeBase $code_base,
+        int $recursion_depth = 0
+    ) : UnionType {
+        return $this;
+    }
+
+    public function replaceWithTemplateTypes(UnionType $template_union_type) : UnionType
+    {
+        return $template_union_type;
+    }
+
+    public function hasTypeWithFQSEN(Type $other) : bool
+    {
+        return false;
     }
 
     /**

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -1179,4 +1179,9 @@ final class EmptyUnionType extends UnionType
     {
         return $this;
     }
+
+    public function withConvertTypesToTemplateTypes(array $template_fix_map) : UnionType
+    {
+        return $this;
+    }
 }

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -2141,6 +2141,101 @@ class Type
 
     /**
      * @param CodeBase $code_base
+     * The code base to use in order to find super classes, etc.
+     *
+     * @param $recursion_depth
+     * This thing has a tendency to run-away on me. This tracks
+     * how bad I messed up by seeing how far the expanded types
+     * go
+     *
+     * @return UnionType
+     * Expands class types to all inherited classes returning
+     * a superset of this type.
+     */
+    public function asExpandedTypesPreservingTemplate(
+        CodeBase $code_base,
+        int $recursion_depth = 0
+    ) : UnionType {
+        // We're going to assume that if the type hierarchy
+        // is taller than some value we probably messed up
+        // and should bail out.
+        if ($recursion_depth >= 20) {
+            throw new RecursionDepthException("Recursion has gotten out of hand");
+        }
+        $union_type = $this->memoize(__METHOD__, /** @return UnionType */ function () use ($code_base, $recursion_depth) {
+            $union_type = $this->asUnionType();
+
+            $class_fqsen = $this->asFQSEN();
+
+            if (!($class_fqsen instanceof FullyQualifiedClassName)) {
+                return $union_type;
+            }
+
+            if (!$code_base->hasClassWithFQSEN($class_fqsen)) {
+                return $union_type;
+            }
+
+            $clazz = $code_base->getClassByFQSEN($class_fqsen);
+
+            $union_type = $union_type->withUnionType(
+                $clazz->getUnionType()
+            );
+
+            if (count($this->template_parameter_type_list) > 0) {
+                $template_union_type = $clazz->resolveParentTemplateType($this->getTemplateParameterTypeMap($code_base))->asExpandedTypesPreservingTemplate($code_base, $recursion_depth + 1);
+                $template_union_type = $template_union_type->withType($this);
+            } else {
+                $template_union_type = UnionType::empty();
+            }
+
+            $additional_union_type = $clazz->getAdditionalTypes();
+            if ($additional_union_type !== null) {
+                $union_type = $union_type->withUnionType($additional_union_type);
+            }
+
+            $representation = $this->__toString();
+            $recursive_union_type_builder = new UnionTypeBuilder();
+            // Recurse up the tree to include all types
+            if (count($this->template_parameter_type_list) > 0) {
+                $recursive_union_type_builder->addUnionType(
+                    $template_union_type
+                );
+            }
+
+            foreach ($union_type->getTypeSet() as $clazz_type) {
+                if ($clazz_type->__toString() !== $representation) {
+                    $recursive_union_type_builder->addUnionType(
+                        $clazz_type->asExpandedTypesPreservingTemplate(
+                            $code_base,
+                            $recursion_depth + 1
+                        )
+                    );
+                } else {
+                    $recursive_union_type_builder->addType($clazz_type);
+                }
+            }
+
+            // Add in aliases
+            // (If enable_class_alias_support is false, this will do nothing)
+            $fqsen_aliases = $code_base->getClassAliasesByFQSEN($class_fqsen);
+            foreach ($fqsen_aliases as $alias_fqsen_record) {
+                $alias_fqsen = $alias_fqsen_record->alias_fqsen;
+                $recursive_union_type_builder->addType(
+                    $alias_fqsen->asType()
+                );
+            }
+
+            $result = $recursive_union_type_builder->getUnionType();
+            if (!$template_union_type->isEmpty()) {
+                return $result->replaceWithTemplateTypes($template_union_type);
+            }
+            return $result;
+        });
+        return $union_type;
+    }
+
+    /**
+     * @param CodeBase $code_base
      *
      * @param Type $parent
      *
@@ -2175,6 +2270,22 @@ class Type
     {
         foreach ($target_type_set as $target_type) {
             if ($this->canCastToType($target_type)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @param Type[] $target_type_set 1 or more types
+     * @return bool
+     * True if this Type can be cast to the given Type cleanly.
+     * This is overridden by ArrayShapeType to allow array{a:string,b:stdClass} to cast to string[]|stdClass[]
+     */
+    public function canCastToAnyTypeInSetHandlingTemplates(array $target_type_set, CodeBase $code_base) : bool
+    {
+        foreach ($target_type_set as $target_type) {
+            if ($this->canCastToTypeHandlingTemplates($target_type, $code_base)) {
                 return true;
             }
         }
@@ -2228,6 +2339,52 @@ class Type
     }
 
     /**
+     * @return bool
+     * True if this Type can be cast to the given Type
+     * cleanly (accounting for templates)
+     */
+    public function canCastToTypeHandlingTemplates(Type $type, CodeBase $code_base) : bool
+    {
+        // Check to see if we have an exact object match
+        if ($this === $type) {
+            return true;
+        }
+
+        if ($type instanceof MixedType) {
+            return true;
+        }
+
+        // A nullable type cannot cast to a non-nullable type
+        if ($this->is_nullable && !$type->is_nullable) {
+            // If this is nullable, but that isn't, and we've
+            // configured nulls to cast as anything (or as arrays), ignore
+            // the nullable part.
+            if (Config::get_null_casts_as_any_type()) {
+                return $this->withIsNullable(false)->canCastToType($type);
+            } elseif (Config::get_null_casts_as_array() && $type->isArrayLike()) {
+                return $this->withIsNullable(false)->canCastToType($type);
+            }
+
+            return false;
+        }
+
+        // Get a non-null version of the type we're comparing
+        // against.
+        if ($type->is_nullable) {
+            $type = $type->withIsNullable(false);
+
+            // Check one more time to see if the types are equal
+            if ($this === $type) {
+                return true;
+            }
+        }
+
+        // Test to see if we can cast to the non-nullable version
+        // of the target type.
+        return $this->canCastToNonNullableTypeHandlingTemplates($type, $code_base);
+    }
+
+    /**
      * @param Type $type
      * A Type which is not nullable. This constraint is not
      * enforced, so be careful.
@@ -2265,6 +2422,41 @@ class Type
             return $this->namespace === '\\' && $this->name === 'Closure';
         }
         return false;
+    }
+
+    /**
+     * @param Type $type
+     * A Type which is not nullable. This constraint is not
+     * enforced, so be careful.
+     *
+     * @return bool
+     * True if this Type can be cast to the given Type
+     * cleanly
+     */
+    protected function canCastToNonNullableTypeHandlingTemplates(Type $type, CodeBase $code_base) : bool
+    {
+        if ($this->canCastToNonNullableType($type)) {
+            return true;
+        }
+        if ($this->isObjectWithKnownFQSEN() && $type->isObjectWithKnownFQSEN()) {
+            if ($this->name === $type->name && $this->namespace === $type->namespace) {
+                return $this->canTemplateTypesCast($type->template_parameter_type_list, $code_base);
+            }
+        }
+        return false;
+    }
+
+    private function canTemplateTypesCast(array $other_template_parameter_type_list, CodeBase $code_base) : bool
+    {
+        foreach ($this->template_parameter_type_list as $i => $param) {
+            $other_param = $other_template_parameter_type_list[$i] ?? null;
+            if ($other_param !== null) {
+                if (!$param->asExpandedTypes($code_base)->canCastToUnionType($other_param)) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 
     /**
@@ -2860,5 +3052,12 @@ class Type
             return false;
         }
         return \count($this->template_parameter_type_list) > 0;
+    }
+    /**
+     * Precondition: Callers should check isObjectWithKnownFQSEN
+     */
+    public function hasSameNamespaceAndName(Type $type) : bool
+    {
+        return $this->name === $type->name && $this->namespace === $type->namespace;
     }
 }

--- a/src/Phan/Language/Type/FunctionLikeDeclarationType.php
+++ b/src/Phan/Language/Type/FunctionLikeDeclarationType.php
@@ -192,6 +192,16 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
     }
 
     /**
+     * @override (Don't include \Closure in the expanded types. It interferes with type casting checking)
+     */
+    public function asExpandedTypesPreservingTemplate(
+        CodeBase $unused_code_base,
+        int $unused_recursion_depth = 0
+    ) : UnionType {
+        return $this->asUnionType();
+    }
+
+    /**
      * @param bool $is_nullable
      * Set to true if the type should be nullable, else pass
      * false

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -360,6 +360,82 @@ final class GenericArrayType extends ArrayType implements GenericArrayInterface
         });
     }
 
+    /**
+     * @param CodeBase $code_base
+     * The code base to use in order to find super classes, etc.
+     *
+     * @param $recursion_depth
+     * This thing has a tendency to run-away on me. This tracks
+     * how bad I messed up by seeing how far the expanded types
+     * go
+     *
+     * @return UnionType
+     * Expands class types to all inherited classes returning
+     * a superset of this type.
+     * @override
+     */
+    public function asExpandedTypesPreservingTemplate(
+        CodeBase $code_base,
+        int $recursion_depth = 0
+    ) : UnionType {
+        // We're going to assume that if the type hierarchy
+        // is taller than some value we probably messed up
+        // and should bail out.
+        if ($recursion_depth >= 20) {
+            throw new RecursionDepthException("Recursion has gotten out of hand");
+        }
+
+        return $this->memoize(__METHOD__, function () use ($code_base, $recursion_depth) : UnionType {
+            $union_type = $this->asUnionType();
+
+            $class_fqsen = FullyQualifiedClassName::fromType($this->genericArrayElementType());
+
+
+            if (!$code_base->hasClassWithFQSEN($class_fqsen)) {
+                return $union_type;
+            }
+
+            $clazz = $code_base->getClassByFQSEN($class_fqsen);
+
+            $class_union_type = $clazz->getUnionType();
+            $additional_union_type = $clazz->getAdditionalTypes();
+            if ($additional_union_type !== null) {
+                $class_union_type = $class_union_type->withUnionType($additional_union_type);
+            }
+
+            $union_type = $union_type->withUnionType(
+                $class_union_type->asGenericArrayTypes($this->key_type)
+            );
+
+            // Recurse up the tree to include all types
+            $recursive_union_type_builder = new UnionTypeBuilder();
+            $representation = $this->__toString();
+            try {
+                foreach ($union_type->getTypeSet() as $clazz_type) {
+                    if ($clazz_type->__toString() !== $representation) {
+                        $recursive_union_type_builder->addUnionType(
+                            $clazz_type->asExpandedTypesPreservingTemplate(
+                                $code_base,
+                                $recursion_depth + 1
+                            )
+                        );
+                    } else {
+                        $recursive_union_type_builder->addType($clazz_type);
+                    }
+                }
+            } catch (RecursionDepthException $_) {
+                return ArrayType::instance($this->is_nullable)->asUnionType();
+            }
+
+            // Add in aliases
+            // (If enable_class_alias_support is false, this will do nothing)
+            if (Config::getValue('enable_class_alias_support')) {
+                self::addClassAliases($code_base, $recursive_union_type_builder, $class_fqsen);
+            }
+            return $recursive_union_type_builder->getUnionType();
+        });
+    }
+
     // (If enable_class_alias_support is false, this will not be called)
     private function addClassAliases(
         CodeBase $code_base,

--- a/src/Phan/Language/Type/NativeType.php
+++ b/src/Phan/Language/Type/NativeType.php
@@ -228,6 +228,23 @@ abstract class NativeType extends Type
     {
         return null;
     }
+
+    /**
+     * Replace the resolved reference to class T (possibly namespaced) with a regular template type.
+     *
+     * @param array<string,TemplateType> $template_fix_map maps the incorrectly resolved name to the template type @phan-unused-param
+     * @return Type
+     */
+    public function withConvertTypesToTemplateTypes(array $template_fix_map) : Type
+    {
+        // TODO: Override in subclasses
+        return $this;
+    }
+
+    public function isTemplateSubtypeOf(Type $unused_type) : bool
+    {
+        return false;
+    }
 }
 \class_exists(ArrayType::class);
 \class_exists(ScalarType::class);

--- a/src/Phan/Language/Type/NativeType.php
+++ b/src/Phan/Language/Type/NativeType.php
@@ -208,6 +208,26 @@ abstract class NativeType extends Type
         return $this->asUnionType();
     }
 
+    /**
+     * @param CodeBase $code_base @phan-unused-param
+     * The code base to use in order to find super classes, etc.
+     *
+     * @param int $recursion_depth @phan-unused-param
+     * This thing has a tendency to run-away on me. This tracks
+     * how bad I messed up by seeing how far the expanded types
+     * go
+     *
+     * @return UnionType
+     * Does nothing for Native Types, but GenericArrayType is an exception to that.
+     * @override
+     */
+    public function asExpandedTypesPreservingTemplate(
+        CodeBase $code_base,
+        int $recursion_depth = 0
+    ) : UnionType {
+        return $this->asUnionType();
+    }
+
     public function hasTemplateParameterTypes() : bool
     {
         return false;

--- a/src/Phan/Language/Type/TemplateType.php
+++ b/src/Phan/Language/Type/TemplateType.php
@@ -67,4 +67,15 @@ final class TemplateType extends Type
     {
         return true;
     }
+
+    /**
+     * Replace the resolved reference to class T (possibly namespaced) with a regular template type.
+     *
+     * @param array<string,TemplateType> $template_fix_map maps the incorrectly resolved name to the template type @phan-unused-param
+     * @return Type
+     */
+    public function withConvertTypesToTemplateTypes(array $template_fix_map) : Type
+    {
+        return $this;
+    }
 }

--- a/src/Phan/Library/Map.php
+++ b/src/Phan/Library/Map.php
@@ -2,19 +2,23 @@
 namespace Phan\Library;
 
 use Closure;
+use SplObjectStorage;
 
 /**
  * A map from object to object with key comparisons
  * based on spl_object_hash.
+ *
+ * @template K
+ * @template V
  */
-class Map extends \SplObjectStorage
+class Map extends SplObjectStorage
 {
 
     /**
      * We redefine the key to be the actual key rather than
      * the index of the key
      *
-     * @return object
+     * @return K
      * @suppress PhanParamSignatureMismatchInternal - This is deliberately changing the phpdoc return type.
      */
     public function key()
@@ -25,6 +29,7 @@ class Map extends \SplObjectStorage
     /**
      * We redefine the current value to the current value rather
      * than the current key
+     * @return V
      */
     public function current()
     {
@@ -40,7 +45,7 @@ class Map extends \SplObjectStorage
      * A closure that maps each value of this map
      * to a new value.
      *
-     * @return Map
+     * @return Map<object,object>
      * A new map containing the mapped keys and
      * values
      */
@@ -55,7 +60,7 @@ class Map extends \SplObjectStorage
     }
 
     /**
-     * @return Map
+     * @return Map<K,V>
      * A new map with each key and value cloned
      * @suppress PhanUnreferencedPublicMethod possibly useful but currently unused
      */
@@ -73,7 +78,7 @@ class Map extends \SplObjectStorage
     }
 
     /**
-     * @return Map
+     * @return Map<K,V>
      * A new map with each value cloned (keys remain uncloned)
      */
     public function deepCopyValues() : Map
@@ -86,7 +91,7 @@ class Map extends \SplObjectStorage
     }
 
     /**
-     * @return Set
+     * @return Set<V>
      * A new set with the unique values from this map.
      * Precondition: values of this map are objects.
      * @suppress PhanUnreferencedPublicMethod possibly useful but currently unused
@@ -101,7 +106,7 @@ class Map extends \SplObjectStorage
     }
 
     /**
-     * @return Set
+     * @return Set<K>
      * A new set with the unique keys from this map.
      * Precondition: values of this set are objects.
      * @suppress PhanUnreferencedPublicMethod possibly useful but currently unused

--- a/src/Phan/Library/Set.php
+++ b/src/Phan/Library/Set.php
@@ -7,13 +7,31 @@ use TypeError;
 /**
  * A set of objects supporting union and
  * intersection
+ *
+ * @template T
+ *
+ * TODO: Start tracking that SplObjectStorage<T,T> extends ArrayAccess<T,T>
+ *
+ * - Afterwards, remove this boilerplate overriding methods of SplObjectStorage<T,T>
+ *
+ * @method attach(T,mixed=):void
+ * @method detach(T):void
+ * @method offsetExists(T):bool
+ * @method offsetGet(T):bool
+ * @method offsetSet(T,mixed=):void
+ * @method offsetUnset(T):void
+ *
+ * @phan-file-suppress PhanParamSignatureMismatchInternal, PhanParamSignaturePHPDocMismatchHasParamType for these comment method overrides
+ * TODO: Make suppressions in the class doc comment work for magic methods.
  */
 class Set extends \SplObjectStorage
 {
 
     /**
-     * @param iterable<object> $element_iterator
+     * @param iterable<T> $element_iterator
      * An optional set of items to add to the set
+     *
+     * @suppress PhanGenericConstructorTypes TODO: Support inferring the template from iterable<T>
      */
     public function __construct($element_iterator = null)
     {
@@ -23,7 +41,7 @@ class Set extends \SplObjectStorage
     }
 
     /**
-     * @return array
+     * @return array<T>
      * An array of all elements in the set is returned
      */
     public function toArray() : array
@@ -32,10 +50,10 @@ class Set extends \SplObjectStorage
     }
 
     /**
-     * @param Set $other
+     * @param Set<T> $other
      * A set of items to intersect with this set
      *
-     * @return Set
+     * @return Set<T>
      * A new set which contains only items in this
      * Set and the given Set
      */
@@ -51,10 +69,10 @@ class Set extends \SplObjectStorage
     }
 
     /**
-     * @param Set[] $set_list
+     * @param Set<T>[] $set_list
      * A list of sets to intersect
      *
-     * @return Set
+     * @return Set<T>
      * A new Set containing only the elements that appear in
      * all parameters
      * @suppress PhanUnreferencedPublicMethod potentially useful but currently unused
@@ -78,10 +96,10 @@ class Set extends \SplObjectStorage
     }
 
     /**
-     * @param Set $other
+     * @param Set<T> $other
      * A set of items to union with this set
      *
-     * @return Set
+     * @return Set<T>
      * A new set which contains only items in this
      * Set and the given Set.
      *
@@ -96,10 +114,10 @@ class Set extends \SplObjectStorage
     }
 
     /**
-     * @param Set[] $set_list
+     * @param Set<T>[] $set_list
      * A list of sets to intersect
      *
-     * @return Set
+     * @return Set<T>
      * A new Set containing any element that appear in
      * any parameters
      * @suppress PhanUnreferencedPublicMethod potentially useful but currently unused
@@ -124,7 +142,7 @@ class Set extends \SplObjectStorage
 
 
     /**
-     * @param array<object> $element_list
+     * @param T[] $element_list
      * @return bool
      * True if this set contains any elements in the given list
      * @suppress PhanUnreferencedPublicMethod potentially useful but currently unused
@@ -141,12 +159,12 @@ class Set extends \SplObjectStorage
     }
 
     /**
-     * @param Closure $closure
+     * @param Closure(T):bool $closure
      * A closure taking a set element that returns a boolean
      * for which true will cause the element to be retained
      * and false will cause the element to be removed
      *
-     * @return Set
+     * @return Set<T>
      * A new set for which all elements when passed to the given
      * closure return true
      * @suppress PhanUnreferencedPublicMethod potentially useful but currently unused
@@ -163,7 +181,7 @@ class Set extends \SplObjectStorage
     }
 
     /**
-     * @param Closure(object):object $closure
+     * @param Closure(T):object $closure
      * A closure that maps each element of this set
      * to a new element
      *
@@ -180,14 +198,14 @@ class Set extends \SplObjectStorage
     }
 
     /**
-     * @return Set
+     * @return Set<T>
      * A new set with each element cloned
      */
     public function deepCopy() : Set
     {
         return $this->map(
             /**
-             * @param object $element
+             * @param T $element
              * @return object
              */
             function ($element) {
@@ -197,10 +215,11 @@ class Set extends \SplObjectStorage
     }
 
     /**
-     * @param Closure $closure
+     * @param Closure(object):bool $closure
      * A closure that takes an element and returns a boolean
+     * TODO: Make this be Closure(T):bool and read the types from the template
      *
-     * @return mixed|bool
+     * @return T|false
      * The first element for which the given closure returns
      * true is returned or false if no elements pass the
      * given closure

--- a/tests/files/expected/0591_template_types.php.expected
+++ b/tests/files/expected/0591_template_types.php.expected
@@ -1,0 +1,8 @@
+%s:64 PhanTypeExpectedObjectPropAccess Expected an object instance when accessing an instance property, but saw an expression with type string
+%s:65 PhanTypeSuspiciousEcho Suspicious argument \stdClass for an echo/print statement
+%s:66 PhanTypeSuspiciousEcho Suspicious argument \ArrayObject for an echo/print statement
+%s:69 PhanTypeMismatchArgument Argument 1 (v) is \ArrayAccess|\ArrayObject|\Countable|\IteratorAggregate|\Serializable|\Traversable|iterable but \SingletonList::hasValue() takes \stdClass defined at %s:37
+%s:71 PhanTypeMismatchArgument Argument 1 (p1) is \ArrayAccess|\ArrayObject|\Countable|\IteratorAggregate|\Serializable|\Traversable|iterable but \SingletonList::hasValueMagic() takes \stdClass defined at %s:7
+%s:73 PhanTypeMismatchArgumentInternal Argument 1 (string) is array<int,T> but \strlen() takes string
+%s:74 PhanTypeMismatchArgumentInternal Argument 1 (string) is array<int,T> but \strlen() takes string
+%s:77 PhanTypeMismatchArgument Argument 1 (v) is \stdClass but \NodeSingletonList::hasValue() takes \ast\Node defined at %s:37

--- a/tests/files/expected/0592_template_types_either.php.expected
+++ b/tests/files/expected/0592_template_types_either.php.expected
@@ -1,0 +1,10 @@
+%s:80 PhanTypeMismatchArgument Argument 1 (e) is \MyNS\Either|\MyNS\Either<\stdClass,\stdClass> but \MyNS\expects_left_object() takes \MyNS\Left<\stdClass> defined at %s:90
+%s:92 PhanTypeSuspiciousEcho Suspicious argument \stdClass for an echo/print statement
+%s:100 PhanTypeMismatchArgument Argument 1 (e) is \MyNS\Either|\MyNS\Either<T,mixed>|\MyNS\Either<\ArrayObject,mixed>|\MyNS\Left|\MyNS\Left<\ArrayObject> but \MyNS\expects_left_object() takes \MyNS\Left<\stdClass> defined at %s:90
+%s:102 PhanTypeMismatchArgument Argument 1 (e) is \MyNS\Either|\MyNS\Either<mixed,T>|\MyNS\Either<mixed,\ArrayObject>|\MyNS\Right|\MyNS\Right<\ArrayObject> but \MyNS\expects_left_object() takes \MyNS\Left<\stdClass> defined at %s:90
+%s:103 PhanTypeMismatchArgument Argument 1 (e) is \MyNS\Either|\MyNS\Either<mixed,T>|\MyNS\Either<mixed,\stdClass>|\MyNS\Right|\MyNS\Right<\stdClass> but \MyNS\expects_left_object() takes \MyNS\Left<\stdClass> defined at %s:90
+%s:105 PhanTypeMismatchArgument Argument 1 (e) is \MyNS\Either|\MyNS\Either<T,mixed>|\MyNS\Either<\ArrayObject,mixed>|\MyNS\Left|\MyNS\Left<\ArrayObject> but \MyNS\expects_either_object() takes \MyNS\Either<\stdClass,\stdClass> defined at %s:78
+%s:107 PhanTypeMismatchArgument Argument 1 (e) is \MyNS\Either|\MyNS\Either<mixed,T>|\MyNS\Either<mixed,\ArrayObject>|\MyNS\Right|\MyNS\Right<\ArrayObject> but \MyNS\expects_either_object() takes \MyNS\Either<\stdClass,\stdClass> defined at %s:78
+%s:119 PhanTypeMismatchReturn Returning type \MyNS\Left<\stdClass> but returns_either_object() is declared to return \MyNS\Either<\ArrayObject,\ArrayObject>
+%s:121 PhanTypeMismatchReturn Returning type \MyNS\Right<\stdClass> but returns_either_object() is declared to return \MyNS\Either<\ArrayObject,\ArrayObject>
+%s:123 PhanTypeMismatchReturn Returning type \MyNS\Right<array> but returns_either_object() is declared to return \MyNS\Either<\ArrayObject,\ArrayObject>

--- a/tests/files/src/0591_template_types.php
+++ b/tests/files/src/0591_template_types.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * @template T
+ * @property T $value
+ * @property string $details
+ * @method hasValueMagic(T):bool
+ */
+class SingletonList {
+    private $_value;
+
+    /**
+     * @param T $value
+     */
+    public function __construct($value) {
+        $this->_value = $value;
+    }
+
+    public function __call($method, array $args) {
+        if ($method === 'hasValueMagic') {
+            return $args[0] === $this->_value;
+        }
+    }
+
+    public function __get($name) {
+        switch ($name) {
+            case 'value':
+                return $this->_value;
+            case 'details':
+                return json_encode($this->_value);
+        }
+    }
+
+    /**
+     * @param T $v
+     */
+    public function hasValue($v) : bool {
+        return $v === $this->_value;
+    }
+
+    /**
+     * @return array<int,T>
+     */
+    public function toArray() : array {
+        return [$this->_value];
+    }
+}
+
+/**
+ * @inherits SingletonList<ast\Node>
+ */
+class NodeSingletonList {
+    public function __construct() {
+        parent::__construct(new ast\Node());
+    }
+}
+
+call_user_func(function () {
+    // The error messages include the types
+    $o = new stdClass();
+    $l = new SingletonList($o);
+    $l2 = new SingletonList(new ArrayObject());
+    echo $l->details;
+    echo $l->details->property;  // Phan should infer $l->details is a string and warn
+    echo $l->value;  // should warn about stdClass
+    echo $l2->value;  // Should warn about this being ArrayObject
+    // TODO: Make Phan warn (It needs to resolve the types for hasValue and hasValueMagic when fetching the info)
+    var_export($l->hasValue($o));  // does not warn
+    var_export($l->hasValue(new ArrayObject()));  // does warn
+    var_export($l->hasValueMagic($o));  // does not warn
+    var_export($l->hasValueMagic(new ArrayObject()));  // should warn
+    // TODO: Make Phan recursively the return types in a future PR
+    echo strlen($l->toArray());
+    echo strlen($l2->toArray());
+
+    $n = new NodeSingletonList();
+    var_export($n->hasValue($o));  // should warn
+});

--- a/tests/files/src/0592_template_types_either.php
+++ b/tests/files/src/0592_template_types_either.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace MyNS;
+
+use ArrayObject;
+use RuntimeException;
+use stdClass;
+
+/**
+ * @template L
+ * @template R
+ */
+abstract class Either {
+    public abstract function getLeft();
+    public abstract function getRight();
+    public abstract function isLeft() : bool;
+}
+
+/**
+ * @template T
+ * @inherits Either<T,mixed>
+ */
+class Left extends Either {
+    /** @var T */
+    private $value;
+
+    /** @param T $value */
+    public function __construct($value) {
+        $this->value = $value;
+    }
+
+    /** @return T */
+    public function getLeft() {
+        return $this->value;
+    }
+
+    /** @throws RuntimeException */
+    public function getRight() {
+        throw new RuntimeException("Does not exist");
+    }
+
+    public function isLeft() : bool {
+        return true;
+    }
+}
+
+/**
+ * @template T
+ * @inherits Either<mixed,T>
+ */
+class Right extends Either {
+    /** @var T */
+    private $value;
+
+    /** @param T $value */
+    public function __construct($value) {
+        $this->value = $value;
+    }
+
+    /** @throws RuntimeException */
+    public function getLeft() {
+        throw new RuntimeException("Does not exist");
+    }
+
+    /** @return T */
+    public function getRight() {
+        return $this->value;
+    }
+
+    public function isLeft() : bool {
+        return false;
+    }
+}
+
+/**
+ * @param Either<stdClass,stdClass> $e
+ */
+function expects_either_object(Either $e) {
+    // should warn
+    expects_left_object($e);
+    if ($e instanceof Left) {
+        // should not warn
+        expects_left_object($e);
+    }
+}
+
+/**
+ * @param Left<stdClass> $e
+ */
+function expects_left_object(Left $e) {
+    var_export($e);
+    echo $e->getLeft();
+}
+
+call_user_func(function () {
+    $la = new Left(new ArrayObject());
+    $ls = new Left(new stdClass());
+    $ra = new Right(new ArrayObject());
+    $rs = new Right(new stdClass());
+    expects_left_object($la);  // should warn
+    expects_left_object($ls);  // should not warn
+    expects_left_object($ra);  // should warn
+    expects_left_object($rs);  // should warn
+
+    expects_either_object($la);  // should warn
+    expects_either_object($ls);  // should not warn
+    expects_either_object($ra);  // should warn
+    expects_either_object($rs);  // should not warn
+});
+
+/**
+ * @return Either<ArrayObject,ArrayObject>
+ */
+function returns_either_object(array $args) {
+    switch (rand() % 4) {
+    case 0:
+        return new Left(new ArrayObject());
+    case 1:
+        return new Left(new stdClass());  // should warn
+    case 2:
+        return new Right(new stdClass());  // should warn
+    case 3:
+        return new Right($args);  // should warn
+    default:
+        return new Right(new ArrayObject());  // should not warn
+    }
+}


### PR DESCRIPTION
Support templates in magic properties and methods.

Support type checking template types when passing arguments to methods of template instances, or when reading the return types of methods of template instances.