### PR TITLE
Avoid repeatedly calculating the terminal's width

### DIFF
--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -1395,7 +1395,11 @@ EOB;
                " " . \sprintf("%1$ 3d", (int)(100 * $p)) . "%" .
                \sprintf(' %0.2dMB/%0.2dMB', $memory, $peak);
 
-        $columns = (new Terminal())->getWidth();
+        static $columns = null;
+        if ( $columns === null ) {
+            // Only call this once per process, since it can be rather expensive
+            $columns = (new Terminal())->getWidth();
+        }
         // strlen("  99% 999MB/999MB") == 17
         $used_length = strlen($left_side) + \max(17, strlen($right_side));
         $remaining_length = $columns - $used_length;


### PR DESCRIPTION
Ever since upgrading to phan 1.26, we've seen OOM issues in our CI when running against [MediaWiki core](https://github.com/wikimedia/mediawiki), our largest PHP repository. https://phabricator.wikimedia.org/T219114 is our downstream ticket, and we seem to have isolated it to a problem with the progress bar.

---

If the `COLUMNS` environment variable isn't explicitly set (most people probably
don't), then Symfony Console will shell out to stty and do a grep, and the
proc_open() will cause a fork of a potentially 2+ GB process. If the instance
is short on memory, the kernel will reject the fork since the child will not
be able to allocate all that memory.

Instead of constantly calculating the width of the terminal each time the
progress needs to be updated, just calculate it once and save that for the
rest of the process. It's possible that people might resize their terminal
window while phan is running, but that is a narrow edge-case.

Credit to @hashar who identified the performance bottleneck at
<https://phabricator.wikimedia.org/T219114#5084302>.