### PR TITLE
Phan v2: Convert PluginV2 to PluginV3 because types were strictened

### DIFF
--- a/.phan/plugins/AlwaysReturnPlugin.php
+++ b/.phan/plugins/AlwaysReturnPlugin.php
@@ -8,9 +8,9 @@ use Phan\Language\Element\FunctionInterface;
 use Phan\Language\Element\Method;
 use Phan\Language\Type\NullType;
 use Phan\Language\Type\VoidType;
-use Phan\PluginV2;
-use Phan\PluginV2\AnalyzeFunctionCapability;
-use Phan\PluginV2\AnalyzeMethodCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\AnalyzeFunctionCapability;
+use Phan\PluginV3\AnalyzeMethodCapability;
 
 /**
  * This file checks if a function, closure or method unconditionally returns.
@@ -29,7 +29,7 @@ use Phan\PluginV2\AnalyzeMethodCapability;
  *
  * A plugin file must
  *
- * - Contain a class that inherits from \Phan\PluginV2
+ * - Contain a class that inherits from \Phan\PluginV3
  *
  * - End by returning an instance of that class.
  *
@@ -39,7 +39,7 @@ use Phan\PluginV2\AnalyzeMethodCapability;
  * Note: When adding new plugins,
  * add them to the corresponding section of README.md
  */
