### PR TITLE
Add a prototype `--automatic-fix` CLI flag.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,9 @@ New features(CLI,Configs)
 + Add config `enable_extended_internal_return_type_plugins` to more aggressively
   infer literal values for functions such as `json_decode`, `strtolower`, `implode`, etc. (disabled by default),
 + Make `--dead-code-detection` load `UnreachableCodePlugin` if that plugin isn't already loaded (#1824)
++ Add `--automatic-fix` to fix any issues Phan is capable of fixing
+  (currently a prototype. Fixes are guessed base on line numbers).
+  This is currently limited to unreferenced use statements on their own line (requires `--dead-code-detection`).
 
 New features(Analysis):
 + Make Phan infer more precise literal types for internal constants such as `PHP_EOF`.

--- a/src/Phan/AST/TolerantASTConverter/NodeUtils.php
+++ b/src/Phan/AST/TolerantASTConverter/NodeUtils.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types=1);
+
+namespace Phan\AST\TolerantASTConverter;
+
+use Microsoft\PhpParser\Node\QualifiedName;
+use Microsoft\PhpParser\Token;
+use Microsoft\PhpParser\TokenKind;
+
+/**
+ * Miscellaneous utilities for converting nodes to strings.
+ *
+ * This deliberately duplicates some functionality in TolerantASTConverter for use outside of TolerantASTConverter.
+ * (static methods are faster inside of TolerantASTConverter)
+ */
+final class NodeUtils
+{
+    /** @var string */
+    private $file_contents;
+
+    public function __construct(string $file_contents)
+    {
+        $this->file_contents = $file_contents;
+    }
+
+    /**
+     * Convert a token to the string it represents, without whitespace or `$`.
+     *
+     * @phan-suppress PhanPartialTypeMismatchArgumentInternal hopefully in range
+     */
+    public function tokenToString(Token $n) : string
+    {
+        $result = \trim($n->getText($this->file_contents));
+        $kind = $n->kind;
+        if ($kind === TokenKind::VariableName) {
+            return \trim($result, '$');
+        }
+        return $result;
+    }
+
+    /**
+     * Converts a qualified name to the string it represents, combining name parts.
+     */
+    public function phpParserNameToString(QualifiedName $name) : string
+    {
+        $name_parts = $name->nameParts;
+        // TODO: Handle error case (can there be missing parts?)
+        $result = '';
+        foreach ($name_parts as $part) {
+            // @phan-suppress-next-line PhanPossiblyNullTypeArgument
+            $part_as_string = $this->tokenToString($part);
+            if ($part_as_string !== '') {
+                $result .= \trim($part_as_string);
+            }
+        }
+        $result = \rtrim(\preg_replace('/\\\\{2,}/', '\\', $result), '\\');
+        if ($result === '') {
+            // Would lead to "The name cannot be empty" when parsing
+            throw new InvalidNodeException();
+        }
+        return $result;
+    }
+}

