### PR TITLE
Fix false positive PhanTypeInvalidDimOffset for unset

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@ Bug fixes:
 + Make the codeclimate plugin analyze the correct directory. Update the dependencies of the codeclimate plugin. (#2139)
 + Fix false positive checking for undefined offset with `$foo['strVal']` when strings are in the union type of `$foo` (#2541)
 + Fix crash in analysis of `call_user_func` (#2576)
++ Fix a false positive PhanTypeInvalidDimOffset for `unset` on array fields in conditional branches. (#2591)
 
 09 Mar 2019, Phan 1.2.6
 -----------------------

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -277,6 +277,8 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             if (!\is_scalar($dim_value)) {
                 return;
             }
+            $variable = clone($variable);
+            $context->getScope()->addVariable($variable);
             $variable->setUnionType($variable->getUnionType()->withoutArrayShapeField($dim_value));
         }
     }

--- a/tests/files/src/0644_unset_false_positive.php
+++ b/tests/files/src/0644_unset_false_positive.php
@@ -1,0 +1,8 @@
+<?php
+function fn644() {
+    $arr = ['x' => true];
+
+    if ($arr['x'] !== null) {  // regression test for false positive PhanTypeInvalidDimOffset
+        unset( $arr['x'] );
+    }
+}


### PR DESCRIPTION
(seen when unsetting array fields in a conditional branch)

Fixes #2591 