### PR TITLE
Fix parsing `?(A|B|C)`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -45,6 +45,7 @@ Bug fixes:
 + Fix bug: `--ignore-undeclared` failed to properly ignore undeclared elements since 1.2.3 (#2502)
 + Fix false positive `PhanTypeInvalidDimOffset` for functions nested within other functions.
 + Support commas in the union types of parameters of magic methods (#2507)
++ Fix parsing `?(A|B|C)` (#2551)
 
 27 Feb 2019, Phan 1.2.5
 -----------------------

--- a/src/Phan/Debug.php
+++ b/src/Phan/Debug.php
@@ -235,11 +235,16 @@ class Debug
             if (!$level) {
                 continue;
             }
-            echo "#" . ($level - 1) . " {$context['file']}:{$context['line']} {$context['class']} ";
+            $file = $context['file'] ?? 'unknown';
+            $line = $context['line'] ?? 1;
+            $class = $context['class'] ?? 'global';
+            $function = $context['function'] ?? '';
+
+            echo "#" . ($level - 1) . " $file:$line $class ";
             if (isset($context['type'])) {
                 echo $context['class'] . $context['type'];
             }
-            echo $context['function'];
+            echo $function;
             echo "\n";
         }
     }

--- a/tests/Phan/Language/UnionTypeTest.php
+++ b/tests/Phan/Language/UnionTypeTest.php
@@ -520,6 +520,12 @@ final class UnionTypeTest extends BaseTest
         $this->assertSame(1, $union_type->typeCount());
     }
 
+    public function testNullableBasicType()
+    {
+        $union_type = self::makePHPDocUnionType('?(int|string|float|false)');
+        $this->assertSame('?false|?float|?int|?string', (string)$union_type);
+    }
+
     public function testNullableBasicArrayType()
     {
         $union_type = self::makePHPDocUnionType('?(int|string)[]');


### PR DESCRIPTION
Fixes #2551