### PR TITLE
Make the codeclimate plugin analyze the correct directory

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -300,6 +300,7 @@ return [
     'file_list' => [
         'phan',
         'phan_client',
+        'plugins/codeclimate/engine',
         'tool/make_stubs',
         'internal/dump_fallback_ast.php',
         'internal/internalsignatures.php',

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,9 @@ Maintenance
   (fix parsing of some edge cases, minor performance improvement, prepare to support php 7.4 in polyfill)
 + Use paratest for phpunit tests in Travis/Appveyor
 
+Bug fixes:
++ Make the codeclimate plugin analyze the correct directory. Update the dependencies of the codeclimate plugin. (#2139)
+
 09 Mar 2019, Phan 1.2.6
 -----------------------
 

--- a/plugins/codeclimate/Dockerfile
+++ b/plugins/codeclimate/Dockerfile
@@ -24,7 +24,7 @@
 # SOFTWARE.
 
 
-FROM alpine:3.7
+FROM alpine:3.9
 
 WORKDIR /usr/src/app
 
@@ -32,7 +32,7 @@ RUN adduser -u 9000 -D app
 
 ENV LAST_MODIFIED_DATE 2018-01-20
 
-ENV PHP_AST_VERSION=0.1.6
+ENV PHP_AST_VERSION=1.0.1
 
 RUN apk add --no-cache \
 	php7 && \
@@ -95,8 +95,6 @@ RUN apk add --no-cache bash \
       build-base \
       php7-dev \
       wget
-COPY plugins/codeclimate/ast.ini /etc/php7/conf.d/
-COPY plugins/codeclimate/engine /usr/src/app/plugins/codeclimate/engine
 
 COPY composer.json composer.lock ./
 RUN apk add --no-cache curl && \
@@ -107,6 +105,9 @@ RUN apk add --no-cache curl && \
 
 COPY .phan .phan
 COPY src src
+
+COPY plugins/codeclimate/ast.ini /etc/php7/conf.d/
+COPY plugins/codeclimate/engine /usr/src/app/plugins/codeclimate/engine
 
 USER app
 

--- a/plugins/codeclimate/README.md
+++ b/plugins/codeclimate/README.md
@@ -4,7 +4,7 @@ Building a new codeclimate image
 From the root directory of the phan installation (Change build tag if publishing)
 
 ```sh
-	sudo docker build -t phan:0.10.3 -f plugins/codeclimate/Dockerfile .
+	sudo docker build -t phan:1.2.6 -f plugins/codeclimate/Dockerfile .
 ```
 
 
@@ -15,7 +15,7 @@ The following example uses the phan codeclimate image to analyze the phan checko
 By running it from a different folder passing in a different config.json to `-v`, options can be changed.
 
 ```sh
-sudo docker run -v $PWD:/code:ro -v $PWD:/code:ro -v $PWD/plugins/codeclimate/config-example.json:/config.json phan:0.10.3
+sudo docker run -v $PWD:/code:ro -v $PWD:/code:ro -v $PWD/plugins/codeclimate/config-example.json:/config.json phan:1.2.6
 ```
 
 Future work

--- a/plugins/codeclimate/engine
+++ b/plugins/codeclimate/engine
@@ -1,5 +1,6 @@
 #!/usr/bin/env php
 <?php declare(strict_types = 1);
+// @phan-file-suppress PhanNativePHPSyntaxCheckPlugin
 
 require_once(__DIR__ . '/../../src/requirements.php');
 
@@ -18,111 +19,122 @@ use Phan\Output\PrinterFactory;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Phan\Phan;
 
-// chdir to the code path in order to support the .phan/config.php file
-$old_cwd = getcwd();
+call_user_func(static function () use ($code_base) {
+    // Create our CLI interface and load arguments
+    chdir('/code');
+    $cli = CLI::fromArgv();
 
-// Create our CLI interface and load arguments
-chdir('/code');
-$cli = CLI::fromArgv();
-chdir($old_cwd);
-
-// Obtain the config
-$codeclimate_config = json_decode(file_get_contents('/config.json'), true);
-
-$inner_config = $codeclimate_config['config'] ?? [];
-
-// Parse the config
-if (isset($inner_config['minimum-severity'])) {
-    $minimum_severity = (int) $codeclimate_config['config']['minimum-severity'];
-} else {
-    $minimum_severity = 0;
-}
-
-$mask = -1;
-
-if ($inner_config['ignore-undeclared'] ?? false) {
-    $mask &= ~Issue::CATEGORY_UNDEFINED;
-}
-
-if (isset($inner_config['quick'])) {
-    Config::setValue('quick_mode', (bool)$inner_config['quick']);
-}
-
-if (isset($inner_config['backward-compatibility-checks'])) {
-    Config::setValue('backward_compatibility_checks', (bool)$inner_config['backward-compatibility-checks']);
-}
-
-if (isset($inner_config['dead-code-detection'])) {
-    Config::setValue('dead_code_detection', (bool)$inner_config['dead-code-detection']);
-}
-
-if (isset($inner_config['file_extensions'])) {
-    $file_extensions = explode(",", $inner_config['file_extensions']);
-} else {
-    $file_extensions = ['php'];
-}
-
-$include_paths = [];
-
-$queue_file = function ($file_path) use (&$include_paths, $file_extensions) {
-    $file_info = new SplFileInfo($file_path);
-
-    if (in_array($file_info->getExtension(), $file_extensions))
-    {
-        $include_paths[] = realpath($file_path);
+    // Obtain the config
+    $config_path = '/config.json';
+    if (!is_file($config_path)) {
+        fwrite(STDERR, "Could not find '$config_path'" . PHP_EOL);
+        exit(1);
     }
-};
+    // @phan-suppress-next-line PhanPossiblyFalseTypeArgumentInternal
+    $codeclimate_config = json_decode(file_get_contents($config_path), true);
 
-// Todo: wrap with `-l` console logic instead of custom function
-$queue_with_include_paths = function ($dir_path) use (&$include_paths, &$queue_with_include_paths, &$queue_file) {
-    foreach (scandir($dir_path) as $f) {
-        if ($f !== '.' and $f !== '..') {
-            if (is_dir("$dir_path/$f")) {
-                $queue_with_include_paths("$dir_path/$f");
-            } else {
-                $queue_file("$dir_path/$f");
+    $inner_config = $codeclimate_config['config'] ?? [];
+
+    // Parse the config
+    if (isset($inner_config['minimum-severity'])) {
+        $minimum_severity = (int) $codeclimate_config['config']['minimum-severity'];
+    } else {
+        $minimum_severity = 0;
+    }
+
+    $mask = -1;
+
+    if ($inner_config['ignore-undeclared'] ?? false) {
+        $mask &= ~Issue::CATEGORY_UNDEFINED;
+    }
+
+    if (isset($inner_config['quick'])) {
+        Config::setValue('quick_mode', (bool)$inner_config['quick']);
+    }
+
+    if (isset($inner_config['backward-compatibility-checks'])) {
+        Config::setValue('backward_compatibility_checks', (bool)$inner_config['backward-compatibility-checks']);
+    }
+
+    if (isset($inner_config['dead-code-detection'])) {
+        Config::setValue('dead_code_detection', (bool)$inner_config['dead-code-detection']);
+    }
+
+    if (isset($inner_config['file_extensions'])) {
+        $file_extensions = explode(",", $inner_config['file_extensions']);
+    } else {
+        $file_extensions = ['php'];
+    }
+
+    $include_paths = [];
+
+    /**
+     * @param string $file_path
+     */
+    $queue_file = function ($file_path) use (&$include_paths, $file_extensions) {
+        $file_info = new SplFileInfo($file_path);
+
+        if (in_array($file_info->getExtension(), $file_extensions))
+        {
+            $include_paths[] = realpath($file_path);
+        }
+    };
+
+    // Todo: wrap with `-l` console logic instead of custom function
+    /**
+     * @param string $dir_path
+     */
+    $queue_with_include_paths = function ($dir_path) use (&$include_paths, &$queue_with_include_paths, &$queue_file) {
+        foreach (scandir($dir_path) as $f) {
+            if ($f !== '.' and $f !== '..') {
+                if (is_dir("$dir_path/$f")) {
+                    $queue_with_include_paths("$dir_path/$f");
+                } else {
+                    $queue_file("$dir_path/$f");
+                }
             }
         }
+    };
+
+    foreach ($codeclimate_config['include_paths'] as $path) {
+        if (is_dir('/code/' . $path)) {
+            $queue_with_include_paths('/code/' . $path);
+        } else {
+            $queue_file("/code/$path");
+        }
     }
-};
 
-foreach ($codeclimate_config['include_paths'] as $path) {
-    if (is_dir('/code/' . $path)) {
-        $queue_with_include_paths('/code/' . $path);
-    } else {
-        $queue_file("/code/$path");
+    // skip run if there are no paths
+    if (empty($include_paths)) {
+        exit();
     }
-}
 
-// skip run if there are no paths
-if (empty($include_paths)) {
-    exit();
-}
+    $output = new ConsoleOutput();
+    $factory = new PrinterFactory();
+    Config::setValue('markdown_issue_messages', true);
+    $printer = $factory->getPrinter('codeclimate', $output);
+    Phan::setPrinter($printer);
 
-$output = new ConsoleOutput();
-$factory = new PrinterFactory();
-Config::setValue('markdown_issue_messages', true);
-$printer = $factory->getPrinter('codeclimate', $output);
-Phan::setPrinter($printer);
+    $filter = new ChainedIssueFilter([
+        new FileIssueFilter(new Phan()),
+        new MinimumSeverityFilter($minimum_severity),
+        new CategoryIssueFilter($mask)
+    ]);
+    $collector = new BufferingCollector($filter);
+    Phan::setIssueCollector($collector);
 
-$filter = new ChainedIssueFilter([
-    new FileIssueFilter(new Phan()),
-    new MinimumSeverityFilter($minimum_severity),
-    new CategoryIssueFilter($mask)
-]);
-$collector = new BufferingCollector($filter);
-Phan::setIssueCollector($collector);
+    // If .phan/config.php specified a list of files to parse and analyze, prefer those over codeclimate.
+    $file_list_from_cli = $cli->getFileList();
+    if (count($file_list_from_cli) > 0) {
+        $force_codeclimate_filelist = $inner_config['force-codeclimate-filelist'] ?? false;
+        if (!$force_codeclimate_filelist) {
+            $include_paths = $file_list_from_cli;
+        }
+    }
 
-// If .phan/config.php specified a list of files to parse and analyze, prefer those over codeclimate.
-$file_list_from_cli = $cli->getFileList();
-if (count($file_list_from_cli) > 0) {
-	$force_codeclimate_filelist = $inner_config['force-codeclimate-filelist'] ?? false;
-	if (!$force_codeclimate_filelist) {
-		$include_paths = $file_list_from_cli;
-	}
-}
-
-// Analyze the file list provided via the CLI
-Phan::analyzeFileList($code_base, function() use($include_paths) {
-	return $include_paths;
+    // Analyze the file list provided via the CLI
+    // @phan-suppress-next-line PhanThrowTypeAbsentForCall if this throws, it's not recoverable.
+    Phan::analyzeFileList($code_base, /** @return string[] */ static function () use($include_paths) {
+        return $include_paths;
+    });
 });

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -3116,7 +3116,7 @@ class Clazz extends AddressableElement
 
     /**
      * Given the FQSEN of an ancestor class and an element definition,
-     * return the overriden element's definition or null if this didn't override anything.
+     * return the overridden element's definition or null if this didn't override anything.
      *
      * TODO: Handle renamed elements from traits.
      *

--- a/src/Phan/Language/Element/Func.php
+++ b/src/Phan/Language/Element/Func.php
@@ -377,7 +377,7 @@ class Func extends AddressableElement implements FunctionInterface
     }
 
     /**
-     * Returns a string that can be used as a stand-alone PHP stub for this global function.
+     * Returns a string that can be used as a standalone PHP stub for this global function.
      * @suppress PhanUnreferencedPublicMethod (toStubInfo is used by callers for more flexibility)
      */
     public function toStub() : string


### PR DESCRIPTION
For #2139

It looks like this was analyzing phan itself,
not the /code folder. Get rid of the extra `chdir()`.