### PR TITLE
Fix Ds\Hashable::hash return type

### DIFF
--- a/src/Phan/Language/Internal/FunctionSignatureMap.php
+++ b/src/Phan/Language/Internal/FunctionSignatureMap.php
@@ -2243,7 +2243,7 @@ return [
 'Ds\Deque::toArray' => ['array'],
 'Ds\Deque::unshift' => ['void', '...values='=>'mixed'],
 'Ds\Hashable::equals' => ['bool', 'obj'=>'mixed'],
-'Ds\Hashable::hash' => ['void'],
+'Ds\Hashable::hash' => ['mixed'],
 'Ds\Map::__construct' => ['void', 'values='=>'mixed'],
 'Ds\Map::allocate' => ['void', 'capacity'=>'int'],
 'Ds\Map::apply' => ['void', 'callback'=>'callable'],


### PR DESCRIPTION
Simply changes the return type from `void` to `mixed`: https://secure.php.net/manual/en/ds-hashable.hash.php