### PR TITLE
Infer template types from other function callables

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@ Phan NEWS
 
 New features(Analysis):
 + Infer that `new $x` is of the template type `T` if `$x` is `class-string<T>` (#2257)
++ Improve detection of invalid arguments in code implicitly calling `__invoke`.
++ Support extracting template types from more forms of `callable` types. (#2264)
 
 30 Dec 2018, Phan 1.1.10
 ------------------------

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1175,7 +1175,7 @@ class UnionTypeVisitor extends AnalysisVisitor
             // And use those closures to infer the (possibly transformed) types
             $template_type_list = [];
             foreach ($template_type_resolvers as $template_type_resolver) {
-                $template_type_list[] = $template_type_resolver($arg_type_list);
+                $template_type_list[] = $template_type_resolver($arg_type_list, $this->context);
             }
 
             // Create a new type that assigns concrete

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -73,6 +73,7 @@ class Issue
     const UndeclaredStaticMethodInCallable = 'PhanUndeclaredStaticMethodInCallable';
     const UndeclaredFunctionInCallable = 'PhanUndeclaredFunctionInCallable';
     const UndeclaredMethodInCallable = 'PhanUndeclaredMethodInCallable';
+    const UndeclaredInvokeInCallable = 'PhanUndeclaredInvokeInCallable';
     const EmptyFQSENInCallable      = 'PhanEmptyFQSENInCallable';
     const InvalidFQSENInCallable    = 'PhanInvalidFQSENInCallable';
     const EmptyFQSENInClasslike     = 'PhanEmptyFQSENInClasslike';
@@ -1036,6 +1037,14 @@ class Issue
                 "Reference to magic constant {CONST} that is undeclared in the current scope",
                 self::REMEDIATION_B,
                 11044
+            ),
+            new Issue(
+                self::UndeclaredInvokeInCallable,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_LOW,
+                "Possible attempt to access missing magic method {FUNCTIONLIKE} of '{CLASS}'",
+                self::REMEDIATION_B,
+                11045
             ),
 
             // Issue::CATEGORY_ANALYSIS
@@ -3614,6 +3623,7 @@ class Issue
     }
 
     /**
+     * @param array<int,mixed> $template_parameters
      * @return IssueInstance
      */
     public function __invoke(

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -2996,7 +2996,7 @@ class Clazz extends AddressableElement
     }
 
     /**
-     * @return array<int,Closure(array<int,mixed>):UnionType>
+     * @return array<int,Closure(array<int,mixed>, Context):UnionType>
      */
     public function getGenericConstructorBuilder(CodeBase $code_base)
     {

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -1411,8 +1411,7 @@ trait FunctionTrait
             );
             $template_type_map = [];
             foreach ($parameter_extracter_map as $name => $closure) {
-                // TODO: Do a better job of
-                $template_type_map[$name] = $closure ? $closure($args_types) : UnionType::empty();
+                $template_type_map[$name] = $closure ? $closure($args_types, $context) : UnionType::empty();
             }
             return $function->getUnionType()->withTemplateParameterTypeMap($template_type_map);
         };
