### PR TITLE
Add plugin to suggest ways to change phpdoc types to regular types

### DIFF
--- a/.phan/plugins/PHPDocToRealTypesPlugin.php
+++ b/.phan/plugins/PHPDocToRealTypesPlugin.php
@@ -1,0 +1,99 @@
+<?php declare(strict_types=1);
+
+use Phan\CodeBase;
+use Phan\IssueInstance;
+use Phan\Language\Element\Method;
+use Phan\Language\Element\Func;
+use Phan\Language\Element\FunctionInterface;
+use Phan\Library\FileCacheEntry;
+use Phan\Plugin\Internal\IssueFixingPlugin\FileEditSet;
+use Phan\PluginV2;
+use Phan\PluginV2\AnalyzeMethodCapability;
+use Phan\PluginV2\AnalyzeFunctionCapability;
+use Phan\PluginV2\AutomaticFixCapability;
+use PHPDocToRealTypesPlugin\Fixers;
+
+/**
+ * This plugin suggests real types that can be used instead of phpdoc types.
+ *
+ * It does not check if the change is safe to make.
+ */
+class PHPDocToRealTypesPlugin extends PluginV2 implements
+    AnalyzeFunctionCapability,
+    AnalyzeMethodCapability,
+    AutomaticFixCapability
+{
+    const CanUsePHP71Void = 'PhanPluginCanUsePHP71Void';
+    const CanUseReturnType = 'PhanPluginCanUseReturnType';
+    const CanUseNullableReturnType = 'PhanPluginCanUseNullableReturnType';
+
+    /**
+     * @return array<string,Closure(CodeBase,FileCacheEntry,IssueInstance):(?FileEditSet)>
+     */
+    public function getAutomaticFixers() : array
+    {
+        require_once __DIR__ .  '/PHPDocToRealTypesPlugin/Fixers.php';
+        return [
+            self::CanUsePHP71Void => Closure::fromCallable([Fixers::class, 'fixReturnType']),
+            self::CanUseReturnType => Closure::fromCallable([Fixers::class, 'fixReturnType']),
+            self::CanUseNullableReturnType => Closure::fromCallable([Fixers::class, 'fixReturnType']),
+        ];
+    }
+
+    public function analyzeFunction(CodeBase $code_base, Func $function)
+    {
+        $this->analyzeFunctionLike($code_base, $function);
+    }
+
+    public function analyzeMethod(CodeBase $code_base, Method $method)
+    {
+        if ($method->getIsMagic() || $method->isPHPInternal()) {
+            return;
+        }
+        if ($method->getFQSEN() !== $method->getDefiningFQSEN()) {
+            return;
+        }
+        if ($method->getIsOverride() || $method->getIsOverriddenByAnother()) {
+            // TODO: Consider allowing this
+            return;
+        }
+        $this->analyzeFunctionLike($code_base, $method);
+    }
+
+    private function analyzeFunctionLike(CodeBase $code_base, FunctionInterface $method)
+    {
+        if (!$method->getRealReturnType()->isEmpty()) {
+            return;
+        }
+        $union_type = $method->getUnionType();
+        if ($union_type->isVoidType()) {
+            self::emitIssue(
+                $code_base,
+                $method->getContext(),
+                self::CanUsePHP71Void,
+                'Can use php 7.1\'s {TYPE} as a return type of {METHOD}',
+                ['void', $method->getName()]
+            );
+            return;
+        }
+        $union_type = $union_type->asNormalizedTypes();
+        if ($union_type->typeCount() !== 1) {
+            return;
+        }
+        $type = $union_type->getTypeSet()[0];
+        if (!$type->canUseInRealSignature()) {
+            return;
+        }
+        self::emitIssue(
+            $code_base,
+            $method->getContext(),
+            $type->getIsNullable() ? self::CanUseNullableReturnType : self::CanUseReturnType,
+            'Can use {TYPE} as a return type of {METHOD}',
+            [$type->asSignatureType(), $method->getName()]
+        );
+    }
+}
+
+// Every plugin needs to return an instance of itself at the
+// end of the file in which it's defined.
+return new PHPDocToRealTypesPlugin();

