### PR TITLE
Add way to globally suppress some unused suppression issues

### DIFF
--- a/.phan/plugins/README.md
+++ b/.phan/plugins/README.md
@@ -36,6 +36,9 @@ or if the relevant parts of the codebase fixed the bug/added annotations)
 - **UnusedPluginSuppression**: `Plugin {STRING_LITERAL} suppresses issue {ISSUETYPE} on this line but this suppression is unused or suppressed elsewhere`
 - **UnusedPluginFileSuppression**: `Plugin {STRING_LITERAL} suppresses issue {ISSUETYPE} in this file but this suppression is unused or suppressed elsewhere`
 
+The setting `'plugin_config' => ['unused_suppression_ignore_list' => ['FlakyPluginIssueName']]` can be used in `.phan/config.php`
+to make this plugin avoid emitting `Unused*Suppression` for a list of issue names.
+
 ### 2. General-Use Plugins
 
 These plugins are useful across a wide variety of code styles, and should give low false positives.

--- a/tests/plugin_test/.phan/config.php
+++ b/tests/plugin_test/.phan/config.php
@@ -108,6 +108,7 @@ return [
 
     'plugin_config' => [
         'php_native_syntax_check_max_processes' => 4,
+        'unused_suppression_ignore_list' => ['Unused-Issue-In-Config'],
     ],
 
     // A list of plugin files to execute

--- a/tests/plugin_test/expected/103_suppress_unused_suppress.php.expected
+++ b/tests/plugin_test/expected/103_suppress_unused_suppress.php.expected
@@ -1,0 +1,1 @@
+src/103_suppress_unused_suppress.php:13 UnusedSuppression Element \test103b suppresses issue Unused-Issue-Not-In-Config but does not use it

--- a/tests/plugin_test/src/103_suppress_unused_suppress.php
+++ b/tests/plugin_test/src/103_suppress_unused_suppress.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @suppress Unused-Issue-In-Config
+ */
+function test103a() {
+    echo "Hello, ";
+}
+
+/**
+ * @suppress Unused-Issue-Not-In-Config
+ */
+function test103b() {
+    echo "World!";
+}
+test103a();
+test103b();


### PR DESCRIPTION
For #2515

- can put this directly in some Phan configuration
  for flaky issues or issues only available with hard to set up/run plugins.
- Other plugins have the ability to add to the array in plugin_config
  (not ideal, but will probably work)