### PR TITLE
In issues, make encoded strings fit on a single line

### DIFF
--- a/.phan/plugins/DuplicateArrayKeyPlugin.php
+++ b/.phan/plugins/DuplicateArrayKeyPlugin.php
@@ -197,7 +197,7 @@ class DuplicateArrayKeyVisitor extends PluginAwarePostAnalysisVisitor
             return (string)json_encode($key);
         }
         $tmp = [$key => true];
-        return var_export(key($tmp), true);
+        return ASTReverter::toShortString(key($tmp));
     }
 
     /**
@@ -213,7 +213,7 @@ class DuplicateArrayKeyVisitor extends PluginAwarePostAnalysisVisitor
             return (string)$key;
         }
         $tmp = [$key => true];
-        return var_export(key($tmp), true);
+        return ASTReverter::toShortString(key($tmp));
     }
 }
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@ Phan NEWS
 ?? ??? 2019, Phan 1.2.8 (dev)
 -----------------------
 
+Maintenance:
++ Make escaped string arguments fit on a single line for more issue types.
+
 22 Mar 2019, Phan 1.2.7
 -----------------------
 

--- a/src/Phan/Language/Type/LiteralStringType.php
+++ b/src/Phan/Language/Type/LiteralStringType.php
@@ -107,8 +107,10 @@ final class LiteralStringType extends StringType implements LiteralTypeInterface
     public function __toString() : string
     {
         // TODO: Finalize escaping
+        // NOTE: Phan has issues with parsing commas in phpdoc, so don't suggest them.
+        // Support for commas should be restored when https://github.com/phan/phan/issues/2597 is fixed
         $inner = \preg_replace_callback(
-            '/[^- ,.\/?:;"!#$%^&*_+=a-zA-Z0-9_\x80-\xff]/',
+            '/[^- .\/?:;"!#$%^&*_+=a-zA-Z0-9_\x80-\xff]/',
             /**
              * @param array{0:string} $match
              * @return string

--- a/src/Phan/Library/StringUtil.php
+++ b/src/Phan/Library/StringUtil.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Phan\Library;
 
+use Phan\AST\ASTReverter;
+
 /**
  * StringUtil contains methods to simplify working with strings in Phan and its plugins.
  */
@@ -11,11 +13,16 @@ class StringUtil
     /**
      * Encode a scalar value in a compact, unambiguous representation for emitted issues.
      * The encoder used by encodeValue may change.
+     * This aims to fit on a single line.
      *
      * @param string|int|float|bool|null $value
      */
     public static function encodeValue($value) : string
     {
+        if (\is_string($value) && \preg_match('/([\0-\15\16-\37])/', $value)) {
+            // Use double quoted strings if this contains newlines, tabs, control characters, etc.
+            return '"' . ASTReverter::escapeInnerString($value, '"') . '"';
+        }
         return \var_export($value, true);
     }
 

--- a/tests/Phan/AST/ASTReverterTest.php
+++ b/tests/Phan/AST/ASTReverterTest.php
@@ -38,6 +38,10 @@ final class ASTReverterTest extends BaseTest
     {
         return [
             ["'2'"],
+            ['"a\tc\nb"'],
+            ['"\0"'],
+            ['"\07"', '"\7"'],
+            ['"\0072"', '"\0072"'],
             ['2'],
             ['false'],
             ['null'],

--- a/tests/plugin_test/expected/101_extended_return_inferences.php.expected
+++ b/tests/plugin_test/expected/101_extended_return_inferences.php.expected
@@ -3,7 +3,7 @@ src/101_extended_return_inferences.php:12 PhanTypeMismatchArgument Argument 1 (x
 src/101_extended_return_inferences.php:13 PhanTypeMismatchArgument Argument 1 (x) is array{0:2} but \expect_zero() takes 0 defined at src/101_extended_return_inferences.php:8
 src/101_extended_return_inferences.php:14 PhanTypeMismatchArgument Argument 1 (x) is \stdClass but \expect_zero() takes 0 defined at src/101_extended_return_inferences.php:8
 src/101_extended_return_inferences.php:15 PhanTypeMismatchArgument Argument 1 (x) is '1' but \expect_zero() takes 0 defined at src/101_extended_return_inferences.php:8
-src/101_extended_return_inferences.php:16 PhanTypeMismatchArgument Argument 1 (x) is '1,2' but \expect_zero() takes 0 defined at src/101_extended_return_inferences.php:8
+src/101_extended_return_inferences.php:16 PhanTypeMismatchArgument Argument 1 (x) is '1\x2c2' but \expect_zero() takes 0 defined at src/101_extended_return_inferences.php:8
 src/101_extended_return_inferences.php:17 PhanTypeMismatchArgument Argument 1 (x) is '12' but \expect_zero() takes 0 defined at src/101_extended_return_inferences.php:8
 src/101_extended_return_inferences.php:18 PhanTypeMismatchArgument Argument 1 (x) is '0' but \expect_zero() takes 0 defined at src/101_extended_return_inferences.php:8
 src/101_extended_return_inferences.php:19 PhanTypeMismatchArgument Argument 1 (x) is 'tset' but \expect_zero() takes 0 defined at src/101_extended_return_inferences.php:8

--- a/tests/plugin_test/expected/105_duplicate_array_key_newline.php.expected
+++ b/tests/plugin_test/expected/105_duplicate_array_key_newline.php.expected
@@ -1,0 +1,2 @@
+src/105_duplicate_array_key_newline.php:15 PhanPluginDuplicateSwitchCase Duplicate/Equivalent switch case("help\n") detected in switch statement - the later entry will be ignored.
+src/105_duplicate_array_key_newline.php:24 PhanPluginDuplicateArrayKey Duplicate/Equivalent array key value("a\nb") detected in array - the earlier entry will be ignored.

--- a/tests/plugin_test/src/105_duplicate_array_key_newline.php
+++ b/tests/plugin_test/src/105_duplicate_array_key_newline.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @suppress PhanUnreferencedFunction
+ */
+function handle105($str) {
+    switch($str) {
+        case "help\n":
+            echo 'extra line';
+            break;
+        case 'h':
+            echo 'short form';
+            break;
+        case "help\n":
+            echo 'extra line';
+            break;
+        default:
+            echo 'unknown';
+            break;
+    }
+}
+return [
+    "a\na" => 1,
+    "a\nb" => 2,
+    "a\nb" => 3,
+];


### PR DESCRIPTION
and escape commas when emitting union types for strings
to make it less likely for users to encounter #2597