--- a/src/Phan/Bootstrap.php
+++ b/src/Phan/Bootstrap.php
@@ -115,8 +115,12 @@ function phan_error_handler($errno, $errstr, $errfile, $errline)
         if (!$did_warn) {
             $did_warn = true;
             if (!getenv('PHAN_SUPPRESS_AST_DEPRECATION')) {
-                fprintf(STDERR, "php-ast AST version %d used by Phan %s has been deprecated. Check if a newer version of Phan is available." . PHP_EOL,
-                    Config::AST_VERSION, CLI::PHAN_VERSION);
+                fprintf(
+                    STDERR,
+                    "php-ast AST version %d used by Phan %s has been deprecated. Check if a newer version of Phan is available." . PHP_EOL,
+                    Config::AST_VERSION,
+                    CLI::PHAN_VERSION
+                );
                 fwrite(STDERR, "(Set PHAN_SUPPRESS_AST_DEPRECATION=1 to suppress this message)" . PHP_EOL);
             }
         }

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -70,6 +70,7 @@ class CLI
      */
     const GETOPT_LONG_OPTIONS = [
         'allow-polyfill-parser',
+        'automatic-fix',
         'backward-compatibility-checks',
         'color',
         'config-file:',
@@ -476,6 +477,12 @@ class CLI
                     Config::setValue('plugins', array_merge(
                         Config::getValue('plugins'),
                         [__DIR__ . '/Plugin/Internal/MethodSearcherPluginLoader.php']
+                    ));
+                    break;
+                case 'automatic-fix':
+                    Config::setValue('plugins', array_merge(
+                        Config::getValue('plugins'),
+                        [__DIR__ . '/Plugin/Internal/IssueFixingPlugin.php']
                     ));
                     break;
                 case 'o':
@@ -1080,6 +1087,11 @@ Extended help:
  --dump-signatures-file <filename>
   Emit JSON serialized signatures to the given file.
   This uses a method signature format similar to FunctionSignatureMap.php.
+
+ --automatic-fix
+  Automatically fix any issues Phan is capable of fixing.
+  NOTE: This is a work in progress and limited to a small subset of issues
+  (e.g. unused imports on their own line)
 
  --find-signature 'paramUnionType1->paramUnionType2->returnUnionType'
   Find a signature in the analyzed codebase that is similar to the argument.

--- a/src/Phan/IssueInstance.php
+++ b/src/Phan/IssueInstance.php
@@ -123,14 +123,14 @@ class IssueInstance
     }
 
     /**
-     * @return ?Suggestion
+     * @return ?Suggestion If this is non-null, this contains suggestions on how to resolve the error.
      */
     public function getSuggestion()
     {
         return $this->suggestion;
     }
 
-    /** @return array<int,string|int|float|FQSEN|Type|UnionType> $template_parameters If this is non-null, this contains suggestions on how to resolve the error. */
+    /** @return array<int,string|int|float|FQSEN|Type|UnionType> $template_parameters */
     public function getTemplateParameters() : array
     {
         return $this->template_parameters;

--- a/src/Phan/Phan.php
+++ b/src/Phan/Phan.php
@@ -162,6 +162,7 @@ class Phan implements IgnoredFilesFilterInterface
             $code_base->eagerlyLoadAllSignatures();
         }
         if ($is_undoable_request) {
+            self::checkForOptionsConflictingWithServerModes();
             $code_base->enableUndoTracking();
         }
 
@@ -300,6 +301,13 @@ class Phan implements IgnoredFilesFilterInterface
         return self::finishAnalyzingRemainingStatements($code_base, $request, $analyze_file_path_list, $temporary_file_mapping);
     }
 
+    private static function checkForOptionsConflictingWithServerModes()
+    {
+        if (in_array(__DIR__ . '/Plugin/Internal/IssueFixingPlugin.php', Config::getValue('plugins'))) {
+            fwrite(STDERR, "Cannot use --automatic-fix in daemon mode or with the language server\n");
+            exit(EXIT_FAILURE);
+        }
+    }
     /**
      * Finish analyzing any files that need to be analyzed.
      * (for full analysis, or a limited number of files for daemon mode, etc.)

--- a/src/Phan/Plugin/Internal/IssueFixingPlugin.php
+++ b/src/Phan/Plugin/Internal/IssueFixingPlugin.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Phan\Plugin\Internal;
+
+use Error;
+use Phan\CodeBase;
+use Phan\Phan;
+use Phan\Plugin\Internal\IssueFixingPlugin\IssueFixer;
+use Phan\PluginV2;
+use Phan\PluginV2\FinalizeProcessCapability;
+
+/**
+ * This plugin fixes a small number of issues automatically.
+ * This uses heuristics to guess where the fix should be applied.
+ *
+ * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
+ */
+class IssueFixingPlugin extends PluginV2 implements
+    FinalizeProcessCapability
+{
+    /**
+     * @override
+     * @throws Error if a syntax check process fails to shut down.
+     */
+    public function finalizeProcess(CodeBase $unused_code_base)
+    {
+        $instances = Phan::getIssueCollector()->getCollectedIssues();
+        if (count($instances) > 0) {
+            IssueFixer::applyFixes($instances);
+        }
+    }
+}
+
+// Every plugin needs to return an instance of itself at the
+// end of the file in which it's defined.
+return new IssueFixingPlugin();

