### PR TITLE
Improve rendering of the progress bar at 100%

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@ Phan NEWS
 ?? ??? 2019, Phan 1.3.3 (dev)
 -----------------------
 
+New features(CLI, Configs):
++ Make the progress bar guaranteed to display 100% at the end of the analysis phase (#2694)
+  Print a newline to stderr once Phan is done updating the progress bar.
+
 New features(Analysis):
 + Emit `PhanDeprecatedClassConstant` for code using a constant marked with `@deprecated`.
 

--- a/src/Phan/Phan.php
+++ b/src/Phan/Phan.php
@@ -481,6 +481,9 @@ class Phan implements IgnoredFilesFilterInterface
             $is_issue_found =
                 0 !== $issue_count;
 
+            // Indicate that --progress-bar or --debug has finished, if needed.
+            CLI::endProgressBar();
+
             // Collect all issues, blocking
             self::display();
 
@@ -499,7 +502,6 @@ class Phan implements IgnoredFilesFilterInterface
             }
             throw $e;
         }
-
 
         if ($request instanceof Request) {
             $request->respondWithIssues($issue_count);


### PR DESCRIPTION
Sometimes, it would end on a percentage that was less than 100%

Also, print a new line after the progress bar

Fixes #2694