### PR TITLE
Warn about missing variable names in `@var` annotations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@ New features(Analysis):
   ancestor class of `function someMethod(MyClass $x) : MyClass {}`.
 
   This is only done when each phpdoc type is compatible with the real signature type.
++ Warn about `@var Type` without a variable name in doc comments of function-likes (#2445)
 
 Plugins:
 + Warn about unspecialized array types of elements in UnknownElementTypePlugin. `mixed[]` can be used when absolutely nothing is known about the array's key or value types.

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -270,12 +270,12 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
         );
 
         // Parse the comment above the function to get
-        // extra meta information about the method.
+        // extra meta information about the function.
         // TODO: Investigate caching information from Comment::fromStringInContext?
         $comment = $function->getComment();
 
-        // For any @var references in the method declaration,
-        // add them as variables to the method's scope
+        // For any @var references in the function declaration,
+        // add them as variables to the function's scope
         if ($comment !== null) {
             foreach ($comment->getVariableList() as $parameter) {
                 $context->addScopeVariable(

--- a/src/Phan/Language/Element/Comment/Builder.php
+++ b/src/Phan/Language/Element/Comment/Builder.php
@@ -431,7 +431,17 @@ final class Builder
     {
         $this->checkCompatible('@var', Comment::HAS_VAR_ANNOTATION, $i);
         $comment_var = self::parameterFromCommentLine($line, true, $i);
-        if ($comment_var->getName() !== '' || !\in_array($this->comment_type, Comment::FUNCTION_LIKE)) {
+        if (\in_array($this->comment_type, Comment::FUNCTION_LIKE)) {
+            if ($comment_var->getName() !== '') {
+                $this->variable_list[] = $comment_var;
+            } else {
+                $this->emitIssue(
+                    Issue::UnextractableAnnotation,
+                    $this->guessActualLineLocation($i),
+                    trim($line)
+                );
+            }
+        } else {
             $this->variable_list[] = $comment_var;
         }
     }
@@ -617,7 +627,17 @@ final class Builder
             case 'phan-var':
                 $this->checkCompatible('@phan-var', Comment::HAS_VAR_ANNOTATION, $i);
                 $comment_var = $this->parameterFromCommentLine($line, true, $i);
-                if ($comment_var->getName() !== '' || !\in_array($this->comment_type, Comment::FUNCTION_LIKE)) {
+                if (\in_array($this->comment_type, Comment::FUNCTION_LIKE)) {
+                    if ($comment_var->getName() !== '') {
+                        $this->phan_overrides['var'][] = $comment_var;
+                    } else {
+                        $this->emitIssue(
+                            Issue::UnextractableAnnotation,
+                            $this->guessActualLineLocation($i),
+                            trim($line)
+                        );
+                    }
+                } else {
                     $this->phan_overrides['var'][] = $comment_var;
                 }
                 return;

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -182,6 +182,7 @@ class UnionType implements Serializable
         $union_type = $memoize_map[$fully_qualified_string] ?? null;
 
         if (\is_null($union_type)) {
+            /** Convert the `|` separated types in the union type to a list of types */
             $types = \array_map(static function (string $type_name) : Type {
                 // @phan-suppress-next-line PhanThrowTypeAbsentForCall FIXME: Standardize on InvalidArgumentException
                 return Type::fromFullyQualifiedString($type_name);

--- a/tests/files/expected/0283_invalid_var.php.expected
+++ b/tests/files/expected/0283_invalid_var.php.expected
@@ -1,2 +1,3 @@
 %s:5 PhanUnextractableAnnotation Saw unextractable annotation for comment '* @var \ is $v - not a good var annotation'
 %s:6 PhanUnextractableAnnotation Saw unextractable annotation for comment '* @var \ $x is not good either'
+%s:7 PhanUnextractableAnnotation Saw unextractable annotation for comment '* @var string|\NS\ $y is not good either'

--- a/tests/files/expected/0634_empty_var_on_function.php.expected
+++ b/tests/files/expected/0634_empty_var_on_function.php.expected
@@ -1,0 +1,2 @@
+%s:5 PhanUnextractableAnnotation Saw unextractable annotation for comment '/** @var int unrelated */'
+%s:10 PhanUnextractableAnnotation Saw unextractable annotation for comment '/** @phan-var int unrelated */'

--- a/tests/files/src/0634_empty_var_on_function.php
+++ b/tests/files/src/0634_empty_var_on_function.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace EmptyVar;
+
+/** @var int unrelated */
+function test() {
+}
+
+class C {
+    /** @phan-var int unrelated */
+    public static function test() {
+    }
+}


### PR DESCRIPTION
(in functions/methods/closures)

For #2445