--- a/src/Phan/Plugin/Internal/IssueFixingPlugin/FileEdit.php
+++ b/src/Phan/Plugin/Internal/IssueFixingPlugin/FileEdit.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Phan\Plugin\Internal\IssueFixingPlugin;
+
+/**
+ * Represents a change to be made to file contents.
+ * The structure of this will change.
+ * @internal
+ */
+class FileEdit
+{
+    /** @var int the byte offset where the replacement will start */
+    public $replace_start;
+    /** @var int the byte offset where the replacement will end */
+    public $replace_end;
+    // TODO: Implement insertion
+    /** @var string the contents to replace the range with */
+    // public $new_text = '';
+
+    /**
+     * Create a new file edit (currently just supports deleting lines)
+     */
+    public function __construct(int $replace_start, int $replace_end)
+    {
+        $this->replace_start = $replace_start;
+        $this->replace_end = $replace_end;
+    }
+}

--- a/src/Phan/Plugin/Internal/IssueFixingPlugin/FileEditSet.php
+++ b/src/Phan/Plugin/Internal/IssueFixingPlugin/FileEditSet.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace Phan\Plugin\Internal\IssueFixingPlugin;
+
+/**
+ * Represents a set of changes to be made to file contents.
+ * The structure of this will change.
+ * @internal
+ */
+class FileEditSet
+{
+    /** @var FileEdit[] */
+    public $edits;
+
+    /**
+     * @param FileEdit[] $edits
+     */
+    public function __construct(array $edits)
+    {
+        $this->edits = $edits;
+    }
+}

