### PR TITLE
Add support for `@param Closure():T`, `@param MyClass<T>`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,9 +14,12 @@ New features(Analysis):
   New issue types: `PhanTemplateTypeNotUsedInFunctionReturn`, `PhanTemplateTypeNotDeclaredInFunctionParams`
 + Make `@template` on classes behave more consistently. (#522)
   Phan will now check the union types of parameters instead of assuming that arguments will always occur in the same order and positions as `@template`.
-+ Phan can now infer types such as `@param T[]` in constructors and regular functions/methods. (#522)
++ Phan can now infer template types from more categories of parameter types in constructors and regular functions/methods. (#522)
+  - `@param T[]`
+  - `@param Closure():T`
+  - `@param OtherClass<\stdClass,T>`
 
-  - Note that this implementation is currently incomplete - Phan is not yet able to extract `T` from many types (e.g. `array{0:T}`, `Closure():T`, `MyClass<T>`, etc.)
+  - Note that this implementation is currently incomplete - Phan is not yet able to extract `T` from types not mentioned here (e.g. `array{0:T}`, `Generator<T>`, etc.)
 
 Plugins:
 + Detect more possible duplicates in `DuplicateArrayKeyPlugin`

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1073,7 +1073,7 @@ class UnionTypeVisitor extends AnalysisVisitor
     public function visitCast(Node $node) : UnionType
     {
         // TODO: Check if the cast is allowed based on the right side type
-        UnionTypeVisitor::unionTypeFromNode($this->code_base, $this->context, $node->children['expr']);
+        $expr_type = UnionTypeVisitor::unionTypeFromNode($this->code_base, $this->context, $node->children['expr']);
         switch ($node->flags) {
             case \ast\flags\TYPE_NULL:
                 return NullType::instance(false)->asUnionType();
@@ -1088,6 +1088,9 @@ class UnionTypeVisitor extends AnalysisVisitor
             case \ast\flags\TYPE_ARRAY:
                 return ArrayType::instance(false)->asUnionType();
             case \ast\flags\TYPE_OBJECT:
+                if ($expr_type->isExclusivelyArray()) {
+                    return UnionType::fromFullyQualifiedString('\stdClass');
+                }
                 return ObjectType::instance(false)->asUnionType();
             default:
                 throw new NodeException(

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -971,6 +971,11 @@ final class EmptyUnionType extends UnionType
         return false;
     }
 
+    public function getTypesWithFQSEN(Type $other) : UnionType
+    {
+        return $this;
+    }
+
     /**
      * As per the Serializable interface
      *

--- a/src/Phan/Language/Type/ClosureType.php
+++ b/src/Phan/Language/Type/ClosureType.php
@@ -82,6 +82,17 @@ final class ClosureType extends Type
     }
 
     /**
+     * Gets the function-like this type was created from.
+     *
+     * TODO: Uses of this may keep outdated data in language server mode.
+     * @return ?FunctionInterface
+     */
+    public function getFunctionLikeOrNull()
+    {
+        return $this->func;
+    }
+
+    /**
      * @return bool
      * True if this Type can be cast to the given Type
      * cleanly

--- a/src/Phan/Language/Type/NativeType.php
+++ b/src/Phan/Language/Type/NativeType.php
@@ -285,6 +285,11 @@ abstract class NativeType extends Type
     {
         return false;
     }
+
+    public function getTemplateTypeExtractorClosure(CodeBase $unused_code_base, TemplateType $unused_template_type)
+    {
+        return null;
+    }
 }
 \class_exists(ArrayType::class);
 \class_exists(ScalarType::class);

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -2649,6 +2649,24 @@ class UnionType implements Serializable
     }
 
     /**
+     * Filters the types with the same FQSEN as $other
+     * @suppress PhanUnreferencedPublicMethod
+     */
+    public function getTypesWithFQSEN(Type $other) : UnionType
+    {
+        if (!$other->isObjectWithKnownFQSEN()) {
+            return UnionType::empty();
+        }
+        $result = $this;
+        foreach ($this->type_set as $type) {
+            if ($type->hasSameNamespaceAndName($other) && $type->isObjectWithKnownFQSEN()) {
+                $result = $result->withoutType($type);
+            }
+        }
+        return $result;
+    }
+
+    /**
      * As per the Serializable interface
      *
      * @return string

--- a/tests/files/expected/0300_misc_types.php.expected
+++ b/tests/files/expected/0300_misc_types.php.expected
@@ -12,7 +12,7 @@
 %s:22 PhanTypeMismatchArgument Argument 1 (x) is 42 but \expect_string_300() takes string defined at %s:3
 %s:22 PhanUnusedVariable Unused definition of variable $refIntVar
 %s:23 PhanTypeMismatchArgument Argument 1 (x) is string but \expect_int_300() takes int defined at %s:4
-%s:25 PhanTypeMismatchArgument Argument 1 (x) is object but \expect_string_300() takes string defined at %s:3
+%s:25 PhanTypeMismatchArgument Argument 1 (x) is \stdClass but \expect_string_300() takes string defined at %s:3
 %s:26 PhanTypeMismatchArgument Argument 1 (x) is 3 but \expect_string_300() takes string defined at %s:3
 %s:27 PhanTypeMismatchArgument Argument 1 (x) is 3 but \expect_string_300() takes string defined at %s:3
 %s:28 PhanUndeclaredFunction Call to undeclared function \expect_default_int_300()
@@ -21,3 +21,4 @@
 %s:34 PhanTypeMismatchArgument Argument 1 (x) is string but \expect_int_300() takes int defined at %s:4
 %s:35 PhanUnusedVariable Unused definition of variable $definedStrVar
 %s:37 PhanContextNotObject Cannot access self when not in object context
+%s:38 PhanTypeMismatchArgument Argument 1 (x) is object but \expect_string_300() takes string defined at %s:3

--- a/tests/files/expected/0599_closure_template_return.php.expected
+++ b/tests/files/expected/0599_closure_template_return.php.expected
@@ -1,0 +1,2 @@
+%s:22 PhanTypeMismatchArgumentInternal Argument 1 (string) is array<int,\stdClass> but \strlen() takes string
+%s:25 PhanTypeMismatchArgumentInternal Argument 1 (string) is array<int,int> but \strlen() takes string

--- a/tests/files/expected/0600_template_from_template.php.expected
+++ b/tests/files/expected/0600_template_from_template.php.expected
@@ -1,0 +1,5 @@
+%s:35 PhanTypeMismatchArgumentInternal Argument 1 (string) is \Base|\Base<\stdClass> but \strlen() takes string
+%s:38 PhanTypeMismatchArgumentInternal Argument 1 (string) is \DerivedBase|\DerivedBase<\stdClass> but \strlen() takes string
+%s:39 PhanTypeMismatchArgumentInternal Argument 1 (string) is \stdClass but \strlen() takes string
+%s:40 PhanTypeMismatchArgumentInternal Argument 1 (string) is \DerivedBase|\DerivedBase<int> but \strlen() takes string
+%s:41 PhanTypeMismatchArgumentInternal Argument 1 (string) is int but \strlen() takes string

--- a/tests/files/src/0300_misc_types.php
+++ b/tests/files/src/0300_misc_types.php
@@ -35,3 +35,4 @@ function test300() {
     expect_string_300($definedStrVar |= $strVar);
 }
 self::missingAndNotInClassScope();
+expect_string_300((object)(new ArrayObject()));

--- a/tests/files/src/0599_closure_template_return.php
+++ b/tests/files/src/0599_closure_template_return.php
@@ -1,0 +1,27 @@
+<?php
+
+function identity($x) {
+    var_dump($x);
+    return $x;
+}
+
+/**
+ * @template T
+ * @param Closure(int $i):T $x
+ * @return array<int,T>
+ */
+function example_closure_usage(Closure $x) {
+    $result = [];
+    for ($i = 0; $i < 10; $i++) {
+        $result[] = identity($x($i));
+    }
+    return $result;
+}
+
+// Warns about being passed an array of stdClass
+echo strlen(example_closure_usage(function (int $i) {
+    return (object)['key' => $i];
+}));
+echo strlen(example_closure_usage(function (int $i) : int {
+    return rand(0,abs($i));
+}));

--- a/tests/files/src/0600_template_from_template.php
+++ b/tests/files/src/0600_template_from_template.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * @template TA
+ */
+class Base {
+    /** @var TA */
+    public $x;
+
+    /**
+     * @param TA $x
+     */
+    public function __construct($x) {
+        $this->x = $x;
+    }
+}
+
+/**
+ * @template TX
+ */
+class DerivedBase {
+    /** @var TX */
+    public $y;
+
+    /** @param Base<TX> $b */
+    public function __construct(Base $b) {
+        $this->y = $b->x;
+    }
+}
+
+call_user_func(function () {
+    $b1 = new Base(new stdClass());
+    $b2 = new Base(rand(0,10));
+
+    echo strlen($b1);
+    $db1 = new DerivedBase($b1);
+    $db2 = new DerivedBase($b2);
+    echo strlen($db1);
+    echo strlen($db1->y);
+    echo strlen($db2);
+    echo strlen($db2->y);
+});


### PR DESCRIPTION
The return type of the function can now be inferred from the passed in
closures/callables.

- This also applies to objects being constructed.

Related to #522

See the tests for examples of how this can be used.