### PR TITLE
Check if methods have overrides when warning

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,12 @@ New features(Analysis):
 + Suggest typo fixes in `PhanMisspelledAnnotation` for `@phan-*` annotations. (#2640)
 + Emit `PhanUnreferencedClass` when the only references to a class or its elements are within that class.
   Previously, it would fail to be emitted when a class referenced itself.
++ Emit `PhanUnusedPublicNoOverrideMethodParameter` for method parameters that are not overridden and are not overrides. (#2539)
+
+  This is expected to have a lower false positive rate than `PhanUnusedPublicMethodParameter` because parameters
+  might be unused by some of the classes overriding/implementing a method.
+
+  Setting `unused_variable_detection_assume_override_exists` to true in `.phan/config.php` can be used to continue emitting the old issue names instead of `*NoOverride*` equivalents.
 
 Language Server/Daemon mode:
 + Analyze new but unsaved files, if they would be analyzed by Phan once they actually were saved to disk.

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -1041,6 +1041,12 @@ Parameter ${PARAMETER} is never used
 
 e.g. [this issue](https://github.com/phan/phan/tree/1.1.2/tests/files/expected/0056_aggressive_return_types.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.1.2/tests/files/src/0056_aggressive_return_types.php#L3).
 
+## PhanUnusedProtectedNoOverrideMethodParameter
+
+```
+Parameter ${PARAMETER} is never used
+```
+
 ## PhanUnusedPublicFinalMethodParameter
 
 ```
@@ -1056,6 +1062,12 @@ Parameter ${PARAMETER} is never used
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/1.1.2/tests/plugin_test/expected/047_crash.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/1.1.2/tests/plugin_test/src/047_crash.php#L6).
+
+## PhanUnusedPublicNoOverrideMethodParameter
+
+```
+Parameter ${PARAMETER} is never used
+```
 
 ## PhanUnusedVariable
 

--- a/internal/Phan-Config-Settings.md
+++ b/internal/Phan-Config-Settings.md
@@ -755,6 +755,14 @@ This has a few known false positives, e.g. for loops or branches.
 
 (Default: `false`)
 
+## unused_variable_detection_assume_override_exists
+
+Set to true in order to emit issues such as `PhanUnusedPublicMethodParameter` instead of `PhanUnusedPublicNoOverrideMethodParameter`
+(i.e. assume any non-final non-private method can have overrides).
+This is useful in situations when parsing only a subset of the available files.
+
+(Default: `false`)
+
 ## warn_about_redundant_use_namespaced_class
 
 Enable this to warn about harmless redundant use for classes and namespaces such as `use Foo\bar` in namespace Foo.

--- a/internal/update_wiki_config_types.php
+++ b/internal/update_wiki_config_types.php
@@ -78,6 +78,7 @@ class ConfigEntry
         'prefer_narrowed_phpdoc_return_type' => self::CATEGORY_ANALYSIS,
         'dead_code_detection' => self::CATEGORY_DEAD_CODE_DETECTION,
         'unused_variable_detection' => self::CATEGORY_DEAD_CODE_DETECTION,
+        'unused_variable_detection_assume_override_exists' => self::CATEGORY_DEAD_CODE_DETECTION,
         'force_tracking_references' => self::CATEGORY_DEAD_CODE_DETECTION,
         'dead_code_detection_prefer_false_negative' => self::CATEGORY_DEAD_CODE_DETECTION,
         'warn_about_redundant_use_namespaced_class' => self::CATEGORY_DEAD_CODE_DETECTION,

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -413,6 +413,11 @@ class Config
         // This has a few known false positives, e.g. for loops or branches.
         'unused_variable_detection' => false,
 
+        // Set to true in order to emit issues such as `PhanUnusedPublicMethodParameter` instead of `PhanUnusedPublicNoOverrideMethodParameter`
+        // (i.e. assume any non-final non-private method can have overrides).
+        // This is useful in situations when parsing only a subset of the available files.
+        'unused_variable_detection_assume_override_exists' => false,
+
         // Set to true in order to force tracking references to elements
         // (functions/methods/consts/protected).
         //

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -317,8 +317,10 @@ class Issue
     const UnusedVariable                        = 'PhanUnusedVariable';
     const UnusedPublicMethodParameter           = 'PhanUnusedPublicMethodParameter';
     const UnusedPublicFinalMethodParameter      = 'PhanUnusedPublicFinalMethodParameter';
+    const UnusedPublicNoOverrideMethodParameter = 'PhanUnusedPublicNoOverrideMethodParameter';
     const UnusedProtectedMethodParameter        = 'PhanUnusedProtectedMethodParameter';
     const UnusedProtectedFinalMethodParameter   = 'PhanUnusedProtectedFinalMethodParameter';
+    const UnusedProtectedNoOverrideMethodParameter = 'PhanUnusedProtectedNoOverrideMethodParameter';
     const UnusedPrivateMethodParameter          = 'PhanUnusedPrivateMethodParameter';
     const UnusedPrivateFinalMethodParameter     = 'PhanUnusedPrivateFinalMethodParameter';
     const UnusedClosureUseVariable              = 'PhanUnusedClosureUseVariable';
@@ -2799,12 +2801,28 @@ class Issue
                 6037
             ),
             new Issue(
+                self::UnusedPublicNoOverrideMethodParameter,
+                self::CATEGORY_NOOP,
+                self::SEVERITY_NORMAL,
+                'Parameter ${PARAMETER} is never used',
+                self::REMEDIATION_B,
+                6060
+            ),
+            new Issue(
                 self::UnusedProtectedMethodParameter,
                 self::CATEGORY_NOOP,
                 self::SEVERITY_NORMAL,
                 'Parameter ${PARAMETER} is never used',
                 self::REMEDIATION_B,
                 6038
+            ),
+            new Issue(
+                self::UnusedProtectedNoOverrideMethodParameter,
+                self::CATEGORY_NOOP,
+                self::SEVERITY_NORMAL,
+                'Parameter ${PARAMETER} is never used',
+                self::REMEDIATION_B,
+                6059
             ),
             new Issue(
                 self::UnusedProtectedFinalMethodParameter,
@@ -4056,8 +4074,9 @@ class Issue
 
     /**
      * @param array<int,mixed> $parameters
+     * @internal
      */
-    private static function shouldSuppressIssue(
+    public static function shouldSuppressIssue(
         CodeBase $code_base,
         Context $context,
         string $issue_type,

--- a/src/Phan/Language/Element/ClassElement.php
+++ b/src/Phan/Language/Element/ClassElement.php
@@ -178,7 +178,7 @@ abstract class ClassElement extends AddressableElement
 
     /**
      * @return bool
-     * True if this method overrides another method
+     * True if this element overrides another element
      */
     public function getIsOverride() : bool
     {
@@ -186,10 +186,10 @@ abstract class ClassElement extends AddressableElement
     }
 
     /**
-     * Sets whether this method overrides another method
+     * Sets whether this element overrides another element
      *
      * @param bool $is_override
-     * True if this method overrides another method
+     * True if this element overrides another element
      *
      * @return void
      */
@@ -204,7 +204,7 @@ abstract class ClassElement extends AddressableElement
 
     /**
      * @return bool
-     * True if this is a static method
+     * True if this is a static element
      */
     public function isStatic() : bool
     {

--- a/src/Phan/Language/Element/Flags.php
+++ b/src/Phan/Language/Element/Flags.php
@@ -50,6 +50,8 @@ class Flags
     const HAS_STATIC_UNION_TYPE = (1 << 23);
     const HAS_TEMPLATE_TYPE = (1 << 24);
 
+    const IS_OVERRIDEN_BY_ANOTHER = (1 << 25);
+
     /**
      * Either enable or disable the given flag on
      * the given bit vector.

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -22,6 +22,7 @@ use Phan\Memoize;
  * Phan's representation of a class's method.
  *
  * @phan-file-suppress PhanPartialTypeMismatchArgument
+ * @method FullyQualifiedMethodName getDefiningFQSEN() @phan-suppress-current-line PhanParamSignaturePHPDocMismatchReturnType
  */
 class Method extends ClassElement implements FunctionInterface
 {
@@ -167,6 +168,32 @@ class Method extends ClassElement implements FunctionInterface
                 $is_override_intended
             )
         );
+    }
+
+    /**
+     * @return bool
+     * True if this element is overridden by at least one other element
+     */
+    public function getIsOverriddenByAnother() : bool
+    {
+        return $this->getPhanFlagsHasState(Flags::IS_OVERRIDEN_BY_ANOTHER);
+    }
+
+    /**
+     * Sets whether this method is overridden by another method
+     *
+     * @param bool $is_overriden_by_another
+     * True if this method is overridden by another method
+     *
+     * @return void
+     */
+    public function setIsOverriddenByAnother(bool $is_overriden_by_another)
+    {
+        $this->setPhanFlags(Flags::bitVectorWithState(
+            $this->getPhanFlags(),
+            Flags::IS_OVERRIDEN_BY_ANOTHER,
+            $is_overriden_by_another
+        ));
     }
 
     /**

--- a/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
+++ b/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
@@ -5,10 +5,12 @@ namespace Phan\Plugin\Internal;
 use AssertionError;
 use ast;
 use ast\Node;
+use Exception;
 use Phan\Config;
 use Phan\Exception\CodeBaseException;
 use Phan\Issue;
 use Phan\IssueFixSuggester;
+use Phan\Language\Element\Method;
 use Phan\Language\Element\Variable;
 use Phan\Plugin\Internal\VariableTracker\VariableGraph;
 use Phan\Plugin\Internal\VariableTracker\VariableTrackerVisitor;
@@ -137,6 +139,24 @@ final class VariableTrackerElementVisitor extends PluginAwarePostAnalysisVisitor
         return $result;
     }
 
+    private function methodHasOverrides() : bool
+    {
+        if (Config::getValue('unused_variable_detection_assume_override_exists')) {
+            return true;
+        }
+        try {
+            $method = $this->context->getFunctionLikeInScope($this->code_base);
+            if (!($method instanceof Method)) {
+                // should never happen
+                return false;
+            }
+
+            return $method->getIsOverride() || $method->getIsOverriddenByAnother();
+        } catch (Exception $_) {
+            // should not happen
+            return false;
+        }
+    }
     /**
      * @return string
      */
@@ -155,9 +175,21 @@ final class VariableTrackerElementVisitor extends PluginAwarePostAnalysisVisitor
         if ($flags & ast\flags\MODIFIER_PRIVATE) {
             return $final ? Issue::UnusedPrivateFinalMethodParameter : Issue::UnusedPrivateMethodParameter;
         } elseif ($flags & ast\flags\MODIFIER_PROTECTED) {
-            return $final ? Issue::UnusedProtectedFinalMethodParameter : Issue::UnusedProtectedMethodParameter;
+            if ($final) {
+                return Issue::UnusedProtectedFinalMethodParameter;
+            }
+            if (!$this->methodHasOverrides()) {
+                return Issue::UnusedProtectedNoOverrideMethodParameter;
+            }
+            return Issue::UnusedProtectedMethodParameter;
         }
-        return $final ? Issue::UnusedPublicFinalMethodParameter : Issue::UnusedPublicMethodParameter;
+        if ($final) {
+            return Issue::UnusedPublicFinalMethodParameter;
+        }
+        if (!$this->methodHasOverrides()) {
+            return Issue::UnusedPublicNoOverrideMethodParameter;
+        }
+        return Issue::UnusedPublicMethodParameter;
     }
 
     private function isParameterFinal(int $flags) : bool
@@ -208,14 +240,22 @@ final class VariableTrackerElementVisitor extends PluginAwarePostAnalysisVisitor
                 }
                 $line = $graph->def_lines[$variable_name][$definition_id] ?? 1;
                 $issue_type = $issue_overrides_for_definition_ids[$definition_id] ?? Issue::UnusedVariable;
+                // Choose a more precise issue type
                 if ($issue_type === Issue::UnusedPublicMethodParameter) {
                     // Narrow down issues about parameters into more specific issues
                     $doc_comment = $method_node->children['docComment'] ?? null;
                     if ($doc_comment && \preg_match('/@param[^$]*\$' . \preg_quote($variable_name) . '\b.*@phan-unused-param\b/', $doc_comment)) {
                         // Don't warn about parameters marked with phan-unused-param
-                        break;
+                        continue;
                     }
                     $issue_type = $this->getParameterCategory($method_node);
+                    if (strpos($issue_type, 'NoOverride') === false && strpos($issue_type, 'MethodParameter') !== false) {
+                        $alternate_issue_type = str_replace('MethodParameter', 'NoOverrideMethodParameter', $issue_type);
+                        // @phan-suppress-next-line PhanAccessMethodInternal
+                        if (Issue::shouldSuppressIssue($this->code_base, $this->context, $alternate_issue_type, $line, [$variable_name], null)) {
+                            continue;
+                        }
+                    }
                 } elseif ($graph->isLoopValueDefinitionId($definition_id)) {
                     $issue_type = Issue::UnusedVariableValueOfForeachWithKey;
                 } elseif ($graph->isCaughtException($definition_id)) {
@@ -227,6 +267,7 @@ final class VariableTrackerElementVisitor extends PluginAwarePostAnalysisVisitor
                     $issue_type,
                     $line,
                     [$variable_name],
+                    // compute the suggestion for $variable_name based on the $issue_type
                     self::makeSuggestion($graph, $variable_name, $issue_type)
                 );
             }

--- a/tests/.phan_for_test/config.php
+++ b/tests/.phan_for_test/config.php
@@ -106,4 +106,7 @@ return [
     // Enable this to warn about the use of relative paths in `require_once`, `include`, etc.
     // Relative paths are harder to reason about, and opcache may have issues with relative paths in edge cases.
     'warn_about_relative_include_statement' => true,
+
+    // Not changing all of these tests to `PhanUnusedPublicNoOverrideMethodParameter` from `PhanUnusedPublicMethodParameter`
+    'unused_variable_detection_assume_override_exists' => true,
 ];

--- a/tests/plugin_test/expected/004_unused_suppression_plugin.php.expected
+++ b/tests/plugin_test/expected/004_unused_suppression_plugin.php.expected
@@ -3,3 +3,4 @@ src/004_unused_suppression_plugin.php:11 UnusedSuppression Element \SuppressionT
 src/004_unused_suppression_plugin.php:15 PhanUnusedPublicMethodParameter Parameter $x is never used
 src/004_unused_suppression_plugin.php:23 UnusedSuppression Element \suppression_test_fn suppresses issue PhanParamTooFew but does not use it
 src/004_unused_suppression_plugin.php:27 PhanTypeMismatchArgument Argument 1 (x) is array{} but \SuppressionTest::bar() takes int defined at src/004_unused_suppression_plugin.php:15
+src/004_unused_suppression_plugin.php:31 PhanUnreferencedClass Possibly zero references to class \ExtraSuppressionTest

--- a/tests/plugin_test/expected/031_sleep.php.expected
+++ b/tests/plugin_test/expected/031_sleep.php.expected
@@ -6,7 +6,7 @@ src/031_sleep.php:17 SleepCheckerInvalidPropName __sleep is returning an array t
 src/031_sleep.php:17 SleepCheckerInvalidPropName __sleep is returning an array that includes _x, which cannot be found
 src/031_sleep.php:17 SleepCheckerMagicPropName __sleep is returning an array that includes z, which is a magic property
 src/031_sleep.php:19 SleepCheckerInvalidPropName __sleep is returning an array that includes _Z, which cannot be found
-src/031_sleep.php:22 PhanUnusedPublicMethodParameter Parameter $x is never used
+src/031_sleep.php:22 PhanUnusedPublicNoOverrideMethodParameter Parameter $x is never used
 src/031_sleep.php:28 SleepCheckerPropertyMissingTransient Property public $_myProp that is not serialized by __sleep should be annotated with @transient or @phan-transient
 src/031_sleep.php:35 SleepCheckerInvalidReturnStatement __sleep must return an array of strings. This is definitely not an array.
 src/031_sleep.php:37 SleepCheckerInvalidReturnStatement __sleep must return an array of strings. This is definitely not an array.

--- a/tests/plugin_test/expected/047_crash.php.expected
+++ b/tests/plugin_test/expected/047_crash.php.expected
@@ -1,3 +1,3 @@
-src/047_crash.php:6 PhanUnusedPublicMethodParameter Parameter $arg is never used
+src/047_crash.php:6 PhanUnusedPublicNoOverrideMethodParameter Parameter $arg is never used
 src/047_crash.php:11 PhanUnreferencedFunction Possibly zero references to function \example()
 src/047_crash.php:12 PhanTypeMismatchArgument Argument 1 (arg) is 'my arg' but \X47::myMethod() takes int defined at src/047_crash.php:6

--- a/tests/plugin_test/src/004_unused_suppression_plugin.php
+++ b/tests/plugin_test/src/004_unused_suppression_plugin.php
@@ -27,3 +27,9 @@ function suppression_test_fn() {
     $c->bar([]);  // should not be suppressed
 }
 suppression_test_fn();
+
+class ExtraSuppressionTest extends SuppressionTest {
+    public function bar(int $x) {
+        echo "Saw $x\n";
+    }
+}


### PR DESCRIPTION
Emit `PhanUnusedPublicNoOverrideMethodParameter` instead of
`PhanUnusedPublicMethodParameter` in those cases.

Phan also starts tracking the existence of overrides of methods.
(and just methods for now)
This can be used by plugins, etc.

For #2539