### PR TITLE
Misc optimizations; Consistently use static closures where possible

### DIFF
--- a/.phan/plugins/PHPUnitAssertionPlugin.php
+++ b/.phan/plugins/PHPUnitAssertionPlugin.php
@@ -100,7 +100,7 @@ class PHPUnitAssertionPlugin extends PluginV2 implements AnalyzeFunctionCallCapa
                 // (at)param mixed $actual
                 // (at)phan-assert T $actual
                 return $method->createClosureForUnionTypeExtractorAndAssertionType(
-                    function (CodeBase $code_base, Context $context, array $args) : UnionType {
+                    static function (CodeBase $code_base, Context $context, array $args) : UnionType {
                         if (\count($args) < 2) {
                             return UnionType::empty();
                         }
@@ -198,7 +198,7 @@ class PHPUnitAssertionPlugin extends PluginV2 implements AnalyzeFunctionCallCapa
                 // (at)param mixed $actual
                 // (at)phan-assert T $actual
                 return $method->createClosureForUnionTypeExtractorAndAssertionType(
-                    function (CodeBase $code_base, Context $context, array $args) : UnionType {
+                    static function (CodeBase $code_base, Context $context, array $args) : UnionType {
                         if (\count($args) < 2) {
                             return UnionType::empty();
                         }

--- a/.phan/plugins/PregRegexCheckerPlugin.php
+++ b/.phan/plugins/PregRegexCheckerPlugin.php
@@ -38,7 +38,7 @@ class PregRegexCheckerPlugin extends PluginV2 implements AnalyzeFunctionCallCapa
          * @suppress PhanParamSuspiciousOrder 100% deliberate use of varying regex and constant $subject for preg_match
          * @return ?array
          */
-        $err = with_disabled_phan_error_handler(function () use ($pattern) {
+        $err = with_disabled_phan_error_handler(static function () use ($pattern) {
             $old_error_reporting = error_reporting();
             \error_reporting(0);
             \ob_start();

--- a/.phan/plugins/PrintfCheckerPlugin.php
+++ b/.phan/plugins/PrintfCheckerPlugin.php
@@ -207,7 +207,7 @@ class PrintfCheckerPlugin extends PluginV2 implements AnalyzeFunctionCallCapabil
             }
             $result = with_disabled_phan_error_handler(
                 /** @return string */
-                function () use ($format_string, $sprintf_args) {
+                static function () use ($format_string, $sprintf_args) {
                     return @vsprintf($format_string, $sprintf_args);
                 }
             );
@@ -604,7 +604,7 @@ class PrintfCheckerPlugin extends PluginV2 implements AnalyzeFunctionCallCapabil
      */
     private function getSpecStringsRepresentation(array $specs) : string
     {
-        return \implode(',', \array_unique(\array_map(function (ConversionSpec $spec) : string {
+        return \implode(',', \array_unique(\array_map(static function (ConversionSpec $spec) : string {
             return $spec->directive;
         }, $specs)));
     }

--- a/internal/lib/IncompatibleSignatureDetectorBase.php
+++ b/internal/lib/IncompatibleSignatureDetectorBase.php
@@ -243,7 +243,7 @@ EOT;
      */
     public static function sortSignatureMap(array &$phan_signatures)
     {
-        uksort($phan_signatures, function (string $a, string $b) : int {
+        uksort($phan_signatures, static function (string $a, string $b) : int {
             $a = strtolower(str_replace("'", "\x0", $a));
             $b = strtolower(str_replace("'", "\x0", $b));
             return $a <=> $b;

--- a/internal/lib/IncompatibleStubsSignatureDetector.php
+++ b/internal/lib/IncompatibleStubsSignatureDetector.php
@@ -90,7 +90,7 @@ class IncompatibleStubsSignatureDetector extends IncompatibleSignatureDetectorBa
                     \RecursiveDirectoryIterator::FOLLOW_SYMLINKS
                 )
             ),
-            function (\SplFileInfo $file_info) : bool {
+            static function (\SplFileInfo $file_info) : bool {
                 if ($file_info->getExtension() !== 'php') {
                     return false;
                 }

--- a/internal/lib/IncompatibleXMLSignatureDetector.php
+++ b/internal/lib/IncompatibleXMLSignatureDetector.php
@@ -627,7 +627,7 @@ class IncompatibleXMLSignatureDetector extends IncompatibleSignatureDetectorBase
         /**
          * @param array<int,string> $matches
          */
-        return preg_replace_callback('/&([-a-zA-Z_.0-9]+);/', function ($matches) use ($entities) : string {
+        return preg_replace_callback('/&([-a-zA-Z_.0-9]+);/', static function ($matches) use ($entities) : string {
             $entity_name = $matches[1];
             if (isset($entities[strtolower($entity_name)])) {
                 return "BEGINENTITY{$entity_name}ENDENTITY";

--- a/internal/package.php
+++ b/internal/package.php
@@ -27,7 +27,7 @@ foreach (['src', 'vendor', '.phan'] as $subdir) {
 // Include all files with suffix .php, excluding those found in the tests folder.
 $iterator = new CallbackFilterIterator(
     $iterators,
-    function (\SplFileInfo $file_info) : bool {
+    static function (\SplFileInfo $file_info) : bool {
         if ($file_info->getExtension() !== 'php') {
             return false;
         }

--- a/internal/update_wiki_config_types.php
+++ b/internal/update_wiki_config_types.php
@@ -275,7 +275,7 @@ EOT;
             }
             $results[$config_name] = $entry;
         }
-        uasort($results, function (ConfigEntry $a, ConfigEntry $b) : int {
+        uasort($results, static function (ConfigEntry $a, ConfigEntry $b) : int {
             return
                 $a->getCategoryIndex() <=> $b->getCategoryIndex() ?:
                 strcasecmp($a->getCategory(), $b->getCategory()) ?:

--- a/internal/update_wiki_issue_types.php
+++ b/internal/update_wiki_issue_types.php
@@ -40,7 +40,7 @@ EOT;
     private static function getSortedIssueMap() : array
     {
         $map = Issue::issueMap();
-        uasort($map, function (Issue $lhs, Issue $rhs) : int {
+        uasort($map, static function (Issue $lhs, Issue $rhs) : int {
             // Order by category, then by the issue name (natural order)
             return ($lhs->getCategory() <=> $rhs->getCategory())
                 // ?: ($rhs->getSeverity() <=> $lhs->getSeverity())
@@ -202,7 +202,7 @@ EOT;
         if ($issue instanceof Issue) {
             self::debugLog("Found $issue_name\n");
             /** @param array<int,string> $unused_match */
-            $text = preg_replace_callback('@\n```\n[^\n]*\n```@', function ($unused_match) use ($issue) : string {
+            $text = preg_replace_callback('@\n```\n[^\n]*\n```@', static function ($unused_match) use ($issue) : string {
                 return "\n```\n{$issue->getTemplateRaw()}\n```";
             }, $text);
             if (!preg_match('@```php|https?://@i', $text)) {
@@ -271,7 +271,7 @@ EOT;
             }
         }
         // Put the longest files first, we overwrite issue names even if they were seen already
-        usort($records, function (UnitTestRecord $a, UnitTestRecord $b) : int {
+        usort($records, static function (UnitTestRecord $a, UnitTestRecord $b) : int {
             return (strlen($b->src_contents) <=> strlen($a->src_contents)) ?: strcmp($a->src_filename, $b->src_filename);
         });
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -9,6 +9,7 @@
   <rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference" />
   <rule ref="SlevomatCodingStandard.Commenting.EmptyComment" />
   <rule ref="SlevomatCodingStandard.ControlStructures.DisallowEmpty" />
+  <rule ref="SlevomatCodingStandard.Functions.StaticClosure" />
   <rule ref="SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash" />
   <rule ref="SlevomatCodingStandard.Namespaces.UselessAlias" />
   <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses">

--- a/src/Phan/AST/ASTReverter.php
+++ b/src/Phan/AST/ASTReverter.php
@@ -63,21 +63,21 @@ class ASTReverter
      */
     public static function init()
     {
-        self::$noop = function (Node $_) : string {
+        self::$noop = static function (Node $_) : string {
             return '(unknown)';
         };
         self::$closure_map = [
-            ast\AST_CLASS_CONST => function (Node $node) : string {
+            ast\AST_CLASS_CONST => static function (Node $node) : string {
                 return self::toShortString($node->children['class']) . '::' . $node->children['const'];
             },
-            ast\AST_CONST => function (Node $node) : string {
+            ast\AST_CONST => static function (Node $node) : string {
                 return self::toShortString($node->children['name']);
             },
-            ast\AST_VAR => function (Node $node) : string {
+            ast\AST_VAR => static function (Node $node) : string {
                 $name_node = $node->children['name'];
                 return '$' . (is_string($name_node) ? $name_node : ('{' . self::toShortString($name_node) . '}'));
             },
-            ast\AST_NAME => function (Node $node) : string {
+            ast\AST_NAME => static function (Node $node) : string {
                 $result = $node->children['name'];
                 switch ($node->flags) {
                     case ast\flags\NAME_FQ:
@@ -88,7 +88,7 @@ class ASTReverter
                         return (string)$result;
                 }
             },
-            ast\AST_ARRAY => function (Node $node) : string {
+            ast\AST_ARRAY => static function (Node $node) : string {
                 $parts = [];
                 foreach ($node->children as $elem) {
                     if (!$elem) {
@@ -113,7 +113,7 @@ class ASTReverter
                 }
             },
             /** @suppress PhanAccessClassConstantInternal */
-            ast\AST_BINARY_OP => function (Node $node) : string {
+            ast\AST_BINARY_OP => static function (Node $node) : string {
                 return \sprintf(
                     "(%s %s %s)",
                     self::toShortString($node->children['left']),
@@ -121,7 +121,7 @@ class ASTReverter
                     self::toShortString($node->children['right'])
                 );
             },
-            ast\AST_PROP => function (Node $node) : string {
+            ast\AST_PROP => static function (Node $node) : string {
                 $prop_node = $node->children['prop'];
                 return \sprintf(
                     '%s->%s',
@@ -129,7 +129,7 @@ class ASTReverter
                     $prop_node instanceof Node ? '{' . self::toShortString($prop_node) . '}' : (string)$prop_node
                 );
             },
-            ast\AST_STATIC_PROP => function (Node $node) : string {
+            ast\AST_STATIC_PROP => static function (Node $node) : string {
                 $prop_node = $node->children['prop'];
                 return \sprintf(
                     '%s::$%s',

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -263,7 +263,7 @@ class ContextNode
                 $trait_method_node->lineno ?? 0,
                 $trait_new_method_name,
                 $trait_original_method_name,
-                '[' . implode(', ', \array_map(function (TraitAdaptations $t) : string {
+                '[' . implode(', ', \array_map(static function (TraitAdaptations $t) : string {
                     return (string) $t->getTraitFQSEN();
                 }, $adaptations_map)) . ']'
             );
@@ -586,7 +586,7 @@ class ContextNode
 
         // TODO: Should this check that count($class_list) > 0 instead? Or just always check?
         if (\count($class_list) === 0 && $expected_type_categories !== self::CLASS_LIST_ACCEPT_ANY) {
-            if (!$union_type->hasTypeMatchingCallback(function (Type $type) use ($expected_type_categories) : bool {
+            if (!$union_type->hasTypeMatchingCallback(static function (Type $type) use ($expected_type_categories) : bool {
                 return $type->isObject() || ($type instanceof MixedType) || ($expected_type_categories === self::CLASS_LIST_ACCEPT_OBJECT_OR_CLASS_NAME && $type instanceof StringType);
             })) {
                 if ($custom_issue_type === Issue::TypeExpectedObjectPropAccess) {

--- a/src/Phan/AST/Parser.php
+++ b/src/Phan/AST/Parser.php
@@ -200,7 +200,7 @@ class Parser
             // TODO: Rename to something better
             $converter = new TolerantASTConverterWithNodeMapping(
                 $request->getTargetByteOffset($file_contents),
-                function (Node $node) {
+                static function (Node $node) {
                     // @phan-suppress-next-line PhanAccessMethodInternal
                     ConfigPluginSet::instance()->prepareNodeSelectionPluginForNode($node);
                 }

--- a/src/Phan/AST/PhanAnnotationAdder.php
+++ b/src/Phan/AST/PhanAnnotationAdder.php
@@ -94,7 +94,7 @@ class PhanAnnotationAdder
          * @param Node $node
          * @return void
          */
-        $binary_op_handler = function ($node) {
+        $binary_op_handler = static function ($node) {
             if ($node->flags === flags\BINARY_COALESCE) {
                 $inner_node = $node->children['left'];
                 if ($inner_node instanceof Node) {
@@ -106,7 +106,7 @@ class PhanAnnotationAdder
          * @param Node $node
          * @return void
          */
-        $dim_handler = function ($node) {
+        $dim_handler = static function ($node) {
             if ($node->flags & self::FLAG_IGNORE_NULLABLE_AND_UNDEF) {
                 $inner_node = $node->children['expr'];
                 if ($inner_node instanceof Node) {
@@ -119,7 +119,7 @@ class PhanAnnotationAdder
          * @param Node $node
          * @return void
          */
-        $ignore_nullable_and_undef_handler = function ($node) {
+        $ignore_nullable_and_undef_handler = static function ($node) {
             $inner_node = $node->children['var'];
             if ($inner_node instanceof Node) {
                 self::markNode($inner_node, self::FLAG_IGNORE_NULLABLE_AND_UNDEF);
@@ -130,7 +130,7 @@ class PhanAnnotationAdder
          * @param Node $node
          * @return void
          */
-        $ignore_nullable_and_undef_expr_handler = function ($node) {
+        $ignore_nullable_and_undef_expr_handler = static function ($node) {
             $inner_node = $node->children['expr'];
             if ($inner_node instanceof Node) {
                 self::markNode($inner_node, self::FLAG_IGNORE_NULLABLE_AND_UNDEF);
@@ -140,7 +140,7 @@ class PhanAnnotationAdder
          * @param Node $node
          * @return void
          */
-        $ast_array_elem_handler = function ($node) {
+        $ast_array_elem_handler = static function ($node) {
             // Handle [$a1, $a2] = $array; - Don't warn about $node
             $bit = $node->flags & self::FLAG_IGNORE_UNDEF;
             if ($bit) {

--- a/src/Phan/AST/TolerantASTConverter/StringUtil.php
+++ b/src/Phan/AST/TolerantASTConverter/StringUtil.php
@@ -152,7 +152,7 @@ final class StringUtil
              * @param array<int,string> $matches
              * @return string
              */
-            function ($matches) {
+            static function ($matches) {
                 $str = $matches[1];
 
                 if (isset(self::REPLACEMENTS[$str])) {

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -364,7 +364,7 @@ class TolerantASTConverter
              * @throws InvalidArgumentException for invalid node classes
              * @throws Error if the environment variable AST_THROW_INVALID is set (for debugging)
              */
-            $fallback_closure = function ($n, int $unused_start_line) {
+            $fallback_closure = static function ($n, int $unused_start_line) {
                 if (!($n instanceof PhpParser\Node) && !($n instanceof Token)) {
                     // @phan-suppress-next-line PhanThrowTypeMismatchForCall debugDumpNodeOrToken can throw
                     throw new \InvalidArgumentException("Invalid type for node: " . (\is_object($n) ? \get_class($n) : \gettype($n)) . ": " . static::debugDumpNodeOrToken($n));
@@ -410,7 +410,7 @@ class TolerantASTConverter
              * @throws InvalidArgumentException|Exception for invalid node classes
              * @throws Error if the environment variable AST_THROW_INVALID is set to debug.
              */
-            $fallback_closure = function ($n, int $unused_start_line) {
+            $fallback_closure = static function ($n, int $unused_start_line) {
                 if (!($n instanceof PhpParser\Node) && !($n instanceof Token)) {
                     throw new \InvalidArgumentException("Invalid type for node: " . (\is_object($n) ? \get_class($n) : \gettype($n)) . ": " . static::debugDumpNodeOrToken($n));
                 }
@@ -468,11 +468,11 @@ class TolerantASTConverter
     {
         $closures = [
             /** @return ?ast\Node */
-            'Microsoft\PhpParser\Node\SourceFileNode' => function (PhpParser\Node\SourceFileNode $n, int $start_line) {
+            'Microsoft\PhpParser\Node\SourceFileNode' => static function (PhpParser\Node\SourceFileNode $n, int $start_line) {
                 return static::phpParserStmtlistToAstNode($n->statementList, $start_line, false);
             },
             /** @return mixed */
-            'Microsoft\PhpParser\Node\Expression\ArgumentExpression' => function (PhpParser\Node\Expression\ArgumentExpression $n, int $start_line) {
+            'Microsoft\PhpParser\Node\Expression\ArgumentExpression' => static function (PhpParser\Node\Expression\ArgumentExpression $n, int $start_line) {
                 $result = static::phpParserNodeToAstNode($n->expression);
                 if ($n->dotDotDotToken !== null) {
                     return new ast\Node(ast\AST_UNPACK, 0, ['expr' => $result], $start_line);
@@ -483,7 +483,7 @@ class TolerantASTConverter
              * @return ast\Node|string|int|float
              * @throws InvalidNodeException
              */
-            'Microsoft\PhpParser\Node\Expression\SubscriptExpression' => function (PhpParser\Node\Expression\SubscriptExpression $n, int $start_line) {
+            'Microsoft\PhpParser\Node\Expression\SubscriptExpression' => static function (PhpParser\Node\Expression\SubscriptExpression $n, int $start_line) {
                 $expr = static::phpParserNodeToAstNode($n->postfixExpression);
                 try {
                     return new ast\Node(ast\AST_DIM, 0, [
@@ -495,7 +495,7 @@ class TolerantASTConverter
                 }
             },
             /** @return ?ast\Node */
-            'Microsoft\PhpParser\Node\Expression\AssignmentExpression' => function (PhpParser\Node\Expression\AssignmentExpression $n, int $start_line) {
+            'Microsoft\PhpParser\Node\Expression\AssignmentExpression' => static function (PhpParser\Node\Expression\AssignmentExpression $n, int $start_line) {
                 try {
                     $var_node = static::phpParserNodeToAstNode($n->leftOperand);
                 } catch (InvalidNodeException $_) {
@@ -518,7 +518,7 @@ class TolerantASTConverter
             /**
              * @return ast\Node|string|float|int (can return a non-Node if the left or right-hand side could not be parsed
              */
-            'Microsoft\PhpParser\Node\Expression\BinaryExpression' => function (PhpParser\Node\Expression\BinaryExpression $n, int $start_line) {
+            'Microsoft\PhpParser\Node\Expression\BinaryExpression' => static function (PhpParser\Node\Expression\BinaryExpression $n, int $start_line) {
                 static $lookup = [
                     TokenKind::AmpersandAmpersandToken              => flags\BINARY_BOOL_AND,
                     TokenKind::AmpersandToken                       => flags\BINARY_BITWISE_AND,
@@ -579,7 +579,7 @@ class TolerantASTConverter
                 }
                 return static::astNodeBinaryop($ast_kind, $n, $start_line);
             },
-            'Microsoft\PhpParser\Node\Expression\UnaryOpExpression' => function (PhpParser\Node\Expression\UnaryOpExpression $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\Expression\UnaryOpExpression' => static function (PhpParser\Node\Expression\UnaryOpExpression $n, int $start_line) : ast\Node {
                 static $lookup = [
                     TokenKind::TildeToken                   => flags\UNARY_BITWISE_NOT,
                     TokenKind::MinusToken                   => flags\UNARY_MINUS,
@@ -598,7 +598,7 @@ class TolerantASTConverter
                     $start_line
                 );
             },
-            'Microsoft\PhpParser\Node\Expression\CastExpression' => function (PhpParser\Node\Expression\CastExpression $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\Expression\CastExpression' => static function (PhpParser\Node\Expression\CastExpression $n, int $start_line) : ast\Node {
                 static $lookup = [
                     // From Parser->parseCastExpression()
                     TokenKind::ArrayCastToken   => flags\TYPE_ARRAY,
@@ -636,7 +636,7 @@ class TolerantASTConverter
                     static::getEndLine($n) ?: $start_line
                 );
             },
-            'Microsoft\PhpParser\Node\Expression\AnonymousFunctionCreationExpression' => function (PhpParser\Node\Expression\AnonymousFunctionCreationExpression $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\Expression\AnonymousFunctionCreationExpression' => static function (PhpParser\Node\Expression\AnonymousFunctionCreationExpression $n, int $start_line) : ast\Node {
                 $ast_return_type = static::phpParserTypeToAstNode($n->returnType, static::getEndLine($n->returnType) ?: $start_line);
                 if (($ast_return_type->children['name'] ?? null) === '') {
                     $ast_return_type = null;
@@ -660,7 +660,7 @@ class TolerantASTConverter
              * @return ?ast\Node
              * @throws InvalidNodeException if the resulting AST would not be analyzable by Phan
              */
-            'Microsoft\PhpParser\Node\Expression\ScopedPropertyAccessExpression' => function (PhpParser\Node\Expression\ScopedPropertyAccessExpression $n, int $start_line) {
+            'Microsoft\PhpParser\Node\Expression\ScopedPropertyAccessExpression' => static function (PhpParser\Node\Expression\ScopedPropertyAccessExpression $n, int $start_line) {
                 $member_name = $n->memberName;
                 if ($member_name instanceof PhpParser\Node\Expression\Variable) {
                     try {
@@ -699,10 +699,10 @@ class TolerantASTConverter
                     return static::phpParserClassconstfetchToAstClassconstfetch($n->scopeResolutionQualifier, $member_name, $start_line);
                 }
             },
-            'Microsoft\PhpParser\Node\Expression\CloneExpression' => function (PhpParser\Node\Expression\CloneExpression $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\Expression\CloneExpression' => static function (PhpParser\Node\Expression\CloneExpression $n, int $start_line) : ast\Node {
                 return new ast\Node(ast\AST_CLONE, 0, ['expr' => static::phpParserNodeToAstNode($n->expression)], $start_line);
             },
-            'Microsoft\PhpParser\Node\Expression\ErrorControlExpression' => function (PhpParser\Node\Expression\ErrorControlExpression $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\Expression\ErrorControlExpression' => static function (PhpParser\Node\Expression\ErrorControlExpression $n, int $start_line) : ast\Node {
                 return new ast\Node(
                     ast\AST_UNARY_OP,
                     flags\UNARY_SILENCE,
@@ -710,10 +710,10 @@ class TolerantASTConverter
                     $start_line
                 );
             },
-            'Microsoft\PhpParser\Node\Expression\EmptyIntrinsicExpression' => function (PhpParser\Node\Expression\EmptyIntrinsicExpression $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\Expression\EmptyIntrinsicExpression' => static function (PhpParser\Node\Expression\EmptyIntrinsicExpression $n, int $start_line) : ast\Node {
                 return new ast\Node(ast\AST_EMPTY, 0, ['expr' => static::phpParserNodeToAstNode($n->expression)], $start_line);
             },
-            'Microsoft\PhpParser\Node\Expression\EvalIntrinsicExpression' => function (PhpParser\Node\Expression\EvalIntrinsicExpression $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\Expression\EvalIntrinsicExpression' => static function (PhpParser\Node\Expression\EvalIntrinsicExpression $n, int $start_line) : ast\Node {
                 return new ast\Node(
                     ast\AST_INCLUDE_OR_EVAL,
                     flags\EXEC_EVAL,
@@ -722,7 +722,7 @@ class TolerantASTConverter
                 );
             },
             /** @return string|ast\Node */
-            'Microsoft\PhpParser\Token' => function (PhpParser\Token $token, int $start_line) {
+            'Microsoft\PhpParser\Token' => static function (PhpParser\Token $token, int $start_line) {
                 $kind = $token->kind;
                 $str = static::tokenToString($token);
                 if ($kind === TokenKind::StaticKeyword) {
@@ -733,21 +733,21 @@ class TolerantASTConverter
             /**
              * @throws InvalidNodeException
              */
-            'Microsoft\PhpParser\MissingToken' => function (PhpParser\MissingToken $unused_node, int $_) {
+            'Microsoft\PhpParser\MissingToken' => static function (PhpParser\MissingToken $unused_node, int $_) {
                 throw new InvalidNodeException();
             },
             /**
              * @throws InvalidNodeException
              */
-            'Microsoft\PhpParser\SkippedToken' => function (PhpParser\SkippedToken $unused_node, int $_) {
+            'Microsoft\PhpParser\SkippedToken' => static function (PhpParser\SkippedToken $unused_node, int $_) {
                 throw new InvalidNodeException();
             },
-            'Microsoft\PhpParser\Node\Expression\ExitIntrinsicExpression' => function (PhpParser\Node\Expression\ExitIntrinsicExpression $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\Expression\ExitIntrinsicExpression' => static function (PhpParser\Node\Expression\ExitIntrinsicExpression $n, int $start_line) : ast\Node {
                 $expression = $n->expression;
                 $expr_node = $expression !== null ? static::phpParserNodeToAstNode($expression) : null;
                 return new ast\Node(ast\AST_EXIT, 0, ['expr' => $expr_node], $start_line);
             },
-            'Microsoft\PhpParser\Node\Expression\CallExpression' => function (PhpParser\Node\Expression\CallExpression $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\Expression\CallExpression' => static function (PhpParser\Node\Expression\CallExpression $n, int $start_line) : ast\Node {
                 $callable_expression = $n->callableExpression;
                 $arg_list = static::phpParserArgListToAstArgList($n->argumentExpressionList, $start_line);
                 if ($callable_expression instanceof PhpParser\Node\Expression\MemberAccessExpression) {  // $a->f()
@@ -772,7 +772,7 @@ class TolerantASTConverter
                     );
                 }
             },
-            'Microsoft\PhpParser\Node\Expression\ScriptInclusionExpression' => function (PhpParser\Node\Expression\ScriptInclusionExpression $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\Expression\ScriptInclusionExpression' => static function (PhpParser\Node\Expression\ScriptInclusionExpression $n, int $start_line) : ast\Node {
                 // @phan-suppress-next-line PhanThrowTypeAbsentForCall should not happen
                 $flags = static::phpParserIncludeTokenToAstIncludeFlags($n->requireOrIncludeKeyword);
                 return new ast\Node(
@@ -785,7 +785,7 @@ class TolerantASTConverter
             /**
              * @return ?ast\Node
              */
-            'Microsoft\PhpParser\Node\Expression\IssetIntrinsicExpression' => function (PhpParser\Node\Expression\IssetIntrinsicExpression $n, int $start_line) {
+            'Microsoft\PhpParser\Node\Expression\IssetIntrinsicExpression' => static function (PhpParser\Node\Expression\IssetIntrinsicExpression $n, int $start_line) {
                 $ast_issets = [];
                 foreach ($n->expressions->children ?? [] as $var) {
                     if ($var instanceof Token) {
@@ -814,13 +814,13 @@ class TolerantASTConverter
                 }
                 return $e;
             },
-            'Microsoft\PhpParser\Node\Expression\ArrayCreationExpression' => function (PhpParser\Node\Expression\ArrayCreationExpression $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\Expression\ArrayCreationExpression' => static function (PhpParser\Node\Expression\ArrayCreationExpression $n, int $start_line) : ast\Node {
                 return static::phpParserArrayToAstArray($n, $start_line);
             },
-            'Microsoft\PhpParser\Node\Expression\ListIntrinsicExpression' => function (PhpParser\Node\Expression\ListIntrinsicExpression $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\Expression\ListIntrinsicExpression' => static function (PhpParser\Node\Expression\ListIntrinsicExpression $n, int $start_line) : ast\Node {
                 return static::phpParserListToAstList($n, $start_line);
             },
-            'Microsoft\PhpParser\Node\Expression\ObjectCreationExpression' => function (PhpParser\Node\Expression\ObjectCreationExpression $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\Expression\ObjectCreationExpression' => static function (PhpParser\Node\Expression\ObjectCreationExpression $n, int $start_line) : ast\Node {
                 $end_line = static::getEndLine($n);
                 $class_type_designator = $n->classTypeDesignator;
                 if ($class_type_designator instanceof Token && $class_type_designator->kind === TokenKind::ClassKeyword) {
@@ -844,20 +844,20 @@ class TolerantASTConverter
                 ], $start_line);
             },
             /** @return mixed */
-            'Microsoft\PhpParser\Node\Expression\ParenthesizedExpression' => function (PhpParser\Node\Expression\ParenthesizedExpression $n, int $_) {
+            'Microsoft\PhpParser\Node\Expression\ParenthesizedExpression' => static function (PhpParser\Node\Expression\ParenthesizedExpression $n, int $_) {
                 return static::phpParserNodeToAstNode($n->expression);
             },
-            'Microsoft\PhpParser\Node\Expression\PrefixUpdateExpression' => function (PhpParser\Node\Expression\PrefixUpdateExpression $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\Expression\PrefixUpdateExpression' => static function (PhpParser\Node\Expression\PrefixUpdateExpression $n, int $start_line) : ast\Node {
                 $type = $n->incrementOrDecrementOperator->kind === TokenKind::PlusPlusToken ? ast\AST_PRE_INC : ast\AST_PRE_DEC;
 
                 return new ast\Node($type, 0, ['var' => static::phpParserNodeToAstNode($n->operand)], $start_line);
             },
-            'Microsoft\PhpParser\Node\Expression\PostfixUpdateExpression' => function (PhpParser\Node\Expression\PostfixUpdateExpression $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\Expression\PostfixUpdateExpression' => static function (PhpParser\Node\Expression\PostfixUpdateExpression $n, int $start_line) : ast\Node {
                 $type = $n->incrementOrDecrementOperator->kind === TokenKind::PlusPlusToken ? ast\AST_POST_INC : ast\AST_POST_DEC;
 
                 return new ast\Node($type, 0, ['var' => static::phpParserNodeToAstNode($n->operand)], $start_line);
             },
-            'Microsoft\PhpParser\Node\Expression\PrintIntrinsicExpression' => function (PhpParser\Node\Expression\PrintIntrinsicExpression $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\Expression\PrintIntrinsicExpression' => static function (PhpParser\Node\Expression\PrintIntrinsicExpression $n, int $start_line) : ast\Node {
                 return new ast\Node(
                     ast\AST_PRINT,
                     0,
@@ -866,10 +866,10 @@ class TolerantASTConverter
                 );
             },
             /** @return ?ast\Node */
-            'Microsoft\PhpParser\Node\Expression\MemberAccessExpression' => function (PhpParser\Node\Expression\MemberAccessExpression $n, int $start_line) {
+            'Microsoft\PhpParser\Node\Expression\MemberAccessExpression' => static function (PhpParser\Node\Expression\MemberAccessExpression $n, int $start_line) {
                 return static::phpParserMemberAccessExpressionToAstProp($n, $start_line);
             },
-            'Microsoft\PhpParser\Node\Expression\TernaryExpression' => function (PhpParser\Node\Expression\TernaryExpression $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\Expression\TernaryExpression' => static function (PhpParser\Node\Expression\TernaryExpression $n, int $start_line) : ast\Node {
                 return new ast\Node(
                     ast\AST_CONDITIONAL,
                     0,
@@ -886,7 +886,7 @@ class TolerantASTConverter
              * @throws InvalidNodeException if the variable would be unanalyzable
              * TODO: Consider ${''} as a placeholder instead?
              */
-            'Microsoft\PhpParser\Node\Expression\Variable' => function (PhpParser\Node\Expression\Variable $n, int $start_line) {
+            'Microsoft\PhpParser\Node\Expression\Variable' => static function (PhpParser\Node\Expression\Variable $n, int $start_line) {
                 $name_node = $n->name;
                 // Note: there are 2 different ways to handle an Error. 1. Add a placeholder. 2. remove all of the statements in that tree.
                 if ($name_node instanceof PhpParser\Node) {
@@ -911,10 +911,10 @@ class TolerantASTConverter
             /**
              * @return ast\Node
              */
-            'Microsoft\PhpParser\Node\Expression\BracedExpression' => function (PhpParser\Node\Expression\BracedExpression $n, int $_) {
+            'Microsoft\PhpParser\Node\Expression\BracedExpression' => static function (PhpParser\Node\Expression\BracedExpression $n, int $_) {
                 return static::phpParserNodeToAstNode($n->expression);
             },
-            'Microsoft\PhpParser\Node\Expression\YieldExpression' => function (PhpParser\Node\Expression\YieldExpression $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\Expression\YieldExpression' => static function (PhpParser\Node\Expression\YieldExpression $n, int $start_line) : ast\Node {
                 $kind = $n->yieldOrYieldFromKeyword->kind === TokenKind::YieldFromKeyword ? ast\AST_YIELD_FROM : ast\AST_YIELD;
 
                 $array_element = $n->arrayElement;
@@ -940,7 +940,7 @@ class TolerantASTConverter
                     $start_line
                 );
             },
-            'Microsoft\PhpParser\Node\ReservedWord' => function (PhpParser\Node\ReservedWord $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\ReservedWord' => static function (PhpParser\Node\ReservedWord $n, int $start_line) : ast\Node {
                 return new ast\Node(
                     ast\AST_NAME,
                     flags\NAME_NOT_FQ,
@@ -948,7 +948,7 @@ class TolerantASTConverter
                     $start_line
                 );
             },
-            'Microsoft\PhpParser\Node\QualifiedName' => function (PhpParser\Node\QualifiedName $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\QualifiedName' => static function (PhpParser\Node\QualifiedName $n, int $start_line) : ast\Node {
                 $name_parts = $n->nameParts;
                 if (\count($name_parts) === 1) {
                     $part = $name_parts[0];
@@ -976,7 +976,7 @@ class TolerantASTConverter
                 }
                 return new ast\Node(ast\AST_NAME, $ast_kind, ['name' => $imploded_parts], $start_line);
             },
-            'Microsoft\PhpParser\Node\Parameter' => function (PhpParser\Node\Parameter $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\Parameter' => static function (PhpParser\Node\Parameter $n, int $start_line) : ast\Node {
                 $type_line = static::getEndLine($n->typeDeclaration) ?: $start_line;
                 $default = $n->default;
                 $default_node = $default !== null ? static::phpParserNodeToAstNode($default) : null;
@@ -991,7 +991,7 @@ class TolerantASTConverter
                 );
             },
             /** @return int|float */
-            'Microsoft\PhpParser\Node\NumericLiteral' => function (PhpParser\Node\NumericLiteral $n, int $_) {
+            'Microsoft\PhpParser\Node\NumericLiteral' => static function (PhpParser\Node\NumericLiteral $n, int $_) {
                 $text = static::tokenToString($n->children);
                 $as_int = \filter_var($text, FILTER_VALIDATE_INT, FILTER_FLAG_ALLOW_OCTAL | FILTER_FLAG_ALLOW_HEX);
                 if ($as_int !== false) {
@@ -1003,7 +1003,7 @@ class TolerantASTConverter
              * @return ast\Node|string
              * @throws Exception if the tokens of the string literal are invalid, etc.
              */
-            'Microsoft\PhpParser\Node\StringLiteral' => function (PhpParser\Node\StringLiteral $n, int $start_line) {
+            'Microsoft\PhpParser\Node\StringLiteral' => static function (PhpParser\Node\StringLiteral $n, int $start_line) {
                 $children = $n->children;
                 if ($children instanceof Token) {
                     $inner_node = static::parseQuotedString($n);
@@ -1021,7 +1021,7 @@ class TolerantASTConverter
                 return $inner_node;
             },
             /** @return mixed - Can return a node or a scalar, depending on the settings */
-            'Microsoft\PhpParser\Node\Statement\CompoundStatementNode' => function (PhpParser\Node\Statement\CompoundStatementNode $n, int $_) {
+            'Microsoft\PhpParser\Node\Statement\CompoundStatementNode' => static function (PhpParser\Node\Statement\CompoundStatementNode $n, int $_) {
                 $children = [];
                 foreach ($n->statements as $parser_node) {
                     // @phan-suppress-next-line PhanPossiblyNullTypeArgument
@@ -1042,7 +1042,7 @@ class TolerantASTConverter
              * null if incomplete
              * int|string for no-op scalar statements like `;2;`
              */
-            'Microsoft\PhpParser\Node\Statement\ExpressionStatement' => function (PhpParser\Node\Statement\ExpressionStatement $n, int $_) {
+            'Microsoft\PhpParser\Node\Statement\ExpressionStatement' => static function (PhpParser\Node\Statement\ExpressionStatement $n, int $_) {
                 $expression = $n->expression;
                 // tolerant-php-parser uses parseExpression(..., $force=true), which can return an array.
                 // It is the only thing that uses $force=true at the time of writing.
@@ -1051,7 +1051,7 @@ class TolerantASTConverter
                 }
                 return static::phpParserNodeToAstNode($n->expression);
             },
-            'Microsoft\PhpParser\Node\Statement\BreakOrContinueStatement' => function (PhpParser\Node\Statement\BreakOrContinueStatement $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\Statement\BreakOrContinueStatement' => static function (PhpParser\Node\Statement\BreakOrContinueStatement $n, int $start_line) : ast\Node {
                 $kind = $n->breakOrContinueKeyword->kind === TokenKind::ContinueKeyword ? ast\AST_CONTINUE : ast\AST_BREAK;
                 $breakout_level = $n->breakoutLevel;
                 if ($breakout_level !== null) {
@@ -1062,7 +1062,7 @@ class TolerantASTConverter
                 }
                 return new ast\Node($kind, 0, ['depth' => $breakout_level], $start_line);
             },
-            'Microsoft\PhpParser\Node\CatchClause' => function (PhpParser\Node\CatchClause $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\CatchClause' => static function (PhpParser\Node\CatchClause $n, int $start_line) : ast\Node {
                 $qualified_name = $n->qualifiedName;
                 $catch_inner_list = [];
                 // Handle `catch()` syntax error
@@ -1084,7 +1084,7 @@ class TolerantASTConverter
                     $start_line
                 );
             },
-            'Microsoft\PhpParser\Node\Statement\InterfaceDeclaration' => function (PhpParser\Node\Statement\InterfaceDeclaration $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\Statement\InterfaceDeclaration' => static function (PhpParser\Node\Statement\InterfaceDeclaration $n, int $start_line) : ast\Node {
                 $end_line = static::getEndLine($n) ?: $start_line;
                 return static::astStmtClass(
                     flags\CLASS_INTERFACE,
@@ -1097,7 +1097,7 @@ class TolerantASTConverter
                     $n->getDocCommentText()
                 );
             },
-            'Microsoft\PhpParser\Node\Statement\ClassDeclaration' => function (PhpParser\Node\Statement\ClassDeclaration $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\Statement\ClassDeclaration' => static function (PhpParser\Node\Statement\ClassDeclaration $n, int $start_line) : ast\Node {
                 $end_line = static::getEndLine($n);
                 $base_class = $n->classBaseClause->baseClass ?? null;
                 return static::astStmtClass(
@@ -1111,7 +1111,7 @@ class TolerantASTConverter
                     $n->getDocCommentText()
                 );
             },
-            'Microsoft\PhpParser\Node\Statement\TraitDeclaration' => function (PhpParser\Node\Statement\TraitDeclaration $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\Statement\TraitDeclaration' => static function (PhpParser\Node\Statement\TraitDeclaration $n, int $start_line) : ast\Node {
                 $end_line = static::getEndLine($n) ?: $start_line;
                 return static::astStmtClass(
                     flags\CLASS_TRAIT,
@@ -1124,18 +1124,18 @@ class TolerantASTConverter
                     $n->getDocCommentText()
                 );
             },
-            'Microsoft\PhpParser\Node\ClassConstDeclaration' => function (PhpParser\Node\ClassConstDeclaration $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\ClassConstDeclaration' => static function (PhpParser\Node\ClassConstDeclaration $n, int $start_line) : ast\Node {
                 return static::phpParserClassConstToAstNode($n, $start_line);
             },
             /** @return null - A stub that will be removed by the caller. */
-            'Microsoft\PhpParser\Node\MissingMemberDeclaration' => function (PhpParser\Node\MissingMemberDeclaration $unused_n, int $unused_start_line) {
+            'Microsoft\PhpParser\Node\MissingMemberDeclaration' => static function (PhpParser\Node\MissingMemberDeclaration $unused_n, int $unused_start_line) {
                 // This node type is generated for something that isn't a function/constant/property. e.g. "public example();"
                 return null;
             },
             /**
              * @throws InvalidNodeException
              */
-            'Microsoft\PhpParser\Node\MethodDeclaration' => function (PhpParser\Node\MethodDeclaration $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\MethodDeclaration' => static function (PhpParser\Node\MethodDeclaration $n, int $start_line) : ast\Node {
                 $statements = $n->compoundStatementOrSemicolon;
                 $ast_return_type = static::phpParserTypeToAstNode($n->returnType, static::getEndLine($n->returnType) ?: $start_line);
                 if (($ast_return_type->children['name'] ?? null) === '') {
@@ -1170,10 +1170,10 @@ class TolerantASTConverter
                     self::nextDeclId()
                 );
             },
-            'Microsoft\PhpParser\Node\Statement\ConstDeclaration' => function (PhpParser\Node\Statement\ConstDeclaration $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\Statement\ConstDeclaration' => static function (PhpParser\Node\Statement\ConstDeclaration $n, int $start_line) : ast\Node {
                 return static::phpParserConstToAstNode($n, $start_line);
             },
-            'Microsoft\PhpParser\Node\Statement\DeclareStatement' => function (PhpParser\Node\Statement\DeclareStatement $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\Statement\DeclareStatement' => static function (PhpParser\Node\Statement\DeclareStatement $n, int $start_line) : ast\Node {
                 $doc_comment = $n->getDocCommentText();
                 $directive = $n->declareDirective;
                 if (!($directive instanceof PhpParser\Node\DeclareDirective)) {
@@ -1185,7 +1185,7 @@ class TolerantASTConverter
                     $start_line
                 );
             },
-            'Microsoft\PhpParser\Node\Statement\DoStatement' => function (PhpParser\Node\Statement\DoStatement $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\Statement\DoStatement' => static function (PhpParser\Node\Statement\DoStatement $n, int $start_line) : ast\Node {
                 return new ast\Node(
                     ast\AST_DO_WHILE,
                     0,
@@ -1199,7 +1199,7 @@ class TolerantASTConverter
             /**
              * @return ast\Node|ast\Node[]
              */
-            'Microsoft\PhpParser\Node\Expression\EchoExpression' => function (PhpParser\Node\Expression\EchoExpression $n, int $start_line) {
+            'Microsoft\PhpParser\Node\Expression\EchoExpression' => static function (PhpParser\Node\Expression\EchoExpression $n, int $start_line) {
                 $ast_echos = [];
                 foreach ($n->expressions->children ?? [] as $expr) {
                     if ($expr instanceof Token && $expr->kind === TokenKind::CommaToken) {
@@ -1217,14 +1217,14 @@ class TolerantASTConverter
             /**
              * @return ?ast\Node
              */
-            'Microsoft\PhpParser\Node\ForeachKey' => function (PhpParser\Node\ForeachKey $n, int $_) {
+            'Microsoft\PhpParser\Node\ForeachKey' => static function (PhpParser\Node\ForeachKey $n, int $_) {
                 $result = static::phpParserNodeToAstNode($n->expression);
                 if (!$result instanceof ast\Node) {
                     return null;
                 }
                 return $result;
             },
-            'Microsoft\PhpParser\Node\Statement\ForeachStatement' => function (PhpParser\Node\Statement\ForeachStatement $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\Statement\ForeachStatement' => static function (PhpParser\Node\Statement\ForeachStatement $n, int $start_line) : ast\Node {
                 $foreach_value = $n->foreachValue;
                 $value = static::phpParserNodeToAstNode($foreach_value->expression);
                 if ($foreach_value->ampersand) {
@@ -1249,13 +1249,13 @@ class TolerantASTConverter
                 );
                 //return static::phpParserStmtlistToAstNode($n->statements, $start_line);
             },
-            'Microsoft\PhpParser\Node\FinallyClause' => function (PhpParser\Node\FinallyClause $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\FinallyClause' => static function (PhpParser\Node\FinallyClause $n, int $start_line) : ast\Node {
                 return static::phpParserStmtlistToAstNode($n->compoundStatement, $start_line, false);
             },
             /**
              * @throws InvalidNodeException
              */
-            'Microsoft\PhpParser\Node\Statement\FunctionDeclaration' => function (PhpParser\Node\Statement\FunctionDeclaration $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\Statement\FunctionDeclaration' => static function (PhpParser\Node\Statement\FunctionDeclaration $n, int $start_line) : ast\Node {
                 $end_line = static::getEndLine($n) ?: $start_line;
                 $ast_return_type = static::phpParserTypeToAstNode($n->returnType, static::getEndLine($n->returnType) ?: $start_line);
                 if (($ast_return_type->children['name'] ?? null) === '') {
@@ -1281,7 +1281,7 @@ class TolerantASTConverter
                 );
             },
             /** @return ast\Node|ast\Node[] */
-            'Microsoft\PhpParser\Node\Statement\GlobalDeclaration' => function (PhpParser\Node\Statement\GlobalDeclaration $n, int $start_line) {
+            'Microsoft\PhpParser\Node\Statement\GlobalDeclaration' => static function (PhpParser\Node\Statement\GlobalDeclaration $n, int $start_line) {
                 $global_nodes = [];
                 foreach ($n->variableNameList->children ?? [] as $var) {
                     if ($var instanceof Token && $var->kind === TokenKind::CommaToken) {
@@ -1291,11 +1291,11 @@ class TolerantASTConverter
                 }
                 return \count($global_nodes) === 1 ? $global_nodes[0] : $global_nodes;
             },
-            'Microsoft\PhpParser\Node\Statement\IfStatementNode' => function (PhpParser\Node\Statement\IfStatementNode $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\Statement\IfStatementNode' => static function (PhpParser\Node\Statement\IfStatementNode $n, int $start_line) : ast\Node {
                 return static::phpParserIfStmtToAstIfStmt($n, $start_line);
             },
             /** @return ast\Node|ast\Node[] */
-            'Microsoft\PhpParser\Node\Statement\InlineHtml' => function (PhpParser\Node\Statement\InlineHtml $n, int $start_line) {
+            'Microsoft\PhpParser\Node\Statement\InlineHtml' => static function (PhpParser\Node\Statement\InlineHtml $n, int $start_line) {
                 $text = $n->text;
                 if ($text === null) {
                     return [];  // For the beginning/end of files
@@ -1308,7 +1308,7 @@ class TolerantASTConverter
                 );
             },
             /** @suppress PhanTypeMismatchArgument TODO: Make ForStatement have more accurate docs? */
-            'Microsoft\PhpParser\Node\Statement\ForStatement' => function (PhpParser\Node\Statement\ForStatement $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\Statement\ForStatement' => static function (PhpParser\Node\Statement\ForStatement $n, int $start_line) : ast\Node {
                 return new ast\Node(
                     ast\AST_FOR,
                     0,
@@ -1322,7 +1322,7 @@ class TolerantASTConverter
                 );
             },
             /** @return ast\Node[] */
-            'Microsoft\PhpParser\Node\Statement\NamespaceUseDeclaration' => function (PhpParser\Node\Statement\NamespaceUseDeclaration $n, int $start_line) {
+            'Microsoft\PhpParser\Node\Statement\NamespaceUseDeclaration' => static function (PhpParser\Node\Statement\NamespaceUseDeclaration $n, int $start_line) {
                 $use_clauses = $n->useClauses;
                 $results = [];
                 $parser_use_kind = $n->functionOrConst->kind ?? null;
@@ -1334,7 +1334,7 @@ class TolerantASTConverter
                 }
                 return $results;
             },
-            'Microsoft\PhpParser\Node\Statement\NamespaceDefinition' => function (PhpParser\Node\Statement\NamespaceDefinition $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\Statement\NamespaceDefinition' => static function (PhpParser\Node\Statement\NamespaceDefinition $n, int $start_line) : ast\Node {
                 $stmt = $n->compoundStatementOrSemicolon;
                 $name_node = $n->name;
                 if ($stmt instanceof PhpParser\Node) {
@@ -1354,20 +1354,20 @@ class TolerantASTConverter
                     $start_line
                 );
             },
-            'Microsoft\PhpParser\Node\Statement\EmptyStatement' => function (PhpParser\Node\Statement\EmptyStatement $unused_node, int $unused_start_line) : array {
+            'Microsoft\PhpParser\Node\Statement\EmptyStatement' => static function (PhpParser\Node\Statement\EmptyStatement $unused_node, int $unused_start_line) : array {
                 // `;;`
                 return [];
             },
-            'Microsoft\PhpParser\Node\PropertyDeclaration' => function (PhpParser\Node\PropertyDeclaration $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\PropertyDeclaration' => static function (PhpParser\Node\PropertyDeclaration $n, int $start_line) : ast\Node {
                 return static::phpParserPropertyToAstNode($n, $start_line);
             },
-            'Microsoft\PhpParser\Node\Statement\ReturnStatement' => function (PhpParser\Node\Statement\ReturnStatement $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\Statement\ReturnStatement' => static function (PhpParser\Node\Statement\ReturnStatement $n, int $start_line) : ast\Node {
                 $e = $n->expression;
                 $expr_node = $e !== null ? static::phpParserNodeToAstNode($e) : null;
                 return new ast\Node(ast\AST_RETURN, 0, ['expr' => $expr_node], $start_line);
             },
             /** @return ast\Node|ast\Node[] */
-            'Microsoft\PhpParser\Node\Statement\FunctionStaticDeclaration' => function (PhpParser\Node\Statement\FunctionStaticDeclaration $n, int $start_line) {
+            'Microsoft\PhpParser\Node\Statement\FunctionStaticDeclaration' => static function (PhpParser\Node\Statement\FunctionStaticDeclaration $n, int $start_line) {
                 $static_nodes = [];
                 foreach ($n->staticVariableNameList->children ?? [] as $var) {
                     if ($var instanceof Token) {
@@ -1386,10 +1386,10 @@ class TolerantASTConverter
                 }
                 return \count($static_nodes) === 1 ? $static_nodes[0] : $static_nodes;
             },
-            'Microsoft\PhpParser\Node\Statement\SwitchStatementNode' => function (PhpParser\Node\Statement\SwitchStatementNode $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\Statement\SwitchStatementNode' => static function (PhpParser\Node\Statement\SwitchStatementNode $n, int $start_line) : ast\Node {
                 return static::phpParserSwitchListToAstSwitch($n, $start_line);
             },
-            'Microsoft\PhpParser\Node\Statement\ThrowStatement' => function (PhpParser\Node\Statement\ThrowStatement $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\Statement\ThrowStatement' => static function (PhpParser\Node\Statement\ThrowStatement $n, int $start_line) : ast\Node {
                 return new ast\Node(
                     ast\AST_THROW,
                     0,
@@ -1398,7 +1398,7 @@ class TolerantASTConverter
                 );
             },
 
-            'Microsoft\PhpParser\Node\TraitUseClause' => function (PhpParser\Node\TraitUseClause $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\TraitUseClause' => static function (PhpParser\Node\TraitUseClause $n, int $start_line) : ast\Node {
                 $clauses_list_node = $n->traitSelectAndAliasClauses;
                 if ($clauses_list_node instanceof PhpParser\Node\DelimitedList\TraitSelectOrAliasClauseList) {
                     $adaptations_inner = [];
@@ -1432,7 +1432,7 @@ class TolerantASTConverter
             /**
              * @return ?ast\Node
              */
-            'Microsoft\PhpParser\Node\TraitSelectOrAliasClause' => function (PhpParser\Node\TraitSelectOrAliasClause $n, int $start_line) {
+            'Microsoft\PhpParser\Node\TraitSelectOrAliasClause' => static function (PhpParser\Node\TraitSelectOrAliasClause $n, int $start_line) {
                 // FIXME targetName phpdoc is wrong.
                 $name = $n->name;
                 if ($n->asOrInsteadOfKeyword->kind === TokenKind::InsteadOfKeyword) {
@@ -1484,7 +1484,7 @@ class TolerantASTConverter
                     return new ast\Node(ast\AST_TRAIT_ALIAS, $flags, $children, $start_line);
                 }
             },
-            'Microsoft\PhpParser\Node\Statement\TryStatement' => function (PhpParser\Node\Statement\TryStatement $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\Statement\TryStatement' => static function (PhpParser\Node\Statement\TryStatement $n, int $start_line) : ast\Node {
                 $finally_clause = $n->finallyClause;
                 return static::astNodeTry(
                     static::phpParserStmtlistToAstNode($n->compoundStatement, $start_line, false), // $n->try
@@ -1494,7 +1494,7 @@ class TolerantASTConverter
                 );
             },
             /** @return ast\Node|ast\Node[] */
-            'Microsoft\PhpParser\Node\Expression\UnsetIntrinsicExpression' => function (PhpParser\Node\Expression\UnsetIntrinsicExpression $n, int $start_line) {
+            'Microsoft\PhpParser\Node\Expression\UnsetIntrinsicExpression' => static function (PhpParser\Node\Expression\UnsetIntrinsicExpression $n, int $start_line) {
                 $stmts = [];
                 foreach ($n->expressions->children ?? [] as $var) {
                     if ($var instanceof Token) {
@@ -1505,18 +1505,18 @@ class TolerantASTConverter
                 }
                 return \count($stmts) === 1 ? $stmts[0] : $stmts;
             },
-            'Microsoft\PhpParser\Node\Statement\WhileStatement' => function (PhpParser\Node\Statement\WhileStatement $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\Statement\WhileStatement' => static function (PhpParser\Node\Statement\WhileStatement $n, int $start_line) : ast\Node {
                 return static::astNodeWhile(
                     static::phpParserNodeToAstNode($n->expression),
                     static::phpParserStmtlistToAstNode($n->statements, $start_line, true),
                     $start_line
                 );
             },
-            'Microsoft\PhpParser\Node\Statement\GotoStatement' => function (PhpParser\Node\Statement\GotoStatement $n, int $start_line) : ast\Node {
+            'Microsoft\PhpParser\Node\Statement\GotoStatement' => static function (PhpParser\Node\Statement\GotoStatement $n, int $start_line) : ast\Node {
                 return new ast\Node(ast\AST_GOTO, 0, ['label' => static::tokenToString($n->name)], $start_line);
             },
             /** @return ast\Node[] */
-            'Microsoft\PhpParser\Node\Statement\NamedLabelStatement' => function (PhpParser\Node\Statement\NamedLabelStatement $n, int $start_line) {
+            'Microsoft\PhpParser\Node\Statement\NamedLabelStatement' => static function (PhpParser\Node\Statement\NamedLabelStatement $n, int $start_line) {
                 $label = new ast\Node(ast\AST_LABEL, 0, ['name' => static::tokenToString($n->name)], $start_line);
                 $statement = static::phpParserNodeToAstNode($n->statement);
                 return [$label, $statement];

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverterWithNodeMapping.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverterWithNodeMapping.php
@@ -343,7 +343,7 @@ class TolerantASTConverterWithNodeMapping extends TolerantASTConverter
              * @throws InvalidArgumentException for invalid token classes
              * @suppress PhanThrowTypeMismatchForCall can throw if debugDumpNodeOrToken fails
              */
-            $fallback_closure = function ($n, int $unused_start_line) : ast\Node {
+            $fallback_closure = static function ($n, int $unused_start_line) : ast\Node {
                 if (!($n instanceof PhpParser\Node) && !($n instanceof Token)) {
                     throw new InvalidArgumentException("Invalid type for node: " . (\is_object($n) ? \get_class($n) : \gettype($n)) . ": " . static::debugDumpNodeOrToken($n));
                 }
@@ -382,7 +382,7 @@ class TolerantASTConverterWithNodeMapping extends TolerantASTConverter
              * @param PhpParser\Node|Token $n
              * @throws InvalidArgumentException for invalid token classes
              */
-            $fallback_closure = function ($n, int $unused_start_line) : ast\Node {
+            $fallback_closure = static function ($n, int $unused_start_line) : ast\Node {
                 if (!($n instanceof PhpParser\Node) && !($n instanceof Token)) {
                     // @phan-suppress-next-line PhanThrowTypeMismatchForCall debugDumpNodeOrToken can throw
                     throw new InvalidArgumentException("Invalid type for node: " . (\is_object($n) ? \get_class($n) : \gettype($n)) . ": " . static::debugDumpNodeOrToken($n));

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -628,7 +628,7 @@ class UnionTypeVisitor extends AnalysisVisitor
         $union_type = $this->__invoke($node->children['type']);
 
         // Make each nullable
-        return $union_type->asMappedUnionType(function (Type $type) : Type {
+        return $union_type->asMappedUnionType(static function (Type $type) : Type {
             return $type->withIsNullable(true);
         });
     }
@@ -2132,7 +2132,7 @@ class UnionTypeVisitor extends AnalysisVisitor
         if ($flags === \ast\flags\UNARY_MINUS) {
             $this->warnAboutInvalidUnaryOp(
                 $node,
-                function (Type $type) : bool {
+                static function (Type $type) : bool {
                     if ($type instanceof LiteralStringType) {
                         // Strings are invalid if they're not numeric
                         return \is_numeric($type->getValue());
@@ -2148,7 +2148,7 @@ class UnionTypeVisitor extends AnalysisVisitor
         } elseif ($flags === \ast\flags\UNARY_PLUS) {
             $this->warnAboutInvalidUnaryOp(
                 $node,
-                function (Type $type) : bool {
+                static function (Type $type) : bool {
                     if ($type instanceof LiteralStringType) {
                         // Strings are invalid if they're not numeric
                         return \is_numeric($type->getValue());
@@ -2164,7 +2164,7 @@ class UnionTypeVisitor extends AnalysisVisitor
         } elseif ($flags === \ast\flags\UNARY_BITWISE_NOT) {
             $this->warnAboutInvalidUnaryOp(
                 $node,
-                function (Type $type) : bool {
+                static function (Type $type) : bool {
                     // Adding $type instanceof StringType in case it becomes necessary later
                     return $type->isValidNumericOperand() || $type instanceof StringType;
                 },

--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -258,7 +258,7 @@ class Analysis
         $plugin_set = ConfigPluginSet::instance();
         $has_function_or_method_plugins = $plugin_set->hasAnalyzeFunctionPlugins() || $plugin_set->hasAnalyzeMethodPlugins();
         $show_progress = CLI::shouldShowProgress();
-        $analyze_function_or_method = function (FunctionInterface $function_or_method) use (
+        $analyze_function_or_method = static function (FunctionInterface $function_or_method) use (
             $code_base,
             $plugin_set,
             $has_function_or_method_plugins,

--- a/src/Phan/Analysis/AssignOperatorAnalysisVisitor.php
+++ b/src/Phan/Analysis/AssignOperatorAnalysisVisitor.php
@@ -410,7 +410,7 @@ class AssignOperatorAnalysisVisitor extends FlagVisitorImplementation
      */
     public function visitBinaryConcat(Node $node)
     {
-        return $this->updateTargetWithType($node, function (UnionType $unused_left) : UnionType {
+        return $this->updateTargetWithType($node, static function (UnionType $unused_left) : UnionType {
             // TODO: Check if both sides can cast to string and warn if they can't.
             return StringType::instance(false)->asUnionType();
         });
@@ -430,7 +430,7 @@ class AssignOperatorAnalysisVisitor extends FlagVisitorImplementation
     public function visitBinaryMod(Node $node)
     {
         $this->warnForInvalidOperandsOfNumericOp($node);
-        return $this->updateTargetWithType($node, function (UnionType $unused_left) : UnionType {
+        return $this->updateTargetWithType($node, static function (UnionType $unused_left) : UnionType {
             // TODO: Check if both sides can cast to string and warn if they can't.
             return IntType::instance(false)->asUnionType();
         });
@@ -460,7 +460,7 @@ class AssignOperatorAnalysisVisitor extends FlagVisitorImplementation
     public function visitBinaryShiftLeft(Node $node)
     {
         $this->analyzeBinaryShift($node);
-        return $this->updateTargetWithType($node, function (UnionType $unused_left) : UnionType {
+        return $this->updateTargetWithType($node, static function (UnionType $unused_left) : UnionType {
             // TODO: Check if both sides can cast to int and warn if they can't.
             // TODO: Handle both sides being literals
             return IntType::instance(false)->asUnionType();
@@ -473,7 +473,7 @@ class AssignOperatorAnalysisVisitor extends FlagVisitorImplementation
     public function visitBinaryShiftRight(Node $node)
     {
         $this->analyzeBinaryShift($node);
-        return $this->updateTargetWithType($node, function (UnionType $unused_left) : UnionType {
+        return $this->updateTargetWithType($node, static function (UnionType $unused_left) : UnionType {
             // TODO: Check if both sides can cast to int and warn if they can't.
             // TODO: Handle both sides being literals
             return IntType::instance(false)->asUnionType();

--- a/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
+++ b/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
@@ -122,11 +122,11 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
             || $right->hasType(FloatType::instance(false))
         ) {
             if ($left->hasTypeMatchingCallback(
-                function (Type $type) : bool {
+                static function (Type $type) : bool {
                     return !($type instanceof FloatType);
                 }
             ) && $right->hasTypeMatchingCallback(
-                function (Type $type) : bool {
+                static function (Type $type) : bool {
                     return !($type instanceof FloatType);
                 }
             )) {

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -637,7 +637,7 @@ class ConditionVisitor extends KindVisitorImplementation implements ConditionVis
             self::analyzeIsObjectAssertion($variable);
         };
         /** @return void */
-        $is_a_callback = function (CodeBase $code_base, Context $context, Variable $variable, array $args) use ($object_callback) {
+        $is_a_callback = static function (CodeBase $code_base, Context $context, Variable $variable, array $args) use ($object_callback) {
             $class_name = $args[1] ?? null;
             if ($class_name instanceof Node) {
                 $class_name = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $class_name)->asSingleScalarValueOrNull();
@@ -686,7 +686,7 @@ class ConditionVisitor extends KindVisitorImplementation implements ConditionVis
         $make_callback = static function (string $extract_types, UnionType $default_if_empty) : Closure {
             $method = new ReflectionMethod(UnionType::class, $extract_types);
             /** @return void */
-            return function (CodeBase $unused_code_base, Context $unused_context, Variable $variable, array $args) use ($method, $default_if_empty) {
+            return static function (CodeBase $unused_code_base, Context $unused_context, Variable $variable, array $args) use ($method, $default_if_empty) {
                 // Change the type to match the is_a relationship
                 // If we already have possible callable types, then keep those
                 // (E.g. Closure|false becomes Closure)

--- a/src/Phan/Analysis/ConditionVisitorUtil.php
+++ b/src/Phan/Analysis/ConditionVisitorUtil.php
@@ -69,10 +69,10 @@ trait ConditionVisitorUtil
         return $this->updateVariableWithConditionalFilter(
             $var_node,
             $context,
-            function (UnionType $type) : bool {
+            static function (UnionType $type) : bool {
                 return $type->containsTruthy();
             },
-            function (UnionType $type) : UnionType {
+            static function (UnionType $type) : UnionType {
                 return $type->nonTruthyClone();
             },
             $suppress_issues
@@ -85,10 +85,10 @@ trait ConditionVisitorUtil
         return $this->updateVariableWithConditionalFilter(
             $var_node,
             $context,
-            function (UnionType $type) : bool {
+            static function (UnionType $type) : bool {
                 return $type->containsFalsey();
             },
-            function (UnionType $type) : UnionType {
+            static function (UnionType $type) : UnionType {
                 return $type->nonFalseyClone();
             },
             $suppress_issues
@@ -101,10 +101,10 @@ trait ConditionVisitorUtil
         return $this->updateVariableWithConditionalFilter(
             $var_node,
             $context,
-            function (UnionType $type) : bool {
+            static function (UnionType $type) : bool {
                 return $type->containsNullable();
             },
-            function (UnionType $type) : UnionType {
+            static function (UnionType $type) : UnionType {
                 return $type->nonNullableClone();
             },
             $suppress_issues
@@ -125,26 +125,26 @@ trait ConditionVisitorUtil
         }
         if ($strict_equality) {
             if (is_int($value)) {
-                $cb = function (Type $type) use ($value) : bool {
+                $cb = static function (Type $type) use ($value) : bool {
                     return $type instanceof LiteralIntType && $type->getValue() === $value;
                 };
             } else { // string
-                $cb = function (Type $type) use ($value) : bool {
+                $cb = static function (Type $type) use ($value) : bool {
                     return $type instanceof LiteralStringType && $type->getValue() === $value;
                 };
             }
         } else {
-            $cb = function (Type $type) use ($value) : bool {
+            $cb = static function (Type $type) use ($value) : bool {
                 return $type instanceof LiteralTypeInterface && $type->getValue() == $value;
             };
         }
         return $this->updateVariableWithConditionalFilter(
             $var_node,
             $context,
-            function (UnionType $union_type) use ($cb) : bool {
+            static function (UnionType $union_type) use ($cb) : bool {
                 return $union_type->hasTypeMatchingCallback($cb);
             },
-            function (UnionType $union_type) use ($cb) : UnionType {
+            static function (UnionType $union_type) use ($cb) : UnionType {
                 $has_nullable = false;
                 foreach ($union_type->getTypeSet() as $type) {
                     if ($cb($type)) {
@@ -169,10 +169,10 @@ trait ConditionVisitorUtil
         return $this->updateVariableWithConditionalFilter(
             $var_node,
             $context,
-            function (UnionType $type) : bool {
+            static function (UnionType $type) : bool {
                 return $type->containsFalse();
             },
-            function (UnionType $type) : UnionType {
+            static function (UnionType $type) : UnionType {
                 return $type->nonFalseClone();
             },
             false
@@ -184,10 +184,10 @@ trait ConditionVisitorUtil
         return $this->updateVariableWithConditionalFilter(
             $var_node,
             $context,
-            function (UnionType $type) : bool {
+            static function (UnionType $type) : bool {
                 return $type->containsTrue();
             },
-            function (UnionType $type) : UnionType {
+            static function (UnionType $type) : UnionType {
                 return $type->nonTrueClone();
             },
             false
@@ -357,7 +357,7 @@ trait ConditionVisitorUtil
                 $variable = clone($variable);
 
                 // TODO: Filter out nullable types
-                $union_type = $variable->getUnionType()->makeFromFilter(function (Type $type) use ($expr_value, $flags) : bool {
+                $union_type = $variable->getUnionType()->makeFromFilter(static function (Type $type) use ($expr_value, $flags) : bool {
                     // @phan-suppress-next-line PhanAccessMethodInternal
                     return $type->canSatisfyComparison($expr_value, $flags);
                 });
@@ -793,7 +793,7 @@ trait ConditionVisitorUtil
         if ($excluded_type->isEmpty()) {
             return $affected_type;
         }
-        return $affected_type->makeFromFilter(function (Type $type) use ($code_base, $excluded_type) : bool {
+        return $affected_type->makeFromFilter(static function (Type $type) use ($code_base, $excluded_type) : bool {
             return $type instanceof MixedType || !$type->asExpandedTypes($code_base)->canCastToUnionType($excluded_type);
         });
     }

--- a/src/Phan/Analysis/ContextMergeVisitor.php
+++ b/src/Phan/Analysis/ContextMergeVisitor.php
@@ -130,7 +130,7 @@ class ContextMergeVisitor extends KindVisitorImplementation
         }
         // Get the list of scopes for each branch of the
         // conditional
-        $scope_list = \array_map(function (Context $context) : Scope {
+        $scope_list = \array_map(static function (Context $context) : Scope {
             return $context->getScope();
         }, $this->child_context_list);
 
@@ -212,7 +212,7 @@ class ContextMergeVisitor extends KindVisitorImplementation
     {
         // Get the list of scopes for each branch of the
         // conditional
-        $scope_list = \array_map(function (Context $context) : Scope {
+        $scope_list = \array_map(static function (Context $context) : Scope {
             return $context->getScope();
         }, $this->child_context_list);
 
@@ -255,7 +255,7 @@ class ContextMergeVisitor extends KindVisitorImplementation
         if (\count($child_context_list) < 2) {
             throw new AssertionError("Expected at least two child contexts in " . __METHOD__);
         }
-        $scope_list = \array_map(function (Context $context) : Scope {
+        $scope_list = \array_map(static function (Context $context) : Scope {
             return $context->getScope();
         }, $child_context_list);
         return $this->combineScopeList($scope_list);
@@ -283,7 +283,7 @@ class ContextMergeVisitor extends KindVisitorImplementation
         // every branch
         $is_defined_on_all_branches =
             /** @return bool */
-            function (string $variable_name) use ($scope_list) {
+            static function (string $variable_name) use ($scope_list) {
                 foreach ($scope_list as $scope) {
                     if (!$scope->hasVariableWithName($variable_name)) {
                         return false;
@@ -296,7 +296,7 @@ class ContextMergeVisitor extends KindVisitorImplementation
         // the variable from every side of the branch
         $union_type =
             /** @return UnionType */
-            function (string $variable_name) use ($scope_list) {
+            static function (string $variable_name) use ($scope_list) {
                 $previous_type = null;
                 $type_list = [];
                 // Get a list of all variables with the given name from

--- a/src/Phan/Analysis/NegatedConditionVisitor.php
+++ b/src/Phan/Analysis/NegatedConditionVisitor.php
@@ -416,7 +416,7 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
      */
     private static function createNegationCallbackMap() : array
     {
-        $remove_null_cb = function (NegatedConditionVisitor $cv, Node $var_node, Context $context) : Context {
+        $remove_null_cb = static function (NegatedConditionVisitor $cv, Node $var_node, Context $context) : Context {
             return $cv->removeNullFromVariable($var_node, $context, false);
         };
 
@@ -426,12 +426,12 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
                 return $cv->updateVariableWithConditionalFilter(
                     $var_node,
                     $context,
-                    function (UnionType $union_type) use ($base_class_name) : bool {
-                        return $union_type->hasTypeMatchingCallback(function (Type $type) use ($base_class_name) : bool {
+                    static function (UnionType $union_type) use ($base_class_name) : bool {
+                        return $union_type->hasTypeMatchingCallback(static function (Type $type) use ($base_class_name) : bool {
                             return $type instanceof $base_class_name;
                         });
                     },
-                    function (UnionType $union_type) use ($base_class_name) : UnionType {
+                    static function (UnionType $union_type) use ($base_class_name) : UnionType {
                         $new_type_builder = new UnionTypeBuilder();
                         $has_null = false;
                         $has_other_nullable_types = false;
@@ -465,10 +465,10 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
                 return $cv->updateVariableWithConditionalFilter(
                     $var_node,
                     $context,
-                    function (UnionType $union_type) use ($type_filter) : bool {
+                    static function (UnionType $union_type) use ($type_filter) : bool {
                         return $union_type->hasTypeMatchingCallback($type_filter);
                     },
-                    function (UnionType $union_type) use ($type_filter) : UnionType {
+                    static function (UnionType $union_type) use ($type_filter) : UnionType {
                         $new_type_builder = new UnionTypeBuilder();
                         $has_null = false;
                         $has_other_nullable_types = false;
@@ -491,13 +491,13 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
                 );
             };
         };
-        $remove_scalar_callback = $remove_conditional_function_callback(function (Type $type) : bool {
+        $remove_scalar_callback = $remove_conditional_function_callback(static function (Type $type) : bool {
             return $type instanceof ScalarType && !($type instanceof NullType);
         });
-        $remove_numeric_callback = $remove_conditional_function_callback(function (Type $type) : bool {
+        $remove_numeric_callback = $remove_conditional_function_callback(static function (Type $type) : bool {
             return $type instanceof IntType || $type instanceof FloatType;
         });
-        $remove_bool_callback = $remove_conditional_function_callback(function (Type $type) : bool {
+        $remove_bool_callback = $remove_conditional_function_callback(static function (Type $type) : bool {
             return $type->getIsInBoolFamily();
         });
         $remove_callable_callback = static function (NegatedConditionVisitor $cv, Node $var_node, Context $context) : Context {
@@ -506,12 +506,12 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
                 $context,
                 // if (!is_callable($x)) removes non-callable/closure types from $x.
                 // TODO: Could check for __invoke()
-                function (UnionType $union_type) : bool {
-                    return $union_type->hasTypeMatchingCallback(function (Type $type) : bool {
+                static function (UnionType $union_type) : bool {
+                    return $union_type->hasTypeMatchingCallback(static function (Type $type) : bool {
                         return $type->isCallable();
                     });
                 },
-                function (UnionType $union_type) : UnionType {
+                static function (UnionType $union_type) : UnionType {
                     $new_type_builder = new UnionTypeBuilder();
                     $has_null = false;
                     $has_other_nullable_types = false;
@@ -542,10 +542,10 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
                 $context,
                 // if (!is_callable($x)) removes non-callable/closure types from $x.
                 // TODO: Could check for __invoke()
-                function (UnionType $union_type) : bool {
+                static function (UnionType $union_type) : bool {
                     return $union_type->hasIterable();
                 },
-                function (UnionType $union_type) use ($traversable_type) : UnionType {
+                static function (UnionType $union_type) use ($traversable_type) : UnionType {
                     $new_type_builder = new UnionTypeBuilder();
                     $has_null = false;
                     $has_other_nullable_types = false;
@@ -580,10 +580,10 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
                 $context,
                 // if (!is_callable($x)) removes non-callable/closure types from $x.
                 // TODO: Could check for __invoke()
-                function (UnionType $union_type) : bool {
+                static function (UnionType $union_type) : bool {
                     return $union_type->hasPossiblyObjectTypes();
                 },
-                function (UnionType $union_type) : UnionType {
+                static function (UnionType $union_type) : UnionType {
                     $new_type_builder = new UnionTypeBuilder();
                     $has_null = false;
                     $has_other_nullable_types = false;

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -431,7 +431,7 @@ class ParameterTypesAnalyzer
         // template type parameters we may have
         if ($type_option->isDefined()) {
             $o_parameter_list =
-                \array_map(function (Parameter $parameter) use ($type_option, $code_base) : Parameter {
+                \array_map(static function (Parameter $parameter) use ($type_option, $code_base) : Parameter {
 
                     if (!$parameter->getUnionType()->hasTemplateTypeRecursive()) {
                         return $parameter;

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -3244,7 +3244,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         try {
             // Even though we don't modify the parameter list, we still need to know the types
             // -- as an optimization, we don't run quick mode again if the types didn't change?
-            $parameter_list = \array_map(/** @return Parameter */ function (Parameter $parameter) {
+            $parameter_list = \array_map(/** @return Parameter */ static function (Parameter $parameter) {
                 return clone($parameter);
             }, $method->getParameterList());
 
@@ -3329,7 +3329,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         try {
             // Even though we don't modify the parameter list, we still need to know the types
             // -- as an optimization, we don't run quick mode again if the types didn't change?
-            $parameter_list = \array_map(function (Parameter $parameter) : Parameter {
+            $parameter_list = \array_map(static function (Parameter $parameter) : Parameter {
                 return $parameter->cloneAsNonVariadic();
             }, $method->getParameterList());
 

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -126,7 +126,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             // Give up, this should be impossible except with the fallback
             $this->emitIssue(
                 Issue::InvalidNode,
-                $node->lineno ?? 0,
+                $node->lineno,
                 "Expected left side of assignment to be a variable"
             );
             return $this->context;
@@ -135,7 +135,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         if ($right_type->isType(VoidType::instance(false))) {
             $this->emitIssue(
                 Issue::TypeVoidAssignment,
-                $node->lineno ?? 0
+                $node->lineno
             );
         }
 
@@ -151,12 +151,12 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
 
         $expr_node = $node->children['expr'];
         if ($expr_node instanceof Node
-            && $expr_node->kind == ast\AST_CLOSURE
+            && $expr_node->kind === ast\AST_CLOSURE
         ) {
             $method = (new ContextNode(
                 $this->code_base,
                 $this->context->withLineNumberStart(
-                    $expr_node->lineno ?? 0
+                    $expr_node->lineno
                 ),
                 $expr_node
             ))->getClosure();
@@ -263,7 +263,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             if (!$union_type->asExpandedTypes($this->code_base)->hasArrayLike() && !$union_type->hasMixedType()) {
                 $this->emitIssue(
                     Issue::TypeArrayUnsetSuspicious,
-                    $node->lineno ?? 0,
+                    $node->lineno,
                     (string)$union_type
                 );
             }
@@ -318,7 +318,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 }
                 $this->emitIssue(
                     Issue::TypeObjectUnsetDeclaredProperty,
-                    $node->lineno ?? 0,
+                    $node->lineno,
                     (string)$type,
                     $prop_name,
                     $prop->getFileRef()->getFile(),
@@ -487,7 +487,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         ) {
             $this->emitIssueWithSuggestion(
                 Issue::UndeclaredVariable,
-                $node->lineno ?? 0,
+                $node->lineno,
                 [$variable_name],
                 IssueFixSuggester::suggestVariableTypoFix($this->code_base, $this->context, $variable_name)
             );
@@ -1154,7 +1154,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         ) {
             $this->emitIssue(
                 Issue::TypeMissingReturn,
-                $node->lineno ?? 0,
+                $node->lineno,
                 (string)$func->getFQSEN(),
                 (string)$return_type
             );
@@ -1830,7 +1830,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 if ($class->isDeprecated()) {
                     $this->emitIssue(
                         Issue::DeprecatedClass,
-                        $node->lineno ?? 0,
+                        $node->lineno,
                         (string)$class->getFQSEN(),
                         $class->getContext()->getFile(),
                         (string)$class->getContext()->getLineNumberStart()
@@ -1841,7 +1841,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                     if ($clazz->isDeprecated()) {
                         $this->emitIssue(
                             Issue::DeprecatedInterface,
-                            $node->lineno ?? 0,
+                            $node->lineno,
                             (string)$clazz->getFQSEN(),
                             $clazz->getContext()->getFile(),
                             (string)$clazz->getContext()->getLineNumberStart()
@@ -1853,7 +1853,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                     if ($clazz->isDeprecated()) {
                         $this->emitIssue(
                             Issue::DeprecatedTrait,
-                            $node->lineno ?? 0,
+                            $node->lineno,
                             (string)$clazz->getFQSEN(),
                             $clazz->getContext()->getFile(),
                             (string)$clazz->getContext()->getLineNumberStart()
@@ -1973,21 +1973,21 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         if ($class->isAbstract()) {
             $this->emitIssue(
                 Issue::TypeInstantiateAbstract,
-                $node->lineno ?? 0,
+                $node->lineno,
                 (string)$class->getFQSEN()
             );
         } elseif ($class->isInterface()) {
             // Make sure we're not instantiating an interface
             $this->emitIssue(
                 Issue::TypeInstantiateInterface,
-                $node->lineno ?? 0,
+                $node->lineno,
                 (string)$class->getFQSEN()
             );
         } elseif ($class->isTrait()) {
             // Make sure we're not instantiating a trait
             $this->emitIssue(
                 Issue::TypeInstantiateTrait,
-                $node->lineno ?? 0,
+                $node->lineno,
                 (string)$class->getFQSEN()
             );
         }
@@ -2020,7 +2020,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         } catch (CodeBaseException $exception) {
             $this->emitIssueWithSuggestion(
                 Issue::UndeclaredClassInstanceof,
-                $node->lineno ?? 0,
+                $node->lineno,
                 [(string)$exception->getFQSEN()],
                 IssueFixSuggester::suggestSimilarClassForGenericFQSEN(
                     $this->code_base,
@@ -2145,7 +2145,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
 
                     $this->emitIssue(
                         Issue::StaticCallToNonStatic,
-                        $node->lineno ?? 0,
+                        $node->lineno,
                         "{$class->getFQSEN()}::{$method_name}()",
                         $method->getFileRef()->getFile(),
                         (string)$method->getFileRef()->getLineNumberStart()
@@ -2230,7 +2230,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 if ($possible_ancestor_type->hasStaticType()) {
                     $this->emitIssue(
                         Issue::AccessOwnConstructor,
-                        $node->lineno ?? 0,
+                        $node->lineno,
                         $static_class
                     );
                     $found_ancestor_constructor = true;
@@ -2238,7 +2238,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                     if ($type->canCastToUnionType($possible_ancestor_type)) {
                         $this->emitIssue(
                             Issue::AccessOwnConstructor,
-                            $node->lineno ?? 0,
+                            $node->lineno,
                             $static_class
                         );
                     }
@@ -2261,7 +2261,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
     {
         $this->emitIssue(
             Issue::UndeclaredStaticMethod,
-            $node->lineno ?? 0,
+            $node->lineno,
             "{$static_class}::{$method_name}()"
         );
     }
@@ -2369,7 +2369,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             ) {
                 $this->emitIssue(
                     Issue::TypeMissingReturn,
-                    $node->lineno ?? 0,
+                    $node->lineno,
                     (string)$method->getFQSEN(),
                     (string)$return_type
                 );
@@ -2379,21 +2379,22 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         if ($method->getHasReturn() && $method->getIsMagicAndVoid()) {
             $this->emitIssue(
                 Issue::TypeMagicVoidWithReturn,
-                $node->lineno ?? 0,
+                $node->lineno,
                 (string)$method->getFQSEN()
             );
         }
 
         $parameters_seen = [];
         foreach ($method->getParameterList() as $i => $parameter) {
-            if (isset($parameters_seen[$parameter->getName()])) {
+            $name = $parameter->getName();
+            if (isset($parameters_seen[$name])) {
                 $this->emitIssue(
                     Issue::ParamRedefined,
-                    $node->lineno ?? 0,
-                    '$' . $parameter->getName()
+                    $node->lineno,
+                    '$' . $name
                 );
             } else {
-                $parameters_seen[$parameter->getName()] = $i;
+                $parameters_seen[$name] = $i;
             }
         }
 
@@ -2426,7 +2427,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         ) {
             $this->emitIssue(
                 Issue::TypeMissingReturn,
-                $node->lineno ?? 0,
+                $node->lineno,
                 (string)$method->getFQSEN(),
                 (string)$return_type
             );
@@ -2437,7 +2438,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             if (isset($parameters_seen[$parameter->getName()])) {
                 $this->emitIssue(
                     Issue::ParamRedefined,
-                    $node->lineno ?? 0,
+                    $node->lineno,
                     '$' . $parameter->getName()
                 );
             } else {
@@ -2878,7 +2879,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             $this->emitIssue(
                 $has_call_magic_method ?
                     Issue::AccessMethodPrivateWithCallMagicMethod : Issue::AccessMethodPrivate,
-                $node->lineno ?? 0,
+                $node->lineno,
                 (string)$method->getFQSEN(),
                 $method->getFileRef()->getFile(),
                 (string)$method->getFileRef()->getLineNumberStart()
@@ -2890,7 +2891,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             $this->emitIssue(
                 $has_call_magic_method ?
                     Issue::AccessMethodProtectedWithCallMagicMethod : Issue::AccessMethodProtected,
-                $node->lineno ?? 0,
+                $node->lineno,
                 (string)$method->getFQSEN(),
                 $method->getFileRef()->getFile(),
                 (string)$method->getFileRef()->getLineNumberStart()
@@ -3195,7 +3196,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
     private function trackReferenceToClosure(Node $argument)
     {
         try {
-            $inner_context = $this->context->withLineNumberStart($argument->lineno ?? 0);
+            $inner_context = $this->context->withLineNumberStart($argument->lineno);
             $method = (new ContextNode(
                 $this->code_base,
                 $inner_context,

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -391,7 +391,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
         $code_base = $this->code_base;
         $context = $this->context;
         $closure_fqsen = FullyQualifiedFunctionName::fromClosureInContext(
-            $context->withLineNumberStart($node->lineno ?? 0),
+            $context->withLineNumberStart($node->lineno),
             $node
         );
         $func = $code_base->getFunctionByFQSEN($closure_fqsen);
@@ -410,7 +410,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
                 if (!($use instanceof Node) || $use->kind != ast\AST_CLOSURE_VAR) {
                     $this->emitIssue(
                         Issue::VariableUseClause,
-                        $node->lineno ?? 0
+                        $node->lineno
                     );
                     continue;
                 }
@@ -438,7 +438,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
                             $this->code_base,
                             clone($context)->withLineNumberStart($use->lineno),
                             Issue::UndeclaredVariable,
-                            $node->lineno ?? 0,
+                            $node->lineno,
                             [$variable_name],
                             IssueFixSuggester::suggestVariableTypoFix($this->code_base, $context, $variable_name)
                         );
@@ -542,7 +542,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
                 // the check is done exactly once.
                 $this->emitIssue(
                     Issue::TypeMismatchReturn,
-                    $node->lineno ?? 0,
+                    $node->lineno,
                     '\\Generator',
                     $func->getNameForIssue(),
                     (string)$func_return_type
@@ -703,14 +703,14 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
         if ($node->flags !== ast\flags\ARRAY_SYNTAX_LIST) {
             $this->emitIssue(
                 Issue::CompatibleShortArrayAssignPHP70,
-                $node->lineno ?? 0
+                $node->lineno
             );
         }
         foreach ($node->children as $array_elem) {
             if (isset($array_elem->children['key'])) {
                 $this->emitIssue(
                     Issue::CompatibleKeyedArrayAssignPHP70,
-                    $array_elem->lineno ?? 0
+                    $array_elem->lineno
                 );
                 break;
             }
@@ -740,7 +740,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
             if (Config::get_closest_target_php_version_id() < 70100 && \count($class_list) > 1) {
                 $this->emitIssue(
                     Issue::CompatibleMultiExceptionCatchPHP70,
-                    $node->lineno ?? 0
+                    $node->lineno
                 );
             }
 
@@ -752,7 +752,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
                 $this->code_base,
                 $this->context,
                 Issue::UndeclaredClassCatch,
-                $node->lineno ?? 0,
+                $node->lineno,
                 [(string)$exception->getFQSEN()],
                 IssueFixSuggester::suggestSimilarClassForGenericFQSEN($this->code_base, $this->context, $exception->getFQSEN())
             );

--- a/src/Phan/Analysis/RegexAnalyzer.php
+++ b/src/Phan/Analysis/RegexAnalyzer.php
@@ -101,7 +101,7 @@ class RegexAnalyzer
         if ($bit & \PREG_SET_ORDER) {
             return $shape_array_type->asGenericArrayTypes(GenericArrayType::KEY_INT);
         }
-        return $shape_array_type->withMappedElementTypes(function (UnionType $type) : UnionType {
+        return $shape_array_type->withMappedElementTypes(static function (UnionType $type) : UnionType {
             return $type->elementTypesToGenericArray(GenericArrayType::KEY_INT);
         });
     }
@@ -115,7 +115,7 @@ class RegexAnalyzer
     ) : UnionType {
         $field_types = array_map(
             /** @param true $_ */
-            function ($_) use ($type) : UnionType {
+            static function ($_) use ($type) : UnionType {
                 return $type;
             },
             $regex_group_keys

--- a/src/Phan/Analysis/ThrowsTypesAnalyzer.php
+++ b/src/Phan/Analysis/ThrowsTypesAnalyzer.php
@@ -53,7 +53,7 @@ class ThrowsTypesAnalyzer
         /**
          * @param array<int,int|string|Type> $args
          */
-        $maybe_emit_for_method = function (string $issue_type, array $args, Suggestion $suggestion = null) use ($code_base, $method) {
+        $maybe_emit_for_method = static function (string $issue_type, array $args, Suggestion $suggestion = null) use ($code_base, $method) {
             Issue::maybeEmitWithParameters(
                 $code_base,
                 $method->getContext(),
@@ -136,7 +136,7 @@ class ThrowsTypesAnalyzer
             $code_base,
             $context,
             $type_fqsen,
-            IssueFixSuggester::createFQSENFilterFromClassFilter($code_base, function (Clazz $class) use ($code_base) : bool {
+            IssueFixSuggester::createFQSENFilterFromClassFilter($code_base, static function (Clazz $class) use ($code_base) : bool {
                 if ($class->isTrait()) {
                     return false;
                 }

--- a/src/Phan/Bootstrap.php
+++ b/src/Phan/Bootstrap.php
@@ -42,7 +42,7 @@ assert_options(ASSERT_CALLBACK, '');  // Can't explicitly set ASSERT_CALLBACK to
  * Print more of the backtrace than is done by default
  * @suppress PhanAccessMethodInternal
  */
-set_exception_handler(function (Throwable $throwable) {
+set_exception_handler(static function (Throwable $throwable) {
     error_log("$throwable\n");
     if (class_exists(CodeBase::class, false)) {
         $most_recent_file = CodeBase::getMostRecentlyParsedOrAnalyzedFile();

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -761,7 +761,7 @@ class CLI
 
             $this->file_list = array_filter(
                 $this->file_list,
-                function (string $file) use ($exclude_file_set) : bool {
+                static function (string $file) use ($exclude_file_set) : bool {
                     // Handle edge cases such as 'mydir/subdir\subsubdir' on Windows, if mydir/subdir was in the Phan config.
                     return !isset($exclude_file_set[\str_replace('\\', '/', $file)]);
                 }
@@ -1133,13 +1133,13 @@ EOB;
     public static function getFlagSuggestionString(
         string $key
     ) : string {
-        $trim = function (string $s) : string {
+        $trim = static function (string $s) : string {
             return rtrim($s, ':');
         };
-        $generate_suggestion = function (string $suggestion) : string {
+        $generate_suggestion = static function (string $suggestion) : string {
             return (strlen($suggestion) === 1 ? '-' : '--') . $suggestion;
         };
-        $generate_suggestion_text = function (string $suggestion, string ...$other_suggestions) use ($generate_suggestion) : string {
+        $generate_suggestion_text = static function (string $suggestion, string ...$other_suggestions) use ($generate_suggestion) : string {
             $suggestions = array_merge([$suggestion], $other_suggestions);
             return ' (did you mean ' . implode(' or ', array_map($generate_suggestion, $suggestions)) . '?)';
         };
@@ -1218,7 +1218,7 @@ EOB;
                         \RecursiveDirectoryIterator::FOLLOW_SYMLINKS
                     )
                 ),
-                function (\SplFileInfo $file_info) use ($file_extensions, $exclude_file_regex) : bool {
+                static function (\SplFileInfo $file_info) use ($file_extensions, $exclude_file_regex) : bool {
                     if (!in_array($file_info->getExtension(), $file_extensions, true)) {
                         return false;
                     }
@@ -1250,7 +1250,7 @@ EOB;
             $file_path = preg_replace('@^(\.[/\\\\]+)+@', '', $file_path);
             $normalized_file_list[$file_path] = $file_path;
         }
-        usort($normalized_file_list, function (string $a, string $b) : int {
+        usort($normalized_file_list, static function (string $a, string $b) : int {
             // Sort lexicographically by paths **within the results for a directory**,
             // to work around some file systems not returning results lexicographically.
             // Keep directories together by replacing directory separators with the null byte

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -643,7 +643,7 @@ class CodeBase
         $this->fqsen_class_map_user_defined->offsetSet($fqsen, $class);
         if ($this->undo_tracker) {
             // @phan-suppress-next-line PhanPossiblyNonClassMethodCall
-            $this->undo_tracker->recordUndo(function (CodeBase $inner) use ($fqsen) {
+            $this->undo_tracker->recordUndo(static function (CodeBase $inner) use ($fqsen) {
                 Daemon::debugf("Undoing addClass %s\n", $fqsen);
                 $inner->fqsen_class_map->offsetUnset($fqsen);
                 $inner->fqsen_class_map_user_defined->offsetUnset($fqsen);
@@ -669,7 +669,7 @@ class CodeBase
         $this->parsed_namespace_maps[$file][$key] = $namespace_map;
         if ($this->undo_tracker) {
             // @phan-suppress-next-line PhanPossiblyNonClassMethodCall
-            $this->undo_tracker->recordUndo(function (CodeBase $inner) use ($file, $key) {
+            $this->undo_tracker->recordUndo(static function (CodeBase $inner) use ($file, $key) {
                 Daemon::debugf("Undoing addParsedNamespaceMap file = %s namespace = %s\n", $file, $key);
                 unset($inner->parsed_namespace_maps[$file][$key]);
                 // Hack: addParsedNamespaceMap is called at least once per each file, so unset file-level suppressions at the same time in daemon mode
@@ -746,7 +746,7 @@ class CodeBase
             // TODO: Track a count of aliases instead? This doesn't work in daemon mode if multiple files add the same alias to the same class.
             // TODO: Allow .phan/config.php to specify aliases or precedences for aliases?
             // @phan-suppress-next-line PhanPossiblyNonClassMethodCall
-            $this->undo_tracker->recordUndo(function (CodeBase $inner) use ($original, $alias_record) {
+            $this->undo_tracker->recordUndo(static function (CodeBase $inner) use ($original, $alias_record) {
                 $fqsen_alias_map = $inner->fqsen_alias_map[$original] ?? null;
                 if ($fqsen_alias_map) {
                     $fqsen_alias_map->detach($alias_record);
@@ -978,7 +978,7 @@ class CodeBase
         if ($this->undo_tracker) {
             // The addClass's recordUndo should remove the class map. Only need to remove it from method_set
             // @phan-suppress-next-line PhanPossiblyNonClassMethodCall
-            $this->undo_tracker->recordUndo(function (CodeBase $inner) use ($method) {
+            $this->undo_tracker->recordUndo(static function (CodeBase $inner) use ($method) {
                 $inner->method_set->detach($method);
             });
         }
@@ -1117,7 +1117,7 @@ class CodeBase
 
         if ($this->undo_tracker) {
             // @phan-suppress-next-line PhanPossiblyNonClassMethodCall
-            $this->undo_tracker->recordUndo(function (CodeBase $inner) use ($function) {
+            $this->undo_tracker->recordUndo(static function (CodeBase $inner) use ($function) {
                 Daemon::debugf("Undoing addFunction on %s\n", $function->getFQSEN());
                 unset($inner->fqsen_func_map[$function->getFQSEN()]);
             });
@@ -1230,7 +1230,7 @@ class CodeBase
         ] = $global_constant;
         if ($this->undo_tracker) {
             // @phan-suppress-next-line PhanPossiblyNonClassMethodCall
-            $this->undo_tracker->recordUndo(function (CodeBase $inner) use ($global_constant) {
+            $this->undo_tracker->recordUndo(static function (CodeBase $inner) use ($global_constant) {
                 Daemon::debugf("Undoing addGlobalConstant on %s\n", $global_constant->getFQSEN());
                 unset($inner->fqsen_global_constant_map[$global_constant->getFQSEN()]);
             });
@@ -1827,7 +1827,7 @@ class CodeBase
         usort($namespaces_for_class, 'strcmp');
 
         /** @suppress PhanThrowTypeAbsentForCall */
-        return array_map(function (string $namespace_name) use ($class_name) : FullyQualifiedClassName {
+        return array_map(static function (string $namespace_name) use ($class_name) : FullyQualifiedClassName {
             return FullyQualifiedClassName::make($namespace_name, $class_name);
         }, $namespaces_for_class);
     }
@@ -1857,7 +1857,7 @@ class CodeBase
         usort($namespaces_for_function, 'strcmp');
 
         /** @suppress PhanThrowTypeAbsentForCall */
-        return array_map(function (string $namespace_name) use ($function_name) : FullyQualifiedFunctionName {
+        return array_map(static function (string $namespace_name) use ($function_name) : FullyQualifiedFunctionName {
             return FullyQualifiedFunctionName::make($namespace_name, $function_name);
         }, $namespaces_for_function);
     }
@@ -1970,7 +1970,7 @@ class CodeBase
         /**
          * @suppress PhanThrowTypeAbsentForCall
          */
-        return array_map(function (string $function_name_lower) use ($namespace, $function_names_in_namespace) : FullyQualifiedFunctionName {
+        return array_map(static function (string $function_name_lower) use ($namespace, $function_names_in_namespace) : FullyQualifiedFunctionName {
             $function_name = $function_names_in_namespace[$function_name_lower];
             return FullyQualifiedFunctionName::make($namespace, $function_name);
         }, $suggested_function_names);
@@ -2025,7 +2025,7 @@ class CodeBase
          * @return string|FullyQualifiedClassName
          * @suppress PhanThrowTypeAbsentForCall
          */
-        return array_map(function (string $class_name_lower) use ($namespace, $class_names_in_namespace) {
+        return array_map(static function (string $class_name_lower) use ($namespace, $class_names_in_namespace) {
             if (!\array_key_exists($class_name_lower, $class_names_in_namespace)) {
                 // This is a builtin type
                 return $class_name_lower;

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -1030,7 +1030,7 @@ class Config
          * @param mixed $value
          * @return ?string
          */
-        $is_scalar = function ($value) {
+        $is_scalar = static function ($value) {
             if (is_null($value) || is_scalar($value)) {
                 return null;
             }
@@ -1040,7 +1040,7 @@ class Config
          * @param mixed $value
          * @return ?string
          */
-        $is_bool = function ($value) {
+        $is_bool = static function ($value) {
             if (is_bool($value)) {
                 return null;
             }
@@ -1050,7 +1050,7 @@ class Config
          * @param mixed $value
          * @return ?string
          */
-        $is_string_or_null = function ($value) {
+        $is_string_or_null = static function ($value) {
             if (is_null($value) || is_string($value)) {
                 return null;
             }
@@ -1060,7 +1060,7 @@ class Config
          * @param mixed $value
          * @return ?string
          */
-        $is_string = function ($value) {
+        $is_string = static function ($value) {
             if (is_string($value)) {
                 return null;
             }
@@ -1070,7 +1070,7 @@ class Config
          * @param mixed $value
          * @return ?string
          */
-        $is_array = function ($value) {
+        $is_array = static function ($value) {
             if (is_array($value)) {
                 return null;
             }
@@ -1080,7 +1080,7 @@ class Config
          * @param mixed $value
          * @return ?string
          */
-        $is_int_strict = function ($value) {
+        $is_int_strict = static function ($value) {
             if (is_int($value)) {
                 return null;
             }
@@ -1090,7 +1090,7 @@ class Config
          * @param mixed $value
          * @return ?string
          */
-        $is_string_list = function ($value) {
+        $is_string_list = static function ($value) {
             if (!is_array($value)) {
                 return 'Expected a list of strings' . self::errSuffixGotType($value);
             }
@@ -1105,7 +1105,7 @@ class Config
          * @param mixed $value
          * @return ?string
          */
-        $is_associative_string_array = function ($value) {
+        $is_associative_string_array = static function ($value) {
             if (!is_array($value)) {
                 return 'Expected an associative array mapping strings to strings'  . self::errSuffixGotType($value);
             }

--- a/src/Phan/Config/Initializer.php
+++ b/src/Phan/Config/Initializer.php
@@ -123,7 +123,7 @@ class Initializer
         if ($lines === null) {
             return '';
         }
-        return implode('', array_map(function (string $line) : string {
+        return implode('', array_map(static function (string $line) : string {
             return "    $line\n";
         }, $lines));
     }

--- a/src/Phan/Daemon.php
+++ b/src/Phan/Daemon.php
@@ -66,7 +66,7 @@ class Daemon
                      * @param int|null $pid
                      * @return void
                      */
-                    function ($signo, $status = null, $pid = null) use (&$got_signal) {
+                    static function ($signo, $status = null, $pid = null) use (&$got_signal) {
                         $got_signal = true;
                         Request::childSignalHandler($signo, $status, $pid);
                     }
@@ -82,7 +82,7 @@ class Daemon
                  * @param int $line
                  * @return bool
                  */
-                $previous_error_handler = set_error_handler(function ($severity, $message, $file, $line) use (&$previous_error_handler) {
+                $previous_error_handler = set_error_handler(static function ($severity, $message, $file, $line) use (&$previous_error_handler) {
                     self::debugf("In new error handler '$message'");
                     if (!preg_match('/stream_socket_accept/i', $message)) {
                         return $previous_error_handler($severity, $message, $file, $line);
@@ -147,7 +147,7 @@ class Daemon
                      * @param int $line
                      * @return bool
                      */
-                    function ($severity, $message, $file, $line) use (&$previous_error_handler) {
+                    static function ($severity, $message, $file, $line) use (&$previous_error_handler) {
                         self::debugf("In new error handler '$message'");
                         if (!preg_match('/stream_socket_accept/i', $message)) {
                             return $previous_error_handler($severity, $message, $file, $line);

--- a/src/Phan/Debug/Breakpoint.php
+++ b/src/Phan/Debug/Breakpoint.php
@@ -2,7 +2,7 @@
 
 namespace Phan\Debug;
 
-readline_completion_function(function (string $input) : array {
+readline_completion_function(static function (string $input) : array {
     $matches = [];
     foreach (\get_declared_classes() as $class_name) {
         if (\strpos($class_name, $input) == 0) {

--- a/src/Phan/Debug/Frame.php
+++ b/src/Phan/Debug/Frame.php
@@ -94,7 +94,7 @@ class Frame
      */
     public static function frameToString(array $frame) : string
     {
-        return with_disabled_phan_error_handler(function () use ($frame) : string {
+        return with_disabled_phan_error_handler(static function () use ($frame) : string {
             $invocation = $frame['function'] ?? '(unknown)';
             if (isset($frame['class'])) {
                 $invocation = $frame['class'] . ($frame['type'] ?? '::') . $invocation;

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -583,7 +583,7 @@ class Issue
         string $template
     ) : string {
         /** @param array<int,string> $matches */
-        return preg_replace_callback('/{([A-Z_]+)}/', function (array $matches) use ($template): string {
+        return preg_replace_callback('/{([A-Z_]+)}/', static function (array $matches) use ($template): string {
             $key = $matches[1];
             $replacement_exists = \array_key_exists($key, self::UNCOLORED_FORMAT_STRING_FOR_TEMPLATE);
             if (!$replacement_exists) {

--- a/src/Phan/IssueFixSuggester.php
+++ b/src/Phan/IssueFixSuggester.php
@@ -47,7 +47,7 @@ class IssueFixSuggester
         /**
          * @param FullyQualifiedClassName $alternate_fqsen
          */
-        return function ($alternate_fqsen) use ($code_base, $class_closure) : bool {
+        return static function ($alternate_fqsen) use ($code_base, $class_closure) : bool {
             if (!($alternate_fqsen instanceof FullyQualifiedClassName)) {
                 return false;
             }
@@ -63,7 +63,7 @@ class IssueFixSuggester
      */
     public static function createFQSENFilterForClasslikeCategories(CodeBase $code_base, bool $allow_class, bool $allow_trait, bool $allow_interface)
     {
-        return self::createFQSENFilterFromClassFilter($code_base, function (Clazz $class) use ($allow_class, $allow_trait, $allow_interface) : bool {
+        return self::createFQSENFilterFromClassFilter($code_base, static function (Clazz $class) use ($allow_class, $allow_trait, $allow_interface) : bool {
             if ($class->isTrait()) {
                 return $allow_trait;
             } elseif ($class->isInterface()) {
@@ -116,7 +116,7 @@ class IssueFixSuggester
         /**
          * @param string|FullyQualifiedFunctionName $fqsen
          */
-        $generate_type_representation = function ($fqsen) : string {
+        $generate_type_representation = static function ($fqsen) : string {
             return $fqsen . '()';
         };
         $suggestion_text = $prefix . ' ' . implode(' or ', array_map($generate_type_representation, $suggested_fqsens));
@@ -163,7 +163,7 @@ class IssueFixSuggester
         /**
          * @param FullyQualifiedClassName|string $fqsen
          */
-        $generate_type_representation = function ($fqsen) use ($code_base) : string {
+        $generate_type_representation = static function ($fqsen) use ($code_base) : string {
             if (\is_string($fqsen)) {
                 return $fqsen;  // Not a class name, e.g. 'int', 'callable', etc.
             }
@@ -421,7 +421,7 @@ class IssueFixSuggester
             $context,
             true
         );
-        return array_map(function (FullyQualifiedFunctionName $fqsen) : string {
+        return array_map(static function (FullyQualifiedFunctionName $fqsen) : string {
             return $fqsen . '()';
         }, $suggested_fqsens);
     }

--- a/src/Phan/IssueInstance.php
+++ b/src/Phan/IssueInstance.php
@@ -67,7 +67,7 @@ class IssueInstance
          * @param string|float|int|FQSEN|Type|UnionType $parameter
          * @return string|float|int
          */
-        $this->template_parameters = \array_map(function ($parameter) {
+        $this->template_parameters = \array_map(static function ($parameter) {
             if (\is_object($parameter)) {
                 return (string)$parameter;
             }

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -426,9 +426,9 @@ class Clazz extends AddressableElement
             if ($contains_templated_type) {
                 $parent_type = Type::fromType(
                     $parent_type,
-                    \array_map(function (UnionType $union_type) use ($template_type_map) : UnionType {
+                    \array_map(static function (UnionType $union_type) use ($template_type_map) : UnionType {
                         return UnionType::of(
-                            \array_map(function (Type $type) use ($template_type_map) : Type {
+                            \array_map(static function (Type $type) use ($template_type_map) : Type {
                                 return $template_type_map[$type->getName()] ?? $type;
                             }, $union_type->getTypeSet())
                         );
@@ -877,7 +877,7 @@ class Clazz extends AddressableElement
                 $class_fqsen,
                 $method_name
             );
-            $real_parameter_list = \array_map(function (\Phan\Language\Element\Comment\Parameter $parameter) use ($context) : Parameter {
+            $real_parameter_list = \array_map(static function (\Phan\Language\Element\Comment\Parameter $parameter) use ($context) : Parameter {
                 return $parameter->asRealParameter($context);
             }, $comment_method->getParameterList());
             $method = new Method(
@@ -1442,7 +1442,7 @@ class Clazz extends AddressableElement
 
                 // Map each method parameter
                 $method->setParameterList(
-                    \array_map(function (Parameter $parameter) use ($type_option, $code_base) : Parameter {
+                    \array_map(static function (Parameter $parameter) use ($type_option, $code_base) : Parameter {
 
                         if (!$parameter->getUnionType()->hasTemplateType()) {
                             return $parameter;
@@ -2464,8 +2464,8 @@ class Clazz extends AddressableElement
 
         // A function that maps a list of elements to the
         // total reference count for all elements
-        $list_count = function (array $list) use ($code_base) : int {
-            return \array_reduce($list, function (
+        $list_count = static function (array $list) use ($code_base) : int {
+            return \array_reduce($list, static function (
                 int $count,
                 AddressableElement $element
             ) use ($code_base) : int {
@@ -2638,7 +2638,7 @@ class Clazz extends AddressableElement
         $constant_map = $this->getConstantMap($code_base);
         if (count($constant_map) > 0) {
             $stub .= "\n\n    // constants\n";
-            $stub .= implode("\n", array_map(function (ClassConstant $constant) : string {
+            $stub .= implode("\n", array_map(static function (ClassConstant $constant) : string {
                 return $constant->toStub();
             }, $constant_map));
         }
@@ -2647,12 +2647,12 @@ class Clazz extends AddressableElement
         if (count($property_map) > 0) {
             $stub .= "\n\n    // properties\n";
 
-            $stub .= implode("\n", array_map(function (Property $property) : string {
+            $stub .= implode("\n", array_map(static function (Property $property) : string {
                 return $property->toStub();
             }, $property_map));
         }
         $reflection_class = new \ReflectionClass((string)$this->getFQSEN());
-        $method_map = array_filter($this->getMethodMap($code_base), function (Method $method) use ($reflection_class) : bool {
+        $method_map = array_filter($this->getMethodMap($code_base), static function (Method $method) use ($reflection_class) : bool {
             if ($method->getFQSEN()->isAlternate()) {
                 return false;
             }
@@ -2666,7 +2666,7 @@ class Clazz extends AddressableElement
             $stub .= "\n\n    // methods\n";
 
             $is_interface = $this->isInterface();
-            $stub .= implode("\n", array_map(function (Method $method) use ($is_interface) : string {
+            $stub .= implode("\n", array_map(static function (Method $method) use ($is_interface) : string {
                 return $method->toStub($is_interface);
             }, $method_map));
         }
@@ -2995,7 +2995,7 @@ class Clazz extends AddressableElement
             // Low priority because that is uncommon
             return array_filter(
                 $this->getPropertyMap($code_base),
-                function (Property $property) : bool {
+                static function (Property $property) : bool {
                     return !$property->isDynamicOrFromPHPDoc();
                 }
             );
@@ -3067,7 +3067,7 @@ class Clazz extends AddressableElement
                                 $this->getFQSEN()
                             );
                         }
-                        $template_type_resolver = function (array $unused_arg_list) : UnionType {
+                        $template_type_resolver = static function (array $unused_arg_list) : UnionType {
                             return MixedType::instance(false)->asUnionType();
                         };
                     }

--- a/src/Phan/Language/Element/Comment/Method.php
+++ b/src/Phan/Language/Element/Comment/Method.php
@@ -124,7 +124,7 @@ class Method
     {
         return array_reduce(
             $this->parameters,
-            function (int $carry, Parameter $parameter) : int {
+            static function (int $carry, Parameter $parameter) : int {
                 return ($carry + ($parameter->isRequired() ? 1 : 0));
             },
             0
@@ -139,7 +139,7 @@ class Method
     {
         return array_reduce(
             $this->parameters,
-            function (int $carry, Parameter $parameter) : int {
+            static function (int $carry, Parameter $parameter) : int {
                 return ($carry + ($parameter->isOptional() ? 1 : 0));
             },
             0

--- a/src/Phan/Language/Element/Func.php
+++ b/src/Phan/Language/Element/Func.php
@@ -226,7 +226,7 @@ class Func extends AddressableElement implements FunctionInterface
 
         $func->setNumberOfRequiredParameters(\array_reduce(
             $parameter_list,
-            function (int $carry, Parameter $parameter) : int {
+            static function (int $carry, Parameter $parameter) : int {
                 return ($carry + ($parameter->isRequired() ? 1 : 0));
             },
             0
@@ -234,7 +234,7 @@ class Func extends AddressableElement implements FunctionInterface
 
         $func->setNumberOfOptionalParameters(\array_reduce(
             $parameter_list,
-            function (int $carry, Parameter $parameter) : int {
+            static function (int $carry, Parameter $parameter) : int {
                 return ($carry + ($parameter->isOptional() ? 1 : 0));
             },
             0
@@ -271,7 +271,7 @@ class Func extends AddressableElement implements FunctionInterface
 
             // FIXME properly handle self/static in closures declared within methods.
             if ($union_type->hasSelfType()) {
-                $union_type = $union_type->makeFromFilter(function (Type $type) : bool {
+                $union_type = $union_type->makeFromFilter(static function (Type $type) : bool {
                     return !$type->isSelfType();
                 });
                 if ($context->isInClassScope()) {
@@ -455,7 +455,7 @@ class Func extends AddressableElement implements FunctionInterface
         if ($this->returnsRef()) {
             $stub .= '&';
         }
-        $stub .= '(' . implode(', ', array_map(function (Parameter $parameter) : string {
+        $stub .= '(' . implode(', ', array_map(static function (Parameter $parameter) : string {
             return $parameter->toStubString();
         }, $this->getRealParameterList())) . ')';
         if ($this->real_return_type && !$this->getRealReturnType()->isEmpty()) {

--- a/src/Phan/Language/Element/FunctionFactory.php
+++ b/src/Phan/Language/Element/FunctionFactory.php
@@ -159,7 +159,7 @@ class FunctionFactory
          * @param array<string,mixed> $map
          * @suppress PhanPossiblyFalseTypeArgumentInternal, PhanPossiblyFalseTypeArgument
          */
-        return \array_map(function ($map) use (
+        return \array_map(static function ($map) use (
             $function,
             &$alternate_id
         ) : FunctionInterface {
@@ -234,7 +234,7 @@ class FunctionFactory
             $alternate_function->setNumberOfRequiredParameters(
                 \array_reduce(
                     $alternate_function->getParameterList(),
-                    function (int $carry, Parameter $parameter) : int {
+                    static function (int $carry, Parameter $parameter) : int {
                         return ($carry + (
                             $parameter->isOptional() ? 0 : 1
                         ));

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -546,7 +546,7 @@ trait FunctionTrait
     public function getRealParameterList()
     {
         // Excessive cloning, to ensure that this stays immutable.
-        return array_map(/** @return Parameter */ function (Parameter $param) {
+        return array_map(/** @return Parameter */ static function (Parameter $param) {
             return clone($param);
         }, $this->real_parameter_list);
     }
@@ -559,7 +559,7 @@ trait FunctionTrait
      */
     public function setRealParameterList(array $parameter_list)
     {
-        $this->real_parameter_list = array_map(/** @return Parameter */ function (Parameter $param) {
+        $this->real_parameter_list = array_map(/** @return Parameter */ static function (Parameter $param) {
             return clone($param);
         }, $parameter_list);
 
@@ -1121,7 +1121,7 @@ trait FunctionTrait
     {
         $this->setParameterList(
             \array_map(
-                function (Parameter $parameter) : Parameter {
+                static function (Parameter $parameter) : Parameter {
                     return clone($parameter);
                 },
                 $this->getParameterList()
@@ -1146,7 +1146,7 @@ trait FunctionTrait
 
     private function createFunctionLikeDeclarationType() : FunctionLikeDeclarationType
     {
-        $params = array_map(function (Parameter $parameter) : ClosureDeclarationParameter {
+        $params = array_map(static function (Parameter $parameter) : ClosureDeclarationParameter {
             return $parameter->asClosureDeclarationParameter();
         }, $this->getParameterList());
 
@@ -1453,12 +1453,12 @@ trait FunctionTrait
             return;
         }
         // Resolve the template types based on the parameters passed to the function
-        $analyzer = function (CodeBase $code_base, Context $context, FunctionInterface $function, array $args) use ($parameter_extracter_map) : UnionType {
+        $analyzer = static function (CodeBase $code_base, Context $context, FunctionInterface $function, array $args) use ($parameter_extracter_map) : UnionType {
             $args_types = array_map(
                 /**
                  * @param mixed $node
                  */
-                function ($node) use ($code_base, $context) : UnionType {
+                static function ($node) use ($code_base, $context) : UnionType {
                     return UnionTypeVisitor::unionTypeFromNode($code_base, $context, $node);
                 },
                 $args
@@ -1490,7 +1490,7 @@ trait FunctionTrait
             }
             $closure = TemplateType::combineParameterClosures(
                 $closure,
-                function (array $parameters, Context $context) use ($code_base, $i, $closure_for_type) : UnionType {
+                static function (array $parameters, Context $context) use ($code_base, $i, $closure_for_type) : UnionType {
                     $param_value = $parameters[$i] ?? null;
                     if ($param_value !== null) {
                         if ($param_value instanceof UnionType) {
@@ -1570,7 +1570,7 @@ trait FunctionTrait
                 return;
             }
         } else {
-            $union_type_extractor = function (CodeBase $unused_code_base, Context $unused_context, array $unused_args) use ($union_type) : UnionType {
+            $union_type_extractor = static function (CodeBase $unused_code_base, Context $unused_context, array $unused_args) use ($union_type) : UnionType {
                 return $union_type;
             };
         }
@@ -1587,7 +1587,7 @@ trait FunctionTrait
     {
         switch ($assertion_type) {
             case Assertion::IS_OF_TYPE:
-                return function (CodeBase $code_base, Context $context, FunctionInterface $unused_function, array $args) use ($i, $union_type_extractor) {
+                return static function (CodeBase $code_base, Context $context, FunctionInterface $unused_function, array $args) use ($i, $union_type_extractor) {
                     $arg = $args[$i] ?? null;
                     if (!($arg instanceof Node)) {
                         return;
@@ -1598,7 +1598,7 @@ trait FunctionTrait
                     $context->setScope($new_context->getScope());
                 };
             case Assertion::IS_NOT_OF_TYPE:
-                return function (CodeBase $code_base, Context $context, FunctionInterface $unused_function, array $args) use ($i, $union_type_extractor) {
+                return static function (CodeBase $code_base, Context $context, FunctionInterface $unused_function, array $args) use ($i, $union_type_extractor) {
                     $arg = $args[$i] ?? null;
                     if (!($arg instanceof Node)) {
                         return;
@@ -1609,7 +1609,7 @@ trait FunctionTrait
                     $context->setScope($new_context->getScope());
                 };
             case Assertion::IS_TRUE:
-                return function (CodeBase $code_base, Context $context, FunctionInterface $unused_function, array $args) use ($i) {
+                return static function (CodeBase $code_base, Context $context, FunctionInterface $unused_function, array $args) use ($i) {
                     $arg = $args[$i] ?? null;
                     if (!($arg instanceof Node)) {
                         return;
@@ -1619,7 +1619,7 @@ trait FunctionTrait
                     $context->setScope($new_context->getScope());
                 };
             case Assertion::IS_FALSE:
-                return function (CodeBase $code_base, Context $context, FunctionInterface $unused_function, array $args) use ($i) {
+                return static function (CodeBase $code_base, Context $context, FunctionInterface $unused_function, array $args) use ($i) {
                     $arg = $args[$i] ?? null;
                     if (!($arg instanceof Node)) {
                         return;
@@ -1659,7 +1659,7 @@ trait FunctionTrait
         if (!$parameter_extractor_map) {
             return null;
         }
-        return function (CodeBase $unused_code_base, Context $context, array $args) use ($type, $parameter_extractor_map) : UnionType {
+        return static function (CodeBase $unused_code_base, Context $context, array $args) use ($type, $parameter_extractor_map) : UnionType {
             $template_type_map = [];
             foreach ($parameter_extractor_map as $template_type_name => $closure) {
                 $template_type_map[$template_type_name] = $closure($args, $context);
@@ -1703,7 +1703,7 @@ trait FunctionTrait
      */
     protected function getRealParameterStubText() : string
     {
-        return implode(', ', array_map(function (Parameter $parameter) : string {
+        return implode(', ', array_map(static function (Parameter $parameter) : string {
             return $parameter->toStubString();
         }, $this->getRealParameterList()));
     }

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -423,7 +423,7 @@ class Method extends ClassElement implements FunctionInterface
 
         $method->setNumberOfRequiredParameters(array_reduce(
             $parameter_list,
-            function (int $carry, Parameter $parameter) : int {
+            static function (int $carry, Parameter $parameter) : int {
                 return ($carry + ($parameter->isRequired() ? 1 : 0));
             },
             0
@@ -431,7 +431,7 @@ class Method extends ClassElement implements FunctionInterface
 
         $method->setNumberOfOptionalParameters(array_reduce(
             $parameter_list,
-            function (int $carry, Parameter $parameter) : int {
+            static function (int $carry, Parameter $parameter) : int {
                 return ($carry + ($parameter->isOptional() ? 1 : 0));
             },
             0

--- a/src/Phan/Language/FQSEN/FullyQualifiedClassName.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedClassName.php
@@ -106,7 +106,7 @@ class FullyQualifiedClassName extends FullyQualifiedGlobalStructuralElement
      */
     public static function getStdClassFQSEN() : FullyQualifiedClassName
     {
-        return self::memoizeStatic(__METHOD__, function () : FullyQualifiedClassName {
+        return self::memoizeStatic(__METHOD__, static function () : FullyQualifiedClassName {
             // @phan-suppress-next-line PhanThrowTypeAbsentForCall
             return self::fromFullyQualifiedString("\stdClass");
         });

--- a/src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php
@@ -133,7 +133,7 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN
         $key = static::class . '|' .
             static::toString(\strtolower($namespace), static::canonicalLookupKey($name), $alternate_id);
 
-        $fqsen = self::memoizeStatic($key, /** @return FullyQualifiedGlobalStructuralElement */ function () use ($namespace, $name, $alternate_id) {
+        $fqsen = self::memoizeStatic($key, /** @return FullyQualifiedGlobalStructuralElement */ static function () use ($namespace, $name, $alternate_id) {
             return new static(
                 $namespace,
                 $name,
@@ -164,7 +164,7 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN
              * @return FullyQualifiedGlobalStructuralElement
              * @throws FQSENException
              */
-            function () use ($fully_qualified_string) {
+            static function () use ($fully_qualified_string) {
                 // Split off the alternate_id
                 $parts = \explode(',', $fully_qualified_string);
                 $fqsen_string = $parts[0];

--- a/src/Phan/Language/FileRef.php
+++ b/src/Phan/Language/FileRef.php
@@ -110,12 +110,24 @@ class FileRef implements \Serializable
      * The starting line number of the element within the file
      *
      * @return static
-     * This context with the given value is returned
+     * This context with the given line number is returned
      */
     public function withLineNumberStart(int $line_number)
     {
         $this->line_number_start = $line_number;
         return $this;
+    }
+
+    /**
+     * @var int $line_number
+     * The starting line number of the element within the file
+     *
+     * @return void
+     * Both this and withLineNumberStart modify the original context.
+     */
+    public function setLineNumberStart(int $line_number)
+    {
+        $this->line_number_start = $line_number;
     }
 
     /**

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -416,7 +416,7 @@ class Type
         $key = ($is_nullable ? '?' : '') . static::KEY_PREFIX . $namespace . '\\' . $type_name;
 
         if ($template_parameter_type_list) {
-            $key .= '<' . \implode(',', \array_map(function (UnionType $union_type) : string {
+            $key .= '<' . \implode(',', \array_map(static function (UnionType $union_type) : string {
                 return $union_type->__toString();
             }, $template_parameter_type_list)) . '>';
         }
@@ -942,7 +942,7 @@ class Type
      */
     private static function createTemplateParameterTypeList(array $template_parameter_type_name_list)
     {
-        return \array_map(function (string $type_name) : UnionType {
+        return \array_map(static function (string $type_name) : UnionType {
             return UnionType::fromFullyQualifiedString($type_name);
         }, $template_parameter_type_name_list);
     }
@@ -1177,7 +1177,7 @@ class Type
         // Map the names of the types to actual types in the
         // template parameter type list
         $template_parameter_type_list =
-            \array_map(function (string $type_name) use ($code_base, $context, $source) : UnionType {
+            \array_map(static function (string $type_name) use ($code_base, $context, $source) : UnionType {
                 return UnionType::fromStringInContext($type_name, $context, $source, $code_base);
             }, $template_parameter_type_name_list);
 
@@ -2693,7 +2693,7 @@ class Type
     final protected function templateParameterTypeListAsString() : string
     {
         return '<' .
-            \implode(',', \array_map(function (UnionType $type) : string {
+            \implode(',', \array_map(static function (UnionType $type) : string {
                 return $type->__toString();
             }, $this->template_parameter_type_list)) . '>';
     }
@@ -3185,7 +3185,7 @@ class Type
             }
             $closure = TemplateType::combineParameterClosures(
                 $closure,
-                function (UnionType $type, Context $context) use ($inner_extracter_closure, $i) : UnionType {
+                static function (UnionType $type, Context $context) use ($inner_extracter_closure, $i) : UnionType {
                     $result = UnionType::empty();
                     foreach ($type->getTypeSet() as $inner_type) {
                         $replacement_type = $inner_type->template_parameter_type_list[$i] ?? null;

--- a/src/Phan/Language/Type/ArrayShapeType.php
+++ b/src/Phan/Language/Type/ArrayShapeType.php
@@ -672,7 +672,7 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
             }
             $closure = TemplateType::combineParameterClosures(
                 $closure,
-                function (UnionType $union_type, Context $context) use ($key, $field_closure) : UnionType {
+                static function (UnionType $union_type, Context $context) use ($key, $field_closure) : UnionType {
                     $result = UnionType::empty();
                     foreach ($union_type->getTypeSet() as $type) {
                         if (!($type instanceof ArrayShapeType)) {

--- a/src/Phan/Language/Type/ClassStringType.php
+++ b/src/Phan/Language/Type/ClassStringType.php
@@ -55,7 +55,7 @@ final class ClassStringType extends StringType
         if (!$template_union_type) {
             return UnionType::empty();
         }
-        return $template_union_type->makeFromFilter(function (Type $type) : bool {
+        return $template_union_type->makeFromFilter(static function (Type $type) : bool {
             return $type instanceof TemplateType || $type->isObjectWithKnownFQSEN();
         });
     }

--- a/src/Phan/Language/Type/FunctionLikeDeclarationType.php
+++ b/src/Phan/Language/Type/FunctionLikeDeclarationType.php
@@ -847,7 +847,7 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
             }
             $closure = TemplateType::combineParameterClosures(
                 $closure,
-                function (UnionType $union_type, Context $context) use ($code_base, $i, $param_closure) : UnionType {
+                static function (UnionType $union_type, Context $context) use ($code_base, $i, $param_closure) : UnionType {
                     $result = UnionType::empty();
                     foreach ($union_type->getTypeSet() as $type) {
                         $func = $type->asFunctionInterfaceOrNull($code_base, $context);
@@ -879,7 +879,7 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
         if (!$return_closure) {
             return null;
         }
-        return function (UnionType $union_type, Context $context) use ($code_base, $return_closure) : UnionType {
+        return static function (UnionType $union_type, Context $context) use ($code_base, $return_closure) : UnionType {
             $result = UnionType::empty();
             foreach ($union_type->getTypeSet() as $type) {
                 $func = $type->asFunctionInterfaceOrNull($code_base, $context);
@@ -894,7 +894,7 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
     public function withTemplateParameterTypeMap(
         array $template_parameter_type_map
     ) : UnionType {
-        $new_params = array_map(function (ClosureDeclarationParameter $param) use ($template_parameter_type_map) : ClosureDeclarationParameter {
+        $new_params = array_map(static function (ClosureDeclarationParameter $param) use ($template_parameter_type_map) : ClosureDeclarationParameter {
             return $param->withTemplateParameterTypeMap($template_parameter_type_map);
         }, $this->params);
         $new_return_type = $this->return_type->withTemplateParameterTypeMap($template_parameter_type_map);

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -692,7 +692,7 @@ class GenericArrayType extends ArrayType implements GenericArrayInterface
             return null;
         }
         // If a function expects T[], then T is the generic array element type of the passed in union type
-        return function (UnionType $array_type, Context $context) use ($closure) : UnionType {
+        return static function (UnionType $array_type, Context $context) use ($closure) : UnionType {
             return $closure($array_type->genericArrayElementTypes(), $context);
         };
     }

--- a/src/Phan/Language/Type/GenericIterableType.php
+++ b/src/Phan/Language/Type/GenericIterableType.php
@@ -156,7 +156,7 @@ final class GenericIterableType extends IterableType
         $closure = $this->element_union_type->getTemplateTypeExtractorClosure($code_base, $template_type);
         if ($closure) {
             // If a function expects T[], then T is the generic array element type of the passed in union type
-            $element_closure = function (UnionType $type, Context $context) use ($code_base, $closure) : UnionType {
+            $element_closure = static function (UnionType $type, Context $context) use ($code_base, $closure) : UnionType {
                 return $closure($type->iterableValueUnionType($code_base), $context);
             };
         } else {
@@ -164,7 +164,7 @@ final class GenericIterableType extends IterableType
         }
         $closure = $this->key_union_type->getTemplateTypeExtractorClosure($code_base, $template_type);
         if ($closure) {
-            $key_closure = function (UnionType $type, Context $context) use ($code_base, $closure) : UnionType {
+            $key_closure = static function (UnionType $type, Context $context) use ($code_base, $closure) : UnionType {
                 return $closure($type->iterableKeyUnionType($code_base), $context);
             };
         } else {

--- a/src/Phan/Language/Type/LiteralStringType.php
+++ b/src/Phan/Language/Type/LiteralStringType.php
@@ -112,7 +112,7 @@ final class LiteralStringType extends StringType implements LiteralTypeInterface
              * @param array{0:string} $match
              * @return string
              */
-            function (array $match) {
+            static function (array $match) {
                 $c = $match[0];
                 return self::ESCAPE_CHARACTER_LOOKUP[$c] ?? \sprintf('\\x%02x', \ord($c));
             },
@@ -140,7 +140,7 @@ final class LiteralStringType extends StringType implements LiteralTypeInterface
         $escaped_string = preg_replace_callback(
             '/\\\\(?:[\'\\\\trn]|x[0-9a-fA-F]{2})/',
             /** @param array{0:string} $matches */
-            function (array $matches) : string {
+            static function (array $matches) : string {
                 $x = $matches[0];
                 if (\strlen($x) === 2) {
                     // Parses one of \t \r \n \\ \'

--- a/src/Phan/Language/Type/NativeType.php
+++ b/src/Phan/Language/Type/NativeType.php
@@ -130,7 +130,7 @@ abstract class NativeType extends Type
         /**
          * @return array<string,bool>
          */
-        $generate_row = function (string ...$permitted_cast_type_names) : array {
+        $generate_row = static function (string ...$permitted_cast_type_names) : array {
             return [
                 ArrayType::NAME    => in_array(ArrayType::NAME, $permitted_cast_type_names, true),
                 IterableType::NAME => in_array(IterableType::NAME, $permitted_cast_type_names, true),

--- a/src/Phan/Language/Type/TemplateType.php
+++ b/src/Phan/Language/Type/TemplateType.php
@@ -151,7 +151,7 @@ final class TemplateType extends Type
         /**
          * @param mixed $params
          */
-        return function ($params, Context $context) use ($left, $right) : UnionType {
+        return static function ($params, Context $context) use ($left, $right) : UnionType {
             return $left($params, $context)->withUnionType($right($params, $context));
         };
     }
@@ -164,7 +164,7 @@ final class TemplateType extends Type
     public function getTemplateTypeExtractorClosure(CodeBase $unused_code_base, TemplateType $template_type)
     {
         if ($this === $template_type) {
-            return function (UnionType $type, Context $_) : UnionType {
+            return static function (UnionType $type, Context $_) : UnionType {
                 return $type;
             };
         }

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -178,7 +178,7 @@ class UnionType implements Serializable
         $union_type = $memoize_map[$fully_qualified_string] ?? null;
 
         if (is_null($union_type)) {
-            $types = \array_map(function (string $type_name) : Type {
+            $types = \array_map(static function (string $type_name) : Type {
                 // @phan-suppress-next-line PhanThrowTypeAbsentForCall FIXME: Standardize on InvalidArgumentException
                 return Type::fromFullyQualifiedString($type_name);
             }, self::extractTypeParts($fully_qualified_string));
@@ -452,7 +452,7 @@ class UnionType implements Serializable
          * @param string|null $type_name
          * @return UnionType|null
          */
-        $get_for_global_context = function ($type_name) {
+        $get_for_global_context = static function ($type_name) {
             if (!$type_name) {
                 return null;
             }
@@ -611,7 +611,7 @@ class UnionType implements Serializable
      */
     public function hasTypeInBoolFamily() : bool
     {
-        return $this->hasTypeMatchingCallback(function (Type $type) : bool {
+        return $this->hasTypeMatchingCallback(static function (Type $type) : bool {
             return $type->getIsInBoolFamily();
         });
     }
@@ -627,7 +627,7 @@ class UnionType implements Serializable
      */
     public function getTypesInBoolFamily() : UnionType
     {
-        return $this->makeFromFilter(function (Type $type) : bool {
+        return $this->makeFromFilter(static function (Type $type) : bool {
             return $type->getIsInBoolFamily();
         });
     }
@@ -652,7 +652,7 @@ class UnionType implements Serializable
         return \array_reduce(
             $this->type_set,
             /** @return array<string,UnionType> */
-            function (array $map, Type $type) use ($code_base) {
+            static function (array $map, Type $type) use ($code_base) {
                 return \array_merge(
                     $type->getTemplateParameterTypeMap($code_base),
                     $map
@@ -698,7 +698,7 @@ class UnionType implements Serializable
      */
     public function hasTemplateType() : bool
     {
-        return $this->hasTypeMatchingCallback(function (Type $type) : bool {
+        return $this->hasTypeMatchingCallback(static function (Type $type) : bool {
             return ($type instanceof TemplateType);
         });
     }
@@ -710,7 +710,7 @@ class UnionType implements Serializable
      */
     public function hasTemplateTypeRecursive() : bool
     {
-        return $this->hasTypeMatchingCallback(function (Type $type) : bool {
+        return $this->hasTypeMatchingCallback(static function (Type $type) : bool {
             return $type->hasTemplateTypeRecursive();
         });
     }
@@ -722,7 +722,7 @@ class UnionType implements Serializable
      */
     public function withoutTemplateTypeRecursive() : UnionType
     {
-        return $this->makeFromFilter(function (Type $type) : bool {
+        return $this->makeFromFilter(static function (Type $type) : bool {
             return !$type->hasTemplateTypeRecursive();
         });
     }
@@ -734,7 +734,7 @@ class UnionType implements Serializable
      */
     public function hasTemplateParameterTypes() : bool
     {
-        return $this->hasTypeMatchingCallback(function (Type $type) : bool {
+        return $this->hasTypeMatchingCallback(static function (Type $type) : bool {
             return $type->hasTemplateParameterTypes();
         });
     }
@@ -891,7 +891,7 @@ class UnionType implements Serializable
             return false;
         }
 
-        return !$this->hasTypeMatchingCallback(function (Type $type) : bool {
+        return !$this->hasTypeMatchingCallback(static function (Type $type) : bool {
             return !$type->isNativeType();
         });
     }
@@ -1425,7 +1425,7 @@ class UnionType implements Serializable
      */
     public function hasIterable() : bool
     {
-        return $this->hasTypeMatchingCallback(function (Type $type) : bool {
+        return $this->hasTypeMatchingCallback(static function (Type $type) : bool {
             return $type->isIterable();
         });
     }
@@ -1746,7 +1746,7 @@ class UnionType implements Serializable
             return false;
         }
 
-        return !$this->hasTypeMatchingCallback(function (Type $type) : bool {
+        return !$this->hasTypeMatchingCallback(static function (Type $type) : bool {
             return !$type->isScalar();
         });
     }
@@ -1761,7 +1761,7 @@ class UnionType implements Serializable
             return true;
         }
 
-        return $this->hasTypeMatchingCallback(function (Type $type) : bool {
+        return $this->hasTypeMatchingCallback(static function (Type $type) : bool {
             return $type->isPrintableScalar();
         });
     }
@@ -1776,7 +1776,7 @@ class UnionType implements Serializable
             return true;
         }
 
-        return $this->hasTypeMatchingCallback(function (Type $type) : bool {
+        return $this->hasTypeMatchingCallback(static function (Type $type) : bool {
             return $type->isValidBitwiseOperand();
         });
     }
@@ -1788,7 +1788,7 @@ class UnionType implements Serializable
      */
     public function hasArrayLike() : bool
     {
-        return $this->hasTypeMatchingCallback(function (Type $type) : bool {
+        return $this->hasTypeMatchingCallback(static function (Type $type) : bool {
             return $type->isArrayLike();
         });
     }
@@ -1800,7 +1800,7 @@ class UnionType implements Serializable
      */
     public function hasArray() : bool
     {
-        return $this->hasTypeMatchingCallback(function (Type $type) : bool {
+        return $this->hasTypeMatchingCallback(static function (Type $type) : bool {
             return $type instanceof ArrayType;
         });
     }
@@ -1812,7 +1812,7 @@ class UnionType implements Serializable
      */
     public function hasGenericArray() : bool
     {
-        return $this->hasTypeMatchingCallback(function (Type $type) : bool {
+        return $this->hasTypeMatchingCallback(static function (Type $type) : bool {
             return $type instanceof GenericArrayInterface;
         });
     }
@@ -1824,7 +1824,7 @@ class UnionType implements Serializable
      */
     public function hasArrayAccess() : bool
     {
-        return $this->hasTypeMatchingCallback(function (Type $type) : bool {
+        return $this->hasTypeMatchingCallback(static function (Type $type) : bool {
             return $type->isArrayAccess();
         });
     }
@@ -1851,7 +1851,7 @@ class UnionType implements Serializable
      */
     public function hasTraversable() : bool
     {
-        return $this->hasTypeMatchingCallback(function (Type $type) : bool {
+        return $this->hasTypeMatchingCallback(static function (Type $type) : bool {
             return $type->isTraversable();
         });
     }
@@ -1868,7 +1868,7 @@ class UnionType implements Serializable
             return false;
         }
 
-        return !$this->hasTypeMatchingCallback(function (Type $type) : bool {
+        return !$this->hasTypeMatchingCallback(static function (Type $type) : bool {
             return !$type->isArrayLike() || $type->getIsNullable();
         });
     }
@@ -1885,7 +1885,7 @@ class UnionType implements Serializable
             return false;
         }
 
-        return !$this->hasTypeMatchingCallback(function (Type $type) : bool {
+        return !$this->hasTypeMatchingCallback(static function (Type $type) : bool {
             return !($type instanceof ArrayType) || $type->getIsNullable();
         });
     }
@@ -1896,7 +1896,7 @@ class UnionType implements Serializable
      */
     public function nonNativeTypes() : UnionType
     {
-        return $this->makeFromFilter(function (Type $type) : bool {
+        return $this->makeFromFilter(static function (Type $type) : bool {
             return !$type->isNativeType();
         });
     }
@@ -2057,7 +2057,7 @@ class UnionType implements Serializable
      */
     public function nonGenericArrayTypes() : UnionType
     {
-        return $this->makeFromFilter(function (Type $type) : bool {
+        return $this->makeFromFilter(static function (Type $type) : bool {
             return !($type instanceof GenericArrayInterface);
         });
     }
@@ -2072,7 +2072,7 @@ class UnionType implements Serializable
      */
     public function genericArrayTypes() : UnionType
     {
-        return $this->makeFromFilter(function (Type $type) : bool {
+        return $this->makeFromFilter(static function (Type $type) : bool {
             return $type instanceof GenericArrayInterface;
         });
     }
@@ -2087,7 +2087,7 @@ class UnionType implements Serializable
      */
     public function objectTypes() : UnionType
     {
-        return $this->makeFromFilter(function (Type $type) : bool {
+        return $this->makeFromFilter(static function (Type $type) : bool {
             return $type->isObject();
         });
     }
@@ -2102,7 +2102,7 @@ class UnionType implements Serializable
      */
     public function objectTypesWithKnownFQSENs() : UnionType
     {
-        return $this->makeFromFilter(function (Type $type) : bool {
+        return $this->makeFromFilter(static function (Type $type) : bool {
             return $type->isObjectWithKnownFQSEN();
         });
     }
@@ -2114,7 +2114,7 @@ class UnionType implements Serializable
      */
     public function hasObjectTypes() : bool
     {
-        return $this->hasTypeMatchingCallback((function (Type $type) : bool {
+        return $this->hasTypeMatchingCallback((static function (Type $type) : bool {
             return $type->isObject();
         }));
     }
@@ -2128,7 +2128,7 @@ class UnionType implements Serializable
      */
     public function hasPossiblyObjectTypes() : bool
     {
-        return $this->hasTypeMatchingCallback((function (Type $type) : bool {
+        return $this->hasTypeMatchingCallback((static function (Type $type) : bool {
             return $type->isPossiblyObject();
         }));
     }
@@ -2146,7 +2146,7 @@ class UnionType implements Serializable
      */
     public function scalarTypes() : UnionType
     {
-        return $this->nonNullableClone()->makeFromFilter(function (Type $type) : bool {
+        return $this->nonNullableClone()->makeFromFilter(static function (Type $type) : bool {
             return $type->isScalar();
         });
     }
@@ -2165,7 +2165,7 @@ class UnionType implements Serializable
      */
     public function callableTypes() : UnionType
     {
-        return $this->makeFromFilter(function (Type $type) : bool {
+        return $this->makeFromFilter(static function (Type $type) : bool {
             return $type->isCallable();
         });
     }
@@ -2181,7 +2181,7 @@ class UnionType implements Serializable
      */
     public function intTypes() : UnionType
     {
-        return $this->makeFromFilter(function (Type $type) : bool {
+        return $this->makeFromFilter(static function (Type $type) : bool {
             // IntType and LiteralType
             return $type instanceof IntType;
         });
@@ -2198,7 +2198,7 @@ class UnionType implements Serializable
      */
     public function stringTypes() : UnionType
     {
-        return $this->makeFromFilter(function (Type $type) : bool {
+        return $this->makeFromFilter(static function (Type $type) : bool {
             // IntType and LiteralStringType
             return $type instanceof StringType;
         });
@@ -2215,7 +2215,7 @@ class UnionType implements Serializable
      */
     public function numericTypes() : UnionType
     {
-        return $this->makeFromFilter(function (Type $type) : bool {
+        return $this->makeFromFilter(static function (Type $type) : bool {
             // IntType and LiteralStringType
             return $type->getIsPossiblyNumeric();
         });
@@ -2236,7 +2236,7 @@ class UnionType implements Serializable
      */
     public function hasCallableType() : bool
     {
-        return $this->hasTypeMatchingCallback(function (Type $type) : bool {
+        return $this->hasTypeMatchingCallback(static function (Type $type) : bool {
             return $type->isCallable();
         });
     }
@@ -2256,7 +2256,7 @@ class UnionType implements Serializable
      */
     public function isExclusivelyCallable() : bool
     {
-        return !$this->hasTypeMatchingCallback(function (Type $type) : bool {
+        return !$this->hasTypeMatchingCallback(static function (Type $type) : bool {
             return !$type->isCallable();
         });
     }
@@ -2290,7 +2290,7 @@ class UnionType implements Serializable
     public function nonArrayTypes() : UnionType
     {
         return $this->makeFromFilter(
-            function (Type $type) : bool {
+            static function (Type $type) : bool {
                 return !($type instanceof ArrayType);
             }
         );
@@ -2307,7 +2307,7 @@ class UnionType implements Serializable
     public function arrayTypes() : UnionType
     {
         return $this->makeFromFilter(
-            function (Type $type) : bool {
+            static function (Type $type) : bool {
                 return $type instanceof ArrayType;
             }
         );
@@ -2323,7 +2323,7 @@ class UnionType implements Serializable
             return false;
         }
 
-        return !$this->hasTypeMatchingCallback(function (Type $type) : bool {
+        return !$this->hasTypeMatchingCallback(static function (Type $type) : bool {
             return !($type instanceof GenericArrayInterface);
         });
     }
@@ -2489,7 +2489,7 @@ class UnionType implements Serializable
      */
     public function elementTypesToGenericArray(int $key_type) : UnionType
     {
-        $parts = \array_map(function (Type $type) use ($key_type) : Type {
+        $parts = \array_map(static function (Type $type) use ($key_type) : Type {
             if ($type instanceof MixedType) {
                 return ArrayType::instance(false);
             }
@@ -2524,7 +2524,7 @@ class UnionType implements Serializable
      */
     public function withMappedElementTypes(Closure $closure) : UnionType
     {
-        return $this->asMappedUnionType(function (Type $type) use ($closure) : Type {
+        return $this->asMappedUnionType(static function (Type $type) use ($closure) : Type {
             if ($type instanceof ArrayShapeType) {
                 $field_types = array_map($closure, $type->getFieldTypes());
                 $result = ArrayShapeType::fromFieldTypes($field_types, $type->getIsNullable());
@@ -2556,7 +2556,7 @@ class UnionType implements Serializable
     public function asGenericArrayTypes(int $key_type) : UnionType
     {
         return $this->asMappedUnionType(
-            function (Type $type) use ($key_type) : Type {
+            static function (Type $type) use ($key_type) : Type {
                 return $type->asGenericArrayType($key_type);
             }
         );
@@ -2576,7 +2576,7 @@ class UnionType implements Serializable
             return ArrayType::instance(false)->asUnionType();
         }
         return $this->asMappedUnionType(
-            function (Type $type) use ($key_type) : Type {
+            static function (Type $type) use ($key_type) : Type {
                 return $type->asGenericArrayType($key_type);
             }
         );
@@ -2767,7 +2767,7 @@ class UnionType implements Serializable
         // representations of each type
         $types = $this->type_set;
         $type_name_list =
-            \array_map(function (Type $type) : string {
+            \array_map(static function (Type $type) : string {
                 return (string)$type;
             }, $types);
 
@@ -3226,7 +3226,7 @@ class UnionType implements Serializable
             // We don't know anything about this type, this should be replaced by more specific argument types.
             return true;
         }
-        return $this->hasTypeMatchingCallback(function (Type $type) : bool {
+        return $this->hasTypeMatchingCallback(static function (Type $type) : bool {
             return $type->shouldBeReplacedBySpecificTypes();
         });
     }
@@ -3368,7 +3368,7 @@ class UnionType implements Serializable
     {
         // TODO: Extend to LiteralFloatType
         /** @param int|float $value */
-        return $this->applyNumericOperation(function ($value) : ScalarType {
+        return $this->applyNumericOperation(static function ($value) : ScalarType {
             $result = -$value;
             if (\is_int($result)) {
                 return LiteralIntType::instanceForValue($result, false);
@@ -3414,7 +3414,7 @@ class UnionType implements Serializable
     public function applyUnaryPlusOperator() : UnionType
     {
         /** @param int|float $value */
-        return $this->applyNumericOperation(function ($value) : ScalarType {
+        return $this->applyNumericOperation(static function ($value) : ScalarType {
             $result = +$value;
             if (\is_int($result)) {
                 return LiteralIntType::instanceForValue($result, false);

--- a/src/Phan/LanguageServer/CompletionRequest.php
+++ b/src/Phan/LanguageServer/CompletionRequest.php
@@ -183,7 +183,7 @@ final class CompletionRequest extends NodeInfoRequest
                      * @param string $a
                      * @param string $b
                      */
-                    function ($a, $b) : int {
+                    static function ($a, $b) : int {
                         $a = ltrim((string)$a, '$');
                         $b = ltrim((string)$b, '$');
                         return (strtolower($a) <=> strtolower($b)) ?: ($a <=> $b);

--- a/src/Phan/LanguageServer/CompletionResolver.php
+++ b/src/Phan/LanguageServer/CompletionResolver.php
@@ -33,7 +33,7 @@ class CompletionResolver
     {
         // TODO: Could use the parent node list
         // (e.g. don't use a method with a void return as an argument to another function)
-        return function (Context $context, Node $node, array $unused_parent_node_list) use ($request, $code_base) {
+        return static function (Context $context, Node $node, array $unused_parent_node_list) use ($request, $code_base) {
             // @phan-suppress-next-line PhanUndeclaredProperty this is overridden
             $selected_fragment = $node->selectedFragment ?? null;
             if (is_string($selected_fragment)) {

--- a/src/Phan/LanguageServer/DefinitionResolver.php
+++ b/src/Phan/LanguageServer/DefinitionResolver.php
@@ -39,7 +39,7 @@ class DefinitionResolver
         /**
          * @param array<int,Node> $parent_node_list
          */
-        return function (Context $context, Node $node, array $parent_node_list = []) use ($request, $code_base) {
+        return static function (Context $context, Node $node, array $parent_node_list = []) use ($request, $code_base) {
             // @phan-suppress-next-line PhanUndeclaredProperty this is overridden
             $selected_fragment = $node->selectedFragment ?? null;
             if (is_string($selected_fragment)) {

--- a/src/Phan/LanguageServer/LanguageServer.php
+++ b/src/Phan/LanguageServer/LanguageServer.php
@@ -257,14 +257,14 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
                  * @param int|null $pid
                  * @return void
                  */
-                function ($signo, $status = null, $pid = null) use (&$got_signal) {
+                static function ($signo, $status = null, $pid = null) use (&$got_signal) {
                     $got_signal = true;
                     Request::childSignalHandler($signo, $status, $pid);
                 }
             );
         }
 
-        $make_language_server = function (ProtocolStreamReader $in, ProtocolStreamWriter $out) use ($code_base, $file_path_lister) : LanguageServer {
+        $make_language_server = static function (ProtocolStreamReader $in, ProtocolStreamWriter $out) use ($code_base, $file_path_lister) : LanguageServer {
             return new LanguageServer(
                 $in,
                 $out,

--- a/src/Phan/LanguageServer/Utils.php
+++ b/src/Phan/LanguageServer/Utils.php
@@ -27,7 +27,7 @@ class Utils
      */
     public static function crash(Throwable $err)
     {
-        Loop\nextTick(function () use ($err) {
+        Loop\nextTick(static function () use ($err) {
             // @phan-suppress-next-line PhanThrowTypeAbsent this is meant to crash the loop for debugging.
             throw $err;
         });

--- a/src/Phan/Library/Map.php
+++ b/src/Phan/Library/Map.php
@@ -75,7 +75,7 @@ class Map extends SplObjectStorage
              * @param K|V $element
              * @return K|V
              */
-            function ($element) {
+            static function ($element) {
                 return clone($element);
             };
         return $this->keyValueMap($clone, $clone);

--- a/src/Phan/Library/Set.php
+++ b/src/Phan/Library/Set.php
@@ -210,7 +210,7 @@ class Set extends \SplObjectStorage
              * @param T $element
              * @return object
              */
-            function ($element) {
+            static function ($element) {
                 return clone($element);
             }
         );

--- a/src/Phan/Ordering.php
+++ b/src/Phan/Ordering.php
@@ -132,7 +132,7 @@ class Ordering
                  * @param array{depth:int,file:string} $a
                  * @param array{depth:int,file:string} $b
                  */
-                function (array $a, array $b) : int {
+                static function (array $a, array $b) : int {
                     return ($a['depth'] <=> $b['depth']) ?:
                            strcmp($a['file'], $b['file']);
                 }

--- a/src/Phan/Output/Colorizing.php
+++ b/src/Phan/Output/Colorizing.php
@@ -116,7 +116,7 @@ class Colorizing
     ) : string {
         $i = 0;
         /** @param array<int,string> $matches */
-        return preg_replace_callback('/{([A-Z_]+)}|%[sdf]/', function (array $matches) use ($template, $template_parameters, &$i) : string {
+        return preg_replace_callback('/{([A-Z_]+)}|%[sdf]/', static function (array $matches) use ($template, $template_parameters, &$i) : string {
             $j = $i++;
             if ($j >= count($template_parameters)) {
                 error_log("Missing argument for colorized output ($template), offset $j");

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -539,7 +539,7 @@ class ParseVisitor extends ScopeVisitor
                         $property->setHasStaticInUnionType(true);
                     }
                 }
-                if ($variable_type->hasGenericArray() && !$original_property_type->hasTypeMatchingCallback(function (Type $type) : bool {
+                if ($variable_type->hasGenericArray() && !$original_property_type->hasTypeMatchingCallback(static function (Type $type) : bool {
                     return \get_class($type) !== ArrayType::class;
                 })) {
                     // Don't convert `/** @var T[] */ public $x = []` to union type `T[]|array`

--- a/src/Phan/Phan.php
+++ b/src/Phan/Phan.php
@@ -334,7 +334,7 @@ class Phan implements IgnoredFilesFilterInterface
             // analysis
             $analyze_file_path_list = array_filter(
                 $analyze_file_path_list,
-                function (string $file_path) : bool {
+                static function (string $file_path) : bool {
                     return !self::isExcludedAnalysisFile($file_path);
                 }
             );
@@ -364,7 +364,7 @@ class Phan implements IgnoredFilesFilterInterface
              * This worker takes a file and analyzes it
              * @return void
              */
-            $analysis_worker = function (int $i, string $file_path) use ($file_count, $code_base, $temporary_file_mapping, $request) {
+            $analysis_worker = static function (int $i, string $file_path) use ($file_count, $code_base, $temporary_file_mapping, $request) {
                 CLI::progress('analyze', ($i + 1) / $file_count);
                 Analysis::analyzeFile($code_base, $file_path, $request, $temporary_file_mapping[$file_path] ?? null);
             };
@@ -391,13 +391,13 @@ class Phan implements IgnoredFilesFilterInterface
                 $pool = new ForkPool(
                     $process_file_list_map,
                     /** @return void */
-                    function () {
+                    static function () {
                         // Remove any issues that were collected prior to forking
                         // to prevent duplicate issues in the output.
                         self::getIssueCollector()->reset();
                     },
                     $analysis_worker,
-                    function () use ($code_base) : array {
+                    static function () use ($code_base) : array {
                         // This closure is run once, after running analysis_worker on each input.
                         // If there are any plugins defining finalizeProcess(), run those.
                         ConfigPluginSet::instance()->finalizeProcess($code_base);

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -742,7 +742,7 @@ final class ConfigPluginSet extends PluginV2 implements
         }
         // Add user-defined plugins.
         $plugin_set = array_map(
-            function (string $plugin_file_name) : PluginV2 {
+            static function (string $plugin_file_name) : PluginV2 {
                 $plugin_file_name = self::normalizePluginPath($plugin_file_name);
 
                 try {

--- a/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
@@ -159,7 +159,7 @@ final class ArrayReturnTypeOverridePlugin extends PluginV2 implements
                     } elseif (\count($args) === 1) {
                         // array_filter with count($args) === 1 implies elements of the resulting array aren't falsey
                         return $generic_passed_array_type->withFlattenedArrayShapeOrLiteralTypeInstances()
-                                                         ->withMappedElementTypes(function (UnionType $union_type) : UnionType {
+                                                         ->withMappedElementTypes(static function (UnionType $union_type) : UnionType {
                                                             return $union_type->nonFalseyClone();
                                                          });
                     }
@@ -231,7 +231,7 @@ final class ArrayReturnTypeOverridePlugin extends PluginV2 implements
             /**
              * @param Node|int|string|float|null $argument
              */
-            $get_argument_type = function ($argument, int $i) use ($code_base, $context, &$cache_outer) : UnionType {
+            $get_argument_type = static function ($argument, int $i) use ($code_base, $context, &$cache_outer) : UnionType {
                 if (isset($cache_outer[$i])) {
                     return $cache_outer[$i];
                 }
@@ -249,7 +249,7 @@ final class ArrayReturnTypeOverridePlugin extends PluginV2 implements
             /**
              * @param Node|int|string|float|null $argument
              */
-            $get_argument_type_for_array_map = function ($argument, int $i) use ($get_argument_type, &$cache) : UnionType {
+            $get_argument_type_for_array_map = static function ($argument, int $i) use ($get_argument_type, &$cache) : UnionType {
                 if (isset($cache[$i])) {
                     return $cache[$i];
                 }

--- a/src/Phan/Plugin/Internal/CallableParamPlugin.php
+++ b/src/Phan/Plugin/Internal/CallableParamPlugin.php
@@ -38,7 +38,7 @@ final class CallableParamPlugin extends PluginV2 implements
         if ($closure !== null) {
             return $closure;
         }
-        $closure = function (CodeBase $code_base, Context $context, FunctionInterface $function, array $args) use ($callable_params, $class_params) {
+        $closure = static function (CodeBase $code_base, Context $context, FunctionInterface $function, array $args) use ($callable_params, $class_params) {
             // TODO: Implement support for variadic callable arguments.
             foreach ($callable_params as $i) {
                 $arg = $args[$i] ?? null;
@@ -93,19 +93,19 @@ final class CallableParamPlugin extends PluginV2 implements
     private function getAnalyzeFunctionCallClosuresStatic(CodeBase $code_base) : array
     {
         $result = [];
-        $add_callable_checker_closure = function (FunctionInterface $function) use (&$result) {
+        $add_callable_checker_closure = static function (FunctionInterface $function) use (&$result) {
             $callable_params = [];
             $class_params = [];
             foreach ($function->getParameterList() as $i => $param) {
                 // If there's a type such as Closure|string|int, don't automatically assume that any string or array passed in is meant to be a callable.
                 // Explicitly require at least one type to be `callable`
-                if ($param->getUnionType()->hasTypeMatchingCallback(function (Type $type) : bool {
+                if ($param->getUnionType()->hasTypeMatchingCallback(static function (Type $type) : bool {
                     // TODO: More specific closure for CallableDeclarationType
                     return $type instanceof CallableInterface;
                 })) {
                     $callable_params[] = $i;
                 }
-                if ($param->getUnionType()->hasTypeMatchingCallback(function (Type $type) : bool {
+                if ($param->getUnionType()->hasTypeMatchingCallback(static function (Type $type) : bool {
                     return $type instanceof ClassStringType;
                 })) {
                     $class_params[] = $i;
@@ -119,14 +119,14 @@ final class CallableParamPlugin extends PluginV2 implements
             $result[$function->getFQSEN()->__toString()] = self::generateClosure($callable_params, $class_params);
         };
 
-        $add_another_closure = function (string $fqsen, Closure $closure) use (&$result) {
+        $add_another_closure = static function (string $fqsen, Closure $closure) use (&$result) {
             $result[$fqsen] = ConfigPluginSet::mergeAnalyzeFunctionCallClosures(
                 $closure,
                 $result[$fqsen] ?? null
             );
         };
 
-        $add_misc_closures = function (FunctionInterface $function) use ($add_callable_checker_closure, $add_another_closure, $code_base) {
+        $add_misc_closures = static function (FunctionInterface $function) use ($add_callable_checker_closure, $add_another_closure, $code_base) {
             $add_callable_checker_closure($function);
             // @phan-suppress-next-line PhanAccessMethodInternal
             $closure = $function->getCommentParamAssertionClosure($code_base);

--- a/src/Phan/Plugin/Internal/ClosureReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ClosureReturnTypeOverridePlugin.php
@@ -156,7 +156,7 @@ final class ClosureReturnTypeOverridePlugin extends PluginV2 implements
                 return ClosureType::instance(false)->asUnionType();
             }
             $types = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $args[0], true);
-            $types = $types->makeFromFilter(function (Type $type) : bool {
+            $types = $types->makeFromFilter(static function (Type $type) : bool {
                 if ($type instanceof ClosureType) {
                     return $type->hasKnownFQSEN();
                 }
@@ -282,7 +282,7 @@ final class ClosureReturnTypeOverridePlugin extends PluginV2 implements
         /**
          * @param Node|int|string|float|null $argument
          */
-        return function ($argument, int $i) use ($code_base, $context, &$cache) : UnionType {
+        return static function ($argument, int $i) use ($code_base, $context, &$cache) : UnionType {
             $argument_type = $cache[$i] ?? null;
             if (isset($argument_type)) {
                 return $argument_type;

--- a/src/Phan/Plugin/Internal/CompactPlugin.php
+++ b/src/Phan/Plugin/Internal/CompactPlugin.php
@@ -46,7 +46,7 @@ final class CompactPlugin extends PluginV2 implements
             Func $unused_func,
             array $args
         ) {
-            $maybe_emit_issue = function (string $variable_name, $arg = null) use ($code_base, $context) {
+            $maybe_emit_issue = static function (string $variable_name, $arg = null) use ($code_base, $context) {
                 if (!$context->getScope()->hasVariableWithName($variable_name)) {
                     Issue::maybeEmitWithParameters(
                         $code_base,

--- a/src/Phan/Plugin/Internal/MethodSearcherPlugin.php
+++ b/src/Phan/Plugin/Internal/MethodSearcherPlugin.php
@@ -122,7 +122,7 @@ final class MethodSearcherPlugin extends PluginV2 implements
             fwrite(STDERR, "Phoogle could not find '$fqsen' in any namespace\n");
             exit(EXIT_FAILURE);
         }
-        return array_map(function (FullyQualifiedClassName $fqsen) use ($type) : Type {
+        return array_map(static function (FullyQualifiedClassName $fqsen) use ($type) : Type {
             return $fqsen->asType()->withIsNullable($type->getIsNullable());
         }, $fqsens);
     }

--- a/src/Phan/Plugin/Internal/MiscParamPlugin.php
+++ b/src/Phan/Plugin/Internal/MiscParamPlugin.php
@@ -49,7 +49,7 @@ final class MiscParamPlugin extends PluginV2 implements
         /**
          * @return void
          */
-        $min_max_callback = function (
+        $min_max_callback = static function (
             CodeBase $code_base,
             Context $context,
             FunctionInterface $function,
@@ -63,7 +63,7 @@ final class MiscParamPlugin extends PluginV2 implements
                 $context,
                 $code_base,
                 ArrayType::instance(false)->asUnionType(),
-                function (UnionType $node_type) use ($context, $function) : IssueInstance {
+                static function (UnionType $node_type) use ($context, $function) : IssueInstance {
                     // "arg#1(values) is %s but {$function->getFQSEN()}() takes array when passed only one arg"
                     return Issue::fromType(Issue::ParamSpecial2)(
                         $context->getFile(),
@@ -82,7 +82,7 @@ final class MiscParamPlugin extends PluginV2 implements
         /**
          * @return void
          */
-        $array_udiff_callback = function (
+        $array_udiff_callback = static function (
             CodeBase $code_base,
             Context $context,
             FunctionInterface $function,
@@ -97,7 +97,7 @@ final class MiscParamPlugin extends PluginV2 implements
                 $context,
                 $code_base,
                 CallableType::instance(false)->asUnionType(),
-                function (UnionType $unused_node_type) use ($context, $function) : IssueInstance {
+                static function (UnionType $unused_node_type) use ($context, $function) : IssueInstance {
                     // "The last argument to {$function->getFQSEN()} must be a callable"
                     return Issue::fromType(Issue::ParamSpecial3)(
                         $context->getFile(),
@@ -116,7 +116,7 @@ final class MiscParamPlugin extends PluginV2 implements
                     $context,
                     $code_base,
                     ArrayType::instance(false)->asUnionType(),
-                    function (UnionType $node_type) use ($context, $function, $i) : IssueInstance {
+                    static function (UnionType $node_type) use ($context, $function, $i) : IssueInstance {
                         // "arg#".($i+1)." is %s but {$function->getFQSEN()}() takes array"
                         return Issue::fromType(Issue::ParamTypeMismatch)(
                             $context->getFile(),
@@ -138,7 +138,7 @@ final class MiscParamPlugin extends PluginV2 implements
          * @throws StopParamAnalysisException
          * to prevent Phan's default incorrect analysis of a call to join()
          */
-        $join_callback = function (
+        $join_callback = static function (
             CodeBase $code_base,
             Context $context,
             FunctionInterface $function,
@@ -153,7 +153,7 @@ final class MiscParamPlugin extends PluginV2 implements
                     $args[0],
                     $context,
                     $code_base,
-                    function (UnionType $node_type) use ($context, $function) : IssueInstance {
+                    static function (UnionType $node_type) use ($context, $function) : IssueInstance {
                         // "arg#1(pieces) is %s but {$function->getFQSEN()}() takes array when passed only 1 arg"
                         return Issue::fromType(Issue::ParamSpecial2)(
                             $context->getFile(),
@@ -252,7 +252,7 @@ final class MiscParamPlugin extends PluginV2 implements
         /**
          * @return void
          */
-        $array_uintersect_uassoc_callback = function (
+        $array_uintersect_uassoc_callback = static function (
             CodeBase $code_base,
             Context $context,
             FunctionInterface $function,
@@ -270,7 +270,7 @@ final class MiscParamPlugin extends PluginV2 implements
                 $context,
                 $code_base,
                 CallableType::instance(false)->asUnionType(),
-                function (UnionType $unused_node_type) use ($context, $function) : IssueInstance {
+                static function (UnionType $unused_node_type) use ($context, $function) : IssueInstance {
                     // "The last argument to {$function->getFQSEN()} must be a callable"
                     return Issue::fromType(Issue::ParamSpecial3)(
                         $context->getFile(),
@@ -288,7 +288,7 @@ final class MiscParamPlugin extends PluginV2 implements
                 $context,
                 $code_base,
                 CallableType::instance(false)->asUnionType(),
-                function (UnionType $unused_node_type) use ($context, $function) : IssueInstance {
+                static function (UnionType $unused_node_type) use ($context, $function) : IssueInstance {
                     // "The second last argument to {$function->getFQSEN()} must be a callable"
                     return Issue::fromType(Issue::ParamSpecial4)(
                         $context->getFile(),
@@ -307,7 +307,7 @@ final class MiscParamPlugin extends PluginV2 implements
                     $context,
                     $code_base,
                     ArrayType::instance(false)->asUnionType(),
-                    function (UnionType $node_type) use ($context, $function, $i) : IssueInstance {
+                    static function (UnionType $node_type) use ($context, $function, $i) : IssueInstance {
                     // "arg#".($i+1)." is %s but {$function->getFQSEN()}() takes array"
                         return Issue::fromType(Issue::ParamTypeMismatch)(
                             $context->getFile(),
@@ -328,7 +328,7 @@ final class MiscParamPlugin extends PluginV2 implements
          * @param Node|int|string|float|null $node
          * @return ?Variable the variable
          */
-        $get_variable = function (
+        $get_variable = static function (
             CodeBase $code_base,
             Context $context,
             $node
@@ -479,7 +479,7 @@ final class MiscParamPlugin extends PluginV2 implements
                 if (!is_string($field_name)) {
                     continue;
                 }
-                $add_variable = function (string $name) use ($context, $field_type, $scope) {
+                $add_variable = static function (string $name) use ($context, $field_type, $scope) {
                     if (!Variable::isValidIdentifier($name)) {
                         return;
                     }

--- a/src/Phan/Profile.php
+++ b/src/Phan/Profile.php
@@ -63,7 +63,7 @@ trait Profile
 
         // Create a shutdown function to emit the log when we're
         // all done
-        register_shutdown_function(function () {
+        register_shutdown_function(static function () {
             $label_metric_map = [];
 
             // Compute whatever metric we care about
@@ -79,7 +79,7 @@ trait Profile
             }
 
             // Sort such that the highest metric value is on top
-            uasort($label_metric_map, function (array $a, array $b) : int {
+            uasort($label_metric_map, static function (array $a, array $b) : int {
                 return $b[1] <=> $a[1];
             });
 
@@ -87,7 +87,7 @@ trait Profile
             foreach ($label_metric_map as $label => $metrics) {
                 print $label
                     . "\t"
-                    . implode("\t", array_map(function (float $v) : string {
+                    . implode("\t", array_map(static function (float $v) : string {
                         return sprintf("%0.6f", $v);
                     }, $metrics))
                     . "\n";

--- a/src/phan.php
+++ b/src/phan.php
@@ -33,7 +33,7 @@ $cli = CLI::fromArgv();
 $is_issue_found =
     Phan::analyzeFileList(
         $code_base,
-        function (bool $recompute_file_list = false) use ($cli) : array {
+        static function (bool $recompute_file_list = false) use ($cli) : array {
             if ($recompute_file_list) {
                 $cli->recomputeFileList();
             }

--- a/src/prep.php
+++ b/src/prep.php
@@ -19,7 +19,7 @@ $file_list = $cli->getFileList();
 
 // This is an example visitor. Do whatever you like here
 // to scan all nodes.
-$visit_node = function (\ast\Node $node, string $file_path) {
+$visit_node = static function (\ast\Node $node, string $file_path) {
 
     // Take a look at Phan\AST\Visitor\Element to see all
     // of the kinds of nodes

--- a/src/spl_object_id.php
+++ b/src/spl_object_id.php
@@ -9,7 +9,7 @@ if (function_exists('spl_object_id')) {
     return;
 }
 // Workaround for global suppression
-call_user_func(function () {
+call_user_func(static function () {
     if (function_exists('runkit_object_id') &&
         !(new ReflectionFunction('runkit_object_id'))->isUserDefined()) {  // @phan-suppress-current-line PhanUndeclaredFunctionInCallable
         /**

--- a/tests/Phan/AST/TolerantASTConverter/ConversionTest.php
+++ b/tests/Phan/AST/TolerantASTConverter/ConversionTest.php
@@ -70,7 +70,7 @@ final class ConversionTest extends BaseTest
             }
             $token_counts[$file] = count(token_get_all($contents));
         }
-        usort($files, function (string $path1, string $path2) use ($token_counts) : int {
+        usort($files, static function (string $path1, string $path2) use ($token_counts) : int {
             return $token_counts[$path1] <=> $token_counts[$path2];
         });
     }

--- a/tests/Phan/AbstractPhanFileTest.php
+++ b/tests/Phan/AbstractPhanFileTest.php
@@ -94,7 +94,7 @@ abstract class AbstractPhanFileTest extends BaseTest implements CodeBaseAwareTes
     {
         $files = array_filter(
             scandir($source_dir) ?: [],
-            function (string $filename) : bool {
+            static function (string $filename) : bool {
                 // Ignore directories and hidden files.
                 return !in_array($filename, ['.', '..'], true) && substr($filename, 0, 1) !== '.' && preg_match('@\.php$@', $filename);
             }
@@ -113,7 +113,7 @@ abstract class AbstractPhanFileTest extends BaseTest implements CodeBaseAwareTes
             $files,
             array_map(
                 /** @return array{0:array{0:string},1:string} */
-                function (string $filename) use ($source_dir, $expected_dir, $suffix) : array {
+                static function (string $filename) use ($source_dir, $expected_dir, $suffix) : array {
                     return [
                         [self::getFileForPHPVersion($source_dir . DIRECTORY_SEPARATOR . $filename, $suffix)],
                         self::getFileForPHPVersion($expected_dir . DIRECTORY_SEPARATOR . $filename . self::EXPECTED_SUFFIX, $suffix),
@@ -124,7 +124,7 @@ abstract class AbstractPhanFileTest extends BaseTest implements CodeBaseAwareTes
         );
     }
 
-    protected function getFileForPHPVersion(string $path, string $suffix) : string
+    protected static function getFileForPHPVersion(string $path, string $suffix) : string
     {
         $suffix_path = $path . $suffix;
         if (file_exists($suffix_path)) {
@@ -177,7 +177,7 @@ abstract class AbstractPhanFileTest extends BaseTest implements CodeBaseAwareTes
         Phan::setIssueCollector(new BufferingCollector());
 
         // @phan-suppress-next-line PhanThrowTypeAbsentForCall should not throw Exception for any passing tests
-        Phan::analyzeFileList($this->code_base, function () use ($test_file_list) : array {
+        Phan::analyzeFileList($this->code_base, static function () use ($test_file_list) : array {
             return $test_file_list;
         });
 

--- a/tests/Phan/CLITest.php
+++ b/tests/Phan/CLITest.php
@@ -46,7 +46,7 @@ final class CLITest extends BaseTest
 
     public function getFlagSuggestionStringProvider() : array
     {
-        $wrap_suggestion = function (string $text) : string {
+        $wrap_suggestion = static function (string $text) : string {
             return " (did you mean $text?)";
         };
         return [

--- a/tests/Phan/Debug/FrameTest.php
+++ b/tests/Phan/Debug/FrameTest.php
@@ -35,7 +35,7 @@ final class FrameTest extends BaseTest
         $this->assertHasEncodedValue('[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ... 5 more element(s)]', range(1, 15));
         $this->assertHasEncodedValue('{"key":"value://something"}', ['key' => 'value://something']);
         $this->assertHasEncodedValue('[]', []);
-        $this->assertHasEncodedValue('Closure', function () {
+        $this->assertHasEncodedValue('Closure', static function () {
         });
         $this->assertHasEncodedValue('stdClass({})', new stdClass());
         $this->assertHasEncodedValue('stdClass({"key":"value","2":"other"})', (object)['key' => 'value', '2' => 'other']);

--- a/tests/Phan/ForkPoolTest.php
+++ b/tests/Phan/ForkPoolTest.php
@@ -28,17 +28,17 @@ final class ForkPoolTest extends BaseTest
         $pool = new ForkPool(
             $data,
             /** @return void */
-            function () {
+            static function () {
             },
             /**
              * @param int $unused_i
              * @param array $data
              * @return void
              */
-            function ($unused_i, $data) use (&$worker_data) {
+            static function ($unused_i, $data) use (&$worker_data) {
                 $worker_data[] = $data;
             },
-            function () use (&$worker_data) : array {
+            static function () use (&$worker_data) : array {
                 return $worker_data;
             }
         );
@@ -57,7 +57,7 @@ final class ForkPoolTest extends BaseTest
             /**
              * @return void
              */
-            function () use (&$did_startup) {
+            static function () use (&$did_startup) {
                 $did_startup = true;
             },
             /**
@@ -65,9 +65,9 @@ final class ForkPoolTest extends BaseTest
              * @param mixed $unused_data
              * @return void
              */
-            function ($unused_i, $unused_data) {
+            static function ($unused_i, $unused_data) {
             },
-            function () use (&$did_startup) : array {
+            static function () use (&$did_startup) : array {
                 return [$did_startup];
             }
         );

--- a/tests/Phan/Language/EmptyUnionTypeTest.php
+++ b/tests/Phan/Language/EmptyUnionTypeTest.php
@@ -166,11 +166,11 @@ final class EmptyUnionTypeTest extends BaseTest
             case Closure::class:
                 return [
                     /** @param mixed ...$unused_args */
-                    function (...$unused_args) : bool {
+                    static function (...$unused_args) : bool {
                         return false;
                     },
                     /** @param mixed ...$unused_args */
-                    function (...$unused_args) : bool {
+                    static function (...$unused_args) : bool {
                         return true;
                     },
                 ];

--- a/tests/Phan/Language/UnionTypeTest.php
+++ b/tests/Phan/Language/UnionTypeTest.php
@@ -459,7 +459,7 @@ final class UnionTypeTest extends BaseTest
         $types = $union_type->getTypeSet();
         $type = reset($types);
 
-        $array_type = function (Type $type) : GenericArrayType {
+        $array_type = static function (Type $type) : GenericArrayType {
             return self::createGenericArrayTypeWithMixedKey($type, false);
         };
 

--- a/tests/Phan/LanguageServer/LanguageServerTest.php
+++ b/tests/Phan/LanguageServer/LanguageServerTest.php
@@ -19,7 +19,7 @@ final class LanguageServerTest extends BaseTest
 {
     public function testInitialize()
     {
-        $mock_file_path_lister = function () : array {
+        $mock_file_path_lister = static function () : array {
             return [];
         };
         $code_base = new CodeBase([], [], [], [], []);


### PR DESCRIPTION
static closures are easier for the interpreter to garbage collect in some cases.

- visitMethod and visitFuncDecl really don't need to merge the context
  lists, they're independent (param list, return type, statement list). That was inefficient and pointless
- Don't use node->lineno ?? 0 if node is non-null
- skip type hint for extremely frequently used methods
