### PR TITLE
Allow missing PHPDoc on anonymous classes

### DIFF
--- a/.phan/plugins/HasPHPDocPlugin.php
+++ b/.phan/plugins/HasPHPDocPlugin.php
@@ -62,6 +62,10 @@ final class HasPHPDocPlugin extends PluginV2 implements
         CodeBase $code_base,
         Clazz $class
     ) {
+        if ($class->isAnonymous()) {
+            // Probably not useful in many cases to document a short anonymous class.
+            return;
+        }
         $doc_comment = $class->getDocComment();
         if (!$doc_comment) {
             self::emitIssue(

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -1908,6 +1908,15 @@ class Clazz extends AddressableElement
     }
 
     /**
+     * @return bool
+     * True if this class is anonymous
+     */
+    public function isAnonymous() : bool
+    {
+        return $this->getFQSEN()->isAnonymous();
+    }
+
+    /**
      * @return FullyQualifiedClassName
      */
     public function getFQSEN() : FullyQualifiedClassName

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -1913,7 +1913,7 @@ class Clazz extends AddressableElement
      */
     public function isAnonymous() : bool
     {
-        return $this->getFQSEN()->isAnonymous();
+        return ($this->getFlags() & \ast\flags\CLASS_ANONYMOUS) > 0;
     }
 
     /**

--- a/src/Phan/Language/FQSEN/FullyQualifiedClassName.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedClassName.php
@@ -111,13 +111,4 @@ class FullyQualifiedClassName extends FullyQualifiedGlobalStructuralElement
             return self::fromFullyQualifiedString("\stdClass");
         });
     }
-
-    /**
-     * @return bool
-     * True if this FQSEN represents an anonymous class
-     */
-    public function isAnonymous() : bool
-    {
-        return (\preg_match('/^anonymous_class_/', $this->getName()) === 1);
-    }
 }

--- a/src/Phan/Language/FQSEN/FullyQualifiedClassName.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedClassName.php
@@ -111,4 +111,13 @@ class FullyQualifiedClassName extends FullyQualifiedGlobalStructuralElement
             return self::fromFullyQualifiedString("\stdClass");
         });
     }
+
+    /**
+     * @return bool
+     * True if this FQSEN represents an anonymous class
+     */
+    public function isAnonymous() : bool
+    {
+        return (\preg_match('/^anonymous_class_/', $this->getName()) === 1);
+    }
 }


### PR DESCRIPTION
This suppresses `PhanPluginNoCommentOnClass` and `PhanPluginDescriptionlessCommentOnClass` on anonymous classes, since the same was done for closures. Another option would be to change the issue name to allow suppressing it.