--- a/src/Phan/Plugin/Internal/IssueFixingPlugin/IssueFixer.php
+++ b/src/Phan/Plugin/Internal/IssueFixingPlugin/IssueFixer.php
@@ -1,0 +1,327 @@
+<?php declare(strict_types=1);
+
+namespace Phan\Plugin\Internal\IssueFixingPlugin;
+
+use Closure;
+use Generator;
+use Microsoft\PhpParser;
+use Microsoft\PhpParser\FilePositionMap;
+use Microsoft\PhpParser\Node\NamespaceUseClause;
+use Microsoft\PhpParser\Node\QualifiedName;
+use Microsoft\PhpParser\Node\Statement\NamespaceUseDeclaration;
+use Microsoft\PhpParser\Parser;
+use Microsoft\PhpParser\TokenKind;
+use Phan\AST\TolerantASTConverter\NodeUtils;
+use Phan\Config;
+use Phan\Issue;
+use Phan\IssueInstance;
+use Phan\Library\FileCache;
+use Phan\Library\StringUtil;
+use RuntimeException;
+
+/**
+ * Represents a set of changes to be made to file contents.
+ * The structure of this will change.
+ */
+class IssueFixer
+{
+
+    /**
+     * @return Generator<void,PhpParser\Node,void,void>
+     */
+    private static function getNodesAtLine(string $file_contents, PhpParser\Node $node, int $line)
+    {
+        $file_position_map = new FilePositionMap($file_contents);
+        foreach ($node->getDescendantNodes() as $node) {
+            $line_for_node = $file_position_map->getStartLine($node);
+            if ($line_for_node < $line) {
+                continue;
+            }
+            if ($line_for_node > $line) {
+                return;
+            }
+            yield $node;
+        }
+    }
+
+    private static function isMatchingNamespaceUseDeclaration(
+        string $file_contents,
+        NamespaceUseDeclaration $declaration,
+        IssueInstance $issue_instance
+    ) : bool {
+        $type = $issue_instance->getIssue()->getType();
+
+        switch ($type) {
+            case Issue::UnreferencedUseNormal:
+                $expected_token_kind = null;
+                break;
+            case Issue::UnreferencedUseFunction:
+                $expected_token_kind = TokenKind::FunctionKeyword;
+                break;
+            case Issue::UnreferencedUseConstant:
+                $expected_token_kind = TokenKind::ConstKeyword;
+                break;
+            default:
+                self::debug(sprintf("Unexpected kind %s in %s\n", $type, __METHOD__));
+                return false;
+        }
+
+        $actual_token_kind = $declaration->functionOrConst->kind ?? null;
+        if ($expected_token_kind !== $actual_token_kind) {
+            self::debug(sprintf("DEBUG: Unexpected type %s in %s\n", $actual_token_kind ?? 'null', __METHOD__));
+            return false;
+        }
+        $list = $declaration->useClauses->children ?? [];
+        if (count($list) !== 1) {
+            self::debug(sprintf("DEBUG: Unexpected count %d in %s\n", count($list), __METHOD__));
+            return false;
+        }
+        $element = $list[0];
+        // $dumper = new \Phan\AST\TolerantASTConverter\NodeDumper($file_contents);
+        // $dumper->setIncludeTokenKind(true);
+        // $dumper->dumpTree($element);
+        if (!($element instanceof NamespaceUseClause)) {
+            return false;
+        }
+        if ($element->openBrace || $element->groupClauses || $element->closeBrace) {
+            // Not supported
+            return false;
+        }
+        // $element->namespaceAliasingClause doesn't matter for the the subsequent checks
+
+        $namespace_name = $element->namespaceName;
+        if (!($namespace_name instanceof QualifiedName)) {
+            return false;
+        }
+        $actual_use_name = (new NodeUtils($file_contents))->phpParserNameToString($namespace_name);
+        // Get the last argument from
+        // Possibly zero references to use statement for classlike/namespace {CLASSLIKE} ({CLASSLIKE})
+        $expected_use_name = $issue_instance->getTemplateParameters()[1];
+
+        if (strcasecmp(ltrim((string)$expected_use_name, "\\"), ltrim($actual_use_name, "\\")) !== 0) {
+            // Not the same fully qualified name.
+            return false;
+        }
+        // This is the same fully qualified name.
+        return true;
+    }
+
+    /**
+     * @return ?FileEdit
+     */
+    private static function maybeRemoveNamespaceUseDeclaration(
+        string $file_contents,
+        NamespaceUseDeclaration $declaration,
+        IssueInstance $issue_instance
+    ) {
+        if (!self::isMatchingNamespaceUseDeclaration($file_contents, $declaration, $issue_instance)) {
+            return null;
+        }
+
+        // @phan-suppress-next-line PhanThrowTypeAbsentForCall
+        $end = $declaration->getEndPosition();
+        $end = self::skipTrailingWhitespaceAndNewlines($file_contents, $end);
+        // @phan-suppress-next-line PhanThrowTypeAbsentForCall
+        return new FileEdit($declaration->getStart(), $end);
+    }
+
+    private static function skipTrailingWhitespaceAndNewlines(string $file_contents, int $end) : int
+    {
+        // Handles \r\n and \n, but doesn't bother handling \r
+        $next = strpos($file_contents, "\n", $end);
+        if ($next === false) {
+            return $end;
+        }
+        $remaining = (string)substr($file_contents, $end, $next - $end);
+        if (trim($remaining) === '') {
+            return $next + 1;
+        }
+        return $end;
+    }
+
+    /**
+     * @return array<string,Closure(string,PhpParser\Node,IssueInstance):(?FileEditSet)>
+     */
+    private static function createClosures() : array
+    {
+        /**
+         * @return ?FileEditSet
+         */
+        $handle_unreferenced_use = static function (
+            string $file_contents,
+            PhpParser\Node $root_node,
+            IssueInstance $issue_instance
+        ) {
+            // 1-based line
+            $line = $issue_instance->getLine();
+            $edits = [];
+            foreach (self::getNodesAtLine($file_contents, $root_node, $line) as $candidate_node) {
+                self::debug(sprintf("Handling %s for %s\n", get_class($candidate_node), (string)$issue_instance));
+                if ($candidate_node instanceof NamespaceUseDeclaration) {
+                    $edit = self::maybeRemoveNamespaceUseDeclaration($file_contents, $candidate_node, $issue_instance);
+                    if ($edit) {
+                        $edits[] = $edit;
+                    }
+                    break;
+                }
+            }
+            if ($edits) {
+                return new FileEditSet($edits);
+            }
+            return null;
+        };
+        return [
+            Issue::UnreferencedUseNormal => $handle_unreferenced_use,
+            Issue::UnreferencedUseConstant => $handle_unreferenced_use,
+            Issue::UnreferencedUseFunction => $handle_unreferenced_use,
+        ];
+    }
+
+    /**
+     * Apply fixes where possible for any issues in $instances.
+     *
+     * @param IssueInstance[] $instances
+     * @return void
+     */
+    public static function applyFixes(array $instances)
+    {
+        $fixers_for_files = self::computeFixersForInstances($instances);
+        foreach ($fixers_for_files as $file => $fixers) {
+            self::attemptFixForIssues((string)$file, $fixers);
+        }
+    }
+
+    /**
+     * Given a list of issue instances,
+     * return arrays of Closures to fix fixable instances in their corresponding files.
+     *
+     * @param IssueInstance[] $instances
+     * @return array<string,array<int,Closure(string,PhpParser\Node):(?FileEditSet)>>
+     */
+    public static function computeFixersForInstances(array $instances)
+    {
+        $closures = self::createClosures();
+        $fixers_for_files = [];
+        foreach ($instances as $instance) {
+            $issue = $instance->getIssue();
+            $type = $issue->getType();
+            $closure = $closures[$type] ?? null;
+            self::debug("Found closure for $type: " . json_encode((bool)$closure));
+            if ($closure) {
+                /**
+                 * @return ?FileEditSet
+                 */
+                $fixers_for_files[$instance->getFile()][] = static function (
+                    string $file_contents,
+                    PhpParser\Node $ast
+                ) use (
+                    $closure,
+                    $instance
+) {
+                    self::debug("Calling for $instance\n");
+                    return $closure($file_contents, $ast, $instance);
+                };
+            }
+        }
+        return $fixers_for_files;
+    }
+
+    /**
+     * @param string $file the file name, for debugging
+     * @param array<int,Closure(string,PhpParser\Node):(?FileEditSet)> $fixers one or more fixers. These return 0 edits if nothing works.
+     * @return ?string the new contents, if fixes could be applied
+     */
+    public static function computeNewContentForFixers(
+        string $file,
+        string $contents,
+        array $fixers
+    ) {
+        // A tolerantparser ast node
+        $ast = (new Parser())->parseSourceFile($contents);
+
+        // $dumper = new \Phan\AST\TolerantASTConverter\NodeDumper($contents);
+        // $dumper->setIncludeTokenKind(true);
+        // $dumper->dumpTree($ast);
+
+        $all_edits = [];
+        foreach ($fixers as $fix) {
+            $edit_set = $fix($contents, $ast);
+            foreach ($edit_set->edits ?? [] as $edit) {
+                $all_edits[] = $edit;
+            }
+        }
+        if (!$all_edits) {
+            self::debug("Phan cannot create any automatic fixes for $file\n");
+            return null;
+        }
+        return self::computeNewContents($file, $contents, $all_edits);
+    }
+
+    /**
+     * @param array<int,Closure(string,PhpParser\Node):(?FileEditSet)> $fixers one or more fixers. These return 0 edits if nothing works.
+     * @return void
+     */
+    private static function attemptFixForIssues(
+        string $file,
+        array $fixers
+    ) {
+        try {
+            $entry = FileCache::getOrReadEntry($file);
+        } catch (RuntimeException $e) {
+            self::error("Could not automatically fix $file: could not read contents: " . $e->getMessage() . "\n");
+            return;
+        }
+        $contents = $entry->getContents();
+        $new_contents = self::computeNewContentForFixers($file, $contents, $fixers);
+        if ($new_contents === null) {
+            return;
+        }
+        // Sort file edits in order of start position
+        $absolute_path = Config::projectPath($file);
+        if (!file_exists($absolute_path)) {
+            // This file should exist - always warn
+            self::error("Giving up on saving changes to $file: expected $absolute_path to exist already\n");
+            return;
+        }
+        file_put_contents($absolute_path, $new_contents);
+    }
+
+    /**
+     * Compute the new contents for a file, given the original contents and a list of edits to apply to that file
+     * @param string $file the path to the file, for logging.
+     * @param string $contents the original contents of the file. This will be modified
+     * @param FileEdit[] $all_edits
+     * @return ?string - the new contents, if successful.
+     */
+    public static function computeNewContents(string $file, string $contents, array $all_edits)
+    {
+        usort($all_edits, static function (FileEdit $a, FileEdit $b) : int {
+            return ($a->replace_start <=> $b->replace_start) ?: ($a->replace_end <=> $b->replace_end);
+        });
+        self::debug("Going to apply these fixes for $file: " . StringUtil::jsonEncode($all_edits) . "\n");
+        $last_end = 0;
+        $new_contents = '';
+        foreach ($all_edits as $edit) {
+            if ($edit->replace_start < $last_end) {
+                self::debug("Giving up on $file: replacement starts before end of another replacement\n");
+                return null;
+            }
+            $new_contents .= substr($contents, $last_end, $edit->replace_start - $last_end);
+            $last_end = $edit->replace_end;
+        }
+        $new_contents .= substr($contents, $last_end);
+        return $new_contents;
+    }
+
+    private static function error(string $message)
+    {
+        fwrite(STDERR, $message);
+    }
+
+    private static function debug(string $message)
+    {
+        if (getenv('PHAN_DEBUG_AUTOMATIC_FIX')) {
+            fwrite(STDERR, $message);
+        }
+    }
+}

