### PR TITLE
Fix bugs in code completion for `::` and `->`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 Phan NEWS
 
+?? ??? 2019, Phan 1.2.2 (dev)
+-----------------------
+
+Language Server/Daemon mode:
++ Make code completion immediately after typing `->` and `::` behave more consistently (#2343)
+  Note: this fix only applies at the very last character of a line
+
 18 Jan 2019, Phan 1.2.1
 -----------------------
 

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -31,7 +31,7 @@ class CLI
     /**
      * This should be updated to x.y.z-dev after every release, and x.y.z before a release.
      */
-    const PHAN_VERSION = '1.2.1';
+    const PHAN_VERSION = '1.2.2-dev';
 
     /**
      * List of short flags passed to getopt

--- a/src/Phan/Language/Type/LiteralIntType.php
+++ b/src/Phan/Language/Type/LiteralIntType.php
@@ -2,9 +2,8 @@
 
 namespace Phan\Language\Type;
 
-use Phan\Language\Type;
 use Phan\Config;
-
+use Phan\Language\Type;
 use RuntimeException;
 
 /**

--- a/src/Phan/LanguageServer/LanguageServer.php
+++ b/src/Phan/LanguageServer/LanguageServer.php
@@ -442,7 +442,7 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
         Position $position,
         bool $is_type_definition_request
     ) : Promise {
-        // TODO: Add a way to "go to definition" without emitting analysis results as a side effect
+        // TODO: Add a way to "go to definition" (etc.) without emitting analysis results as a side effect
         $path_to_analyze = Utils::uriToPath($uri);
         $logType = $is_type_definition_request ? 'awaitTypeDefinition' : 'awaitDefinition';
         Logger::logInfo("Called LanguageServer->$logType, uri=$uri, position=" . StringUtil::jsonEncode($position));

--- a/src/Phan/LanguageServer/Protocol/Position.php
+++ b/src/Phan/LanguageServer/Protocol/Position.php
@@ -82,4 +82,12 @@ class Position
             $data['character'] ?? null
         );
     }
+
+    /**
+     * Used for debugging
+     */
+    public function __toString() : string
+    {
+        return "$this->line:$this->character";
+    }
 }

--- a/tests/Phan/Language/TypeTest.php
+++ b/tests/Phan/Language/TypeTest.php
@@ -688,7 +688,6 @@ final class TypeTest extends BaseTest
             $this->assertCanCastToType($zero_string, $false_type, 'scalar_implicit_cast is disabled');
             $this->assertCannotCastToType($regular_string, $false_type, 'scalar_implicit_cast is disabled');
             $this->assertCanCastToType($regular_string, $true_type, 'scalar_implicit_cast is disabled');
-
         } finally {
             Config::setValue('scalar_implicit_cast', false);
         }

--- a/tests/Phan/LanguageServer/LanguageServerIntegrationTest.php
+++ b/tests/Phan/LanguageServer/LanguageServerIntegrationTest.php
@@ -305,6 +305,13 @@ EOT;
         $this->messageId = 0;
         list($proc, $proc_in, $proc_out) = $this->createPhanLanguageServer($pcntl_enabled, true, ['vscode_compatible_completions' => $for_vscode]);
         try {
+            /*
+            // This block can be uncommented when developing tests for completions
+            $line_contents = explode("\n", $file_contents)[$position->line];
+            $completion_cursor = substr($line_contents, 0, $position->character) . '<>' . substr($line_contents, $position->character);
+            fwrite(STDERR, "Checking at $completion_cursor\n");
+             */
+
             $this->writeInitializeRequestAndAwaitResponse($proc_in, $proc_out);
             $this->writeInitializedNotification($proc_in);
             $this->writeDidChangeNotificationToDefaultFile($proc_in, $file_contents);
@@ -386,7 +393,19 @@ const M9AnotherConst = 33;
 class M9InnerClass {}
 /** @return array<int,int>  */
 function M9InnerFunction() { return [2]; }
-
+// line 35
+}
+namespace Other {
+function M9InnerFunction($first_arg, \M9Example $second_arg) {
+    // here, we look for completions
+    if (rand(0, 1) > 0) {  // line 40
+        echo \M9Example::
+        return $second_arg;
+    } else {
+        echo $second_arg->
+        return $first_arg;
+    }
+}
 }
 EOT;
 
@@ -431,6 +450,15 @@ EOT;
             'label' => 'my_static_function',
             'kind' => CompletionItemKind::METHOD,
             'detail' => 'mixed',
+            'documentation' => null,
+            'sortText' => null,
+            'filterText' => null,
+            'insertText' => null,
+        ];
+        $my_instance_property_item = [
+            'label' => 'myInstanceVar',
+            'kind' => CompletionItemKind::PROPERTY,
+            'detail' => 'int',
             'documentation' => null,
             'sortText' => null,
             'filterText' => null,
@@ -485,6 +513,10 @@ EOT;
             $my_static_function_item,
             $property_completion_item,
         ];
+        $all_instance_completions = [
+            $my_static_function_item,
+            $my_instance_property_item,
+        ];
         $all_constant_completions = [
             $my_class_item,
             $my_global_constant_item,
@@ -497,6 +529,8 @@ EOT;
             [new Position(11, 19), $static_property_completions_substr, $for_vscode],
             [new Position(12, 16), $all_static_completions, $for_vscode],
             [new Position(20, 7), $all_constant_completions, $for_vscode],
+            [new Position(41, 25), $all_static_completions, $for_vscode],
+            [new Position(44, 26), $all_instance_completions, $for_vscode],
         ];
     }
     /**


### PR DESCRIPTION
These worked inconsistently (and were more reliable when the next token
was `;` or `}`)

This change makes them work more consistently,
but only when the cursor is at the last character of a line.

This has been tested in VS Code

Fixes #2343