### PR TITLE
Run all unit tests, fix failure in MethodSearcherPluginTest

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -80,6 +80,9 @@
         <testsuite name="PHP73Test">
             <file>tests/Phan/PHP73Test.php</file>
         </testsuite>
+        <testsuite name="All">
+            <directory>tests/Phan</directory>
+        </testsuite>
     </testsuites>
     <filter>
         <whitelist>
@@ -89,6 +92,4 @@
             </exclude>
         </whitelist>
     </filter>
-    <!-- Just in case a bug is introduced causing infinite recursion, add a memory limit. -->
-    <ini name="memory_limit" value="1G" />
 </phpunit>

--- a/src/Phan/Bootstrap.php
+++ b/src/Phan/Bootstrap.php
@@ -160,7 +160,7 @@ if (extension_loaded('ast')) {
     // Warn if the php-ast version is too low.
     $ast_version = (new ReflectionExtension('ast'))->getVersion();
     if (PHP_VERSION_ID >= 70400) {
-        if (version_compare($ast_version, '1.0.1') < 0) {
+        if (version_compare($ast_version, '1.0.0') <= 0) {
             fwrite(STDERR, "Phan is being run with php-ast version $ast_version.\n");
             fwrite(STDERR, "However, when run with PHP 7.4+, Phan requires php-ast 1.0.1 or newer. Older versions of php-ast will crash Phan.\n");
             fwrite(STDERR, "Alternately, to run this version of Phan with PHP 7.4 without upgrading php-ast, uninstall/disable php-ast in php.ini,"

--- a/tests/Phan/BaseTest.php
+++ b/tests/Phan/BaseTest.php
@@ -18,7 +18,8 @@ abstract class BaseTest extends TestCase
     public static function setUpBeforeClass()
     {
         parent::setUpBeforeClass();
-        ini_set('memory_limit', '1G');
+        // Need more than 1G to generate code coverage reports
+        ini_set('memory_limit', '2G');
         chdir(dirname(__DIR__, 2));
         Config::reset();
     }
@@ -35,6 +36,7 @@ abstract class BaseTest extends TestCase
         ],
         'Phan\AST\ASTReverter' => [
             'closure_map',
+            'noop',
         ],
         'Phan\Language\Type' => [
             'canonical_object_map',
@@ -50,6 +52,13 @@ abstract class BaseTest extends TestCase
         ],
         'Phan\Language\UnionType' => [
             'empty_instance',
+        ],
+        // Back this up because it takes 306 ms.
+        'Phan\Tests\Language\UnionTypeTest' => [
+            'code_base',
+        ],
+        'Phan\Tests\Plugin\Internal\MethodSearcherPluginTest' => [
+            'code_base',
         ],
     ];
 }

--- a/tests/Phan/CLITest.php
+++ b/tests/Phan/CLITest.php
@@ -79,6 +79,9 @@ final class CLITest extends BaseTest
     {
         $opts = array_merge(['project-root-directory' => dirname(__DIR__) . '/misc/config/'], $opts);
         $expected_changed_options = array_merge(['directory_list' => ['src']], $expected_changed_options);
+        if (!extension_loaded('pcntl')) {
+            $expected_changed_options = array_merge(['language_server_use_pcntl_fallback' => true], $expected_changed_options);
+        }
         $cli = CLI::fromRawValues($opts, []);
         $changed = [];
         foreach (Config::DEFAULT_CONFIGURATION as $key => $value) {

--- a/tests/Phan/Language/UnionTypeTest.php
+++ b/tests/Phan/Language/UnionTypeTest.php
@@ -45,37 +45,6 @@ final class UnionTypeTest extends BaseTest
     /** @var CodeBase The code base within which this unit test is operating */
     protected static $code_base = null;
 
-    /**
-     * Based on BaseTest
-     * TODO: Investigate instantiating CodeBase in a cheaper way (lazily?)
-     * @suppress PhanReadOnlyProtectedProperty read by phpunit framework
-     */
-    // phpcs:ignore
-    protected $backupStaticAttributesBlacklist = [
-        'Phan\AST\PhanAnnotationAdder' => [
-            'closures_for_kind',
-        ],
-        'Phan\Language\Type' => [
-            'canonical_object_map',
-            'internal_fn_cache',
-        ],
-        'Phan\Language\Type\LiteralIntType' => [
-            'nullable_int_type',
-            'non_nullable_int_type',
-        ],
-        'Phan\Language\Type\LiteralStringType' => [
-            'nullable_string_type',
-            'non_nullable_string_type',
-        ],
-        'Phan\Language\UnionType' => [
-            'empty_instance',
-        ],
-        // Back this up because it takes 306 ms.
-        'Phan\Tests\Language\UnionTypeTest' => [
-            'code_base',
-        ],
-    ];
-
     protected function setUp()
     {
         // Deliberately not calling parent::setUp()

--- a/tests/Phan/PhanTestListener.php
+++ b/tests/Phan/PhanTestListener.php
@@ -13,8 +13,9 @@ $internal_trait_name_list = get_declared_traits();
 $internal_function_name_list = get_defined_functions()['internal'];
 
 use Phan\CodeBase;
-use PHPUnit\Framework\BaseTestListener;
 use PHPUnit\Framework\Test;
+use PHPUnit\Framework\TestListener;
+use PHPUnit\Framework\TestListenerDefaultImplementation;
 
 /**
  * Utilities for creating and cleaning up clones of CodeBase instances when running tests
@@ -22,8 +23,10 @@ use PHPUnit\Framework\Test;
  * @suppress PhanUnreferencedClass
  * This class is referenced in phpunit.xml
  */
-final class PhanTestListener extends BaseTestListener
+final class PhanTestListener implements TestListener
 {
+    use TestListenerDefaultImplementation;
+
     public function startTest(Test $test)
     {
         if ($test instanceof CodeBaseAwareTestInterface) {

--- a/tests/Phan/Plugin/Internal/MethodSearcherPluginTest.php
+++ b/tests/Phan/Plugin/Internal/MethodSearcherPluginTest.php
@@ -15,37 +15,6 @@ final class MethodSearcherPluginTest extends BaseTest
     /** @var CodeBase|null The code base within which this unit test is operating */
     protected static $code_base = null;
 
-    /**
-     * Based on BaseTest
-     * TODO: Investigate instantiating CodeBase in a cheaper way (lazily?)
-     * @suppress PhanReadOnlyProtectedProperty read by phpunit framework
-     */
-    // phpcs:ignore
-    protected $backupStaticAttributesBlacklist = [
-        'Phan\AST\PhanAnnotationAdder' => [
-            'closures_for_kind',
-        ],
-        'Phan\Language\Type' => [
-            'canonical_object_map',
-            'internal_fn_cache',
-        ],
-        'Phan\Language\Type\LiteralIntType' => [
-            'nullable_int_type',
-            'non_nullable_int_type',
-        ],
-        'Phan\Language\Type\LiteralStringType' => [
-            'nullable_string_type',
-            'non_nullable_string_type',
-        ],
-        'Phan\Language\UnionType' => [
-            'empty_instance',
-        ],
-        // Back this up because it takes 306 ms.
-        'Phan\Tests\Language\UnionTypeTest' => [
-            'code_base',
-        ],
-    ];
-
     protected function setUp()
     {
         // Deliberately not calling parent::setUp()
@@ -62,6 +31,13 @@ final class MethodSearcherPluginTest extends BaseTest
                 $internal_function_name_list
             );
         }
+    }
+
+    public static function tearDownAfterClass()
+    {
+        parent::tearDownAfterClass();
+        // @phan-suppress-next-line PhanTypeMismatchProperty
+        self::$code_base = null;
     }
 
     /**


### PR DESCRIPTION
Don't try to serialize closures there.

Fixes #2453

Remove the invalid `ini` directive - this is duplicated in BaseTest and
becomes a warning in newer PHP versions