### PR TITLE
Warn when a non-string is used for dynamic property access

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@ New features(Analysis):
   This is only done when each phpdoc type is compatible with the real signature type.
 + Warn about `@var Type` without a variable name in doc comments of function-likes (#2445)
 + Infer side effects of `array_push` and `array_unshift` on complex expressions such as properties. (#2365)
++ Warn when a non-string is used as a property name for a dynamic property access (#1402)
 
 Plugins:
 + Warn about unspecialized array types of elements in UnknownElementTypePlugin. `mixed[]` can be used when absolutely nothing is known about the array's key or value types.

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -2144,6 +2144,14 @@ Instance method name must be a string, got {TYPE}
 
 e.g. [this issue](https://github.com/phan/phan/tree/1.1.2/tests/files/expected/0540_invalid_method_name.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.1.2/tests/files/src/0540_invalid_method_name.php#L4).
 
+## PhanTypeInvalidPropertyName
+
+```
+Saw a dynamic usage of an instance property with a name of type {TYPE} but expected the name to be a string
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0636_invalid_property_name_type.php.expected#L4) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0636_invalid_property_name_type.php#L8).
+
 ## PhanTypeInvalidRequire
 
 ```
@@ -2191,6 +2199,14 @@ Static method name must be a string, got {TYPE}
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/1.1.2/tests/files/expected/0540_invalid_method_name.php.expected#L3) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.1.2/tests/files/src/0540_invalid_method_name.php#L6).
+
+## PhanTypeInvalidStaticPropertyName
+
+```
+Saw a dynamic usage of a static property with a name of type {TYPE} but expected the name to be a string
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0636_invalid_property_name_type.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0636_invalid_property_name_type.php#L5).
 
 ## PhanTypeInvalidThrowsIsInterface
 

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -184,6 +184,8 @@ class Issue
     const InfiniteRecursion               = 'PhanInfiniteRecursion';
     const TypeComparisonToInvalidClass    = 'PhanTypeComparisonToInvalidClass';
     const TypeComparisonToInvalidClassType = 'PhanTypeComparisonToInvalidClassType';
+    const TypeInvalidPropertyName = 'PhanTypeInvalidPropertyName';
+    const TypeInvalidStaticPropertyName = 'PhanTypeInvalidStaticPropertyName';
 
     // Issue::CATEGORY_ANALYSIS
     const Unanalyzable              = 'PhanUnanalyzable';
@@ -1898,6 +1900,22 @@ class Issue
                 "Invalid operator: unary operand of {STRING_LITERAL} is {TYPE} (expected int or string or float)",
                 self::REMEDIATION_B,
                 10099
+            ),
+            new Issue(
+                self::TypeInvalidPropertyName,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,  // Not a runtime Error for an instance property
+                "Saw a dynamic usage of an instance property with a name of type {TYPE} but expected the name to be a string",
+                self::REMEDIATION_B,
+                10102
+            ),
+            new Issue(
+                self::TypeInvalidStaticPropertyName,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_CRITICAL,  // Likely to be an Error for a static property
+                "Saw a dynamic usage of a static property with a name of type {TYPE} but expected the name to be a string",
+                self::REMEDIATION_B,
+                10103
             ),
             // Issue::CATEGORY_VARIABLE
             new Issue(

--- a/tests/files/expected/0047_backwards_compatibility.php.expected
+++ b/tests/files/expected/0047_backwards_compatibility.php.expected
@@ -10,4 +10,5 @@
 %s:5 PhanUndeclaredVariable Variable $bar is undeclared
 %s:5 PhanUndeclaredVariable Variable $foo is undeclared
 %s:15 PhanCompatiblePHP7 Expression may not be PHP 7 compatible
+%s:15 PhanTypeInvalidPropertyName Saw a dynamic usage of an instance property with a name of type array<int,string> but expected the name to be a string
 %s:28 PhanAccessPropertyStaticAsNonStatic Accessing static property \Test::$vals as non static

--- a/tests/files/expected/0636_invalid_property_name_type.php.expected
+++ b/tests/files/expected/0636_invalid_property_name_type.php.expected
@@ -1,0 +1,4 @@
+%s:5 PhanTypeInvalidStaticPropertyName Saw a dynamic usage of a static property with a name of type array{} but expected the name to be a string
+%s:6 PhanTypeInvalidMethodName Instance method name must be a string, got array{}
+%s:7 PhanTypeInvalidStaticMethodName Static method name must be a string, got array{}
+%s:8 PhanTypeInvalidPropertyName Saw a dynamic usage of an instance property with a name of type array{} but expected the name to be a string

--- a/tests/files/src/0047_backwards_compatibility.php
+++ b/tests/files/src/0047_backwards_compatibility.php
@@ -11,8 +11,8 @@ class C {
 class T {
     public $b = null;
     function fn($a) {
-      $this->b = new C;
-      echo $this->b->$a[1];
+        $this->b = new C;
+        echo $this->b->$a[1];
     }
 }
 $t = new T;

--- a/tests/files/src/0202_generic_class.php
+++ b/tests/files/src/0202_generic_class.php
@@ -23,8 +23,8 @@ class Tuple2 {
         $e0,
         $e1
     ) {
-        $this->$e0 = $e0;
-        $this->$e1 = $e1;
+        $this->e0 = $e0;
+        $this->e1 = $e1;
     }
 
     /** @return T0 */

--- a/tests/files/src/0544_phan_generic_class.php
+++ b/tests/files/src/0544_phan_generic_class.php
@@ -23,8 +23,8 @@ class PhanTuple2 {
         $e0,
         $e1
     ) {
-        $this->$e0 = $e0;
-        $this->$e1 = $e1;
+        $this->e0 = $e0;
+        $this->e1 = $e1;
     }
 
     /** @return T0 */

--- a/tests/files/src/0636_invalid_property_name_type.php
+++ b/tests/files/src/0636_invalid_property_name_type.php
@@ -1,0 +1,8 @@
+<?php
+
+$x = new ArrayObject();
+$methodName = [];
+var_export(ArrayObject::${$methodName});  // also for instance and static property access
+var_export($x->$methodName());  // Phan should warn about expecting string for method name (IMPLEMENTED)
+ArrayObject::$methodName();
+var_export($x->$methodName);  // also for instance and static property access


### PR DESCRIPTION
Fixes #1402