### PR TITLE
Emit warning for more expression types when unused

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,11 @@ Phan NEWS
 ?? ??? 2019, Phan 1.2.3 (dev)
 -----------------------
 
+New features(Analysis):
++ Detect more expressions without side effects: `PhanNoopEmpty` and `PhanNoopIsset` (for `isset(expr)` and `empty(expr)`) (#2389)
++ Also emit `PhanNoopBinaryOperator` for the `??`, `||`, and `&&` operators,
+  but only when the result is unused and the right hand side has no obvious side effects. (#2389)
+
 Maintenance
 + Don't emit a warning to stderr when `--language-server-completion-vscode` is used.
 

--- a/src/Phan/AST/ASTSimplifier.php
+++ b/src/Phan/AST/ASTSimplifier.php
@@ -179,8 +179,9 @@ class ASTSimplifier
      * (E.g. returns true for `MY_CONST` or `false` in `if (MY_CONST === ($x = y))`
      *
      * @param Node|string|float|int $node
+     * @internal the way this behaves may change
      */
-    private static function isExpressionWithoutSideEffects($node) : bool
+    public static function isExpressionWithoutSideEffects($node) : bool
     {
         if (!($node instanceof Node)) {
             return true;
@@ -190,6 +191,8 @@ class ASTSimplifier
             case \ast\AST_MAGIC_CONST:
             case \ast\AST_NAME:
                 return true;
+            case \ast\AST_UNARY_OP:
+                return self::isExpressionWithoutSideEffects($node->children['expr']);
             case \ast\AST_BINARY_OP:
                 return self::isExpressionWithoutSideEffects($node->children['left']) &&
                     self::isExpressionWithoutSideEffects($node->children['right']);

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -271,6 +271,9 @@ class Issue
     const NoopStringLiteral             = 'PhanNoopStringLiteral';
     const NoopEncapsulatedStringLiteral = 'PhanNoopEncapsulatedStringLiteral';
     const NoopNumericLiteral            = 'PhanNoopNumericLiteral';
+    const NoopEmpty                     = 'PhanNoopEmpty';
+    const NoopIsset                     = 'PhanNoopIsset';
+    const NoopCast                      = 'PhanNoopCast';
     const UnreachableCatch              = 'PhanUnreachableCatch';
     const UnreferencedClass             = 'PhanUnreferencedClass';
     const UnreferencedFunction          = 'PhanUnreferencedFunction';
@@ -2444,6 +2447,30 @@ class Issue
                 "Unused result of a string literal {STRING_LITERAL} near this line",
                 self::REMEDIATION_B,
                 6029
+            ),
+            new Issue(
+                self::NoopEmpty,
+                self::CATEGORY_NOOP,
+                self::SEVERITY_LOW,
+                "Unused result of an empty(expr) check",
+                self::REMEDIATION_B,
+                6051
+            ),
+            new Issue(
+                self::NoopIsset,
+                self::CATEGORY_NOOP,
+                self::SEVERITY_LOW,
+                "Unused result of an isset(expr) check",
+                self::REMEDIATION_B,
+                6052
+            ),
+            new Issue(
+                self::NoopCast,
+                self::CATEGORY_NOOP,
+                self::SEVERITY_LOW,
+                "Unused result of a ({TYPE})(expr) cast",
+                self::REMEDIATION_B,
+                6053
             ),
             new Issue(
                 self::NoopEncapsulatedStringLiteral,

--- a/tests/files/expected/0620_more_noop_expressions.php.expected
+++ b/tests/files/expected/0620_more_noop_expressions.php.expected
@@ -1,0 +1,13 @@
+%s:3 PhanNoopEmpty Unused result of an empty(expr) check
+%s:4 PhanNoopIsset Unused result of an isset(expr) check
+%s:7 PhanNoopCast Unused result of a (string)(expr) cast
+%s:8 PhanNoopCast Unused result of a (int)(expr) cast
+%s:9 PhanNoopCast Unused result of a (bool)(expr) cast
+%s:10 PhanNoopCast Unused result of a (unset)(expr) cast
+%s:11 PhanNoopCast Unused result of a (float)(expr) cast
+%s:12 PhanNoopCast Unused result of a (array)(expr) cast
+%s:13 PhanNoopCast Unused result of a (object)(expr) cast
+%s:22 PhanNoopBinaryOperator Unused result of a binary '??' operator
+%s:26 PhanNoopBinaryOperator Unused result of a binary '??' operator
+%s:28 PhanNoopBinaryOperator Unused result of a binary '&&' operator
+%s:29 PhanNoopBinaryOperator Unused result of a binary '||' operator

--- a/tests/files/src/0620_more_noop_expressions.php
+++ b/tests/files/src/0620_more_noop_expressions.php
@@ -1,0 +1,29 @@
+<?php
+$a = 2;
+empty($a);
+isset($a);
+
+// TODO: Also warn about whether these casts are impossible (e.g. certain scalars to/from array/object)
+(string)$a;
+(int)$a;
+(bool)$a;
+(unset)$a;
+(float)$a;
+(array)$a;
+(object)$a;
+
+function some_function() : ?string {
+    echo "Something";
+    return rand(0,1) ? "value" : null;
+}
+// This is a NoopBinaryOperator because it does the same thing without the right hand side
+// of the `??` expression - evaluating the right hand s.
+// Other `??` expressions might not be.
+some_function() ?? 'default';
+// this does not emit NoopBinaryOperator - The right hand side has side effects
+some_function() ?? printf("This has side effects - %s\n", PHP_VERSION);
+// This does - it can guess if complicated expressions have no side effects
+some_function() ?? (stdClass::class . (PHP_VERSION_ID & ~1));
+// Should also do the same thing check of the right hand side for short-circuiting binary expressions
+some_function() && 'default';
+some_function() || true;

--- a/tests/misc/fallback_test/expected/011_isset_intrinsic_expression5.php.expected
+++ b/tests/misc/fallback_test/expected/011_isset_intrinsic_expression5.php.expected
@@ -1,1 +1,2 @@
+src/011_isset_intrinsic_expression5.php:2 PhanNoopIsset Unused result of an isset(expr) check
 src/011_isset_intrinsic_expression5.php:2 PhanSyntaxError syntax error, unexpected 'ISSET' (T_ISSET), expecting '('

--- a/tests/plugin_test/expected/078_merge_bool_and.php.expected
+++ b/tests/plugin_test/expected/078_merge_bool_and.php.expected
@@ -1,3 +1,4 @@
 src/078_merge_bool_and.php:3 PhanPossiblyFalseTypeArgumentInternal Argument 1 (string) is '10'|false but \strlen() takes string (false is incompatible)
+src/078_merge_bool_and.php:4 PhanNoopBinaryOperator Unused result of a binary '&&' operator
 src/078_merge_bool_and.php:4 PhanPluginNonBoolInLogicalArith Non bool value of type '10'|false in logical arithmetic
 src/078_merge_bool_and.php:5 PhanPossiblyFalseTypeArgumentInternal Argument 1 (string) is '10'|false but \strlen() takes string (false is incompatible)

--- a/tests/plugin_test/expected/079_both_booleans.php.expected
+++ b/tests/plugin_test/expected/079_both_booleans.php.expected
@@ -1,0 +1,2 @@
+src/079_both_booleans.php:5 PhanNoopBinaryOperator Unused result of a binary '&&' operator
+src/079_both_booleans.php:6 PhanNoopBinaryOperator Unused result of a binary '||' operator


### PR DESCRIPTION
Fixes #2389

Check `isset`, `empty`,
and some cases of `&&`, `||`, and `??`