--- a/.phan/plugins/PHPDocToRealTypesPlugin/Fixers.php
+++ b/.phan/plugins/PHPDocToRealTypesPlugin/Fixers.php
@@ -1,0 +1,94 @@
+<?php declare(strict_types=1);
+
+namespace PHPDocToRealTypesPlugin;
+
+use Microsoft\PhpParser\FunctionLike;
+use Microsoft\PhpParser\Node\Expression\AnonymousFunctionCreationExpression;
+use Microsoft\PhpParser\Node\MethodDeclaration;
+use Microsoft\PhpParser\Node\Statement\FunctionDeclaration;
+use Phan\AST\TolerantASTConverter\NodeUtils;
+use Phan\CodeBase;
+use Phan\IssueInstance;
+use Phan\Library\FileCacheEntry;
+use Phan\Plugin\Internal\IssueFixingPlugin\FileEditSet;
+use Phan\Plugin\Internal\IssueFixingPlugin\FileEdit;
+
+/**
+ * This plugin implements --automatic-fix for PHPDocToRealTypesPlugin
+ */
+class Fixers {
+
+    /**
+     * Add a missing return type to the real signature
+     * @return ?FileEditSet
+     */
+    public static function fixReturnType(
+        CodeBase $unused_code_base,
+        FileCacheEntry $contents,
+        IssueInstance $instance
+    ) {
+        $params = $instance->getTemplateParameters();
+        $return_type = $params[0];
+        $name = $params[1];
+        fwrite(STDERR, "TODO: Add $return_type to $name\n");
+        // @phan-suppress-next-line PhanPartialTypeMismatchArgument
+        $declaration = self::findFunctionLikeDeclaration($contents, $instance->getLine(), $name);
+        if (!$declaration) {
+            return null;
+        }
+        return self::computeEditsForReturnTypeDeclaration($declaration, (string)$return_type);
+    }
+
+    /**
+     * @return ?FileEditSet
+     */
+    private static function computeEditsForReturnTypeDeclaration(FunctionLike $declaration, string $return_type)
+    {
+        if (!$return_type) {
+            return null;
+        }
+        // @phan-suppress-next-line PhanUndeclaredProperty
+        $close_bracket = $declaration->closeParen;
+        if (!$close_bracket) {
+            return null;
+        }
+        // get the byte where the `)` of the argument list ends
+        $last_byte_index = $close_bracket->getEndPosition();
+        $file_edit = new FileEdit($last_byte_index, $last_byte_index, " : $return_type");
+        return new FileEditSet([$file_edit]);
+    }
+
+    /**
+     * @return ?FunctionLike
+     */
+    private static function findFunctionLikeDeclaration(
+        FileCacheEntry $contents,
+        int $line,
+        string $name
+    ) {
+        $candidates = [];
+        foreach ($contents->getNodesAtLine($line) as $node) {
+            fwrite(STDERR, "Saw " . get_class($node) . "\n");
+            if ($node instanceof FunctionDeclaration || $node instanceof MethodDeclaration) {
+                echo "Processing node";
+                $name_node = $node->name;
+                if (!$name_node) {
+                    continue;
+                }
+                $declaration_name = (new NodeUtils($contents->getContents()))->tokenToString($name_node);
+                echo "Comparing $declaration_name to $name\n";
+                if ($declaration_name === $name) {
+                    $candidates[] = $node;
+                }
+            } elseif ($node instanceof AnonymousFunctionCreationExpression) {
+                if ($name === '{closure}') {
+                    $candidates[] = $node;
+                }
+            }
+        }
+        if (count($candidates) === 1) {
+            return $candidates[0];
+        }
+        return null;
+    }
+}

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,10 @@ Backwards Incompatible Changes:
 
 Plugins:
 + Third party plugins may need to be upgraded to support changes in AST version 70, e.g. the new node kinds `AST_PROP_GROUP` and `AST_CLASS_NAME`
