### PR TITLE
Refactor the way `@template` annotations are parsed

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,12 +18,12 @@ environment:
       VC_VERSION: 15
       PHP_AST_VERSION: 1.0.0
     - PHP_EXT_VERSION: '7.0'
-      PHP_VERSION: '7.0.32'
+      PHP_VERSION: '7.0.33'
       VC_VERSION: 14
       PHP_AST_VERSION: 0.1.5
       PHAN_RUN_INTEGRATION_TEST: 1
     - PHP_EXT_VERSION: '7.1'
-      PHP_VERSION: '7.1.24'
+      PHP_VERSION: '7.1.25'
       VC_VERSION: 14
       PHP_AST_VERSION: 0.1.7
     - PHP_EXT_VERSION: '7.2'

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@ Phan NEWS
 ?? ??? 201?, Phan 1.1.10(dev)
 -----------------------
 
+Bug fixes:
++ Refactor the way `@template` annotations are parsed on classes and function-likes to avoid various edge cases (#2253)
+
 27 Dec 2018, Phan 1.1.9
 -----------------------
 

--- a/src/Phan/Language/Element/Comment/Method.php
+++ b/src/Phan/Language/Element/Comment/Method.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Phan\Language\Element\Comment;
 
-use Phan\Language\Type\TemplateType;
 use Phan\Language\UnionType;
 
 /**
@@ -164,19 +163,5 @@ class Method
         }
 
         return $string;
-    }
-
-    /**
-     * Replace the resolved reference to class T (possibly namespaced) with a regular template type, in this (at)method annotation.
-     *
-     * @param array<string,TemplateType> $template_types maps the incorrectly resolved name to the template type
-     * @return void
-     */
-    public function convertTypesToTemplateTypes(array $template_types)
-    {
-        $this->type = $this->type->withConvertTypesToTemplateTypes($template_types);
-        foreach ($this->parameters as $parameter) {
-            $parameter->convertTypesToTemplateTypes($template_types);
-        }
     }
 }

--- a/src/Phan/Language/Element/Comment/Parameter.php
+++ b/src/Phan/Language/Element/Comment/Parameter.php
@@ -5,7 +5,6 @@ namespace Phan\Language\Element\Comment;
 
 use Phan\Language\Context;
 use Phan\Language\Element\Variable;
-use Phan\Language\Type\TemplateType;
 use Phan\Language\UnionType;
 
 /**
@@ -198,16 +197,5 @@ class Parameter
         }
 
         return $string;
-    }
-
-    /**
-     * Replace the resolved reference to class T (possibly namespaced) with a regular template type.
-     *
-     * @param array<string,TemplateType> $template_fix_map maps the incorrectly resolved name to the template type
-     * @return void
-     */
-    public function convertTypesToTemplateTypes(array $template_fix_map)
-    {
-        $this->type = $this->type->withConvertTypesToTemplateTypes($template_fix_map);
     }
 }

--- a/src/Phan/Language/Element/Comment/Property.php
+++ b/src/Phan/Language/Element/Comment/Property.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Phan\Language\Element\Comment;
 
-use Phan\Language\Type\TemplateType;
 use Phan\Language\UnionType;
 
 /**
@@ -105,16 +104,5 @@ class Property
         $string .= '$' . $this->name;
 
         return $string;
-    }
-
-    /**
-     * Replace the resolved reference to class T (possibly namespaced) with a regular template type.
-     *
-     * @param array<string,TemplateType> $template_fix_map maps the incorrectly resolved name to the template type
-     * @return void
-     */
-    public function convertTypesToTemplateTypes(array $template_fix_map)
-    {
-        $this->type = $this->type->withConvertTypesToTemplateTypes($template_fix_map);
     }
 }

--- a/src/Phan/Language/Element/Comment/ReturnComment.php
+++ b/src/Phan/Language/Element/Comment/ReturnComment.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Phan\Language\Element\Comment;
 
