### PR TITLE
Use the full progress bar for Windows, check for utf-8 support

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@ Phan NEWS
 ?? ??? 2019, Phan 1.2.7 (dev)
 -----------------------
 
+New features(CLI,Configs)
++ Use a progress bar for `--progress-bar` on Windows instead of printing dots. (#2572)
+  Use ASCII characters for the progress bar instead of UTF-8 if the code page isn't utf-8 or if Phan can't infer the terminal's code page (e.g. in PHP < 7.1)
+
 Maintenance:
 + Update tolerant-php-parser version to 0.0.17
   (fix parsing of some edge cases, minor performance improvement, prepare to support php 7.4 in polyfill)


### PR DESCRIPTION
The full block characters used would be rendered incorrectly in some
locales. This fixes it by using ASCII if those wouldn't work.

Fixes #2572