### PR TITLE
Warn when declaring a constant conflicting with builtin keyword

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,7 @@ Bug fixes:
 + Fix a crash seen when parsing return typehint for `Closure` in a different case (e.g. `closure`) (#2438)
 + Fix an issue loading the autoloader multiple times when the `vendor` folder is not lowercase on case-sensitive filesystems (#2440)
 + Fix bug causing template types on methods to not work properly when inherited from a trait method.
++ Catch and warn when declaring a constant that would conflict with built in keywords (true/false/null) and prevent it from affecting inferences. (#1642)
 
 10 Feb 2019, Phan 1.2.3
 -----------------------

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -191,6 +191,7 @@ class Issue
     const Unanalyzable              = 'PhanUnanalyzable';
     const UnanalyzableInheritance   = 'PhanUnanalyzableInheritance';
     const InvalidConstantFQSEN      = 'PhanInvalidConstantFQSEN';
+    const ReservedConstantName      = 'PhanReservedConstantName';
 
     // Issue::CATEGORY_VARIABLE
     const VariableUseClause         = 'PhanVariableUseClause';
@@ -1081,6 +1082,14 @@ class Issue
                 "'{CONST}' is an invalid FQSEN for a constant",
                 self::REMEDIATION_B,
                 2002
+            ),
+            new Issue(
+                self::ReservedConstantName,
+                self::CATEGORY_ANALYSIS,
+                self::SEVERITY_NORMAL,
+                "'{CONST}' has a reserved keyword in the constant name",
+                self::REMEDIATION_B,
+                2003
             ),
 
             // Issue::CATEGORY_TYPE

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -1200,6 +1200,22 @@ class ParseVisitor extends ScopeVisitor
         bool $use_future_union_type,
         bool $is_fully_qualified = false
     ) {
+        $i = \strrpos($name, '\\');
+        if ($i !== false) {
+            $name_fragment = (string)\substr($name, $i + 1);
+        } else {
+            $name_fragment = $name;
+        }
+        if (\in_array(\strtolower($name_fragment), ['true', 'false', 'null'], true)) {
+            Issue::maybeEmit(
+                $code_base,
+                $context,
+                Issue::ReservedConstantName,
+                $lineno,
+                $name
+            );
+            return;
+        }
         try {
             // Give it a fully-qualified name
             if ($is_fully_qualified) {

--- a/tests/plugin_test/expected/091_redeclare_constant.php.expected
+++ b/tests/plugin_test/expected/091_redeclare_constant.php.expected
@@ -1,0 +1,5 @@
+src/091_redeclare_constant.php:2 PhanNativePHPSyntaxCheckPlugin Saw error or notice for php --syntax-check: "Fatal error: Cannot redeclare constant 'true'"
+src/091_redeclare_constant.php:2 PhanReservedConstantName 'true' has a reserved keyword in the constant name
+src/091_redeclare_constant.php:3 PhanReservedConstantName 'foo\false' has a reserved keyword in the constant name
+src/091_redeclare_constant.php:4 PhanReservedConstantName 'NULL' has a reserved keyword in the constant name
+src/091_redeclare_constant.php:6 PhanPluginDuplicateArrayKey Duplicate/Equivalent array key value(1) detected in array - the earlier entry will be ignored.

--- a/tests/plugin_test/src/091_redeclare_constant.php
+++ b/tests/plugin_test/src/091_redeclare_constant.php
@@ -1,0 +1,6 @@
+<?php
+const true='x';
+define('foo\false', 'value');
+const NULL='nil';
+// These should not affect Phan's inferences
+var_export([true => 'x', true => 'y']);


### PR DESCRIPTION
And don't use the value of that constant.

Fixes #1642