### PR TITLE
Prevent the `&&` operator from unintentionally changing the left hand side

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@ Phan NEWS
 
 New features(Analysis):
 + Infer that the result of `array_map` has integer keys when passed two or more arrays (#2277)
++ Improve inferences about the left hand side of `&&` statements such as `$leftVar && (other_expression);` (#2300)
 
 Plugins:
 + Add a new issue type to `DuplicateExpressionPlugin`: `PhanPluginBothLiteralsBinaryOp`. (#2297)

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -1250,17 +1250,22 @@ class BlockAnalysisVisitor extends AnalysisVisitor
             $context_with_left_condition = (new ConditionVisitor(
                 $this->code_base,
                 $base_context
-            ))($left_node);
+            ))->__invoke($left_node);
+            $context_with_false_left_condition = (new NegatedConditionVisitor(
+                $this->code_base,
+                $base_context
+            ))->__invoke($left_node);
         } else {
             $context_with_left_condition = $context;
+            $context_with_false_left_condition = $context;
         }
 
         if ($right_node instanceof Node) {
             $right_context = $this->analyzeAndGetUpdatedContext($context_with_left_condition, $node, $right_node);
             $context = (new ContextMergeVisitor(
                 $context,
-                [$context, $context_with_left_condition, $right_context]
-            ))($node);
+                [$context, $context_with_false_left_condition, $right_context]
+            ))->combineChildContextList();
         }
 
         $context = $this->postOrderAnalyze($context, $node);