-use Phan\Language\Type\TemplateType;
 use Phan\Language\UnionType;
 
 /**
@@ -46,17 +45,6 @@ class ReturnComment
     public function getLineno() : int
     {
         return $this->lineno;
-    }
-
-    /**
-     * Replace the resolved reference to class T (possibly namespaced) with a regular template type.
-     *
-     * @param array<string,TemplateType> $template_fix_map maps the incorrectly resolved name to the template type
-     * @return void
-     */
-    public function convertTypesToTemplateTypes(array $template_fix_map)
-    {
-        $this->type = $this->type->withConvertTypesToTemplateTypes($template_fix_map);
     }
 
     /**

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -180,6 +180,12 @@ final class EmptyUnionType extends UnionType
         return false;
     }
 
+    /** @override */
+    public function withoutTemplateTypeRecursive() : UnionType
+    {
+        return $this;
+    }
+
     /**
      * @return bool
      * True if this union type has any types that have generic
@@ -1231,11 +1237,6 @@ final class EmptyUnionType extends UnionType
     }
 
     public function getTypeAfterIncOrDec() : UnionType
-    {
-        return $this;
-    }
-
-    public function withConvertTypesToTemplateTypes(array $template_fix_map) : UnionType
     {
         return $this;
     }

--- a/src/Phan/Language/Scope/TemplateScope.php
+++ b/src/Phan/Language/Scope/TemplateScope.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace Phan\Language\Scope;
+
+use InvalidArgumentException;
+use Phan\Language\Scope;
+use Phan\Language\Type\TemplateType;
+
+/**
+ * A scope that adds (at)template annotations to the current outer scope.
+ * Used for parsing phpdoc comments.
+ */
+class TemplateScope extends Scope
+{
+    /**
+     * @param TemplateType[] $template_type_list
+     */
+    public function __construct(Scope $other, array $template_type_list)
+    {
+        parent::__construct($other, $other->fqsen, $other->flags);
+        if (\count($template_type_list) === 0) {
+            throw new InvalidArgumentException("TemplateScope should only be used to add templates");
+        }
+        foreach ($template_type_list as $template_type) {
+            $this->addTemplateType($template_type);
+        }
+    }
+}

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -3085,36 +3085,6 @@ class Type
     }
 
     /**
-     * Replace the resolved reference to class T (possibly namespaced) with a regular template type.
-     *
-     * @param array<string,TemplateType> $template_fix_map maps the incorrectly resolved name to the template type
-     * @return Type
-     *
-     * @see UnionType::withTemplateParameterTypeMap() for the opposite
-     */
-    public function withConvertTypesToTemplateTypes(array $template_fix_map) : Type
-    {
-        $result = $template_fix_map[$this->__toString()] ?? null;
-        if ($result) {
-            return $result;
-        }
-        $template_parameter_type_list = $this->template_parameter_type_list;
-        foreach ($template_parameter_type_list as $i => $type) {
-            $template_parameter_type_list[$i] = $type->withConvertTypesToTemplateTypes($template_fix_map);
-        }
-        if ($template_parameter_type_list === $this->template_parameter_type_list) {
-            return $this;
-        }
-        return static::make(
-            $this->namespace,
-            $this->name,
-            $template_parameter_type_list,
-            $this->is_nullable,
-            Type::FROM_TYPE
-        );
-    }
-
-    /**
      * Returns true if this is `MyNs\MyClass<T..>` when $type is `MyNs\MyClass`
      */
     public function isTemplateSubtypeOf(Type $type) : bool
@@ -3149,8 +3119,6 @@ class Type
      * mapped to concrete types defined in the given map.
      *
      * Overridden in subclasses
-     *
-     * @see self::withConvertTypesToTemplateTypes() for the opposite
      */
     public function withTemplateParameterTypeMap(
         array $template_parameter_type_map

--- a/src/Phan/Language/Type/ClassStringType.php
+++ b/src/Phan/Language/Type/ClassStringType.php
@@ -5,11 +5,12 @@ namespace Phan\Language\Type;
 use Closure;
 use Phan\CodeBase;
 use Phan\Language\FQSEN\FullyQualifiedClassName;
-use Phan\Language\Type;
 use Phan\Language\UnionType;
 
 /**
- * Phan's representation for `class-string` and `class-string<T>`
+ * A type representing a string with an unknown value that is a fully qualified class name.
+ *
+ * Phan's representation for `class-string` and `class-string<T>`.
  */
 final class ClassStringType extends StringType
 {
@@ -74,31 +75,5 @@ final class ClassStringType extends StringType
             }
             return $result;
         };
