### PR TITLE
 Track inferences about properties of $this

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,9 @@ New features(CLI):
 + Suggest similarly named plugins if `--plugin SomePluginName` refers to a built-in plugin that doesn't exist.
 
 New features(Analysis):
++ Support locally tracking assignments to and conditionals on `$this->prop` inside of function scopes. (#805, #204)
+
+  This supports only one level of nesting.
 + Fix false positives with dead code detection for internal stubs in `autoload_internal_extension_signatures`. (#2605)
 + Add a way to escape/unescape array shape keys (newlines, binary data, etc) (#1664)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@ New features(Analysis):
 + Support locally tracking assignments to and conditionals on `$this->prop` inside of function scopes. (#805, #204)
 
   This supports only one level of nesting.
+
+  Properties are deliberately tracked for just the variable `$this` (which can't be reassigned), and not other variables.
 + Fix false positives with dead code detection for internal stubs in `autoload_internal_extension_signatures`. (#2605)
 + Add a way to escape/unescape array shape keys (newlines, binary data, etc) (#1664)
 

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -198,8 +198,7 @@ class ContextNode
      */
     public function getTraitAdaptationsMap(array $trait_fqsen_list) : array
     {
-        $node = $this->node;
-        if (!($node instanceof Node)) {
+        if (!($this->node instanceof Node)) {
             return [];
         }
 
@@ -1824,12 +1823,11 @@ class ContextNode
      */
     public function getUnqualifiedNameForAnonymousClass() : string
     {
-        $node = $this->node;
-        if (!($node instanceof Node)) {
+        if (!($this->node instanceof Node)) {
             throw new AssertionError('$this->node must be a node');
         }
 
-        if (!($node->flags & ast\flags\CLASS_ANONYMOUS)) {
+        if (!($this->node->flags & ast\flags\CLASS_ANONYMOUS)) {
             throw new AssertionError('Node must be an anonymous class node');
         }
 

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -488,6 +488,35 @@ class ConditionVisitor extends KindVisitorImplementation implements ConditionVis
 
     /**
      * @param Node $node
+     * A node to parse, with kind ast\AST_PROP (e.g. `if ($this->prop_name)`)
+     *
+     * @return Context
+     * A new or an unchanged context resulting from
+     * parsing the node
+     */
+    public function visitProp(Node $node) : Context
+    {
+        $expr_node = $node->children['expr'];
+        if (!($expr_node instanceof Node)) {
+            return $this->context;
+        }
+        if ($expr_node->kind !== ast\AST_VAR || $expr_node->children['name'] !== 'this') {
+            return $this->context;
+        }
+        if (!\is_string($node->children['prop'])) {
+            return $this->context;
+        }
+        return $this->modifyPropertyOfThisSimple(
+            $node,
+            static function (UnionType $type) : UnionType {
+                return $type->nonFalseyClone();
+            },
+            $this->context
+        );
+    }
+
+    /**
+     * @param Node $node
      * A node to parse
      *
      * @return Context

--- a/src/Phan/Analysis/ConditionVisitorUtil.php
+++ b/src/Phan/Analysis/ConditionVisitorUtil.php
@@ -202,6 +202,8 @@ trait ConditionVisitorUtil
      * and update the context.
      *
      * Note: It's expected that $should_filter_cb returns false on the new UnionType of that variable.
+     *
+     * @param Node $var_node a node of kind ast\AST_VAR, ast\AST_PROP, or ast\AST_DIM
      */
     final protected function updateVariableWithConditionalFilter(
         Node $var_node,
@@ -216,6 +218,8 @@ trait ConditionVisitorUtil
             if (\is_null($variable)) {
                 if ($var_node->kind === ast\AST_DIM) {
                     return $this->updateDimExpressionWithConditionalFilter($var_node, $context, $should_filter_cb, $filter_union_type_cb, $suppress_issues);
+                } elseif ($var_node->kind === ast\AST_PROP) {
+                    return $this->updatePropertyExpressionWithConditionalFilter($var_node, $context, $should_filter_cb, $filter_union_type_cb, $suppress_issues);
                 }
                 return $context;
             }
@@ -294,12 +298,59 @@ trait ConditionVisitorUtil
         return $context;
     }
 
+    /**
+     * @param Node|mixed $node
+     */
+    protected static function isThisVarNode($node) : bool
+    {
+        return $node instanceof Node && $node->kind === ast\AST_VAR &&
+            $node->children['name'] === 'this';
+    }
+
+    /**
+     * Analyze an expression such as `assert(!is_int($this->prop_name))`
+     * and infer the effects on $this->prop_name in the local scope.
+     *
+     * @param Node $node a node of kind ast\AST_PROP
+     */
+    final protected function updatePropertyExpressionWithConditionalFilter(
+        Node $node,
+        Context $context,
+        Closure $should_filter_cb,
+        Closure $filter_union_type_cb,
+        bool $unused_suppress_issues
+    ) : Context {
+        if (!self::isThisVarNode($node->children['expr'])) {
+            return $context;
+        }
+        $property_name = $node->children['prop'];
+        if (!is_string($property_name)) {
+            return $context;
+        }
+        return $this->modifyPropertyOfThisSimple(
+            $node,
+            static function (UnionType $type) use ($should_filter_cb, $filter_union_type_cb) : UnionType {
+                if (!$should_filter_cb($type)) {
+                    return $type;
+                }
+                return $filter_union_type_cb($type);
+            },
+            $context
+        );
+    }
+
     final protected function updateVariableWithNewType(
         Node $var_node,
         Context $context,
         UnionType $new_union_type,
         bool $suppress_issues
     ) : Context {
+        if ($var_node->kind === ast\AST_PROP) {
+            return $this->modifyPropertySimple($var_node, function (UnionType $unused) use ($new_union_type) : UnionType{
+                return $new_union_type;
+            }, $context);
+        }
+        // TODO: Support ast\AST_DIM
         try {
             // Get the variable we're operating on
             $variable = $this->getVariableFromScope($var_node, $context);
@@ -341,36 +392,15 @@ trait ConditionVisitorUtil
         Context $context = null
     ) : Context {
         $context = $context ?? $this->context;
-        $var_name = $var_node->children['name'] ?? null;
-        // Don't analyze variables such as $$a
-        if (\is_string($var_name) && $var_name) {
-            try {
-                $expr_type = UnionTypeVisitor::unionTypeFromLiteralOrConstant($this->code_base, $context, $expr);
-                if (!$expr_type) {
-                    return $context;
-                }
-                // Get the variable we're operating on
-                $variable = $this->getVariableFromScope($var_node, $context);
-                if (\is_null($variable)) {
-                    return $context;
-                }
-
-                // Make a copy of the variable
-                $variable = clone($variable);
-
-                $variable->setUnionType($expr_type);
-
-                // Overwrite the variable with its new type in this
-                // scope without overwriting other scopes
-                $context = $context->withScopeVariable(
-                    $variable
-                );
+        try {
+            $expr_type = UnionTypeVisitor::unionTypeFromLiteralOrConstant($this->code_base, $context, $expr);
+            if (!$expr_type) {
                 return $context;
-            } catch (\Exception $_) {
-                // Swallow it (E.g. IssueException for undefined variable)
             }
+        } catch (\Exception $_) {
+            return $context;
         }
-        return $context;
+        return $this->updateVariableWithNewType($var_node, $context, $expr_type, true);
     }
 
     /**
@@ -435,7 +465,7 @@ trait ConditionVisitorUtil
     }
 
     /**
-     * @param Node $var_node
+     * @param Node $var_node a node of type ast\AST_VAR, ast\AST_DIM (planned), or ast\AST_PROP
      * @param Node|int|float|string $expr
      * @return Context - Constant after inferring type from an expression such as `if ($x !== 'literal')`
      * @suppress PhanUnreferencedPublicMethod referenced in ConditionVisitorInterface
@@ -446,31 +476,28 @@ trait ConditionVisitorUtil
         Context $context = null
     ) : Context {
         $context = $context ?? $this->context;
-        $var_name = $var_node->children['name'] ?? null;
-        if (\is_string($var_name)) {
-            try {
-                if ($expr instanceof Node) {
-                    if ($expr->kind === ast\AST_CONST) {
-                        $expr_name_node = $expr->children['name'];
-                        if ($expr_name_node->kind === ast\AST_NAME) {
-                            // Currently, only add this inference when we're absolutely sure this is a check rejecting null/false/true
-                            $expr_name = $expr_name_node->children['name'];
-                            switch (\strtolower($expr_name)) {
-                                case 'null':
-                                    return $this->removeNullFromVariable($var_node, $context, false);
-                                case 'false':
-                                    return $this->removeFalseFromVariable($var_node, $context);
-                                case 'true':
-                                    return $this->removeTrueFromVariable($var_node, $context);
-                            }
+        try {
+            if ($expr instanceof Node) {
+                if ($expr->kind === ast\AST_CONST) {
+                    $expr_name_node = $expr->children['name'];
+                    if ($expr_name_node->kind === ast\AST_NAME) {
+                        // Currently, only add this inference when we're absolutely sure this is a check rejecting null/false/true
+                        $expr_name = $expr_name_node->children['name'];
+                        switch (\strtolower($expr_name)) {
+                            case 'null':
+                                return $this->removeNullFromVariable($var_node, $context, false);
+                            case 'false':
+                                return $this->removeFalseFromVariable($var_node, $context);
+                            case 'true':
+                                return $this->removeTrueFromVariable($var_node, $context);
                         }
                     }
-                } else {
-                    return $this->removeLiteralScalarFromVariable($var_node, $context, $expr, true);
                 }
-            } catch (\Exception $_) {
-                // Swallow it (E.g. IssueException for undefined variable)
+            } else {
+                return $this->removeLiteralScalarFromVariable($var_node, $context, $expr, true);
             }
+        } catch (\Exception $_) {
+            // Swallow it (E.g. IssueException for undefined variable)
         }
         return $context;
     }
@@ -594,8 +621,14 @@ trait ConditionVisitorUtil
     {
         '@phan-var ConditionVisitorUtil|ConditionVisitorInterface $this';
         $kind = $var_node->kind;
-        if ($kind === ast\AST_VAR) {
+        if ($kind === ast\AST_VAR || $kind === ast\AST_DIM) {
             return $condition->analyzeVar($this, $var_node, $expr_node);
+        }
+        if ($kind === ast\AST_PROP) {
+            if (self::isThisVarNode($var_node->children['expr']) && is_string($var_node->children['prop'])) {
+                return $condition->analyzeVar($this, $var_node, $expr_node);
+            }
+            return null;
         }
         if ($kind === ast\AST_CALL) {
             $name = $var_node->children['expr']->children['name'] ?? null;
@@ -801,8 +834,8 @@ trait ConditionVisitorUtil
     {
         if (\count($args) >= 1) {
             $arg = $args[0];
-            // Phan also supports `if (!is_array($x['field']))`
-            return ($arg instanceof Node) && (\in_array($arg->kind, [ast\AST_VAR, ast\AST_DIM], true));
+            // Phan also supports `if (!is_array($x['field']))` and `if (!is_array($this->propName))`
+            return ($arg instanceof Node) && (\in_array($arg->kind, [ast\AST_VAR, ast\AST_DIM, ast\AST_PROP], true));
         }
         return false;
     }
@@ -888,6 +921,10 @@ trait ConditionVisitorUtil
         }
         if ($node->kind === ast\AST_DIM) {
             return $this->modifyComplexDimExpression($node, $type_modification_callback, $context, $args);
+        } elseif ($node->kind === ast\AST_PROP) {
+            if (self::isThisVarNode($node->children['expr'])) {
+                return $this->modifyPropertyOfThis($node, $type_modification_callback, $context, $args);
+            }
         }
         return $context;
     }
@@ -897,12 +934,11 @@ trait ConditionVisitorUtil
      * @param Closure(CodeBase,Context,Variable,array<int,mixed>):void $type_modification_callback
      *        A closure acting on a Variable instance (not really a variable) to modify its type
      *
-     *        This is a function such as is_array, is_null (questionable),
+     *        This is a function such as is_array, is_null (questionable), etc.
      * @param Context $context
      * @param array<int,mixed> $args
-     * @return Context
      */
-    protected function modifyComplexDimExpression(Node $node, Closure $type_modification_callback, Context $context, array $args)
+    protected function modifyComplexDimExpression(Node $node, Closure $type_modification_callback, Context $context, array $args) : Context
     {
         $var_name = $this->getVarNameOfDimNode($node->children['expr']);
         if (!is_string($var_name)) {
@@ -928,6 +964,74 @@ trait ConditionVisitorUtil
             $node,
             $new_field_type
         ))->__invoke($node);
+    }
+
+    /**
+     * Return a context with overrides for the type of a property in the local scope.
+     *
+     * @param Node $node a node of kind ast\AST_PROP (e.g. the argument of is_array($this->prop_name))
+     * @param Closure(CodeBase,Context,Variable,array<int,mixed>):void $type_modification_callback
+     *        A closure acting on a Variable instance (not really a variable) to modify its type
+     *
+     *        This is a function such as is_array, is_null, etc.
+     * @param Context $context
+     * @param array<int,mixed> $args
+     */
+    protected function modifyPropertyOfThis(Node $node, Closure $type_modification_callback, Context $context, array $args) : Context
+    {
+        $property_name = $node->children['prop'];
+        if (!is_string($property_name)) {
+            return $context;
+        }
+        // Give the property a type and compute the new type
+        $old_property_type = UnionTypeVisitor::unionTypeFromNode($this->code_base, $context, $node);
+        $property_variable = new Variable($context, "__phan", $old_property_type, 0);
+        $type_modification_callback($this->code_base, $context, $property_variable, $args);
+        $new_property_type = $property_variable->getUnionType();
+        if ($new_property_type->isEqualTo($old_property_type)) {
+            // This didn't change anything
+            return $context;
+        }
+        return $context->withThisPropertySetToTypeByName($property_name, $new_property_type);
+    }
+
+    /**
+     * Return a context with overrides for the type of a property in the local scope.
+     *
+     * @param Node $node a node of kind ast\AST_PROP (e.g. the argument of is_array($this->prop_name))
+     * @param Closure(UnionType):UnionType $type_mapping_callback
+     *        Given a union type, returns the resulting union type.
+     * @param Context $context
+     */
+    protected function modifyPropertyOfThisSimple(Node $node, Closure $type_mapping_callback, Context $context) : Context
+    {
+        $property_name = $node->children['prop'];
+        if (!is_string($property_name)) {
+            return $context;
+        }
+        // Give the property a type and compute the new type
+        $old_property_type = UnionTypeVisitor::unionTypeFromNode($this->code_base, $context, $node);
+        $new_property_type = $type_mapping_callback($old_property_type);
+        if ($new_property_type->isEqualTo($old_property_type)) {
+            // This didn't change anything
+            return $context;
+        }
+        return $context->withThisPropertySetToTypeByName($property_name, $new_property_type);
+    }
+
+    /**
+     * @param Node $node a node of kind ast\AST_PROP (e.g. the argument of is_array($this->prop_name))
+     *                   This is a no-op of the expression is not $this.
+     * @param Closure(UnionType):UnionType $type_mapping_callback
+     *        Given a union type, returns the resulting union type.
+     * @param Context $context
+     */
+    protected function modifyPropertySimple(Node $node, Closure $type_mapping_callback, Context $context) : Context
+    {
+        if (!self::isThisVarNode($node->children['expr'])) {
+            return $context;
+        }
+        return self::modifyPropertyOfThisSimple($node, $type_mapping_callback, $context);
     }
 
     /**

--- a/src/Phan/Daemon/Request.php
+++ b/src/Phan/Daemon/Request.php
@@ -130,9 +130,8 @@ class Request
      */
     public function shouldUseMappingPolyfill(string $file_path) : bool
     {
-        $most_recent_node_info_request = $this->most_recent_node_info_request;
-        if ($most_recent_node_info_request) {
-            return $most_recent_node_info_request->getPath() === Config::projectPath($file_path);
+        if ($this->most_recent_node_info_request) {
+            return $this->most_recent_node_info_request->getPath() === Config::projectPath($file_path);
         }
         return false;
     }
@@ -142,10 +141,8 @@ class Request
      */
     public function shouldAddPlaceholdersForPath(string $file_path) : bool
     {
-        $most_recent_node_info_request = $this->most_recent_node_info_request;
-        if ($most_recent_node_info_request) {
-            return $most_recent_node_info_request->getPath() === Config::projectPath($file_path) &&
-                $most_recent_node_info_request instanceof CompletionRequest;
+        if ($this->most_recent_node_info_request instanceof CompletionRequest) {
+            return $this->most_recent_node_info_request->getPath() === Config::projectPath($file_path);
         }
         return false;
     }
@@ -155,9 +152,8 @@ class Request
      */
     public function getTargetByteOffset(string $file_contents) : int
     {
-        $most_recent_node_info_request = $this->most_recent_node_info_request;
-        if ($most_recent_node_info_request) {
-            $position = $most_recent_node_info_request->getPosition();
+        if ($this->most_recent_node_info_request) {
+            $position = $this->most_recent_node_info_request->getPosition();
             return $position->toOffset($file_contents);
         }
         return -1;
@@ -395,9 +391,8 @@ class Request
      */
     public function rejectLanguageServerRequestsRequiringAnalysis()
     {
-        $most_recent_node_info_request = $this->most_recent_node_info_request;
-        if ($most_recent_node_info_request) {
-            $most_recent_node_info_request->finalize();
+        if ($this->most_recent_node_info_request) {
+            $this->most_recent_node_info_request->finalize();
             $this->most_recent_node_info_request = null;
         }
     }
@@ -412,20 +407,18 @@ class Request
      */
     public function sendJSONResponse(array $response)
     {
-        $responder = $this->responder;
-        if (!$responder) {
+        if (!$this->responder) {
             Daemon::debugf("Already sent response");
             return;
         }
-        $responder->sendResponseAndClose($response);
+        $this->responder->sendResponseAndClose($response);
         $this->responder = null;
     }
 
     public function __destruct()
     {
-        $responder = $this->responder;
-        if ($responder) {
-            $responder->sendResponseAndClose([
+        if ($this->responder) {
+            $this->responder->sendResponseAndClose([
                 'status' => self::STATUS_ERROR_UNKNOWN,
                 'message' => 'failed to send a response - Possibly encountered an exception. See daemon output: ' . StringUtil::jsonEncode(\debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS)),
             ]);

--- a/src/Phan/Debug.php
+++ b/src/Phan/Debug.php
@@ -153,6 +153,10 @@ class Debug
         $string .= "\n";
 
         foreach ($node->children as $name => $child_node) {
+            if (\is_string($name) && \strncmp($name, 'phan', 4) === 0) {
+                // Dynamic property added by Phan
+                continue;
+            }
             $string .= self::nodeToString(
                 $child_node,
                 $name,

--- a/src/Phan/IssueInstance.php
+++ b/src/Phan/IssueInstance.php
@@ -143,11 +143,10 @@ class IssueInstance
     /** @return ?string */
     public function getSuggestionMessage()
     {
-        $suggestion = $this->suggestion;
-        if (!$suggestion) {
+        if (!$this->suggestion) {
             return null;
         }
-        $text = $suggestion->getMessage();
+        $text = $this->suggestion->getMessage();
         if (!$text) {
             return null;
         }

--- a/src/Phan/Language/Element/ClassElement.php
+++ b/src/Phan/Language/Element/ClassElement.php
@@ -71,11 +71,10 @@ abstract class ClassElement extends AddressableElement
      */
     public function getDefiningFQSEN() : FullyQualifiedClassElement
     {
-        $defining_fqsen = $this->defining_fqsen;
-        if ($defining_fqsen === null) {
+        if ($this->defining_fqsen === null) {
             throw new AssertionError('should check hasDefiningFQSEN');
         }
-        return $defining_fqsen;
+        return $this->defining_fqsen;
     }
 
     /**

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -464,9 +464,8 @@ class Clazz extends AddressableElement
      */
     public function getParentTypeOption()
     {
-        $parent_type = $this->parent_type;
-        if ($parent_type !== null) {
-            return new Some($parent_type);
+        if ($this->parent_type !== null) {
+            return new Some($this->parent_type);
         }
 
         return new None();
@@ -2643,9 +2642,8 @@ class Clazz extends AddressableElement
         $implements_types = [];
         $parent_implements_types = [];
 
-        $parent_type = $this->parent_type;
-        if ($parent_type) {
-            $extend_types[] = FullyQualifiedClassName::fromType($parent_type);
+        if ($this->parent_type) {
+            $extend_types[] = FullyQualifiedClassName::fromType($this->parent_type);
             $parent_class = $this->getParentClass($code_base);
             $parent_implements_types = $parent_class->interface_fqsen_list;
         }
@@ -3048,14 +3046,13 @@ class Clazz extends AddressableElement
         if (\count($template_parameter_type_map) === 0) {
             return UnionType::empty();
         }
-        $parent_type = $this->parent_type;
-        if ($parent_type === null) {
+        if ($this->parent_type === null) {
             return UnionType::empty();
         }
-        if (!$parent_type->hasTemplateParameterTypes()) {
+        if (!$this->parent_type->hasTemplateParameterTypes()) {
             return UnionType::empty();
         }
-        $parent_template_parameter_type_list = $parent_type->getTemplateParameterTypeList();
+        $parent_template_parameter_type_list = $this->parent_type->getTemplateParameterTypeList();
         $changed = false;
         foreach ($parent_template_parameter_type_list as $i => $template_type) {
             $new_template_type = $template_type->withTemplateParameterTypeMap($template_parameter_type_map);
@@ -3068,7 +3065,7 @@ class Clazz extends AddressableElement
         if (!$changed) {
             return UnionType::empty();
         }
-        return Type::fromType($parent_type, $parent_template_parameter_type_list)->asUnionType();
+        return Type::fromType($this->parent_type, $parent_template_parameter_type_list)->asUnionType();
     }
 
     /**

--- a/src/Phan/Language/Element/Comment.php
+++ b/src/Phan/Language/Element/Comment.php
@@ -461,11 +461,10 @@ class Comment
      */
     public function getReturnType() : UnionType
     {
-        $return_comment = $this->return_comment;
-        if (!$return_comment) {
+        if (!$this->return_comment) {
             throw new AssertionError('Should check hasReturnUnionType');
         }
-        return $return_comment->getType();
+        return $this->return_comment->getType();
     }
 
     /**
@@ -474,11 +473,10 @@ class Comment
      */
     public function getReturnLineno() : int
     {
-        $return_comment = $this->return_comment;
-        if (!$return_comment) {
+        if (!$this->return_comment) {
             throw new AssertionError('Should check hasReturnUnionType');
         }
-        return $return_comment->getLineno();
+        return $this->return_comment->getLineno();
     }
 
     /**
@@ -671,9 +669,8 @@ class Comment
             $string  .= " * @param $parameter\n";
         }
 
-        $return_comment = $this->return_comment;
-        if ($return_comment) {
-            $string .= " * @return {$return_comment->getType()}\n";
+        if ($this->return_comment) {
+            $string .= " * @return {$this->return_comment->getType()}\n";
         }
         foreach ($this->throw_union_type->getTypeSet() as $type) {
             $string .= " * @throws {$type}\n";

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -1372,11 +1372,10 @@ trait FunctionTrait
                 );
             }
         }
-        $comment = $this->comment;
-        if ($comment) {
+        if ($this->comment) {
             // Add plugins **after** the phpdoc and real comment types were merged.
             // Plugins affecting return types (for template in (at)return)
-            $template_type_list = $comment->getTemplateTypeList();
+            $template_type_list = $this->comment->getTemplateTypeList();
             if ($template_type_list) {
                 $this->addClosureForDependentTemplateType($code_base, $context, $template_type_list);
             }
@@ -1388,10 +1387,9 @@ trait FunctionTrait
      */
     public function declaresTemplateTypeInComment(TemplateType $template_type) : bool
     {
-        $comment = $this->comment;
-        if ($comment) {
+        if ($this->comment) {
             // Template types are identical if they have the same name. See TemplateType::instanceForId.
-            return \in_array($template_type, $comment->getTemplateTypeList(), true);
+            return \in_array($template_type, $this->comment->getTemplateTypeList(), true);
         }
         return false;
     }
@@ -1403,9 +1401,8 @@ trait FunctionTrait
             return true;
         }
 
-        $comment = $this->comment;
-        if ($comment) {
-            foreach ($comment->getParamAssertionMap() as $assertion) {
+        if ($this->comment) {
+            foreach ($this->comment->getParamAssertionMap() as $assertion) {
                 // @phan-suppress-next-line PhanAccessPropertyInternal
                 if ($assertion->union_type->usesTemplateType($type)) {
                     // used in `@phan-assert`

--- a/src/Phan/Language/Element/Parameter.php
+++ b/src/Phan/Language/Element/Parameter.php
@@ -153,8 +153,7 @@ class Parameter extends Variable
      */
     public function handleDefaultValueOfNull()
     {
-        $default_value_type = $this->default_value_type;
-        if ($default_value_type && $default_value_type->isType(NullType::instance(false))) {
+        if ($this->default_value_type && $this->default_value_type->isType(NullType::instance(false))) {
             // If it isn't already nullable, convert the parameter type to nullable.
             $this->convertToNullable();
         }

--- a/src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php
@@ -394,15 +394,10 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN
      */
     public function __toString() : string
     {
-        $as_string = $this->as_string;
-        if ($as_string === null) {
-            $as_string = static::toString(
-                $this->getNamespace(),
-                $this->getName(),
-                $this->getAlternateId()
-            );
-            $this->as_string = $as_string;
-        }
-        return $as_string;
+        return $this->as_string ?? $this->as_string = static::toString(
+            $this->getNamespace(),
+            $this->getName(),
+            $this->getAlternateId()
+        );
     }
 }

--- a/src/Phan/Language/Type/ArrayShapeType.php
+++ b/src/Phan/Language/Type/ArrayShapeType.php
@@ -157,14 +157,13 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
      */
     private function computeGenericArrayTypeInstances() : array
     {
-        $field_types = $this->field_types;
-        if (\count($field_types) === 0) {
+        if (\count($this->field_types) === 0) {
             // there are 0 fields, so we know nothing about the field types (and there's no way to indicate an empty array yet)
             return [ArrayType::instance($this->is_nullable)];
         }
 
         $union_type_builder = new UnionTypeBuilder();
-        foreach ($field_types as $key => $field_union_type) {
+        foreach ($this->field_types as $key => $field_union_type) {
             foreach ($field_union_type->getTypeSet() as $type) {
                 $union_type_builder->addType(GenericArrayType::fromElementType(
                     $type->asNonLiteralType(),

--- a/src/Phan/Language/Type/ClosureType.php
+++ b/src/Phan/Language/Type/ClosureType.php
@@ -93,9 +93,8 @@ final class ClosureType extends Type
         if ($type->isCallable()) {
             if ($type instanceof FunctionLikeDeclarationType) {
                 // Check if the function declaration is known and available. It's not available for the generic \Closure.
-                $func = $this->func;
-                if ($func) {
-                    return $func->asFunctionLikeDeclarationType()->canCastToNonNullableFunctionLikeDeclarationType($type);
+                if ($this->func) {
+                    return $this->func->asFunctionLikeDeclarationType()->canCastToNonNullableFunctionLikeDeclarationType($type);
                 }
             }
             return true;
@@ -148,9 +147,8 @@ final class ClosureType extends Type
 
     public function __toString()
     {
-        $func = $this->func;
-        if ($func) {
-            $result = $func->asFunctionLikeDeclarationType()->__toString();
+        if ($this->func) {
+            $result = $this->func->asFunctionLikeDeclarationType()->__toString();
         } else {
             $result = '\Closure';
         }

--- a/src/Phan/Library/RAII.php
+++ b/src/Phan/Library/RAII.php
@@ -33,9 +33,8 @@ class RAII
      */
     public function callFinalizerOnce()
     {
-        $finalizer = $this->finalizer;
-        if ($finalizer) {
-            $finalizer();
+        if ($this->finalizer) {
+            ($this->finalizer)();
             $this->finalizer = null;
         }
     }

--- a/src/Phan/Output/Printer/FilteringPrinter.php
+++ b/src/Phan/Output/Printer/FilteringPrinter.php
@@ -72,9 +72,8 @@ final class FilteringPrinter implements BufferedPrinterInterface
      */
     public function flush()
     {
-        $printer = $this->printer;
-        if ($printer instanceof BufferedPrinterInterface) {
-            $printer->flush();
+        if ($this->printer instanceof BufferedPrinterInterface) {
+            $this->printer->flush();
         }
     }
 }

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -442,10 +442,9 @@ final class ConfigPluginSet extends PluginV2 implements
                 $parameters,
                 $suggestion
             )) {
-                $unused_suppression_plugin = $this->unused_suppression_plugin;
-                if ($unused_suppression_plugin) {
+                if ($this->unused_suppression_plugin) {
                     // @phan-suppress-next-line PhanAccessMethodInternal
-                    $unused_suppression_plugin->recordPluginSuppression($plugin, $context->getFile(), $issue_type, $lineno);
+                    $this->unused_suppression_plugin->recordPluginSuppression($plugin, $context->getFile(), $issue_type, $lineno);
                 }
                 return true;
             }
@@ -641,8 +640,7 @@ final class ConfigPluginSet extends PluginV2 implements
      */
     public function prepareNodeSelectionPluginForNode(Node $node)
     {
-        $node_selection_plugin = $this->node_selection_plugin;
-        if (!$node_selection_plugin) {
+        if (!$this->node_selection_plugin) {
             \fwrite(STDERR, "Error: " . __METHOD__ . " called before node selection plugin was created\n");
             return;
         }

--- a/src/Phan/Plugin/Internal/IssueFixingPlugin/FileContents.php
+++ b/src/Phan/Plugin/Internal/IssueFixingPlugin/FileContents.php
@@ -131,9 +131,8 @@ class FileContents
      */
     public function getLines() : array
     {
-        $lines = $this->lines;
-        if (\is_array($lines)) {
-            return $lines;
+        if (\is_array($this->lines)) {
+            return $this->lines;
         }
         $lines = \preg_split("/^/m", $this->contents);
         // TODO: Use a better way to not include false when arguments are both valid

--- a/tests/files/expected/0477_array_negation.php.expected
+++ b/tests/files/expected/0477_array_negation.php.expected
@@ -1,2 +1,2 @@
 %s:6 PhanTypeMismatchArgumentInternal Argument 1 (string) is null but \strlen() takes string
-%s:11 PhanTypeMismatchArgumentInternal Argument 1 (string) is array{}|null but \strlen() takes string
+%s:11 PhanTypeMismatchArgumentInternal Argument 1 (string) is ?array{} but \strlen() takes string

--- a/tests/files/expected/0660_this_assign.php.expected
+++ b/tests/files/expected/0660_this_assign.php.expected
@@ -1,0 +1,3 @@
+%s:15 PhanTypeMismatchArgumentInternal Argument 1 (string) is 2 but \strlen() takes string
+%s:20 PhanTypeMismatchArgumentInternal Argument 1 (string) is \stdClass but \strlen() takes string
+%s:23 PhanTypeMismatchArgumentInternal Argument 1 (string) is null but \strlen() takes string

--- a/tests/files/expected/0661_this_property.php.expected
+++ b/tests/files/expected/0661_this_property.php.expected
@@ -1,0 +1,1 @@
+%s:42 PhanTypeMismatchArgument Argument 1 (i) is null but \NS661\DoubleInt() takes int defined at %s:6

--- a/tests/files/expected/0662_instanceof_this_prop.php.expected
+++ b/tests/files/expected/0662_instanceof_this_prop.php.expected
@@ -1,0 +1,3 @@
+%s:23 PhanUndeclaredMethod Call to undeclared method \N662\C::asdf
+%s:26 PhanUndeclaredMethod Call to undeclared method \N662\C::asdf
+%s:30 PhanNonClassMethodCall Call to method asdf on non-class type null

--- a/tests/files/expected/0663_null_this_compare.php.expected
+++ b/tests/files/expected/0663_null_this_compare.php.expected
@@ -1,0 +1,1 @@
+%s:17 PhanTypeMismatchArgumentInternal Argument 1 (var) is null but \count() takes \Countable|array

--- a/tests/files/src/0660_this_assign.php
+++ b/tests/files/src/0660_this_assign.php
@@ -1,0 +1,26 @@
+<?php
+
+class Foo660 {
+    /** @var ?int description */
+    public $prop;
+
+    /**
+     * @var ?stdClass
+     */
+    public $possibly_null;
+
+    // Warning messages include Phan's inferred types
+    public function example() {
+        $this->prop = 2;
+        echo strlen($this->prop);
+    }
+
+    public function example2() {
+        if ($this->possibly_null) {
+            echo strlen($this->possibly_null);
+        } else {
+            echo "this is null\n";
+            echo strlen($this->possibly_null);
+        }
+    }
+}

--- a/tests/files/src/0661_this_property.php
+++ b/tests/files/src/0661_this_property.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+namespace NS661;
+
+function DoubleInt(int $i) : int
+{
+    return $i * 2;
+}
+
+/**
+ * @param ?int $i
+ * @return ?int
+ */
+function DoubleIntOrNull($i)
+{
+    if (is_int($i)) {
+        return DoubleInt($i);
+    }
+    return null;
+}
+
+class Example
+{
+
+    /** @var ?int */
+    protected $i;
+
+    /**
+     * @param ?int $i
+     */
+    public function __construct($i)
+    {
+        $this->i = $i;
+    }
+    /** @return ?int */
+    public function doubleMe()
+    {
+        if (is_int($this->i)) {
+            return DoubleInt($this->i);
+        }
+        return DoubleInt($this->i);
+    }
+}
+
+$ex = new Example(5);
+echo $ex->doubleMe(), "\n";

--- a/tests/files/src/0662_instanceof_this_prop.php
+++ b/tests/files/src/0662_instanceof_this_prop.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace N662;
+
+class C {
+}
+
+class D extends C {
+    function asdf() {}
+}
+
+class E {
+    /** @var C */
+    private $c;
+
+    /** @var ?D */
+    private $d;
+
+    public function foo() {
+        if ($this->c instanceof D) {
+            $this->c->asdf(); // should not warn
+        } else {
+            $this->c->asdf(); // should warn
+        }
+
+        $this->c->asdf(); // should warn
+        if ($this->d instanceof D) {
+            $this->d->asdf(); // should not warn
+        } else {
+            $this->d->asdf(); // should warn, d is null
+        }
+    }
+}

--- a/tests/files/src/0663_null_this_compare.php
+++ b/tests/files/src/0663_null_this_compare.php
@@ -1,0 +1,20 @@
+<?php
+
+class Foo663
+{
+    /**
+     * An array of static hostnames.
+     *
+     * @var ?array<int,string>
+     */
+    protected $_staticHostnames = null;
+
+    public function staticHostname() : string
+    {
+        if ($this->_staticHostnames !== null) {
+            return $this->_staticHostnames[0];
+        }
+        echo count($this->_staticHostnames);
+        return '';
+    }
+}


### PR DESCRIPTION
This supports only one level of nesting of property accesses (and does not support fields of properties).

This deliberately supports only `$this`, because `$this` cannot be
reassigned.

A future release may make method calls on $this invalidate the inferred
property types.

This does not track array fields of $this.