### PR TITLE
Limit each stack frame to 1000 bytes in crash reports

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,9 @@ New features(Analysis):
 Plugins:
 + Warn about unspecialized array types of elements in UnknownElementTypePlugin. `mixed[]` can be used when absolutely nothing is known about the array's key or value types.
 
+Maintenance
++ Limit frames of stack traces in crash reports to 1000 bytes of encoded data. (#2444)
+
 Bug fixes:
 + Fix a crash seen when parsing return typehint for `Closure` in a different case (e.g. `closure`) (#2438)
 + Fix an issue loading the autoloader multiple times when the `vendor` folder is not lowercase on case-sensitive filesystems (#2440)

--- a/internal/update_wiki_config_types.php
+++ b/internal/update_wiki_config_types.php
@@ -96,6 +96,7 @@ class ConfigEntry
         'dump_ast' => self::CATEGORY_HIDDEN_CLI_ONLY,
         'dump_signatures_file' => self::CATEGORY_HIDDEN_CLI_ONLY,
         'dump_parsed_file_list' => self::CATEGORY_HIDDEN_CLI_ONLY,
+        'debug_max_frame_length' => self::CATEGORY_HIDDEN_CLI_ONLY,
         'progress_bar' => self::CATEGORY_HIDDEN_CLI_ONLY,
         'progress_bar_sample_interval' => self::CATEGORY_HIDDEN_CLI_ONLY,
         'processes' => self::CATEGORY_ANALYSIS,

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -645,6 +645,9 @@ class Config
         // By default, Phan will warn if the 'tokenizer' module isn't installed and enabled.
         'skip_missing_tokenizer_warning' => false,
 
+        // This is the maximum frame length for crash reports
+        'debug_max_frame_length' => 1000,
+
         // You can put paths to stubs of internal extensions in this config option.
         // If the corresponding extension is **not** loaded, then Phan will use the stubs instead.
         // Phan will continue using its detailed type annotations,


### PR DESCRIPTION
(by default)

Fixes #2444