### PR TITLE
Warn about numeric operations on unknown strings and literal strings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@ New features(Analysis):
   might be unused by some of the classes overriding/implementing a method.
 
   Setting `unused_variable_detection_assume_override_exists` to true in `.phan/config.php` can be used to continue emitting the old issue names instead of `*NoOverride*` equivalents.
++ Warn about more numeric operations(+, /, etc) on unknown strings and non-numeric literal strings (#2656)
+  The settings `scalar_implicit_cast` and `scalar_implicit_partial` affect this for the `string` union type but not for literals.
 
 Language Server/Daemon mode:
 + Analyze new but unsaved files, if they would be analyzed by Phan once they actually were saved to disk.

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -2130,11 +2130,6 @@ class UnionTypeVisitor extends AnalysisVisitor
             $this->warnAboutInvalidUnaryOp(
                 $node,
                 static function (Type $type) : bool {
-                    if ($type instanceof LiteralStringType) {
-                        // Strings are invalid if they're not numeric
-                        return \is_numeric($type->getValue());
-                    }
-                    // TODO: Stricten this to warn about 'string's based on user config.
                     return $type->isValidNumericOperand();
                 },
                 $result,
@@ -2146,12 +2141,8 @@ class UnionTypeVisitor extends AnalysisVisitor
             $this->warnAboutInvalidUnaryOp(
                 $node,
                 static function (Type $type) : bool {
-                    if ($type instanceof LiteralStringType) {
-                        // Strings are invalid if they're not numeric
-                        return \is_numeric($type->getValue());
-                    }
                     // NOTE: Don't be as strict because this is a way to cast to a number
-                    return $type->isValidNumericOperand();
+                    return $type->isValidNumericOperand() || \get_class($type) === StringType::class;
                 },
                 $result,
                 '+',

--- a/src/Phan/Language/Type/LiteralStringType.php
+++ b/src/Phan/Language/Type/LiteralStringType.php
@@ -316,6 +316,11 @@ final class LiteralStringType extends StringType implements LiteralTypeInterface
         $function_like_fqsens = UnionTypeVisitor::functionLikeListFromNodeAndContext($code_base, $context, $this->value, true);
         return $function_like_fqsens[0] ?? null;
     }
+
+    public function isValidNumericOperand() : bool
+    {
+        return filter_var($this->value, FILTER_VALIDATE_FLOAT) !== false;
+    }
 }
 
 LiteralStringType::init();

--- a/src/Phan/Language/Type/StringType.php
+++ b/src/Phan/Language/Type/StringType.php
@@ -2,6 +2,7 @@
 
 namespace Phan\Language\Type;
 
+use Phan\Config;
 use Phan\Language\Type;
 use Phan\Language\UnionType;
 
@@ -42,6 +43,18 @@ class StringType extends ScalarType
     public function getTypeAfterIncOrDec() : UnionType
     {
         return UnionType::fromFullyQualifiedString('int|string|float');
+    }
+
+    public function isValidNumericOperand() : bool
+    {
+        if (Config::getValue('scalar_implicit_cast')) {
+            return true;
+        }
+        $string_casts = Config::getValue('scalar_implicit_partial')['string'] ?? null;
+        if (!is_array($string_casts)) {
+            return false;
+        }
+        return \in_array('int', $string_casts, true) || \in_array('float', $string_casts, true);
     }
 }
 \class_exists(ClassStringType::class);

--- a/tests/files/expected/0012_closures.php.expected
+++ b/tests/files/expected/0012_closures.php.expected
@@ -1,3 +1,4 @@
 %s:13 PhanUndeclaredVariable Variable $c is undeclared
 %s:13 PhanUnusedClosureUseVariable Closure use variable $c is never used
+%s:15 PhanTypeInvalidRightOperandOfAdd Invalid operator: right operand of + is 'string' (expected array or number)
 %s:24 PhanUndeclaredVariable Variable $this is undeclared

--- a/tests/files/expected/0580_numeric_string.php.expected
+++ b/tests/files/expected/0580_numeric_string.php.expected
@@ -8,5 +8,10 @@
 %s:10 PhanTypeMismatchArgumentInternal Argument 1 (string) is 0 but \strlen() takes string
 %s:12 PhanTypeMismatchArgumentInternal Argument 1 (string) is 123 but \strlen() takes string
 %s:13 PhanTypeMismatchArgumentInternal Argument 1 (string) is -123 but \strlen() takes string
+%s:16 PhanTypeInvalidUnaryOperandNumeric Invalid operator: unary operand of - is string (expected number)
 %s:21 PhanTypeMismatchArgumentInternal Argument 1 (string) is float but \strlen() takes string
 %s:22 PhanTypeMismatchArgumentInternal Argument 1 (string) is float but \strlen() takes string
+%s:23 PhanTypeInvalidLeftOperandOfAdd Invalid operator: left operand of + is 'hello\x2c ' (expected array or number)
+%s:23 PhanTypeInvalidRightOperandOfAdd Invalid operator: right operand of + is 'world!' (expected array or number)
+%s:24 PhanTypeInvalidLeftOperandOfNumericOp Invalid operator: left operand of / is 'hello\x2c ' (expected number)
+%s:24 PhanTypeInvalidRightOperandOfNumericOp Invalid operator: right operand of / is 'world!' (expected number)

--- a/tests/files/src/0580_numeric_string.php
+++ b/tests/files/src/0580_numeric_string.php
@@ -20,4 +20,6 @@ function testString(string $s, int $i, float $f) {
     echo -$f;
     echo strlen(+"1.2");  // infers float
     echo strlen(-"1.3");  // infers float
+    echo "hello, " + "world!";
+    echo "hello, " / "world!";
 }


### PR DESCRIPTION
Warn if they can't be cast to a number.

scalar_implicit_cast or scalar_implicit_partial
will allow casting unknown strings to numbers