### PR TITLE
Improve analysis of `@template` on functions&methods

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,15 @@ New features(Analysis):
   (`target_php_version` can now be set to `'5.6'` if you have a PHP 5.6 project that uses those)
 + Infer more accurate literal string for `::class` constant.
 + Fix a false positive `PhanUnreferencedConstant` seen when calling `define()` with a dynamic name. (#2245)
++ Support analyzing `@template` in PHPDoc of closures, functions and methods. (#522)
+  Phan currently requires the template type to be part of the parameter type(s) as well as the return type.
+
+  New issue types: `PhanTemplateTypeNotUsedInFunctionReturn`, `PhanTemplateTypeNotDeclaredInFunctionParams`
++ Make `@template` on classes behave more consistently. (#522)
+  Phan will now check the union types of parameters instead of assuming that arguments will always occur in the same order and positions as `@template`.
++ Phan can now infer types such as `@param T[]` in constructors and regular functions/methods. (#522)
+
+  - Note that this implementation is currently incomplete - Phan is not yet able to extract `T` from many types (e.g. `array{0:T}`, `Closure():T`, `MyClass<T>`, etc.)
 
 Plugins:
 + Detect more possible duplicates in `DuplicateArrayKeyPlugin`

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -2919,10 +2919,10 @@ This category contains issues related to [Phan's generic type support](https://g
 ## PhanGenericConstructorTypes
 
 ```
-Missing template parameters {PARAMETER} on constructor for generic class {CLASS}
+Missing template parameter for type {TYPE} on constructor for generic class {CLASS}
 ```
 
-e.g. [this issue](https://github.com/phan/phan/tree/1.1.2/tests/files/expected/0203_generic_errors.php.expected#L7) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.1.2/tests/files/src/0203_generic_errors.php#L27).
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0203_generic_errors.php.expected#L7) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0203_generic_errors.php#L27).
 
 ## PhanGenericGlobalVariable
 
@@ -2937,6 +2937,22 @@ This is emitted when a class constant's PHPDoc contains a type declared in a cla
 ```
 constant {CONST} may not have a template type
 ```
+
+## PhanTemplateTypeNotDeclaredInFunctionParams
+
+```
+Template type {TYPE} not declared in parameters of function/method {FUNCTIONLIKE} (or Phan can't extract template types for this use case)
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0597_template_support.php.expected#L6) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0597_template_support.php#L66).
+
+## PhanTemplateTypeNotUsedInFunctionReturn
+
+```
+Template type {TYPE} not used in return value of function/method {FUNCTIONLIKE}
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0577_unknown_tags.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0577_unknown_tags.php#L20).
 
 ## PhanTemplateTypeStaticMethod
 

--- a/src/Phan/Analysis/ArgumentType.php
+++ b/src/Phan/Analysis/ArgumentType.php
@@ -538,7 +538,7 @@ final class ArgumentType
 
         $parameter_type = $alternate_parameter->getNonVariadicUnionType();
 
-        if ($parameter_type->hasTemplateType()) {
+        if ($parameter_type->hasTemplateTypeRecursive()) {
             // Don't worry about **unresolved** template types.
             // We resolve them if possible in ContextNode->getMethod()
             return;

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -882,7 +882,7 @@ class AssignmentVisitor extends AnalysisVisitor
         }
 
         $property_union_type = $property->getUnionType();
-        if ($property_union_type->hasTemplateType()) {
+        if ($property_union_type->hasTemplateTypeRecursive()) {
             $property_union_type = $property_union_type->asExpandedTypes($this->code_base);
         }
 

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -2096,16 +2096,6 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                     (string)$return_type
                 );
             }
-
-            if ($method->isStatic()
-                && $method->getUnionType()->hasTemplateType()
-            ) {
-                $this->emitIssue(
-                    Issue::TemplateTypeStaticMethod,
-                    $node->lineno ?? 0,
-                    (string)$method->getFQSEN()
-                );
-            }
         }
 
         if ($method->getHasReturn() && $method->getIsMagicAndVoid()) {

--- a/src/Phan/Analysis/ThrowsTypesAnalyzer.php
+++ b/src/Phan/Analysis/ThrowsTypesAnalyzer.php
@@ -67,8 +67,9 @@ class ThrowsTypesAnalyzer
             return false;
         }
         if ($type instanceof TemplateType) {
-            // TODO: Add unit tests of templates for return types and checks
-            if ($method instanceof Method && $method->isStatic()) {
+            // TODO: Add unit tests of templates for return types and checks.
+            // E.g. should warn if passing in something that can't cast to throwable
+            if ($method instanceof Method && $method->isStatic() && !$method->declaresTemplateTypeInComment($type)) {
                 $maybe_emit_for_method(
                     Issue::TemplateTypeStaticMethod,
                     [(string)$method->getFQSEN()]

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -382,6 +382,8 @@ class Issue
     const TemplateTypeStaticProperty = 'PhanTemplateTypeStaticProperty';
     const GenericGlobalVariable      = 'PhanGenericGlobalVariable';
     const GenericConstructorTypes    = 'PhanGenericConstructorTypes';
+    const TemplateTypeNotUsedInFunctionReturn = 'PhanTemplateTypeNotUsedInFunctionReturn';
+    const TemplateTypeNotDeclaredInFunctionParams = 'PhanTemplateTypeNotDeclaredInFunctionParams';
 
     // Issue::CATEGORY_COMMENT
     const InvalidCommentForDeclarationType = 'PhanInvalidCommentForDeclarationType';
@@ -3206,9 +3208,25 @@ class Issue
                 self::GenericConstructorTypes,
                 self::CATEGORY_GENERIC,
                 self::SEVERITY_NORMAL,
-                "Missing template parameters {PARAMETER} on constructor for generic class {CLASS}",
+                "Missing template parameter for type {TYPE} on constructor for generic class {CLASS}",
                 self::REMEDIATION_B,
                 14004
+            ),
+            new Issue(
+                self::TemplateTypeNotUsedInFunctionReturn,
+                self::CATEGORY_GENERIC,
+                self::SEVERITY_NORMAL,
+                "Template type {TYPE} not used in return value of function/method {FUNCTIONLIKE}",
+                self::REMEDIATION_B,
+                14005
+            ),
+            new Issue(
+                self::TemplateTypeNotDeclaredInFunctionParams,
+                self::CATEGORY_GENERIC,
+                self::SEVERITY_NORMAL,
+                "Template type {TYPE} not declared in parameters of function/method {FUNCTIONLIKE} (or Phan can't extract template types for this use case)",
+                self::REMEDIATION_B,
+                14006
             ),
 
             // Issue::CATEGORY_INTERNAL

--- a/src/Phan/Language/Element/Comment.php
+++ b/src/Phan/Language/Element/Comment.php
@@ -51,6 +51,12 @@ class Comment
         self::ON_CONST,
     ];
 
+    const HAS_TEMPLATE_ANNOTATION = [
+        self::ON_CLASS,
+        self::ON_FUNCTION,
+        self::ON_METHOD,
+    ];
+
     const NAME_FOR_TYPE = [
         self::ON_CLASS      => 'class',
         self::ON_VAR        => 'variable',

--- a/src/Phan/Language/Element/Comment/Builder.php
+++ b/src/Phan/Language/Element/Comment/Builder.php
@@ -290,9 +290,15 @@ final class Builder
         }
 
         if (\count($this->template_type_list)) {
-            if ($this->comment_type === Comment::ON_CLASS) {
-                // Resolve template types in magic methods, properties, etc.
-                $this->fixClassTemplateTypes();
+            switch ($this->comment_type) {
+                case Comment::ON_CLASS:
+                    // Resolve template types in magic methods, properties, etc.
+                    $this->fixClassTemplateTypes();
+                    break;
+                case Comment::ON_FUNCTION:
+                case Comment::ON_METHOD:
+                    $this->fixMethodTemplateTypes();
+                    break;
             }
         }
         if ($this->issues) {
@@ -320,6 +326,19 @@ final class Builder
     }
 
     /**
+     * @return array<string,TemplateType>
+     */
+    private function buildTemplateFixMap(Context $context)
+    {
+        $template_fix_map = [];
+        foreach ($this->template_type_list as $t) {
+            $regular_type = Type::fromStringInContext($t->getName(), $context, Type::FROM_PHPDOC);
+            $template_fix_map[$regular_type->__toString()] = $t;
+        }
+        return $template_fix_map;
+    }
+
+    /**
      * Fix any uses of (at)template annotations within this class comment.
      * Affects (at)method annotations, (at)property annotations, etc.
      *
@@ -327,13 +346,30 @@ final class Builder
      */
     private function fixClassTemplateTypes()
     {
-        $template_fix_map = [];
-        foreach ($this->template_type_list as $t) {
-            $regular_type = Type::fromStringInContext($t->getName(), $this->context, Type::FROM_PHPDOC);
-            $template_fix_map[$regular_type->__toString()] = $t;
-        }
+        $template_fix_map = $this->buildTemplateFixMap($this->context);
         foreach ($this->magic_method_list as $method) {
             $method->convertTypesToTemplateTypes($template_fix_map);
+        }
+        foreach ($this->magic_property_list as $property) {
+            $property->convertTypesToTemplateTypes($template_fix_map);
+        }
+    }
+
+    /**
+     * Fix any uses of (at)template annotations within this function/method comment.
+     * Affects (at)param annotations, (at)return annotations, etc.
+     *
+     * Precondition: $this->template_type_list has 1 or more elements
+     */
+    private function fixMethodTemplateTypes()
+    {
+        $template_fix_map = $this->buildTemplateFixMap($this->context);
+        foreach ($this->parameter_list as $parameter) {
+            $parameter->convertTypesToTemplateTypes($template_fix_map);
+        }
+        $return_comment = $this->return_comment;
+        if ($return_comment) {
+            $return_comment->convertTypesToTemplateTypes($template_fix_map);
         }
         foreach ($this->magic_property_list as $property) {
             $property->convertTypesToTemplateTypes($template_fix_map);
@@ -432,7 +468,7 @@ final class Builder
     {
         // Make sure support for generic types is enabled
         if (Config::getValue('generic_types_enabled')) {
-            $this->checkCompatible('@template', [Comment::ON_CLASS], $i);
+            $this->checkCompatible('@template', Comment::HAS_TEMPLATE_ANNOTATION, $i);
             $template_type = $this->templateTypeFromCommentLine($line);
             if ($template_type) {
                 $this->template_type_list[] = $template_type;
@@ -444,7 +480,7 @@ final class Builder
     {
         // Make sure support for generic types is enabled
         if (Config::getValue('generic_types_enabled')) {
-            $this->checkCompatible('@template', [Comment::ON_CLASS], $i);
+            $this->checkCompatible('@template', Comment::HAS_TEMPLATE_ANNOTATION, $i);
             $template_type = $this->templateTypeFromCommentLine($line);
             if ($template_type) {
                 $this->phan_overrides['template'][] = $template_type;
@@ -737,7 +773,7 @@ final class Builder
         // Backslashes or nested templates wouldn't make sense, so use WORD_REGEX.
         if (preg_match('/@(?:phan-)?template\s+(' . self::WORD_REGEX . ')/', $line, $match)) {
             $template_type_identifier = $match[1];
-            return new TemplateType($template_type_identifier);
+            return TemplateType::instanceForId($template_type_identifier, false);
         }
 
         return null;

--- a/src/Phan/Language/Element/Comment/ReturnComment.php
+++ b/src/Phan/Language/Element/Comment/ReturnComment.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Phan\Language\Element\Comment;
 
+use Phan\Language\Type\TemplateType;
 use Phan\Language\UnionType;
 
 /**
@@ -45,5 +46,24 @@ class ReturnComment
     public function getLineno() : int
     {
         return $this->lineno;
+    }
+
+    /**
+     * Replace the resolved reference to class T (possibly namespaced) with a regular template type.
+     *
+     * @param array<string,TemplateType> $template_fix_map maps the incorrectly resolved name to the template type
+     * @return void
+     */
+    public function convertTypesToTemplateTypes(array $template_fix_map)
+    {
+        $this->type = $this->type->withConvertTypesToTemplateTypes($template_fix_map);
+    }
+
+    /**
+     * Helper for debugging
+     */
+    public function __toString() : string
+    {
+        return "ReturnComment(type=$this->type)";
     }
 }

--- a/src/Phan/Language/Element/FunctionInterface.php
+++ b/src/Phan/Language/Element/FunctionInterface.php
@@ -10,6 +10,7 @@ use Phan\Language\FQSEN\FullyQualifiedMethodName;
 use Phan\Language\Scope\ClosedScope;
 use Phan\Language\Type;
 use Phan\Language\Type\FunctionLikeDeclarationType;
+use Phan\Language\Type\TemplateType;
 use Phan\Language\UnionType;
 
 /**
@@ -411,4 +412,9 @@ interface FunctionInterface extends AddressableElementInterface
      * @return void
      */
     public function analyzeReturnTypes(CodeBase $code_base);
+
+    /**
+     * Does this function/method declare an (at)template type for this type?
+     */
+    public function declaresTemplateTypeInComment(TemplateType $template_type) : bool;
 }

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -767,8 +767,7 @@ class Method extends ClassElement implements FunctionInterface
 
     /**
      * Does this method have template types anywhere in its parameters or return type?
-     *
-     * TODO: Make the check recursive
+     * (This check is recursive)
      */
     public function hasTemplateType() : bool
     {

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -11,6 +11,7 @@ use Phan\Language\Element\Clazz;
 use Phan\Language\FQSEN\FullyQualifiedClassName;
 use Phan\Language\Type\ArrayType;
 use Phan\Language\Type\IntType;
+use Phan\Language\Type\TemplateType;
 
 /**
  * NOTE: there may also be instances of UnionType that are empty, due to the constructor being public
@@ -1232,5 +1233,10 @@ final class EmptyUnionType extends UnionType
     public function withConvertTypesToTemplateTypes(array $template_fix_map) : UnionType
     {
         return $this;
+    }
+
+    public function getTemplateTypeExtractorClosure(CodeBase $code_base, TemplateType $template_type)
+    {
+        return null;
     }
 }

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -4,6 +4,7 @@ namespace Phan\Language;
 
 use AssertionError;
 use ast\flags;
+use Closure;
 use Error;
 use InvalidArgumentException;
 use Phan\AST\UnionTypeVisitor;
@@ -3104,5 +3105,17 @@ class Type
     public function hasSameNamespaceAndName(Type $type) : bool
     {
         return $this->name === $type->name && $this->namespace === $type->namespace;
+    }
+
+    /**
+     * @param CodeBase $code_base may be used for resolving inheritance @phan-unused-param
+     * @param TemplateType $template_type the template type that this union type is being searched for @phan-unused-param
+     *
+     * @return ?Closure(UnionType):UnionType a closure to map types to the template type wherever it was in the original union type
+     */
+    public function getTemplateTypeExtractorClosure(CodeBase $code_base, TemplateType $template_type)
+    {
+        // Overridden in subclasses
+        return null;
     }
 }

--- a/src/Phan/Language/Type/FunctionLikeDeclarationType.php
+++ b/src/Phan/Language/Type/FunctionLikeDeclarationType.php
@@ -751,6 +751,12 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
         // do nothing
     }
 
+    public function declaresTemplateTypeInComment(TemplateType $template_type) : bool
+    {
+        // not supported yet
+        return false;
+    }
+
     ////////////////////////////////////////////////////////////////////////////////
     // End FunctionInterface overrides
     ////////////////////////////////////////////////////////////////////////////////

--- a/src/Phan/Language/Type/TemplateType.php
+++ b/src/Phan/Language/Type/TemplateType.php
@@ -2,6 +2,8 @@
 
 namespace Phan\Language\Type;
 
+use Closure;
+use Phan\CodeBase;
 use Phan\Language\Type;
 use Phan\Language\UnionType;
 
@@ -18,10 +20,46 @@ final class TemplateType extends Type
      * @param string $template_type_identifier
      * An identifier for the template type
      */
-    public function __construct(
-        string $template_type_identifier
+    protected function __construct(
+        string $template_type_identifier,
+        bool $is_nullable
     ) {
         $this->template_type_identifier = $template_type_identifier;
+        $this->is_nullable = $is_nullable;
+    }
+
+    /**
+     * Create an instance for this ID
+     */
+    public static function instanceForId(string $id, bool $is_nullable) : TemplateType
+    {
+        if ($is_nullable) {
+            static $nullable_cache = [];
+            return $nullable_cache[$id] ?? ($nullable_cache[$id] = new self($id, true));
+        }
+        static $cache = [];
+        return $cache[$id] ?? ($cache[$id] = new self($id, false));
+    }
+
+    /**
+     * @param bool $is_nullable
+     * Set to true if the type should be nullable, else pass
+     * false
+     *
+     * @return Type
+     * A new type that is a copy of this type but with the
+     * given nullability value.
+     */
+    public function withIsNullable(bool $is_nullable) : Type
+    {
+        if ($is_nullable === $this->is_nullable) {
+            return $this;
+        }
+
+        return self::instanceForId(
+            $this->template_type_identifier,
+            $is_nullable
+        );
     }
 
     /**
@@ -105,5 +143,44 @@ final class TemplateType extends Type
         array $template_parameter_type_map
     ) : UnionType {
         return $template_parameter_type_map[$this->template_type_identifier] ?? $this->asUnionType();
+    }
+
+    /**
+     * Combine two closures that generate union types
+     * @param ?Closure(mixed):UnionType $left
+     * @param ?Closure(mixed):UnionType $right
+     * @return ?Closure(mixed):UnionType
+     */
+    public static function combineParameterClosures($left, $right)
+    {
+        if (!$left) {
+            return $right;
+        }
+        if (!$right) {
+            return $left;
+        }
+
+        /**
+         * @param mixed $params
+         */
+        return function ($params) use ($left, $right) : UnionType {
+            return $left($params)->withUnionType($right($params));
+        };
+    }
+
+    /**
+     * @param TemplateType $template_type the template type that this union type is being searched for.
+     *
+     * @return ?Closure(UnionType):UnionType a closure to map types to the template type wherever it was in the original union type
+     */
+    public function getTemplateTypeExtractorClosure(CodeBase $unused_code_base, TemplateType $template_type)
+    {
+        if ($this === $template_type) {
+            return function (UnionType $type) : UnionType {
+                return $type;
+            };
+        }
+        // Overridden in subclasses
+        return null;
     }
 }

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -3624,6 +3624,23 @@ class UnionType implements Serializable
         }
         return $result;
     }
+
+    /**
+     * @param TemplateType $template_type the template type that this union type is being searched for
+     *
+     * @return ?Closure(UnionType):UnionType a closure to map types to the template type wherever it was in the original union type
+     */
+    public function getTemplateTypeExtractorClosure(CodeBase $code_base, TemplateType $template_type)
+    {
+        $closure = null;
+        foreach ($this->type_set as $type) {
+            $closure = TemplateType::combineParameterClosures(
+                $closure,
+                $type->getTemplateTypeExtractorClosure($code_base, $template_type)
+            );
+        }
+        return $closure;
+    }
 }
 
 UnionType::init();

--- a/src/Phan/Library/Map.php
+++ b/src/Phan/Library/Map.php
@@ -11,6 +11,7 @@ use SplObjectStorage;
  *
  * @template K
  * @template V
+ * @suppress PhanTemplateTypeNotDeclaredInFunctionParams
  */
 class Map extends SplObjectStorage
 {

--- a/tests/Phan/Language/EmptyUnionTypeTest.php
+++ b/tests/Phan/Language/EmptyUnionTypeTest.php
@@ -14,6 +14,7 @@ use Phan\Language\Type\GenericArrayType;
 use Phan\Language\Type\IntType;
 use Phan\Language\Type\MixedType;
 use Phan\Language\Type\ObjectType;
+use Phan\Language\Type\TemplateType;
 use Phan\Language\UnionType;
 use Phan\Tests\BaseTest;
 use ReflectionClass;
@@ -172,6 +173,11 @@ final class EmptyUnionTypeTest extends BaseTest
                     function (...$unused_args) : bool {
                         return true;
                     },
+                ];
+            case TemplateType::class:
+                return [
+                    TemplateType::instanceForId('T', false),
+                    TemplateType::instanceForId('TKey', true),
                 ];
             case '':
                 if ($param->getName() === 'field_key') {

--- a/tests/files/expected/0203_generic_errors.php.expected
+++ b/tests/files/expected/0203_generic_errors.php.expected
@@ -4,7 +4,7 @@
 %s:21 PhanTypeMissingReturn Method \C::g is declared to return T but has no return value
 %s:24 PhanUnextractableAnnotationElementName Saw possibly unextractable annotation for a fragment of comment '* @param int': after int, did not see an element name (will guess based on comment order)
 %s:25 PhanUnextractableAnnotationElementName Saw possibly unextractable annotation for a fragment of comment '* @param X': after X, did not see an element name (will guess based on comment order)
-%s:27 PhanGenericConstructorTypes Missing template parameters T on constructor for generic class \C
+%s:27 PhanGenericConstructorTypes Missing template parameter for type T on constructor for generic class \C
 %s:27 PhanUndeclaredTypeParameter Parameter $p2 has undeclared type \X (Did you mean class \C)
 %s:30 PhanParamTooFew Call with 0 arg(s) to \C::__construct() which requires 2 arg(s) defined at %s:27
 %s:36 PhanUnextractableAnnotationElementName Saw possibly unextractable annotation for a fragment of comment '* @param int': after int, did not see an element name (will guess based on comment order)

--- a/tests/files/expected/0577_unknown_tags.php.expected
+++ b/tests/files/expected/0577_unknown_tags.php.expected
@@ -1,2 +1,2 @@
-%s:16 PhanInvalidCommentForDeclarationType The phpdoc comment for @template cannot occur on a method
+%s:20 PhanTemplateTypeNotUsedInFunctionReturn Template type X not used in return value of function/method test()
 %s:21 PhanTypeMismatchArgumentInternal Argument 1 (string) is int but \strlen() takes string

--- a/tests/files/expected/0597_template_support.php.expected
+++ b/tests/files/expected/0597_template_support.php.expected
@@ -1,0 +1,16 @@
+%s:7 PhanTemplateTypeNotUsedInFunctionReturn Template type T not used in return value of function/method badTemplateReturn()
+%s:21 PhanTypeMismatchArgumentInternal Argument 1 (string) is \stdClass[] but \strlen() takes string
+%s:38 PhanTypeMismatchArgumentInternal Argument 1 (string) is \stdClass but \strlen() takes string
+%s:39 PhanTypeMismatchArgumentInternal Argument 1 (string) is int but \strlen() takes string
+%s:47 PhanTemplateTypeNotUsedInFunctionReturn Template type T not used in return value of function/method badTemplateReturn()
+%s:66 PhanTemplateTypeNotDeclaredInFunctionParams Template type T not declared in parameters of function/method missingTemplateParams() (or Phan can't extract template types for this use case)
+%s:68 PhanTypeMismatchReturn Returning type array{0:array<string,int>} but missingTemplateParams() is declared to return T[]
+%s:92 PhanTemplateTypeNotDeclaredInFunctionParams Template type TKey not declared in parameters of function/method combinationIterable() (or Phan can't extract template types for this use case)
+%s:105 PhanTypeMismatchArgumentInternal Argument 1 (string) is \stdClass[] but \strlen() takes string
+%s:109 PhanTypeMismatchArgumentInternal Argument 1 (string) is \stdClass but \strlen() takes string
+%s:110 PhanTypeMismatchArgumentInternal Argument 1 (string) is int but \strlen() takes string
+%s:111 PhanTypeMismatchArgumentInternal Argument 1 (string) is T[] but \strlen() takes string
+%s:112 PhanTypeMismatchArgumentInternal Argument 1 (string) is array<int,TKey>|array<int,TValue> but \strlen() takes string
+%s:112 PhanTypeMismatchArgument Argument 1 (i) is iterable<string,\stdClass> but \TemplateOnMethods::combinationIterable() takes iterable<\TKey,\TValue> defined at %s:92
+%s:137 PhanTypeMismatchArgumentInternal Argument 1 (string) is \stdClass but \strlen() takes string
+%s:138 PhanTypeMismatchArgumentInternal Argument 1 (string) is \ArrayAccess|\ArrayObject|\Countable|\IteratorAggregate|\Serializable|\Traversable|iterable but \strlen() takes string

--- a/tests/files/expected/0598_closure_template_support.php.expected
+++ b/tests/files/expected/0598_closure_template_support.php.expected
@@ -1,0 +1,1 @@
+%s:20 PhanTypeMismatchArgumentInternal Argument 1 (string) is \stdClass but \strlen() takes string

--- a/tests/files/src/0547_suppress_on_method.php
+++ b/tests/files/src/0547_suppress_on_method.php
@@ -5,7 +5,7 @@
  */
 class C{
     /**
-     * @suppress PhanGenericConstructorTypes
+     * @suppress PhanGenericConstructorTypes, PhanTemplateTypeNotDeclaredInFunctionParams
      */
     public function __construct(int $x) {
     }

--- a/tests/files/src/0577_unknown_tags.php
+++ b/tests/files/src/0577_unknown_tags.php
@@ -13,7 +13,7 @@ class TemplateClass577 {
 
     /**
      * @template-another-thing VV should not warn - this is an unsupported tag that might be used by other tools
-     * @template X should warn
+     * @template X Phan should warn that it couldn't figure out how X is used
      * @param int $x
      * @param-other-tag VV $x should not warn
      */

--- a/tests/files/src/0597_template_support.php
+++ b/tests/files/src/0597_template_support.php
@@ -1,0 +1,138 @@
+<?php
+
+/**
+ * @template T
+ * @param T $x should warn about not using in return
+ */
+function badTemplateReturn($x) {
+    var_export($x);
+}
+
+/**
+ * @template T
+ * @param T $x
+ * @return T[]
+ */
+function goodTemplateReturn($x) {
+    var_export($x);
+    return [$x];
+}
+
+echo strlen(goodTemplateReturn(new stdClass()));  // should infer \stdClass[]
+
+/**
+ * @template T
+ * @param T[] $x
+ * @return T
+ * @throws InvalidArgumentException
+ */
+function goodTemplateReturnFromArray(array $x) {
+    if (count($x) == 0) {
+        throw new InvalidArgumentException("Expected one element");
+    }
+    return reset($x);
+}
+call_user_func(function () {
+    // should warn about these values having types stdClass and int
+    $result = goodTemplateReturnFromArray([new stdClass()]);
+    echo strlen($result);  // should infer stdClass
+    echo strlen(goodTemplateReturnFromArray(['key' => rand(0,10)]));  // should infer int
+});
+class TemplateOnMethods {
+    /**
+     * @template T
+     * @param T $x
+     * Should warn that the return type doesn't use the template
+     */
+    public static function badTemplateReturn($x) {
+        var_export($x);
+    }
+
+    /**
+     * @template T
+     * @param T $x
+     * @return T[]
+     */
+    public static function goodTemplateReturn($x) {
+        var_export($x);
+        return [$x];
+    }
+
+    /**
+     * @template T
+     * @return T[]
+     * Should warn that it can't infer T from params
+     */
+    public static function missingTemplateParams($x) {
+        var_export($x);
+        return [$x];
+    }
+
+    /**
+     * @template T
+     * @param T[] $x
+     * @return T
+     * @throws InvalidArgumentException
+     */
+    public static function goodTemplateReturnFromArray(array $x) {
+        if (count($x) == 0) {
+            throw new InvalidArgumentException("Expected one element");
+        }
+        return reset($x);
+    }
+
+    /**
+     * @template TKey
+     * @template TValue
+     * @param iterable<TKey,TValue> $i
+     * @return array<int,TKey|TValue>
+     *
+     * TODO: Finish fixing bugs in parsing TKey as a template type in the union type
+     */
+    public static function combinationIterable(iterable $i) {
+        $result = [];
+        foreach ($i as $k => $v) {
+            $result[] = $k;
+            $result[] = $v;
+        }
+        return $result;
+    }
+
+    /**
+     * @param iterable<string,\stdClass> $it
+     */
+    public static function assertions(iterable $it) {
+        echo strlen(self::goodTemplateReturn(new stdClass()));
+
+        // should warn about these values having types stdClass and int
+        $result = self::goodTemplateReturnFromArray([new stdClass()]);
+        echo strlen($result);
+        echo strlen(self::goodTemplateReturnFromArray(['key' => rand(0,10)]));
+        echo strlen(self::missingTemplateParams(['key' => rand(0,10)]));  // should warn about
+        echo strlen(self::combinationIterable($it));  // should infer array<int,string|\stdClass>
+    }
+}
+
+/**
+ * The order of (at)template declarations should no longer matter
+ * @template R
+ * @template L
+ */
+class TemplateConstructor {
+    /** @var L */
+    public $left;
+    /** @var R */
+    public $right;
+    /**
+     * @param L[] $left
+     * @param R[] $right
+     */
+    public function __construct($left, $right) {
+        $this->left = reset($left);
+        $this->right = reset($right);
+    }
+}
+
+$t = new TemplateConstructor([new stdClass()], [new ArrayObject()]);
+echo strlen($t->left);
+echo strlen($t->right);

--- a/tests/files/src/0598_closure_template_support.php
+++ b/tests/files/src/0598_closure_template_support.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @return mixed
+ */
+function myClone($a) {
+    return clone($a);
+}
+
+call_user_func(function () {
+    /**
+     * @template T
+     * @param T[] $x
+     * @return T
+     */
+    $c = function ($x) {
+        return myClone($x[0]);
+    };
+    $v = $c([new stdClass()]);
+    echo strlen($v);
+});


### PR DESCRIPTION
Allow using `@template` on functions, closures, and instance/static
methods. Previously, this was only allowed on classes.

Support `@param T[] $x` as a way to indicate a function expects an array of
the template parameters.

- Support for extracting templates from other types
  (e.g. `MyClass<T>`, `iterable<T>`, `callable():T`, `array{0:T}`, etc.
  is not implemented yet)

Be more strict about `@template` on class. Warn if the constructor doesn't
reference the template in PHPDoc (instead of just checking if positions
were used)

Related to #522