### PR TITLE
Catch RecursionDepthException; improve details about the exception

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@ New features(Analysis):
 
 Maintenance
 + Don't emit a warning to stderr when `--language-server-completion-vscode` is used.
++ Catch the rare RecursionDepthException in more places, improve readability of its exception message. (#2386)
 
 Bug fixes:
 + Fix edge cases in checking if properties/methods are accessible from a trait (#2371)

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -13,6 +13,7 @@ use Phan\Exception\EmptyFQSENException;
 use Phan\Exception\FQSENException;
 use Phan\Exception\IssueException;
 use Phan\Exception\NodeException;
+use Phan\Exception\RecursionDepthException;
 use Phan\Exception\UnanalyzableException;
 use Phan\Issue;
 use Phan\IssueFixSuggester;
@@ -767,10 +768,13 @@ class ContextNode
                     $method_name
                 );
                 if ($method->hasTemplateType()) {
-                    return $method->resolveTemplateType(
-                        $this->code_base,
-                        UnionTypeVisitor::unionTypeFromNode($this->code_base, $this->context, $node->children['expr'] ?? $node->children['class'])
-                    );
+                    try {
+                        return $method->resolveTemplateType(
+                            $this->code_base,
+                            UnionTypeVisitor::unionTypeFromNode($this->code_base, $this->context, $node->children['expr'] ?? $node->children['class'])
+                        );
+                    } catch (RecursionDepthException $_) {
+                    }
                 }
                 return $method;
             } elseif (!$is_static && $class->allowsCallingUndeclaredInstanceMethod($this->code_base)) {

--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -18,6 +18,7 @@ use Phan\AST\TolerantASTConverter\ParseException;
 use Phan\AST\Visitor\Element;
 use Phan\Daemon\Request;
 use Phan\Exception\FQSENException;
+use Phan\Exception\RecursionDepthException;
 use Phan\Language\Context;
 use Phan\Language\Element\Func;
 use Phan\Language\Element\FunctionInterface;
@@ -432,7 +433,11 @@ class Analysis
             }
         }
         foreach ($classes as $class) {
-            $class->analyze($code_base);
+            try {
+                $class->analyze($code_base);
+            } catch (RecursionDepthException $_) {
+                continue;
+            }
         }
     }
 

--- a/src/Phan/Analysis/ArgumentType.php
+++ b/src/Phan/Analysis/ArgumentType.php
@@ -11,6 +11,7 @@ use Phan\CodeBase;
 use Phan\Config;
 use Phan\Exception\CodeBaseException;
 use Phan\Exception\IssueException;
+use Phan\Exception\RecursionDepthException;
 use Phan\Issue;
 use Phan\Language\Context;
 use Phan\Language\Element\FunctionInterface;
@@ -495,8 +496,12 @@ final class ArgumentType
     public static function analyzeParameter(CodeBase $code_base, Context $context, FunctionInterface $method, UnionType $argument_type, int $lineno, int $i)
     {
         // Expand it to include all parent types up the chain
-        $argument_type_expanded =
-            $argument_type->asExpandedTypes($code_base);
+        try {
+            $argument_type_expanded =
+                $argument_type->asExpandedTypes($code_base);
+        } catch (RecursionDepthException $_) {
+            return;
+        }
 
         // Check the method to see if it has the correct
         // parameter types. If not, keep hunting through

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -12,6 +12,7 @@ use Phan\Config;
 use Phan\Exception\CodeBaseException;
 use Phan\Exception\IssueException;
 use Phan\Exception\NodeException;
+use Phan\Exception\RecursionDepthException;
 use Phan\Exception\UnanalyzableException;
 use Phan\Issue;
 use Phan\IssueFixSuggester;
@@ -716,7 +717,11 @@ class AssignmentVisitor extends AnalysisVisitor
                 );
                 return $this->context;
             }
-            return $this->analyzePropAssignment($clazz, $property, $node);
+            try {
+                return $this->analyzePropAssignment($clazz, $property, $node);
+            } catch (RecursionDepthException $_) {
+                return $this->context;
+            }
         }
 
         // Check if it is a built in class with dynamic properties but (possibly) no __set, such as SimpleXMLElement or stdClass or V8Js
@@ -1047,7 +1052,11 @@ class AssignmentVisitor extends AnalysisVisitor
                 return $this->context;
             }
 
