### PR TITLE
Fix crash parsing string literal with comma inside array

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,8 @@ Maintenance:
 
 Bug fixes:
 + Fix edge cases in how Phan checks if files are in `exclude_analysis_directory_list` (#2651)
++ Fix crash parsing comma in string literal in array shape (#2597)
+  (e.g. `@param array{0:'test,other'} $x`)
 
 06 Apr 2019, Phan 1.2.8
 -----------------------

--- a/tests/Phan/Language/TypeTest.php
+++ b/tests/Phan/Language/TypeTest.php
@@ -479,6 +479,7 @@ final class TypeTest extends BaseTest
             ['?Closure(int):int', '?Closure'],
             ['?Closure(int):int', '?callable'],
             ['?Closure', '?Closure(int):int'],
+            ['?Closure(\'0,2\'):int', '?Closure(string):int'],
             ['?callable(int):int', '?callable'],
             ['?callable', '?callable(int):int'],
         ];
@@ -507,6 +508,8 @@ final class TypeTest extends BaseTest
             ['?Closure(int):int', '?Closure(int):void'],
             ['?Closure(int):int', 'Closure(int):int'],
             ['?Closure(int):int', '?Closure(string):int'],
+            ['?Closure(int):int', '?Closure(\'0,2\'):int'],
+            ['?Closure(\'0,2\',\'other\'):int', '?Closure(string):int'],
             ['?callable(int):int', '?callable(int):void'],
             ['?callable(int):int', 'callable(int):int'],
             ['?callable(int):int', '?callable(string):int'],
@@ -533,6 +536,7 @@ final class TypeTest extends BaseTest
         $this->assertRegExp('@^' . Type::type_regex_or_this . '$@', $type_string, "Failed to parse '$type_string' with type_regex_or_this");
         $actual_type = self::makePHPDocType($type_string);
         $expected_flattened_type = UnionType::fromStringInContext($normalized_union_type_string, new Context(), Type::FROM_PHPDOC);
+        $this->assertSame($normalized_union_type_string, $expected_flattened_type->__toString());
         if (!$actual_type instanceof ArrayShapeType) {
             throw new \RuntimeException(\sprintf("Failed to create expected class for %s: saw %s instead of %s", $type_string, get_class($actual_type), ArrayShapeType::class));
         }
@@ -565,11 +569,11 @@ final class TypeTest extends BaseTest
                 'array{0:int,1:string}'
             ],
             [
-                'array<int,int>|array<int,string>|array<string,stdClass>',
+                'array<int,int>|array<int,string>|array<string,\stdClass>',
                 'array{0:int, 1:string, key : stdClass}'
             ],
             [
-                'array<int,int>|array<int,stdClass>|array<int,string>',
+                'array<int,\stdClass>|array<int,int>|array<int,string>',
                 'array{0:int,1:string,2:stdClass}'
             ],
             [
@@ -595,6 +599,10 @@ final class TypeTest extends BaseTest
             [
                 'array<string,array{innerField:int}>',
                 'array{field:array{innerField:int}}'
+            ],
+            [
+                'array<string,array{0:\'test\x2cother\',1:\'x\'}>',
+                'array{field:array{0:\'test,other\',1:\'x\'}}'
             ],
         ];
     }

--- a/tests/files/expected/0651_comma_crash.php.expected
+++ b/tests/files/expected/0651_comma_crash.php.expected
@@ -1,0 +1,1 @@
+%s:8 PhanTypeMismatchArgument Argument 1 (x) is array{0:'test\x2cwrong'} but \test651() takes array{0:'test\x2cother'} defined at %s:5

--- a/tests/files/src/0651_comma_crash.php
+++ b/tests/files/src/0651_comma_crash.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * @param array{0:'test,other'} $x
+ */
+function test651($x) {
+}
+test651(['test,other']);
+test651(['test,wrong']);


### PR DESCRIPTION
Fixes #2597

Also add tests for quoted string literals in closures