### PR TITLE
Emit PhanPossiblyNullTypeMismatchProperty instead for `?T`

### DIFF
--- a/internal/PHP_CodeSniffer/composer.lock
+++ b/internal/PHP_CodeSniffer/composer.lock
@@ -58,26 +58,26 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "165c96a374c4bfa4c2da543a8893671223dd8fde"
+                "reference": "971b856b0a2c06d86996465b98b7d069b39574a6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/165c96a374c4bfa4c2da543a8893671223dd8fde",
-                "reference": "165c96a374c4bfa4c2da543a8893671223dd8fde",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/971b856b0a2c06d86996465b98b7d069b39574a6",
+                "reference": "971b856b0a2c06d86996465b98b7d069b39574a6",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1",
                 "phpstan/phpdoc-parser": "^0.3.1",
-                "squizlabs/php_codesniffer": "^3.4.0"
+                "squizlabs/php_codesniffer": "^3.4.1"
             },
             "require-dev": {
                 "jakub-onderka/php-parallel-lint": "1.0.0",
                 "phing/phing": "2.16.1",
-                "phpstan/phpstan": "0.11.1",
+                "phpstan/phpstan": "0.11.4",
                 "phpstan/phpstan-phpunit": "0.11",
                 "phpstan/phpstan-strict-rules": "0.11",
-                "phpunit/phpunit": "8.0.0"
+                "phpunit/phpunit": "8.0.5"
             },
             "type": "phpcodesniffer-standard",
             "autoload": {
@@ -90,7 +90,7 @@
                 "MIT"
             ],
             "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
-            "time": "2019-02-12T20:53:21+00:00"
+            "time": "2019-04-20T05:53:19+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -98,12 +98,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "e4da24f399d71d1077f93114a72e305286020415"
+                "reference": "1d7c6576a578fb57723c8c0fbc716cb88dae4f13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/e4da24f399d71d1077f93114a72e305286020415",
-                "reference": "e4da24f399d71d1077f93114a72e305286020415",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1d7c6576a578fb57723c8c0fbc716cb88dae4f13",
+                "reference": "1d7c6576a578fb57723c8c0fbc716cb88dae4f13",
                 "shasum": ""
             },
             "require": {
@@ -141,7 +141,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2019-02-15T05:33:10+00:00"
+            "time": "2019-04-16T03:35:30+00:00"
         }
     ],
     "packages-dev": [],

