### PR TITLE
Fix crash when parsing two classes of the same name on the same line

### DIFF
--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -116,6 +116,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
             );
         } while ($this->context->getProjectRelativePath()
                 != $clazz->getFileRef()->getProjectRelativePath()
+            || $node->children['__declId'] != $clazz->getDeclId()
             || $this->context->getLineNumberStart() != $clazz->getFileRef()->getLineNumberStart()
         );
 

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -120,6 +120,12 @@ class Clazz extends AddressableElement
     private $additional_union_types = null;
 
     /**
+     * An additional id to disambiguate classes on the same line
+     * https://github.com/phan/phan/issues/1988
+     */
+    private $decl_id = 0;
+
+    /**
      * @param Context $context
      * The context in which the structural element lives
      *
@@ -3230,5 +3236,23 @@ class Clazz extends AddressableElement
         }
         $method = $code_base->getMethodByFQSEN($method_fqsen);
         $method->setIsOverriddenByAnother(true);
+    }
+
+    /**
+     * Sets the declaration id of the node containing this user-defined class
+     * @return void
+     */
+    public function setDeclId(int $id)
+    {
+        $this->decl_id = $id;
+    }
+
+    /**
+     * Gets the declaration id of the node containing this user-defined class.
+     * Returns 0 for internal classes.
+     */
+    public function getDeclId() : int
+    {
+        return $this->decl_id;
     }
 }

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -134,6 +134,7 @@ class ParseVisitor extends ScopeVisitor
             $node->flags ?? 0,
             $class_fqsen
         );
+        $class->setDeclId($node->children['__declId']);
         $class->setDidFinishParsing(false);
         try {
             // Set the scope of the class's context to be the

--- a/tests/files/expected/0667_duplicate_class_same_line.php.expected
+++ b/tests/files/expected/0667_duplicate_class_same_line.php.expected
@@ -1,0 +1,1 @@
+%s:3 PhanRedefineClass Class \Base667 defined at %s:3 was previously defined as Class \Base667 at %s:3

--- a/tests/files/src/0667_duplicate_class_same_line.php
+++ b/tests/files/src/0667_duplicate_class_same_line.php
@@ -1,0 +1,3 @@
+<?php
+
+class Base667 {public function foo() {}}class Base667 {public function bar() {}}


### PR DESCRIPTION
Fixes #1988