### PR TITLE
Fix false positive PhanUnreferencedConstant in define()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ New features(Analysis):
 + Warn about `split` and other functions that were removed in PHP 7.0 by default. (#2235, #2236)
   (`target_php_version` can now be set to `'5.6'` if you have a PHP 5.6 project that uses those)
 + Infer more accurate literal string for `::class` constant.
++ Fix a false positive `PhanUnreferencedConstant` seen when calling `define()` with a dynamic name. (#2245)
 
 Plugins:
 + Detect more possible duplicates in `DuplicateArrayKeyPlugin`

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -1223,15 +1223,6 @@ class ParseVisitor extends ScopeVisitor
             );
             return;
         }
-        if ($code_base->hasGlobalConstantWithFQSEN($fqsen)) {
-            $other_context = $code_base->getGlobalConstantByFQSEN($fqsen)->getContext();
-            if (!$other_context->equals($context)) {
-                // Be consistent about the constant's type and only track the first declaration seen when parsing (or redeclarations)
-                // Note that global constants don't have alternates.
-                return;
-            }
-            // Otherwise, add the constant now that we know about all of the elements in the codebase
-        }
 
         // Create the constant
         $constant = new GlobalConstant(
@@ -1241,6 +1232,20 @@ class ParseVisitor extends ScopeVisitor
             $flags,
             $fqsen
         );
+
+        if ($code_base->hasGlobalConstantWithFQSEN($fqsen)) {
+            $other_constant = $code_base->getGlobalConstantByFQSEN($fqsen);
+            $other_context = $other_constant->getContext();
+            if (!$other_context->equals($context)) {
+                // Be consistent about the constant's type and only track the first declaration seen when parsing (or redeclarations)
+                // Note that global constants don't have alternates.
+                return;
+            }
+            // Keep track of old references to the new constant
+            $constant->copyReferencesFrom($other_constant);
+
+            // Otherwise, add the constant now that we know about all of the elements in the codebase
+        }
 
         // Get a comment on the declaration
         $comment = Comment::fromStringInContext(

--- a/tests/plugin_test/expected/063_unused_dynamic_constant.php.expected
+++ b/tests/plugin_test/expected/063_unused_dynamic_constant.php.expected
@@ -1,0 +1,1 @@
+src/063_unused_dynamic_constant.php:8 PhanUnreferencedConstant Possibly zero references to global constant \foo\dynamic2

--- a/tests/plugin_test/src/063_unused_dynamic_constant.php
+++ b/tests/plugin_test/src/063_unused_dynamic_constant.php
@@ -1,0 +1,9 @@
+<?php
+namespace foo;
+
+class C {
+    const BAR = \foo\dynamic1;
+}
+define(__NAMESPACE__ . '\dynamic1', 'value');
+define(__NAMESPACE__ . '\dynamic2', 'value');
+echo C::BAR . "\n";


### PR DESCRIPTION
This can happen when the constant name is a dynamic value.

Fixes #2245