### PR TITLE
Check if ASSERT_QUIET_EVAL is defined

### DIFF
--- a/src/Phan/Bootstrap.php
+++ b/src/Phan/Bootstrap.php
@@ -41,7 +41,10 @@ ini_set('assert.exception', '1');
 assert_options(ASSERT_ACTIVE, true);
 assert_options(ASSERT_WARNING, false);
 assert_options(ASSERT_BAIL, false);
-assert_options(ASSERT_QUIET_EVAL, false);
+// ASSERT_QUIET_EVAL has been removed starting with PHP 8
+if (defined('ASSERT_QUIET_EVAL')) {
+    assert_options(ASSERT_QUIET_EVAL, false);
+}
 assert_options(ASSERT_CALLBACK, '');  // Can't explicitly set ASSERT_CALLBACK to null?
 
 /**


### PR DESCRIPTION
ASSERT_QUIET_EVAL has been removed starting with PHP 8.
Reference: https://github.com/php/php-src/blob/master/UPGRADING#L173