### PR TITLE
Don't incorrectly emit PhanInfiniteRecursion in `A?B:C`

### DIFF
--- a/src/Phan/Analysis/ReachabilityChecker.php
+++ b/src/Phan/Analysis/ReachabilityChecker.php
@@ -262,6 +262,33 @@ final class ReachabilityChecker extends KindVisitorImplementation
     }
 
     /**
+     * Analyzes a node with kind \ast\AST_CONDITIONAL
+     * @return ?bool the result seen for a conditional
+     */
+    public function visitConditional(Node $node)
+    {
+        $cond = $node->children['cond'];
+        if ($cond instanceof Node) {
+            $result = $this->__invoke($cond);
+            if ($result !== null) {
+                return $result;
+            }
+        }
+        foreach (['true', 'false'] as $sub_node_name) {
+            $value = $node->children[$sub_node_name];
+            if (!($value instanceof Node)) {
+                continue;
+            }
+            $result = $this->__invoke($value);
+            if ($result !== null) {
+                // This is a conditional; it's not guaranteed to work
+                return false;
+            }
+        }
+        return null;
+    }
+
+    /**
      * Returns true if there are no break/return/throw/etc statements
      * within the method that would prevent $inner (a descendant node of $node)
      * to be reached from the start of evaluating the statements in $node.

--- a/tests/files/expected/0621_infinite_recursion_conditional.php.expected
+++ b/tests/files/expected/0621_infinite_recursion_conditional.php.expected
@@ -1,0 +1,2 @@
+%s:5 PhanInfiniteRecursion main() is calling itself in a way that may cause infinite recursion.
+%s:19 PhanInfiniteRecursion infiniteRecursion() is calling itself in a way that may cause infinite recursion.

--- a/tests/files/src/0620_more_noop_expressions.php
+++ b/tests/files/src/0620_more_noop_expressions.php
@@ -11,8 +11,8 @@ isset($a);
 (float)$a;
 (array)$a;
 (object)$a;
-
-function some_function() : ?string {
+/** @return ?string */
+function some_function() {
     echo "Something";
     return rand(0,1) ? "value" : null;
 }

--- a/tests/files/src/0621_infinite_recursion_conditional.php
+++ b/tests/files/src/0621_infinite_recursion_conditional.php
@@ -1,0 +1,21 @@
+<?php
+
+class Example {
+    public static function main() : bool {
+        return self::main() ? false : (rand(0,1) > 0);
+    }
+
+    public static function notInfinite() : bool {
+        return rand(0,1) > 0 ? self::notInfinite() : (rand(0,2) > 0);
+    }
+
+    public static function notInfinite2() : bool {
+        return rand(0,1) > 0 ? (rand(0,2) > 0) : self::notInfinite2();
+    }
+
+    public static function infiniteRecursion() : bool {
+        $x = rand(0,1) > 0 ? (rand(0,2) > 0) : self::infiniteRecursion();
+        var_export($x);
+        return self::infiniteRecursion();
+    }
+}


### PR DESCRIPTION
Fixes #2380