--- a/src/Phan/AST/ASTSimplifier.php
+++ b/src/Phan/AST/ASTSimplifier.php
@@ -772,7 +772,7 @@ class ASTSimplifier
         $list = $catches->children;
         $new_list = array_map(
             /** @return mixed */
-            function (Node $node) {
+            static function (Node $node) {
                 return self::applyToStmts($node);
             },
             // @phan-suppress-next-line PhanPartialTypeMismatchArgument should be impossible to be float

--- a/src/Phan/AST/TolerantASTConverter/ast_shim.php
+++ b/src/Phan/AST/TolerantASTConverter/ast_shim.php
@@ -235,7 +235,7 @@ if (!\class_exists('\ast\Node')) {
         /**
          * A constructor which validates data types but not the values themselves.
          * For backwards compatibility reasons, all values are optional and properties default to null
-         * @suppress PhanTypeMismatchProperty
+         * @suppress PhanPossiblyNullTypeMismatchProperty
          */
         public function __construct(int $kind = null, int $flags = null, array $children = null, int $lineno = null)
         {

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -835,14 +835,26 @@ class AssignmentVisitor extends AnalysisVisitor
                 && !($this->right_type->hasTypeInBoolFamily() && $property_union_type->hasTypeInBoolFamily())
                 && !$clazz->getHasDynamicProperties($this->code_base)
             ) {
-                // TODO: optionally, change the message from "::" to "->"?
-                $this->emitIssue(
-                    Issue::TypeMismatchProperty,
-                    $node->lineno ?? 0,
-                    (string)$this->right_type,
-                    $property->getRepresentationForIssue(),
-                    (string)$property_union_type
-                );
+                if ($this->right_type->nonNullableClone()->canCastToExpandedUnionType($property_union_type, $this->code_base) &&
+                        !$this->right_type->isType(NullType::instance(false))) {
+                    $this->emitIssue(
+                        Issue::PossiblyNullTypeMismatchProperty,
+                        $node->lineno ?? 0,
+                        (string)$this->right_type,
+                        $property->getRepresentationForIssue(),
+                        (string)$property_union_type,
+                        'null'
+                    );
+                } else {
+                    // TODO: optionally, change the message from "::" to "->"?
+                    $this->emitIssue(
+                        Issue::TypeMismatchProperty,
+                        $node->lineno ?? 0,
+                        (string)$this->right_type,
+                        $property->getRepresentationForIssue(),
+                        (string)$property_union_type
+                    );
+                }
                 return $this->context;
             }
 

--- a/src/Phan/LanguageServer/Protocol/Diagnostic.php
+++ b/src/Phan/LanguageServer/Protocol/Diagnostic.php
@@ -60,7 +60,7 @@ class Diagnostic
      * @param  int    $code     The diagnostic's code
      * @param  int    $severity DiagnosticSeverity
      * @param  string $source   A human-readable string describing the source of this diagnostic
-     * @suppress PhanTypeMismatchProperty
+     * @suppress PhanPossiblyNullTypeMismatchProperty
      * @suppress PhanTypeMismatchDeclaredParamNullable
      */
     public function __construct(string $message = null, Range $range = null, int $code = null, int $severity = null, string $source = null)

--- a/src/Phan/LanguageServer/Protocol/Position.php
+++ b/src/Phan/LanguageServer/Protocol/Position.php
@@ -26,7 +26,7 @@ class Position
     public $character;
 
     /**
-     * @suppress PhanTypeMismatchProperty
+     * @suppress PhanPossiblyNullTypeMismatchProperty
      */
     public function __construct(int $line = null, int $character = null)
     {

--- a/src/Phan/LanguageServer/Protocol/Range.php
+++ b/src/Phan/LanguageServer/Protocol/Range.php
@@ -27,7 +27,7 @@ class Range
      */
     public $end;
 
-    /** @suppress PhanTypeMismatchProperty anything useful will be non-null */
+    /** @suppress PhanPossiblyNullTypeMismatchProperty anything useful will be non-null */
     public function __construct(Position $start = null, Position $end = null)
     {
         $this->start = $start;

--- a/tests/Phan/AbstractPhanFileTest.php
+++ b/tests/Phan/AbstractPhanFileTest.php
@@ -28,7 +28,7 @@ abstract class AbstractPhanFileTest extends BaseTest implements CodeBaseAwareTes
 
     /**
      * @return void
-     * @suppress PhanTypeMismatchProperty
+     * @suppress PhanPossiblyNullTypeMismatchProperty
      */
     public function setCodeBase(CodeBase $code_base = null)
     {

--- a/tests/Phan/Plugin/Internal/MethodSearcherPluginTest.php
+++ b/tests/Phan/Plugin/Internal/MethodSearcherPluginTest.php
@@ -18,7 +18,7 @@ final class MethodSearcherPluginTest extends BaseTest implements CodeBaseAwareTe
 
     public function setCodeBase(CodeBase $code_base = null)
     {
-        // @phan-suppress-next-line PhanTypeMismatchProperty
+        // @phan-suppress-next-line PhanPossiblyNullTypeMismatchProperty
         $this->code_base = $code_base;
     }
 

--- a/tests/files/expected/0658_property_nullable_cast.php.expected
+++ b/tests/files/expected/0658_property_nullable_cast.php.expected
@@ -1,0 +1,2 @@
+%s:22 PhanPossiblyNullTypeMismatchProperty Assigning ?\NS658\Subclass to property but \NS658\O::$nonnull_var is \NS658\Base (null is incompatible)
+%s:23 PhanTypeMismatchProperty Assigning null to property but \NS658\O::$nonnull_var is \NS658\Base

--- a/tests/files/src/0658_property_nullable_cast.php
+++ b/tests/files/src/0658_property_nullable_cast.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace NS658;
+
+class Base {
+}
+class Subclass extends Base {
+}
+
+class O {
+    /** @var Base|null */
+    public static $var;
+
+    /** @var Base */
+    public static $nonnull_var;
+}
+/**
+ * @param ?Subclass $x
+ */
+function handle_nullable_base($x) {
+    O::$var = $x;
+    O::$nonnull_var = $x;  // Should emit PhanPossiblyNullTypeMismatchProperty
+    O::$nonnull_var = null;  // Should emit PhanTypeMismatchProperty
+}


### PR DESCRIPTION
Previously, this would be PhanTypeMismatchProperty for converting `?T`
to `T` (and PhanPossiblyNullTypeMismatchProperty for `T|null` to `T`)