### PR TITLE
Support --output-mode <mode> and --color in phan_client

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,14 @@ New features(Analysis):
 + Improve inferences about the left hand side of `&&` statements such as `$leftVar && (other_expression);` (#2300)
 + Warn about passing an undefined variable to a function expecting a reference parameter with a real, non-nullable type (#1344)
 
+Maintenance:
++ End the output for `--output-mode <json>` with a newline.
+
+Language Server/Daemon mode:
++ Add `--output-mode <mode>` to `phan_client`. (#1568)
+  Supported formats: `phan_client` (default), `text`, `json`, `csv`, `codeclimate`, `checkstyle`, or `pylint`
++ Add `--color` to `phan_client` (e.g. for use with `--output-mode text`)
+
 Plugins:
 + Add a new issue type to `DuplicateExpressionPlugin`: `PhanPluginBothLiteralsBinaryOp`. (#2297)
   (warns about suspicious expressions such as `null == 'a literal` in `$x ?? null == 'a literal'`)

--- a/composer.lock
+++ b/composer.lock
@@ -497,16 +497,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v3.4.20",
+            "version": "v3.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "8f80fc39bbc3b7c47ee54ba7aa2653521ace94bb"
+                "reference": "a700b874d3692bc8342199adfb6d3b99f62cc61a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/8f80fc39bbc3b7c47ee54ba7aa2653521ace94bb",
-                "reference": "8f80fc39bbc3b7c47ee54ba7aa2653521ace94bb",
+                "url": "https://api.github.com/repos/symfony/console/zipball/a700b874d3692bc8342199adfb6d3b99f62cc61a",
+                "reference": "a700b874d3692bc8342199adfb6d3b99f62cc61a",
                 "shasum": ""
             },
             "require": {
@@ -562,20 +562,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2018-11-26T12:48:07+00:00"
+            "time": "2019-01-04T04:42:43+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v3.4.20",
+            "version": "v3.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "a2233f555ddf55e5600f386fba7781cea1cb82d3"
+                "reference": "26d7f23b9bd0b93bee5583e4d6ca5cb1ab31b186"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/a2233f555ddf55e5600f386fba7781cea1cb82d3",
-                "reference": "a2233f555ddf55e5600f386fba7781cea1cb82d3",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/26d7f23b9bd0b93bee5583e4d6ca5cb1ab31b186",
+                "reference": "26d7f23b9bd0b93bee5583e4d6ca5cb1ab31b186",
                 "shasum": ""
             },
             "require": {
@@ -618,7 +618,7 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2018-11-27T12:43:10+00:00"
+            "time": "2019-01-01T13:45:19+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",

--- a/phan_client
+++ b/phan_client
@@ -182,6 +182,13 @@ class PhanPHPLinter
             'files' => $real_files,
             'format' => 'json',
         ];
+        if ($opts->output_mode) {
+            $request['format'] = $opts->output_mode;
+            $request['is_user_specified_format'] = true;
+        }
+        if ($opts->color) {
+            $request['color'] = true;
+        }
 
         if (count($temporary_file_mapping_contents) > 0) {
             $request['temporary_file_mapping_contents'] = $temporary_file_mapping_contents;
@@ -220,7 +227,7 @@ class PhanPHPLinter
         }
         $status = isset($response['status']) ? $response['status'] : null;
         if ($status === 'ok') {
-            self::dumpJSONIssues($response, $file_mapping);
+            self::dumpJSONIssues($response, $file_mapping, $request);
         } else {
             self::debugError(sprintf("Invalid response from phan for %s: %s", $opts->url, $response_bytes));
         }
@@ -231,18 +238,35 @@ class PhanPHPLinter
      * @param string[] $file_mapping
      * @return void
      */
-    private static function dumpJSONIssues(array $response, array $file_mapping)
+    private static function dumpJSONIssues(array $response, array $file_mapping, array $request)
     {
         $did_debug = false;
         $lines = [];
         // if ($response['issue_count'] > 0)
         $issues = $response['issues'];
-        if (!\is_array($issues)) {
-            if (\is_string($issues)) {
-                self::debugError(sprintf("Invalid issues response from phan: %s\n", $issues));
-            } else {
-                self::debugError(sprintf("Invalid type for issues response from phan: %s\n", gettype($issues)));
+        $format = $request['format'];
+        if ($format === 'json') {
+            if (!\is_array($issues)) {
+                if (\is_string($issues)) {
+                    self::debugError(sprintf("Invalid issues response from phan: %s\n", $issues));
+                } else {
+                    self::debugError(sprintf("Invalid type for issues response from phan: %s\n", gettype($issues)));
+                }
+                return;
             }
+            if (isset($request['is_user_specified_format'])) {
+                // The user requested the raw JSON, not what `phan_client` converts it to
+                echo json_encode($issues) . "\n";
+                return;
+            }
+        } else {
+            // When formats other than 'json' are requested, the Phan daemon returns the issues as a raw string.
+            // (e.g. codeclimate returns a string with JSON separated by "\x00")
+            if (!\is_string($issues)) {
+                self::debugError(sprintf("Invalid type for issues response from phan: %s\n", gettype($issues)));
+                return;
+            }
+            echo $issues;
             return;
         }
         foreach ($issues as $issue) {
@@ -294,6 +318,12 @@ class PhanPHPLinterOpts
     /** @var bool should this client request analysis from the Phan server when the file has syntax errors */
     public $use_fallback_parser;
 
+    /** @var ?string the output mode to use. If null, use the default from the daemon */
+    public $output_mode = null;
+
+    /** @var bool whether to color the output on the client */
+    public $color = false;
+
     /**
      * @var bool should this client print a usage text if an **unexpected** error occurred.
      */
@@ -333,6 +363,9 @@ Usage: {$argv[0]} [options] -l file.php [ -l file2.php]
   Syntax check, and if the Phan daemon is running, analyze the following file (absolute path or relative to current working directory)
   This will only analyze the file if a full phan check (with .phan/config.php) would analyze the file.
 
+ -m <mode>, --output-mode
+  Output mode from 'phan_client' (default), 'text', 'json', 'csv', 'codeclimate', 'checkstyle', or 'pylint'
+
  -t, --temporary-file-map '{"file.php":"/path/to/tmp/file_copy.php"}'
   A json mapping from original path to absolute temporary path (E.g. of a file that is still being edited)
 
@@ -365,7 +398,7 @@ EOB;
 
         // Parse command line args
         $optind = 0;
-        $shortopts = "s:p:l:t:f:vhd";
+        $shortopts = "s:p:l:t:f:m:vhd";
         $longopts = [
             'help',
             'daemonize-socket:',
@@ -375,6 +408,8 @@ EOB;
             'temporary-file-map:',
             'use-fallback-parser',
             'flycheck-file:',
+            'output-mode:',
+            'color',
             'verbose',
         ];
         $getopt_reflection = new ReflectionFunction('getopt');
@@ -486,6 +521,21 @@ EOB;
                 case 'v':
                 case 'verbose':
                     break;  // already parsed.
+                case 'color':
+                    $this->color = true;
+                    break;
+                case 'm':
+                case 'output-mode':
+                    if (!is_string($value) || !in_array($value, ['text', 'json', 'csv', 'codeclimate', 'checkstyle', 'pylint', 'phan_client'])) {
+                        $this->usage("Expected --output-mode {text,json,csv,codeclimate,checkstyle,pylint}, but got " . json_encode($value), 1);
+                        break;  // unreachable
+                    }
+                    if ($value === 'phan_client') {
+                        // We're requesting the default
+                        break;
+                    }
+                    $this->output_mode = $value;
+                    break;
                 default:
                     $this->usage("Unknown option '-$key'", 1);
                     break;

--- a/src/Phan/Output/Printer/JSONPrinter.php
+++ b/src/Phan/Output/Printer/JSONPrinter.php
@@ -58,7 +58,7 @@ final class JSONPrinter implements BufferedPrinterInterface
         if (!is_string($encoded_message)) {
             throw new AssertionError("Failed to encode anything for what should be an array");
         }
-        $this->output->write($encoded_message, false, OutputInterface::OUTPUT_RAW);
+        $this->output->write($encoded_message . "\n", false, OutputInterface::OUTPUT_RAW);
         $this->messages = [];
     }
 

--- a/tests/Phan/Output/Printer/JSONPrinterTest.php
+++ b/tests/Phan/Output/Printer/JSONPrinterTest.php
@@ -24,7 +24,7 @@ final class JSONPrinterTest extends BaseTest
         $printer->print(new IssueInstance(Issue::fromType(Issue::SyntaxError), 'test.php', 1, ['fake error']));
         $printer->flush();
         // phpcs:ignore
-        $expected_output = '[{"type":"issue","type_id":11027,"check_name":"PhanUndeclaredVariableDim","description":"UndefError PhanUndeclaredVariableDim Variable $varName was undeclared, but array fields are being added to it.","severity":0,"location":{"path":"dim.php","lines":{"begin":10,"end":10}}},{"type":"issue","type_id":17000,"check_name":"PhanSyntaxError","description":"Syntax PhanSyntaxError fake error","severity":10,"location":{"path":"test.php","lines":{"begin":1,"end":1}}}]';
+        $expected_output = '[{"type":"issue","type_id":11027,"check_name":"PhanUndeclaredVariableDim","description":"UndefError PhanUndeclaredVariableDim Variable $varName was undeclared, but array fields are being added to it.","severity":0,"location":{"path":"dim.php","lines":{"begin":10,"end":10}}},{"type":"issue","type_id":17000,"check_name":"PhanSyntaxError","description":"Syntax PhanSyntaxError fake error","severity":10,"location":{"path":"test.php","lines":{"begin":1,"end":1}}}]' . "\n";
         $this->assertSame($expected_output, $output->fetch());
     }
 }


### PR DESCRIPTION
`--output-mode` was already supported in the daemon server.
Using `--color` will require the latest version of the Phan daemon server.

Fixes #1568