### PR TITLE
Fix variable completion of `$`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,7 @@ Language Server/Daemon mode:
 + Add `--language-server-completion-vscode`. This is a workaround to make completion of variables and static properties work in [the Phan plugin for VS Code](https://github.com/tysonandre/vscode-php-phan)
 + Include Phan's signature types in hover text for internal and user-defined methods (instead of just the real types) (#2309)
   Also, show defaults of non-nullable parameters as `= default` instead of `= null`
++ Properly return a result set when requesting variable completion of `$` followed by nothing.
 
 Plugins:
 + Add a new issue type to `DuplicateExpressionPlugin`: `PhanPluginBothLiteralsBinaryOp`. (#2297)

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -104,6 +104,7 @@ class TolerantASTConverter
 
     const INCOMPLETE_CLASS_CONST = '__INCOMPLETE_CLASS_CONST__';
     const INCOMPLETE_PROPERTY = '__INCOMPLETE_PROPERTY__';
+    const INCOMPLETE_VARIABLE = '__INCOMPLETE_VARIABLE__';
 
     /**
      * @var int - A version in SUPPORTED_AST_VERSIONS
@@ -499,7 +500,7 @@ class TolerantASTConverter
                     $var_node = static::phpParserNodeToAstNode($n->leftOperand);
                 } catch (InvalidNodeException $_) {
                     if (self::$should_add_placeholders) {
-                        $var_node = new ast\Node(ast\AST_VAR, 0, ['name' => '__INCOMPLETE_VARIABLE__'], $start_line);
+                        $var_node = new ast\Node(ast\AST_VAR, 0, ['name' => self::INCOMPLETE_VARIABLE], $start_line);
                     } else {
                         // convert `;= $b;` to `;$b;`
                         return static::phpParserNodeToAstNode($n->rightOperand);

--- a/src/Phan/LanguageServer/CompletionRequest.php
+++ b/src/Phan/LanguageServer/CompletionRequest.php
@@ -71,7 +71,7 @@ final class CompletionRequest extends NodeInfoRequest
     /**
      * Records the definition of an element that can be used for a code completion
      *
-     * @param CodeBase $code_base used for resolving type location in "Go To Type Definition"
+     * @param CodeBase $code_base used for resolving type location in "Completion"
      * @param ClassConstant|Clazz|Func|GlobalConstant|Method|Property|Variable $element
      * @return void
      */

--- a/src/Phan/LanguageServer/CompletionResolver.php
+++ b/src/Phan/LanguageServer/CompletionResolver.php
@@ -99,6 +99,9 @@ class CompletionResolver
                     if (!is_string($var_name)) {
                         return;
                     }
+                    if ($var_name === TolerantASTConverter::INCOMPLETE_VARIABLE) {
+                        $var_name = '';
+                    }
                     self::locateVariableCompletion($request, $code_base, $context, $var_name);
                     return;
             }


### PR DESCRIPTION
CompletionResolver failed to check for the magic value that was inserted
when the polyfill built a Node with an empty variable name in completion mode.