++ Add `PHPDocToRealTypesPlugin` to suggest real types to replace (or use alongside) phpdoc return types.
+  This does not check that the phpdoc types are correct.
+
+  `--automatic-fix` can be used to automate making these changes for issues that are not suppressed.
 
 ?? ??? 2019, Phan 1.3.3 (dev)
 -----------------------

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -1286,4 +1286,9 @@ final class EmptyUnionType extends UnionType
     {
         return false;
     }
+
+    public function isVoidType() : bool
+    {
+        return false;
+    }
 }

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -3239,4 +3239,24 @@ class Type
     {
         yield $this;
     }
+
+    /**
+     * Returns true if this type or a parent type can be used in a signature.
+     * Returns false for template types, resources, object, etc.
+     */
+    public function canUseInRealSignature() : bool
+    {
+        return true;
+    }
+
+    /**
+     * Returns the corresponding type that would be used in a signature
+     */
+    public function asSignatureType() : Type
+    {
+        if ($this->template_parameter_type_list) {
+            return self::fromType($this, []);
+        }
+        return $this;
+    }
 }

--- a/src/Phan/Language/Type/ArrayShapeType.php
+++ b/src/Phan/Language/Type/ArrayShapeType.php
@@ -865,4 +865,13 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
             $escaped_key
         );
     }
+
+    /**
+     * Returns the corresponding type that would be used in a signature
+     * @override
+     */
+    public function asSignatureType() : Type
+    {
+        return ArrayType::instance($this->is_nullable);
+    }
 }

--- a/src/Phan/Language/Type/CallableDeclarationType.php
+++ b/src/Phan/Language/Type/CallableDeclarationType.php
@@ -37,4 +37,13 @@ final class CallableDeclarationType extends FunctionLikeDeclarationType implemen
     {
         return true;
     }
+
+    /**
+     * Returns the corresponding type that would be used in a signature
+     * @override
+     */
+    public function asSignatureType() : Type
+    {
+        return CallableType::instance($this->is_nullable);
+    }
 }

--- a/src/Phan/Language/Type/ClosureDeclarationType.php
+++ b/src/Phan/Language/Type/ClosureDeclarationType.php
@@ -29,4 +29,13 @@ final class ClosureDeclarationType extends FunctionLikeDeclarationType
 
         return parent::canCastToNonNullableType($type);
     }
+
+    /**
+     * Returns the corresponding type that would be used in a signature
+     * @override
+     */
+    public function asSignatureType() : Type
+    {
+        return ClosureType::instance($this->is_nullable);
+    }
 }

--- a/src/Phan/Language/Type/FalseType.php
+++ b/src/Phan/Language/Type/FalseType.php
@@ -90,4 +90,13 @@ final class FalseType extends ScalarType
     }
 
     // public function getTypeAfterIncOrDec() : UnionType - doesn't need to be changed
+    //
+    /**
+     * Returns the corresponding type that would be used in a signature
+     * @override
+     */
+    public function asSignatureType() : Type
+    {
+        return BoolType::instance($this->is_nullable);
+    }
 }

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -706,4 +706,13 @@ class GenericArrayType extends ArrayType implements GenericArrayInterface
     {
         return $this->element_type->getReferencedClasses();
     }
+
+    /**
+     * Returns the corresponding type that would be used in a signature
+     * @override
+     */
+    public function asSignatureType() : Type
+    {
+        return ArrayType::instance($this->is_nullable);
+    }
 }

--- a/src/Phan/Language/Type/LiteralIntType.php
+++ b/src/Phan/Language/Type/LiteralIntType.php
@@ -195,6 +195,11 @@ final class LiteralIntType extends IntType implements LiteralTypeInterface
     {
         return self::performComparison($this->value, $scalar, $flags);
     }
