### PR TITLE
Attempted fixes for issues with the issue filter on Windows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,11 @@ New features(Analysis):
 + Emit `PhanTypeInstantiateTrait` when calling `new TraitName()` (#2379)
 + Emit `PhanTemplateTypeConstant` when using `@var T` on a class constant's doc comment. (#2402)
 
+Language Server/Daemon mode:
++ Attempted fixes for bugs with issue filtering in the language server on Windows.
++ Add `--language-server-disable-output-filter`, which disables the language server filter to limit outputted issues
+  to those in files currently open in the IDE.
+
 Maintenance
 + Don't emit a warning to stderr when `--language-server-completion-vscode` is used.
 + Catch the rare RecursionDepthException in more places, improve readability of its exception message. (#2386)

--- a/internal/update_wiki_config_types.php
+++ b/internal/update_wiki_config_types.php
@@ -126,6 +126,7 @@ class ConfigEntry
         'language_server_config' => self::CATEGORY_HIDDEN_CLI_ONLY,
         'language_server_analyze_only_on_save' => self::CATEGORY_HIDDEN_CLI_ONLY,
         'language_server_debug_level' => self::CATEGORY_HIDDEN_CLI_ONLY,
+        'language_server_disable_output_filter' => self::CATEGORY_HIDDEN_CLI_ONLY,
         'language_server_use_pcntl_fallback' => self::CATEGORY_HIDDEN_CLI_ONLY,
         'language_server_enable_go_to_definition' => self::CATEGORY_HIDDEN_CLI_ONLY,
         'language_server_enable_hover' => self::CATEGORY_HIDDEN_CLI_ONLY,

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -80,6 +80,7 @@ class CLI
         'language-server-tcp-connect:',
         'language-server-tcp-server:',
         'language-server-verbose',
+        'language-server-disable-output-filter',
         'language-server-hide-category',
         'language-server-allow-missing-pcntl',
         'language-server-force-missing-pcntl',
@@ -546,6 +547,9 @@ class CLI
                     break;
                 case 'language-server-verbose':
                     Config::setValue('language_server_debug_level', 'info');
+                    break;
+                case 'language-server-disable-output-filter':
+                    Config::setValue('language_server_disable_output_filter', true);
                     break;
                 case 'x':
                 case 'dead-code-detection':
@@ -1038,6 +1042,13 @@ Extended help:
 
  --language-server-verbose
   Emit verbose logging messages related to the language server implementation to stderr.
+  This is useful when developing or debugging language server clients.
+
+ --language-server-disable-output-filter
+  Emit all issues detected from the language server (e.g. invalid phpdoc in parsed files),
+  not just issues in files currently open in the editor/IDE.
+  This can be very verbose and has more false positives.
+
   This is useful when developing or debugging language server clients.
 
  --language-server-allow-missing-pcntl

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -696,6 +696,11 @@ class Config
         // Valid values: null, 'info'. Used when developing or debugging a language server client of Phan.
         'language_server_debug_level' => null,
 
+        // Set this to true to emit all issues detected from the language server (e.g. invalid phpdoc in parsed files),
+        // not just issues in files currently open in the editor/IDE.
+        // This can be very verbose and has more false positives.
+        'language_server_disable_output_filter' => false,
+
         // This should only be set by CLI (`--language-server-force-missing-pcntl` or `language-server-require-pcntl`), which will set this to true for debugging.
         // When true, this will manually back up the state of the PHP process and restore it.
         'language_server_use_pcntl_fallback' => false,
@@ -1158,6 +1163,7 @@ class Config
             'language_server_analyze_only_on_save' => $is_bool,
             // 'language_server_config' => array|false,  // should not be set directly
             'language_server_debug_level' => $is_string_or_null,
+            'language_server_disable_output_filter' => $is_bool,
             'language_server_enable_completion' => $is_scalar,
             'language_server_enable_go_to_definition' => $is_bool,
             'language_server_enable_hover' => $is_bool,

--- a/src/Phan/Daemon/Request.php
+++ b/src/Phan/Daemon/Request.php
@@ -264,7 +264,7 @@ class Request
         // Otherwise, there might be an overwhelming number of issues to solve in some projects before using this in the IDE (e.g. PhanUnreferencedUseNormal)
         $printer = $factory->getPrinter($format, $this->buffered_output);
         $files = $this->request_config[self::PARAM_FILES] ?? null;
-        if (is_array($files) && count($files) > 0) {
+        if (is_array($files) && count($files) > 0 && !Config::getValue('language_server_disable_output_filter')) {
             return new FilteringPrinter($files, $printer);
         }
         return $printer;

--- a/src/Phan/LanguageServer/Utils.php
+++ b/src/Phan/LanguageServer/Utils.php
@@ -69,12 +69,24 @@ class Utils
             throw new InvalidArgumentException("Not a valid file URI: $uri");
         }
         $filepath = \urldecode($fragments['path']);
-        if (strpos($filepath, ':') !== false) {
-            if ($filepath[0] === '/') {
-                $filepath = (string)\substr($filepath, 1);
-            }
-            $filepath = \str_replace('/', '\\', $filepath);
+        if (DIRECTORY_SEPARATOR === "\\") {
+            $filepath = self::normalizePathFromWindowsURI($filepath);
         }
         return $filepath;
+    }
+
+    /**
+     * Converts "/C:/something/else.php" to "C:\something\else.php"
+     *
+     * Does nothing if not an absolute path.
+     */
+    public static function normalizePathFromWindowsURI(string $filepath) : string {
+        if (!preg_match('@[a-zA-Z]:[\\\\/]@', $filepath)) {
+            return $filepath;
+        }
+        if ($filepath[0] === '/') {
+            $filepath = (string)\substr($filepath, 1);
+        }
+        return \str_replace('/', '\\', $filepath);
     }
 }

--- a/src/Phan/Output/Printer/FilteringPrinter.php
+++ b/src/Phan/Output/Printer/FilteringPrinter.php
@@ -23,6 +23,14 @@ final class FilteringPrinter implements BufferedPrinterInterface
     /** @var IssuePrinterInterface the wrapped printer */
     private $printer;
 
+    /**
+     * @param string $file
+     */
+    private static function normalize($file) : string
+    {
+        return str_replace(DIRECTORY_SEPARATOR, "//", (string)$file);
+    }
+
     /** @param array<int, string> $files a non-empty list of relative file paths. */
     public function __construct(
         array $files,
@@ -32,7 +40,7 @@ final class FilteringPrinter implements BufferedPrinterInterface
             throw new InvalidArgumentException("FilteringPrinter expects 1 or more files");
         }
         foreach ($files as $file) {
-            $this->file_set[$file] = true;
+            $this->file_set[self::normalize($file)] = true;
         }
         $this->printer = $printer;
     }
