### PR TITLE
Fix --ignore-undeclared

### DIFF
--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -491,7 +491,7 @@ class CLI
                     break;
                 case 'i':
                 case 'ignore-undeclared':
-                    $mask |= Issue::CATEGORY_UNDEFINED;
+                    $mask &= ~Issue::CATEGORY_UNDEFINED;
                     break;
                 case '3':
                 case 'exclude-directory-list':


### PR DESCRIPTION
3cf47f972c4a40f161b8fea6bf6cae44ddc5a894 (between versions 1.2.2 and 1.2.3) broke -i / --ignore-undeclared. Because $mask is a bitmask with all bits set to 1 by default, OR'ing in a value does not change it. We have to use the opposite here, `&= ~`.