### PR TITLE
Suggest typo fixes with `PhanUnusedVariable`

### DIFF
--- a/.phan/plugins/PHPUnitAssertionPlugin.php
+++ b/.phan/plugins/PHPUnitAssertionPlugin.php
@@ -62,80 +62,80 @@ class PHPUnitAssertionPlugin extends PluginV2 implements AnalyzeFunctionCallCapa
     {
         // TODO: Add a helper method which will convert a doc comment and a stub php function source code to a closure for a param index (or indices)
         switch (\strtolower($name)) {
-        case 'asserttrue':
-        case 'assertnotfalse':
-            return $method->createClosureForAssertion(
-                $code_base,
-                new Assertion(UnionType::empty(), 'unusedParamName', Assertion::IS_TRUE),
-                0
-            );
-        case 'assertfalse':
-        case 'assertnottrue':
-            return $method->createClosureForAssertion(
-                $code_base,
-                new Assertion(UnionType::empty(), 'unusedParamName', Assertion::IS_FALSE),
-                0
-            );
-        case 'assertnull':
-            return $method->createClosureForAssertion(
-                $code_base,
-                new Assertion(UnionType::fromFullyQualifiedString('null'), 'unusedParamName', Assertion::IS_OF_TYPE),
-                0
-            );
-        case 'assertnotnull':
-            return $method->createClosureForAssertion(
-                $code_base,
-                new Assertion(UnionType::fromFullyQualifiedString('null'), 'unusedParamName', Assertion::IS_NOT_OF_TYPE),
-                0
-            );
-        case 'assertsame':
-            // Sets the type of $actual to $expected
-            //
-            // This is equivalent to the side effects of the below doc comment.
-            // Note that the doc comment would make phan emit warnings about invalid classes, etc.
-            // TODO: Reuse the code for templates here
-            //
-            // (at)template T
-            // (at)param T $expected
-            // (at)param mixed $actual
-            // (at)phan-assert T $actual
-            return $method->createClosureForUnionTypeExtractorAndAssertionType(
-                function (CodeBase $code_base, Context $context, array $args) : UnionType {
-                    if (\count($args) < 2) {
-                        return UnionType::empty();
-                    }
-                    return UnionTypeVisitor::unionTypeFromNode($code_base, $context, $args[0]);
-                },
-                Assertion::IS_OF_TYPE,
-                1
-            );
-        case 'assertinstanceof':
-            // This is equivalent to the side effects of the below doc comment.
-            // Note that the doc comment would make phan emit warnings about invalid classes, etc.
-            // TODO: Reuse the code for class-string<T> here.
-            //
-            // (at)template T
-            // (at)param class-string<T> $expected
-            // (at)param mixed $actual
-            // (at)phan-assert T $actual
-            return $method->createClosureForUnionTypeExtractorAndAssertionType(
-                function (CodeBase $code_base, Context $context, array $args) : UnionType {
-                    if (\count($args) < 2) {
-                        return UnionType::empty();
-                    }
-                    $string = (UnionTypeVisitor::unionTypeFromNode($code_base, $context, $args[0]))->asSingleScalarValueOrNull();
-                    if (!is_string($string)) {
-                        return UnionType::empty();
-                    }
-                    try {
-                        return FullyQualifiedClassName::fromFullyQualifiedString($string)->asType()->asUnionType();
-                    } catch (\Exception $_) {
-                        return UnionType::empty();
-                    }
-                },
-                Assertion::IS_OF_TYPE,
-                1
-            );
+            case 'asserttrue':
+            case 'assertnotfalse':
+                return $method->createClosureForAssertion(
+                    $code_base,
+                    new Assertion(UnionType::empty(), 'unusedParamName', Assertion::IS_TRUE),
+                    0
+                );
+            case 'assertfalse':
+            case 'assertnottrue':
+                return $method->createClosureForAssertion(
+                    $code_base,
+                    new Assertion(UnionType::empty(), 'unusedParamName', Assertion::IS_FALSE),
+                    0
+                );
+            case 'assertnull':
+                return $method->createClosureForAssertion(
+                    $code_base,
+                    new Assertion(UnionType::fromFullyQualifiedString('null'), 'unusedParamName', Assertion::IS_OF_TYPE),
+                    0
+                );
+            case 'assertnotnull':
+                return $method->createClosureForAssertion(
+                    $code_base,
+                    new Assertion(UnionType::fromFullyQualifiedString('null'), 'unusedParamName', Assertion::IS_NOT_OF_TYPE),
+                    0
+                );
+            case 'assertsame':
+                // Sets the type of $actual to $expected
+                //
+                // This is equivalent to the side effects of the below doc comment.
+                // Note that the doc comment would make phan emit warnings about invalid classes, etc.
+                // TODO: Reuse the code for templates here
+                //
+                // (at)template T
+                // (at)param T $expected
+                // (at)param mixed $actual
+                // (at)phan-assert T $actual
+                return $method->createClosureForUnionTypeExtractorAndAssertionType(
+                    function (CodeBase $code_base, Context $context, array $args) : UnionType {
+                        if (\count($args) < 2) {
+                            return UnionType::empty();
+                        }
+                        return UnionTypeVisitor::unionTypeFromNode($code_base, $context, $args[0]);
+                    },
+                    Assertion::IS_OF_TYPE,
+                    1
+                );
+            case 'assertinstanceof':
+                // This is equivalent to the side effects of the below doc comment.
+                // Note that the doc comment would make phan emit warnings about invalid classes, etc.
+                // TODO: Reuse the code for class-string<T> here.
+                //
+                // (at)template T
+                // (at)param class-string<T> $expected
+                // (at)param mixed $actual
+                // (at)phan-assert T $actual
+                return $method->createClosureForUnionTypeExtractorAndAssertionType(
+                    function (CodeBase $code_base, Context $context, array $args) : UnionType {
+                        if (\count($args) < 2) {
+                            return UnionType::empty();
+                        }
+                        $string = (UnionTypeVisitor::unionTypeFromNode($code_base, $context, $args[0]))->asSingleScalarValueOrNull();
+                        if (!is_string($string)) {
+                            return UnionType::empty();
+                        }
+                        try {
+                            return FullyQualifiedClassName::fromFullyQualifiedString($string)->asType()->asUnionType();
+                        } catch (\Exception $_) {
+                            return UnionType::empty();
+                        }
+                    },
+                    Assertion::IS_OF_TYPE,
+                    1
+                );
         }
     }
 }

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@ New features(Analysis):
   - This can be used in combination with Phan's template support.
 
   See [tests/plugin_test/src/072_custom_assertions.php](tests/plugin_test/src/072_custom_assertions.php) for example uses of these annotations.
