### PR TITLE
Fix false positive analyzing array access

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@ New features(CLI,Configs)
   - issues emitted by `WhitespacePlugin` (#2523)
   - unqualified global function calls/constant uses from namespaces (requires `NotFullyQualifiedUsagePlugin`)
     (will do the wrong thing for functions that are both global and in the same namespace)
++ Be more aggressive about inferring that the result is `null` when accessing array offsets that don't exist. (#2541)
 
 New features(Analysis):
 + Make Phan infer more precise literal types for internal constants such as `PHP_EOF`.

--- a/tests/files/expected/0354_string_index.php.expected
+++ b/tests/files/expected/0354_string_index.php.expected
@@ -10,12 +10,11 @@
 %s:27 PhanTypeMismatchDimFetch When fetching an array index from a value of type array{offset:'c'}, found an array index of type array{}, but expected the index to be of type string
 %s:28 PhanTypeMismatchDimFetchNullable When fetching an array index from a value of type array{offset:'c'}, found an array index of type null, but expected the index to be of the non-nullable type string
 %s:29 PhanTypeInvalidDimOffset Invalid offset 0 of array type array{offset:'c'}
-%s:29 PhanTypeMismatchDimFetch When fetching an array index from a value of type array{offset:'c'}, found an array index of type 0, but expected the index to be of type string
 %s:30 PhanTypeInvalidDimOffset Invalid offset 31 of array type array{offset:'c'}
-%s:30 PhanTypeMismatchDimFetch When fetching an array index from a value of type array{offset:'c'}, found an array index of type 31, but expected the index to be of type string
 %s:31 PhanTypeInvalidDimOffset Invalid offset "otherOffset" of array type array{offset:'c'}
 %s:33 PhanTypeInvalidDimOffset Invalid offset "offset2" of array type array{offset:'c'}
 %s:35 PhanTypeInvalidDimOffset Invalid offset "offset2" of array type array{offset:'c'}
 %s:40 PhanTypeMismatchArgumentInternal Argument 1 (string) is 2 but \strlen() takes string
 %s:41 PhanTypeInvalidDimOffset Invalid offset 2 of array type array{0:1,1:2,3:'x'}
+%s:41 PhanTypeMismatchArgumentInternal Argument 1 (string) is null but \strlen() takes string
 %s:43 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is 'x' but \intdiv() takes int

--- a/tests/files/expected/0439_multi.php.expected
+++ b/tests/files/expected/0439_multi.php.expected
@@ -1,1 +1,2 @@
 %s:4 PhanTypeInvalidDimOffset Invalid offset "otherOffset" of array type array{offset:'value',first:2}
+%s:4 PhanTypeSuspiciousEcho Suspicious argument null for an echo/print statement

--- a/tests/files/expected/0447_parse_url.php.expected
+++ b/tests/files/expected/0447_parse_url.php.expected
@@ -1,4 +1,5 @@
 %s:5 PhanTypeMismatchArgumentInternal Argument 1 (string) is int but \strlen() takes string
 %s:6 PhanTypeMismatchArgumentInternal Argument 1 (var) is string but \count() takes \Countable|array
 %s:7 PhanTypeInvalidDimOffset Invalid offset "Host" of array type array{scheme?:string,host?:string,port?:int,user?:string,pass?:string,path?:string,query?:string,fragment?:string}|false
+%s:7 PhanTypeSuspiciousEcho Suspicious argument null for an echo/print statement
 %s:10 PhanTypeMismatchArgumentInternal Argument 1 (var) is false|int|null|string but \count() takes \Countable|array

--- a/tests/files/expected/0508_unset_crash.php.expected
+++ b/tests/files/expected/0508_unset_crash.php.expected
@@ -1,1 +1,2 @@
 %s:6 PhanTypeInvalidDimOffset Invalid offset 2 of array type array{4:'y'}
+%s:6 PhanTypeSuspiciousEcho Suspicious argument null for an echo/print statement

--- a/tests/files/expected/0523_regex_group_extraction.php.expected
+++ b/tests/files/expected/0523_regex_group_extraction.php.expected
@@ -1,4 +1,5 @@
 %s:4 PhanTypeInvalidDimOffset Invalid offset 2 of array type array{0:string,1:string}
+%s:4 PhanTypeSuspiciousEcho Suspicious argument null for an echo/print statement
 %s:7 PhanTypeInvalidDimOffset Invalid offset 2 of array type array{0:array{0:string,1:int},1:array{0:string,1:int}}
 %s:10 PhanTypeMismatchArgumentInternal Argument 1 (string) is array{0:array{0:string,1:int},name:array{0:string,1:int},1:array{0:string,1:int}} but \strlen() takes string
 %s:13 PhanTypeMismatchArgumentInternal Argument 1 (string) is array{0:string,name:string,1:string} but \strlen() takes string

--- a/tests/files/expected/0608_regex_features.php.expected
+++ b/tests/files/expected/0608_regex_features.php.expected
@@ -1,6 +1,12 @@
 %s:5 PhanTypeInvalidDimOffset Invalid offset 2 of array type array{0:string,1:string}
+%s:5 PhanTypeSuspiciousEcho Suspicious argument null for an echo/print statement
 %s:10 PhanTypeInvalidDimOffset Invalid offset 2 of array type array{0:string,1:string}
+%s:10 PhanTypeSuspiciousEcho Suspicious argument null for an echo/print statement
 %s:15 PhanTypeInvalidDimOffset Invalid offset 2 of array type array{0:string,name:string,1:string}
+%s:15 PhanTypeSuspiciousEcho Suspicious argument null for an echo/print statement
 %s:21 PhanTypeInvalidDimOffset Invalid offset 2 of array type array{0:string,a:string,1:string}
+%s:21 PhanTypeSuspiciousEcho Suspicious argument null for an echo/print statement
 %s:25 PhanTypeInvalidDimOffset Invalid offset 2 of array type array{0:string,de:string,1:string}
+%s:25 PhanTypeSuspiciousEcho Suspicious argument null for an echo/print statement
 %s:29 PhanTypeInvalidDimOffset Invalid offset 2 of array type array{0:string,caseInsensitive:string,1:string}
+%s:29 PhanTypeSuspiciousEcho Suspicious argument null for an echo/print statement

--- a/tests/files/expected/0641_array_shape_offset.php.expected
+++ b/tests/files/expected/0641_array_shape_offset.php.expected
@@ -1,0 +1,7 @@
+%s:8 PhanTypeMismatchArgumentInternal Argument 1 (string) is array<string,array{mode:'Foo'}>[]|array{} but \strlen() takes string
+%s:8 PhanTypeMismatchArgumentInternal Argument 1 (string) is array{} but \strlen() takes string
+%s:9 PhanTypeInvalidDimOffset Invalid offset "class" of array type array{mode:'Foo'}
+%s:9 PhanTypeInvalidDimOffset Invalid offset 0 of array type array{}
+%s:10 PhanNonClassMethodCall Call to method __construct on non-class type null
+%s:10 PhanTypeExpectedObjectOrClassName Expected an object instance or the name of a class but saw expression with type null
+%s:10 PhanUnusedVariable Unused definition of variable $test

--- a/tests/files/src/0641_array_shape_offset.php
+++ b/tests/files/src/0641_array_shape_offset.php
@@ -1,0 +1,26 @@
+<?php
+
+abstract class PhanUndeclaredClassFailure
+{
+	private $fields = array();
+	public function set($data, $value = null)
+	{
+        echo strlen($this->fields);
+		$class = $this->fields[0]['opt']['class'];
+		$test = new $class();
+	}
+
+	public function addField($field)
+	{
+		$this->fields[$field] = [
+			'opt' => [
+				'mode' => 'Foo'
+			]
+		];
+	}
+
+	public function findFirst()
+	{
+		$this->set([]);
+	}
+}

--- a/tests/plugin_test/expected/094_combination_regex.php.expected
+++ b/tests/plugin_test/expected/094_combination_regex.php.expected
@@ -1,3 +1,6 @@
 src/094_combination_regex.php:4 PhanTypeInvalidDimOffset Invalid offset 2 of array type array{0:string,1:string}
+src/094_combination_regex.php:4 PhanTypeSuspiciousEcho Suspicious argument null for an echo/print statement
 src/094_combination_regex.php:6 PhanTypeInvalidDimOffset Invalid offset 2 of array type array{0:string,1:string}
+src/094_combination_regex.php:6 PhanTypeSuspiciousEcho Suspicious argument null for an echo/print statement
 src/094_combination_regex.php:8 PhanTypeInvalidDimOffset Invalid offset 3 of array type array{0:string,1:string,2:string}
+src/094_combination_regex.php:8 PhanTypeSuspiciousEcho Suspicious argument null for an echo/print statement


### PR DESCRIPTION
Fixes #2541

Be more aggressive about inferring null for field uses when the accessed type's
array types are exclusively array shapes.