### PR TITLE
Fix checks for accessing internal elements from root NS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,8 @@ Maintenance:
 Bug fixes:
 + Emit a warning and exit if `--config-file <file>` does not exist (#2271)
 + Fix inferences about `foreach ($arr as [[$nested]]) {...}` (#2362)
++ Properly analyze accesses of `@internal` elements of the root namespace from other parts of the root namespace. (#2366)
++ Consistently emit `UseNormalNoEffect` (etc.) when using names/functions/constants of the global scrope from the global scope.
 
 18 Jan 2019, Phan 1.2.1
 -----------------------

--- a/internal/reflection_completeness_check.php
+++ b/internal/reflection_completeness_check.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
  */
 require_once dirname(__DIR__) . '/vendor/autoload.php';
 
-use Exception;
 use Phan\Config;
 use Phan\Language\FQSEN\FullyQualifiedFunctionName;
 use Phan\Language\FQSEN\FullyQualifiedMethodName;

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -1366,10 +1366,10 @@ class ContextNode
                     Issue::AccessPropertyInternal,
                     $node->lineno,
                     $property->getRepresentationForIssue(),
-                    $property->getElementNamespace(),
+                    $property->getElementNamespace() ?: '\\',
                     $property->getFileRef()->getFile(),
                     $property->getFileRef()->getLineNumberStart(),
-                    $this->context->getNamespace()
+                    $this->context->getNamespace() ?: '\\'
                 );
             }
 

--- a/src/Phan/Analysis/ScopeVisitor.php
+++ b/src/Phan/Analysis/ScopeVisitor.php
@@ -161,7 +161,7 @@ abstract class ScopeVisitor extends AnalysisVisitor
                 self::analyzeUseElemCompatibility($alias, $target, $target_php_version, $lineno);
             }
             if (\strcasecmp($target->getNamespace(), $context->getNamespace()) === 0) {
-                $this->maybeWarnSameNamespaceUse($target, $flags, $lineno);
+                $this->maybeWarnSameNamespaceUse($alias, $target, $flags, $lineno);
             }
             $context = $context->withNamespaceMap(
                 $flags,
@@ -174,8 +174,11 @@ abstract class ScopeVisitor extends AnalysisVisitor
         return $context;
     }
 
