### PR TITLE
Fix bug in InvalidVariableIssetPlugin with `isset(self::FOO['dim'])`

### DIFF
--- a/.phan/plugins/InvalidVariableIssetPlugin.php
+++ b/.phan/plugins/InvalidVariableIssetPlugin.php
@@ -61,6 +61,8 @@ class InvalidVariableIssetVisitor extends PluginAwarePostAnalysisVisitor
                 $variable = $variable->children['expr'];
             } elseif (in_array($variable->kind, self::CLASSES, true)) {
                 $variable = $variable->children['class'];
+            } else {
+                return $this->context;
             }
         }
         $name = $variable->children['name'];

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,12 +12,13 @@ New features(Analysis):
 + Warn about `@var Type` without a variable name in doc comments of function-likes (#2445)
 + Infer side effects of `array_push` and `array_unshift` on complex expressions such as properties. (#2365)
 + Warn when a non-string is used as a property name for a dynamic property access (#1402)
-+ Don't warn about `if ($this instanceof OtherClasslike) { $this->protectedMethod(); }` being inaccessible (e.g. in closures) (#2462)
-  (This only applies to uses of the variable `$this`)
++ Don't emit `PhanAccessMethodProtected` for `if ($this instanceof OtherClasslike) { $this->protectedMethod(); }` (#2372)
+  (This only applies to uses of the variable `$this`, e.g. in closures or when checking interfaces)
 
 Plugins:
 + Warn about unspecialized array types of elements in UnknownElementTypePlugin. `mixed[]` can be used when absolutely nothing is known about the array's key or value types.
 + Warn about failing to use the return value of `var_export($value, true)` (and `print_r`) in `UseReturnValuePlugin` (#2391)
++ Fix plugin causing `InvalidVariableIssetPlugin` to go into an infinite loop for `isset(self::CONST['offset'])` (#2446)
 
 Maintenance
 + Limit frames of stack traces in crash reports to 1000 bytes of encoded data. (#2444)

--- a/tests/plugin_test/expected/092_isset_plugin_hang.php.expected
+++ b/tests/plugin_test/expected/092_isset_plugin_hang.php.expected
@@ -1,0 +1,1 @@
+src/092_isset_plugin_hang.php:7 PhanUnreferencedPublicMethod Possibly zero references to public method \TestPhan::test()

--- a/tests/plugin_test/src/092_isset_plugin_hang.php
+++ b/tests/plugin_test/src/092_isset_plugin_hang.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types = 1);
+
+class TestPhan
+{
+    const TOTO = [];
+    public function test()
+    {
+        /* Comment next line to unlock Phan */
+        return isset(self::TOTO['a']);
+    }
+}


### PR DESCRIPTION
Fixes #2446