### PR TITLE
Make language server analyze new files without needing to save them

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,9 @@ New features(Analysis):
 + In issue descriptions and suggestions, replace invalid utf-8 (and literal newlines) with placeholders (#2645)
 + Suggest typo fixes in `PhanMisspelledAnnotation` for `@phan-*` annotations. (#2640)
 
+Language Server/Daemon mode:
++ Analyze new but unsaved files, if they would be analyzed by Phan once they actually were saved to disk.
+
 Plugins:
 + Warn about assignments where the left and right hand side are the same expression in `DuplicateExpressionPlugin` (#2641)
   New issue type: `PhanPluginDuplicateExpressionAssignment`

--- a/internal/update_wiki_config_types.php
+++ b/internal/update_wiki_config_types.php
@@ -224,6 +224,9 @@ class ConfigEntry
      */
     public function isHidden() : bool
     {
+        if (strncmp($this->config_name, '__', 2) === 0) {
+            return true;
+        }
         return $this->category === self::CATEGORY_HIDDEN_CLI_ONLY;
     }
 

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -1245,6 +1245,30 @@ EOB;
     }
 
     /**
+     * Checks if a file (not a folder) which has potentially not yet been created on disk should be parsed.
+     * @param string $file_path a relative path to a file within the project
+     */
+    public static function shouldParse(string $file_path) : bool
+    {
+        $exclude_file_regex = Config::getValue('exclude_file_regex');
+        if ($exclude_file_regex && self::isPathExcludedByRegex($exclude_file_regex, $file_path)) {
+            return false;
+        }
+        $file_extensions = Config::getValue('analyzed_file_extensions');
+
+        if (!\is_array($file_extensions) || count($file_extensions) === 0) {
+            return false;
+        }
+        $extension = pathinfo($file_path, PATHINFO_EXTENSION);
+        if (!$extension || !in_array($extension, $file_extensions)) {
+            return false;
+        }
+
+        $directory_regex = Config::getValue('__directory_regex');
+        return $directory_regex && preg_match($directory_regex, $file_path) > 0;
+    }
+
+    /**
      * @param string $directory_name
      * The name of a directory to scan for files ending in `.php`.
      *

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -144,6 +144,9 @@ class Config
         // your application should be included in this list.
         'directory_list' => [],
 
+        // For internal use by Phan to quickly check for membership in directory_list.
+        '__directory_regex' => null,
+
         // List of case-insensitive file extensions supported by Phan.
         // (e.g. `['php', 'html', 'htm']`)
         'analyzed_file_extensions' => ['php'],
@@ -1023,6 +1026,9 @@ class Config
                 break;
             case 'exclude_analysis_directory_list':
                 self::$configuration['__exclude_analysis_regex'] = self::generateDirectoryListRegex($value);
+                break;
+            case 'directory_list':
+                self::$configuration['__directory_regex'] = self::generateDirectoryListRegex($value);
                 break;
         }
     }

--- a/tests/Phan/CLITest.php
+++ b/tests/Phan/CLITest.php
@@ -78,7 +78,10 @@ final class CLITest extends BaseTest
     public function testSetsConfigOptions(array $expected_changed_options, array $opts, array $extra = [])
     {
         $opts += ['project-root-directory' => \dirname(__DIR__) . '/misc/config/'];
-        $expected_changed_options += ['directory_list' => ['src']];
+        $expected_changed_options += [
+            '__directory_regex' => '@^(\./)*(src)([/\\\\]|$)@',
+            'directory_list' => ['src'],
+        ];
         if (!\extension_loaded('pcntl')) {
             $expected_changed_options += ['language_server_use_pcntl_fallback' => true];
         }


### PR DESCRIPTION
Previously, the language server would need the files
to be on disk for them to be included in the generated list of parsed files.

Also, avoid a redundant regeneration of the file list in the language server mode