-    private function maybeWarnSameNamespaceUse(FullyQualifiedGlobalStructuralElement $target, int $flags, int $lineno)
+    private function maybeWarnSameNamespaceUse(string $alias, FullyQualifiedGlobalStructuralElement $target, int $flags, int $lineno)
     {
+        if (\strcasecmp($alias, $target->getName()) !== 0) {
+            return;
+        }
         if ($flags === ast\flags\USE_FUNCTION) {
             if ($target->getNamespace() !== '\\') {
                 return;

--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -30,9 +30,10 @@ class Context extends FileRef
 {
     /**
      * @var string
-     * The namespace of the file
+     * The namespace of the file.
+     * To be consistent with what ScopeVisitor sets in visitNamespace(), this is '\\' for the root namespace as well.
      */
-    private $namespace = '';
+    private $namespace = '\\';
 
     /**
      * @var int

--- a/src/Phan/Language/Element/AddressableElement.php
+++ b/src/Phan/Language/Element/AddressableElement.php
@@ -196,10 +196,10 @@ abstract class AddressableElement extends TypedElement implements AddressableEle
         Context $context
     ) : bool {
         // Figure out which namespace this element is within
-        $element_namespace = $this->getElementNamespace();
+        $element_namespace = $this->getElementNamespace() ?: '\\';
 
         // Get our current namespace from the context
-        $context_namespace = $context->getNamespace();
+        $context_namespace = $context->getNamespace() ?: '\\';
 
         // Test to see if the context is within the same
         // namespace as where the element is defined

--- a/tests/files/expected/0531_magic_method_override.php.expected
+++ b/tests/files/expected/0531_magic_method_override.php.expected
@@ -1,3 +1,4 @@
+%s:2 PhanUseNormalNoEffect The use statement for class/namespace \Iterator in the global namespace has no effect
 %s:113 PhanParamSignatureMismatch Declaration of function addItem(\ScalarType531 $item) : array should be compatible with function addItem(mixed $item) : static defined in %s:41
 %s:113 PhanParamSignaturePHPDocMismatchHasParamType Declaration of real/@method function addItem(\ScalarType531 $item) should be compatible with real/@method function addItem($item) (parameter #1 has type '\ScalarType531' which cannot replace original parameter with no type) defined in %s:41
 %s:114 PhanParamSignatureMismatch Declaration of function setItems(\ScalarType531[] $item) : array should be compatible with function setItems(array $items) : static defined in %s:31

--- a/tests/files/expected/0564_global_namespace_functions_constants.php.expected
+++ b/tests/files/expected/0564_global_namespace_functions_constants.php.expected
@@ -1,3 +1,5 @@
+%s:4 PhanUnreferencedUseNormal Possibly zero references to use statement for classlike/namespace uselessimport (\uselessimport)
+%s:4 PhanUseNormalNoEffect The use statement for class/namespace \uselessimport in the global namespace has no effect
 %s:21 PhanUndeclaredClassMethod Call to method __construct from undeclared class \a\Missing
 %s:22 PhanUndeclaredConstant Reference to undeclared constant \ast\MISSING_CONST
 %s:23 PhanUndeclaredFunction Call to undeclared function \ast\missing_function()

--- a/tests/files/expected/0618_internal_in_root_ns.php.expected
+++ b/tests/files/expected/0618_internal_in_root_ns.php.expected
@@ -1,0 +1,4 @@
+%s:37 PhanAccessPropertyInternal Cannot access internal property \OtherNS\OtherInternalClass::$internal_prop of namespace \OtherNS defined at %s:54 from namespace \
+%s:38 PhanAccessClassConstantInternal Cannot access internal class constant \OtherNS\OtherInternalClass::FOO defined at %s:58
+%s:39 PhanAccessMethodInternal Cannot access internal method \OtherNS\OtherInternalClass::test() of namespace \OtherNS defined at %s:62 from namespace \
+%s:40 PhanAccessMethodInternal Cannot access internal method \OtherNS\other_internal_function() of namespace \OtherNS defined at %s:47 from namespace \

--- a/tests/files/src/0564_global_namespace_functions_constants.php
+++ b/tests/files/src/0564_global_namespace_functions_constants.php
@@ -1,7 +1,7 @@
 <?php
 
 use ast as a;
-
+use uselessimport as uselessimport;
 // Should not warn
 var_export(ast\parse_code('', 50));
 var_export(ast\AST_UNPACK);

--- a/tests/files/src/0617_internal_in_root_ns.php
+++ b/tests/files/src/0617_internal_in_root_ns.php
@@ -1,0 +1,40 @@
+<?php
+
+// Regression test for earlier bugs caused because namespace {} is treated slightly differently from the absense of a namespace statement.
+// This was fixed already.
+
+/**
+ * @internal
+ */
+function internalGlobalFunction2() {
+}
+
+/**
+ * @internal
+ */
+class ClassWithInternalPublicProperty2
+{
+    /**
+     * @internal
+     */
+    public $typeId;
+    /**
+     * @internal
+     */
+    const MY_CONST = 3;
+
+    /**
+     * @internal
+     */
+    public static function internalMethod() {
+    }
+
+    public function test()
+    {
+        $this->typeId = 1;
+        var_export(self::MY_CONST);
+        var_export(new ClassWithInternalPublicProperty2());
+        self::internalMethod();
+        internalGlobalFunction2();
+    }
+}

--- a/tests/files/src/0618_internal_in_root_ns.php
+++ b/tests/files/src/0618_internal_in_root_ns.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace {
+/**
+ * @internal
+ */
+function internalGlobalFunction() {
+}
+
+/**
+ * @internal
+ */
+class ClassWithInternalPublicProperty
+{
+    /**
+     * @internal
+     */
+    public $typeId;
+    /**
+     * @internal
+     */
+    const MY_CONST = 3;
+
+    /**
+     * @internal
+     */
+    public static function internalMethod() {
+    }
+
+    public function test()
+    {
+        $this->typeId = 1;
+        var_export(self::MY_CONST);
+        var_export(new ClassWithInternalPublicProperty());
+        self::internalMethod();
+        internalGlobalFunction();
+        var_export(OtherNS\OtherInternalClass::$internal_prop);
+        var_export(OtherNS\OtherInternalClass::FOO);
+        var_export(OtherNS\OtherInternalClass::test());
+        var_export(OtherNS\other_internal_function());
+    }
+}
+}
+
+namespace OtherNS {
+/** @internal */
+function other_internal_function() {
+}
+/** @internal */
+class OtherInternalClass {
+    /**
+     * @internal
+     */
+    public static $internal_prop;
+    /**
+     * @internal
+     */
+    const FOO = 'foo';
+    /**
+     * @internal
+     */
+    public static function test() {
+    }
+}
+}


### PR DESCRIPTION
The namespace comparison was incorrectly implemented.

Fixes #2366