### PR TITLE
Fix edge cases of UseReturnValuePlugin

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,7 @@ Bug fixes:
 
 Plugins:
 + Infer a literal string return value when calling `sprintf` on known literal scalar types in `PrintfCheckerPlugin`. (#2131)
++ Infer that `;@foo();` is not a usage of `foo()` in `UseReturnValuePlugin`. (#2412)
 
 02 Feb 2019, Phan 1.2.2
 -----------------------

--- a/tests/plugin_test/expected/081_use_return_value.php.expected
+++ b/tests/plugin_test/expected/081_use_return_value.php.expected
@@ -1,3 +1,10 @@
 src/081_use_return_value.php:2 PhanPluginUseReturnValueInternalKnown Expected to use the return value of the internal function/method \sprintf
 src/081_use_return_value.php:3 PhanPluginUseReturnValueInternalKnown Expected to use the return value of the internal function/method \count
-src/081_use_return_value.php:8 PhanPluginUseReturnValueInternalKnown Expected to use the return value of the internal function/method \Exception::getMessage
+src/081_use_return_value.php:4 PhanNoopUnaryOperator Unused result of a unary '-' operator
+src/081_use_return_value.php:4 PhanPluginUseReturnValueInternalKnown Expected to use the return value of the internal function/method \count
+src/081_use_return_value.php:9 PhanPluginUseReturnValueInternalKnown Expected to use the return value of the internal function/method \Exception::getMessage
+src/081_use_return_value.php:11 PhanPluginUseReturnValueInternalKnown Expected to use the return value of the internal function/method \Exception::getCode
+src/081_use_return_value.php:12 PhanPluginUseReturnValueInternalKnown Expected to use the return value of the internal function/method \Exception::getCode
+src/081_use_return_value.php:13 PhanUndeclaredMethod Call to undeclared method \Exception::getMissing
+src/081_use_return_value.php:17 PhanNoopUnaryOperator Unused result of a unary '-' operator
+src/081_use_return_value.php:17 PhanPluginUseReturnValueInternalKnown Expected to use the return value of the internal function/method \Exception::getCode

--- a/tests/plugin_test/src/081_use_return_value.php
+++ b/tests/plugin_test/src/081_use_return_value.php
@@ -1,9 +1,18 @@
 <?php
 sprintf("%s is not used\n", 'return value');
 count([]);
+-count([]);  // should also warn
 try {
 } catch (Exception $e) {
     // Should warn - The message is usually used.
     // TODO: Make PhanPluginUseReturnValueInternalKnown also check for methods that override methods of Exception
     $e->getMessage();
+    // should also warn
+    $e->getCode();
+    @$e->getCode();
+    @$e->getMissing();
+    // should not warn
+    var_export(-$e->getCode());
+    // should warn
+    -$e->getCode();
 }


### PR DESCRIPTION
Fixes #2414

`;@foo();` should not be marked as a usage of foo
because of the unary operator between it and the statement list.

- This PR fixes that.