### PR TITLE
Print a notice to stderr if PHP 7.0 is used to run Phan

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -33,9 +33,13 @@ Plugins:
 + Warn about assignments where the left and right hand side are the same expression in `DuplicateExpressionPlugin` (#2641)
   New issue type: `PhanPluginDuplicateExpressionAssignment`
 
-Maintenance:
+Deprecations:
 + Print a message to stderr if the installed php-ast version is older than 1.0.1.
   A future major Phan version of Phan will probably depend on AST version 70 to support new syntax found in PHP 7.4.
++ Print a message to stderr if the installed PHP version is 7.0.
+  A future major version of Phan will require PHP 7.1+ to run.
+
+  Phan will still continue to support setting `target_php_version` to `'7.0'` and `--target-php-version 7.0` in that release.
 
 Bug fixes:
 + Fix edge cases in how Phan checks if files are in `exclude_analysis_directory_list` (#2651)

--- a/composer.lock
+++ b/composer.lock
@@ -497,16 +497,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v3.4.24",
+            "version": "v3.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "98ae3cdc4bec48fe7ee24afc81dbb4a242186c9e"
+                "reference": "15a9104356436cb26e08adab97706654799d31d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/98ae3cdc4bec48fe7ee24afc81dbb4a242186c9e",
-                "reference": "98ae3cdc4bec48fe7ee24afc81dbb4a242186c9e",
+                "url": "https://api.github.com/repos/symfony/console/zipball/15a9104356436cb26e08adab97706654799d31d8",
+                "reference": "15a9104356436cb26e08adab97706654799d31d8",
                 "shasum": ""
             },
             "require": {
@@ -565,20 +565,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2019-03-31T11:33:18+00:00"
+            "time": "2019-04-08T09:29:13+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v3.4.24",
+            "version": "v3.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "adbdd5d66342fb0a0bce7422ba68181842b6610d"
+                "reference": "681afbb26488903c5ac15e63734f1d8ac430c9b9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/adbdd5d66342fb0a0bce7422ba68181842b6610d",
-                "reference": "adbdd5d66342fb0a0bce7422ba68181842b6610d",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/681afbb26488903c5ac15e63734f1d8ac430c9b9",
+                "reference": "681afbb26488903c5ac15e63734f1d8ac430c9b9",
                 "shasum": ""
             },
             "require": {
@@ -621,7 +621,7 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2019-03-10T17:07:42+00:00"
+            "time": "2019-04-11T09:48:14+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -2114,16 +2114,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v3.4.24",
+            "version": "v3.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "009f8dda80930e89e8344a4e310b08f9ff07dd2e"
+                "reference": "a9c4dfbf653023b668c282e4e02609d131f4057a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/009f8dda80930e89e8344a4e310b08f9ff07dd2e",
-                "reference": "009f8dda80930e89e8344a4e310b08f9ff07dd2e",
+                "url": "https://api.github.com/repos/symfony/process/zipball/a9c4dfbf653023b668c282e4e02609d131f4057a",
+                "reference": "a9c4dfbf653023b668c282e4e02609d131f4057a",
                 "shasum": ""
             },
             "require": {
@@ -2159,7 +2159,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2019-01-16T13:27:11+00:00"
+            "time": "2019-04-08T16:15:54+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/src/Phan/Bootstrap.php
+++ b/src/Phan/Bootstrap.php
@@ -202,10 +202,10 @@ if (extension_loaded('ast')) {
     $ast_version = (new ReflectionExtension('ast'))->getVersion();
     if (version_compare($ast_version, '1.0.0') <= 0) {
         if (PHP_VERSION_ID >= 70400) {
-            fwrite(STDERR, "Phan is being run with php-ast version $ast_version.\n");
-            fwrite(STDERR, "However, when run with PHP 7.4+, Phan requires php-ast 1.0.1 or newer. Older versions of php-ast will crash Phan.\n");
+            fwrite(STDERR, "Phan is being run with php-ast version $ast_version." . PHP_EOL);
+            fwrite(STDERR, "However, when run with PHP 7.4+, Phan requires php-ast 1.0.1 or newer. Older versions of php-ast will crash Phan." . PHP_EOL);
             fwrite(STDERR, "Alternately, to run this version of Phan with PHP 7.4 without upgrading php-ast, uninstall/disable php-ast in php.ini,"
-               . " then add the CLI option --allow-polyfill-parser (which is noticeably slower)\n");
+               . " then add the CLI option --allow-polyfill-parser (which is noticeably slower)" . PHP_EOL);
             exit(EXIT_FAILURE);
         }
         if (!getenv('PHAN_SUPPRESS_AST_UPGRADE_NOTICE')) {
@@ -218,6 +218,17 @@ if (extension_loaded('ast')) {
         }
     }
     if (version_compare($ast_version, '0.1.5') < 0) {
-        fprintf(STDERR, "Phan supports php-ast version 0.1.5 or newer, but the installed php-ast version is %s. You may see bugs in some edge cases\n", $ast_version);
+        fprintf(STDERR, "Phan supports php-ast version 0.1.5 or newer, but the installed php-ast version is %s. You may see bugs in some edge cases" . PHP_EOL, $ast_version);
+    }
+}
+if (PHP_VERSION_ID < 70100) {
+    if (!getenv('PHAN_SUPPRESS_PHP_UPGRADE_NOTICE')) {
+        fprintf(
+            STDERR,
+            "A future major version of Phan will require PHP 7.1+ to run, but PHP %s is installed." . PHP_EOL,
+            PHP_VERSION
+        );
+        fwrite(STDERR, "PHP 7.0 reached its end of life in December 2018." . PHP_EOL);
+        fwrite(STDERR, "(Set PHAN_SUPPRESS_PHP_UPGRADE_NOTICE=1 to suppress this message)" . PHP_EOL);
     }
 }


### PR DESCRIPTION
Support for PHP 7.0 will be dropped in a future major release.

This is holding back the libraries used by Phan (and would in the future)
and prevents using features such as nullable types/void.

- mostly test libraries right now
- This also adds extra work to make test cases compatible with php 7.0

PHP 7.0 reached EOL 4 months ago.