### PR TITLE
Emit a warning if running Phan and no files were parsed

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@ Phan NEWS
 -----------------------
 
 New features(CLI):
++ Emit a warning to stderr if no files were parsed when Phan is invoked. (#2289)
+
+New features(Analysis):
 + Add `@phan-extends` and `@extends` as an alias of `@inherits` (#2351)
 
 Language Server/Daemon mode:

--- a/src/Phan/Phan.php
+++ b/src/Phan/Phan.php
@@ -11,6 +11,7 @@ use Phan\Language\Type;
 use Phan\LanguageServer\LanguageServer;
 use Phan\LanguageServer\Logger as LanguageServerLogger;
 use Phan\Library\FileCache;
+use Phan\Library\StringUtil;
 use Phan\Output\BufferedPrinterInterface;
 use Phan\Output\Collector\BufferingCollector;
 use Phan\Output\IgnoredFilesFilterInterface;
@@ -134,6 +135,9 @@ class Phan implements IgnoredFilesFilterInterface
         $file_path_list = $file_path_lister();
 
         $file_count = count($file_path_list);
+        if ($file_count === 0) {
+            fprintf(STDERR, "Phan did not parse any files in the project %s - This may be an issue with the Phan config or CLI options.\n", StringUtil::jsonEncode(Config::getProjectRootDirectory()));
+        }
 
         // We'll construct a set of files that we'll
         // want to run an analysis on

--- a/tests/Phan/LanguageServer/LanguageServerIntegrationTest.php
+++ b/tests/Phan/LanguageServer/LanguageServerIntegrationTest.php
@@ -308,20 +308,20 @@ EOT;
                 ], $definition_response, "Unexpected result at $position");
             };
 
-            $assert_has_definition(new Position(5, 6),   1);
-            $assert_has_definition(new Position(5, 15),  3);
+            $assert_has_definition(new Position(5, 6), 1);
+            $assert_has_definition(new Position(5, 15), 3);
             // new MyExample() gives location of MyExample::__construct at "new"
-            $assert_has_definition(new Position(6, 5),   2);
+            $assert_has_definition(new Position(6, 5), 2);
             // new MyExample() gives location of MyExample::__construct at "MyExample"
-            $assert_has_definition(new Position(6, 17),  2);
+            $assert_has_definition(new Position(6, 17), 2);
             // Foo::class gives location of "class Foo"
-            $assert_has_definition(new Position(7, 17),  1);
+            $assert_has_definition(new Position(7, 17), 1);
             // new MyExampleWithoutConstructor() gives the location of "class MyExampleWithoutConstructor"
-            $assert_has_definition(new Position(9, 9),   8);
+            $assert_has_definition(new Position(9, 9), 8);
             // Referring to a class in a comment works.
             $assert_has_definition(new Position(10, 31), 1);
             // A function call can be located
-            $assert_has_definition(new Position(12, 0),  11);
+            $assert_has_definition(new Position(12, 0), 11);
             // A function name in a comment can be located
             $assert_has_definition(new Position(13, 32), 11);
             // A global constant name can be located (in comments and code)


### PR DESCRIPTION
This can happen if running Phan from the wrong working directory,
for example.

Fixes #2289