### PR TITLE
Fix a crash running Phan without php-ast when no files were parsed

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,7 @@ Plugins:
 
 Bug fixes:
 - Infer that some internal classes' properties (such as `\Exception->message`) are protected (#2283)
+- Fix a crash running Phan without php-ast when no files were parsed (#2287)
 
 30 Dec 2018, Phan 1.1.10
 ------------------------

--- a/src/Phan/Phan.php
+++ b/src/Phan/Phan.php
@@ -98,6 +98,10 @@ class Phan implements IgnoredFilesFilterInterface
         CodeBase $code_base,
         Closure $file_path_lister
     ) : bool {
+        if (!class_exists('\ast\Node')) {
+            // Fix for https://github.com/phan/phan/issues/2287
+            require_once __DIR__ . '/AST/TolerantASTConverter/ast_shim.php';
+        }
         FileCache::setMaxCacheSize(FileCache::MINIMUM_CACHE_SIZE);
         self::checkForSlowPHPOptions();
         self::loadConfiguredPHPExtensionStubs($code_base);


### PR DESCRIPTION
Fixes #2287