-    }
-
-    /**
-     * Replace the resolved reference to class T (possibly namespaced) with a regular template type.
-     *
-     * @param array<string,TemplateType> $template_fix_map maps the incorrectly resolved name to the template type
-     * @return Type
-     *
-     * @see UnionType::withTemplateParameterTypeMap() for the opposite
-     */
-    public function withConvertTypesToTemplateTypes(array $template_fix_map) : Type
-    {
-        $template_union_type = $this->template_parameter_type_list[0] ?? null;
-        if (!$template_union_type) {
-            return $this;
-        }
-        $new_type = $template_union_type->withConvertTypesToTemplateTypes($template_fix_map);
-        if ($new_type === $template_union_type) {
-            return $this;
-        }
-        return new self(
-            '',
-            'class-string',
-            [$new_type],
-            $this->is_nullable
-        );
     }
 }

--- a/src/Phan/Language/Type/ClosureDeclarationParameter.php
+++ b/src/Phan/Language/Type/ClosureDeclarationParameter.php
@@ -172,17 +172,4 @@ final class ClosureDeclarationParameter
         }
         return $result;
     }
-
-    /**
-     * Replace the resolved reference to class T (possibly namespaced) with a regular template type.
-     */
-    public function withConvertTypesToTemplateTypes(
-        array $template_fix_map
-    ) : ClosureDeclarationParameter {
-        $new_type = $this->type->withConvertTypesToTemplateTypes($template_fix_map);
-        if ($this->type === $new_type) {
-            return $this;
-        }
-        return new self($this->type, $this->is_variadic, $this->is_reference, $this->is_optional);
-    }
 }

--- a/src/Phan/Language/Type/FunctionLikeDeclarationType.php
+++ b/src/Phan/Language/Type/FunctionLikeDeclarationType.php
@@ -800,29 +800,6 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
     }
 
     /**
-     * Replace the resolved reference to class T (possibly namespaced) with a regular template type.
-     *
-     * @param array<string,TemplateType> $template_fix_map maps the incorrectly resolved name to the template type
-     * @return Type
-     *
-     * Overridden in subclasses
-     *
-     * @see self::withTemplateParameterTypeMap() for the opposite
-     */
-    public function withConvertTypesToTemplateTypes(
-        array $template_fix_map
-    ) : Type {
-        $return_type = $this->return_type->withConvertTypesToTemplateTypes($template_fix_map);
-        $params = array_map(function (ClosureDeclarationParameter $param) use ($template_fix_map) : ClosureDeclarationParameter {
-            return $param->withConvertTypesToTemplateTypes($template_fix_map);
-        }, $this->params);
-        if ($params === $this->params && $return_type === $this->return_type) {
-            return $this;
-        }
-        return new static($this->file_ref, $params, $return_type, $this->returns_reference, $this->is_nullable);
-    }
-
-    /**
      * Returns true for `T` and `T[]` and `\MyClass<T>`, but not `\MyClass<\OtherClass>` or `false`
      */
     public function hasTemplateTypeRecursive() : bool

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -657,8 +657,6 @@ final class GenericArrayType extends ArrayType implements GenericArrayInterface
      * mapped to concrete types defined in the given map.
      *
      * Overridden in subclasses
-     *
-     * @see self::withConvertTypesToTemplateTypes() for the opposite
      */
     public function withTemplateParameterTypeMap(
         array $template_parameter_type_map
@@ -670,32 +668,6 @@ final class GenericArrayType extends ArrayType implements GenericArrayInterface
         }
         // TODO: Override in array shape subclass
         return $new_element_type->asGenericArrayTypes($this->getKeyType());
