### PR TITLE
Fix visibility checks of properties/methods from trait

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,9 @@ New features(Analysis):
 Maintenance
 + Don't emit a warning to stderr when `--language-server-completion-vscode` is used.
 
+Bug fixes:
++ Fix edge cases in checking if properties/methods are accessible from a trait (#2371)
+
 02 Feb 2019, Phan 1.2.2
 -----------------------
 

--- a/src/Phan/Language/Element/ClassElement.php
+++ b/src/Phan/Language/Element/ClassElement.php
@@ -78,6 +78,17 @@ abstract class ClassElement extends AddressableElement
     }
 
     /**
+     * Gets the real defining FQSEN.
+     * This differs from getDefiningFQSEN() if the definition was from a trait.
+     *
+     * @return FullyQualifiedClassElement
+     */
+    public function getRealDefiningFQSEN()
+    {
+        return $this->getDefiningFQSEN();
+    }
+
+    /**
      * @return FullyQualifiedClassName
      * The FQSEN of this class element from where it was
      * originally defined
@@ -239,7 +250,19 @@ abstract class ClassElement extends AddressableElement
         if ($defining_fqsen === $accessing_class_fqsen) {
             return true;
         }
+        $real_defining_fqsen = $this->getRealDefiningFQSEN()->getFullyQualifiedClassName();
+        if ($real_defining_fqsen === $accessing_class_fqsen) {
+            return true;
+        }
         if ($this->isPrivate()) {
+            if ($code_base->hasClassWithFQSEN($defining_fqsen)) {
+                $defining_class = $code_base->getClassByFQSEN($defining_fqsen);
+                foreach ($defining_class->getTraitFQSENList() as $trait_fqsen) {
+                    if ($trait_fqsen === $accessing_class_fqsen) {
+                        return true;
+                    }
+                }
+            }
             return false;
         }
         return $this->checkCanAccessProtectedElement($code_base, $defining_fqsen, $accessing_class_fqsen);

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -2310,6 +2310,9 @@ class Type
      * @return bool
      * True if this type represents a class which is a sub-type of
      * the class represented by the passed type.
+     *
+     * @deprecated
+     * @suppress PhanUnreferencedPublicMethod
      */
     public function isSubclassOf(CodeBase $code_base, Type $parent) : bool
     {

--- a/tests/files/expected/0623_trait_access.php.expected
+++ b/tests/files/expected/0623_trait_access.php.expected
@@ -1,0 +1,2 @@
+%s:23 PhanAccessPropertyPrivate Cannot access private property \NS2371\SubClass->inaccessiblePrivateProp defined at %s:42
+%s:24 PhanAccessMethodPrivate Cannot access private method \NS2371\SubClass::inaccessiblePrivateMethod defined at %s:43

--- a/tests/files/src/0622_foreach_complex.php
+++ b/tests/files/src/0622_foreach_complex.php
@@ -1,0 +1,17 @@
+<?php
+function example_foreach_1601() {
+    $fields = ['key' => 'value'];
+    $x = [];
+    $o = new stdClass();
+    foreach ($fields as $x['field'] => $o->propName) {
+        var_export($x);
+        var_export($o);
+    }
+    foreach ($fields as $o->propName2 => $x['field2']) {
+        var_export($x);
+        var_export($o);
+    }
+    // Should warn with inference that $x is an array and $o is an stdClass
+    echo strlen($x);
+    echo strlen($o);
+}

--- a/tests/files/src/0623_trait_access.php
+++ b/tests/files/src/0623_trait_access.php
@@ -1,0 +1,49 @@
+<?php
+namespace NS2371;
+
+trait FooTrait {
+    private $prop = 'private prop';
+    public function test(ClassUsingTrait $o) {
+        echo $o->prop;
+        if ($this instanceof ClassUsingTrait) {
+            // Same issue seen for class elements such as methods, etc.
+            echo $this->prop;
+            $this->privateMethod();
+        }
+        // TODO: Phan should **not** warn here for the property/method
+        echo $o->otherPrivateProp;
+        $o->otherPrivateMethod();
+        echo $o->otherProtectedProp;
+        $o->otherProtectedMethod();
+    }
+
+    public function testSubclass(SubClass $s) {
+        echo $s->otherPrivateProp;
+        $s->otherPrivateMethod();
+        echo $s->inaccessiblePrivateProp;
+        $s->inaccessiblePrivateMethod();
+    }
+    private function privateMethod() {
+    }
+}
+
+class ClassUsingTrait {
+    use FooTrait;
+    private $otherPrivateProp = "private\n";
+    private function otherPrivateMethod() {
+        echo "In private method of class using trait\n";
+    }
+    protected $otherProtectedProp = "protected\n";
+    private function otherProtectedMethod() {
+        echo "In protected method of class using trait\n";
+    }
+}
+class SubClass extends ClassUsingTrait {
+    private $inaccessiblePrivateProp = "inaccessible\n";
+    private function inaccessiblePrivateMethod() {
+        echo "In private method of subclass\n";
+    }
+}
+$c = new ClassUsingTrait();
+echo $c->test($c);
+echo $c->testSubclass(new SubClass());


### PR DESCRIPTION
e.g. don't warn if accessing a private property/method of a class
when that property/method was originally defined in that trait,
or that class directly uses that trait.

Fixes #2371