-final class AlwaysReturnPlugin extends PluginV2 implements
+final class AlwaysReturnPlugin extends PluginV3 implements
     AnalyzeFunctionCapability,
     AnalyzeMethodCapability
 {

--- a/.phan/plugins/DemoPlugin.php
+++ b/.phan/plugins/DemoPlugin.php
@@ -6,13 +6,13 @@ use Phan\Language\Element\Clazz;
 use Phan\Language\Element\Func;
 use Phan\Language\Element\Method;
 use Phan\Language\Element\Property;
-use Phan\PluginV2;
-use Phan\PluginV2\AnalyzeClassCapability;
-use Phan\PluginV2\AnalyzeFunctionCapability;
-use Phan\PluginV2\AnalyzeMethodCapability;
-use Phan\PluginV2\AnalyzePropertyCapability;
-use Phan\PluginV2\PluginAwarePostAnalysisVisitor;
-use Phan\PluginV2\PostAnalyzeNodeCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\AnalyzeClassCapability;
+use Phan\PluginV3\AnalyzeFunctionCapability;
+use Phan\PluginV3\AnalyzeMethodCapability;
+use Phan\PluginV3\AnalyzePropertyCapability;
+use Phan\PluginV3\PluginAwarePostAnalysisVisitor;
+use Phan\PluginV3\PostAnalyzeNodeCapability;
 
 /**
  * This file demonstrates plugins for Phan.
@@ -40,7 +40,7 @@ use Phan\PluginV2\PostAnalyzeNodeCapability;
  *
  * A plugin file must
  *
- * - Contain a class that inherits from \Phan\PluginV2
+ * - Contain a class that inherits from \Phan\PluginV3
  *   and implements one or more `Capability`s.
  *
  * - End by returning an instance of that class.
@@ -51,7 +51,7 @@ use Phan\PluginV2\PostAnalyzeNodeCapability;
  * Note: When adding new plugins,
  * add them to the corresponding section of README.md
  */
-class DemoPlugin extends PluginV2 implements
+class DemoPlugin extends PluginV3 implements
     AnalyzeClassCapability,
     AnalyzeFunctionCapability,
     AnalyzeMethodCapability,

--- a/.phan/plugins/DollarDollarPlugin.php
+++ b/.phan/plugins/DollarDollarPlugin.php
@@ -1,9 +1,9 @@
 <?php declare(strict_types=1);
 
 use ast\Node;
-use Phan\PluginV2;
-use Phan\PluginV2\PluginAwarePostAnalysisVisitor;
-use Phan\PluginV2\PostAnalyzeNodeCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\PluginAwarePostAnalysisVisitor;
+use Phan\PluginV3\PostAnalyzeNodeCapability;
 
 /**
  * This plugin checks for occurrences of `$$x`,
@@ -18,7 +18,7 @@ use Phan\PluginV2\PostAnalyzeNodeCapability;
  *
  * A plugin file must
  *
- * - Contain a class that inherits from \Phan\PluginV2
+ * - Contain a class that inherits from \Phan\PluginV3
  *
  * - End by returning an instance of that class.
  *
@@ -28,7 +28,7 @@ use Phan\PluginV2\PostAnalyzeNodeCapability;
  * Note: When adding new plugins,
  * add them to the corresponding section of README.md
  */
-class DollarDollarPlugin extends PluginV2 implements PostAnalyzeNodeCapability
+class DollarDollarPlugin extends PluginV3 implements PostAnalyzeNodeCapability
 {
 
     /**

--- a/.phan/plugins/DuplicateArrayKeyPlugin.php
+++ b/.phan/plugins/DuplicateArrayKeyPlugin.php
@@ -5,16 +5,16 @@ use Phan\AST\ASTHasher;
 use Phan\AST\ASTReverter;
 use Phan\AST\UnionTypeVisitor;
 use Phan\Issue;
-use Phan\PluginV2;
-use Phan\PluginV2\PluginAwarePostAnalysisVisitor;
-use Phan\PluginV2\PostAnalyzeNodeCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\PluginAwarePostAnalysisVisitor;
+use Phan\PluginV3\PostAnalyzeNodeCapability;
 
 /**
  * Checks for duplicate/equivalent array keys and case statements, as well as arrays mixing `key => value, with `value,`.
  *
  * @see DollarDollarPlugin for generic plugin documentation.
  */
-class DuplicateArrayKeyPlugin extends PluginV2 implements PostAnalyzeNodeCapability
+class DuplicateArrayKeyPlugin extends PluginV3 implements PostAnalyzeNodeCapability
 {
     /**
      * @return string - name of PluginAwarePostAnalysisVisitor subclass

--- a/.phan/plugins/DuplicateExpressionPlugin.php
+++ b/.phan/plugins/DuplicateExpressionPlugin.php
@@ -6,9 +6,9 @@ use ast\Node;
 use Phan\Analysis\PostOrderAnalysisVisitor;
 use Phan\AST\ASTHasher;
 use Phan\AST\ASTReverter;
-use Phan\PluginV2;
-use Phan\PluginV2\PluginAwarePostAnalysisVisitor;
-use Phan\PluginV2\PostAnalyzeNodeCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\PluginAwarePostAnalysisVisitor;
+use Phan\PluginV3\PostAnalyzeNodeCapability;
 
 /**
  * This plugin checks for duplicate expressions in a statement
@@ -25,7 +25,7 @@ use Phan\PluginV2\PostAnalyzeNodeCapability;
  *
  * A plugin file must
  *
- * - Contain a class that inherits from \Phan\PluginV2
+ * - Contain a class that inherits from \Phan\PluginV3
  *
  * - End by returning an instance of that class.
  *
@@ -35,7 +35,7 @@ use Phan\PluginV2\PostAnalyzeNodeCapability;
  * Note: When adding new plugins,
  * add them to the corresponding section of README.md
  */
-class DuplicateExpressionPlugin extends PluginV2 implements PostAnalyzeNodeCapability
+class DuplicateExpressionPlugin extends PluginV3 implements PostAnalyzeNodeCapability
 {
 
     /**

--- a/.phan/plugins/FFIAnalysisPlugin.php
+++ b/.phan/plugins/FFIAnalysisPlugin.php
@@ -4,18 +4,18 @@ declare(strict_types=1);
 use ast\Node;
 use Phan\Language\Element\Variable;
 use Phan\Language\UnionType;
-use Phan\PluginV2;
-use Phan\PluginV2\PluginAwarePostAnalysisVisitor;
-use Phan\PluginV2\PluginAwarePreAnalysisVisitor;
-use Phan\PluginV2\PostAnalyzeNodeCapability;
-use Phan\PluginV2\PreAnalyzeNodeCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\PluginAwarePostAnalysisVisitor;
+use Phan\PluginV3\PluginAwarePreAnalysisVisitor;
+use Phan\PluginV3\PostAnalyzeNodeCapability;
+use Phan\PluginV3\PreAnalyzeNodeCapability;
 
 /**
  * This plugin modifies Phan's analysis of code using FFI\CData variables.
  *
  * A plugin file must
  *
- * - Contain a class that inherits from \Phan\PluginV2
+ * - Contain a class that inherits from \Phan\PluginV3
  *
  * - End by returning an instance of that class.
  *
@@ -27,7 +27,7 @@ use Phan\PluginV2\PreAnalyzeNodeCapability;
  * Note: When adding new plugins,
  * add them to the corresponding section of README.md
  */
-class FFIAnalysisPlugin extends PluginV2 implements PostAnalyzeNodeCapability, PreAnalyzeNodeCapability
+class FFIAnalysisPlugin extends PluginV3 implements PostAnalyzeNodeCapability, PreAnalyzeNodeCapability
 {
     /**
      * @return class-string - name of PluginAwarePostAnalysisVisitor subclass

--- a/.phan/plugins/HasPHPDocPlugin.php
+++ b/.phan/plugins/HasPHPDocPlugin.php
@@ -7,11 +7,11 @@ use Phan\Language\Element\Func;
 use Phan\Language\Element\MarkupDescription;
 use Phan\Language\Element\Method;
 use Phan\Language\Element\Property;
-use Phan\PluginV2;
-use Phan\PluginV2\AnalyzeClassCapability;
-use Phan\PluginV2\AnalyzeFunctionCapability;
-use Phan\PluginV2\AnalyzeMethodCapability;
-use Phan\PluginV2\AnalyzePropertyCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\AnalyzeClassCapability;
+use Phan\PluginV3\AnalyzeFunctionCapability;
+use Phan\PluginV3\AnalyzeMethodCapability;
+use Phan\PluginV3\AnalyzePropertyCapability;
 
 /**
  * This file checks if an element (class or property) has a PHPDoc comment,
@@ -31,7 +31,7 @@ use Phan\PluginV2\AnalyzePropertyCapability;
  *
  * A plugin file must
  *
- * - Contain a class that inherits from \Phan\PluginV2
+ * - Contain a class that inherits from \Phan\PluginV3
  *
  * - End by returning an instance of that class.
  *
@@ -41,7 +41,7 @@ use Phan\PluginV2\AnalyzePropertyCapability;
  * Note: When adding new plugins,
  * add them to the corresponding section of README.md
  */
-final class HasPHPDocPlugin extends PluginV2 implements
+final class HasPHPDocPlugin extends PluginV3 implements
     AnalyzeClassCapability,
     AnalyzeFunctionCapability,
     AnalyzeMethodCapability,

--- a/.phan/plugins/InvalidVariableIssetPlugin.php
+++ b/.phan/plugins/InvalidVariableIssetPlugin.php
@@ -5,14 +5,14 @@
 use ast\Node;
 use Phan\Language\Context;
 use Phan\Language\Element\Variable;
-use Phan\PluginV2;
-use Phan\PluginV2\PluginAwarePostAnalysisVisitor;
-use Phan\PluginV2\PostAnalyzeNodeCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\PluginAwarePostAnalysisVisitor;
+use Phan\PluginV3\PostAnalyzeNodeCapability;
 
 /**
  * This plugin detects undeclared variables within isset() checks.
  */
-class InvalidVariableIssetPlugin extends PluginV2 implements PostAnalyzeNodeCapability
+class InvalidVariableIssetPlugin extends PluginV3 implements PostAnalyzeNodeCapability
 {
 
     /**

--- a/.phan/plugins/InvokePHPNativeSyntaxCheckPlugin.php
+++ b/.phan/plugins/InvokePHPNativeSyntaxCheckPlugin.php
@@ -4,10 +4,10 @@ use ast\Node;
 use Phan\CodeBase;
 use Phan\Config;
 use Phan\Language\Context;
-use Phan\PluginV2;
-use Phan\PluginV2\AfterAnalyzeFileCapability;
-use Phan\PluginV2\BeforeAnalyzeFileCapability;
-use Phan\PluginV2\FinalizeProcessCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\AfterAnalyzeFileCapability;
+use Phan\PluginV3\BeforeAnalyzeFileCapability;
+use Phan\PluginV3\FinalizeProcessCapability;
 
 /**
  * This plugin invokes the equivalent of `php --no-php-ini --syntax-check $analyzed_file_path`.
@@ -24,7 +24,7 @@ use Phan\PluginV2\FinalizeProcessCapability;
  *
  * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
-class InvokePHPNativeSyntaxCheckPlugin extends PluginV2 implements
+class InvokePHPNativeSyntaxCheckPlugin extends PluginV3 implements
     AfterAnalyzeFileCapability,
     BeforeAnalyzeFileCapability,
     FinalizeProcessCapability

--- a/.phan/plugins/NoAssertPlugin.php
+++ b/.phan/plugins/NoAssertPlugin.php
@@ -1,9 +1,9 @@
 <?php declare(strict_types=1);
 
 use ast\Node;
-use Phan\PluginV2;
-use Phan\PluginV2\PluginAwarePostAnalysisVisitor;
-use Phan\PluginV2\PostAnalyzeNodeCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\PluginAwarePostAnalysisVisitor;
+use Phan\PluginV3\PostAnalyzeNodeCapability;
 
 /**
  * This plugin checks for occurrences of `assert(cond)` for Phan's self-analysis.
@@ -19,7 +19,7 @@ use Phan\PluginV2\PostAnalyzeNodeCapability;
  *
  * A plugin file must
  *
- * - Contain a class that inherits from \Phan\PluginV2
+ * - Contain a class that inherits from \Phan\PluginV3
  *
  * - End by returning an instance of that class.
  *
@@ -29,7 +29,7 @@ use Phan\PluginV2\PostAnalyzeNodeCapability;
  * Note: When adding new plugins,
  * add them to the corresponding section of README.md
  */
-class NoAssertPlugin extends PluginV2 implements PostAnalyzeNodeCapability
+class NoAssertPlugin extends PluginV3 implements PostAnalyzeNodeCapability
 {
 
     /**

--- a/.phan/plugins/NonBoolBranchPlugin.php
+++ b/.phan/plugins/NonBoolBranchPlugin.php
@@ -6,16 +6,16 @@ use ast\Node;
 use Phan\AST\UnionTypeVisitor;
 use Phan\Exception\IssueException;
 use Phan\Language\Context;
-use Phan\PluginV2;
-use Phan\PluginV2\PluginAwarePreAnalysisVisitor;
-use Phan\PluginV2\PreAnalyzeNodeCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\PluginAwarePreAnalysisVisitor;
+use Phan\PluginV3\PreAnalyzeNodeCapability;
 
 /**
  * This plugin warns if an expression which has types other than `bool` is used in an if/else if.
  *
  * Note that the 'simplify_ast' setting's default of true will interfere with this plugin.
  */
-class NonBoolBranchPlugin extends PluginV2 implements PreAnalyzeNodeCapability
+class NonBoolBranchPlugin extends PluginV3 implements PreAnalyzeNodeCapability
 {
     /**
      * @return string - name of PluginAwarePreAnalysisVisitor subclass

--- a/.phan/plugins/NonBoolInLogicalArithPlugin.php
+++ b/.phan/plugins/NonBoolInLogicalArithPlugin.php
@@ -3,15 +3,15 @@
 use ast\Node;
 use Phan\AST\UnionTypeVisitor;
 use Phan\Language\Context;
-use Phan\PluginV2;
-use Phan\PluginV2\PluginAwarePostAnalysisVisitor;
-use Phan\PluginV2\PostAnalyzeNodeCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\PluginAwarePostAnalysisVisitor;
+use Phan\PluginV3\PostAnalyzeNodeCapability;
 
 /**
  * This plugin checks for non-booleans in either side of logical arithmetic operators
  * (e.g. &&, ||, xor)
  */
-class NonBoolInLogicalArithPlugin extends PluginV2 implements PostAnalyzeNodeCapability
+class NonBoolInLogicalArithPlugin extends PluginV3 implements PostAnalyzeNodeCapability
 {
 
     /**

--- a/.phan/plugins/NotFullyQualifiedUsagePlugin.php
+++ b/.phan/plugins/NotFullyQualifiedUsagePlugin.php
@@ -2,9 +2,9 @@
 
 use ast\Node;
 use Phan\Config;
-use Phan\PluginV2;
-use Phan\PluginV2\PluginAwarePostAnalysisVisitor;
-use Phan\PluginV2\PostAnalyzeNodeCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\PluginAwarePostAnalysisVisitor;
+use Phan\PluginV3\PostAnalyzeNodeCapability;
 
 /**
  * This warns if references to global functions or global constants are not fully qualified.
@@ -15,7 +15,7 @@ use Phan\PluginV2\PostAnalyzeNodeCapability;
  *   This method returns a class that is called on every AST node from every
  *   file being analyzed
  */
-class NotFullyQualifiedUsagePlugin extends PluginV2 implements PostAnalyzeNodeCapability
+class NotFullyQualifiedUsagePlugin extends PluginV3 implements PostAnalyzeNodeCapability
 {
 
     /**

--- a/.phan/plugins/NumericalComparisonPlugin.php
+++ b/.phan/plugins/NumericalComparisonPlugin.php
@@ -3,15 +3,15 @@
 use ast\Node;
 use Phan\AST\UnionTypeVisitor;
 use Phan\Language\Context;
-use Phan\PluginV2;
-use Phan\PluginV2\PluginAwarePostAnalysisVisitor;
-use Phan\PluginV2\PostAnalyzeNodeCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\PluginAwarePostAnalysisVisitor;
+use Phan\PluginV3\PostAnalyzeNodeCapability;
 
 /**
  * This plugin enforces that loose equality is used for numeric operands (e.g. `2 == 2.0`),
  * and that strict equality is used for non-numeric operands (e.g. `"2" === "2e0"` is false).
  */
-class NumericalComparisonPlugin extends PluginV2 implements PostAnalyzeNodeCapability
+class NumericalComparisonPlugin extends PluginV3 implements PostAnalyzeNodeCapability
 {
 
     /**

--- a/.phan/plugins/PHPDocRedundantPlugin.php
+++ b/.phan/plugins/PHPDocRedundantPlugin.php
@@ -9,11 +9,11 @@ use Phan\Language\Element\Method;
 use Phan\Library\FileCacheEntry;
 use Phan\Library\StringUtil;
 use Phan\Plugin\Internal\IssueFixingPlugin\FileEditSet;
-use Phan\PluginV2;
-use Phan\PluginV2\AnalyzeFunctionCapability;
-use Phan\PluginV2\AnalyzeMethodCapability;
-use Phan\PluginV2\AutomaticFixCapability;
-// use Phan\PluginV2\AutomaticFixCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\AnalyzeFunctionCapability;
+use Phan\PluginV3\AnalyzeMethodCapability;
+use Phan\PluginV3\AutomaticFixCapability;
+// use Phan\PluginV3\AutomaticFixCapability;
 use PHPDocRedundantPlugin\Fixers;
 
 /**
@@ -26,7 +26,7 @@ use PHPDocRedundantPlugin\Fixers;
  *
  * It does not check if the change is safe to make.
  */
-class PHPDocRedundantPlugin extends PluginV2 implements
+class PHPDocRedundantPlugin extends PluginV3 implements
     AnalyzeFunctionCapability,
     AnalyzeMethodCapability,
     AutomaticFixCapability

--- a/.phan/plugins/PHPDocToRealTypesPlugin.php
+++ b/.phan/plugins/PHPDocToRealTypesPlugin.php
@@ -7,11 +7,11 @@ use Phan\Language\Element\FunctionInterface;
 use Phan\Language\Element\Method;
 use Phan\Library\FileCacheEntry;
 use Phan\Plugin\Internal\IssueFixingPlugin\FileEditSet;
-use Phan\PluginV2;
-use Phan\PluginV2\AnalyzeFunctionCapability;
-use Phan\PluginV2\AnalyzeMethodCapability;
-use Phan\PluginV2\AutomaticFixCapability;
-use Phan\PluginV2\BeforeAnalyzePhaseCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\AnalyzeFunctionCapability;
+use Phan\PluginV3\AnalyzeMethodCapability;
+use Phan\PluginV3\AutomaticFixCapability;
+use Phan\PluginV3\BeforeAnalyzePhaseCapability;
 use PHPDocToRealTypesPlugin\Fixers;
 
 /**
@@ -19,7 +19,7 @@ use PHPDocToRealTypesPlugin\Fixers;
  *
  * It does not check if the change is safe to make.
  */
-class PHPDocToRealTypesPlugin extends PluginV2 implements
+class PHPDocToRealTypesPlugin extends PluginV3 implements
     AnalyzeFunctionCapability,
     AnalyzeMethodCapability,
     AutomaticFixCapability,

--- a/.phan/plugins/PHPUnitAssertionPlugin.php
+++ b/.phan/plugins/PHPUnitAssertionPlugin.php
@@ -9,8 +9,8 @@ use Phan\Language\Element\FunctionInterface;
 use Phan\Language\Element\Method;
 use Phan\Language\FQSEN\FullyQualifiedClassName;
 use Phan\Language\UnionType;
-use Phan\PluginV2;
-use Phan\PluginV2\AnalyzeFunctionCallCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\AnalyzeFunctionCallCapability;
 
 /**
  * Mark PHPUnit helper assertions as having side effects.
@@ -24,7 +24,7 @@ use Phan\PluginV2\AnalyzeFunctionCallCapability;
  *
  * NOTE: This will probably be rewritten
  */
-class PHPUnitAssertionPlugin extends PluginV2 implements AnalyzeFunctionCallCapability
+class PHPUnitAssertionPlugin extends PluginV3 implements AnalyzeFunctionCallCapability
 {
     /**
      * @override

--- a/.phan/plugins/PHPUnitNotDeadCodePlugin.php
+++ b/.phan/plugins/PHPUnitNotDeadCodePlugin.php
@@ -6,9 +6,9 @@ use Phan\Language\Element\Clazz;
 use Phan\Language\Element\Method;
 use Phan\Language\FQSEN\FullyQualifiedClassName;
 use Phan\Language\Type;
-use Phan\PluginV2;
-use Phan\PluginV2\PluginAwarePostAnalysisVisitor;
-use Phan\PluginV2\PostAnalyzeNodeCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\PluginAwarePostAnalysisVisitor;
+use Phan\PluginV3\PostAnalyzeNodeCapability;
 
 /**
  * Mark all phpunit test cases as used for dead code detection during Phan's self-analysis.
@@ -20,9 +20,9 @@ use Phan\PluginV2\PostAnalyzeNodeCapability;
  *   Returns the name of a class extending PluginAwarePostAnalysisVisitor, which will be used to analyze nodes in the analysis phase.
  *   If the PluginAwarePostAnalysisVisitor subclass has an instance property called parent_node_list,
  *   Phan will automatically set that property to the list of parent nodes (The nodes deepest in the AST are at the end of the list)
- *   (implement \Phan\PluginV2\PostAnalyzeNodeCapability)
+ *   (implement \Phan\PluginV3\PostAnalyzeNodeCapability)
  */
-class PHPUnitNotDeadCodePlugin extends PluginV2 implements PostAnalyzeNodeCapability
+class PHPUnitNotDeadCodePlugin extends PluginV3 implements PostAnalyzeNodeCapability
 {
     /**
      * @override

--- a/.phan/plugins/PhanSelfCheckPlugin.php
+++ b/.phan/plugins/PhanSelfCheckPlugin.php
@@ -15,8 +15,8 @@ use Phan\Language\FQSEN\FullyQualifiedMethodName;
 use Phan\Language\Type\ArrayShapeType;
 use Phan\Library\ConversionSpec;
 use Phan\Library\StringUtil;
-use Phan\PluginV2;
-use Phan\PluginV2\AnalyzeFunctionCallCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\AnalyzeFunctionCallCapability;
 use function count;
 use function is_string;
 
@@ -29,7 +29,7 @@ use function is_string;
  *
  * NOTE: This does not check Issue::fromType($typename)(...args)
  */
-class PhanSelfCheckPlugin extends PluginV2 implements AnalyzeFunctionCallCapability
+class PhanSelfCheckPlugin extends PluginV3 implements AnalyzeFunctionCallCapability
 {
     const TooManyArgumentsForIssue = 'PhanPluginTooManyArgumentsForIssue';
     const TooFewArgumentsForIssue = 'PhanPluginTooFewArgumentsForIssue';
@@ -179,7 +179,7 @@ class PhanSelfCheckPlugin extends PluginV2 implements AnalyzeFunctionCallCapabil
             '\Phan\Language\Element\Comment\Builder::emitIssue' => $make_type_and_parameters_callback(0, 2),
         ];
         // @phan-suppress-next-line PhanThrowTypeAbsentForCall
-        $emit_plugin_issue_fqsen = FullyQualifiedMethodName::fromFullyQualifiedString('\Phan\PluginV2\IssueEmitter::emitPluginIssue');
+        $emit_plugin_issue_fqsen = FullyQualifiedMethodName::fromFullyQualifiedString('\Phan\PluginV3\IssueEmitter::emitPluginIssue');
         // @phan-suppress-next-line PhanThrowTypeAbsentForCall
         $analysis_visitor_fqsen = FullyQualifiedMethodName::fromFullyQualifiedString('\Phan\AST\AnalysisVisitor::emitIssue');
 

--- a/.phan/plugins/PossiblyStaticMethodPlugin.php
+++ b/.phan/plugins/PossiblyStaticMethodPlugin.php
@@ -6,9 +6,9 @@ use Phan\CodeBase;
 use Phan\Config;
 use Phan\Language\Element\Method;
 use Phan\Language\ElementContext;
-use Phan\PluginV2;
-use Phan\PluginV2\AnalyzeMethodCapability;
-use Phan\PluginV2\FinalizeProcessCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\AnalyzeMethodCapability;
+use Phan\PluginV3\FinalizeProcessCapability;
 
 /**
  * This file checks if a method can be made static without causing any errors.
@@ -24,7 +24,7 @@ use Phan\PluginV2\FinalizeProcessCapability;
  *
  * A plugin file must
  *
- * - Contain a class that inherits from \Phan\PluginV2
+ * - Contain a class that inherits from \Phan\PluginV3
  *
  * - End by returning an instance of that class.
  *
@@ -34,7 +34,7 @@ use Phan\PluginV2\FinalizeProcessCapability;
  * Note: When adding new plugins,
  * add them to the corresponding section of README.md
  */
-final class PossiblyStaticMethodPlugin extends PluginV2 implements
+final class PossiblyStaticMethodPlugin extends PluginV3 implements
     AnalyzeMethodCapability,
     FinalizeProcessCapability
 {

--- a/.phan/plugins/PregRegexCheckerPlugin.php
+++ b/.phan/plugins/PregRegexCheckerPlugin.php
@@ -10,8 +10,8 @@ use Phan\Language\Type\IterableType;
 use Phan\Language\Type\LiteralStringType;
 use Phan\Library\RegexKeyExtractor;
 use Phan\Library\StringUtil;
-use Phan\PluginV2;
-use Phan\PluginV2\AnalyzeFunctionCallCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\AnalyzeFunctionCallCapability;
 
 /**
  * This plugin checks for invalid regexes in calls to preg_match. (And all of the other internal PCRE functions).
@@ -23,7 +23,7 @@ use Phan\PluginV2\AnalyzeFunctionCallCapability;
  * - getAnalyzeFunctionCallClosures
  *   This method returns a map from function/method FQSEN to closures that are called on invocations of those closures.
  */
-class PregRegexCheckerPlugin extends PluginV2 implements AnalyzeFunctionCallCapability
+class PregRegexCheckerPlugin extends PluginV3 implements AnalyzeFunctionCallCapability
 {
     // Skip over analyzing regex keys that couldn't be resolved.
     // Don't try to convert values to PHP data (should be closures)

--- a/.phan/plugins/PrintfCheckerPlugin.php
+++ b/.phan/plugins/PrintfCheckerPlugin.php
@@ -19,9 +19,9 @@ use Phan\Language\Type\LiteralStringType;
 use Phan\Language\Type\StringType;
 use Phan\Language\UnionType;
 use Phan\Library\ConversionSpec;
-use Phan\PluginV2;
-use Phan\PluginV2\AnalyzeFunctionCallCapability;
-use Phan\PluginV2\ReturnTypeOverrideCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\AnalyzeFunctionCallCapability;
+use Phan\PluginV3\ReturnTypeOverrideCapability;
 use function count;
 use function implode;
 use function is_object;
@@ -46,7 +46,7 @@ use function var_export;
  * TODO: Add optional verbose warnings about unanalyzable strings
  * TODO: Check if arg can cast to string.
  */
-class PrintfCheckerPlugin extends PluginV2 implements AnalyzeFunctionCallCapability, ReturnTypeOverrideCapability
+class PrintfCheckerPlugin extends PluginV3 implements AnalyzeFunctionCallCapability, ReturnTypeOverrideCapability
 {
 
     // Pylint error codes for emitted issues.

--- a/.phan/plugins/SleepCheckerPlugin.php
+++ b/.phan/plugins/SleepCheckerPlugin.php
@@ -5,9 +5,9 @@ use Phan\AST\ContextNode;
 use Phan\AST\UnionTypeVisitor;
 use Phan\Config;
 use Phan\Language\Type\StringType;
-use Phan\PluginV2;
-use Phan\PluginV2\PluginAwarePostAnalysisVisitor;
-use Phan\PluginV2\PostAnalyzeNodeCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\PluginAwarePostAnalysisVisitor;
+use Phan\PluginV3\PostAnalyzeNodeCapability;
 
 /**
  * This plugin checks uses of __sleep()
@@ -19,7 +19,7 @@ use Phan\PluginV2\PostAnalyzeNodeCapability;
  * It is assumed without being checked that plugins aren't
  * mangling state within the passed code base or context.
  */
-class SleepCheckerPlugin extends PluginV2 implements PostAnalyzeNodeCapability
+class SleepCheckerPlugin extends PluginV3 implements PostAnalyzeNodeCapability
 {
 
     /**

--- a/.phan/plugins/SuspiciousParamOrderPlugin.php
+++ b/.phan/plugins/SuspiciousParamOrderPlugin.php
@@ -5,15 +5,15 @@ use Phan\AST\ContextNode;
 use Phan\AST\UnionTypeVisitor;
 use Phan\Exception\CodeBaseException;
 use Phan\Language\Element\FunctionInterface;
-use Phan\PluginV2;
-use Phan\PluginV2\PluginAwarePostAnalysisVisitor;
-use Phan\PluginV2\PostAnalyzeNodeCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\PluginAwarePostAnalysisVisitor;
+use Phan\PluginV3\PostAnalyzeNodeCapability;
 
 /**
  * A plugin that checks if calls to a function or method pass in arguments in a suspicious order.
  * E.g. calling `function example($offset, $count)` as `example($count, $offset)`
  */
-class SuspiciousParamOrderPlugin extends PluginV2 implements PostAnalyzeNodeCapability
+class SuspiciousParamOrderPlugin extends PluginV3 implements PostAnalyzeNodeCapability
 {
     /**
      * @return string - name of PluginAwarePostAnalysisVisitor subclass

--- a/.phan/plugins/UnknownElementTypePlugin.php
+++ b/.phan/plugins/UnknownElementTypePlugin.php
@@ -9,15 +9,15 @@ use Phan\Language\Type;
 use Phan\Language\Type\ArrayType;
 use Phan\Language\Type\NullType;
 use Phan\Language\UnionType;
-use Phan\PluginV2;
-use Phan\PluginV2\AnalyzeFunctionCapability;
-use Phan\PluginV2\AnalyzeMethodCapability;
-use Phan\PluginV2\AnalyzePropertyCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\AnalyzeFunctionCapability;
+use Phan\PluginV3\AnalyzeMethodCapability;
+use Phan\PluginV3\AnalyzePropertyCapability;
 
 /**
  * This file checks if any elements in the codebase have undeclared types.
  */
-class UnknownElementTypePlugin extends PluginV2 implements
+class UnknownElementTypePlugin extends PluginV3 implements
     AnalyzeFunctionCapability,
     AnalyzeMethodCapability,
     AnalyzePropertyCapability

--- a/.phan/plugins/UnreachableCodePlugin.php
+++ b/.phan/plugins/UnreachableCodePlugin.php
@@ -2,9 +2,9 @@
 
 use ast\Node;
 use Phan\Analysis\BlockExitStatusChecker;
-use Phan\PluginV2;
-use Phan\PluginV2\PluginAwarePostAnalysisVisitor;
-use Phan\PluginV2\PostAnalyzeNodeCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\PluginAwarePostAnalysisVisitor;
+use Phan\PluginV3\PostAnalyzeNodeCapability;
 
 /**
  * This file checks for syntactically unreachable statements in
@@ -18,7 +18,7 @@ use Phan\PluginV2\PostAnalyzeNodeCapability;
  *
  * A plugin file must
  *
- * - Contain a class that inherits from \Phan\PluginV2
+ * - Contain a class that inherits from \Phan\PluginV3
  *
  * - End by returning an instance of that class.
  *
@@ -28,7 +28,7 @@ use Phan\PluginV2\PostAnalyzeNodeCapability;
  * Note: When adding new plugins,
  * add them to the corresponding section of README.md
  */
-final class UnreachableCodePlugin extends PluginV2 implements PostAnalyzeNodeCapability
+final class UnreachableCodePlugin extends PluginV3 implements PostAnalyzeNodeCapability
 {
 
     /**

--- a/.phan/plugins/UnusedSuppressionPlugin.php
+++ b/.phan/plugins/UnusedSuppressionPlugin.php
@@ -10,14 +10,14 @@ use Phan\Language\Element\Func;
 use Phan\Language\Element\Method;
 use Phan\Language\Element\Property;
 use Phan\Plugin\ConfigPluginSet;
-use Phan\PluginV2;
-use Phan\PluginV2\AnalyzeClassCapability;
-use Phan\PluginV2\AnalyzeFunctionCapability;
-use Phan\PluginV2\AnalyzeMethodCapability;
-use Phan\PluginV2\AnalyzePropertyCapability;
-use Phan\PluginV2\BeforeAnalyzeFileCapability;
-use Phan\PluginV2\FinalizeProcessCapability;
-use Phan\PluginV2\SuppressionCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\AnalyzeClassCapability;
+use Phan\PluginV3\AnalyzeFunctionCapability;
+use Phan\PluginV3\AnalyzeMethodCapability;
+use Phan\PluginV3\AnalyzePropertyCapability;
+use Phan\PluginV3\BeforeAnalyzeFileCapability;
+use Phan\PluginV3\FinalizeProcessCapability;
+use Phan\PluginV3\SuppressionCapability;
 
 /**
  * Check for unused (at)suppress annotations.
@@ -25,7 +25,7 @@ use Phan\PluginV2\SuppressionCapability;
  * NOTE! This plugin only produces correct results when Phan
  *       is run on a single processor (via the `-j1` flag).
  */
-class UnusedSuppressionPlugin extends PluginV2 implements
+class UnusedSuppressionPlugin extends PluginV3 implements
     BeforeAnalyzeFileCapability,
     AnalyzeClassCapability,
     AnalyzeFunctionCapability,

--- a/.phan/plugins/UseReturnValuePlugin.php
+++ b/.phan/plugins/UseReturnValuePlugin.php
@@ -8,10 +8,10 @@ use Phan\Exception\CodeBaseException;
 use Phan\Language\Context;
 use Phan\Language\Element\Func;
 use Phan\Language\Element\FunctionInterface;
-use Phan\PluginV2;
-use Phan\PluginV2\FinalizeProcessCapability;
-use Phan\PluginV2\PluginAwarePostAnalysisVisitor;
-use Phan\PluginV2\PostAnalyzeNodeCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\FinalizeProcessCapability;
+use Phan\PluginV3\PluginAwarePostAnalysisVisitor;
+use Phan\PluginV3\PostAnalyzeNodeCapability;
 
 /**
  * A plugin that checks for invocations of functions/methods where the return value should be used.
@@ -33,7 +33,7 @@ use Phan\PluginV2\PostAnalyzeNodeCapability;
  *
  *   For dynamic checks, use this value instead of the default of 98 (should be between 0.01 and 100)
  */
-class UseReturnValuePlugin extends PluginV2 implements PostAnalyzeNodeCapability, FinalizeProcessCapability
+class UseReturnValuePlugin extends PluginV3 implements PostAnalyzeNodeCapability, FinalizeProcessCapability
 {
     // phpcs:disable Generic.NamingConventions.UpperCaseConstantName.ClassConstantNotUpperCase
     // this is deliberate for issue names

--- a/.phan/plugins/WhitespacePlugin.php
+++ b/.phan/plugins/WhitespacePlugin.php
@@ -6,14 +6,14 @@ use Phan\IssueInstance;
 use Phan\Language\Context;
 use Phan\Library\FileCacheEntry;
 use Phan\Plugin\Internal\IssueFixingPlugin\FileEditSet;
-use Phan\PluginV2;
-use Phan\PluginV2\AfterAnalyzeFileCapability;
-use Phan\PluginV2\AutomaticFixCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\AfterAnalyzeFileCapability;
+use Phan\PluginV3\AutomaticFixCapability;
 
 /**
  * This plugin checks the whitespace in analyzed PHP files for (1) tabs, (2) windows newlines, and (3) trailing whitespace.
  */
-class WhitespacePlugin extends PluginV2 implements
+class WhitespacePlugin extends PluginV3 implements
     AfterAnalyzeFileCapability,
     AutomaticFixCapability
 {

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@ Backwards Incompatible Changes:
   Phan switched from using [AST version 50 to version 70](https://github.com/nikic/php-ast#ast-versioning).
 
 Plugins:
++ Change `PluginV2` to `PluginV3` because type signatures are stricter (and incompatible with existing plugins) and some of Phan's methods will be removed, changed, or renamed.
 + Third party plugins may need to be upgraded to support changes in AST version 70, e.g. the new node kinds `AST_PROP_GROUP` and `AST_CLASS_NAME`
 + Add `PHPDocToRealTypesPlugin` to suggest real types to replace (or use alongside) phpdoc return types.
   This does not check that the phpdoc types are correct.

--- a/src/Phan/Analysis/ArgumentType.php
+++ b/src/Phan/Analysis/ArgumentType.php
@@ -22,7 +22,7 @@ use Phan\Language\Type;
 use Phan\Language\Type\FalseType;
 use Phan\Language\Type\NullType;
 use Phan\Language\UnionType;
-use Phan\PluginV2\StopParamAnalysisException;
+use Phan\PluginV3\StopParamAnalysisException;
 
 use function is_string;
 

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -43,7 +43,7 @@ class Config
      * Plugin files that wish to be backwards compatible may check this and
      * return different classes based on its existence and
      * the results of version_compare.
-     * PluginV2 will correspond to 2.x.y, PluginV3 will correspond to 3.x.y, etc.
+     * PluginV3 will correspond to 2.x.y, PluginV3 will correspond to 3.x.y, etc.
      * New features increment minor versions, and bug fixes increment patch versions.
      * @suppress PhanUnreferencedPublicClassConstant
      */

--- a/src/Phan/Daemon/Request.php
+++ b/src/Phan/Daemon/Request.php
@@ -450,10 +450,6 @@ class Request
     public static function normalizeFileMappingContents(array $file_mapping_contents, ?string &$error_message) : array
     {
         $error_message = null;
-        if (!\is_array($file_mapping_contents)) {
-            $error_message = 'Invalid value of temporary_file_mapping_contents';
-            return [];
-        }
         $new_file_mapping_contents = [];
         foreach ($file_mapping_contents ?? [] as $file => $contents) {
             if (!\is_string($file)) {

--- a/src/Phan/IssueFixSuggester.php
+++ b/src/Phan/IssueFixSuggester.php
@@ -49,9 +49,6 @@ class IssueFixSuggester
          * @param FullyQualifiedClassName $alternate_fqsen
          */
         return static function (\Phan\Language\FQSEN\FullyQualifiedClassName $alternate_fqsen) use ($code_base, $class_closure) : bool {
-            if (!($alternate_fqsen instanceof FullyQualifiedClassName)) {
-                return false;
-            }
             if (!$code_base->hasClassWithFQSEN($alternate_fqsen)) {
                 return false;
             }

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -1468,7 +1468,7 @@ trait FunctionTrait
             );
             $template_type_map = [];
             foreach ($parameter_extractor_map as $name => $closure) {
-                $template_type_map[$name] = $closure ? $closure($args_types, $context) : UnionType::empty();
+                $template_type_map[$name] = $closure($args_types, $context);
             }
             return $function->getUnionType()->withTemplateParameterTypeMap($template_type_map);
         };

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -41,25 +41,25 @@ use Phan\Plugin\Internal\RequireExistsPlugin;
 use Phan\Plugin\Internal\StringFunctionPlugin;
 use Phan\Plugin\Internal\ThrowAnalyzerPlugin;
 use Phan\Plugin\Internal\VariableTrackerPlugin;
-use Phan\PluginV2;
-use Phan\PluginV2\AfterAnalyzeFileCapability;
-use Phan\PluginV2\AnalyzeClassCapability;
-use Phan\PluginV2\AnalyzeFunctionCallCapability;
-use Phan\PluginV2\AnalyzeFunctionCapability;
-use Phan\PluginV2\AnalyzeMethodCapability;
-use Phan\PluginV2\AnalyzePropertyCapability;
-use Phan\PluginV2\AutomaticFixCapability;
-use Phan\PluginV2\BeforeAnalyzeCapability;
-use Phan\PluginV2\BeforeAnalyzeFileCapability;
-use Phan\PluginV2\BeforeAnalyzePhaseCapability;
-use Phan\PluginV2\FinalizeProcessCapability;
-use Phan\PluginV2\HandleLazyLoadInternalFunctionCapability;
-use Phan\PluginV2\PluginAwarePostAnalysisVisitor;
-use Phan\PluginV2\PluginAwarePreAnalysisVisitor;
-use Phan\PluginV2\PostAnalyzeNodeCapability;
-use Phan\PluginV2\PreAnalyzeNodeCapability;
-use Phan\PluginV2\ReturnTypeOverrideCapability;
-use Phan\PluginV2\SuppressionCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\AfterAnalyzeFileCapability;
+use Phan\PluginV3\AnalyzeClassCapability;
+use Phan\PluginV3\AnalyzeFunctionCallCapability;
+use Phan\PluginV3\AnalyzeFunctionCapability;
+use Phan\PluginV3\AnalyzeMethodCapability;
+use Phan\PluginV3\AnalyzePropertyCapability;
+use Phan\PluginV3\AutomaticFixCapability;
+use Phan\PluginV3\BeforeAnalyzeCapability;
+use Phan\PluginV3\BeforeAnalyzeFileCapability;
+use Phan\PluginV3\BeforeAnalyzePhaseCapability;
+use Phan\PluginV3\FinalizeProcessCapability;
+use Phan\PluginV3\HandleLazyLoadInternalFunctionCapability;
+use Phan\PluginV3\PluginAwarePostAnalysisVisitor;
+use Phan\PluginV3\PluginAwarePreAnalysisVisitor;
+use Phan\PluginV3\PostAnalyzeNodeCapability;
+use Phan\PluginV3\PreAnalyzeNodeCapability;
+use Phan\PluginV3\ReturnTypeOverrideCapability;
+use Phan\PluginV3\SuppressionCapability;
 use Phan\Suggestion;
 use ReflectionException;
 use ReflectionProperty;
@@ -81,7 +81,7 @@ use const STDERR;
  *
  * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod TODO: Document
  */
-final class ConfigPluginSet extends PluginV2 implements
+final class ConfigPluginSet extends PluginV3 implements
     AfterAnalyzeFileCapability,
     AnalyzeClassCapability,
     AnalyzeFunctionCapability,
@@ -96,7 +96,7 @@ final class ConfigPluginSet extends PluginV2 implements
     SuppressionCapability
 {
 
-    /** @var array<int,PluginV2>|null - Cached plugin set for this instance. Lazily generated. */
+    /** @var array<int,PluginV3>|null - Cached plugin set for this instance. Lazily generated. */
     private $plugin_set;
 
     /**
@@ -787,7 +787,7 @@ final class ConfigPluginSet extends PluginV2 implements
         if (!is_null($this->plugin_set)) {
             return;
         }
-        $load_plugin = static function (string $plugin_file_name) : PluginV2 {
+        $load_plugin = static function (string $plugin_file_name) : PluginV3 {
             $plugin_file_name = self::normalizePluginPath($plugin_file_name);
 
             try {
@@ -812,8 +812,8 @@ final class ConfigPluginSet extends PluginV2 implements
                 throw new AssertionError("Plugins must return an instance of the plugin. The plugin at $plugin_file_name does not.");
             }
 
-            if (!($plugin_instance instanceof PluginV2)) {
-                throw new AssertionError("Plugins must extend \Phan\PluginV2. The plugin at $plugin_file_name does not.");
+            if (!($plugin_instance instanceof PluginV3)) {
+                throw new AssertionError("Plugins must extend \Phan\PluginV3. The plugin at $plugin_file_name does not.");
             }
 
             return $plugin_instance;
@@ -883,7 +883,7 @@ final class ConfigPluginSet extends PluginV2 implements
     }
 
     /**
-     * @param array<int,PluginV2> $plugin_set
+     * @param array<int,PluginV3> $plugin_set
      * @return void
      */
     private static function registerIssueFixerClosures(array $plugin_set) : void
@@ -913,7 +913,7 @@ final class ConfigPluginSet extends PluginV2 implements
     }
 
     /**
-     * @param array<int,PluginV2> $plugin_set
+     * @param array<int,PluginV3> $plugin_set
      * @return array<int,Closure(CodeBase,Context,Node,array<int,Node>=):void>
      *         Returned value maps ast\Node->kind to [function(CodeBase $code_base, Context $context, Node $node, array<int,Node> $parent_node_list = []): void]
      */
@@ -1011,7 +1011,7 @@ final class ConfigPluginSet extends PluginV2 implements
     }
 
     /**
-     * @param array<int,PluginV2> $plugin_set
+     * @param array<int,PluginV3> $plugin_set
      * @return array<int,\Closure> - [function(CodeBase $code_base, Context $context, Node $node, array<int,Node> $parent_node_list = []): void]
      */
     private static function filterPostAnalysisPlugins(array $plugin_set) : array
@@ -1117,7 +1117,7 @@ final class ConfigPluginSet extends PluginV2 implements
 
     /**
      * @template T
-     * @param array<int,PluginV2> $plugin_set
+     * @param array<int,PluginV3> $plugin_set
      * @param class-string<T> $interface_name
      * @return array<int,T>
      * @suppress PhanPartialTypeMismatchReturn unable to infer this
@@ -1134,7 +1134,7 @@ final class ConfigPluginSet extends PluginV2 implements
     }
 
     /**
-     * @param PluginV2[] $plugin_set
+     * @param PluginV3[] $plugin_set
      * @return ?UnusedSuppressionPlugin
      */
     private static function findUnusedSuppressionPlugin(array $plugin_set) : ?\UnusedSuppressionPlugin

--- a/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
@@ -19,8 +19,8 @@ use Phan\Language\Type\MixedType;
 use Phan\Language\Type\NullType;
 use Phan\Language\Type\StringType;
 use Phan\Language\UnionType;
-use Phan\PluginV2;
-use Phan\PluginV2\ReturnTypeOverrideCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\ReturnTypeOverrideCapability;
 use function count;
 
 /**
@@ -30,7 +30,7 @@ use function count;
  *
  * @phan-file-suppress PhanUnusedClosureParameter
  */
-final class ArrayReturnTypeOverridePlugin extends PluginV2 implements
+final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
     ReturnTypeOverrideCapability
 {
 

--- a/src/Phan/Plugin/Internal/BuiltinSuppressionPlugin.php
+++ b/src/Phan/Plugin/Internal/BuiltinSuppressionPlugin.php
@@ -13,8 +13,8 @@ use Phan\Language\FQSEN;
 use Phan\Language\Type;
 use Phan\Language\UnionType;
 use Phan\Library\FileCache;
-use Phan\PluginV2;
-use Phan\PluginV2\SuppressionCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\SuppressionCapability;
 use Phan\Suggestion;
 
 /**
@@ -22,7 +22,7 @@ use Phan\Suggestion;
  *
  * NOTE: This is automatically loaded by phan. Do not include it in a config.
  */
-final class BuiltinSuppressionPlugin extends PluginV2 implements
+final class BuiltinSuppressionPlugin extends PluginV3 implements
     SuppressionCapability
 {
     /**

--- a/src/Phan/Plugin/Internal/CallableParamPlugin.php
+++ b/src/Phan/Plugin/Internal/CallableParamPlugin.php
@@ -14,9 +14,9 @@ use Phan\Language\Type;
 use Phan\Language\Type\CallableInterface;
 use Phan\Language\Type\ClassStringType;
 use Phan\Plugin\ConfigPluginSet;
-use Phan\PluginV2;
-use Phan\PluginV2\AnalyzeFunctionCallCapability;
-use Phan\PluginV2\HandleLazyLoadInternalFunctionCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\AnalyzeFunctionCallCapability;
+use Phan\PluginV3\HandleLazyLoadInternalFunctionCapability;
 use function count;
 
 /**
@@ -25,7 +25,7 @@ use function count;
  * TODO: Analyze returning callables (function() : callable) for any callables that are returned as literals?
  * This would be difficult.
  */
-final class CallableParamPlugin extends PluginV2 implements
+final class CallableParamPlugin extends PluginV3 implements
     AnalyzeFunctionCallCapability,
     HandleLazyLoadInternalFunctionCapability
 {

--- a/src/Phan/Plugin/Internal/ClosureReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ClosureReturnTypeOverridePlugin.php
@@ -16,16 +16,16 @@ use Phan\Language\Element\Method;
 use Phan\Language\Type;
 use Phan\Language\Type\ClosureType;
 use Phan\Language\UnionType;
-use Phan\PluginV2;
-use Phan\PluginV2\AnalyzeFunctionCallCapability;
-use Phan\PluginV2\ReturnTypeOverrideCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\AnalyzeFunctionCallCapability;
+use Phan\PluginV3\ReturnTypeOverrideCapability;
 
 /**
  * NOTE: This is automatically loaded by phan. Do not include it in a config.
  *
  * TODO: Refactor this.
  */
-final class ClosureReturnTypeOverridePlugin extends PluginV2 implements
+final class ClosureReturnTypeOverridePlugin extends PluginV3 implements
     AnalyzeFunctionCallCapability,
     ReturnTypeOverrideCapability
 {

--- a/src/Phan/Plugin/Internal/CompactPlugin.php
+++ b/src/Phan/Plugin/Internal/CompactPlugin.php
@@ -9,13 +9,13 @@ use Phan\Issue;
 use Phan\IssueFixSuggester;
 use Phan\Language\Context;
 use Phan\Language\Element\Func;
-use Phan\PluginV2;
-use Phan\PluginV2\AnalyzeFunctionCallCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\AnalyzeFunctionCallCapability;
 
 /**
  * NOTE: This is automatically loaded by phan. Do not include it in a config.
  */
-final class CompactPlugin extends PluginV2 implements
+final class CompactPlugin extends PluginV3 implements
     AnalyzeFunctionCallCapability
 {
 

--- a/src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php
@@ -17,8 +17,8 @@ use Phan\Language\Type\StringType;
 use Phan\Language\Type\TrueType;
 use Phan\Language\Type\VoidType;
 use Phan\Language\UnionType;
-use Phan\PluginV2;
-use Phan\PluginV2\ReturnTypeOverrideCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\ReturnTypeOverrideCapability;
 
 use function count;
 use function is_int;
@@ -32,7 +32,7 @@ use function is_string;
  *
  * e.g. explode($var, ':') or strpos(':', $x)
  */
-final class DependentReturnTypeOverridePlugin extends PluginV2 implements
+final class DependentReturnTypeOverridePlugin extends PluginV3 implements
     ReturnTypeOverrideCapability
 {
     /**

--- a/src/Phan/Plugin/Internal/DumpPHPDocPlugin.php
+++ b/src/Phan/Plugin/Internal/DumpPHPDocPlugin.php
@@ -10,19 +10,19 @@ use Phan\Language\Element\MarkupDescription;
 use Phan\Language\Element\Method;
 use Phan\Language\Element\Property;
 use Phan\Phan;
-use Phan\PluginV2;
-use Phan\PluginV2\AnalyzeClassCapability;
-use Phan\PluginV2\AnalyzeFunctionCapability;
-use Phan\PluginV2\AnalyzeMethodCapability;
-use Phan\PluginV2\AnalyzePropertyCapability;
-use Phan\PluginV2\FinalizeProcessCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\AnalyzeClassCapability;
+use Phan\PluginV3\AnalyzeFunctionCapability;
+use Phan\PluginV3\AnalyzeMethodCapability;
+use Phan\PluginV3\AnalyzePropertyCapability;
+use Phan\PluginV3\FinalizeProcessCapability;
 
 /**
  * This file dumps Phan's inferred signatures and markup descriptions as markdown.
  *
  * NOTE: This is automatically loaded by phan. Do not include it in a config.
  */
-final class DumpPHPDocPlugin extends PluginV2 implements
+final class DumpPHPDocPlugin extends PluginV3 implements
     AnalyzeClassCapability,
     AnalyzeFunctionCapability,
     AnalyzeMethodCapability,

--- a/src/Phan/Plugin/Internal/ExtendedDependentReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ExtendedDependentReturnTypeOverridePlugin.php
@@ -14,8 +14,8 @@ use Phan\Language\Type\IntType;
 use Phan\Language\Type\MixedType;
 use Phan\Language\Type\StringType;
 use Phan\Language\UnionType;
-use Phan\PluginV2;
-use Phan\PluginV2\ReturnTypeOverrideCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\ReturnTypeOverrideCapability;
 use Throwable;
 
 use function count;
@@ -26,7 +26,7 @@ use function count;
  * This internal plugin will aggressively infer return types
  * for certain methods if all arguments are known literal values (e.g. str_replace, implode)
  */
-final class ExtendedDependentReturnTypeOverridePlugin extends PluginV2 implements
+final class ExtendedDependentReturnTypeOverridePlugin extends PluginV3 implements
     ReturnTypeOverrideCapability
 {
     /**

--- a/src/Phan/Plugin/Internal/IssueFixingPlugin.php
+++ b/src/Phan/Plugin/Internal/IssueFixingPlugin.php
@@ -6,14 +6,14 @@ use Error;
 use Phan\CodeBase;
 use Phan\Phan;
 use Phan\Plugin\Internal\IssueFixingPlugin\IssueFixer;
-use Phan\PluginV2;
-use Phan\PluginV2\FinalizeProcessCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\FinalizeProcessCapability;
 
 /**
  * This plugin fixes a small number of issues automatically.
  * This uses heuristics to guess where the fix should be applied.
  */
-class IssueFixingPlugin extends PluginV2 implements
+class IssueFixingPlugin extends PluginV3 implements
     FinalizeProcessCapability
 {
     /**

--- a/src/Phan/Plugin/Internal/MethodSearcherPlugin.php
+++ b/src/Phan/Plugin/Internal/MethodSearcherPlugin.php
@@ -12,8 +12,8 @@ use Phan\Language\Type;
 use Phan\Language\Type\GenericArrayType;
 use Phan\Language\Type\MixedType;
 use Phan\Language\UnionType;
-use Phan\PluginV2;
-use Phan\PluginV2\BeforeAnalyzeCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\BeforeAnalyzeCapability;
 use TypeError;
 use function count;
 
@@ -24,7 +24,7 @@ use function count;
  *
  * @internal
  */
-final class MethodSearcherPlugin extends PluginV2 implements
+final class MethodSearcherPlugin extends PluginV3 implements
     BeforeAnalyzeCapability
 {
     /** @var array<int,UnionType> the param type we're looking for. */

--- a/src/Phan/Plugin/Internal/MiscParamPlugin.php
+++ b/src/Phan/Plugin/Internal/MiscParamPlugin.php
@@ -26,9 +26,9 @@ use Phan\Language\Type\GenericArrayType;
 use Phan\Language\Type\StringType;
 use Phan\Language\UnionType;
 use Phan\Parse\ParseVisitor;
-use Phan\PluginV2;
-use Phan\PluginV2\AnalyzeFunctionCallCapability;
-use Phan\PluginV2\StopParamAnalysisException;
+use Phan\PluginV3;
+use Phan\PluginV3\AnalyzeFunctionCallCapability;
+use Phan\PluginV3\StopParamAnalysisException;
 use function count;
 
 /**
@@ -37,7 +37,7 @@ use function count;
  * TODO: Analyze returning callables (function() : callable) for any callables that are returned as literals?
  * This would be difficult.
  */
-final class MiscParamPlugin extends PluginV2 implements
+final class MiscParamPlugin extends PluginV3 implements
     AnalyzeFunctionCallCapability
 {
     /**

--- a/src/Phan/Plugin/Internal/NodeSelectionPlugin.php
+++ b/src/Phan/Plugin/Internal/NodeSelectionPlugin.php
@@ -5,14 +5,14 @@ namespace Phan\Plugin\Internal;
 use ast\Node;
 use Closure;
 use Phan\Language\Context;
-use Phan\PluginV2;
-use Phan\PluginV2\PluginAwarePostAnalysisVisitor;
-use Phan\PluginV2\PostAnalyzeNodeCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\PluginAwarePostAnalysisVisitor;
+use Phan\PluginV3\PostAnalyzeNodeCapability;
 
 /**
  * This plugin checks for the definition of a region selected by a user.
  */
-class NodeSelectionPlugin extends PluginV2 implements PostAnalyzeNodeCapability
+class NodeSelectionPlugin extends PluginV3 implements PostAnalyzeNodeCapability
 {
     /**
      * @param ?Closure(Context,Node,array<int,Node>):void $closure

--- a/src/Phan/Plugin/Internal/RequireExistsPlugin.php
+++ b/src/Phan/Plugin/Internal/RequireExistsPlugin.php
@@ -11,9 +11,9 @@ use Phan\Config;
 use Phan\Issue;
 use Phan\Language\Type\StringType;
 use Phan\Library\Paths;
-use Phan\PluginV2;
-use Phan\PluginV2\PluginAwarePostAnalysisVisitor;
-use Phan\PluginV2\PostAnalyzeNodeCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\PluginAwarePostAnalysisVisitor;
+use Phan\PluginV3\PostAnalyzeNodeCapability;
 
 use function file_exists;
 use function is_file;
@@ -21,7 +21,7 @@ use function is_file;
 /**
  * Analyzes require/include/require_once/include_once statements to check if the file exists
  */
-class RequireExistsPlugin extends PluginV2 implements PostAnalyzeNodeCapability
+class RequireExistsPlugin extends PluginV3 implements PostAnalyzeNodeCapability
 {
     public static function getPostAnalyzeNodeVisitorClassName() : string
     {

--- a/src/Phan/Plugin/Internal/StringFunctionPlugin.php
+++ b/src/Phan/Plugin/Internal/StringFunctionPlugin.php
@@ -9,8 +9,8 @@ use Phan\CodeBase;
 use Phan\Issue;
 use Phan\Language\Context;
 use Phan\Language\Element\FunctionInterface;
-use Phan\PluginV2;
-use Phan\PluginV2\AnalyzeFunctionCallCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\AnalyzeFunctionCallCapability;
 
 /**
  * NOTE: This is automatically loaded by phan. Do not include it in a config.
@@ -20,7 +20,7 @@ use Phan\PluginV2\AnalyzeFunctionCallCapability;
  *
  * e.g. explode($var, ':') or strpos(':', $x)
  */
-final class StringFunctionPlugin extends PluginV2 implements
+final class StringFunctionPlugin extends PluginV3 implements
     AnalyzeFunctionCallCapability
 {
     /**

--- a/src/Phan/Plugin/Internal/ThrowAnalyzerPlugin.php
+++ b/src/Phan/Plugin/Internal/ThrowAnalyzerPlugin.php
@@ -15,14 +15,14 @@ use Phan\Language\Context;
 use Phan\Language\Element\FunctionInterface;
 use Phan\Language\Type;
 use Phan\Language\UnionType;
-use Phan\PluginV2;
-use Phan\PluginV2\PluginAwarePostAnalysisVisitor;
-use Phan\PluginV2\PostAnalyzeNodeCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\PluginAwarePostAnalysisVisitor;
+use Phan\PluginV3\PostAnalyzeNodeCapability;
 
 /**
  * Analyzes throw statements and compares them against the phpdoc (at)throws annotations
  */
-class ThrowAnalyzerPlugin extends PluginV2 implements PostAnalyzeNodeCapability
+class ThrowAnalyzerPlugin extends PluginV3 implements PostAnalyzeNodeCapability
 {
     /**
      * This is invalidated every time this plugin is loaded (e.g. for tests)

--- a/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
+++ b/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
@@ -15,9 +15,9 @@ use Phan\Language\Element\Variable;
 use Phan\Plugin\Internal\VariableTracker\VariableGraph;
 use Phan\Plugin\Internal\VariableTracker\VariableTrackerVisitor;
 use Phan\Plugin\Internal\VariableTracker\VariableTrackingScope;
-use Phan\PluginV2;
-use Phan\PluginV2\PluginAwarePostAnalysisVisitor;
-use Phan\PluginV2\PostAnalyzeNodeCapability;
+use Phan\PluginV3;
+use Phan\PluginV3\PluginAwarePostAnalysisVisitor;
+use Phan\PluginV3\PostAnalyzeNodeCapability;
 use Phan\Suggestion;
 use function count;
 use function is_string;
@@ -27,7 +27,7 @@ use function strlen;
  * NOTE: This is automatically loaded by phan based on config settings.
  * Do not include it in the 'plugins' config.
  */
-final class VariableTrackerPlugin extends PluginV2 implements
+final class VariableTrackerPlugin extends PluginV3 implements
     PostAnalyzeNodeCapability
 {
 

--- a/src/Phan/PluginV3.php
+++ b/src/Phan/PluginV3.php
@@ -2,7 +2,7 @@
 
 namespace Phan;
 
-use Phan\PluginV2\IssueEmitter;
+use Phan\PluginV3\IssueEmitter;
 
 /**
  * Plugins can be defined in the config and will have
@@ -19,33 +19,33 @@ use Phan\PluginV2\IssueEmitter;
  *
  *  1. public function analyzeClass(CodeBase $code_base, Clazz $class)
  *     Analyze (and modify) a class definition, after parsing and before analyzing.
- *     (implement \Phan\PluginV2\AnalyzeClassCapability)
+ *     (implement \Phan\PluginV3\AnalyzeClassCapability)
  *
  *  2. public function analyzeFunction(CodeBase $code_base, Func $function)
  *     Analyze (and modify) a function definition, after parsing and before analyzing.
- *     (implement \Phan\PluginV2\AnalyzeFunctionCapability)
+ *     (implement \Phan\PluginV3\AnalyzeFunctionCapability)
  *
  *  3. public function analyzeMethod(CodeBase $code_base, Method $method)
  *     Analyze (and modify) a method definition, after parsing and before analyzing.
- *     (implement \Phan\PluginV2\AnalyzeMethodCapability)
+ *     (implement \Phan\PluginV3\AnalyzeMethodCapability)
  *
  *  4. public static function getPostAnalyzeNodeVisitorClassName() : string
  *     Returns the name of a class extending PluginAwarePostAnalysisVisitor, which will be used to analyze nodes in the analysis phase.
  *     If the PluginAwarePostAnalysisVisitor subclass has an instance property called parent_node_list,
  *     Phan will automatically set that property to the list of parent nodes (The nodes deepest in the AST are at the end of the list)
- *     (implement \Phan\PluginV2\PostAnalyzeNodeCapability)
+ *     (implement \Phan\PluginV3\PostAnalyzeNodeCapability)
  *
  *  5. public static function getPreAnalyzeNodeVisitorClassName() : string
  *     Returns the name of a class extending PluginAwarePreAnalysisVisitor, which will be used to pre-analyze nodes in the analysis phase.
- *     (implement \Phan\PluginV2\PreAnalyzeNodeCapability)
+ *     (implement \Phan\PluginV3\PreAnalyzeNodeCapability)
  *
  *  6. public function analyzeProperty(CodeBase $code_base, Property $property)
  *     Analyze (and modify) a property definition, after parsing and before analyzing.
- *     (implement \Phan\PluginV2\AnalyzePropertyCapability)
+ *     (implement \Phan\PluginV3\AnalyzePropertyCapability)
  *
  *  7. public function finalize(CodeBase $code_base)
  *     Called after the analysis phase is complete.
- *     (implement \Phan\PluginV2\FinalizeProcessCapability)
+ *     (implement \Phan\PluginV3\FinalizeProcessCapability)
  *
  *  8. public function getAnalyzeFunctionCallClosures(CodeBase $code_base) : array<string, Closure(CodeBase,Context,Func|Method,array):void>
  *     Maps FQSEN of function or method to a closure used to analyze the function in question.
@@ -54,13 +54,13 @@ use Phan\PluginV2\IssueEmitter;
  *
  *      Closure Type: function(CodeBase $code_base, Context $context, Func|Method $function, array $args) : void {...}
  *
- *      (implement \Phan\PluginV2\AnalyzeFunctionCallCapability)
+ *      (implement \Phan\PluginV3\AnalyzeFunctionCallCapability)
  *  9. public function getReturnTypeOverrides(CodeBase $code_base) : array<string,Closure(CodeBase,Context,Func|Method,array):UnionType>
  *     Maps FQSEN of function or method to a closure used to override the returned UnionType.
  *     See \Phan\Plugin\Internal\ArrayReturnTypeOverridePlugin as an example (That is automatically loaded by phan)
  *
  *     Closure type: function(CodeBase $code_base, Context $context, Func|Method $function, array $args) : UnionType {...}
- *      (implement \Phan\PluginV2\ReturnTypeOverrideCapability)
+ *      (implement \Phan\PluginV3\ReturnTypeOverrideCapability)
  * 10. public function shouldSuppress(CodeBase $code_base, IssueInstance $instance, string $file_contents) : bool
  *
  *     Called in every phase when Phan is emitting an issue(parse, method, analysis, etc)
@@ -69,13 +69,13 @@ use Phan\PluginV2\IssueEmitter;
  *
  *     Called by UnusedSuppressionPlugin to check if the plugin's suppressions are no longer needed.
  *
- *     (implement \Phan\PluginV2\SuppressionCapability)
+ *     (implement \Phan\PluginV3\SuppressionCapability)
  * 11. public function beforeAnalyze(CodeBase $code_base) : void
  *
  *     Called before analyzing a project (e.g. to run checks before analysis)
  *     beforeAnalyze is invoked immediately before analyzing methods and before forking analysis workers and before starting the analysis phase.
  *
- *     (implement \Phan\PluginV2\BeforeAnalyzeCapability)
+ *     (implement \Phan\PluginV3\BeforeAnalyzeCapability)
  *
  *     Most plugins should use BeforeAnalyzePhaseCapability instead.
  * 12. public function beforeAnalyzeFile(CodeBase $code_base, Context $context, string $file_contents, Node $node);
@@ -83,36 +83,36 @@ use Phan\PluginV2\IssueEmitter;
  *     Called before analyzing a file (with the absolute path Config::projectPath($context->getFile())).
  *     NOTE: This does not run on empty files.
  *
- *     (implement \Phan\PluginV2\BeforeAnalyzeFileCapability)
+ *     (implement \Phan\PluginV3\BeforeAnalyzeFileCapability)
  * 13. public function afterAnalyzeFile(CodeBase $code_base, Context $context, string $file_contents, Node $node);
  *
  *     This method is called after Phan analyzes a file.
  *
- *     (implement \Phan\PluginV2\AfterAnalyzeFileCapability)
+ *     (implement \Phan\PluginV3\AfterAnalyzeFileCapability)
  * 14. public function handleLazyLoadInternalFunction(CodeBase $code_base, Func $function)
  *
  *     This method is called after Phan lazily loads a global internal function.
  *     This is useful to handle functions getAnalyzeFunctionCallClosures did not pick up
  *
- *     (implement \Phan\PluginV2\HandleLazyLoadInternalFunctionCapability)
+ *     (implement \Phan\PluginV3\HandleLazyLoadInternalFunctionCapability)
  * 15. getAutomaticFixers() : array<string,Closure(CodeBase,FileCacheEntry,IssueInstance):(?FileEditSet)>
  *
  *     This method is called to fetch the issue names the plugin can sometimes automatically fix.
  *     Returns a map from issue name to the closure to generate a fix for instances of that issue.
  *
- *     (implement \Phan\PluginV2\AutomaticFixCapability)
+ *     (implement \Phan\PluginV3\AutomaticFixCapability)
  * 16. public function beforeAnalyzePhase(CodeBase $code_base) : void
  *
  *     Called before analyzing a project (e.g. to run checks before analysis)
  *     beforeAnalyze is invoked immediately after analyzing methods and before forking analysis workers and before starting the analysis phase.
  *
- *     (implement \Phan\PluginV2\BeforeAnalyzePhaseCapability)
+ *     (implement \Phan\PluginV3\BeforeAnalyzePhaseCapability)
  *
  * TODO: Implement a way to notify plugins that a parsed file is no longer valid,
  * if the replacement for pcntl is being used.
  * (Most of the plugins bundled with Phan don't need this)
  */
-abstract class PluginV2
+abstract class PluginV3
 {
     use IssueEmitter {
         emitPluginIssue as emitIssue;

--- a/src/Phan/PluginV3/AfterAnalyzeFileCapability.php
+++ b/src/Phan/PluginV3/AfterAnalyzeFileCapability.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Phan\PluginV2;
+namespace Phan\PluginV3;
 
 use ast\Node;
 use Phan\CodeBase;

--- a/src/Phan/PluginV3/AnalyzeClassCapability.php
+++ b/src/Phan/PluginV3/AnalyzeClassCapability.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Phan\PluginV2;
+namespace Phan\PluginV3;
 
 use Phan\CodeBase;
 use Phan\Language\Element\Clazz;

--- a/src/Phan/PluginV3/AnalyzeFunctionCallCapability.php
+++ b/src/Phan/PluginV3/AnalyzeFunctionCallCapability.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Phan\PluginV2;
+namespace Phan\PluginV3;
 
 use Phan\CodeBase;
 

--- a/src/Phan/PluginV3/AnalyzeFunctionCapability.php
+++ b/src/Phan/PluginV3/AnalyzeFunctionCapability.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Phan\PluginV2;
+namespace Phan\PluginV3;
 
 use Phan\CodeBase;
 use Phan\Language\Element\Func;

--- a/src/Phan/PluginV3/AnalyzeMethodCapability.php
+++ b/src/Phan/PluginV3/AnalyzeMethodCapability.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Phan\PluginV2;
+namespace Phan\PluginV3;
 
 use Phan\CodeBase;
 use Phan\Language\Element\Method;

--- a/src/Phan/PluginV3/AnalyzePropertyCapability.php
+++ b/src/Phan/PluginV3/AnalyzePropertyCapability.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Phan\PluginV2;
+namespace Phan\PluginV3;
 
 use Phan\CodeBase;
 use Phan\Language\Element\Property;

--- a/src/Phan/PluginV3/AutomaticFixCapability.php
+++ b/src/Phan/PluginV3/AutomaticFixCapability.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Phan\PluginV2;
+namespace Phan\PluginV3;
 
 use Closure;
 use Phan\CodeBase;

--- a/src/Phan/PluginV3/BeforeAnalyzeCapability.php
+++ b/src/Phan/PluginV3/BeforeAnalyzeCapability.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Phan\PluginV2;
+namespace Phan\PluginV3;
 
 use Phan\CodeBase;
 

--- a/src/Phan/PluginV3/BeforeAnalyzeFileCapability.php
+++ b/src/Phan/PluginV3/BeforeAnalyzeFileCapability.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Phan\PluginV2;
+namespace Phan\PluginV3;
 
 use ast\Node;
 use Phan\CodeBase;

--- a/src/Phan/PluginV3/BeforeAnalyzePhaseCapability.php
+++ b/src/Phan/PluginV3/BeforeAnalyzePhaseCapability.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Phan\PluginV2;
+namespace Phan\PluginV3;
 
 use Phan\CodeBase;
 

--- a/src/Phan/PluginV3/FinalizeProcessCapability.php
+++ b/src/Phan/PluginV3/FinalizeProcessCapability.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Phan\PluginV2;
+namespace Phan\PluginV3;
 
 use Phan\CodeBase;
 
@@ -11,7 +11,7 @@ interface FinalizeProcessCapability
 {
     /**
      * This is called after the other forms of analysis are finished running.
-     * Useful if a PluginV2 needs to aggregate results of analysis.
+     * Useful if a PluginV3 needs to aggregate results of analysis.
      * This may be used to emit additional issues.
      *
      * This is run once per forked analysis process.

--- a/src/Phan/PluginV3/HandleLazyLoadInternalFunctionCapability.php
+++ b/src/Phan/PluginV3/HandleLazyLoadInternalFunctionCapability.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Phan\PluginV2;
+namespace Phan\PluginV3;
 
 use Phan\CodeBase;
 use Phan\Language\Element\Func;

--- a/src/Phan/PluginV3/IssueEmitter.php
+++ b/src/Phan/PluginV3/IssueEmitter.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Phan\PluginV2;
+namespace Phan\PluginV3;
 
 use Phan\CodeBase;
 use Phan\Issue;

--- a/src/Phan/PluginV3/PluginAwareBaseAnalysisVisitor.php
+++ b/src/Phan/PluginV3/PluginAwareBaseAnalysisVisitor.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Phan\PluginV2;
+namespace Phan\PluginV3;
 
 use ast\Node;
 use Phan\AST\AnalysisVisitor;

--- a/src/Phan/PluginV3/PluginAwarePostAnalysisVisitor.php
+++ b/src/Phan/PluginV3/PluginAwarePostAnalysisVisitor.php
@@ -1,12 +1,12 @@
 <?php declare(strict_types=1);
 
-namespace Phan\PluginV2;
+namespace Phan\PluginV3;
+
+// use ast\Node;
 
 /**
- * For plugins which define their own pre-order analysis behaviors in the analysis phase.
- * Called on a node before PluginAwarePreAnalysisVisitor implementations.
- *
- * Public APIs for use by plugins:
+ * For plugins which define their own post-order analysis behaviors in the analysis phase.
+ * Called on a node after PluginAwarePreAnalysisVisitor implementations.
  *
  * - visit<VisitSuffix>(...) (Override these methods)
  * - emitPluginIssue(CodeBase $code_base, Config $config, ...) (Call these methods)
@@ -19,7 +19,7 @@ namespace Phan\PluginV2;
  * - Phan is able to figure out which methods a subclass implements, and only call the plugin's visitor for those types,
  *   but only when the plugin's visitor does not override the fallback visit() method.
  */
-abstract class PluginAwarePreAnalysisVisitor extends PluginAwareBaseAnalysisVisitor
+abstract class PluginAwarePostAnalysisVisitor extends PluginAwareBaseAnalysisVisitor
 {
     // Subclasses should declare protected $parent_node_list as an instance property if they need to know the list.
 

--- a/src/Phan/PluginV3/PluginAwarePreAnalysisVisitor.php
+++ b/src/Phan/PluginV3/PluginAwarePreAnalysisVisitor.php
@@ -1,12 +1,12 @@
 <?php declare(strict_types=1);
 
-namespace Phan\PluginV2;
-
-// use ast\Node;
+namespace Phan\PluginV3;
 
 /**
- * For plugins which define their own post-order analysis behaviors in the analysis phase.
- * Called on a node after PluginAwarePreAnalysisVisitor implementations.
+ * For plugins which define their own pre-order analysis behaviors in the analysis phase.
+ * Called on a node before PluginAwarePreAnalysisVisitor implementations.
+ *
+ * Public APIs for use by plugins:
  *
  * - visit<VisitSuffix>(...) (Override these methods)
  * - emitPluginIssue(CodeBase $code_base, Config $config, ...) (Call these methods)
@@ -19,7 +19,7 @@ namespace Phan\PluginV2;
  * - Phan is able to figure out which methods a subclass implements, and only call the plugin's visitor for those types,
  *   but only when the plugin's visitor does not override the fallback visit() method.
  */
-abstract class PluginAwarePostAnalysisVisitor extends PluginAwareBaseAnalysisVisitor
+abstract class PluginAwarePreAnalysisVisitor extends PluginAwareBaseAnalysisVisitor
 {
     // Subclasses should declare protected $parent_node_list as an instance property if they need to know the list.
 

--- a/src/Phan/PluginV3/PostAnalyzeNodeCapability.php
+++ b/src/Phan/PluginV3/PostAnalyzeNodeCapability.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Phan\PluginV2;
+namespace Phan\PluginV3;
 
 /**
  * Plugins can implement this to have their visitor run to analyze a node in the analysis phase

--- a/src/Phan/PluginV3/PreAnalyzeNodeCapability.php
+++ b/src/Phan/PluginV3/PreAnalyzeNodeCapability.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Phan\PluginV2;
+namespace Phan\PluginV3;
 
 /**
  * Plugins can implement this to specify a visitor to pre-analyze a node in the analysis phase.

--- a/src/Phan/PluginV3/ReturnTypeOverrideCapability.php
+++ b/src/Phan/PluginV3/ReturnTypeOverrideCapability.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Phan\PluginV2;
+namespace Phan\PluginV3;
 
 use Phan\CodeBase;
 

--- a/src/Phan/PluginV3/StopParamAnalysisException.php
+++ b/src/Phan/PluginV3/StopParamAnalysisException.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Phan\PluginV2;
+namespace Phan\PluginV3;
 
 use Exception;
 

--- a/src/Phan/PluginV3/SuppressionCapability.php
+++ b/src/Phan/PluginV3/SuppressionCapability.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Phan\PluginV2;
+namespace Phan\PluginV3;
 
 use Phan\CodeBase;
 use Phan\Language\Context;

--- a/src/Phan/README.md
+++ b/src/Phan/README.md
@@ -73,10 +73,10 @@ In the parse phase, all code is parsed in order to build maps from FQSENs to ele
 This contains implementation details for working with the set of plugins loaded by the user (ConfigPluginSet).
 `Plugin/Internal` also contains plugins Phan loads automatically (e.g. for improving analysis of `array_map`, `call_user_func`, etc.)
 
-### PluginV2
+### PluginV3
 
-This contains the current implementation (v2) of the plugin system.
-`*Capability.php` contains capabilities that PluginV2 instances can extend.
+This contains the current implementation (v3) of the plugin system.
+`*Capability.php` contains capabilities that PluginV3 instances can extend.
 See https://github.com/phan/phan/wiki/Writing-Plugins-for-Phan for more information on plugin development.
 
 Files
@@ -156,12 +156,20 @@ Implementations such as `./phan` or the code climate integration call into this.
 
 ### Plugin.php
 
-Deprecated version of plugin system, use PluginV2 instead.
+Deprecated version of plugin system, use PluginV3 instead.
 
 ### PluginV2.php
 
+TODO: Reintroduce PluginV2 and its capabilities to Phan 2.0 in terms of PluginV3 to make migration easier.
+
+This is deprecated, and should only be used if the plugin needs to continue to support Phan 1.x.
+
+### PluginV3.php
+
+Introduced in Phan 2.0
+
 Plugins must extend this class
-(And at least one of the interfaces corresponding to plugin capabilities in PluginV2 folder)
+(And at least one of the interfaces corresponding to plugin capabilities in PluginV3 folder)
 and return an instance of themselves.
 
 ### Prep.php

--- a/tests/Phan/PluginV2Test.php
+++ b/tests/Phan/PluginV2Test.php
@@ -2,23 +2,23 @@
 
 namespace Phan\Tests;
 
-use Phan\PluginV2;
+use Phan\PluginV3;
 use ReflectionClass;
 
 /**
- * Unit tests of PluginV2's documentation
+ * Unit tests of PluginV3's documentation
  *
  * @phan-file-suppress PhanAccessMethodInternal
  */
-final class PluginV2Test extends BaseTest
+final class PluginV3Test extends BaseTest
 {
     public function testDocumentation() : void
     {
-        $comment = (new ReflectionClass(PluginV2::class))->getDocComment();
+        $comment = (new ReflectionClass(PluginV3::class))->getDocComment();
         $this->assertIsString($comment);
 
         $capabilities = [];
-        foreach (\scandir(\dirname(__DIR__, 2) . '/src/Phan/PluginV2') as $file) {
+        foreach (\scandir(\dirname(__DIR__, 2) . '/src/Phan/PluginV3') as $file) {
             if (!\preg_match('/^(\w+Capability)\.php$/', $file, $matches)) {
                 continue;
             }
@@ -31,6 +31,6 @@ final class PluginV2Test extends BaseTest
                 $missing_capabilities[] = $capability;
             }
         }
-        $this->assertSame([], $missing_capabilities, 'should document all PluginV2 capabilities');
+        $this->assertSame([], $missing_capabilities, 'should document all PluginV3 capabilities');
     }
 }


### PR DESCRIPTION
PluginV3 should be used for code that only supports
AST version 70 and Phan 2.x.

Phan 2.0 will include various refactorings and renamings,
so many PluginV2 versions would work, but others wouldn't.

Also, PluginV3 starts using nullable types

A PluginV2 compatibility layer will probably be reintroduced before 2.0
is out.

Also, remove some redundant checks.