### PR TITLE
Show hover text of ancestors of class elements when useful

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@ New features(Analysis):
 
 Language Server/Daemon mode:
 + Fix an error in the language server on didChangeConfiguration
++ Show hover text of ancestors for class elements (methods, constants, and properties) when no summary is available for the class element. (#1945)
 
 Maintenance
 + Don't exit if the AST version Phan uses (currently version 50) is deprecated by php-ast (#1134)

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -3113,4 +3113,42 @@ class Clazz extends AddressableElement
             }
         );
     }
+
+    /**
+     * Given the FQSEN of an ancestor class and an element definition,
+     * return the overriden element's definition or null if this didn't override anything.
+     *
+     * TODO: Handle renamed elements from traits.
+     *
+     * @return ?ClassElement if non-null, this is of the same type as $element
+     */
+    public static function getAncestorElement(CodeBase $code_base, FullyQualifiedClassName $ancestor_fqsen, ClassElement $element)
+    {
+        if (!$code_base->hasClassWithFQSEN($ancestor_fqsen)) {
+            return null;
+        }
+        $ancestor_class = $code_base->getClassByFQSEN($ancestor_fqsen);
+        $name = $element->getName();
+        if ($element instanceof Method) {
+            if (!$ancestor_class->hasMethodWithName($code_base, $name)) {
+                return null;
+            }
+            return $ancestor_class->getMethodByName($code_base, $name);
+        } elseif ($element instanceof ClassConstant) {
+            if (!$ancestor_class->hasConstantWithName($code_base, $name)) {
+                return null;
+            }
+            $constant_fqsen = FullyQualifiedClassConstantName::make(
+                $ancestor_fqsen,
+                $name
+            );
+            return $code_base->getClassConstantByFQSEN($constant_fqsen);
+        } elseif ($element instanceof Property) {
+            if (!$ancestor_class->hasPropertyWithName($code_base, $name)) {
+                return null;
+            }
+            return $ancestor_class->getPropertyByName($code_base, $name);
+        }
+        return null;
+    }
 }

--- a/tests/Phan/LanguageServer/LanguageServerIntegrationTest.php
+++ b/tests/Phan/LanguageServer/LanguageServerIntegrationTest.php
@@ -892,6 +892,10 @@ function test(ExampleClass $c) {  // line 25
     $n = ast\parse_code('<?php $x = 2;', 50);
     var_export($n->kind);  // line 30
     var_export($_ENV);
+    $y = new class extends ArrayObject { public function count() : int {return 0;} };  // no comment
+    var_export($y->count());
+    $z = new class extends ArrayObject {};
+    var_export($z->count());
 }
 EOT;
         return [
@@ -1146,6 +1150,34 @@ EOT
                 new Position(31, 18),  // $_ENV
                 <<<'EOT'
 `array<string,string>` An associative array of variables passed to the current script via the environment method.
+EOT
+                ,
+                null,
+                true
+            ],
+            [
+                $example_file_contents,
+                new Position(33, 22),  // ArrayObject->count() (override)
+                <<<'EOT'
+```php
+public function count() : int
+```
+
+Get the number of public properties in the ArrayObject
+EOT
+                ,
+                null,
+                true
+            ],
+            [
+                $example_file_contents,
+                new Position(35, 22),  // ArrayObject->count() (inherited)
+                <<<'EOT'
+```php
+public function count() : int
+```
+
+Get the number of public properties in the ArrayObject
 EOT
                 ,
                 null,


### PR DESCRIPTION
Do this when no summary is available for the class element,
but there are summaries of the ancestors of the class element.

For #1945 (doesn't support inline `{@inheritDoc}` yet, but should make that easier)