### PR TITLE
Don't emit PhanWriteOnlyPrivateProperty when references are used

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@ New features(Analysis):
 
   In most cases, that shouldn't matter.
 + Emit `PhanPluginPrintfVariableFormatString` in `PrintfCheckerPlugin` if the inferred format string isn't a single literal (#2431)
++ Don't emit `PhanWriteOnlyPrivateProperty` with dead code detection when at least one assignment is by reference (#1658)
 
 Language Server/Daemon mode:
 + Fix an error in the language server on didChangeConfiguration

--- a/tests/plugin_test/expected/102_dead_code_detection_references.php.expected
+++ b/tests/plugin_test/expected/102_dead_code_detection_references.php.expected
@@ -1,0 +1,1 @@
+src/102_dead_code_detection_references.php:9 PhanWriteOnlyPublicProperty Possibly zero read references to public property \Test102->z

--- a/tests/plugin_test/src/102_dead_code_detection_references.php
+++ b/tests/plugin_test/src/102_dead_code_detection_references.php
@@ -1,0 +1,20 @@
+<?php
+
+class Test102 {
+    /** @var string should not warn about being read-only; a reference of this is taken */
+    public $x = 'default';
+    /** @var int|string should not warn about being read-only; a reference of this is taken */
+    public $y = 'default';
+    /** @var int|string */
+    public $z = 'default';
+}
+$t = new Test102();
+$x = 'global';
+$other =& $t->x;
+var_export($other);
+$other = 'value';
+
+$t->y =& $x;
+$t->y = 2;
+echo $x;
+$t->z = $x;


### PR DESCRIPTION
Fixes #1658