--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -361,6 +361,19 @@ class Context extends FileRef
     }
 
     /**
+     * Returns a string representing this Context for debugging
+     * @suppress PhanUnreferencedPublicMethod kept around to make it easy to dump variables in a context
+     */
+    public function toDebugString() : string
+    {
+        $result = (string)$this;
+        foreach ($this->getScope()->getVariableMap() as $variable) {
+            $result .= "\n$variable";
+        }
+        return $result;
+    }
+
+    /**
      * @return bool
      * True if this context is currently within a class
      * scope, else false.

--- a/tests/plugin_test/expected/077_both_literals.php.expected
+++ b/tests/plugin_test/expected/077_both_literals.php.expected
@@ -1,0 +1,19 @@
+src/077_both_literals.php:3 PhanPluginBothLiteralsBinaryOp Suspicious usage of a binary operator where both operands are literals. Expression: 2 <=> 3 (result is -1)
+src/077_both_literals.php:4 PhanPluginBothLiteralsBinaryOp Suspicious usage of a binary operator where both operands are literals. Expression: null == 9 (result is false)
+src/077_both_literals.php:4 PhanPluginNumericalComparison non numerical values compared by the operators '==' or '!='
+src/077_both_literals.php:5 PhanPluginBothLiteralsBinaryOp Suspicious usage of a binary operator where both operands are literals. Expression: null === 9 (result is false)
+src/077_both_literals.php:6 PhanPluginBothLiteralsBinaryOp Suspicious usage of a binary operator where both operands are literals. Expression: 1 !== 9 (result is true)
+src/077_both_literals.php:7 PhanPluginBothLiteralsBinaryOp Suspicious usage of a binary operator where both operands are literals. Expression: 1 != 9 (result is true)
+src/077_both_literals.php:7 PhanPluginNumericalComparison non numerical values compared by the operators '==' or '!='
+src/077_both_literals.php:8 PhanPluginBothLiteralsBinaryOp Suspicious usage of a binary operator where both operands are literals. Expression: 1 != 9 (result is true)
+src/077_both_literals.php:8 PhanPluginNumericalComparison non numerical values compared by the operators '==' or '!='
+src/077_both_literals.php:9 PhanPluginBothLiteralsBinaryOp Suspicious usage of a binary operator where both operands are literals. Expression: 2 < 3 (result is true)
+src/077_both_literals.php:10 PhanPluginDuplicateExpressionBinaryOp Both sides of the binary operator <= are the same: 2
+src/077_both_literals.php:11 PhanPluginBothLiteralsBinaryOp Suspicious usage of a binary operator where both operands are literals. Expression: 2 <= '700' (result is true)
+src/077_both_literals.php:12 PhanPluginBothLiteralsBinaryOp Suspicious usage of a binary operator where both operands are literals. Expression: 3 > 2 (result is true)
+src/077_both_literals.php:13 PhanPluginBothLiteralsBinaryOp Suspicious usage of a binary operator where both operands are literals. Expression: 3 >= 4 (result is false)
+src/077_both_literals.php:14 PhanPluginBothLiteralsBinaryOp Suspicious usage of a binary operator where both operands are literals. Expression: true && false (result is false)
+src/077_both_literals.php:15 PhanPluginBothLiteralsBinaryOp Suspicious usage of a binary operator where both operands are literals. Expression: true && 'aString' (result is true)
+src/077_both_literals.php:15 PhanPluginNonBoolInLogicalArith Non bool value of type 'aString' in logical arithmetic
+src/077_both_literals.php:16 PhanPluginBothLiteralsBinaryOp Suspicious usage of a binary operator where both operands are literals. Expression: true || false (result is true)
+src/077_both_literals.php:17 PhanPluginBothLiteralsBinaryOp Suspicious usage of a binary operator where both operands are literals. Expression: true xor false (result is true)

--- a/tests/plugin_test/expected/078_merge_bool_and.php
+++ b/tests/plugin_test/expected/078_merge_bool_and.php
@@ -1,0 +1,3 @@
+src/078_merge_bool_and.php:3 PhanPossiblyFalseTypeArgumentInternal Argument 1 (string) is '10'|false but \strlen() takes string (false is incompatible)
+src/078_merge_bool_and.php:4 PhanPluginNonBoolInLogicalArith Non bool value of type '10'|false in logical arithmetic
+src/078_merge_bool_and.php:5 PhanPossiblyFalseTypeArgumentInternal Argument 1 (string) is '10'|false but \strlen() takes string (false is incompatible)

--- a/tests/plugin_test/expected/078_merge_bool_and.php.expected
+++ b/tests/plugin_test/expected/078_merge_bool_and.php.expected
@@ -1,0 +1,3 @@
+src/078_merge_bool_and.php:3 PhanPossiblyFalseTypeArgumentInternal Argument 1 (string) is '10'|false but \strlen() takes string (false is incompatible)
+src/078_merge_bool_and.php:4 PhanPluginNonBoolInLogicalArith Non bool value of type '10'|false in logical arithmetic
+src/078_merge_bool_and.php:5 PhanPossiblyFalseTypeArgumentInternal Argument 1 (string) is '10'|false but \strlen() takes string (false is incompatible)

--- a/tests/plugin_test/src/077_both_literals.php
+++ b/tests/plugin_test/src/077_both_literals.php
@@ -1,0 +1,17 @@
+<?php
+$x = rand(0,10) ?: null;
+var_export(2 <=> 3);
+var_export($x ?? null == 9);
+var_export($x ?? null === 9);
+var_export($x ?? 1 !== 9);
+var_export($x ?? 1 != 9);
+var_export($x ?? 1 != 9);
+var_export(2 < 3);
+var_export(2 <= 2);  // If PhanPluginDuplicateExpressionBinaryOp is emitted, don't bother emitting PhanPluginBothLiteralsBinaryOp
+var_export(2 <= '700');  // If PhanPluginDuplicateExpressionBinaryOp is emitted, don't bother emitting PhanPluginBothLiteralsBinaryOp
+var_export(3 > 2);
+var_export(3 >= 4);
+var_export(true && false);
+var_export(true and 'aString');
+var_export(true || false);
+var_export(true xor false);

--- a/tests/plugin_test/src/078_merge_bool_and.php
+++ b/tests/plugin_test/src/078_merge_bool_and.php
@@ -1,0 +1,5 @@
+<?php
+$x = rand(0,1) ? '10' : false;
+echo strlen($x);
+$x && false;
+echo strlen($x);

--- a/tests/plugin_test/src/079_both_booleans.php
+++ b/tests/plugin_test/src/079_both_booleans.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+$bool = false;
+$bool && false;
+$bool || false;


### PR DESCRIPTION
Fixes #2300