### PR TITLE
Fix a bug causing false positive issues in the wrong file

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,7 @@ Bug fixes:
 + Fix inferences about `foreach ($arr as [[$nested]]) {...}` (#2362)
 + Properly analyze accesses of `@internal` elements of the root namespace from other parts of the root namespace. (#2366)
 + Consistently emit `UseNormalNoEffect` (etc.) when using names/functions/constants of the global scrope from the global scope.
++ Fix a bug causing incorrect warnings due to uses of global/class constants.
 
 18 Jan 2019, Phan 1.2.1
 -----------------------

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -5,6 +5,7 @@ namespace Phan\AST;
 use AssertionError;
 use ast;
 use ast\Node;
+use Exception;
 use Phan\CodeBase;
 use Phan\Config;
 use Phan\Exception\CodeBaseException;
@@ -1638,18 +1639,14 @@ class ContextNode
             )
         ) {
             // TODO: Refactor and also check namespaced constants
-            throw new IssueException(
-                Issue::fromType(Issue::AccessConstantInternal)(
-                    $context->getFile(),
-                    $node->lineno ?? 0,
-                    [
-                        (string)$constant->getFQSEN(),
-                        $constant->getElementNamespace(),
-                        $constant->getFileRef()->getFile(),
-                        $constant->getFileRef()->getLineNumberStart(),
-                        $context->getNamespace()
-                    ]
-                )
+            $this->emitIssue(
+                Issue::AccessConstantInternal,
+                $node->lineno,
+                (string)$constant->getFQSEN(),
+                $constant->getElementNamespace(),
+                $constant->getFileRef()->getFile(),
+                $constant->getFileRef()->getLineNumberStart(),
+                $context->getNamespace()
             );
         }
 
@@ -1747,16 +1744,12 @@ class ContextNode
                     $this->context
                 )
             ) {
-                throw new IssueException(
-                    Issue::fromType(Issue::AccessClassConstantInternal)(
-                        $this->context->getFile(),
-                        $node->lineno ?? 0,
-                        [
-                            (string)$constant->getFQSEN(),
-                            $constant->getFileRef()->getFile(),
-                            $constant->getFileRef()->getLineNumberStart(),
-                        ]
-                    )
+                $this->emitIssue(
+                    Issue::AccessClassConstantInternal,
+                    $node->lineno,
+                    (string)$constant->getFQSEN(),
+                    $constant->getFileRef()->getFile(),
+                    $constant->getFileRef()->getLineNumberStart()
                 );
             }
 
@@ -2151,14 +2144,15 @@ class ContextNode
             }
             try {
                 $constant = (new ContextNode($this->code_base, $this->context, $node))->getConst();
-            } catch (\Exception $_) {
+            } catch (Exception $_) {
+                // Is there a need to catch IssueException as well?
                 return $node;
             }
             // TODO: Recurse, but don't try to resolve constants again
             $new_node = $constant->getNodeForValue();
             if (is_object($new_node)) {
                 // Avoid infinite recursion, only resolve once
-                $new_node = $this->getEquivalentPHPValueForNode($new_node, $flags & ~self::RESOLVE_CONSTANTS);
+                $new_node = (new ContextNode($this->code_base, $constant->getContext(), $new_node))->getEquivalentPHPValueForNode($new_node, $flags & ~self::RESOLVE_CONSTANTS);
             }
             return $new_node;
         } elseif ($kind === ast\AST_CLASS_CONST) {
@@ -2174,7 +2168,7 @@ class ContextNode
             $new_node = $constant->getNodeForValue();
             if (is_object($new_node)) {
                 // Avoid infinite recursion, only resolve once
-                $new_node = $this->getEquivalentPHPValueForNode($new_node, $flags & ~self::RESOLVE_CONSTANTS);
+                $new_node = (new ContextNode($this->code_base, $constant->getContext(), $new_node))->getEquivalentPHPValueForNode($new_node, $flags & ~self::RESOLVE_CONSTANTS);
             }
             return $new_node;
         } elseif ($kind === ast\AST_MAGIC_CONST) {


### PR DESCRIPTION
The constant definition has a different context than the ContextNode
using the constant definition

This was noticed when making emitting warnings about internal constants more consistent