-    }
-
-    /**
-     * Replace the resolved reference to class T (possibly namespaced) with a regular template type.
-     *
-     * @param array<string,TemplateType> $template_fix_map maps the incorrectly resolved name to the template type
-     * @return Type
-     *
-     * Overridden in subclasses
-     *
-     * @see self::withTemplateParameterTypeMap() for the opposite
-     */
-    public function withConvertTypesToTemplateTypes(
-        array $template_fix_map
-    ) : Type {
-        $element_type = $this->genericArrayElementType();
-        $new_element_type = $element_type->withConvertTypesToTemplateTypes($template_fix_map);
-        if ($element_type === $new_element_type) {
-            return $this;
-        }
-        // TODO: Override in array shape subclass
-        return GenericArrayType::fromElementType(
-            $new_element_type,
-            $this->is_nullable,
-            $this->key_type
-        );
     }
 
     /**

--- a/src/Phan/Language/Type/GenericIterableType.php
+++ b/src/Phan/Language/Type/GenericIterableType.php
@@ -116,8 +116,6 @@ final class GenericIterableType extends IterableType
      * mapped to concrete types defined in the given map.
      *
      * Overridden in subclasses
-     *
-     * @see self::withConvertTypesToTemplateTypes() for the opposite
      */
     public function withTemplateParameterTypeMap(
         array $template_parameter_type_map

--- a/src/Phan/Language/Type/NativeType.php
+++ b/src/Phan/Language/Type/NativeType.php
@@ -255,18 +255,6 @@ abstract class NativeType extends Type
     }
 
     /**
-     * Replace the resolved reference to class T (possibly namespaced) with a regular template type.
-     *
-     * @param array<string,TemplateType> $template_fix_map maps the incorrectly resolved name to the template type @phan-unused-param
-     * @return Type
-     */
-    public function withConvertTypesToTemplateTypes(array $template_fix_map) : Type
-    {
-        // TODO: Override in subclasses
-        return $this;
-    }
-
-    /**
      * @override
      */
     public function withTemplateParameterTypeMap(

--- a/src/Phan/Language/Type/TemplateType.php
+++ b/src/Phan/Language/Type/TemplateType.php
@@ -109,17 +109,6 @@ final class TemplateType extends Type
     }
 
     /**
-     * Replace the resolved reference to class T (possibly namespaced) with a regular template type.
-     *
-     * @param array<string,TemplateType> $template_fix_map maps the incorrectly resolved name to the template type @phan-unused-param
-     * @return Type
-     */
-    public function withConvertTypesToTemplateTypes(array $template_fix_map) : Type
-    {
-        return $this;
-    }
-
-    /**
      * Returns true for `T` and `T[]` and `\MyClass<T>`, but not `\MyClass<\OtherClass>`
      *
      * Overridden in subclasses.
@@ -136,8 +125,6 @@ final class TemplateType extends Type
      * @return UnionType
      * This UnionType with any template types contained herein
      * mapped to concrete types defined in the given map.
-     *
-     * @see UnionType::withConvertTypesToTemplateTypes() for the opposite
      */
     public function withTemplateParameterTypeMap(
         array $template_parameter_type_map

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -669,8 +669,6 @@ class UnionType implements Serializable
      * @return UnionType
      * This UnionType with any template types contained herein
      * mapped to concrete types defined in the given map.
-     *
-     * @see UnionType::withConvertTypesToTemplateTypes() for the opposite
      */
     public function withTemplateParameterTypeMap(
         array $template_parameter_type_map
@@ -713,6 +711,18 @@ class UnionType implements Serializable
     {
         return $this->hasTypeMatchingCallback(function (Type $type) : bool {
             return $type->hasTemplateTypeRecursive();
+        });
+    }
+
+    /**
+     * @return UnionType
+     * Removes template types from this union type, e.g. converts T|\stdClass to \stdClass.
+     * @suppress PhanUnreferencedPublicMethod
+     */
+    public function withoutTemplateTypeRecursive() : UnionType
+    {
+        return $this->makeFromFilter(function (Type $type) : bool {
+            return !$type->hasTemplateTypeRecursive();
         });
     }
 
@@ -3619,27 +3629,6 @@ class UnionType implements Serializable
         $result = UnionType::empty();
         foreach ($this->type_set as $type) {
             $result = $result->withUnionType($type->getTypeAfterIncOrDec());
-        }
-        return $result;
-    }
-
-    /**
-     * Replace the resolved reference to class T (possibly namespaced) with a regular template type.
-     *
-     * @param array<string,TemplateType> $template_fix_map maps the incorrectly resolved name to the template type
-     * @return UnionType
-     *
-     * @see UnionType::withTemplateParameterTypeMap() for the opposite
-     */
-    public function withConvertTypesToTemplateTypes(array $template_fix_map) : UnionType
-    {
-        $result = $this;
-        foreach ($this->getTypeSet() as $type) {
-            $new_type = $type->withConvertTypesToTemplateTypes($template_fix_map);
-            if ($new_type === $type) {
-                continue;
-            }
-            $result = $result->withoutType($type)->withType($new_type);
         }
         return $result;
     }

--- a/src/Phan/Plugin/Internal/ThrowAnalyzerPlugin.php
+++ b/src/Phan/Plugin/Internal/ThrowAnalyzerPlugin.php
@@ -135,6 +135,9 @@ class ThrowVisitor extends PluginAwarePostAnalysisVisitor
             if (!$this->shouldWarnAboutThrowType($expanded_type)) {
                 continue;
             }
+            if ($type->hasTemplateTypeRecursive()) {
+                continue;
+            }
             $throws_union_type = $analyzed_function->getThrowsUnionType();
             if ($throws_union_type->isEmpty()) {
                 if ($call !== null) {

--- a/tests/files/expected/0597_template_support.php.expected
+++ b/tests/files/expected/0597_template_support.php.expected
@@ -5,12 +5,10 @@
 %s:47 PhanTemplateTypeNotUsedInFunctionReturn Template type T not used in return value of function/method badTemplateReturn()
 %s:66 PhanTemplateTypeNotDeclaredInFunctionParams Template type T not declared in parameters of function/method missingTemplateParams() (or Phan can't extract template types for this use case)
 %s:68 PhanTypeMismatchReturn Returning type array{0:array<string,int>} but missingTemplateParams() is declared to return T[]
-%s:92 PhanTemplateTypeNotDeclaredInFunctionParams Template type TKey not declared in parameters of function/method combinationIterable() (or Phan can't extract template types for this use case)
 %s:105 PhanTypeMismatchArgumentInternal Argument 1 (string) is \stdClass[] but \strlen() takes string
 %s:109 PhanTypeMismatchArgumentInternal Argument 1 (string) is \stdClass but \strlen() takes string
 %s:110 PhanTypeMismatchArgumentInternal Argument 1 (string) is int but \strlen() takes string
 %s:111 PhanTypeMismatchArgumentInternal Argument 1 (string) is T[] but \strlen() takes string
-%s:112 PhanTypeMismatchArgumentInternal Argument 1 (string) is array<int,TKey>|array<int,TValue> but \strlen() takes string
-%s:112 PhanTypeMismatchArgument Argument 1 (i) is iterable<string,\stdClass> but \TemplateOnMethods::combinationIterable() takes iterable<\TKey,\TValue> defined at %s:92
+%s:112 PhanTypeMismatchArgumentInternal Argument 1 (string) is array<int,\stdClass>|array<int,string> but \strlen() takes string
 %s:137 PhanTypeMismatchArgumentInternal Argument 1 (string) is \stdClass but \strlen() takes string
 %s:138 PhanTypeMismatchArgumentInternal Argument 1 (string) is \ArrayAccess|\ArrayObject|\Countable|\IteratorAggregate|\Serializable|\Traversable|iterable but \strlen() takes string

--- a/tests/files/src/0597_template_support.php
+++ b/tests/files/src/0597_template_support.php
@@ -87,7 +87,7 @@ class TemplateOnMethods {
      * @param iterable<TKey,TValue> $i
      * @return array<int,TKey|TValue>
      *
-     * TODO: Finish fixing bugs in parsing TKey as a template type in the union type
+     * Phan can parse both TKey and TValue
      */
     public static function combinationIterable(iterable $i) {
         $result = [];

--- a/tests/plugin_test/expected/066_class_string_create.php.expected
+++ b/tests/plugin_test/expected/066_class_string_create.php.expected
@@ -1,0 +1,11 @@
+src/066_class_string_create.php:13 PhanStaticCallToNonStatic Static call to non-static method \C66::create_class() defined at src/066_class_string_create.php:8
+src/066_class_string_create.php:14 PhanStaticCallToNonStatic Static call to non-static method \C66::create_class() defined at src/066_class_string_create.php:8
+src/066_class_string_create.php:14 PhanTypeMismatchArgumentInternal Argument 1 (string) is \stdClass but \strlen() takes string
+src/066_class_string_create.php:15 PhanStaticCallToNonStatic Static call to non-static method \C66::create_class() defined at src/066_class_string_create.php:8
+src/066_class_string_create.php:15 PhanTypeMismatchArgumentInternal Argument 1 (string) is \invalidclass but \strlen() takes string
+src/066_class_string_create.php:15 PhanUndeclaredClassReference Reference to undeclared class \invalidclass
+src/066_class_string_create.php:16 PhanStaticCallToNonStatic Static call to non-static method \C66::create_class() defined at src/066_class_string_create.php:8
+src/066_class_string_create.php:16 PhanTypeMismatchArgumentInternal Argument 1 (string) is \int but \strlen() takes string
+src/066_class_string_create.php:16 PhanUndeclaredClassReference Reference to undeclared class \int
+src/066_class_string_create.php:17 PhanEmptyFQSENInClasslike Possible use of a classlike '' with an empty FQSEN.
+src/066_class_string_create.php:17 PhanStaticCallToNonStatic Static call to non-static method \C66::create_class() defined at src/066_class_string_create.php:8

--- a/tests/plugin_test/expected/067_throws_template.php.expected
+++ b/tests/plugin_test/expected/067_throws_template.php.expected
@@ -1,0 +1,1 @@
+src/067_throws_template.php:21 PhanTypeMismatchArgumentInternal Argument 1 (var) is \Exception|\Throwable but \count() takes \Countable|array

--- a/tests/plugin_test/src/066_class_string_create.php
+++ b/tests/plugin_test/src/066_class_string_create.php
@@ -1,0 +1,17 @@
+<?php
+class C66 {
+    /**
+     * @phan-template T
+     * @phan-param class-string<T> $name
+     * @phan-return T
+     */
+    function create_class(string $name) {
+        return new $name;
+    }
+}
+// Here, we con
+echo strlen(C66::create_class(0));  // should warn
+echo strlen(C66::create_class('stdClass'));  // should infer that this creates an instance of stdClass (and warn about it being invalid for strlen)
+echo strlen(C66::create_class('invalidclass'));  // should warn
+echo strlen(C66::create_class('int'));  // should warn
+echo strlen(C66::create_class(''));  // should warn

--- a/tests/plugin_test/src/067_throws_template.php
+++ b/tests/plugin_test/src/067_throws_template.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @phan-template T
+ * @param T $x
+ * @throws T
+ * @return T
+ */
+function maybe_throw($x) {
+    if (rand() % 2 > 0) {
+        return $x;
+    }
+    throw $x;
+}
+
+/**
+ * Phan should do something reasonable here
+ */
+function test_throws_template() {
+    $result = maybe_throw(new Exception("fail"));
+    echo count($result);
+}
+test_throws_template();


### PR DESCRIPTION
(on classes and function-likes).

Fixes #2253 and other similar edge cases

This may introduce `TemplateType` to the type system
where it was previously unexpected.
(The previous approach made it easier to gradually add
template types only where they were expected)