### PR TITLE
Improve nullable type checks. Improve type assertions on array fields

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,8 @@ New features(Analysis):
 + Warn about more numeric operations(+, /, etc) on unknown strings and non-numeric literal strings (#2656)
   The settings `scalar_implicit_cast` and `scalar_implicit_partial` affect this for the `string` union type but not for literals.
 + Improve types inferred from checks such as `if (is_array($var['field'])) { use($var['field']); }` and `if ($var['field'] instanceof stdClass) {...}` (#2601)
++ Infer that $varName is non-null and an object for conditions such as `if (isset($varName->field['prop']))`
++ Be more consistent about warning when passing `?SomeClass` to a parameter expecting non-null `SomeClass`.
 
 Language Server/Daemon mode:
 + Analyze new but unsaved files, if they would be analyzed by Phan once they actually were saved to disk.

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@ New features(Analysis):
   Setting `unused_variable_detection_assume_override_exists` to true in `.phan/config.php` can be used to continue emitting the old issue names instead of `*NoOverride*` equivalents.
 + Warn about more numeric operations(+, /, etc) on unknown strings and non-numeric literal strings (#2656)
   The settings `scalar_implicit_cast` and `scalar_implicit_partial` affect this for the `string` union type but not for literals.
++ Improve types inferred from checks such as `if (is_array($var['field'])) { use($var['field']); }` and `if ($var['field'] instanceof stdClass) {...}` (#2601)
 
 Language Server/Daemon mode:
 + Analyze new but unsaved files, if they would be analyzed by Phan once they actually were saved to disk.

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,9 @@ New features(Analysis):
 + Improve types inferred from checks such as `if (is_array($var['field'])) { use($var['field']); }` and `if ($var['field'] instanceof stdClass) {...}` (#2601)
 + Infer that $varName is non-null and an object for conditions such as `if (isset($varName->field['prop']))`
 + Be more consistent about warning when passing `?SomeClass` to a parameter expecting non-null `SomeClass`.
++ Add `PhanTypeMismatchArgumentNullable*` and `PhanTypeMismatchReturnNullable` when the main reason the type check failed was nullability
+
+  Previously, Phan would fail to detect that some nullable class instances were incompatible with the non-null expected types in some cases.
 
 Language Server/Daemon mode:
 + Analyze new but unsaved files, if they would be analyzed by Phan once they actually were saved to disk.

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -145,13 +145,20 @@ class ContextNode
          * @param Node|int|string|float|null $name_node
          * @throws FQSENException
          */
-        return \array_map(function ($name_node) : FullyQualifiedClassName {
-            return (new ContextNode(
+        $result = [];
+        foreach ($this->node->children as $name_node) {
+            $trait_fqsen = (new ContextNode(
                 $this->code_base,
                 $this->context,
                 $name_node
             ))->getTraitFQSEN([]);
-        }, $this->node->children);
+            if ($trait_fqsen) {
+                // Should never be null but check anyway
+                // TODO warn
+                $result[] = $trait_fqsen;
+            }
+        }
+        return $result;
     }
 
     /**
@@ -1072,6 +1079,7 @@ class ContextNode
                 return new Variable(
                     $this->context,
                     $variable_name,
+                    // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
                     Variable::getUnionTypeOfHardcodedGlobalVariableWithName($variable_name),
                     0
                 );
@@ -1128,6 +1136,7 @@ class ContextNode
                     return new Variable(
                         $this->context,
                         $variable_name,
+                        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
                         Variable::getUnionTypeOfHardcodedGlobalVariableWithName($variable_name),
                         0
                     );

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -696,6 +696,7 @@ class TolerantASTConverter
                     $n->staticModifier !== null,
                     static::phpParserParamsToAstParams($n->parameters, $start_line),
                     static::phpParserClosureUsesToAstClosureUses($n->anonymousFunctionUseClause->useVariableNameList ?? null, $start_line),
+                    // @phan-suppress-next-line PhanTypeMismatchArgumentNullable return_null_on_empty is false.
                     static::phpParserStmtlistToAstNode($n->compoundStatementOrSemicolon->statements, self::getStartLine($n->compoundStatementOrSemicolon), false),
                     $ast_return_type,
                     $start_line,
@@ -1127,7 +1128,8 @@ class TolerantASTConverter
                 return static::astStmtCatch(
                     $catch_list_node,
                     static::variableTokenToString($n->variableName),
-                    static::phpParserStmtlistToAstNode($n->compoundStatement, $start_line, true),
+                    // @phan-suppress-next-line PhanTypeMismatchArgumentNullable return_null_on_empty is false.
+                    static::phpParserStmtlistToAstNode($n->compoundStatement, $start_line, false),
                     $start_line
                 );
             },
@@ -1297,6 +1299,7 @@ class TolerantASTConverter
                 //return static::phpParserStmtlistToAstNode($n->statements, $start_line);
             },
             'Microsoft\PhpParser\Node\FinallyClause' => static function (PhpParser\Node\FinallyClause $n, int $start_line) : ast\Node {
+                // @phan-suppress-next-line PhanTypeMismatchReturnNullable return_null_on_empty is false.
                 return static::phpParserStmtlistToAstNode($n->compoundStatement, $start_line, false);
             },
             /**
@@ -1535,6 +1538,7 @@ class TolerantASTConverter
             'Microsoft\PhpParser\Node\Statement\TryStatement' => static function (PhpParser\Node\Statement\TryStatement $n, int $start_line) : ast\Node {
                 $finally_clause = $n->finallyClause;
                 return static::astNodeTry(
+                    // @phan-suppress-next-line PhanTypeMismatchArgumentNullable return_null_on_empty is false.
                     static::phpParserStmtlistToAstNode($n->compoundStatement, $start_line, false), // $n->try
                     static::phpParserCatchlistToAstCatchlist($n->catchClauses ?? [], $start_line),
                     $finally_clause !== null ? static::phpParserStmtlistToAstNode($finally_clause->compoundStatement, self::getStartLine($finally_clause), false) : null,
@@ -1556,7 +1560,8 @@ class TolerantASTConverter
             'Microsoft\PhpParser\Node\Statement\WhileStatement' => static function (PhpParser\Node\Statement\WhileStatement $n, int $start_line) : ast\Node {
                 return static::astNodeWhile(
                     static::phpParserNodeToAstNode($n->expression),
-                    static::phpParserStmtlistToAstNode($n->statements, $start_line, true),
+                    // @phan-suppress-next-line PhanTypeMismatchArgumentNullable return_null_on_empty is false.
+                    static::phpParserStmtlistToAstNode($n->statements, $start_line, false),
                     $start_line
                 );
             },
@@ -2320,10 +2325,11 @@ class TolerantASTConverter
     {
         $if_elem = static::astIfElem(
             static::phpParserNodeToAstNode($node->expression),
+            // @phan-suppress-next-line PhanTypeMismatchArgumentNullable return_null_on_empty is false.
             static::phpParserStmtlistToAstNode(
                 $node->statements,
                 self::getStartLineOfStatementOrStatements($node->statements) ?: $start_line,
-                true
+                false
             ),
             $start_line
         );
@@ -2332,6 +2338,7 @@ class TolerantASTConverter
             $if_elem_line = self::getStartLine($else_if);
             $if_elem = static::astIfElem(
                 static::phpParserNodeToAstNode($else_if->expression),
+                // @phan-suppress-next-line PhanTypeMismatchArgumentNullable return_null_on_empty is false.
                 static::phpParserStmtlistToAstNode(
                     $else_if->statements,
                     self::getStartLineOfStatementOrStatements($else_if->statements)
@@ -2345,7 +2352,8 @@ class TolerantASTConverter
             $parser_else_line = self::getStartLineOfStatementOrStatements($parser_else_node->statements);
             $if_elems[] = static::astIfElem(
                 null,
-                static::phpParserStmtlistToAstNode($parser_else_node->statements, $parser_else_line),
+                // @phan-suppress-next-line PhanTypeMismatchArgumentNullable return_null_on_empty is false.
+                static::phpParserStmtlistToAstNode($parser_else_node->statements, $parser_else_line, false),
                 $parser_else_line
             );
         }

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1655,6 +1655,7 @@ class UnionTypeVisitor extends AnalysisVisitor
 
         if (!$this->context->getScope()->hasVariableWithName($variable_name)) {
             if (Variable::isHardcodedVariableInScopeWithName($variable_name, $this->context->isInGlobalScope())) {
+                // @phan-suppress-next-line PhanTypeMismatchReturnNullable variable existence was checked
                 return Variable::getUnionTypeOfHardcodedGlobalVariableWithName($variable_name);
             }
             if (!Config::getValue('ignore_undeclared_variables_in_global_scope')

--- a/src/Phan/Analysis/ArgumentType.php
+++ b/src/Phan/Analysis/ArgumentType.php
@@ -639,7 +639,8 @@ final class ArgumentType
             Issue::maybeEmit(
                 $code_base,
                 $context,
-                Issue::TypeMismatchArgumentInternal,
+                // @phan-suppress-next-line PhanAccessMethodInternal
+                $argument_type_expanded->canCastToUnionTypeIfNonNull($parameter_type) ? Issue::TypeMismatchArgumentNullableInternal : Issue::TypeMismatchArgumentInternal,
                 $lineno,
                 ($i + 1),
                 $alternate_parameter->getName(),
@@ -652,7 +653,8 @@ final class ArgumentType
         Issue::maybeEmit(
             $code_base,
             $context,
-            Issue::TypeMismatchArgument,
+            // @phan-suppress-next-line PhanAccessMethodInternal
+            $argument_type_expanded->canCastToUnionTypeIfNonNull($parameter_type) ? Issue::TypeMismatchArgumentNullable : Issue::TypeMismatchArgument,
             $lineno,
             ($i + 1),
             $alternate_parameter->getName(),

--- a/src/Phan/Analysis/AssignOperatorAnalysisVisitor.php
+++ b/src/Phan/Analysis/AssignOperatorAnalysisVisitor.php
@@ -221,11 +221,13 @@ class AssignOperatorAnalysisVisitor extends FlagVisitorImplementation
                 !$left->genericArrayElementTypes()->isEmpty()
                 && $left->nonArrayTypes()->isEmpty()
             ) || $left->isType($array_type);
+            // @phan-suppress-previous-line PhanTypeMismatchArgumentNullable false positive from static init
 
             $right_is_array = (
                 !$right->genericArrayElementTypes()->isEmpty()
                 && $right->nonArrayTypes()->isEmpty()
             ) || $right->isType($array_type);
+            // @phan-suppress-previous-line PhanTypeMismatchArgumentNullable false positive from static init
 
             if ($left_is_array || $right_is_array) {
                 if ($left_is_array && $right_is_array) {

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -1251,12 +1251,14 @@ class AssignmentVisitor extends AnalysisVisitor
                         'int'
                     );
                 } else {
+                    // @phan-suppress-next-line PhanTypeMismatchArgumentNullable false positive for static
                     if ($right_type->canCastToUnionType($string_array_type)) {
                         // e.g. $a = 'aaa'; $a[0] = 'x';
                         // (Currently special casing this, not handling deeper dimensions)
                         return StringType::instance(false)->asUnionType();
                     }
                 }
+            // @phan-suppress-next-line PhanTypeMismatchArgumentNullable false positive for static
             } elseif (!$assign_type->hasType($mixed_type) && !$assign_type->hasType($simple_xml_element_type)) {
                 // Imitate the check in UnionTypeVisitor, don't warn for mixed, etc.
                 $this->emitIssue(

--- a/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
+++ b/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
@@ -612,6 +612,7 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
      *
      * @return UnionType
      * The resulting type(s) of the binary operation
+     * @suppress PhanTypeMismatchArgumentNullable false positives for static initializing
      */
     public function visitBinaryAdd(Node $node) : UnionType
     {
@@ -681,11 +682,13 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
             !$left->genericArrayElementTypes()->isEmpty()
             && $left->nonArrayTypes()->isEmpty()
         ) || $left->isType($array_type);
+        // @phan-suppress-previous-line PhanTypeMismatchArgumentNullable false positive for static initialization
 
         $right_is_array = (
             !$right->genericArrayElementTypes()->isEmpty()
             && $right->nonArrayTypes()->isEmpty()
         ) || $right->isType($array_type);
+        // @phan-suppress-previous-line PhanTypeMismatchArgumentNullable false positive for static initialization
 
         if ($left_is_array || $right_is_array) {
             if ($left_is_array && $right_is_array) {

--- a/src/Phan/Analysis/BlockExitStatusChecker.php
+++ b/src/Phan/Analysis/BlockExitStatusChecker.php
@@ -210,6 +210,7 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
         $combined_status = 0;
         // Try to cover all possible cases, such as try { return throwsException(); } catch(Exception $e) { break; }
         foreach ($node->children as $catch_node) {
+            // @phan-suppress-next-line PhanTypeMismatchArgumentNullable this is never null for catch nodes
             $catch_node_status = $this->visitStmtList($catch_node->children['stmts']);
             $combined_status |= $catch_node_status;
         }
@@ -285,6 +286,7 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
      */
     private function computeStatusOfSwitchCase(Node $case_node, int $index, array $siblings) : int
     {
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable this is never null
         $status = $this->visitStmtList($case_node->children['stmts']);
         if (($status & self::STATUS_PROCEED) === 0) {
             // Check if the current switch case will not fall through.
@@ -536,6 +538,7 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
         $has_if_elems_for_all_cases = false;
         $combined_statuses = 0;
         foreach ($node->children as $child_node) {
+            // @phan-suppress-next-line PhanTypeMismatchArgumentNullable this is never null
             $status = $this->visitStmtList($child_node->children['stmts']);
             $combined_statuses |= $status;
 
@@ -559,6 +562,7 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
      */
     public function visitDoWhile(Node $node)
     {
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable this is never null
         $inner_status = $this->visitStmtList($node->children['stmts']);
         if (($inner_status & ~self::STATUS_THROW_OR_RETURN_BITMASK) === 0) {
             // The inner block throws or returns before the end can be reached.
@@ -589,6 +593,7 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
         if ($status) {
             return $status;
         }
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable this is never null
         $status = $this->visitStmtList($node->children['stmts']);
         $node->flags = $status;
         return $status;

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -546,7 +546,8 @@ class ConditionVisitor extends KindVisitorImplementation implements ConditionVis
     /**
      * Modifies the union type of $variable in place
      */
-    private function setInstanceofVariableType(Variable $variable, Node $class_node) {
+    private function setInstanceofVariableType(Variable $variable, Node $class_node)
+    {
         // Get the type that we're checking it against
         $type = UnionTypeVisitor::unionTypeFromNode(
             $this->code_base,

--- a/src/Phan/Analysis/ConditionVisitorUtil.php
+++ b/src/Phan/Analysis/ConditionVisitorUtil.php
@@ -934,7 +934,8 @@ trait ConditionVisitorUtil
      * @param Node|mixed $node
      * @return ?string the name of the variable in a chain of field accesses such as $varName['field'][$i]
      */
-    private static function getVarNameOfDimNode($node) {
+    private static function getVarNameOfDimNode($node)
+    {
         // Loop to support getting the var name in is_array($x['field'][0])
         while (true) {
             if (!($node instanceof Node)) {

--- a/src/Phan/Analysis/ContextMergeVisitor.php
+++ b/src/Phan/Analysis/ContextMergeVisitor.php
@@ -112,6 +112,7 @@ class ContextMergeVisitor extends KindVisitorImplementation
         //      try { $x = expr(); } catch (Exception $e) { echo "Caught"; return; } catch (OtherException $e) { continue; }
         // Phan should infer that $x is guaranteed to be defined.
         foreach ($node->children['catches']->children ?? [] as $catch_node) {
+            // @phan-suppress-next-line PhanTypeMismatchArgumentNullable this is never null
             if (BlockExitStatusChecker::willUnconditionallySkipRemainingStatements($catch_node->children['stmts'])) {
                 return true;
             }
@@ -137,6 +138,7 @@ class ContextMergeVisitor extends KindVisitorImplementation
         $catch_scope_list = [];
         $catch_nodes = $node->children['catches']->children;
         foreach ($catch_nodes as $i => $catch_node) {
+            // @phan-suppress-next-line PhanTypeMismatchArgumentNullable this is never null
             if (!BlockExitStatusChecker::willUnconditionallySkipRemainingStatements($catch_node->children['stmts'])) {
                 $catch_scope_list[] = $scope_list[$i + 1];
             }

--- a/src/Phan/Analysis/ReachabilityChecker.php
+++ b/src/Phan/Analysis/ReachabilityChecker.php
@@ -253,6 +253,7 @@ final class ReachabilityChecker extends KindVisitorImplementation
                 return $result;
             }
         }
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable this is never null
         $result = $this->__invoke($node->children['stmts']);
         if ($result !== null) {
             // This is a conditional; it's not guaranteed to work

--- a/src/Phan/Analysis/RegexAnalyzer.php
+++ b/src/Phan/Analysis/RegexAnalyzer.php
@@ -59,19 +59,24 @@ class RegexAnalyzer
         }
 
         if (!\is_int($bit)) {
+            // @phan-suppress-next-line PhanTypeMismatchReturnNullable false positive for static init
             return $array_type;
         }
         // TODO: Support PREG_UNMATCHED_AS_NULL
         if ($bit & \PREG_OFFSET_CAPTURE) {
             if (\is_array($regex_group_keys)) {
+                // @phan-suppress-next-line PhanTypeMismatchArgumentNullable false positive for static init
                 return self::makeArrayShape($regex_group_keys, $shape_array_inner_type);
             }
+            // @phan-suppress-next-line PhanTypeMismatchReturnNullable false positive for static init
             return $shape_array_type;
         }
 
         if (\is_array($regex_group_keys)) {
+            // @phan-suppress-next-line PhanTypeMismatchArgumentNullable false positive for static init
             return self::makeArrayShape($regex_group_keys, $string_type);
         }
+        // @phan-suppress-next-line PhanTypeMismatchReturnNullable false positive for static init
         return $string_array_type;
     }
 

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -831,8 +831,10 @@ class BlockAnalysisVisitor extends AnalysisVisitor
                     $visitor = new ConditionVisitor($this->code_base, $child_context);
                     $child_context = $switch_variable_condition($child_context, $cond_node);
                     if ($previous_child_context !== null) {
+                        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable this being non-null is implied by switch_variable_condition
                         $variable = $visitor->getVariableFromScope($switch_variable_node, $child_context);
                         if ($variable) {
+                            // @phan-suppress-next-line PhanTypeMismatchArgumentNullable this being non-null is implied by switch_variable_condition
                             $old_variable = $visitor->getVariableFromScope($switch_variable_node, $previous_child_context);
 
                             if ($old_variable) {
@@ -853,6 +855,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
             // We can improve analysis of `case` blocks by using
             // a BlockExitStatusChecker to avoid propagating invalid inferences.
             $stmts_node = $child_node->children['stmts'];
+            // @phan-suppress-next-line PhanTypeMismatchArgumentNullable this is never null
             $block_exit_status = (new BlockExitStatusChecker())->__invoke($stmts_node);
             // equivalent to !willUnconditionallyThrowOrReturn()
             $previous_child_context = null;
@@ -1003,6 +1006,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
             // to reduce false positives.
             // (Variables will be available in `catch` and `finally`)
             // This is mitigated by finally and catch blocks being unaware of new variables from try{} blocks.
+            // @phan-suppress-next-line PhanTypeMismatchArgumentNullable this is never null
             if (BlockExitStatusChecker::willUnconditionallySkipRemainingStatements($child_node->children['stmts'])) {
                 // e.g. "if (!is_string($x)) { return; }"
                 $excluded_elem_count++;

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -120,7 +120,9 @@ class Issue
     const TypeInvalidThrowsIsInterface           = 'PhanTypeInvalidThrowsIsInterface';
     const TypeMagicVoidWithReturn                = 'PhanTypeMagicVoidWithReturn';
     const TypeMismatchArgument                   = 'PhanTypeMismatchArgument';
+    const TypeMismatchArgumentNullable           = 'PhanTypeMismatchArgumentNullable';
     const TypeMismatchArgumentInternal           = 'PhanTypeMismatchArgumentInternal';
+    const TypeMismatchArgumentNullableInternal   = 'PhanTypeMismatchArgumentNullableInternal';
     const PartialTypeMismatchArgument            = 'PhanPartialTypeMismatchArgument';
     const PartialTypeMismatchArgumentInternal    = 'PhanPartialTypeMismatchArgumentInternal';
     const PossiblyNullTypeArgument  = 'PhanPossiblyNullTypeArgument';
@@ -147,6 +149,7 @@ class Issue
     const PossiblyFalseTypeMismatchProperty = 'PhanPossiblyFalseTypeMismatchProperty';
     const PartialTypeMismatchProperty = 'PhanPartialTypeMismatchProperty';
     const TypeMismatchReturn        = 'PhanTypeMismatchReturn';
+    const TypeMismatchReturnNullable = 'PhanTypeMismatchReturnNullable';
     const PartialTypeMismatchReturn = 'PhanPartialTypeMismatchReturn';
     const PossiblyNullTypeReturn  = 'PhanPossiblyNullTypeReturn';
     const PossiblyFalseTypeReturn  = 'PhanPossiblyFalseTypeReturn';
@@ -1176,12 +1179,28 @@ class Issue
                 10003
             ),
             new Issue(
+                self::TypeMismatchArgumentNullable,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_LOW,
+                "Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} defined at {FILE}:{LINE} (expected type to be non-nullable)",
+                self::REMEDIATION_B,
+                10105
+            ),
+            new Issue(
                 self::TypeMismatchArgumentInternal,
                 self::CATEGORY_TYPE,
                 self::SEVERITY_NORMAL,
                 "Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE}",
                 self::REMEDIATION_B,
                 10004
+            ),
+            new Issue(
+                self::TypeMismatchArgumentNullableInternal,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_LOW,
+                "Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} (expected type to be non-nullable)",
+                self::REMEDIATION_B,
+                10106
             ),
             new Issue(
                 self::TypeMismatchGeneratorYieldValue,
@@ -1262,6 +1281,14 @@ class Issue
                 "Returning type {TYPE} but {FUNCTIONLIKE} is declared to return {TYPE}",
                 self::REMEDIATION_B,
                 10005
+            ),
+            new Issue(
+                self::TypeMismatchReturnNullable,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                "Returning type {TYPE} but {FUNCTIONLIKE} is declared to return {TYPE} (expected returned value to be non-nullable)",
+                self::REMEDIATION_B,
+                10107
             ),
             new Issue(
                 self::PartialTypeMismatchReturn,

--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -299,6 +299,20 @@ class Context extends FileRef
     }
 
     /**
+     * @return Context
+     *
+     * A new context with the a clone of the current scope.
+     * This is useful when using AssignmentVisitor for things that aren't actually assignment operations.
+     * (AssignmentVisitor modifies the passed in scope variables in place)
+     */
+    public function withClonedScope() : Context
+    {
+        $context = clone($this);
+        $context->scope = clone($context->scope);
+        return $context;
+    }
+
+    /**
      * @param Variable $variable
      * A variable to add to the scope for the new
      * context

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -401,12 +401,12 @@ class Clazz extends AddressableElement
     }
 
     /**
-     * @param Type|null $parent_type
+     * @param Type $parent_type
      * The type of the parent (extended) class of this class.
      *
      * @return void
      */
-    public function setParentType(Type $parent_type = null)
+    public function setParentType(Type $parent_type)
     {
         if ($parent_type && $this->getInternalScope()->hasAnyTemplateType()) {
             // Get a reference to the local list of templated
@@ -1009,6 +1009,7 @@ class Clazz extends AddressableElement
 
         // If the property exists and is accessible, return it
         if ($is_property_accessible) {
+            // @phan-suppress-next-line PhanTypeMismatchReturnNullable is_property_accessible ensures that this is non-null
             return $property;
         }
 

--- a/src/Phan/Language/Element/MarkupDescription.php
+++ b/src/Phan/Language/Element/MarkupDescription.php
@@ -23,7 +23,7 @@ class MarkupDescription
      */
     public static function buildForElement(
         AddressableElementInterface $element,
-        CodeBase $code_base = null
+        CodeBase $code_base
     ) : string {
         // TODO: Use the doc comments of the ancestors if unavailable or if (at)inheritDoc is used.
         $markup = $element->getMarkupDescription();

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -479,6 +479,19 @@ final class EmptyUnionType extends UnionType
         return true;  // Empty can cast to anything. See parent implementation.
     }
 
+    /**
+     * Precondition: $this->canCastToUnionType() is false.
+     *
+     * This tells us if it would have succeeded if the source type was not nullable.
+     *
+     * @internal
+     * @override
+     */
+    public function canCastToUnionTypeIfNonNull(UnionType $target) : bool
+    {
+        return false;
+    }
+
     public function canCastToUnionTypeHandlingTemplates(
         UnionType $target,
         CodeBase $code_base

--- a/src/Phan/Language/Scope.php
+++ b/src/Phan/Language/Scope.php
@@ -113,7 +113,7 @@ abstract class Scope
     /**
      * @return FQSEN in which this scope was declared
      * (e.g. a FullyQualifiedFunctionName, FullyQualifiedClassName, etc.)
-     * @suppress PhanPossiblyNullTypeReturn callers should call hasFQSEN
+     * @suppress PhanPossiblyNullTypeReturn, PhanPartialTypeMismatchReturn callers should call hasFQSEN
      */
     public function getFQSEN()
     {

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -2124,7 +2124,7 @@ class Type
             );
             $additional_union_type = $clazz->getAdditionalTypes();
             if ($additional_union_type !== null) {
-                $union_type = $union_type->withUnionType($additional_union_type);
+                $union_type = $union_type->withUnionType($additional_union_type->withIsNullable($this->is_nullable));
             }
 
             // Recurse up the tree to include all types
@@ -2154,7 +2154,7 @@ class Type
             foreach ($fqsen_aliases as $alias_fqsen_record) {
                 $alias_fqsen = $alias_fqsen_record->alias_fqsen;
                 $recursive_union_type_builder->addType(
-                    $alias_fqsen->asType()
+                    $alias_fqsen->asType()->withIsNullable($this->is_nullable)
                 );
             }
 
@@ -2214,7 +2214,7 @@ class Type
 
             $additional_union_type = $clazz->getAdditionalTypes();
             if ($additional_union_type !== null) {
-                $union_type = $union_type->withUnionType($additional_union_type);
+                $union_type = $union_type->withUnionType($additional_union_type->withIsNullable($this->is_nullable));
             }
 
             $representation = $this->__toString();
@@ -2245,7 +2245,7 @@ class Type
             foreach ($fqsen_aliases as $alias_fqsen_record) {
                 $alias_fqsen = $alias_fqsen_record->alias_fqsen;
                 $recursive_union_type_builder->addType(
-                    $alias_fqsen->asType()
+                    $alias_fqsen->asType()->withIsNullable($this->is_nullable)
                 );
             }
 

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -2120,7 +2120,7 @@ class Type
             $clazz = $code_base->getClassByFQSEN($class_fqsen);
 
             $union_type = $union_type->withUnionType(
-                $clazz->getUnionType()
+                $clazz->getUnionType()->withIsNullable($this->is_nullable)
             );
             $additional_union_type = $clazz->getAdditionalTypes();
             if ($additional_union_type !== null) {
@@ -2202,7 +2202,7 @@ class Type
             $clazz = $code_base->getClassByFQSEN($class_fqsen);
 
             $union_type = $union_type->withUnionType(
-                $clazz->getUnionType()
+                $clazz->getUnionType()->withIsNullable($this->is_nullable)
             );
 
             if (count($this->template_parameter_type_list) > 0) {
@@ -2586,12 +2586,9 @@ class Type
 
         // Test to see if this (or any ancestor types) can cast to the given union type.
         $expanded_types = $this_resolved->asExpandedTypes($code_base);
-        if ($expanded_types->canCastToUnionType(
+        return $expanded_types->canCastToUnionType(
             $union_type
-        )) {
-            return true;
-        }
-        return false;
+        );
     }
 
     /**

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -486,6 +486,7 @@ class GenericArrayType extends ArrayType implements GenericArrayInterface
 
     /**
      * @return UnionType a union type corresponding to $key_type
+     * @suppress PhanTypeMismatchReturnNullable false positive with static init
      */
     public static function unionTypeForKeyType(int $key_type, int $behavior = self::CONVERT_KEY_MIXED_TO_INT_OR_STRING_UNION_TYPE) : UnionType
     {

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -1688,6 +1688,27 @@ class UnionType implements Serializable
     }
 
     /**
+     * Precondition: $this->canCastToUnionType() is false.
+     *
+     * This tells us if it would have succeeded if the source type was not nullable.
+     *
+     * @internal
+     */
+    public function canCastToUnionTypeIfNonNull(UnionType $target) : bool
+    {
+        $non_null = $this->nonNullableClone();
+        if ($non_null === $this) {
+            // This wasn't nullable in the first place
+            return false;
+        }
+        if ($non_null->isEmpty()) {
+            // This was exclusively null - It should be a full TypeMismatch
+            return false;
+        }
+        return $non_null->canCastToUnionType($target);
+    }
+
+    /**
      * @param UnionType $target
      * A type to check to see if this can cast to it.
      *
@@ -2414,6 +2435,7 @@ class UnionType implements Serializable
      * @param CodeBase $code_base (for detecting the iterable value types of `class MyIterator extends Iterator`)
      *
      * @return UnionType
+     * @suppress PhanTypeMismatchArgumentNullable false positive in static init
      */
     public function iterableValueUnionType(CodeBase $code_base) : UnionType
     {
@@ -2459,6 +2481,7 @@ class UnionType implements Serializable
      * Takes `array{field:int,other:string}` and returns `int|string`
      *
      * @return UnionType
+     * @suppress PhanTypeMismatchArgumentNullable false positive in static init
      */
     public function genericArrayElementTypes() : UnionType
     {
@@ -3069,6 +3092,7 @@ class UnionType implements Serializable
      * @param UnionTypeBuilder $builder (Containing only non-nullable values)
      * @return void
      * @var int $bool_id
+     * @suppress PhanTypeMismatchArgumentNullable false positive in static init
      */
     private static function convertToTypeSetWithNormalizedNonNullableBools(UnionTypeBuilder $builder)
     {
@@ -3093,6 +3117,7 @@ class UnionType implements Serializable
      * Removes ?false|?true types and adds ?bool
      *
      * @param UnionTypeBuilder $builder (Containing only non-nullable values)
+     * @suppress PhanTypeMismatchArgumentNullable false positive in static init
      */
     private static function convertToTypeSetWithNormalizedNullableBools(UnionTypeBuilder $builder)
     {

--- a/src/Phan/LanguageServer/ClientHandler.php
+++ b/src/Phan/LanguageServer/ClientHandler.php
@@ -58,10 +58,14 @@ class ClientHandler
              * @suppress PhanUndeclaredProperty taken care of by isResponse checks on msg->body
              */
             $listener = function (Protocol\Message $msg) use ($id, $promise, &$listener) {
-                if (AdvancedJsonRpc\Response::isResponse($msg->body) && $msg->body->id === $id) {
+                $body = $msg->body;
+                if (!$body) {
+                    return;
+                }
+                if (AdvancedJsonRpc\Response::isResponse($body) && $body->id === $id) {
                     // Received a response
                     $this->protocolReader->removeListener('message', $listener);
-                    if (AdvancedJsonRpc\SuccessResponse::isSuccessResponse($msg->body)) {
+                    if (AdvancedJsonRpc\SuccessResponse::isSuccessResponse($body)) {
                         $promise->fulfill($msg->body->result);
                     } else {
                         $promise->reject($msg->body->error);

--- a/src/Phan/LanguageServer/CompletionResolver.php
+++ b/src/Phan/LanguageServer/CompletionResolver.php
@@ -389,6 +389,7 @@ class CompletionResolver
                 new Variable(
                     $context,
                     $superglobal_name,
+                    // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
                     Variable::getUnionTypeOfHardcodedGlobalVariableWithName($superglobal_name),
                     0
                 ),

--- a/src/Phan/LanguageServer/GoToDefinitionRequest.php
+++ b/src/Phan/LanguageServer/GoToDefinitionRequest.php
@@ -390,16 +390,16 @@ final class GoToDefinitionRequest extends NodeInfoRequest
      */
     public function finalize()
     {
-        $promise = $this->promise;
-        if ($promise) {
-            if ($this->request_type === self::REQUEST_HOVER) {
-                $result = $this->hover_response;
-            } else {
-                $result = $this->locations ? \array_values($this->locations) : null;
-            }
-            $promise->fulfill($result);
-            $this->promise = null;
+        if ($this->fulfilled) {
+            return;
         }
+        $this->fulfilled = true;
+        if ($this->request_type === self::REQUEST_HOVER) {
+            $result = $this->hover_response;
+        } else {
+            $result = $this->locations ? \array_values($this->locations) : null;
+        }
+        $this->promise->fulfill($result);
     }
 
     /**
@@ -420,10 +420,10 @@ final class GoToDefinitionRequest extends NodeInfoRequest
 
     public function __destruct()
     {
-        $promise = $this->promise;
-        if ($promise) {
-            $promise->reject(new Exception('Failed to send a valid textDocument/completion result'));
-            $this->promise = null;
+        if ($this->fulfilled) {
+            return;
         }
+        $this->fulfilled = true;
+        $this->promise->reject(new Exception('Failed to send a valid textDocument/completion result'));
     }
 }

--- a/src/Phan/LanguageServer/NodeInfoRequest.php
+++ b/src/Phan/LanguageServer/NodeInfoRequest.php
@@ -21,8 +21,13 @@ abstract class NodeInfoRequest
     protected $path;
     /** @var Position the position of the cursor within $this->uri where information is being requested. */
     protected $position;
-    /** @var Promise|null this should be resolve()d with the requested information, or null on failure or if the request was aborted */
+    /** @var Promise this should be resolve()d with the requested information, or resolve()d with null (or rejected) on failure or if the request was aborted */
     protected $promise;
+
+    /**
+     * @var bool
+     */
+    protected $fulfilled = false;
 
     public function __construct(
         string $uri,
@@ -63,7 +68,7 @@ abstract class NodeInfoRequest
         return $this->position;
     }
 
-    /** @return ?Promise */
+    /** @return Promise */
     final public function getPromise()
     {
         return $this->promise;

--- a/src/Phan/LanguageServer/Protocol/Range.php
+++ b/src/Phan/LanguageServer/Protocol/Range.php
@@ -27,6 +27,7 @@ class Range
      */
     public $end;
 
+    /** @suppress PhanTypeMismatchProperty anything useful will be non-null */
     public function __construct(Position $start = null, Position $end = null)
     {
         $this->start = $start;

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
@@ -22,6 +22,8 @@ use function is_string;
  * TODO: Improve analysis within the ternary operator (cond() ? ($x = 2) : ($x = 3);
  * TODO: Support unset
  * TODO: Fix tests/files/src/0426_inline_var_force.php
+ *
+ * @phan-file-suppress PhanTypeMismatchArgumentNullable child nodes as used here are non-null
  */
 final class VariableTrackerVisitor extends AnalysisVisitor
 {

--- a/tests/Phan/AbstractPhanFileTest.php
+++ b/tests/Phan/AbstractPhanFileTest.php
@@ -28,6 +28,7 @@ abstract class AbstractPhanFileTest extends BaseTest implements CodeBaseAwareTes
 
     /**
      * @return void
+     * @suppress PhanTypeMismatchProperty
      */
     public function setCodeBase(CodeBase $code_base = null)
     {

--- a/tests/Phan/Plugin/Internal/IssueFixingPluginTest.php
+++ b/tests/Phan/Plugin/Internal/IssueFixingPluginTest.php
@@ -37,7 +37,7 @@ final class IssueFixingPluginTest extends BaseTest implements CodeBaseAwareTestI
         $this->assertCount(1, $fixers);
         $fixers_for_file = $fixers[self::FILE];
         // echo "Going to apply to \n$original_contents\n";
-        // @phan-suppress-next-line PhanPossiblyNullTypeArgument
+        // @phan-suppress-next-line PhanPossiblyNullTypeArgument, PhanPartialTypeMismatchArgument
         $new_contents = IssueFixer::computeNewContentForFixers($this->code_base, self::FILE, $original_contents, $fixers_for_file);
         $this->assertSame($expected_contents, $new_contents, 'unexpected contents after applying fixes');
     }

--- a/tests/Phan/Plugin/Internal/MethodSearcherPluginTest.php
+++ b/tests/Phan/Plugin/Internal/MethodSearcherPluginTest.php
@@ -13,11 +13,12 @@ use Phan\Tests\CodeBaseAwareTestInterface;
  */
 final class MethodSearcherPluginTest extends BaseTest implements CodeBaseAwareTestInterface
 {
-    /** @var CodeBase|null The code base within which this unit test is operating */
+    /** @var CodeBase The code base within which this unit test is operating */
     private $code_base = null;
 
     public function setCodeBase(CodeBase $code_base = null)
     {
+        // @phan-suppress-next-line PhanTypeMismatchProperty
         $this->code_base = $code_base;
     }
 
@@ -28,7 +29,7 @@ final class MethodSearcherPluginTest extends BaseTest implements CodeBaseAwareTe
     {
         $actual_signature_type = UnionType::fromFullyQualifiedString($actual);
         $desired_signature_type = UnionType::fromFullyQualifiedString($desired);
-        // @phan-suppress-next-line PhanAccessMethodInternal, PhanPossiblyNullTypeArgument
+        // @phan-suppress-next-line PhanAccessMethodInternal
         $this->assertSame($expected_score, MethodSearcherPlugin::getTypeMatchingBonus($this->code_base, $actual_signature_type, $desired_signature_type));
     }
 

--- a/tests/files/expected/0086_conditional_instanceof_type.php.expected
+++ b/tests/files/expected/0086_conditional_instanceof_type.php.expected
@@ -1,1 +1,2 @@
 %s:8 PhanNonClassMethodCall Call to method f on non-class type null
+%s:14 PhanTypeMismatchArgumentNullable Argument 1 (p) is ?\A but \A::f() takes \A defined at %s:3 (expected type to be non-nullable)

--- a/tests/files/expected/0152_closure_casts_callable.php.expected
+++ b/tests/files/expected/0152_closure_casts_callable.php.expected
@@ -1,0 +1,1 @@
+%s:4 PhanTypeMismatchArgumentNullableInternal Argument 2 (cmp_function) is ?\Closure but \usort() takes callable(mixed,mixed):int (expected type to be non-nullable)

--- a/tests/files/expected/0341_negated_condition_visitor.php.expected
+++ b/tests/files/expected/0341_negated_condition_visitor.php.expected
@@ -3,7 +3,7 @@
 %s:17 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is string but \intdiv() takes int
 %s:23 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is null but \intdiv() takes int
 %s:27 PhanTypeMismatchArgumentInternal Argument 1 (string) is int but \strlen() takes string
-%s:33 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is ?int but \intdiv() takes int
+%s:33 PhanTypeMismatchArgumentNullableInternal Argument 1 (numerator) is ?int but \intdiv() takes int (expected type to be non-nullable)
 %s:35 PhanTypeMismatchArgumentInternal Argument 1 (string) is int but \strlen() takes string
 %s:44 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is string but \intdiv() takes int
 %s:45 PhanTypeMismatchArgumentInternal Argument 1 (string) is int but \strlen() takes string

--- a/tests/files/expected/0347_global_ternarytest.php.expected
+++ b/tests/files/expected/0347_global_ternarytest.php.expected
@@ -2,5 +2,5 @@
 %s:17 PhanTypeMismatchArgumentInternal Argument 2 (divisor) is null but \intdiv() takes int
 %s:20 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is \A347 but \intdiv() takes int
 %s:22 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is null but \intdiv() takes int
-%s:27 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is ?\A347|\A347 but \intdiv() takes int
-%s:28 PhanTypeMismatchArgumentInternal Argument 2 (divisor) is ?\A347|\A347 but \intdiv() takes int
+%s:27 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is ?\A347 but \intdiv() takes int
+%s:28 PhanTypeMismatchArgumentInternal Argument 2 (divisor) is ?\A347 but \intdiv() takes int

--- a/tests/files/expected/0451_switch_cases.php.expected
+++ b/tests/files/expected/0451_switch_cases.php.expected
@@ -1,2 +1,2 @@
 %s:4 PhanUnusedVariable Unused definition of variable $x
-%s:13 PhanTypeMismatchArgumentInternal Argument 1 (var) is ?array{} but \count() takes \Countable|array
+%s:13 PhanTypeMismatchArgumentNullableInternal Argument 1 (var) is ?array{} but \count() takes \Countable|array (expected type to be non-nullable)

--- a/tests/files/expected/0464_false_positive_nullable.php.expected
+++ b/tests/files/expected/0464_false_positive_nullable.php.expected
@@ -1,3 +1,3 @@
-%s:3 PhanTypeMismatchArgumentInternal Argument 1 (input) is ?array but \array_values() takes array
+%s:3 PhanTypeMismatchArgumentNullableInternal Argument 1 (input) is ?array but \array_values() takes array (expected type to be non-nullable)
 %s:17 PhanTypeArraySuspiciousNullable Suspicious array access to nullable ?array
 %s:18 PhanTypeArraySuspiciousNullable Suspicious array access to nullable ?array

--- a/tests/files/expected/0571_static_type_prop.php.expected
+++ b/tests/files/expected/0571_static_type_prop.php.expected
@@ -1,12 +1,12 @@
 %s:14 PhanStaticPropIsStaticType Static property \Chain::$static_prop_parent is declared to have type static, but the only instance is shared among all subclasses (Did you mean \Chain)
 %s:31 PhanTypeMismatchArgumentInternal Argument 1 (string) is \Chain|false but \strlen() takes string
 %s:32 PhanTypeMismatchArgumentInternal Argument 1 (string) is \Chain|\Request|null but \strlen() takes string
-%s:33 PhanTypeMismatchArgumentInternal Argument 1 (string) is ?\Request|?bool|\Chain|\Request but \strlen() takes string
+%s:33 PhanTypeMismatchArgumentInternal Argument 1 (string) is ?\Chain|?\Request|?bool but \strlen() takes string
 %s:34 PhanTypeMismatchArgumentInternal Argument 1 (string) is \Chain|\Request|false but \strlen() takes string
 %s:35 PhanTypeMismatchArgumentInternal Argument 1 (string) is \Chain|null but \strlen() takes string
-%s:36 PhanTypeMismatchArgumentInternal Argument 1 (string) is ?\Chain|?bool|\Chain but \strlen() takes string
+%s:36 PhanTypeMismatchArgumentInternal Argument 1 (string) is ?\Chain|?bool but \strlen() takes string
 %s:37 PhanTypeMismatchArgumentInternal Argument 1 (string) is \Chain|\Fence|null but \strlen() takes string
-%s:38 PhanTypeMismatchArgumentInternal Argument 1 (string) is ?\Fence|?bool|\Chain|\Fence but \strlen() takes string
+%s:38 PhanTypeMismatchArgumentInternal Argument 1 (string) is ?\Chain|?\Fence|?bool but \strlen() takes string
 %s:39 PhanTypeMismatchArgumentInternal Argument 1 (string) is \Chain|\Fence|false but \strlen() takes string
 %s:40 PhanTypeSuspiciousEcho Suspicious argument \Chain for an echo/print statement
 %s:41 PhanTypeSuspiciousEcho Suspicious argument \Chain for an echo/print statement

--- a/tests/files/expected/0574_inc_dec.php.expected
+++ b/tests/files/expected/0574_inc_dec.php.expected
@@ -38,7 +38,7 @@
 %s:51 PhanTypeInvalidUnaryOperandIncOrDec Invalid operator: unary operand of --(expr) is ?\stdClass (expected int or string or float)
 %s:51 PhanTypeMismatchArgumentInternal Argument 1 (string) is \stdClass|int but \strlen() takes string
 %s:52 PhanTypeInvalidUnaryOperandIncOrDec Invalid operator: unary operand of (expr)-- is ?\stdClass (expected int or string or float)
-%s:52 PhanTypeMismatchArgumentInternal Argument 1 (string) is ?\stdClass|\stdClass but \strlen() takes string
+%s:52 PhanTypeMismatchArgumentInternal Argument 1 (string) is ?\stdClass but \strlen() takes string
 %s:54 PhanTypeMismatchArgumentInternal Argument 1 (string) is int but \strlen() takes string
 %s:56 PhanTypeMismatchArgumentInternal Argument 1 (string) is int but \strlen() takes string
 %s:58 PhanTypeMismatchArgumentInternal Argument 1 (string) is float but \strlen() takes string

--- a/tests/files/expected/0652_array_narrow.php.expected
+++ b/tests/files/expected/0652_array_narrow.php.expected
@@ -1,0 +1,5 @@
+%s:12 PhanTypeMismatchArgumentInternal Argument 1 (string) is array but \strlen() takes string
+%s:25 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is array|string but \intdiv() takes int
+%s:35 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is string but \intdiv() takes int
+%s:37 PhanTypeMismatchArgumentInternal Argument 1 (string) is array but \strlen() takes string
+%s:39 PhanTypeMismatchArgumentInternal Argument 1 (string) is array{hooks:array}|array{hooks:string} but \strlen() takes string

--- a/tests/files/expected/0652_array_narrow.php.expected
+++ b/tests/files/expected/0652_array_narrow.php.expected
@@ -1,5 +1,5 @@
 %s:12 PhanTypeMismatchArgumentInternal Argument 1 (string) is array but \strlen() takes string
-%s:25 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is array|string but \intdiv() takes int
+%s:25 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is array{0:string} but \intdiv() takes int
 %s:35 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is string but \intdiv() takes int
 %s:37 PhanTypeMismatchArgumentInternal Argument 1 (string) is array but \strlen() takes string
 %s:39 PhanTypeMismatchArgumentInternal Argument 1 (string) is array{hooks:array}|array{hooks:string} but \strlen() takes string

--- a/tests/files/expected/0653_instanceof_array_field.php.expected
+++ b/tests/files/expected/0653_instanceof_array_field.php.expected
@@ -1,0 +1,10 @@
+%s:10 PhanUndeclaredMethod Call to undeclared method \ArrayAccess::someMethod
+%s:13 PhanTypeMismatchArgumentInternal Argument 1 (string) is object but \strlen() takes string
+%s:22 PhanNonClassMethodCall Call to method count on non-class type null
+%s:22 PhanTypeInvalidDimOffset Invalid offset "field" of array type array{0:\Countable}
+%s:25 PhanUndeclaredMethod Call to undeclared method \stdClass::count
+%s:36 PhanNonClassMethodCall Call to method count on non-class type null
+%s:36 PhanTypeInvalidDimOffset Invalid offset 4 of array type array{5:\Countable}
+%s:39 PhanUndeclaredMethod Call to undeclared method \stdClass::count
+%s:47 PhanTypeMismatchReturn Returning type \stdClass but check_var_negate() is declared to return string
+%s:49 PhanTypeMismatchReturn Returning type int but check_var_negate() is declared to return string

--- a/tests/files/expected/0654_isset_prop.php.expected
+++ b/tests/files/expected/0654_isset_prop.php.expected
@@ -1,5 +1,5 @@
-%s:7 PhanTypeMismatchArgumentInternal Argument 1 (obj) is ?\stdClass but \spl_object_hash() takes object
-%s:11 PhanTypeMismatchArgumentInternal Argument 1 (obj) is ?\stdClass but \spl_object_hash() takes object
-%s:16 PhanTypeMismatchArgumentInternal Argument 1 (obj) is ?\stdClass but \spl_object_hash() takes object
-%s:20 PhanTypeMismatchArgumentInternal Argument 1 (obj) is ?\stdClass but \spl_object_hash() takes object
+%s:7 PhanTypeMismatchArgumentNullableInternal Argument 1 (obj) is ?\stdClass but \spl_object_hash() takes object (expected type to be non-nullable)
+%s:11 PhanTypeMismatchArgumentNullableInternal Argument 1 (obj) is ?\stdClass but \spl_object_hash() takes object (expected type to be non-nullable)
+%s:16 PhanTypeMismatchArgumentNullableInternal Argument 1 (obj) is ?\stdClass but \spl_object_hash() takes object (expected type to be non-nullable)
+%s:20 PhanTypeMismatchArgumentNullableInternal Argument 1 (obj) is ?\stdClass but \spl_object_hash() takes object (expected type to be non-nullable)
 %s:30 PhanTypeMismatchArgumentInternal Argument 1 (string) is array but \strlen() takes string

--- a/tests/files/expected/0654_isset_prop.php.expected
+++ b/tests/files/expected/0654_isset_prop.php.expected
@@ -1,0 +1,5 @@
+%s:7 PhanTypeMismatchArgumentInternal Argument 1 (obj) is ?\stdClass but \spl_object_hash() takes object
+%s:11 PhanTypeMismatchArgumentInternal Argument 1 (obj) is ?\stdClass but \spl_object_hash() takes object
+%s:16 PhanTypeMismatchArgumentInternal Argument 1 (obj) is ?\stdClass but \spl_object_hash() takes object
+%s:20 PhanTypeMismatchArgumentInternal Argument 1 (obj) is ?\stdClass but \spl_object_hash() takes object
+%s:30 PhanTypeMismatchArgumentInternal Argument 1 (string) is array but \strlen() takes string

--- a/tests/files/src/0652_array_narrow.php
+++ b/tests/files/src/0652_array_narrow.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+namespace TestFieldAssertions;
+
+/**
+ * @param array<string,string|array> $options
+ */
+function foo(array $options)
+{
+    if (is_array($options['hooks'])) {
+        echo strlen($options['hooks']);
+        foreach ($options['hooks'] as $hook) {
+            var_export($hook);
+        }
+    }
+}
+
+/**
+ * @param array<string,string|array> $options
+ */
+function foo2(array $options)
+{
+    if (is_string($options['hooks'][0])) {
+        echo intdiv($options['hooks'], 2);  // should infer string|array - both can have an integer field
+    }
+}
+
+/**
+ * @param array{hooks:string|array} $options
+ */
+function foo3(array $options)
+{
+    if (is_string($options['hooks'])) {
+        echo intdiv($options['hooks'], 2);  // should infer string and warn
+    } else {
+        echo strlen($options['hooks']);  // should infer array and warn
+    }
+    echo strlen($options);  // should still infer array{hooks:string|array}
+}

--- a/tests/files/src/0652_array_narrow.php
+++ b/tests/files/src/0652_array_narrow.php
@@ -22,7 +22,7 @@ function foo(array $options)
 function foo2(array $options)
 {
     if (is_string($options['hooks'][0])) {
-        echo intdiv($options['hooks'], 2);  // should infer string|array - both can have an integer field
+        echo intdiv($options['hooks'], 2);  // TODO(optional): could infer string|array|array{0:string} instead. - both can have an integer field. This isn't a common edge case in practice.
     }
 }
 

--- a/tests/files/src/0653_instanceof_array_field.php
+++ b/tests/files/src/0653_instanceof_array_field.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace NS653;
+
+/**
+ * @param array{field:object} $array
+ */
+function check_instanceof($array) {
+    if ($array['field'] instanceof \ArrayAccess) {
+        $array['field']->someMethod();
+        return;
+    }
+    echo strlen($array['field']);
+}
+
+/**
+ * @param array{0:\stdClass|\Countable} $array
+ */
+function check_instanceof_negate($array) {
+    if ($array[0] instanceof \Countable) {
+        var_export($array[0]->count());
+        var_export($array['field']->count());
+        return;
+    }
+    var_export($array[0]->count());
+}
+
+const FIVE = 5;
+
+/**
+ * @param array{5:\stdClass|\Countable} $array
+ */
+function check_instanceof_negate_2($array) {
+    if ($array[FIVE] instanceof \Countable) {
+        var_export($array[FIVE]->count());
+        var_export($array[4]->count());
+        return;
+    }
+    var_export($array[FIVE]->count());
+}
+
+/**
+ * @param \stdClass|int $o
+ */
+function check_var_negate($o) : string {
+    if ($o instanceof \stdClass) {
+        return $o;
+    }
+    return $o;
+}

--- a/tests/files/src/0654_isset_prop.php
+++ b/tests/files/src/0654_isset_prop.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @param ?stdClass $x
+ */
+function test_object(stdClass $x = null) {
+    echo spl_object_hash($x);  // should infer ?stdClass
+    if (isset($x->prop)) {
+        echo spl_object_hash($x);  // should not warn
+    } else {
+        echo spl_object_hash($x);  // should warn
+    }
+}
+
+function test_object_field_isset(stdClass $nested = null) {
+    echo spl_object_hash($nested);  // should infer ?stdClass
+    if (isset($nested->prop['a'][rand() % 2])) {
+        echo spl_object_hash($nested);  // should not warn
+    } else {
+        echo spl_object_hash($nested);  // should warn
+    }
+}
+
+/**
+ * @param array{field:?array} $x
+ */
+function test_isset_nested(array $x) {
+    if (isset($x['field'][0])) {
+        // Should infer field is non-null
+        echo strlen($x['field']);
+    }
+}

--- a/tests/plugin_test/expected/010_printf_types.php.expected
+++ b/tests/plugin_test/expected/010_printf_types.php.expected
@@ -1,7 +1,7 @@
 src/010_printf_types.php:7 PhanPluginPrintfIncompatibleArgumentTypeWeak Format string "Hello, %s" refers to argument #1 as %s, so type string is expected. However, printf was passed the type float (which is weaker than string)
 src/010_printf_types.php:8 PhanPluginPrintfIncompatibleArgumentTypeWeak Format string "Hello, %s" refers to argument #1 as %s, so type string is expected. However, printf was passed the type 2 (which is weaker than string)
 src/010_printf_types.php:9 PhanPluginPrintfIncompatibleArgumentType Format string "Hello, %s" refers to argument #1 as %s, so type string is expected, but printf was passed incompatible type ?int
-src/010_printf_types.php:9 PhanTypeMismatchArgumentInternal Argument 2 (args) is ?int but \printf() takes float|int|string
+src/010_printf_types.php:9 PhanTypeMismatchArgumentNullableInternal Argument 2 (args) is ?int but \printf() takes float|int|string (expected type to be non-nullable)
 src/010_printf_types.php:10 PhanPluginPrintfIncompatibleArgumentType Format string "Hello, %s" refers to argument #1 as %s, so type string is expected, but printf was passed incompatible type false
 src/010_printf_types.php:10 PhanTypeMismatchArgumentInternal Argument 2 (args) is false but \printf() takes float|int|string
 src/010_printf_types.php:11 PhanPluginPrintfIncompatibleArgumentType Format string "Hello, %s" refers to argument #1 as %s, so type string is expected, but printf was passed incompatible type array{}


### PR DESCRIPTION
+ Improve types inferred from checks such as `if (is_array($var['field'])) { use($var['field']); }` and `if ($var['field'] instanceof stdClass) {...}` (#2601)
+ Infer that $varName is non-null and an object for conditions such as `if (isset($varName->field['prop']))`


Fixes #2601 

Also, add nullable type mismatch issues for arguments/return values

Previously, these weren't getting detected in some cases,
for nullable class instances.
