### PR TITLE
Properly analyze `foreach ($arr as $x->prop => $v)`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ New features(Analysis):
 + Detect more expressions without side effects: `PhanNoopEmpty` and `PhanNoopIsset` (for `isset(expr)` and `empty(expr)`) (#2389)
 + Also emit `PhanNoopBinaryOperator` for the `??`, `||`, and `&&` operators,
   but only when the result is unused and the right hand side has no obvious side effects. (#2389)
++ Properly analyze effects of a property/field access expression as the key of a `foreach` statement. (#1601)
 
 Maintenance
 + Don't emit a warning to stderr when `--language-server-completion-vscode` is used.

--- a/src/Phan/AST/TolerantASTConverter/ast_shim.php
+++ b/src/Phan/AST/TolerantASTConverter/ast_shim.php
@@ -28,7 +28,6 @@ declare(strict_types=1);
 namespace ast;
 
 const AST_ARG_LIST = 128;
-const AST_LIST = 255;
 const AST_ARRAY = 129;
 const AST_ENCAPS_LIST = 130;
 const AST_EXPR_LIST = 131;

--- a/tests/files/expected/0622_foreach_complex.php.expected
+++ b/tests/files/expected/0622_foreach_complex.php.expected
@@ -1,0 +1,2 @@
+%s:15 PhanTypeMismatchArgumentInternal Argument 1 (string) is array{field2:'value',field:string} but \strlen() takes string
+%s:16 PhanTypeMismatchArgumentInternal Argument 1 (string) is \stdClass but \strlen() takes string


### PR DESCRIPTION
Properly analyze effects of a property/field access expression as the
key of a `foreach` statement.

Also, remove references to AST_LIST,
those aren't generated by AST version 50.

Fixes #1601