### PR TITLE
Don't emit `PhanAccessMethodProtected` for $this->protectedMethod()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@ New features(Analysis):
 + Warn about `@var Type` without a variable name in doc comments of function-likes (#2445)
 + Infer side effects of `array_push` and `array_unshift` on complex expressions such as properties. (#2365)
 + Warn when a non-string is used as a property name for a dynamic property access (#1402)
++ Don't warn about `if ($this instanceof OtherClasslike) { $this->protectedMethod(); }` being inaccessible (e.g. in closures) (#2462)
+  (This only applies to uses of the variable `$this`)
 
 Plugins:
 + Warn about unspecialized array types of elements in UnknownElementTypePlugin. `mixed[]` can be used when absolutely nothing is known about the array's key or value types.

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -1353,7 +1353,8 @@ class ContextNode
                 $this->code_base,
                 $property_name,
                 $this->context,
-                $is_static
+                $is_static,
+                $node
             );
 
             if ($property->isDeprecated()) {
@@ -1398,7 +1399,8 @@ class ContextNode
                         $this->code_base,
                         $property_name,
                         $this->context,
-                        $is_static
+                        $is_static,
+                        $node
                     );
                 }
             }
@@ -1419,7 +1421,8 @@ class ContextNode
                     $this->code_base,
                     $property_name,
                     $this->context,
-                    $is_static
+                    $is_static,
+                    $node
                 );
             }
         }

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -708,7 +708,8 @@ class AssignmentVisitor extends AnalysisVisitor
                     $this->code_base,
                     $property_name,
                     $this->context,
-                    false
+                    false,
+                    $node
                 );
             } catch (IssueException $exception) {
                 Issue::maybeEmitInstance(

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -2887,6 +2887,9 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 (string)$method->getFileRef()->getLineNumberStart()
             );
         } else {
+            if (Clazz::isAccessToElementOfThis($node)) {
+                return;
+            }
             $has_call_magic_method = !$method->isStatic()
                 && $method->getDefiningClass($this->code_base)->hasMethodWithName($this->code_base, '__call');
 

--- a/tests/files/expected/0637_access_protected_of_this.php.expected
+++ b/tests/files/expected/0637_access_protected_of_this.php.expected
@@ -1,0 +1,4 @@
+%s:14 PhanUndeclaredStaticMethod Static call to undeclared method \AccessProtectedTest\Unrelated::staticMethod
+%s:15 PhanUndeclaredStaticProperty Static property 'static_something' on \AccessProtectedTest\Unrelated is undeclared
+%s:17 PhanUndeclaredStaticMethod Static call to undeclared method \AccessProtectedTest\Unrelated::staticMethod
+%s:18 PhanUndeclaredStaticProperty Static property 'static_something' on \AccessProtectedTest\Unrelated is undeclared

--- a/tests/files/src/0637_access_protected_of_this.php
+++ b/tests/files/src/0637_access_protected_of_this.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace AccessProtectedTest;
+
+class Unrelated {
+    public function main() {
+        $closure = function () {
+            if ($this instanceof SomeClass) {
+                // Observed: Emits PhanAccessMethodProtected and PhanAccessPropertyProtected
+                // Expected: Should not emit, but only when the variable name is `$this`
+                $this->method();
+                echo $this->something;
+                // TODO: This should not warn because of inferences about $this
+                echo static::staticMethod();
+                echo static::$static_something;
+                // This should warn
+                echo self::staticMethod();
+                echo self::$static_something;
+            }
+        };
+        $c = new SomeClass();
+        // Phan does not analyze bind/bindTo
+        // The place where the closure is used might be unanalyzable
+        $closure = $closure->bindTo($c, SomeClass::class);
+        $closure();
+    }
+}
+class SomeClass {
+    protected $something = 2;
+    protected static $static_something = 3;
+    protected function method() {
+        echo "in method";
+    }
+    protected static function staticMethod() {
+        echo "in static method";
+    }
+}
+(new Unrelated())->main();


### PR DESCRIPTION
(when the variable name is $this and is known to be an additional
class-like)