### PR TITLE
Improve duplicate key detection

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,10 @@ Phan NEWS
 New features(Analysis):
 + Warn about `split` and other functions that were removed in PHP 7.0 by default. (#2235, #2236)
   (`target_php_version` can now be set to `'5.6'` if you have a PHP 5.6 project that uses those)
++ Infer more accurate literal string for `::class` constant.
+
+Plugins:
++ Detect more possible duplicates in `DuplicateArrayKeyPlugin`
 
 Bug fixes:
 + Fix a bug parsing the CLI option `--target-php-version major.minor` (Phan will now correctly set the `target_php_version` config setting)

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -2238,12 +2238,17 @@ class ContextNode
             $this->context,
             $node
         );
-        return $node_type->asSingleScalarValueOrNull() ?? $node;
+        $value = $node_type->asSingleScalarValueOrNullOrSelf();
+        if (\is_object($value)) {
+            return $node;
+        }
+        return $value;
     }
 
     /**
      * @return array|string|int|float|bool|null|Node the value of the corresponding PHP constant,
      * or the original node if that could not be determined
+     * @suppress PhanUnreferencedPublicMethod
      */
     public function getValueForMagicConst()
     {

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1675,8 +1675,8 @@ class UnionTypeVisitor extends AnalysisVisitor
                 $this->code_base,
                 $this->context,
                 $part
-            )->asSingleScalarValueOrNull() : $part;
-            if ($part_string === null) {
+            )->asSingleScalarValueOrNullOrSelf() : $part;
+            if (\is_object($part_string)) {
                 return StringType::instance(false)->asUnionType();
             }
             $result .= $part_string;

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -572,7 +572,7 @@ class AssignmentVisitor extends AnalysisVisitor
                 $this->context,
                 $dim_node
             );
-            $dim_value = $dim_type->asSingleScalarValueOrNull();
+            $dim_value = $dim_type->asSingleScalarValueOrNullOrSelf();
         } elseif (\is_scalar($dim_node) && $dim_node !== null) {
             $dim_value = $dim_node;
             $dim_type = Type::fromObject($dim_node)->asUnionType();
@@ -582,7 +582,7 @@ class AssignmentVisitor extends AnalysisVisitor
             $dim_value = null;
         }
 
-        if ($dim_value !== null) {
+        if ($dim_type !== null && !\is_object($dim_value)) {
             $right_type = ArrayShapeType::fromFieldTypes([
                 $dim_value => $this->right_type,
             ], false)->asUnionType();

--- a/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
+++ b/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
@@ -412,8 +412,8 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
             $this->context,
             $left_node,
             $this->should_catch_issue_exception
-        )->asSingleScalarValueOrNull() : $left_node;
-        if ($left_value === null) {
+        )->asSingleScalarValueOrNullOrSelf() : $left_node;
+        if (\is_object($left_value)) {
             return StringType::instance(false)->asUnionType();
         }
         $right_node = $node->children['right'];
@@ -422,8 +422,8 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
             $this->context,
             $right_node,
             $this->should_catch_issue_exception
-        )->asSingleScalarValueOrNull() : $right_node;
-        if ($right_value === null) {
+        )->asSingleScalarValueOrNullOrSelf() : $right_node;
+        if (\is_object($right_value)) {
             return StringType::instance(false)->asUnionType();
         }
         return LiteralStringType::instanceForValue($left_value . $right_value, false)->asUnionType();

--- a/src/Phan/Analysis/ConditionVisitorUtil.php
+++ b/src/Phan/Analysis/ConditionVisitorUtil.php
@@ -282,11 +282,9 @@ trait ConditionVisitorUtil
                 if (!$expr_type) {
                     return $context;
                 }
-                $expr_value = $expr_type->asSingleScalarValueOrNull();
-                if ($expr_value === null) {
-                    if (!$expr_type->isType(NullType::instance(false))) {
-                        return $context;
-                    }
+                $expr_value = $expr_type->asSingleScalarValueOrNullOrSelf();
+                if (\is_object($expr_value)) {
+                    return $context;
                 }
                 // Get the variable we're operating on
                 $variable = $this->getVariableFromScope($var_node, $context);

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -2651,11 +2651,12 @@ class Clazz extends AddressableElement
         }
 
         // Create the 'class' constant
+        $class_constant_value = \ltrim($this->getFQSEN()->__toString(), '\\');
         $class_constant = new ClassConstant(
             $this->getContext(),
             'class',
             LiteralStringType::instanceForValue(
-                \ltrim($this->getFQSEN()->__toString(), '\\'),
+                $class_constant_value,
                 false
             )->asUnionType(),
             0,
@@ -2664,7 +2665,7 @@ class Clazz extends AddressableElement
                 'class'
             )
         );
-        $class_constant->setNodeForValue((string)$this->getFQSEN());
+        $class_constant->setNodeForValue($class_constant_value);
         $this->addConstant($code_base, $class_constant);
 
         // Add variable '$this' to the scope

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -1183,6 +1183,11 @@ final class EmptyUnionType extends UnionType
         return null;
     }
 