++ Suggest typo fixes when emitting `PhanUnusedVariable`, if only one definition was seen. (#2281)
 
 Plugins:
 - Add `PHPUnitAssertionPlugin`.

--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -765,7 +765,7 @@ class Context extends FileRef
      * @suppress PhanTypeSuspiciousNonTraversableForeach
      * @return void
      */
-    protected final function copyPropertiesFrom(Context $other)
+    final protected function copyPropertiesFrom(Context $other)
     {
         foreach ($other as $k => $v) {
             $this->{$k} = $v;

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableGraph.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableGraph.php
@@ -76,6 +76,11 @@ final class VariableGraph
      */
     public function recordVariableUsage(string $name, Node $node, VariableTrackingScope $scope)
     {
+        if (!\array_key_exists($name, $this->variable_types)) {
+            // Set this to 0 to record that the variable was used somewhere
+            // (it will be overridden later if there are flags to set)
+            $this->variable_types[$name] = 0;
+        }
         $defs_for_variable = $scope->getDefinition($name);
         if (!$defs_for_variable) {
             return;

--- a/tests/files/expected/0079_conditional_types.php.expected
+++ b/tests/files/expected/0079_conditional_types.php.expected
@@ -1,1 +1,1 @@
-%s:10 PhanUnusedVariable Unused definition of variable $v2
+%s:10 PhanUnusedVariable Unused definition of variable $v2 (Did you mean $v1)

--- a/tests/files/expected/0109_conditional_ignored_types.php.expected
+++ b/tests/files/expected/0109_conditional_ignored_types.php.expected
@@ -1,1 +1,1 @@
-%s:5 PhanUnusedVariable Unused definition of variable $v2
+%s:5 PhanUnusedVariable Unused definition of variable $v2 (Did you mean $v1)

--- a/tests/files/expected/0205_undeclared_property.php.expected
+++ b/tests/files/expected/0205_undeclared_property.php.expected
@@ -1,3 +1,3 @@
 %s:7 PhanUnusedVariable Unused definition of variable $v
-%s:9 PhanUnusedVariable Unused definition of variable $v2
+%s:9 PhanUnusedVariable Unused definition of variable $v2 (Did you mean $a2)
 %s:9 PhanUnusedVariable Unused definition of variable $v3

--- a/tests/files/expected/0219_superglobal_type_check.php.expected
+++ b/tests/files/expected/0219_superglobal_type_check.php.expected
@@ -10,6 +10,6 @@
 %s:34 PhanTypeMismatchArgumentInternal Argument 1 (string) is array<string,array<int,int>>|array<string,array<int,string>>|array<string,int>|array<string,string> but \strlen() takes string
 %s:37 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is array<string,array<int,int>>|array<string,array<int,string>>|array<string,int>|array<string,string> but \intdiv() takes int
 %s:40 PhanTypeMismatchArgumentInternal Argument 1 (string) is array<int,string>|null but \strlen() takes string
-%s:43 PhanUnusedVariable Unused definition of variable $http_response_headers
+%s:43 PhanUnusedVariable Unused definition of variable $http_response_headers (Did you mean $http_response_header)
 %s:49 PhanUndeclaredVariable Variable $argc is undeclared
 %s:50 PhanUndeclaredVariable Variable $argv is undeclared

--- a/tests/files/expected/0278_internal_elements.php.expected
+++ b/tests/files/expected/0278_internal_elements.php.expected
@@ -1,16 +1,16 @@
 %s:35 PhanTypeVoidAssignment Cannot assign void return value
 %s:61 PhanTypeVoidAssignment Cannot assign void return value
-%s:61 PhanUnusedVariable Unused definition of variable $v01
-%s:62 PhanUnusedVariable Unused definition of variable $v02
+%s:61 PhanUnusedVariable Unused definition of variable $v01 (Did you mean $v1)
+%s:62 PhanUnusedVariable Unused definition of variable $v02 (Did you mean $v2)
 %s:63 PhanUnusedVariable Unused definition of variable $v03
-%s:66 PhanUnusedVariable Unused definition of variable $v11
-%s:67 PhanUnusedVariable Unused definition of variable $v12
-%s:68 PhanUnusedVariable Unused definition of variable $v13
-%s:71 PhanUnusedVariable Unused definition of variable $v21
-%s:72 PhanUnusedVariable Unused definition of variable $v22
-%s:73 PhanUnusedVariable Unused definition of variable $v23
-%s:74 PhanUnusedVariable Unused definition of variable $v24
-%s:75 PhanUnusedVariable Unused definition of variable $v25
+%s:66 PhanUnusedVariable Unused definition of variable $v11 (Did you mean $v1)
+%s:67 PhanUnusedVariable Unused definition of variable $v12 (Did you mean $v1 or $v2)
+%s:68 PhanUnusedVariable Unused definition of variable $v13 (Did you mean $v1)
+%s:71 PhanUnusedVariable Unused definition of variable $v21 (Did you mean $v1 or $v2)
+%s:72 PhanUnusedVariable Unused definition of variable $v22 (Did you mean $v2)
+%s:73 PhanUnusedVariable Unused definition of variable $v23 (Did you mean $v2)
+%s:74 PhanUnusedVariable Unused definition of variable $v24 (Did you mean $v2)
+%s:75 PhanUnusedVariable Unused definition of variable $v25 (Did you mean $v2)
 %s:92 PhanAccessMethodInternal Cannot access internal method \NS278\A\f() of namespace \NS278\A defined at %s:33 from namespace \NS278\B
 %s:92 PhanTypeVoidAssignment Cannot assign void return value
 %s:94 PhanAccessConstantInternal Cannot access internal constant \NS278\A\CONST_INTERNAL of namespace \NS278\A defined at %s:8 from namespace \NS278\B

--- a/tests/files/expected/0278_internal_elements.php.expected70
+++ b/tests/files/expected/0278_internal_elements.php.expected70
@@ -1,16 +1,16 @@
 %s:35 PhanTypeVoidAssignment Cannot assign void return value
 %s:61 PhanTypeVoidAssignment Cannot assign void return value
-%s:61 PhanUnusedVariable Unused definition of variable $v01
-%s:62 PhanUnusedVariable Unused definition of variable $v02
+%s:61 PhanUnusedVariable Unused definition of variable $v01 (Did you mean $v1)
+%s:62 PhanUnusedVariable Unused definition of variable $v02 (Did you mean $v2)
 %s:63 PhanUnusedVariable Unused definition of variable $v03
-%s:66 PhanUnusedVariable Unused definition of variable $v11
-%s:67 PhanUnusedVariable Unused definition of variable $v12
-%s:68 PhanUnusedVariable Unused definition of variable $v13
-%s:71 PhanUnusedVariable Unused definition of variable $v21
-%s:72 PhanUnusedVariable Unused definition of variable $v22
-%s:73 PhanUnusedVariable Unused definition of variable $v23
-%s:74 PhanUnusedVariable Unused definition of variable $v24
-%s:75 PhanUnusedVariable Unused definition of variable $v25
+%s:66 PhanUnusedVariable Unused definition of variable $v11 (Did you mean $v1)
+%s:67 PhanUnusedVariable Unused definition of variable $v12 (Did you mean $v1 or $v2)
+%s:68 PhanUnusedVariable Unused definition of variable $v13 (Did you mean $v1)
+%s:71 PhanUnusedVariable Unused definition of variable $v21 (Did you mean $v1 or $v2)
+%s:72 PhanUnusedVariable Unused definition of variable $v22 (Did you mean $v2)
+%s:73 PhanUnusedVariable Unused definition of variable $v23 (Did you mean $v2)
+%s:74 PhanUnusedVariable Unused definition of variable $v24 (Did you mean $v2)
+%s:75 PhanUnusedVariable Unused definition of variable $v25 (Did you mean $v2)
 %s:92 PhanAccessMethodInternal Cannot access internal method \NS278\A\f() of namespace \NS278\A defined at %s:33 from namespace \NS278\B
 %s:92 PhanTypeVoidAssignment Cannot assign void return value
 %s:96 PhanAccessMethodInternal Cannot access internal method \NS278\A\C1::__construct() of namespace \NS278\A defined at %s:11 from namespace \NS278\B

--- a/tests/files/expected/0313_undefined_array_push.php.expected
+++ b/tests/files/expected/0313_undefined_array_push.php.expected
@@ -1,4 +1,4 @@
-%s:7 PhanUnusedVariable Unused definition of variable $myVar
+%s:7 PhanUnusedVariable Unused definition of variable $myVar (Did you mean $myvAR or $myvar)
 %s:8 PhanUndeclaredVariableDim Variable $myvar was undeclared, but array fields are being added to it.
 %s:9 PhanUndeclaredVariableDim Variable $myvAR was undeclared, but array fields are being added to it.
 %s:11 PhanUndeclaredProperty Reference to undeclared property \Foo313->prop

--- a/tests/files/expected/0479_typo_suggest.php.expected
+++ b/tests/files/expected/0479_typo_suggest.php.expected
@@ -1,4 +1,4 @@
-%s:4 PhanUnusedVariable Unused definition of variable $myValue
+%s:4 PhanUnusedVariable Unused definition of variable $myValue (Did you mean $my_value)
 %s:5 PhanUndeclaredVariable Variable $Param2 is undeclared (Did you mean $param2)
 %s:5 PhanUnusedVariable Unused definition of variable $x
 %s:7 PhanUndeclaredVariable Variable $my_value is undeclared (Did you mean $myValue)
@@ -9,8 +9,8 @@
 %s:11 PhanUnusedVariable Unused definition of variable $w
 %s:17 PhanUndeclaredVariable Variable $_prop is undeclared (Did you mean $this->_prop)
 %s:17 PhanUnusedVariable Unused definition of variable $x
-%s:18 PhanUnusedVariable Unused definition of variable $prop
+%s:18 PhanUnusedVariable Unused definition of variable $prop (Did you mean $_prop)
 %s:19 PhanUndeclaredVariable Variable $_prop is undeclared (Did you mean $prop or $this->_prop)
 %s:19 PhanUnusedVariable Unused definition of variable $y
-%s:20 PhanUnusedVariable Unused definition of variable $my_really_longname
+%s:20 PhanUnusedVariable Unused definition of variable $my_really_longname (Did you mean $myReallyLongname)
 %s:21 PhanUndeclaredVariable Variable $myReallyLongname is undeclared (Did you mean $my_really_longname)

--- a/tests/files/src/0079_conditional_types.php
+++ b/tests/files/src/0079_conditional_types.php
@@ -7,6 +7,6 @@ class B {
     public function f(A $p = null) {
         $p = $p ?: new A();
         $p->f($v1);
-        $v2 = $v1;
+        $v2 = $v1;  // TODO: Suggestion for PhanUnusedVariable is pointless here
     }
 }

--- a/tests/plugin_test/expected/075_variable_suggestions.php.expected
+++ b/tests/plugin_test/expected/075_variable_suggestions.php.expected
@@ -1,0 +1,3 @@
+src/075_variable_suggestions.php:4 PhanUnusedVariable Unused definition of variable $unrelatedValuename (Did you mean $unrelatedValueName)
+src/075_variable_suggestions.php:8 PhanUnusedVariable Unused definition of variable $value2 (Did you mean $value1 or $value3)
+src/075_variable_suggestions.php:12 PhanUndeclaredVariable Variable $unrelatedValueName is undeclared (Did you mean $unrelatedValuename)

--- a/tests/plugin_test/src/075_variable_suggestions.php
+++ b/tests/plugin_test/src/075_variable_suggestions.php
@@ -1,0 +1,14 @@
+<?php
+function test_variable_suggestions() {
+    $value3 = 33;
+    $unrelatedValuename = 'value';
+    if (rand() % 2 > 0) {
+        $value1 = 1;
+    } else {
+        $value2 = 2;
+    }
+    echo $value1;
+    echo $value3;
+    echo $unrelatedValueName;
+}
+test_variable_suggestions();


### PR DESCRIPTION
Suggest fixes if there was only one definition with that variable name.