### PR TITLE
Don't warn if passed --language-server-completion-vscode

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@ Phan NEWS
 ?? ??? 2019, Phan 1.2.3 (dev)
 -----------------------
 
+Maintenance
++ Don't emit a warning to stderr when `--language-server-completion-vscode` is used.
+
 02 Feb 2019, Phan 1.2.2
 -----------------------
 

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -1158,7 +1158,7 @@ class Config
             'language_server_analyze_only_on_save' => $is_bool,
             // 'language_server_config' => array|false,  // should not be set directly
             'language_server_debug_level' => $is_string_or_null,
-            'language_server_enable_completion' => $is_bool,
+            'language_server_enable_completion' => $is_scalar,
             'language_server_enable_go_to_definition' => $is_bool,
             'language_server_enable_hover' => $is_bool,
             'language_server_hide_category_of_issues' => $is_bool,

--- a/tests/Phan/ConfigTest.php
+++ b/tests/Phan/ConfigTest.php
@@ -51,4 +51,25 @@ final class ConfigTest extends BaseTest
         ];
         $this->assertSame($expected_errors, Config::getConfigErrors($config), 'Should warn for invalid settings');
     }
+
+    /**
+     * @dataProvider warnsEnableCompletionProvider
+     * @param mixed $value
+     */
+    public function testWarnsEnableCompletion($value, string ...$expected_errors)
+    {
+        $config = ['language_server_enable_completion' => $value];
+        $this->assertSame($expected_errors, Config::getConfigErrors($config));
+    }
+
+
+    public function warnsEnableCompletionProvider() : array
+    {
+        return [
+            [false],
+            [true],
+            [Config::COMPLETION_VSCODE],
+            [[], "Invalid config value for 'language_server_enable_completion': Expected a scalar, but got type 'array'"],
+        ];
+    }
 }


### PR DESCRIPTION
The config checks assumed `language_server_enable_completion` would be a
boolean.