### PR TITLE
Fix a crash seen when parsing `closure` in a different case

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@ Phan NEWS
 ?? ??? 2019, Phan 1.2.4 (dev)
 -----------------------
 
+Bug fixes:
++ Fix a crash seen when parsing return typehint for `Closure` in a different case (e.g. `closure`) (#2438)
+
 10 Feb 2019, Phan 1.2.3
 -----------------------
 

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -431,11 +431,11 @@ class Type
         $value = self::$canonical_object_map[$key] ?? null;
         if (!$value) {
             if ($namespace === '\\') {
-                switch ($type_name) {
-                    case 'Closure':
+                switch (strtolower($type_name)) {
+                    case 'closure':
                         $value = new ClosureType(
                             $namespace,
-                            $type_name,
+                            'Closure',
                             $template_parameter_type_list,
                             $is_nullable
                         );
@@ -443,7 +443,7 @@ class Type
                     case 'callable':
                         $value = new CallableType(
                             $namespace,
-                            $type_name,
+                            'callable',
                             $template_parameter_type_list,
                             $is_nullable
                         );
@@ -451,7 +451,7 @@ class Type
                     case 'callable-string':
                         $value = new CallableStringType(
                             $namespace,
-                            $type_name,
+                            'callable-string',
                             $template_parameter_type_list,
                             $is_nullable
                         );
@@ -459,7 +459,7 @@ class Type
                     case 'class-string':
                         $value = new ClassStringType(
                             $namespace,
-                            $type_name,
+                            'class-string',
                             $template_parameter_type_list,
                             $is_nullable
                         );

--- a/tests/files/expected/0632_closure_crash.php.expected
+++ b/tests/files/expected/0632_closure_crash.php.expected
@@ -1,0 +1,3 @@
+%s:7 PhanTypeMismatchReturn Returning type false but foo() is declared to return \Closure
+%s:15 PhanTypeMismatchReturn Returning type false but foo2() is declared to return \Closure
+%s:22 PhanTypeMismatchReturn Returning type false but foo_callable() is declared to return callable

--- a/tests/files/src/0632_closure_crash.php
+++ b/tests/files/src/0632_closure_crash.php
@@ -1,0 +1,26 @@
+<?php
+// XXX: In phpdoc, only Closure is accepted as an implementation detail (case-sensitive)
+function foo(): closure {
+    if (rand() % 2 > 0) {
+        return function() {};
+    }
+    return false;
+}
+
+/** @return closure */
+function foo2() {
+    if (rand() % 2 > 0) {
+        return function() {};
+    }
+    return false;
+}
+
+function foo_callable(): Callable {
+    if (rand() % 2 > 0) {
+        return 'strlen';
+    }
+    return false;
+}
+
+$bar = function() {
+};


### PR DESCRIPTION
Fixes #2438