### PR TITLE
Track didChange in --language-server-analyze-only-on-save

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,7 @@ Language Server/Daemon mode:
 + Include Phan's signature types in hover text for internal and user-defined methods (instead of just the real types) (#2309)
   Also, show defaults of non-nullable parameters as `= default` instead of `= null`
 + Properly return a result set when requesting variable completion of `$` followed by nothing.
++ Fix code completion when `--language-server-analyze-only-on-save` is on. (#2327)
 
 Plugins:
 + Add a new issue type to `DuplicateExpressionPlugin`: `PhanPluginBothLiteralsBinaryOp`. (#2297)

--- a/src/Phan/LanguageServer/LanguageServer.php
+++ b/src/Phan/LanguageServer/LanguageServer.php
@@ -928,7 +928,7 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
     {
         $textDocumentSyncOptions = new TextDocumentSyncOptions();
         $textDocumentSyncOptions->openClose = true;
-        $textDocumentSyncOptions->change = Config::getValue('language_server_analyze_only_on_save') ? TextDocumentSyncKind::NONE : TextDocumentSyncKind::FULL;
+        $textDocumentSyncOptions->change = TextDocumentSyncKind::FULL;
 
         $saveOptions = new SaveOptions();
         $saveOptions->includeText = true;

--- a/src/Phan/LanguageServer/Protocol/TextDocumentSyncKind.php
+++ b/src/Phan/LanguageServer/Protocol/TextDocumentSyncKind.php
@@ -13,6 +13,7 @@ abstract class TextDocumentSyncKind
 {
     /**
      * Documents should not be synced at all.
+     * @suppress PhanUnreferencedPublicClassConstant (unused)
      */
     const NONE = 0;
 

--- a/src/Phan/LanguageServer/Server/TextDocument.php
+++ b/src/Phan/LanguageServer/Server/TextDocument.php
@@ -147,8 +147,11 @@ class TextDocument
             $this->file_mapping->addOverrideURI($textDocument->uri, $change->text);
         }
         Logger::logInfo("Called textDocument/didChange, uri={$textDocument->uri} version={$textDocument->version}");
+        if (Config::getValue('language_server_analyze_only_on_save')) {
+            // Track the change to the file, but don't trigger analysis.
+            return;
+        }
         $this->server->analyzeURIAsync($textDocument->uri);
-
         // TODO:   Maybe allow reloading .phan/config, at least the files and directories to parse/analyze
     }
 


### PR DESCRIPTION
This is necessary for completion to work.
Note that code completion currently triggers a re-analysis,
which will report syntax errors (etc) as a side effect

Fixes #2327