@@ -1422,7 +1421,7 @@ trait FunctionTrait
     /**
      * @param TemplateType $template_type the template type that this function is looking for references to in parameters
      *
-     * @return ?Closure(array<int,UnionType>):UnionType
+     * @return ?Closure(array<int,UnionType>, Context):UnionType
      */
     public function getTemplateTypeExtractorClosure(CodeBase $code_base, TemplateType $template_type)
     {
@@ -1434,10 +1433,10 @@ trait FunctionTrait
             }
             $closure = TemplateType::combineParameterClosures(
                 $closure,
-                function (array $parameters) use ($i, $closure_for_type) : UnionType {
+                function (array $parameters, Context $context) use ($i, $closure_for_type) : UnionType {
                     $param_type = $parameters[$i] ?? null;
                     if ($param_type) {
-                        return $closure_for_type($param_type);
+                        return $closure_for_type($param_type, $context);
                     }
                     return UnionType::empty();
                 }

--- a/src/Phan/Language/Type/ArrayShapeType.php
+++ b/src/Phan/Language/Type/ArrayShapeType.php
@@ -3,10 +3,15 @@
 namespace Phan\Language\Type;
 
 use Closure;
+use Exception;
 use Phan\CodeBase;
 use Phan\Config;
 use Phan\Exception\RecursionDepthException;
+use Phan\Issue;
 use Phan\Language\AnnotatedUnionType;
+use Phan\Language\Context;
+use Phan\Language\Element\FunctionInterface;
+use Phan\Language\FQSEN\FullyQualifiedClassName;
 use Phan\Language\Type;
 use Phan\Language\UnionType;
 use Phan\Language\UnionTypeBuilder;
@@ -654,7 +659,7 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
      * If this generic array type in a parameter declaration has template types, get the closure to extract the real types for that template type from argument union types
      *
      * @param CodeBase $code_base
-     * @return ?Closure(UnionType):UnionType
+     * @return ?Closure(UnionType, Context):UnionType
      */
     public function getTemplateTypeExtractorClosure(CodeBase $code_base, TemplateType $template_type)
     {
@@ -666,7 +671,7 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
             }
             $closure = TemplateType::combineParameterClosures(
                 $closure,
-                function (UnionType $union_type) use ($key, $field_closure) : UnionType {
+                function (UnionType $union_type, Context $context) use ($key, $field_closure) : UnionType {
                     $result = UnionType::empty();
                     foreach ($union_type->getTypeSet() as $type) {
                         if (!($type instanceof ArrayShapeType)) {
@@ -674,7 +679,7 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
                         }
                         $field_type = $type->field_types[$key] ?? null;
                         if ($field_type) {
-                            $result = $result->withUnionType($field_closure($field_type));
+                            $result = $result->withUnionType($field_closure($field_type, $context));
                         }
                     }
                     return $result;
@@ -682,5 +687,70 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
             );
         }
         return $closure;
+    }
+
+    /**
+     * Returns the function interface this references
+     * @return ?FunctionInterface
+     */
+    public function asFunctionInterfaceOrNull(CodeBase $code_base, Context $context)
+    {
+        if (\count($this->field_types) !== 2) {
+            Issue::maybeEmit(
+                $code_base,
+                $context,
+                Issue::TypeInvalidCallableArraySize,
+                $context->getLineNumberStart(),
+                \count($this->field_types)
+            );
+            return null;
+        }
+        $i = 0;
+        foreach ($this->field_types as $key => $_) {
+            if ($key !== $i) {
+                // TODO: Be more consistent about emitting issues in Type->asFunctionInterfaceOrNull and its subclasses (e.g. if missing __invoke)
+                Issue::maybeEmit(
+                    $code_base,
+                    $context,
+                    Issue::TypeInvalidCallableArrayKey,
+                    $context->getLineNumberStart(),
+                    $i
+                );
+                return null;
+            }
+            $i++;
+        }
+        $method_name = $this->field_types[1]->asSingleScalarValueOrNull();
+        if (!\is_string($method_name)) {
+            return null;
+        }
+        foreach ($this->field_types[0]->getTypeSet() as $type) {
+            $class = null;
+            if ($type instanceof LiteralStringType) {
+                try {
+                    $fqsen = FullyQualifiedClassName::fromFullyQualifiedString($type->getValue());
+                    if (!$code_base->hasClassWithFQSEN($fqsen)) {
+                        continue;
+                    }
+                } catch (Exception $_) {
+                    continue;
+                }
+            } elseif ($type->isObjectWithKnownFQSEN()) {
+                $fqsen = $type->asFQSEN();
+                if (!$fqsen instanceof FullyQualifiedClassName) {
+                    continue;
+                }
+            } else {
+                continue;
+            }
+            if ($code_base->hasClassWithFQSEN($fqsen)) {
+                $class = $code_base->getClassByFQSEN($fqsen);
+                if ($class->hasMethodWithName($code_base, $method_name)) {
+                    return $class->getMethodByName($code_base, $method_name);
+                }
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Phan/Language/Type/ClosureType.php
+++ b/src/Phan/Language/Type/ClosureType.php
@@ -3,6 +3,8 @@
 namespace Phan\Language\Type;
 
 use AssertionError;
+use Phan\CodeBase;
+use Phan\Language\Context;
 use Phan\Language\Element\FunctionInterface;
 use Phan\Language\FQSEN;
 use Phan\Language\Type;
@@ -79,17 +81,6 @@ final class ClosureType extends Type
     public function asFQSEN() : FQSEN
     {
         return $this->fqsen ?? parent::asFQSEN();
-    }
-
-    /**
-     * Gets the function-like this type was created from.
-     *
-     * TODO: Uses of this may keep outdated data in language server mode.
-     * @return ?FunctionInterface
-     */
-    public function getFunctionLikeOrNull()
-    {
-        return $this->func;
     }
 
     /**
@@ -175,5 +166,23 @@ final class ClosureType extends Type
     public function isDefiniteNonCallableType() : bool
     {
         return false;
+    }
+
+    /**
+     * Gets the function-like this type was created from.
+     *
+     * TODO: Uses of this may keep outdated data in language server mode.
+     * @return ?FunctionInterface
+     * @deprecated use asFunctionInterfaceOrNull
+     * @suppress PhanUnreferencedPublicMethod
+     */
+    public function getFunctionLikeOrNull()
+    {
+        return $this->func;
+    }
+
+    public function asFunctionInterfaceOrNull(CodeBase $unused_codebase, Context $unused_context)
+    {
+        return $this->func;
     }
 }

--- a/src/Phan/Language/Type/GenericArrayTemplateKeyType.php
+++ b/src/Phan/Language/Type/GenericArrayTemplateKeyType.php
@@ -4,6 +4,7 @@ namespace Phan\Language\Type;
 
 use Closure;
 use Phan\CodeBase;
+use Phan\Language\Context;
 use Phan\Language\Type;
 use Phan\Language\UnionType;
 
@@ -66,7 +67,7 @@ class GenericArrayTemplateKeyType extends GenericArrayType
      * get the closure to extract the real types for that template type from argument union types
      *
      * @param CodeBase $code_base
-     * @return ?Closure(UnionType):UnionType
+     * @return ?Closure(UnionType, Context):UnionType
      */
     public function getTemplateTypeExtractorClosure(CodeBase $code_base, TemplateType $template_type)
     {

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -682,7 +682,7 @@ class GenericArrayType extends ArrayType implements GenericArrayInterface
      * If this generic array type in a parameter declaration has template types, get the closure to extract the real types for that template type from argument union types
      *
      * @param CodeBase $code_base
-     * @return ?Closure(UnionType):UnionType
+     * @return ?Closure(UnionType,Context):UnionType
      */
     public function getTemplateTypeExtractorClosure(CodeBase $code_base, TemplateType $template_type)
     {
@@ -691,8 +691,8 @@ class GenericArrayType extends ArrayType implements GenericArrayInterface
             return null;
         }
         // If a function expects T[], then T is the generic array element type of the passed in union type
-        return function (UnionType $array_type) use ($closure) : UnionType {
-            return $closure($array_type->genericArrayElementTypes());
+        return function (UnionType $array_type, Context $context) use ($closure) : UnionType {
+            return $closure($array_type->genericArrayElementTypes(), $context);
         };
     }
 }

--- a/src/Phan/Language/Type/GenericIterableType.php
+++ b/src/Phan/Language/Type/GenericIterableType.php
@@ -4,6 +4,7 @@ namespace Phan\Language\Type;
 
 use Closure;
 use Phan\CodeBase;
+use Phan\Language\Context;
 use Phan\Language\Type;
 use Phan\Language\UnionType;
 
@@ -148,23 +149,23 @@ final class GenericIterableType extends IterableType
      * If this generic array type in a parameter declaration has template types, get the closure to extract the real types for that template type from argument union types
      *
      * @param CodeBase $code_base
-     * @return ?Closure(UnionType):UnionType
+     * @return ?Closure(UnionType, Context):UnionType
      */
     public function getTemplateTypeExtractorClosure(CodeBase $code_base, TemplateType $template_type)
     {
         $closure = $this->element_union_type->getTemplateTypeExtractorClosure($code_base, $template_type);
         if ($closure) {
             // If a function expects T[], then T is the generic array element type of the passed in union type
-            $element_closure = function (UnionType $type) use ($code_base, $closure) : UnionType {
-                return $closure($type->iterableValueUnionType($code_base));
+            $element_closure = function (UnionType $type, Context $context) use ($code_base, $closure) : UnionType {
+                return $closure($type->iterableValueUnionType($code_base), $context);
             };
         } else {
             $element_closure = null;
         }
         $closure = $this->key_union_type->getTemplateTypeExtractorClosure($code_base, $template_type);
         if ($closure) {
-            $key_closure = function (UnionType $type) use ($code_base, $closure) : UnionType {
-                return $closure($type->iterableKeyUnionType($code_base));
+            $key_closure = function (UnionType $type, Context $context) use ($code_base, $closure) : UnionType {
+                return $closure($type->iterableKeyUnionType($code_base), $context);
             };
         } else {
             $key_closure = null;

--- a/src/Phan/Language/Type/LiteralStringType.php
+++ b/src/Phan/Language/Type/LiteralStringType.php
@@ -3,7 +3,11 @@
 namespace Phan\Language\Type;
 
 use InvalidArgumentException;
+use Phan\AST\UnionTypeVisitor;
+use Phan\CodeBase;
 use Phan\Config;
+use Phan\Language\Context;
+use Phan\Language\Element\FunctionInterface;
 use Phan\Language\Type;
 use Phan\Language\UnionType;
 use RuntimeException;
@@ -252,6 +256,21 @@ final class LiteralStringType extends StringType implements LiteralTypeInterface
         $v = $this->value;
         ++$v;
         return Type::nonLiteralFromObject($v)->asUnionType();
+    }
+
+    /**
+     * Returns the function interface that would be used if this type's string were a callable, or null.
+     * @param CodeBase $code_base the code base in which the function interface is found
+     * @param Context $context the context where the function interface is referenced (for emitting issues)
+     *
+     * @return ?FunctionInterface
+     */
+    public function asFunctionInterfaceOrNull(CodeBase $code_base, Context $context)
+    {
+        // parse 'function_name' or 'class_name::method_name'
+        // NOTE: In other subclasses of Type, calling this might recurse.
+        $function_like_fqsens = UnionTypeVisitor::functionLikeListFromNodeAndContext($code_base, $context, $this->value, true);
+        return $function_like_fqsens[0] ?? null;
     }
 }
 

--- a/src/Phan/Language/Type/NativeType.php
+++ b/src/Phan/Language/Type/NativeType.php
@@ -3,6 +3,7 @@
 namespace Phan\Language\Type;
 
 use Phan\CodeBase;
+use Phan\Language\Context;
 use Phan\Language\Type;
 use Phan\Language\UnionType;
 
@@ -280,6 +281,12 @@ abstract class NativeType extends Type
 
     public function getTemplateTypeExtractorClosure(CodeBase $unused_code_base, TemplateType $unused_template_type)
     {
+        return null;
+    }
+
+    public function asFunctionInterfaceOrNull(CodeBase $unused_codebase, Context $unused_context)
+    {
+        // overridden in subclasses
         return null;
     }
 }

--- a/src/Phan/Language/Type/TemplateType.php
+++ b/src/Phan/Language/Type/TemplateType.php
@@ -4,6 +4,7 @@ namespace Phan\Language\Type;
 
 use Closure;
 use Phan\CodeBase;
+use Phan\Language\Context;
 use Phan\Language\Type;
 use Phan\Language\UnionType;
 
@@ -134,9 +135,9 @@ final class TemplateType extends Type
 
     /**
      * Combine two closures that generate union types
-     * @param ?Closure(mixed):UnionType $left
-     * @param ?Closure(mixed):UnionType $right
-     * @return ?Closure(mixed):UnionType
+     * @param ?Closure(mixed, Context):UnionType $left
+     * @param ?Closure(mixed, Context):UnionType $right
+     * @return ?Closure(mixed, Context):UnionType
      */
     public static function combineParameterClosures($left, $right)
     {
@@ -150,20 +151,20 @@ final class TemplateType extends Type
         /**
          * @param mixed $params
          */
-        return function ($params) use ($left, $right) : UnionType {
-            return $left($params)->withUnionType($right($params));
+        return function ($params, Context $context) use ($left, $right) : UnionType {
+            return $left($params, $context)->withUnionType($right($params, $context));
         };
     }
 
     /**
      * @param TemplateType $template_type the template type that this union type is being searched for.
      *
-     * @return ?Closure(UnionType):UnionType a closure to map types to the template type wherever it was in the original union type
+     * @return ?Closure(UnionType, Context):UnionType a closure to map types to the template type wherever it was in the original union type
      */
     public function getTemplateTypeExtractorClosure(CodeBase $unused_code_base, TemplateType $template_type)
     {
         if ($this === $template_type) {
-            return function (UnionType $type) : UnionType {
+            return function (UnionType $type, Context $_) : UnionType {
                 return $type;
             };
         }

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -3636,7 +3636,7 @@ class UnionType implements Serializable
     /**
      * @param TemplateType $template_type the template type that this union type is being searched for
      *
-     * @return ?Closure(UnionType):UnionType a closure to map types to the template type wherever it was in the original union type
+     * @return ?Closure(UnionType, Context):UnionType a closure to map types to the template type wherever it was in the original union type
      */
     public function getTemplateTypeExtractorClosure(CodeBase $code_base, TemplateType $template_type)
     {

--- a/tests/Phan/Language/ContextTest.php
+++ b/tests/Phan/Language/ContextTest.php
@@ -15,6 +15,7 @@ use Phan\Tests\BaseTest;
 /**
  * Unit tests of Context and scopes
  * @phan-file-suppress PhanThrowTypeAbsentForCall
+ * @phan-file-suppress PhanPartialTypeMismatchArgument
  */
 final class ContextTest extends BaseTest
 {

--- a/tests/plugin_test/expected/062_strict_function_checking.php.expected
+++ b/tests/plugin_test/expected/062_strict_function_checking.php.expected
@@ -6,6 +6,7 @@ src/062_strict_function_checking.php:36 PhanTypePossiblyInvalidCallable Saw type
 src/062_strict_function_checking.php:37 PhanTypeInvalidCallable Saw type array<string,mixed> which cannot be a callable
 src/062_strict_function_checking.php:38 PhanTypePossiblyInvalidCallable Saw type null|string which is possibly not a callable
 src/062_strict_function_checking.php:39 PhanTypePossiblyInvalidCallable Saw type int|string which is possibly not a callable
+src/062_strict_function_checking.php:42 PhanTypeInvalidCallableArraySize In a place where phan was expecting a callable, saw an array of size 1, but callable arrays must be of size 2
 src/062_strict_function_checking.php:42 PhanTypeInvalidCallable Saw type array{key:string} which cannot be a callable
 src/062_strict_function_checking.php:44 PhanTypeInvalidCallable Saw type 2 which cannot be a callable
 src/062_strict_function_checking.php:45 PhanPluginUnreachableCode Unreachable statement detected

--- a/tests/plugin_test/expected/071_other_callable_methods.php.expected
+++ b/tests/plugin_test/expected/071_other_callable_methods.php.expected
@@ -1,0 +1,15 @@
+src/071_other_callable_methods.php:22 PhanTypeMismatchArgumentInternal Argument 1 (string) is \ArrayAccess|\ArrayObject|\Countable|\IteratorAggregate|\Serializable|\Traversable|iterable but \strlen() takes string
+src/071_other_callable_methods.php:23 PhanUndeclaredStaticMethodInCallable Reference to undeclared static method \InvokableTemplateTest::missingMethod in callable
+src/071_other_callable_methods.php:24 PhanTypeMismatchArgumentInternal Argument 1 (string) is \ArrayAccess|\ArrayObject|\Countable|\IteratorAggregate|\Serializable|\Traversable|iterable but \strlen() takes string
+src/071_other_callable_methods.php:25 PhanUndeclaredMethodInCallable Call to undeclared method missingMethod in callable. Possible object type(s) for that method are \InvokableTemplateTest
+src/071_other_callable_methods.php:26 PhanUndeclaredInvokeInCallable Possible attempt to access missing magic method __invoke of '\ArrayObject'
+src/071_other_callable_methods.php:28 PhanParamTooFew Call with 0 arg(s) to \InvokableTemplateTest::__invoke() which requires 1 arg(s) defined at src/071_other_callable_methods.php:4
+src/071_other_callable_methods.php:29 PhanUndeclaredInvokeInCallable Possible attempt to access missing magic method __invoke of '\stdClass'
+src/071_other_callable_methods.php:30 PhanTypeInvalidCallableArraySize In a place where phan was expecting a callable, saw an array of size 1, but callable arrays must be of size 2
+src/071_other_callable_methods.php:35 PhanUndeclaredStaticMethodInCallable Reference to undeclared static method \InvokableTemplateTest::missingMethod in callable
+src/071_other_callable_methods.php:37 PhanUndeclaredMethodInCallable Call to undeclared method missingMethod in callable. Possible object type(s) for that method are \InvokableTemplateTest
+src/071_other_callable_methods.php:38 PhanTypeMismatchArgument Argument 1 (c) is \ArrayAccess|\ArrayObject|\Countable|\IteratorAggregate|\Serializable|\Traversable|iterable but \non_template_return_test() takes callable defined at src/071_other_callable_methods.php:31
+src/071_other_callable_methods.php:39 PhanTypeMismatchArgument Argument 1 (c) is array{0:\InvokableTemplateTest|callable} but \non_template_return_test() takes callable defined at src/071_other_callable_methods.php:31
+src/071_other_callable_methods.php:41 PhanUnreferencedFunction Possibly zero references to function \create_from_closure()
+src/071_other_callable_methods.php:59 PhanUndeclaredInvokeInCallable Possible attempt to access missing magic method __invoke of '\stdClass'
+src/071_other_callable_methods.php:60 PhanTypeMismatchArgumentInternal Argument 1 (string) is int[] but \strlen() takes string

--- a/tests/plugin_test/src/071_other_callable_methods.php
+++ b/tests/plugin_test/src/071_other_callable_methods.php
@@ -1,0 +1,60 @@
+<?php
+
+class InvokableTemplateTest {
+    public function __invoke($arg) : stdClass {
+        return (object)['arg' => $arg];
+    }
+
+    public static function createArrayObject($args) : ArrayObject {
+        return new ArrayObject($args);
+    }
+}
+
+/**
+ * @template T
+ * @param callable(mixed):T $c
+ * @return T
+ */
+function template_return_test(callable $c) {
+    return $c('arg');
+}
+$o = new InvokableTemplateTest();
+echo strlen(template_return_test(['InvokableTemplateTest', 'createArrayObject']));
+echo strlen(template_return_test(['InvokableTemplateTest', 'missingMethod']));
+echo strlen(template_return_test([$o, 'createArrayObject']));
+echo strlen(template_return_test([$o, 'missingMethod']));
+echo strlen(template_return_test(new ArrayObject()));
+$c = [$o];
+var_export($o());
+var_export((new stdClass())());
+echo strlen(template_return_test($c));
+function non_template_return_test(callable $c) {
+    var_export($c('arg'));
+}
+non_template_return_test(['InvokableTemplateTest', 'createArrayObject']);
+non_template_return_test(['InvokableTemplateTest', 'missingMethod']);
+non_template_return_test([$o, 'createArrayObject']);
+non_template_return_test([$o, 'missingMethod']);
+non_template_return_test(new ArrayObject());
+non_template_return_test($c);
+
+function create_from_closure(Closure $x, callable $y) {
+    echo strlen(template_return_test($x));  // should not warn, type is unknown
+    echo strlen(template_return_test($y));  // should not warn, type is unknown
+}
+
+/**
+ * NOTE: Currently may only detect some issue types when templates are involved,
+ * but not detect them when templates aren't involved.
+ *
+ * @template T
+ * @param array<mixed,callable(mixed):T> $a
+ * @return T[]
+ */
+function template_return_test_array(array $a) {
+    return [$a[0]('value')];
+}
+// TODO: A side effect of the current implementation
+// is that this only warns about misuse of templates when the return value is used.
+var_export(template_return_test_array([new stdClass()]));
+echo strlen(template_return_test_array(['strlen']));


### PR DESCRIPTION
And improve analysis of implicit calls to `__invoke()`

Fixes #2264