--- a/tests/Phan/Plugin/Internal/IssueFixingPluginTest.php
+++ b/tests/Phan/Plugin/Internal/IssueFixingPluginTest.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types=1);
+
+namespace Phan\Tests\Plugin\Internal;
+
+use Phan\CodeBase;
+use Phan\Issue;
+use Phan\IssueInstance;
+use Phan\Plugin\Internal\IssueFixingPlugin\IssueFixer;
+use Phan\Tests\BaseTest;
+
+/**
+ * Unit tests of fixes to issues
+ */
+final class IssueFixingPluginTest extends BaseTest
+{
+    /** @var CodeBase|null The code base within which this unit test is operating */
+    protected static $code_base = null;
+
+    const FILE = 'fix_test.php';
+
+    /**
+     * @param IssueInstance[] $instances
+     * @dataProvider computeAndApplyFixesProvider
+     */
+    public function testComputeAndApplyFixes(string $expected_contents, string $original_contents, array $instances)
+    {
+        $fixers = IssueFixer::computeFixersForInstances($instances);
+        //var_export($instances);
+
+        $this->assertCount(1, $fixers);
+        $fixers_for_file = $fixers[self::FILE];
+        // echo "Going to apply to \n$original_contents\n";
+        $new_contents = IssueFixer::computeNewContentForFixers(self::FILE, $original_contents, $fixers_for_file);
+        $this->assertSame($expected_contents, $new_contents, 'unexpected contents after applying fixes');
+    }
+
+    /**
+     * @return array<int,array{0:string,1:string,2:array<int,IssueInstance>}>
+     */
+    public function computeAndApplyFixesProvider() : array
+    {
+        /**
+         * @param int|string ...$args
+         */
+        $make = static function (string $type, int $line, ...$args) : IssueInstance {
+            return new IssueInstance(Issue::fromType($type), self::FILE, $line, $args);
+        };
+        return [
+            [
+                <<<'EOT'
+<?php
+namespace test;
+use function strlen;
+echo "Hello, world!";
+echo strlen($argv[0]);
+EOT
+                ,
+                <<<'EOT'
+<?php
+namespace test;
+use ast\Node;
+use function foo;
+use function strlen;
+use const ast\AST_VERSION;
+echo "Hello, world!";
+echo strlen($argv[0]);
+EOT
+                ,
+                [
+                    $make(Issue::UnreferencedUseNormal, 3, 'Node', '\ast\Node'),
+                    $make(Issue::UnreferencedUseFunction, 4, 'foo', '\foo'),
+                    $make(Issue::UnreferencedUseConstant, 6, 'AST_VERSION', '\ast\AST_VERSION'),
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/Phan/Plugin/Internal/IssueFixingPluginTest.php
+++ b/tests/Phan/Plugin/Internal/IssueFixingPluginTest.php
@@ -2,7 +2,6 @@
 
 namespace Phan\Tests\Plugin\Internal;
 
-use Phan\CodeBase;
 use Phan\Issue;
 use Phan\IssueInstance;
 use Phan\Plugin\Internal\IssueFixingPlugin\IssueFixer;
@@ -13,9 +12,6 @@ use Phan\Tests\BaseTest;
  */
 final class IssueFixingPluginTest extends BaseTest
 {
-    /** @var CodeBase|null The code base within which this unit test is operating */
-    protected static $code_base = null;
-
     const FILE = 'fix_test.php';
 
     /**

--- a/tests/fixer_test/.phan/config.php
+++ b/tests/fixer_test/.phan/config.php
@@ -1,0 +1,136 @@
+<?php
+
+use \Phan\Issue;
+
+/**
+ * This configuration will be read and overlaid on top of the
+ * default configuration. Command line arguments will be applied
+ * after this file is read.
+ *
+ * @see src/Phan/Config.php
+ * See Config for all configurable options.
+ *
+ * This is a config file which tests all built in plugins,
+ * in addition to testing backwards compatibility checks and dead code detection.
+ */
+return [
+    'target_php_version' => '7.1',
+
+    // If true, missing properties will be created when
+    // they are first seen. If false, we'll report an
+    // error message.
+    'allow_missing_properties' => false,
+
+    // Allow null to be cast as any type and for any
+    // type to be cast to null.
+    'null_casts_as_any_type' => false,
+
+    // If enabled, scalars (int, float, bool, string, null)
+    // are treated as if they can cast to each other.
+    'scalar_implicit_cast' => false,
+
+    // If enabled, Phan will warn if **any** type in the method's object
+    // is definitely not an object.
+    // Setting this to true will introduce numerous false positives
+    // (and reveal some bugs).
+    'strict_method_checking' => true,
+
+    // If enabled, Phan will warn if **any** type in the argument's type
+    // cannot be cast to a type in the parameter's expected type.
+    // Setting this to true will introduce a large number of false positives (and some bugs).
+    // (For self-analysis, Phan has a large number of suppressions and file-level suppressions, due to \ast\Node being difficult to type check)
+    'strict_param_checking' => true,
+
+    // If enabled, Phan will warn if **any** type in a property assignment's type
+    // cannot be cast to a type in the property's expected type.
+    // Setting this to true will introduce a large number of false positives (and some bugs).
+    // (For self-analysis, Phan has a large number of suppressions and file-level suppressions, due to \ast\Node being difficult to type check)
+    'strict_property_checking' => true,
+
+    // If enabled, Phan will warn if **any** type in the return statement's type
+    // cannot be cast to a type in the method's declared return type.
+    // Setting this to true will introduce a large number of false positives (and some bugs).
+    // (For self-analysis, Phan has a large number of suppressions and file-level suppressions, due to \ast\Node being difficult to type check)
+    'strict_return_checking' => true,
+
+    // If true, seemingly undeclared variables in the global
+    // scope will be ignored. This is useful for projects
+    // with complicated cross-file globals that you have no
+    // hope of fixing.
+    'ignore_undeclared_variables_in_global_scope' => false,
+
+    // Backwards Compatibility Checking
+    // Check for $$var[] and $foo->$bar['baz'] and Foo::$bar['baz']() and $this->$bar['baz']
+    'backward_compatibility_checks' => false,
+
+    // If enabled, check all methods that override a
+    // parent method to make sure its signature is
+    // compatible with the parent's. This check
+    // can add quite a bit of time to the analysis.
+    'analyze_signature_compatibility' => true,
+
+    // Test dead code detection
+    'dead_code_detection' => true,
+
+    // TODO: Test unused variable detection
+    'unused_variable_detection' => true,
+
+    'globals_type_map' => ['test_global_exception' => 'Exception', 'test_global_error' => '\\Error'],
+
+    'quick_mode' => false,
+
+    'generic_types_enabled' => true,
+
+    'guess_unknown_parameter_type_using_default' => true,
+
+    // If enabled, warn about throw statement where the exception types
+    // are not documented in the PHPDoc of functions, methods, and closures.
+    'warn_about_undocumented_throw_statements' => true,
+
+    // If enabled (and warn_about_undocumented_throw_statements is enabled),
+    // warn about function/closure/method calls that have (at)throws
+    // without the invoking method documenting that exception.
+    'warn_about_undocumented_exceptions_thrown_by_invoked_functions' => true,
+
+    'minimum_severity' => Issue::SEVERITY_LOW,
+
+    'directory_list' => ['src'],
+
+    'analyzed_file_extensions' => ['php'],
+
+    // Set this to true to enable the plugins that Phan uses to infer more accurate literal return types of `implode`, `implode`, and many other functions.
+    //
+    // Phan is slightly faster when these are disabled.
+    'enable_extended_internal_return_type_plugins' => true,
+
+    // This is a unit test of Phan itself, so don't cache it because the polyfill implementation may change before the next release.
+    'cache_polyfill_asts' => false,
+
+    'plugin_config' => [
+        'php_native_syntax_check_max_processes' => 4,
+    ],
+
+    // A list of plugin files to execute
+    // (Execute all of them.)
+    // FooName is shorthand for /path/to/phan/.phan/plugins/FooName.php.
+    'plugins' => [
+        __DIR__ . '/../../../.phan/plugins/AlwaysReturnPlugin.php',  // This is testing the plugin locator, use old syntax
+        '../../.phan/plugins/DemoPlugin.php',  // Test behavior of the plugin locator.
+        'DollarDollarPlugin',
+        'DuplicateArrayKeyPlugin',
+        'InvalidVariableIssetPlugin',
+        'InvokePHPNativeSyntaxCheckPlugin',
+        'NonBoolBranchPlugin',
+        'NonBoolInLogicalArithPlugin',
+        'NumericalComparisonPlugin',
+        'PregRegexCheckerPlugin',
+        'PrintfCheckerPlugin',
+        'UnreachableCodePlugin',
+        'UnusedSuppressionPlugin',
+        'UseReturnValuePlugin',
+        'SleepCheckerPlugin',
+        'DuplicateExpressionPlugin',
+        'SuspiciousParamOrderPlugin',
+        'WhitespacePlugin',
+    ],
+];

--- a/tests/fixer_test/README.md
+++ b/tests/fixer_test/README.md
@@ -1,0 +1,1 @@
+NOTE: This has not been implemented yet.

--- a/tests/fixer_test/src/000_unused_use.php
+++ b/tests/fixer_test/src/000_unused_use.php
@@ -1,0 +1,6 @@
+<?php
+namespace test;
+
+use ast\Node;
+use function is_string;
+use const PHP_VERSION_ID;

--- a/tests/fixer_test/test.sh
+++ b/tests/fixer_test/test.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+EXPECTED_PATH=expected/all_output.expected
+ACTUAL_PATH=all_output.actual
+if [ ! -d expected  ]; then
+	echo "Error: must run this script from tests/fixer_test folder" 1>&2
+	exit 1
+fi
+echo "Generating test cases"
+for path in $(echo expected/*.php.expected | LC_ALL=C sort); do cat $path; done > $EXPECTED_PATH
+if [[ $? != 0 ]]; then
+	echo "Failed to concatenate test cases" 1>&2
+	exit 1
+fi
+echo "Running phan in '$PWD' ..."
+rm $ACTUAL_PATH -f || exit 1
+
+# We use the polyfill parser because it behaves consistently in all php versions.
+../../phan --automatic-fix --dead-code-detection --force-polyfill-parser --memory-limit 1G | tee $ACTUAL_PATH
+
+# diff returns a non-zero exit code if files differ or are missing
+# This outputs the difference between actual and expected output.
+echo
+echo "Comparing the output:"
+
+diff $EXPECTED_PATH $ACTUAL_PATH
+EXIT_CODE=$?
+if [ "$EXIT_CODE" == 0 ]; then
+	echo "Files $EXPECTED_PATH and output $ACTUAL_PATH are identical"
+    rm $ACTUAL_PATH
+fi
+exit $EXIT_CODE


### PR DESCRIPTION
This fixes issues in code based off of line numbers and part of the issue text.
This uses tolerant-php-parser because it contains all information about
the columns.