### PR TITLE
Include phpdoc param/return types in hover text

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,8 @@ Language Server/Daemon mode:
   Supported formats: `phan_client` (default), `text`, `json`, `csv`, `codeclimate`, `checkstyle`, or `pylint`
 + Add `--color` to `phan_client` (e.g. for use with `--output-mode text`)
 + Add `--language-server-completion-vscode`. This is a workaround to make completion of variables and static properties work in [the Phan plugin for VS Code](https://github.com/tysonandre/vscode-php-phan)
++ Include Phan's signature types in hover text for internal and user-defined methods (instead of just the real types) (#2309)
+  Also, show defaults of non-nullable parameters as `= default` instead of `= null`
 
 Plugins:
 + Add a new issue type to `DuplicateExpressionPlugin`: `PhanPluginBothLiteralsBinaryOp`. (#2297)

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -1683,4 +1683,24 @@ trait FunctionTrait
         }
         return null;
     }
+
+    /**
+     * Returns stub text for the phpdoc parameters that can be used in markdown
+     */
+    protected function getParameterStubText() : string
+    {
+        return implode(', ', array_map(function (Parameter $parameter) : string {
+            return $parameter->toStubString($this->isPHPInternal());
+        }, $this->getParameterList()));
+    }
+
+    /**
+     * Returns stub text for the real parameters that can be used in `tool/make_stubs`
+     */
+    protected function getRealParameterStubText() : string
+    {
+        return implode(', ', array_map(function (Parameter $parameter) : string {
+            return $parameter->toStubString();
+        }, $this->getRealParameterList()));
+    }
 }

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -702,12 +702,15 @@ class Method extends ClassElement implements FunctionInterface
         }
         $string .= $this->getName();
 
-        $string .= '(' . implode(', ', array_map(function (Parameter $parameter) : string {
-            return $parameter->toStubString();
-        }, $this->getRealParameterList())) . ')';
+        $string .= '(' . $this->getParameterStubText() . ')';
 
-        if (!$this->getRealReturnType()->isEmpty()) {
-            $string .= ' : ' . (string)$this->getRealReturnType();
+        if ($this->isPHPInternal()) {
+            $return_type = $this->getUnionType();
+        } else {
+            $return_type = $this->real_return_type;
+        }
+        if ($return_type && !$return_type->isEmpty()) {
+            $string .= ' : ' . (string)$return_type;
         }
 
         return $string;
@@ -752,9 +755,7 @@ class Method extends ClassElement implements FunctionInterface
         }
         $string .= $this->getName();
 
-        $string .= '(' . implode(', ', array_map(function (Parameter $parameter) : string {
-            return $parameter->toStubString();
-        }, $this->getRealParameterList())) . ')';
+        $string .= '(' . $this->getRealParameterStubText() . ')';
 
         if (!$this->getRealReturnType()->isEmpty()) {
             $string .= ' : ' . (string)$this->getRealReturnType();

--- a/tests/Phan/LanguageServer/LanguageServerIntegrationTest.php
+++ b/tests/Phan/LanguageServer/LanguageServerIntegrationTest.php
@@ -793,6 +793,9 @@ function example(MyClass $arg) {
 function example2($strVal, array $arrVal) {
     var_export($strVal);
     var_export($arrVal);  // line 20
+    $strVal = (string)$strVal;
+    echo strlen($strVal);
+    $n = ast\parse_code($strVal, 50);
 }
 EOT;
         return [
@@ -864,10 +867,10 @@ EOT
                 new Position(7, 4),  // MY_NAMESPACED_CONST
                 <<<'EOT'
 ```php
-function global_function_with_comment(int $x, $y)
+function global_function_with_comment(int $x, ?string $y) : void
 ```
 
-This has a mix of comments and annotations, annotations are excluded from hover
+This has a mix of comments and annotations, annotations are included in hover
 
 - Markup in comments is preserved,
   and leading whitespace is as well.
@@ -923,6 +926,32 @@ EOT
                 $example_file_contents,
                 new Position(20, 20),  // $arrVal
                 '`array<string,\stdClass>`',
+                null,
+                true
+            ],
+            [
+                $example_file_contents,
+                new Position(22, 10),  // strlen
+                <<<'EOT'
+```php
+function strlen(string $string) : int
+```
+EOT
+                ,
+                null,
+                true
+            ],
+            // Currently, the namespace is left out from the hover text
+            [
+                $example_file_contents,
+                new Position(23, 14),  // ast\parse_code
+                <<<'EOT'
+```php
+namespace ast;
+function parse_code(string $code, int $version, string $filename = default) : \ast\Node
+```
+EOT
+                ,
                 null,
                 true
             ],

--- a/tests/misc/lsp/src/definitions.php
+++ b/tests/misc/lsp/src/definitions.php
@@ -36,14 +36,14 @@ class MyNamespacedClass {
 
 namespace {
 /**
- * This has a mix of comments and annotations, annotations are excluded from hover
+ * This has a mix of comments and annotations, annotations are included in hover
  *
  * - Markup in comments is preserved,
  *   and leading whitespace is as well.
  *
  * @param ?string $y
  * @return void
- * Comment lines after the first phpdoc tag are ignored
+ * Comment lines after the first phpdoc tag are ignored (with a few exceptions)
  */
 function global_function_with_comment(int $x, $y) {
 }

--- a/tests/tool_test/json_stubs.expected
+++ b/tests/tool_test/json_stubs.expected
@@ -9,8 +9,8 @@ interface JsonSerializable {
     function jsonSerialize();
 }
 
-function json_decode($json, $assoc = NULL, $depth = NULL, $options = NULL) {}
-function json_encode($value, $options = NULL, $depth = NULL) {}
+function json_decode($json, $assoc = null, $depth = null, $options = null) {}
+function json_encode($value, $options = null, $depth = null) {}
 function json_last_error() {}
 function json_last_error_msg() {}
 const JSON_BIGINT_AS_STRING = 2;


### PR DESCRIPTION
And change the rendering of the default to `= default` (not `= null`)
for non-nullable optional internal function parameters.

For #2309