### PR TITLE
Warn about `$foo = $foo` in DuplicateExpressionPlugin

### DIFF
--- a/.phan/plugins/DuplicateExpressionPlugin.php
+++ b/.phan/plugins/DuplicateExpressionPlugin.php
@@ -161,6 +161,44 @@ class RedundantNodeVisitor extends PluginAwarePostAnalysisVisitor
     }
 
     /**
+     * @param Node $node
+     * An assignment operation node to analyze
+     *
+     * @return void
+     * @override
+     */
+    public function visitAssignRef(Node $node)
+    {
+        $this->visitAssign($node);
+    }
+
+    /**
+     * @param Node $node
+     * An assignment operation node to analyze
+     *
+     * @return void
+     * @override
+     */
+    public function visitAssign(Node $node)
+    {
+        $var = $node->children['var'];
+        $expr = $node->children['expr'];
+        if (ASTHasher::hash($var) === ASTHasher::hash($expr)) {
+            $this->emitPluginIssue(
+                $this->code_base,
+                $this->context,
+                'PhanPluginDuplicateExpressionAssignment',
+                'Both sides of the assignment {OPERATOR} are the same: {CODE}',
+                [
+                    $node->kind === ast\AST_ASSIGN_REF ? '=&' : '=',
+                    ASTReverter::toShortString($var),
+                ]
+            );
+            return;
+        }
+    }
+
+    /**
      * Compute result of a binary operator for a PhanPluginBothLiteralsBinaryOp warning
      * @param int|string|float|bool|null $left left hand side of operation
      * @param int|string|float|bool|null $right right hand side of operation

--- a/.phan/plugins/README.md
+++ b/.phan/plugins/README.md
@@ -281,6 +281,7 @@ Warns about elements containing unknown types (function/method/closure return ty
 This plugin checks for duplicate expressions in a statement
 that are likely to be a bug. (e.g. `expr1 == expr`)
 
+- **PhanPluginDuplicateExpressionAssignment**: `Both sides of the assignment {OPERATOR} are the same: {CODE}`
 - **PhanPluginDuplicateExpressionBinaryOp**: `Both sides of the binary operator {OPERATOR} are the same: {CODE}`
 - **PhanPluginDuplicateConditionalTernaryDuplication**: `"X ? X : Y" can usually be simplified to "X ?: Y". The duplicated expression X was {CODE}`
 - **PhanPluginDuplicateConditionalNullCoalescing**: `"isset(X) ? X : Y" can usually be simplified to "X ?? Y" in PHP 7. The duplicated expression X was {CODE}`

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,10 @@ Phan NEWS
 New features(Analysis):
 + Fix false positive UnusedSuppression when a doc comment suppresses an issue about itself. (#2571)
 
+Plugins:
++ Warn about assignments where the left and right hand side are the same expression in `DuplicateExpressionPlugin` (#2641)
+  New issue type: `PhanPluginDuplicateExpressionAssignment`
+
 Maintenance:
 + Print a message to stderr if the installed php-ast version is older than 1.0.1.
   A future major Phan version of Phan will probably depend on AST version 70 to support new syntax found in PHP 7.4.

--- a/src/Phan/AST/ASTReverter.php
+++ b/src/Phan/AST/ASTReverter.php
@@ -121,6 +121,15 @@ class ASTReverter
                 $name_node = $node->children['name'];
                 return '$' . (is_string($name_node) ? $name_node : ('{' . self::toShortString($name_node) . '}'));
             },
+            ast\AST_DIM => static function (Node $node) : string {
+                $expr_str = self::toShortString($node->children['expr']);
+                if ($expr_str === '(unknown)') {
+                    return  '(unknown)';
+                }
+
+                $dim_str = self::toShortString($node->children['dim']);
+                return "${expr_str}[${dim_str}]";
+            },
             ast\AST_NAME => static function (Node $node) : string {
                 $result = $node->children['name'];
                 switch ($node->flags) {

--- a/tests/plugin_test/expected/110_duplicate_assignment.php.expected
+++ b/tests/plugin_test/expected/110_duplicate_assignment.php.expected
@@ -1,0 +1,2 @@
+src/110_duplicate_assignment.php:3 PhanPluginDuplicateExpressionAssignment Both sides of the assignment = are the same: $x
+src/110_duplicate_assignment.php:4 PhanPluginDuplicateExpressionAssignment Both sides of the assignment =& are the same: $y[0]

--- a/tests/plugin_test/src/110_duplicate_assignment.php
+++ b/tests/plugin_test/src/110_duplicate_assignment.php
@@ -1,0 +1,7 @@
+<?php
+function f110($x, array $y) {
+    $x = $x;
+    $y[0] =& $y[0];
+    var_export([$x, $y]);
+}
+f110('x', [2]);


### PR DESCRIPTION
Fixes #2641