### PR TITLE
Fix inferences about `foreach ($arr as [[$nested]]) {...}`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,7 @@ Maintenance:
 
 Bug fixes:
 + Emit a warning and exit if `--config-file <file>` does not exist (#2271)
++ Fix inferences about `foreach ($arr as [[$nested]]) {...}` (#2362)
 
 18 Jan 2019, Phan 1.2.1
 -----------------------

--- a/tests/files/expected/0615_nested_array_foreach.php.expected
+++ b/tests/files/expected/0615_nested_array_foreach.php.expected
@@ -1,0 +1,2 @@
+%s:26 PhanTypeMismatchArgumentInternal Argument 1 (var) is int but \count() takes \Countable|array
+%s:28 PhanTypeSuspiciousEcho Suspicious argument \stdClass for an echo/print statement

--- a/tests/files/src/0615_nested_array_foreach.php
+++ b/tests/files/src/0615_nested_array_foreach.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+function test_nested_array_foreach() {
+    $array = [
+        [
+            ['a', 'b'],
+            ['x', 'y'],
+        ],
+    ];
+
+    foreach ($array as $key => [[$_1, $_2], [$_3, $_4]]) {
+        echo "{$key}: {$_1}, {$_2}, {$_3}, {$_4}", PHP_EOL;
+    }
+}
+
+function test_bad_nested_array_foreach(stdClass $o) {
+    $badArray = [
+        [
+            ['a', $o],
+            ['x', 'y'],
+        ],
+    ];
+    foreach ($badArray as $key => [[$_1, $_2], [$_3, $_4]]) {
+        echo count($key);  // this warns, $key is an int
+        echo $_1;
+        echo $_2;  // this warns, this is an stdClass
+        echo $_3;
+        echo $_4;
+    }
+}

--- a/tests/files/src/0615_nested_array_foreach.php70
+++ b/tests/files/src/0615_nested_array_foreach.php70
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+function test_nested_array_foreach() {
+    $array = [
+        [
+            ['a', 'b'],
+            ['x', 'y'],
+        ],
+    ];
+
+    foreach ($array as $key => list(list($_1, $_2), list($_3, $_4))) {
+        echo "{$key}: {$_1}, {$_2}, {$_3}, {$_4}", PHP_EOL;
+    }
+}
+
+function test_bad_nested_array_foreach(stdClass $o) {
+    $badArray = [
+        [
+            ['a', $o],
+            ['x', 'y'],
+        ],
+    ];
+    foreach ($badArray as $key => list(list($_1, $_2), list($_3, $_4))) {
+        echo count($key);  // this warns, $key is an int
+        echo $_1;
+        echo $_2;  // this warns, this is an stdClass
+        echo $_3;
+        echo $_4;
+    }
+}


### PR DESCRIPTION
Previously, this didn't support nested array destructuring in foreach
statements.

Fixes #2362