### PR TITLE
Add PassByReferenceVariable::getElement()

### DIFF
--- a/src/Phan/Language/Element/PassByReferenceVariable.php
+++ b/src/Phan/Language/Element/PassByReferenceVariable.php
@@ -118,6 +118,7 @@ class PassByReferenceVariable extends Variable
     /**
      * Get the argument passed in to this object.
      * @return TypedElement|UnaddressableTypedElement
+     * @suppress PhanUnreferencedPublicMethod
      */
     public function getElement()
     {

--- a/src/Phan/Language/Element/PassByReferenceVariable.php
+++ b/src/Phan/Language/Element/PassByReferenceVariable.php
@@ -114,4 +114,13 @@ class PassByReferenceVariable extends Variable
     {
         return $this->element->isPHPInternal();
     }
+
+    /**
+     * Get the argument passed in to this object.
+     * @return TypedElement|UnaddressableTypedElement
+     */
+    public function getElement()
+    {
+        return $this->element;
+    }
 }


### PR DESCRIPTION
This public method can be used to read the $element property of the class. I understand that this class is meant to just mimick it, but there may be cases where we need the full element object. For instance, I'd need it in the SecurityCheckPlugin. Yes, the plugin is a bit hacky, but I guess a public getter can't cause any harm.

[0]: https://github.com/wikimedia/phan-taint-check-plugin