### PR TITLE
fix TypeError when using CLI option "-3"

### DIFF
--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -206,7 +206,7 @@ class CLI
         $pruneargv = [];
         foreach ($opts as $opt => $value) {
             foreach ($argv as $key => $chunk) {
-                $regex = '/^' . (isset($opt[1]) ? '--' : '-') . preg_quote($opt, '/') . '/';
+                $regex = '/^' . (isset($opt[1]) ? '--' : '-') . preg_quote((string) $opt, '/') . '/';
 
                 if (in_array($chunk, is_array($value) ? $value : [$value])
                     && $argv[$key - 1][0] == '-'


### PR DESCRIPTION
If the short command line option `-3` is used, a TypeError will be
raised when trying to preg_quote the integer array key `3`.

Fix by forcing the type of preg_quote's arg1 to string.