+
+    public function asSignatureType() : Type
+    {
+        return IntType::instance($this->is_nullable);
+    }
 }
 
 LiteralIntType::init();

--- a/src/Phan/Language/Type/LiteralStringType.php
+++ b/src/Phan/Language/Type/LiteralStringType.php
@@ -321,6 +321,11 @@ final class LiteralStringType extends StringType implements LiteralTypeInterface
     {
         return filter_var($this->value, FILTER_VALIDATE_FLOAT) !== false;
     }
+
+    public function asSignatureType() : Type
+    {
+        return StringType::instance($this->is_nullable);
+    }
 }
 
 LiteralStringType::init();

--- a/src/Phan/Language/Type/MixedType.php
+++ b/src/Phan/Language/Type/MixedType.php
@@ -96,4 +96,9 @@ final class MixedType extends NativeType
     {
         return false;
     }
+
+    public function canUseInRealSignature() : bool
+    {
+        return false;
+    }
 }

--- a/src/Phan/Language/Type/ObjectType.php
+++ b/src/Phan/Language/Type/ObjectType.php
@@ -48,4 +48,10 @@ final class ObjectType extends NativeType
     {
         return true;
     }
+
+    public function canUseInRealSignature() : bool
+    {
+        // Callers should check this separately if they want to support php 7.2
+        return false;
+    }
 }

--- a/src/Phan/Language/Type/ResourceType.php
+++ b/src/Phan/Language/Type/ResourceType.php
@@ -19,4 +19,9 @@ final class ResourceType extends NativeType
     {
         return false;
     }
+
+    public function canUseInRealSignature() : bool
+    {
+        return false;
+    }
 }

--- a/src/Phan/Language/Type/TemplateType.php
+++ b/src/Phan/Language/Type/TemplateType.php
@@ -171,4 +171,12 @@ final class TemplateType extends Type
         // Overridden in subclasses
         return null;
     }
+
+    /**
+     * @override
+     */
+    public function canUseInRealSignature() : bool
+    {
+        return false;
+    }
 }

--- a/src/Phan/Language/Type/TrueType.php
+++ b/src/Phan/Language/Type/TrueType.php
@@ -80,4 +80,13 @@ final class TrueType extends ScalarType
     }
 
     // public function getTypeAfterIncOrDec() : UnionType - doesn't need to be changed
+
+    /**
+     * Returns the corresponding type that would be used in a signature
+     * @override
+     */
+    public function asSignatureType() : Type
+    {
+        return BoolType::instance($this->is_nullable);
+    }
 }

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -37,6 +37,7 @@ use Phan\Language\Type\StaticType;
 use Phan\Language\Type\StringType;
 use Phan\Language\Type\TemplateType;
 use Phan\Language\Type\TrueType;
+use Phan\Language\Type\VoidType;
 use Serializable;
 use function substr;
 
@@ -3840,6 +3841,20 @@ class UnionType implements Serializable
             $template_type->getName() => UnionType::fromFullyQualifiedString('mixed'),
         ]);
         return !$this->isEqualTo($new_union_type);
+    }
+
+    /**
+     * @return bool
+     * True if this is the void type
+     * @see self::isVoid()
+     */
+    public function isVoidType() : bool
+    {
+        $type_set = $this->type_set;
+        if (\count($type_set) !== 1) {
+            return false;
+        }
+        return \reset($type_set) instanceof VoidType;
     }
 }
 

--- a/src/Phan/Plugin/ClosuresForKind.php
+++ b/src/Phan/Plugin/ClosuresForKind.php
@@ -65,7 +65,7 @@ class ClosuresForKind
      * @param Closure $flattener
      * @return array<int,Closure> (Maps a subset of node kinds to a closure to execute for that node kind.)
      */
-    public function getFlattenedClosures(Closure $flattener)
+    public function getFlattenedClosures(Closure $flattener) : array
     {
         \ksort($this->closures);
         $merged_closures = [];


### PR DESCRIPTION
e.g. to upgrade to php 7.1 and automatically add `void` return types