@@ -44,7 +52,7 @@ final class FilteringPrinter implements BufferedPrinterInterface
     public function print(IssueInstance $instance)
     {
         $file = $instance->getFile();
-        if (!isset($this->file_set[$file])) {
+        if (!isset($this->file_set[self::normalize($file)])) {
             return;
         }
         $this->printer->print($instance);

--- a/tests/Phan/LanguageServer/UtilsTest.php
+++ b/tests/Phan/LanguageServer/UtilsTest.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Phan\Tests\LanguageServer;
+
+use Phan\LanguageServer\Utils;
+use Phan\Tests\BaseTest;
+
+/**
+ * Unit tests of FileCache
+ */
+final class UtilsTest extends BaseTest
+{
+    public function testUriToPath()
+    {
+        $this->assertSame('/foo/bar/baz.php', Utils::uriToPath('file:///foo/bar/baz.php'));
+        $this->assertSame('/foo/bar/baz:2.php', Utils::uriToPath('file:///foo/bar/baz:2.php'));
+        $this->assertSame('/foo/bar/baz bat.php', Utils::uriToPath('file:///foo/bar/baz%20bat.php'));
+    }
+
+    public function testNormalizePathFromWindowsURI()
+    {
+        $this->assertSame('C:\foo\bar\baz.php', Utils::normalizePathFromWindowsURI('C:/foo/bar/baz.php'));
+        $this->assertSame('C:\foo\bar\baz:2.php', Utils::normalizePathFromWindowsURI('/C:/foo/bar/baz:2.php'));
+    }
+}


### PR DESCRIPTION
Patches for #2377

Normalize paths when checking if they're currently open in the IDE
(treat \ and / the same way on windows)

Related to https://github.com/TysonAndre/vscode-php-phan/issues/55