### PR TITLE
Don't exit if php-ast deprecates AST version 50

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,9 @@ New features(Analysis):
 Language Server/Daemon mode:
 + Fix an error in the language server on didChangeConfiguration
 
+Maintenance
++ Don't exit if the AST version Phan uses (currently version 50) is deprecated by php-ast (#1134)
+
 Plugins:
 + Write `PhanSelfCheckPlugin` for self-analysis of Phan and plugins for Phan. (#1576)
   This warns if too many/too few arguments are provided for the issue template when emitting an issue.

--- a/src/Phan/Bootstrap.php
+++ b/src/Phan/Bootstrap.php
@@ -110,6 +110,19 @@ function phan_error_handler($errno, $errstr, $errfile, $errline)
         // Don't execute the PHP internal error handler
         return true;
     }
+    if ($errno === E_DEPRECATED && preg_match('/ast\\\\parse_/', $errstr)) {
+        static $did_warn = false;
+        if (!$did_warn) {
+            $did_warn = true;
+            if (!getenv('PHAN_SUPPRESS_AST_DEPRECATION')) {
+                fprintf(STDERR, "php-ast AST version %d used by Phan %s has been deprecated. Check if a newer version of Phan is available." . PHP_EOL,
+                    Config::AST_VERSION, CLI::PHAN_VERSION);
+                fwrite(STDERR, "(Set PHAN_SUPPRESS_AST_DEPRECATION=1 to suppress this message)" . PHP_EOL);
+            }
+        }
+        // Don't execute the PHP internal error handler
+        return true;
+    }
     fwrite(STDERR, "$errfile:$errline [$errno] $errstr\n");
     if (error_reporting() === 0) {
         // https://secure.php.net/manual/en/language.operators.errorcontrol.php


### PR DESCRIPTION
Fixes #1134

The Phan error handler previously exited immediately.

This may be useful for future upgrades of php-ast for
Phan installations.