+    public function asSingleScalarValueOrNullOrSelf()
+    {
+        return $this;
+    }
+
     public function asStringScalarValues() : array
     {
         return [];

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -3423,6 +3423,37 @@ class UnionType implements Serializable
     }
 
     /**
+     * @return ?string|?float|?int|bool|null|?UnionType
+     * If this union type can be represented by a single scalar value or null,
+     * then this returns that scalar value.
+     *
+     * Otherwise, this returns $this.
+     */
+    public function asSingleScalarValueOrNullOrSelf()
+    {
+        $type_set = $this->type_set;
+        if (\count($type_set) !== 1) {
+            return $this;
+        }
+        $type = \reset($type_set);
+        // @phan-suppress-next-line PhanPossiblyFalseTypeArgumentInternal
+        switch (\get_class($type)) {
+            case LiteralIntType::class:
+                return $type->getIsNullable() ? null : $type->getValue();
+            case LiteralStringType::class:
+                return $type->getIsNullable() ? null : $type->getValue();
+            case FalseType::class:
+                return false;
+            case TrueType::class:
+                return true;
+            case NullType::class:
+                return null;
+            default:
+                return $this;
+        }
+    }
+
+    /**
      * @return array<int,string>
      * Returns a list of known strings for LiteralStringType instances in this union type.
      * E.g. for `?'foo'|?'bar'|?false|?T`, returns `['foo', 'bar']`

--- a/tests/plugin_test/expected/012_duplicate_array_key.php.expected
+++ b/tests/plugin_test/expected/012_duplicate_array_key.php.expected
@@ -1,4 +1,8 @@
 src/012_duplicate_array_key.php:16 PhanPluginDuplicateArrayKey Duplicate/Equivalent array key value(1) detected in array - the earlier entry will be ignored.
 src/012_duplicate_array_key.php:17 PhanPluginDuplicateArrayKey Duplicate/Equivalent array key value(1) detected in array - the earlier entry will be ignored.
+src/012_duplicate_array_key.php:18 PhanPluginDuplicateArrayKey Duplicate/Equivalent array key value(1) detected in array - the earlier entry will be ignored.
+src/012_duplicate_array_key.php:20 PhanPluginDuplicateArrayKey Duplicate/Equivalent array key value(1) detected in array - the earlier entry will be ignored.
+src/012_duplicate_array_key.php:21 PhanPluginDuplicateArrayKey Duplicate/Equivalent array key value(0) detected in array - the earlier entry will be ignored.
+src/012_duplicate_array_key.php:22 PhanPluginDuplicateArrayKey Duplicate/Equivalent array key value(0) detected in array - the earlier entry will be ignored.
 src/012_duplicate_array_key.php:23 PhanPluginDuplicateArrayKey Duplicate/Equivalent array key value(1) detected in array - the earlier entry will be ignored.
 src/012_duplicate_array_key.php:25 PhanPluginDuplicateArrayKey Duplicate/Equivalent array key value('') detected in array - the earlier entry will be ignored.

--- a/tests/plugin_test/expected/018_duplicate_switch.php.expected
+++ b/tests/plugin_test/expected/018_duplicate_switch.php.expected
@@ -1,5 +1,10 @@
 src/018_duplicate_switch.php:18 PhanPluginDuplicateSwitchCase Duplicate/Equivalent switch case(1) detected in switch statement - the later entry will be ignored.
 src/018_duplicate_switch.php:19 PhanPluginDuplicateSwitchCase Duplicate/Equivalent switch case(1) detected in switch statement - the later entry will be ignored.
-src/018_duplicate_switch.php:25 PhanPluginDuplicateSwitchCase Duplicate/Equivalent switch case(1) detected in switch statement - the later entry will be ignored.
-src/018_duplicate_switch.php:27 PhanPluginDuplicateSwitchCase Duplicate/Equivalent switch case('') detected in switch statement - the later entry will be ignored.
+src/018_duplicate_switch.php:22 PhanPluginDuplicateSwitchCase Duplicate/Equivalent switch case(true) detected in switch statement - the later entry will be ignored.
+src/018_duplicate_switch.php:23 PhanPluginDuplicateSwitchCase Duplicate/Equivalent switch case(false) detected in switch statement - the later entry will be ignored.
+src/018_duplicate_switch.php:24 PhanPluginDuplicateSwitchCase Duplicate/Equivalent switch case(false) detected in switch statement - the later entry will be ignored.
+src/018_duplicate_switch.php:25 PhanPluginDuplicateSwitchCase Duplicate/Equivalent switch case(true) detected in switch statement - the later entry will be ignored.
 src/018_duplicate_switch.php:29 PhanPluginDuplicateSwitchCase Duplicate/Equivalent switch case('(test literal)') detected in switch statement - the later entry will be ignored.
+src/018_duplicate_switch.php:33 PhanPluginDuplicateSwitchCase Duplicate/Equivalent switch case(32) detected in switch statement - the later entry will be ignored.
+src/018_duplicate_switch.php:34 PhanPluginDuplicateSwitchCase Duplicate/Equivalent switch case('') detected in switch statement - the later entry will be ignored.
+src/018_duplicate_switch.php:35 PhanPluginDuplicateSwitchCase Duplicate/Equivalent switch case(null) detected in switch statement - the later entry will be ignored.

--- a/tests/plugin_test/src/018_duplicate_switch.php
+++ b/tests/plugin_test/src/018_duplicate_switch.php
@@ -30,5 +30,8 @@ case '(test literal)': return 16;
 // Could analyze these later, but not doing that yet. For now, just check that this doesn't warn.
 case __FILE__: return 15;
 case __LINE__: return 15;
+case __LINE__ - 1: return 15;
+case '': return 15;
+case null: return 14;
 default: return 'default';
 };


### PR DESCRIPTION
And store the correct value for the `::class` magic constant

And infer that null will cast to the empty string when used as a string