### PR TITLE
Move max recursion depth to Config

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,9 @@ Phan NEWS
 New features(CLI, Configs):
 + Make the progress bar guaranteed to display 100% at the end of the analysis phase (#2694)
   Print a newline to stderr once Phan is done updating the progress bar.
++ Add `maximum_recursion_depth` - This setting specifies the maximum recursion depth that
+  can be reached during re-analysis.
+  Default is 2.
 
 New features(Analysis):
 + Emit `PhanDeprecatedClassConstant` for code using a constant marked with `@deprecated`.

--- a/src/Phan/Analysis/Analyzable.php
+++ b/src/Phan/Analysis/Analyzable.php
@@ -27,13 +27,6 @@ trait Analyzable
 
     /**
      * @var int
-     * The maximum recursion depth we can use for this analyzable.
-     * @suppress PhanReadOnlyPrivateProperty Treat it as a constant.
-     */
-    private static $max_recursion_depth = 3;
-
-    /**
-     * @var int
      * The depth of recursion on this analyzable
      * object
      */
@@ -124,9 +117,8 @@ trait Analyzable
                 return $context;
             }
         }
-        // Don't go deeper than one level in
-        // TODO: Due to optimizations in checking for duplicate parameter lists, it should now be possible to increase this depth limit.
-        if (self::$recursion_depth >= self::$max_recursion_depth) {
+        // Stop upon reaching the maximum depth
+        if (self::$recursion_depth >= self::getMaxRecursionDepth()) {
             return $context;
         }
 
@@ -149,5 +141,13 @@ trait Analyzable
     public function getRecursionDepth() : int
     {
         return self::$recursion_depth;
+    }
+
+	/**
+     * Gets the maximum recursion depth.
+     */
+    public static function getMaxRecursionDepth() : int
+    {
+        return Config::getValue('maximum_recursion_depth');
     }
 }

--- a/src/Phan/Analysis/Analyzable.php
+++ b/src/Phan/Analysis/Analyzable.php
@@ -18,17 +18,18 @@ trait Analyzable
 {
 
     /**
-     * The maximum recursion depth we can use for this analyzable
-     */
-    const MAX_RECURSION_DEPTH = 3;
-
-    /**
      * @var Node
      * The AST Node defining this object. We keep a
      * reference to this so that we can come to it
      * and
      */
     private $node = null;
+
+    /**
+     * @var int
+     * The maximum recursion depth we can use for this analyzable. Treat it as a constant.
+     */
+    private static MAX_RECURSION_DEPTH = 3;
 
     /**
      * @var int

--- a/src/Phan/Analysis/Analyzable.php
+++ b/src/Phan/Analysis/Analyzable.php
@@ -18,6 +18,11 @@ trait Analyzable
 {
 
     /**
+     * The maximum recursion depth we can use for this analyzable
+     */
+    const MAX_RECURSION_DEPTH = 3;
+
+    /**
      * @var Node
      * The AST Node defining this object. We keep a
      * reference to this so that we can come to it
@@ -119,7 +124,7 @@ trait Analyzable
         }
         // Don't go deeper than one level in
         // TODO: Due to optimizations in checking for duplicate parameter lists, it should now be possible to increase this depth limit.
-        if (self::$recursion_depth >= 2) {
+        if (self::$recursion_depth >= self::MAX_RECURSION_DEPTH) {
             return $context;
         }
 

--- a/src/Phan/Analysis/Analyzable.php
+++ b/src/Phan/Analysis/Analyzable.php
@@ -143,7 +143,7 @@ trait Analyzable
         return self::$recursion_depth;
     }
 
-	/**
+    /**
      * Gets the maximum recursion depth.
      */
     public static function getMaxRecursionDepth() : int

--- a/src/Phan/Analysis/Analyzable.php
+++ b/src/Phan/Analysis/Analyzable.php
@@ -29,7 +29,7 @@ trait Analyzable
      * @var int
      * The maximum recursion depth we can use for this analyzable. Treat it as a constant.
      */
-    private static MAX_RECURSION_DEPTH = 3;
+    private static $max_recursion_depth = 3;
 
     /**
      * @var int
@@ -125,7 +125,7 @@ trait Analyzable
         }
         // Don't go deeper than one level in
         // TODO: Due to optimizations in checking for duplicate parameter lists, it should now be possible to increase this depth limit.
-        if (self::$recursion_depth >= self::MAX_RECURSION_DEPTH) {
+        if (self::$recursion_depth >= self::$max_recursion_depth) {
             return $context;
         }
 

--- a/src/Phan/Analysis/Analyzable.php
+++ b/src/Phan/Analysis/Analyzable.php
@@ -27,7 +27,8 @@ trait Analyzable
 
     /**
      * @var int
-     * The maximum recursion depth we can use for this analyzable. Treat it as a constant.
+     * The maximum recursion depth we can use for this analyzable.
+     * @suppress PhanReadOnlyPrivateProperty Treat it as a constant.
      */
     private static $max_recursion_depth = 3;
 

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -257,6 +257,14 @@ class Config
         // `string` instead of an `int` as declared.
         'quick_mode' => false,
 
+		// The maximum recursion depth that can be reached when analyzing the code.
+		// This setting only takes effect when quick_mode is disabled.
+		// A higher limit will make the analysis more accurate, but could possibly
+		// make it harder to track the code bit where a detected issue originates.
+		// As long as this is kept relatively low, performance is usually not affected
+		// by changing this setting.
+		'maximum_recursion_depth' => 2
+
         // If enabled, check all methods that override a
         // parent method to make sure its signature is
         // compatible with the parent's.

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -257,13 +257,13 @@ class Config
         // `string` instead of an `int` as declared.
         'quick_mode' => false,
 
-		// The maximum recursion depth that can be reached when analyzing the code.
-		// This setting only takes effect when quick_mode is disabled.
-		// A higher limit will make the analysis more accurate, but could possibly
-		// make it harder to track the code bit where a detected issue originates.
-		// As long as this is kept relatively low, performance is usually not affected
-		// by changing this setting.
-		'maximum_recursion_depth' => 2
+        // The maximum recursion depth that can be reached when analyzing the code.
+        // This setting only takes effect when quick_mode is disabled.
+        // A higher limit will make the analysis more accurate, but could possibly
+        // make it harder to track the code bit where a detected issue originates.
+        // As long as this is kept relatively low, performance is usually not affected
+        // by changing this setting.
+        'maximum_recursion_depth' => 2,
 
         // If enabled, check all methods that override a
         // parent method to make sure its signature is


### PR DESCRIPTION
And put it inside a class constant.
I checked the runtime on the whole MediaWiki core, both with max = 2 and max = 3. In both cases, I ran phan twice, and the times were exactly the same: 1 min 15 sec. If there's no performance loss on a project this big, I believe there's nothing to be afraid of.