### PR TITLE
Fix polyfill's parsing of `$a && $b = $c`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@ New features(Analysis):
 
 Maintenance:
 + End the output for `--output-mode <json>` with a newline.
++ Upgrade tolerant-php-parser, making the polyfill/fallback properly parse `$a && $b = $c` (#2180)
 
 Language Server/Daemon mode:
 + Add `--output-mode <mode>` to `phan_client`. (#1568)

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "composer/semver": "^1.4",
         "composer/xdebug-handler": "^1.3",
         "felixfbecker/advanced-json-rpc": "^3.0.3",
-        "microsoft/tolerant-php-parser": "0.0.15",
+        "microsoft/tolerant-php-parser": "0.0.16",
         "sabre/event": "^5.0",
         "symfony/console": "^2.3|^3.0|~4.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a52a3b48fc369fb87264a9940ba27b17",
+    "content-hash": "6cf607fc6cc2f3ae632c08e0a1bd4b9a",
     "packages": [
         {
             "name": "composer/semver",
@@ -155,16 +155,16 @@
         },
         {
             "name": "microsoft/tolerant-php-parser",
-            "version": "v0.0.15",
+            "version": "v0.0.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Microsoft/tolerant-php-parser.git",
-                "reference": "54a84f1250dcde5641e86b5e966fec5f0e201f71"
+                "reference": "b662587eb797685a98239d1d52d25168a03fdfb2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Microsoft/tolerant-php-parser/zipball/54a84f1250dcde5641e86b5e966fec5f0e201f71",
-                "reference": "54a84f1250dcde5641e86b5e966fec5f0e201f71",
+                "url": "https://api.github.com/repos/Microsoft/tolerant-php-parser/zipball/b662587eb797685a98239d1d52d25168a03fdfb2",
+                "reference": "b662587eb797685a98239d1d52d25168a03fdfb2",
                 "shasum": ""
             },
             "require": {
@@ -192,7 +192,7 @@
                 }
             ],
             "description": "Tolerant PHP-to-AST parser designed for IDE usage scenarios",
-            "time": "2018-09-26T05:43:26+00:00"
+            "time": "2018-12-29T00:31:32+00:00"
         },
         {
             "name": "netresearch/jsonmapper",


### PR DESCRIPTION
My fix for this is in the latest release of tolerant-php-parser

Fixes #2180