### PR TITLE
Inherit phpdoc types even when there are real signature types

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,11 @@ New features(CLI):
   and the exclude option (`-3 <file_or_list> -3 <file_or_list>`).
 
 New features(Analysis):
++ Inherit more specific phpdoc types even when there are real types in the signature. (#2409)
+  e.g. inherit `@param array<int,\stdClass>` and `@return MyClass[]` from the
+  ancestor class of `function someMethod(array $x) : array {}`.
+
+  This is only done when each phpdoc type is compatible with the real signature type.
 + Detect more expressions without side effects: `PhanNoopEmpty` and `PhanNoopIsset` (for `isset(expr)` and `empty(expr)`) (#2389)
 + Also emit `PhanNoopBinaryOperator` for the `??`, `||`, and `&&` operators,
   but only when the result is unused and the right hand side has no obvious side effects. (#2389)

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -398,6 +398,11 @@ final class EmptyUnionType extends UnionType
         return $this;
     }
 
+    public function isExclusivelyNarrowedFormOf(CodeBase $code_base, UnionType $other) : bool
+    {
+        return $other->isEmpty();
+    }
+
     /**
      * @param Type[] $type_list
      * A list of types

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -1380,6 +1380,23 @@ class UnionType implements Serializable
     }
      */
 
+    // TODO: Callers should call withStaticResolvedInContext?
+    public function isExclusivelyNarrowedFormOf(CodeBase $code_base, UnionType $other) : bool
+    {
+        if ($other->isEmpty()) {
+            return true;
+        }
+        if ($this->isEmpty()) {
+            return false;
+        }
+        foreach ($this->type_set as $type) {
+            if (!$type->asExpandedTypes($code_base)->canStrictCastToUnionType($other)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     /**
      * @param Type[] $type_list
      * A list of types
@@ -1676,7 +1693,7 @@ class UnionType implements Serializable
         // every single type in T overlaps with T, a future call to Type->canCastToType will pass.
         $matches = true;
         foreach ($type_set as $type) {
-            if (!\in_array($type, $target_type_set)) {
+            if (!\in_array($type, $target_type_set, true)) {
                 $matches = false;
                 break;
             }

--- a/tests/files/expected/0629_comment.php.expected
+++ b/tests/files/expected/0629_comment.php.expected
@@ -1,0 +1,4 @@
+%s:21 PhanTypeMismatchArgumentInternal Argument 1 (string) is array<string,string>|null but \strlen() takes string
+%s:45 PhanTypeMismatchArgumentInternal Argument 1 (string) is \stdClass[] but \strlen() takes string
+%s:46 PhanTypeMismatchReturn Returning type array{key:2} but acceptList() is declared to return array<int,\stdClass>
+%s:53 PhanTypeMismatchReturn Returning type array{0:int} but acceptList() is declared to return array<int,\stdClass>

--- a/tests/files/src/0629_comment.php
+++ b/tests/files/src/0629_comment.php
@@ -1,0 +1,55 @@
+<?php
+
+interface AssetRepositoryInterface
+{
+    /**
+     * Find all assets optionally matching criteria and return a paginate object.
+     *
+     * @param array<string,string>|null $orderBy Ordering where the results should be returned by.
+     */
+    public function paginateByFilterCommand(array $orderBy = null): stdClass;
+}
+
+class AssetRepository implements AssetRepositoryInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function paginateByFilterCommand(array $orderBy = null): stdClass
+    {
+        // Expected: should infer ?array<string,string> instead of ?array in the error message emitted by the below line
+        echo strlen($orderBy);  // src/standalone.php:20 PhanTypeMismatchArgumentInternal Argument 1 (string) is ?array but \strlen() takes string
+        return new stdClass();
+    }
+}
+
+class ParamBase1 {
+    /**
+     * @return array<int,stdClass>
+     */
+    public function acceptList(array $x) : array {
+        var_export($x);
+        return [new stdClass()];
+    }
+}
+
+class ParamSubclass1 extends ParamBase1 {
+    /**
+     * Because this doesn't explicitly specify (at)return array,
+     * this inherits the return type from the ancestor class
+     * and warns about not returning `array<int,stdClass>`.
+     *
+     * @param stdClass[] $x
+     */
+    public function acceptList(array $x) : array {
+        echo strlen($x);  // should infer stdClass[]
+        return ['key' => 2];
+    }
+}
+
+// should also warn
+class ParamSubclass2 extends ParamBase1 {
+    public function acceptList(array $x) : array {
+        return [count($x)];
+    }
+}


### PR DESCRIPTION
This affects both param and return types.

Do this if the phpdoc types are more specific than the real signature
types (and all of the types in the union type are compatible)

Fixes #2409