### PR TITLE
Add plugin to warn about non-FQ uses of functions/constants

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -439,7 +439,6 @@ return [
     // or relative/absolute paths to the plugin (Relative to the project root).
     'plugins' => [
         'AlwaysReturnPlugin',
-        'DemoPlugin',
         'DollarDollarPlugin',
         'UnreachableCodePlugin',
         'DuplicateArrayKeyPlugin',

--- a/.phan/plugins/NotFullyQualifiedUsagePlugin.php
+++ b/.phan/plugins/NotFullyQualifiedUsagePlugin.php
@@ -1,0 +1,196 @@
+<?php declare(strict_types=1);
+
+use ast\Node;
+use Phan\PluginV2;
+use Phan\PluginV2\PluginAwarePostAnalysisVisitor;
+use Phan\PluginV2\PostAnalyzeNodeCapability;
+
+/**
+ * This warns if references to global functions or global constants are not fully qualified.
+ *
+ * This Plugin hooks into one event:
+ *
+ * - getPostAnalyzeNodeVisitorClassName
+ *   This method returns a class that is called on every AST node from every
+ *   file being analyzed
+ */
+class NotFullyQualifiedUsagePlugin extends PluginV2 implements PostAnalyzeNodeCapability
+{
+
+    /**
+     * @return string - The name of the visitor that will be called (formerly analyzeNode)
+     * @override
+     */
+    public static function getPostAnalyzeNodeVisitorClassName() : string
+    {
+        return NotFullyQualifiedUsageVisitor::class;
+    }
+}
+
+/**
+ * When __invoke on this class is called with a node, a method
+ * will be dispatched based on the `kind` of the given node.
+ *
+ * Visitors such as this are useful for defining lots of different
+ * checks on a node based on its kind.
+ */
+class NotFullyQualifiedUsageVisitor extends PluginAwarePostAnalysisVisitor
+{
+    // Subclasses should declare protected $parent_node_list as an instance property if they need to know the list.
+
+    // @var array<int,Node> - Set after the constructor is called if an instance property with this name is declared
+    // protected $parent_node_list;
+
+    // A plugin's visitors should NOT implement visit(), unless they need to.
+
+    const NotFullyQualifiedFunctionCall = 'PhanPluginNotFullyQualifiedFunctionCall';
+    const NotFullyQualifiedOptimizableFunctionCall = 'PhanPluginNotFullyQualifiedOptimizableFunctionCall';
+    const NotFullyQualifiedGlobalConstant = 'PhanPluginNotFullyQualifiedGlobalConstant';
+
+    /**
+     * Source of functions: `zend_try_compile_special_func` from https://github.com/php/php-src/blob/master/Zend/zend_compile.c
+     */
+    const OPTIMIZABLE_FUNCTIONS = [
+        'array_key_exists' => true,
+        'array_slice' => true,
+        'boolval' => true,
+        'call_user_func' => true,
+        'call_user_func_array' => true,
+        'chr' => true,
+        'count' => true,
+        'defined' => true,
+        'doubleval' => true,
+        'floatval' => true,
+        'func_get_args' => true,
+        'func_num_args' => true,
+        'get_called_class' => true,
+        'get_class' => true,
+        'gettype' => true,
+        'in_array' => true,
+        'intval' => true,
+        'is_array' => true,
+        'is_bool' => true,
+        'is_double' => true,
+        'is_float' => true,
+        'is_int' => true,
+        'is_integer' => true,
+        'is_long' => true,
+        'is_null' => true,
+        'is_object' => true,
+        'is_real' => true,
+        'is_resource' => true,
+        'is_string' => true,
+        'ord' => true,
+        'strlen' => true,
+        'strval' => true,
+    ];
+
+    /**
+     * @param Node $node
+     * A node to analyze of type ast\AST_CALL (call to a global function)
+     *
+     * @return void
+     *
+     * @override
+     */
+    public function visitCall(Node $node)
+    {
+        $expression = $node->children['expr'];
+        if (!($expression instanceof Node) || $expression->kind !== ast\AST_NAME) {
+            return;
+        }
+        if (($expression->flags & ast\flags\NAME_NOT_FQ) !== ast\flags\NAME_NOT_FQ) {
+            // This is namespace\foo() or \NS\foo()
+            return;
+        }
+        if ($this->context->getNamespace() === '\\') {
+            // This is in the global namespace and is always fully qualified
+            return;
+        }
+        $function_name = $expression->children['name'];
+        if (!is_string($function_name)) {
+            // Possibly redundant.
+            return;
+        }
+        // TODO: Probably wrong for ast\parse_code - should check namespace map of USE_NORMAL for 'ast' there.
+        // Same for ContextNode->getFunction()
+        if ($this->context->hasNamespaceMapFor(\ast\flags\USE_FUNCTION, $function_name)) {
+            return;
+        }
+        $this->warnNotFullyQualifiedFunctionCall($function_name, $expression);
+    }
+
+    private function warnNotFullyQualifiedFunctionCall(string $function_name, Node $expression)
+    {
+        if (array_key_exists(strtolower($function_name), self::OPTIMIZABLE_FUNCTIONS)) {
+            $issue_type = self::NotFullyQualifiedOptimizableFunctionCall;
+            $issue_msg = 'Expected function call to {FUNCTION}() to be fully qualified or have a use statement but none were found in namespace {NAMESPACE} (opcache can optimize fully qualified calls to this function in recent php versions)';
+        } else {
+            $issue_type = self::NotFullyQualifiedFunctionCall;
+            $issue_msg = 'Expected function call to {FUNCTION}() to be fully qualified or have a use statement but none were found in namespace {NAMESPACE}';
+        }
+        $this->emitPluginIssue(
+            $this->code_base,
+            clone($this->context)->withLineNumberStart($expression->lineno),
+            $issue_type,
+            $issue_msg,
+            [$function_name, $this->context->getNamespace()]
+        );
+    }
+
+    /**
+     * @param Node $node
+     * A node to analyze of type ast\AST_CONST (reference to a constant)
+     *
+     * @return void
+     *
+     * @override
+     */
+    public function visitConst(Node $node)
+    {
+        $expression = $node->children['name'];
+        if (!($expression instanceof Node) || $expression->kind !== ast\AST_NAME) {
+            return;
+        }
+        if (($expression->flags & ast\flags\NAME_NOT_FQ) !== ast\flags\NAME_NOT_FQ) {
+            // This is namespace\SOME_CONST or \NS\SOME_CONST
+            return;
+        }
+        if ($this->context->getNamespace() === '\\') {
+            // This is in the global namespace and is always fully qualified
+            return;
+        }
+        $constant_name = $expression->children['name'];
+        if (!is_string($constant_name)) {
+            // Possibly redundant.
+            return;
+        }
+        $constant_name_lower = strtolower($constant_name);
+        if ($constant_name_lower === 'true' || $constant_name_lower === 'false' || $constant_name_lower === 'null') {
+            // These are keywords and are the same in any namespace
+            return;
+        }
+
+        // TODO: Probably wrong for ast\AST_NAME - should check namespace map of USE_NORMAL for 'ast' there.
+        // Same for ContextNode->getConst()
+        if ($this->context->hasNamespaceMapFor(\ast\flags\USE_CONST, $constant_name)) {
+            return;
+        }
+        $this->warnNotFullyQualifiedConstantUsage($constant_name, $expression);
+    }
+
+    private function warnNotFullyQualifiedConstantUsage(string $constant_name, Node $expression)
+    {
+        $this->emitPluginIssue(
+            $this->code_base,
+            clone($this->context)->withLineNumberStart($expression->lineno),
+            self::NotFullyQualifiedGlobalConstant,
+            'Expected usage of {CONST} to be fully qualified or have a use statement but none were found in namespace {NAMESPACE}',
+            [$constant_name, $this->context->getNamespace()]
+        );
+    }
+}
+
+// Every plugin needs to return an instance of itself at the
+// end of the file in which it's defined.
+return new NotFullyQualifiedUsagePlugin();

--- a/.phan/plugins/PrintfCheckerPlugin.php
+++ b/.phan/plugins/PrintfCheckerPlugin.php
@@ -20,7 +20,11 @@ use Phan\Language\UnionType;
 use Phan\PluginV2;
 use Phan\PluginV2\AnalyzeFunctionCallCapability;
 use Phan\PluginV2\ReturnTypeOverrideCapability;
+use function count;
 use function implode;
+use function is_object;
+use function is_string;
+use function strcasecmp;
 use function var_export;
 
 /**
@@ -328,7 +332,7 @@ class PrintfCheckerPlugin extends PluginV2 implements AnalyzeFunctionCallCapabil
 
     protected function encodeString(string $str) : string
     {
-        $result = \json_encode($str, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $result = \json_encode($str, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE);
         if ($result !== false) {
             return $result;
         }
@@ -754,7 +758,7 @@ class ConversionSpec
     {
         // echo "format is $fmt_str\n";
         $directives = [];
-        \preg_match_all(self::FORMAT_STRING_REGEX, (string) $fmt_str, $matches, PREG_SET_ORDER);
+        \preg_match_all(self::FORMAT_STRING_REGEX, (string) $fmt_str, $matches, \PREG_SET_ORDER);
         $unnamed_count = 0;
         foreach ($matches as $match) {
             if ($match[0] === '%%') {

--- a/.phan/plugins/README.md
+++ b/.phan/plugins/README.md
@@ -223,6 +223,14 @@ See https://secure.php.net/assert
 
 - **PhanPluginNoAssert**: `assert() is discouraged. Although phan supports using assert() for type annotations, PHP's documentation recommends assertions only for debugging, and assert() has surprising behaviors.`
 
+#### NotFullyQualifiedUsagePlugin.php
+
+Encourages the usage of fully qualified global functions and constants (slightly faster, especially for functions such as `strlen`, `count`, etc.)
+
+- **PhanPluginNotFullyQualifiedFunctionCall**: `Expected function call to {FUNCTION}() to be fully qualified or have a use statement but none were found in namespace {NAMESPACE}`
+- **PhanPluginNotFullyQualifiedOptimizableFunctionCall**: `Expected function call to {FUNCTION}() to be fully qualified or have a use statement but none were found in namespace {NAMESPACE} (opcache can optimize fully qualified calls to this function in recent php versions)`
+- **PhanPluginNotFullyQualifiedGlobalConstant**: `Expected usage of {CONST} to be fully qualified or have a use statement but none were found in namespace {NAMESPACE}`
+
 #### NumericalComparisonPlugin.php
 
 Enforces that loose equality is used for numeric operands (e.g. `2 == 2.0`), and that strict equality is used for non-numeric operands (e.g. `"2" === "2e0"` is false).

--- a/NEWS.md
+++ b/NEWS.md
@@ -41,6 +41,7 @@ Bug fixes:
 Plugins:
 + Infer a literal string return value when calling `sprintf` on known literal scalar types in `PrintfCheckerPlugin`. (#2131)
 + Infer that `;@foo();` is not a usage of `foo()` in `UseReturnValuePlugin`. (#2412)
++ Implement `NotFullyQualifiedUsagePlugin` to warn about uses of global functions and constants that aren't fully qualified. (#857)
 
 02 Feb 2019, Phan 1.2.2
 -----------------------


### PR DESCRIPTION
The PHP interpreter (and opcache) is not able to fully optimize uses
of functions/constants if the namespace is ambiguous.

This is useful in performance-sensitive files/functions,
but has negligible impact in infrequently used functions.

Fixes #857

Also, remove DemoPlugin from Phan's own config, this was added because it was the first plugin but it isn't that useful in practice for detecting issues.