-            return $this->analyzePropAssignment($clazz, $property, $node);
+            try {
+                return $this->analyzePropAssignment($clazz, $property, $node);
+            } catch (RecursionDepthException $_) {
+                return $this->context;
+            }
         }
 
         if (\count($class_list) > 0) {

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -5,6 +5,7 @@ namespace Phan\Analysis;
 use Phan\CodeBase;
 use Phan\Config;
 use Phan\Exception\CodeBaseException;
+use Phan\Exception\RecursionDepthException;
 use Phan\Issue;
 use Phan\IssueFixSuggester;
 use Phan\Language\Element\Clazz;
@@ -42,6 +43,19 @@ class ParameterTypesAnalyzer
      * @return void
      */
     public static function analyzeParameterTypes(
+        CodeBase $code_base,
+        FunctionInterface $method
+    ) {
+        try {
+            self::analyzeParameterTypesInner($code_base, $method);
+        } catch (RecursionDepthException $_) {
+        }
+    }
+
+    /**
+     * @see analyzeParameterTypes
+     */
+    private static function analyzeParameterTypesInner(
         CodeBase $code_base,
         FunctionInterface $method
     ) {

--- a/src/Phan/Analysis/ThrowsTypesAnalyzer.php
+++ b/src/Phan/Analysis/ThrowsTypesAnalyzer.php
@@ -3,6 +3,7 @@
 namespace Phan\Analysis;
 
 use Phan\CodeBase;
+use Phan\Exception\RecursionDepthException;
 use Phan\Issue;
 use Phan\IssueFixSuggester;
 use Phan\Language\Context;
@@ -30,9 +31,12 @@ class ThrowsTypesAnalyzer
         CodeBase $code_base,
         FunctionInterface $method
     ) {
-        foreach ($method->getThrowsUnionType()->getTypeSet() as $type) {
-            // TODO: When analyzing the method body, only check the valid exceptions
-            self::analyzeSingleThrowType($code_base, $method, $type);
+        try {
+            foreach ($method->getThrowsUnionType()->getTypeSet() as $type) {
+                // TODO: When analyzing the method body, only check the valid exceptions
+                self::analyzeSingleThrowType($code_base, $method, $type);
+            }
+        } catch (RecursionDepthException $_) {
         }
     }
 

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -158,13 +158,14 @@ class CLI
      * @param string|string[] $value
      * @return array<int,string>
      */
-    public static function readCommaSeparatedListOrLists($value) : array {
+    public static function readCommaSeparatedListOrLists($value) : array
+    {
         if (is_array($value)) {
             $value = implode(',', $value);
         }
         $value_set = [];
         foreach (explode(',', (string)$value) as $file) {
-            if ($file === '')  {
+            if ($file === '') {
                 continue;
             }
             $value_set[$file] = true;

--- a/src/Phan/Debug/Frame.php
+++ b/src/Phan/Debug/Frame.php
@@ -103,4 +103,23 @@ class Frame
             return $invocation . '(). Args: ' . self::encodeValue($args);
         });
     }
+
+    /**
+     * Returns details about a call to asExpandedTypes that hit a RecursionDepthException
+     */
+    public static function getExpandedTypesDetails() : string
+    {
+        $result = [];
+        foreach (debug_backtrace() as $frame) {
+            if (($frame['function'] ?? null) === 'asExpandedTypes' && isset($frame['object'])) {
+                $object = $frame['object'];
+                if ($object instanceof Type) {
+                    $result[] = 'when expanding type (' . (string)$object . ')';
+                } elseif ($object instanceof UnionType) {
+                    $result[] = 'when expanding union type (' . (string)$object . ')';
+                }
+            }
+        }
+        return implode("\n", $result);
+    }
 }

--- a/src/Phan/Language/Element/ClassElement.php
+++ b/src/Phan/Language/Element/ClassElement.php
@@ -5,6 +5,7 @@ namespace Phan\Language\Element;
 use AssertionError;
 use Phan\CodeBase;
 use Phan\Exception\CodeBaseException;
+use Phan\Exception\RecursionDepthException;
 use Phan\Language\Context;
 use Phan\Language\FQSEN;
 use Phan\Language\FQSEN\FullyQualifiedClassElement;
@@ -280,16 +281,19 @@ abstract class ClassElement extends AddressableElement
 
         // If the definition of the property is protected,
         // then the subclasses of the defining class can access it.
-        foreach ($accessing_class_type->asExpandedTypes($code_base)->getTypeSet() as $type) {
-            if ($type->canCastToType($type_of_class_of_property)) {
-                return true;
+        try {
+            foreach ($accessing_class_type->asExpandedTypes($code_base)->getTypeSet() as $type) {
+                if ($type->canCastToType($type_of_class_of_property)) {
+                    return true;
+                }
             }
-        }
-        // and base classes of the defining class can access it
-        foreach ($type_of_class_of_property->asExpandedTypes($code_base)->getTypeSet() as $type) {
-            if ($type->canCastToType($accessing_class_type)) {
-                return true;
+            // and base classes of the defining class can access it
+            foreach ($type_of_class_of_property->asExpandedTypes($code_base)->getTypeSet() as $type) {
+                if ($type->canCastToType($accessing_class_type)) {
+                    return true;
+                }
             }
+        } catch (RecursionDepthException $_) {
         }
         return false;
     }

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -14,6 +14,7 @@ use Phan\CodeBase;
 use Phan\Config;
 use Phan\Exception\CodeBaseException;
 use Phan\Exception\IssueException;
+use Phan\Exception\RecursionDepthException;
 use Phan\Issue;
 use Phan\IssueFixSuggester;
 use Phan\Language\Context;
@@ -2780,6 +2781,7 @@ class Clazz extends AddressableElement
      * This method should be called after hydration
      *
      * @return void
+     * @throws RecursionDepthException for deep class hierarchies
      */
     final public function analyze(CodeBase $code_base)
     {

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -11,6 +11,7 @@ use Phan\Analysis\ParameterTypesAnalyzer;
 use Phan\AST\UnionTypeVisitor;
 use Phan\CodeBase;
 use Phan\Config;
+use Phan\Exception\RecursionDepthException;
 use Phan\Issue;
 use Phan\IssueFixSuggester;
 use Phan\Language\Context;
@@ -1218,7 +1219,10 @@ trait FunctionTrait
             return;
         }
         $this->did_analyze_return_types = true;
-        $this->analyzeReturnTypesInner($code_base);
+        try {
+            $this->analyzeReturnTypesInner($code_base);
+        } catch (RecursionDepthException $_) {
+        }
     }
 
     /**

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -10,6 +10,7 @@ use InvalidArgumentException;
 use Phan\AST\UnionTypeVisitor;
 use Phan\CodeBase;
 use Phan\Config;
+use Phan\Debug\Frame;
 use Phan\Exception\EmptyFQSENException;
 use Phan\Exception\FQSENException;
 use Phan\Exception\InvalidFQSENException;
@@ -2146,7 +2147,7 @@ class Type
         // is taller than some value we probably messed up
         // and should bail out.
         if ($recursion_depth >= 20) {
-            throw new RecursionDepthException("Recursion has gotten out of hand: expanding type=$this");
+            throw new RecursionDepthException("Recursion has gotten out of hand: " . Frame::getExpandedTypesDetails());
         }
         $union_type = $this->memoize(__METHOD__, /** @return UnionType */ function () use ($code_base, $recursion_depth) {
             $union_type = $this->asUnionType();
@@ -2228,7 +2229,7 @@ class Type
         // is taller than some value we probably messed up
         // and should bail out.
         if ($recursion_depth >= 20) {
-            throw new RecursionDepthException("Recursion has gotten out of hand: expanding type=$this");
+            throw new RecursionDepthException("Recursion has gotten out of hand: " . Frame::getExpandedTypesDetails());
         }
         $union_type = $this->memoize(__METHOD__, /** @return UnionType */ function () use ($code_base, $recursion_depth) {
             $union_type = $this->asUnionType();

--- a/src/Phan/Language/Type/ArrayShapeType.php
+++ b/src/Phan/Language/Type/ArrayShapeType.php
@@ -6,6 +6,7 @@ use Closure;
 use Exception;
 use Phan\CodeBase;
 use Phan\Config;
+use Phan\Debug\Frame;
 use Phan\Exception\RecursionDepthException;
 use Phan\Issue;
 use Phan\Language\AnnotatedUnionType;
@@ -455,7 +456,7 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
         // is taller than some value we probably messed up
         // and should bail out.
         if ($recursion_depth >= 20) {
-            throw new RecursionDepthException("Recursion has gotten out of hand");
+            throw new RecursionDepthException("Recursion has gotten out of hand: " . Frame::getExpandedTypesDetails());
         }
         return $this->memoize(__METHOD__, function () use ($code_base, $recursion_depth) : UnionType {
             $result_fields = [];
@@ -502,7 +503,7 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
         // is taller than some value we probably messed up
         // and should bail out.
         if ($recursion_depth >= 20) {
-            throw new RecursionDepthException("Recursion has gotten out of hand");
+            throw new RecursionDepthException("Recursion has gotten out of hand: " . Frame::getExpandedTypesDetails());
         }
         return $this->memoize(__METHOD__, function () use ($code_base, $recursion_depth) : UnionType {
             $result_fields = [];

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 use Phan\AST\UnionTypeVisitor;
 use Phan\CodeBase;
 use Phan\Config;
+use Phan\Debug\Frame;
 use Phan\Exception\RecursionDepthException;
 use Phan\Language\Context;
 use Phan\Language\FQSEN\FullyQualifiedClassName;
@@ -308,7 +309,7 @@ class GenericArrayType extends ArrayType implements GenericArrayInterface
         // is taller than some value we probably messed up
         // and should bail out.
         if ($recursion_depth >= 20) {
-            throw new RecursionDepthException("Recursion has gotten out of hand");
+            throw new RecursionDepthException("Recursion has gotten out of hand: " . Frame::getExpandedTypesDetails());
         }
 
         return $this->memoize(__METHOD__, function () use ($code_base, $recursion_depth) : UnionType {
@@ -387,7 +388,7 @@ class GenericArrayType extends ArrayType implements GenericArrayInterface
         // is taller than some value we probably messed up
         // and should bail out.
         if ($recursion_depth >= 20) {
-            throw new RecursionDepthException("Recursion has gotten out of hand");
+            throw new RecursionDepthException("Recursion has gotten out of hand: " . Frame::getExpandedTypesDetails());
         }
 
         return $this->memoize(__METHOD__, function () use ($code_base, $recursion_depth) : UnionType {

--- a/src/Phan/Language/Type/GenericMultiArrayType.php
+++ b/src/Phan/Language/Type/GenericMultiArrayType.php
@@ -4,6 +4,7 @@ namespace Phan\Language\Type;
 
 use InvalidArgumentException;
 use Phan\CodeBase;
+use Phan\Debug\Frame;
 use Phan\Exception\RecursionDepthException;
 use Phan\Language\Type;
 use Phan\Language\UnionType;
@@ -191,7 +192,7 @@ final class GenericMultiArrayType extends ArrayType implements MultiType, Generi
         // is taller than some value we probably messed up
         // and should bail out.
         if ($recursion_depth >= 20) {
-            throw new RecursionDepthException("Recursion has gotten out of hand");
+            throw new RecursionDepthException("Recursion has gotten out of hand: " . Frame::getExpandedTypesDetails());
         }
 
         // TODO: Use UnionType::merge from a future change?
@@ -234,7 +235,7 @@ final class GenericMultiArrayType extends ArrayType implements MultiType, Generi
         // is taller than some value we probably messed up
         // and should bail out.
         if ($recursion_depth >= 20) {
-            throw new RecursionDepthException("Recursion has gotten out of hand");
+            throw new RecursionDepthException("Recursion has gotten out of hand: " . Frame::getExpandedTypesDetails());
         }
 
         // TODO: Use UnionType::merge from a future change?

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -7,6 +7,7 @@ use Generator;
 use InvalidArgumentException;
 use Phan\CodeBase;
 use Phan\Config;
+use Phan\Debug\Frame;
 use Phan\Exception\CodeBaseException;
 use Phan\Exception\IssueException;
 use Phan\Exception\RecursionDepthException;
@@ -2581,7 +2582,7 @@ class UnionType implements Serializable
         int $recursion_depth = 0
     ) : UnionType {
         if ($recursion_depth >= 12) {
-            throw new RecursionDepthException("Recursion has gotten out of hand: expanding union type=$this");
+            throw new RecursionDepthException("Recursion has gotten out of hand: " . Frame::getExpandedTypesDetails());
         }
 
         $type_set = $this->type_set;
@@ -2626,7 +2627,7 @@ class UnionType implements Serializable
         int $recursion_depth = 0
     ) : UnionType {
         if ($recursion_depth >= 12) {
-            throw new RecursionDepthException("Recursion has gotten out of hand: expanding union type=$this");
+            throw new RecursionDepthException("Recursion has gotten out of hand: " . Frame::getExpandedTypesDetails());
         }
 
         $type_set = $this->type_set;


### PR DESCRIPTION
Catch RecursionDepthException in places where it would often be uncaught
(if used with deep class hierarchies).

- This may lead to rare false positives, but is better than crashing

Also, give a much better stack trace with details on what was being
expanded. This will help with future uncaught RecursionDepthExceptions

Fixes #2386