### PR TITLE
Language server improvements for "Go to Definition"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,9 @@ Language Server/Daemon mode:
 + Make code completion immediately after typing `->` and `::` behave more consistently (#2343)
   Note: this fix only applies at the very last character of a line
 + Be more consistent about including types in hover text for properties (#2348)
++ Make "Go to Definition" on `new MyClass` go to `MyClass::__construct` if it exists. (#2276)
++ Support "Go to Definition" for references to global functions and global constants in comments and literal strings.
+  Previously, Phan would only look for class definitions in comments and literal strings.
 
 18 Jan 2019, Phan 1.2.1
 -----------------------

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverterWithNodeMapping.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverterWithNodeMapping.php
@@ -277,7 +277,7 @@ class TolerantASTConverterWithNodeMapping extends TolerantASTConverter
                 $ast_node->isSelectedApproximate = self::$closest_node_or_token_symbol;
                 $ast_node->selectedFragment = $fragment;
             }
-            // fwrite(STDERR, "Marking node with kind $ast_node->kind as selected\n");
+            // fwrite(STDERR, "Marking node with kind " . ast\get_kind_name($ast_node->kind) . " as selected\n");
             $ast_node->isSelected = true;
             $closure = self::$handle_selected_node;
             if ($closure) {

--- a/src/Phan/LanguageServer/CompletionResolver.php
+++ b/src/Phan/LanguageServer/CompletionResolver.php
@@ -24,14 +24,16 @@ use Phan\Language\FQSEN\FullyQualifiedClassName;
 class CompletionResolver
 {
     /**
-     * @return Closure(Context,Node):void
+     * @return Closure(Context,Node, array<int,Node>):void
      * NOTE: The helper methods distinguish between "Go to definition"
      * and "go to type definition" in their implementations,
      * based on $request->getIsTypeDefinitionRequest()
      */
     public static function createCompletionClosure(CompletionRequest $request, CodeBase $code_base)
     {
-        return function (Context $context, Node $node) use ($request, $code_base) {
+        // TODO: Could use the parent node list
+        // (e.g. don't use a method with a void return as an argument to another function)
+        return function (Context $context, Node $node, array $unused_parent_node_list) use ($request, $code_base) {
             // @phan-suppress-next-line PhanUndeclaredProperty this is overridden
             $selected_fragment = $node->selectedFragment ?? null;
             if (is_string($selected_fragment)) {

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -633,12 +633,9 @@ final class ConfigPluginSet extends PluginV2 implements
             throw new AssertionError("Invalid kind for node");
         }
 
-        /**
-         * @phan-closure-scope NodeSelectionVisitor
-         */
-        $closure = (static function (CodeBase $code_base, Context $context, Node $node, array $unused_parent_node_list = []) {
+        $closure = (static function (CodeBase $code_base, Context $context, Node $node, array $parent_node_list = []) {
             $visitor = new NodeSelectionVisitor($code_base, $context);
-            $visitor->visitCommonImplementation($node);
+            $visitor->visitCommonImplementation($node, $parent_node_list);
         });
 
         $this->addNodeSelectionClosureForKind($node->kind, $closure);

--- a/src/Phan/Plugin/Internal/NodeSelectionPlugin.php
+++ b/src/Phan/Plugin/Internal/NodeSelectionPlugin.php
@@ -15,7 +15,7 @@ use Phan\PluginV2\PostAnalyzeNodeCapability;
 class NodeSelectionPlugin extends PluginV2 implements PostAnalyzeNodeCapability
 {
     /**
-     * @param ?Closure(Context,Node):void $closure
+     * @param ?Closure(Context,Node,array<int,Node>):void $closure
      * @return void
      * TODO: Fix false positive TypeMismatchDeclaredParam with Closure $closure = null in this method
      */
@@ -42,7 +42,7 @@ class NodeSelectionPlugin extends PluginV2 implements PostAnalyzeNodeCapability
  */
 class NodeSelectionVisitor extends PluginAwarePostAnalysisVisitor
 {
-    /** @var ?Closure(Context,Node):void $closure */
+    /** @var ?Closure(Context,Node,Node[]):void $closure */
     public static $closure = null;
 
     // A plugin's visitors should not override visit() unless they need to.
@@ -52,10 +52,12 @@ class NodeSelectionVisitor extends PluginAwarePostAnalysisVisitor
      * @param Node $node
      * A node to check
      *
+     * @param array<int,Node> $parent_node_list
+     *
      * @return void
      * @see ConfigPluginSet::prepareNodeSelectionPlugin() for how this is called
      */
-    public function visitCommonImplementation(Node $node)
+    public function visitCommonImplementation(Node $node, array $parent_node_list)
     {
         if (!\property_exists($node, 'isSelected')) {
             return;
@@ -66,7 +68,7 @@ class NodeSelectionVisitor extends PluginAwarePostAnalysisVisitor
             // fwrite(STDERR, "Calling NodeSelectionVisitor without a closure\n");
             return;
         }
-        $closure($this->context, $node);
+        $closure($this->context, $node, $parent_node_list);
     }
 }
 


### PR DESCRIPTION
Fixes #2276 - "go to definition" on "new MyClass" now goes to
the declaration of `__construct()` if it exists