### PR TITLE
v2: Replace getIsFoo()/getHasFoo() with isFoo()/hasFoo()

### DIFF
--- a/.phan/plugins/AlwaysReturnPlugin.php
+++ b/.phan/plugins/AlwaysReturnPlugin.php
@@ -130,7 +130,7 @@ final class AlwaysReturnPlugin extends PluginV3 implements
     {
         if (!$func->hasNode()) {
             return null;
-        } elseif ($func->getHasYield()) {
+        } elseif ($func->hasYield()) {
             // generators always return Generator.
             return null;
         }

--- a/.phan/plugins/FFIAnalysisPlugin.php
+++ b/.phan/plugins/FFIAnalysisPlugin.php
@@ -99,7 +99,7 @@ class FFIPreAnalysisVisitor extends PluginAwarePreAnalysisVisitor
             if (strcasecmp('CData', $type->getName()) !== 0) {
                 continue;
             }
-            if ($type->getIsNullable()) {
+            if ($type->isNullable()) {
                 return self::PARTIALLY_FFI_CDATA;
             }
             if ($union_type->typeCount() > 1) {

--- a/.phan/plugins/HasPHPDocPlugin.php
+++ b/.phan/plugins/HasPHPDocPlugin.php
@@ -79,6 +79,9 @@ final class HasPHPDocPlugin extends PluginV3 implements
         }
         $description = MarkupDescription::extractDescriptionFromDocComment($class);
         if (!$description) {
+            if (strpos($doc_comment, '@deprecated') !== false) {
+                return;
+            }
             self::emitIssue(
                 $code_base,
                 $class->getContext(),
@@ -163,7 +166,7 @@ final class HasPHPDocPlugin extends PluginV3 implements
             // Phan does not track descriptions of (at)method.
             return;
         }
-        if ($method->getIsMagic()) {
+        if ($method->isMagic()) {
             // Don't require a description for `__construct()`, `__sleep()`, etc.
             return;
         }
@@ -172,7 +175,7 @@ final class HasPHPDocPlugin extends PluginV3 implements
             // Don't warn about subclasses inheriting this method.
             return;
         }
-        if ($method->getIsOverride()) {
+        if ($method->isOverride()) {
             // Note: This deliberately avoids requiring a summary for methods that are just overrides of other methods
             // This reduces the number of false positives
             return;

--- a/.phan/plugins/PHPDocRedundantPlugin.php
+++ b/.phan/plugins/PHPDocRedundantPlugin.php
@@ -42,7 +42,7 @@ class PHPDocRedundantPlugin extends PluginV3 implements
 
     public function analyzeMethod(CodeBase $code_base, Method $method) : void
     {
-        if ($method->getIsMagic() || $method->isPHPInternal()) {
+        if ($method->isMagic() || $method->isPHPInternal()) {
             return;
         }
         if ($method->getFQSEN() !== $method->getDefiningFQSEN()) {

--- a/.phan/plugins/PHPDocToRealTypesPlugin.php
+++ b/.phan/plugins/PHPDocToRealTypesPlugin.php
@@ -59,7 +59,7 @@ class PHPDocToRealTypesPlugin extends PluginV3 implements
 
     public function analyzeMethod(CodeBase $unused_code_base, Method $method) : void
     {
-        if ($method->isFromPHPDoc() || $method->getIsMagic() || $method->isPHPInternal()) {
+        if ($method->isFromPHPDoc() || $method->isMagic() || $method->isPHPInternal()) {
             return;
         }
         if ($method->getFQSEN() !== $method->getDefiningFQSEN()) {
@@ -72,7 +72,7 @@ class PHPDocToRealTypesPlugin extends PluginV3 implements
     {
         $ignore_overrides = (bool)getenv('PHPDOC_TO_REAL_TYPES_IGNORE_INHERITANCE');
         foreach ($this->deferred_analysis_methods as $method) {
-            if ($method->getIsOverride() || $method->getIsOverriddenByAnother()) {
+            if ($method->isOverride() || $method->isOverriddenByAnother()) {
                 if (!$ignore_overrides) {
                     continue;
                 }
@@ -106,7 +106,7 @@ class PHPDocToRealTypesPlugin extends PluginV3 implements
             self::emitIssue(
                 $code_base,
                 $method->getContext(),
-                $type->getIsNullable() ? self::CanUseNullableParamType : self::CanUseParamType,
+                $type->isNullable() ? self::CanUseNullableParamType : self::CanUseParamType,
                 'Can use {TYPE} as a return type of parameter ${PARAMETER} of {METHOD}',
                 [$type->asSignatureType(), $parameter->getName(), $method->getName()]
             );
@@ -138,7 +138,7 @@ class PHPDocToRealTypesPlugin extends PluginV3 implements
         self::emitIssue(
             $code_base,
             $method->getContext(),
-            $type->getIsNullable() ? self::CanUseNullableReturnType : self::CanUseReturnType,
+            $type->isNullable() ? self::CanUseNullableReturnType : self::CanUseReturnType,
             'Can use {TYPE} as a return type of {METHOD}',
             [$type->asSignatureType(), $method->getName()]
         );

--- a/.phan/plugins/PhanSelfCheckPlugin.php
+++ b/.phan/plugins/PhanSelfCheckPlugin.php
@@ -259,7 +259,7 @@ class PhanSelfCheckPlugin extends PluginV3 implements AnalyzeFunctionCallCapabil
         }
         $field_types = $array_shape_type->getFieldTypes();
         foreach ($field_types as $field_type) {
-            if ($field_type->getIsPossiblyUndefined()) {
+            if ($field_type->isPossiblyUndefined()) {
                 return null;
             }
         }

--- a/.phan/plugins/PossiblyStaticMethodPlugin.php
+++ b/.phan/plugins/PossiblyStaticMethodPlugin.php
@@ -57,11 +57,11 @@ final class PossiblyStaticMethodPlugin extends PluginV3 implements
         CodeBase $code_base,
         Method $method
     ) : void {
-        if ($method->getIsOverride()) {
+        if ($method->isOverride()) {
             // This method can't be static unless its parent is also static.
             return;
         }
-        if ($method->getIsOverriddenByAnother()) {
+        if ($method->isOverriddenByAnother()) {
             // Changing this method causes a fatal error.
             return;
         }
@@ -205,7 +205,7 @@ final class PossiblyStaticMethodPlugin extends PluginV3 implements
             // This is what we want.
             return;
         }
-        if ($method->getIsMagic()) {
+        if ($method->isMagic()) {
             // Magic methods can't be static.
             return;
         }

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -1402,7 +1402,7 @@ class ContextNode
         if (!$is_static) {
             foreach ($class_list as $class) {
                 if (Config::getValue('allow_missing_properties')
-                    || $class->getHasDynamicProperties($this->code_base)
+                    || $class->hasDynamicProperties($this->code_base)
                 ) {
                     return $class->getPropertyByNameInContext(
                         $this->code_base,

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1420,7 +1420,7 @@ class UnionTypeVisitor extends AnalysisVisitor
     private static function isSuspiciousNullable(UnionType $union_type) : bool
     {
         foreach ($union_type->getTypeSet() as $type) {
-            if ($type->getIsNullable() && ($type instanceof ArrayType || $type instanceof StringType)) {
+            if ($type->isNullable() && ($type instanceof ArrayType || $type instanceof StringType)) {
                 return true;
             }
         }

--- a/src/Phan/Analysis/ArgumentType.php
+++ b/src/Phan/Analysis/ArgumentType.php
@@ -361,7 +361,7 @@ final class ArgumentType
     ) : void {
         // There's nothing reasonable we can do here
         if ($method instanceof Method) {
-            if ($method->getIsMagicCall() || $method->getIsMagicCallStatic()) {
+            if ($method->isMagicCall() || $method->isMagicCallStatic()) {
                 return;
             }
         }
@@ -424,7 +424,7 @@ final class ArgumentType
     ) : void {
         // There's nothing reasonable we can do here
         if ($method instanceof Method) {
-            if ($method->getIsMagicCall() || $method->getIsMagicCallStatic()) {
+            if ($method->isMagicCall() || $method->isMagicCallStatic()) {
                 return;
             }
         }
@@ -627,7 +627,7 @@ final class ArgumentType
         if ($method->isPHPInternal()) {
             // If we are not in strict mode and we accept a string parameter
             // and the argument we are passing has a __toString method then it is ok
-            if (!$context->getIsStrictTypes() && $parameter_type->hasNonNullStringType()) {
+            if (!$context->isStrictTypes() && $parameter_type->hasNonNullStringType()) {
                 try {
                     foreach ($argument_type_expanded->asClassList($code_base, $context) as $clazz) {
                         if ($clazz->hasMethodWithName($code_base, "__toString")) {
@@ -733,7 +733,7 @@ final class ArgumentType
                 if ($method->isPHPInternal()) {
                     // If we are not in strict mode and we accept a string parameter
                     // and the argument we are passing has a __toString method then it is ok
-                    if (!$context->getIsStrictTypes() && $parameter_type->hasNonNullStringType()) {
+                    if (!$context->isStrictTypes() && $parameter_type->hasNonNullStringType()) {
                         if ($individual_type_expanded->hasClassWithToStringMethod($code_base, $context)) {
                             continue;  // don't warn about $type
                         }

--- a/src/Phan/Analysis/AssignOperatorAnalysisVisitor.php
+++ b/src/Phan/Analysis/AssignOperatorAnalysisVisitor.php
@@ -492,7 +492,7 @@ class AssignOperatorAnalysisVisitor extends FlagVisitorImplementation
         $this->warnAboutInvalidUnionType(
             $node,
             static function (Type $type) : bool {
-                return $type instanceof IntType && !$type->getIsNullable();
+                return $type instanceof IntType && !$type->isNullable();
             },
             $left,
             $right,

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -727,7 +727,7 @@ class AssignmentVisitor extends AnalysisVisitor
         }
 
         // Check if it is a built in class with dynamic properties but (possibly) no __set, such as SimpleXMLElement or stdClass or V8Js
-        $is_class_with_arbitrary_types = isset($class_list[0]) ? $class_list[0]->getHasDynamicProperties($this->code_base) : false;
+        $is_class_with_arbitrary_types = isset($class_list[0]) ? $class_list[0]->hasDynamicProperties($this->code_base) : false;
 
         if ($is_class_with_arbitrary_types || Config::getValue('allow_missing_properties')) {
             try {
@@ -838,7 +838,7 @@ class AssignmentVisitor extends AnalysisVisitor
                 $this->code_base
             )
                 && !($this->right_type->hasTypeInBoolFamily() && $property_union_type->hasTypeInBoolFamily())
-                && !$clazz->getHasDynamicProperties($this->code_base)
+                && !$clazz->hasDynamicProperties($this->code_base)
             ) {
                 if ($this->right_type->nonNullableClone()->canCastToExpandedUnionType($property_union_type, $this->code_base) &&
                         !$this->right_type->isType(NullType::instance(false))) {

--- a/src/Phan/Analysis/ConditionVisitorUtil.php
+++ b/src/Phan/Analysis/ConditionVisitorUtil.php
@@ -150,7 +150,7 @@ trait ConditionVisitorUtil
                 foreach ($union_type->getTypeSet() as $type) {
                     if ($cb($type)) {
                         $union_type = $union_type->withoutType($type);
-                        $has_nullable = $has_nullable || $type->getIsNullable();
+                        $has_nullable = $has_nullable || $type->isNullable();
                     }
                 }
                 if ($has_nullable) {

--- a/src/Phan/Analysis/ContextMergeVisitor.php
+++ b/src/Phan/Analysis/ContextMergeVisitor.php
@@ -348,7 +348,7 @@ class ContextMergeVisitor extends KindVisitorImplementation
             $name = (string)$name;
             // Skip variables that are only partially defined
             if (!$is_defined_on_all_branches($name)) {
-                if ($this->context->getIsStrictTypes()) {
+                if ($this->context->isStrictTypes()) {
                     continue;
                 } else {
                     // Limit the type of the variable to the subset

--- a/src/Phan/Analysis/NegatedConditionVisitor.php
+++ b/src/Phan/Analysis/NegatedConditionVisitor.php
@@ -499,10 +499,10 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
                         // Add types which are not instances of $base_class_name
                         foreach ($union_type->getTypeSet() as $type) {
                             if ($type instanceof $base_class_name) {
-                                $has_null = $has_null || $type->getIsNullable();
+                                $has_null = $has_null || $type->isNullable();
                                 continue;
                             }
-                            $has_other_nullable_types = $has_other_nullable_types || $type->getIsNullable();
+                            $has_other_nullable_types = $has_other_nullable_types || $type->isNullable();
                             $new_type_builder->addType($type);
                         }
                         // Add Null if some of the rejected types were were nullable, and none of the accepted types were nullable
@@ -536,10 +536,10 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
                         // Add types which are not scalars
                         foreach ($union_type->getTypeSet() as $type) {
                             if ($type_filter($type)) {
-                                $has_null = $has_null || $type->getIsNullable();
+                                $has_null = $has_null || $type->isNullable();
                                 continue;
                             }
-                            $has_other_nullable_types = $has_other_nullable_types || $type->getIsNullable();
+                            $has_other_nullable_types = $has_other_nullable_types || $type->isNullable();
                             $new_type_builder->addType($type);
                         }
                         // Add Null if some of the rejected types were were nullable, and none of the accepted types were nullable
@@ -559,7 +559,7 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
             return $type instanceof IntType || $type instanceof FloatType;
         });
         $remove_bool_callback = $remove_conditional_function_callback(static function (Type $type) : bool {
-            return $type->getIsInBoolFamily();
+            return $type->isInBoolFamily();
         });
         $remove_callable_callback = static function (NegatedConditionVisitor $cv, Node $var_node, Context $context) : Context {
             return $cv->updateVariableWithConditionalFilter(
@@ -579,10 +579,10 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
                     // Add types which are not callable
                     foreach ($union_type->getTypeSet() as $type) {
                         if ($type->isCallable()) {
-                            $has_null = $has_null || $type->getIsNullable();
+                            $has_null = $has_null || $type->isNullable();
                             continue;
                         }
-                        $has_other_nullable_types = $has_other_nullable_types || $type->getIsNullable();
+                        $has_other_nullable_types = $has_other_nullable_types || $type->isNullable();
                         $new_type_builder->addType($type);
                     }
                     // Add Null if some of the rejected types were were nullable, and none of the accepted types were nullable
@@ -613,15 +613,15 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
                     // Add types which are not callable
                     foreach ($union_type->getTypeSet() as $type) {
                         if ($type instanceof ArrayType) {
-                            $has_null = $has_null || $type->getIsNullable();
+                            $has_null = $has_null || $type->isNullable();
                             continue;
                         }
 
-                        $has_other_nullable_types = $has_other_nullable_types || $type->getIsNullable();
+                        $has_other_nullable_types = $has_other_nullable_types || $type->isNullable();
 
                         if (\get_class($type) === IterableType::class) {
                             // An iterable that is not an object must be an array
-                            $new_type_builder->addType($traversable_type->withIsNullable($type->getIsNullable()));
+                            $new_type_builder->addType($traversable_type->withIsNullable($type->isNullable()));
                             continue;
                         }
                         $new_type_builder->addType($type);
@@ -651,14 +651,14 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
                     // Add types which are not callable
                     foreach ($union_type->getTypeSet() as $type) {
                         if ($type->isObject()) {
-                            $has_null = $has_null || $type->getIsNullable();
+                            $has_null = $has_null || $type->isNullable();
                             continue;
                         }
-                        $has_other_nullable_types = $has_other_nullable_types || $type->getIsNullable();
+                        $has_other_nullable_types = $has_other_nullable_types || $type->isNullable();
 
                         if (\get_class($type) === IterableType::class) {
                             // An iterable that is not an array must be a Traversable
-                            $new_type_builder->addType(ArrayType::instance($type->getIsNullable()));
+                            $new_type_builder->addType(ArrayType::instance($type->isNullable()));
                             continue;
                         }
                         $new_type_builder->addType($type);

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -183,8 +183,8 @@ class ParameterTypesAnalyzer
             foreach ($real_parameter->getUnionType()->getTypeSet() as $type) {
                 $type_class = \get_class($type);
                 if ($php70_checks) {
-                    if ($type->getIsNullable()) {
-                        if ($real_parameter->getIsUsingNullableSyntax()) {
+                    if ($type->isNullable()) {
+                        if ($real_parameter->isUsingNullableSyntax()) {
                             Issue::maybeEmit(
                                 $code_base,
                                 $method->getContext(),
@@ -218,7 +218,7 @@ class ParameterTypesAnalyzer
         foreach ($method->getRealReturnType()->getTypeSet() as $type) {
             $type_class = \get_class($type);
             if ($php70_checks) {
-                if ($type->getIsNullable()) {
+                if ($type->isNullable()) {
                     Issue::maybeEmit(
                         $code_base,
                         $method->getContext(),
@@ -321,7 +321,7 @@ class ParameterTypesAnalyzer
 
         // Make sure we're actually overriding something
         // TODO(in another PR): check that signatures of magic methods are valid, if not done already (e.g. __get expects one param, most can't define return types, etc.)?
-        $is_actually_override = $method->getIsOverride();
+        $is_actually_override = $method->isOverride();
 
         if (!$is_actually_override && $method->isOverrideIntended()) {
             self::analyzeOverrideComment($code_base, $method);
@@ -358,7 +358,7 @@ class ParameterTypesAnalyzer
 
     private static function analyzeOverrideComment(CodeBase $code_base, Method $method) : void
     {
-        if ($method->getIsMagic()) {
+        if ($method->isMagic()) {
             return;
         }
         // Only emit this issue on the base class, not for the subclass which inherited it

--- a/src/Phan/Analysis/ParentConstructorCalledAnalyzer.php
+++ b/src/Phan/Analysis/ParentConstructorCalledAnalyzer.php
@@ -55,7 +55,7 @@ class ParentConstructorCalledAnalyzer
         );
 
         if (!$parent_clazz->isAbstract()
-            && !$clazz->getIsParentConstructorCalled()
+            && !$clazz->isParentConstructorCalled()
         ) {
             Issue::maybeEmit(
                 $code_base,

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -632,7 +632,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 );
                 return $context;
             }
-            if (!$context->getIsStrictTypes()) {
+            if (!$context->isStrictTypes()) {
                 try {
                     foreach ($type->asExpandedTypes($code_base)->asClassList($code_base, $context) as $clazz) {
                         if ($clazz->hasMethodWithName($code_base, "__toString")) {
@@ -799,7 +799,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         $this->warnAboutInvalidUnionType(
             $node,
             static function (Type $type) : bool {
-                return $type instanceof IntType && !$type->getIsNullable();
+                return $type instanceof IntType && !$type->isNullable();
             },
             $left,
             $right,
@@ -1187,7 +1187,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         $return_type = $func->getUnionType();
 
         if (!$return_type->isEmpty()
-            && !$func->getHasReturn()
+            && !$func->hasReturn()
             && !self::declOnlyThrows($node)
             && !$return_type->hasType(VoidType::instance(false))
             && !$return_type->hasType(NullType::instance(false))
@@ -1231,7 +1231,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         // Get the method/function/closure we're in
         $method = $context->getFunctionLikeInScope($code_base);
 
-        if ($method->getHasYield()) {  // Function that is syntactically a Generator.
+        if ($method->hasYield()) {  // Function that is syntactically a Generator.
             $this->analyzeReturnInGenerator($method, $node);
             // TODO: Compare against TReturn of Generator<TKey,TValue,TSend,TReturn>
             return $context;  // Analysis was completed in PreOrderAnalysisVisitor
@@ -1584,7 +1584,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 if ($method->isPHPInternal()) {
                     // If we are not in strict mode and we accept a string parameter
                     // and the argument we are passing has a __toString method then it is ok
-                    if (!$context->getIsStrictTypes() && $method_return_type->hasNonNullStringType()) {
+                    if (!$context->isStrictTypes() && $method_return_type->hasNonNullStringType()) {
                         if ($individual_type_expanded->hasClassWithToStringMethod($code_base, $context)) {
                             continue;
                         }
@@ -2419,7 +2419,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             && !$method->isFromPHPDoc()
             && !$has_interface_class
             && !$return_type->isEmpty()
-            && !$method->getHasReturn()
+            && !$method->hasReturn()
             && !self::declOnlyThrows($node)
             && !$return_type->hasType(VoidType::instance(false))
             && !$return_type->hasType(NullType::instance(false))
@@ -2432,7 +2432,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             );
         }
 
-        if ($method->getHasReturn() && $method->getIsMagicAndVoid()) {
+        if ($method->hasReturn() && $method->isMagicAndVoid()) {
             $this->emitIssue(
                 Issue::TypeMagicVoidWithReturn,
                 $node->lineno,
@@ -2483,7 +2483,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         $return_type = $method->getUnionType();
 
         if (!$return_type->isEmpty()
-            && !$method->getHasReturn()
+            && !$method->hasReturn()
             && !self::declOnlyThrows($node)
             && !$return_type->hasType(VoidType::instance(false))
             && !$return_type->hasType(NullType::instance(false))

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -211,7 +211,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
         }
 
         // TODO: Why is the check for yield in PreOrderAnalysisVisitor?
-        if ($method->getHasYield()) {
+        if ($method->hasYield()) {
             $this->setReturnTypeOfGenerator($method, $node);
         }
 
@@ -300,10 +300,10 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
             }
         }
 
-        if ($function->getHasYield()) {
+        if ($function->hasYield()) {
             $this->setReturnTypeOfGenerator($function, $node);
         }
-        if (!$function->getHasReturn() && $function->getUnionType()->isEmpty()) {
+        if (!$function->hasReturn() && $function->getUnionType()->isEmpty()) {
             $function->setUnionType(VoidType::instance(false)->asUnionType());
         }
 
@@ -477,7 +477,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
                 $func->getInternalScope()->addVariable($variable);
             }
         }
-        if (!$func->getHasReturn() && $func->getUnionType()->isEmpty()) {
+        if (!$func->hasReturn() && $func->getUnionType()->isEmpty()) {
             $func->setUnionType(VoidType::instance(false)->asUnionType());
         }
 
@@ -506,7 +506,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
             }
         }
 
-        if ($func->getHasYield()) {
+        if ($func->hasYield()) {
             $this->setReturnTypeOfGenerator($func, $node);
         }
 

--- a/src/Phan/Analysis/ReferenceCountsAnalyzer.php
+++ b/src/Phan/Analysis/ReferenceCountsAnalyzer.php
@@ -236,7 +236,7 @@ class ReferenceCountsAnalyzer
 
             // Don't analyze elements defined in a parent class.
             // We copy references to methods, properties, and constants into the defining trait or class before this.
-            if ($element->getIsOverride()) {
+            if ($element->isOverride()) {
                 continue;
             }
 
@@ -245,7 +245,7 @@ class ReferenceCountsAnalyzer
 
             if ($element instanceof Method) {
                 // Ignore magic methods
-                if ($element->getIsMagic()) {
+                if ($element->isMagic()) {
                     continue;
                 }
                 // Don't analyze abstract methods, as they're uncallable.

--- a/src/Phan/Language/AnnotatedUnionType.php
+++ b/src/Phan/Language/AnnotatedUnionType.php
@@ -59,7 +59,8 @@ class AnnotatedUnionType extends UnionType
         }
         return parent::asValueOrNullOrSelf();
     }
-    public function getIsPossiblyUndefined() : bool
+
+    public function isPossiblyUndefined() : bool
     {
         return $this->is_possibly_undefined;
     }

--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -258,12 +258,21 @@ class Context extends FileRef
 
     /**
      * @return bool
-     * True if strict_types is set to 1 in this
-     * context.
+     * Returns true if strict_types is set to 1 in this context.
      */
-    public function getIsStrictTypes() : bool
+    public function isStrictTypes() : bool
     {
         return (1 === $this->strict_types);
+    }
+
+    /**
+     * Returns true if strict_types is set to 1 in this context.
+     * @deprecated use isStrictTypes
+     * @suppress PhanUnreferencedPublicMethod
+     */
+    public final function getIsStrictTypes() : bool
+    {
+        return $this->isStrictTypes();
     }
 
     /**
@@ -896,7 +905,7 @@ class Context extends FileRef
                 return null;
             }
             $extra = $type->getFieldTypes()[$name] ?? null;
-            if (!$extra || $extra->getIsPossiblyUndefined()) {
+            if (!$extra || $extra->isPossiblyUndefined()) {
                 return null;
             }
             $result = $result->withUnionType($extra);

--- a/src/Phan/Language/Element/ClassElement.php
+++ b/src/Phan/Language/Element/ClassElement.php
@@ -179,9 +179,19 @@ abstract class ClassElement extends AddressableElement
      * @return bool
      * True if this element overrides another element
      */
-    public function getIsOverride() : bool
+    public function isOverride() : bool
     {
         return $this->getPhanFlagsHasState(Flags::IS_OVERRIDE);
+    }
+
+    /**
+     * True if this element overrides another element
+     * @deprecated use isOverride
+     * @suppress PhanUnreferencedPublicMethod
+     */
+    public final function getIsOverride() : bool
+    {
+        return $this->isOverride();
     }
 
     /**

--- a/src/Phan/Language/Element/FunctionFactory.php
+++ b/src/Phan/Language/Element/FunctionFactory.php
@@ -119,7 +119,7 @@ class FunctionFactory
             - $reflection_method->getNumberOfRequiredParameters()
         );
 
-        if ($method->getIsMagicCall() || $method->getIsMagicCallStatic()) {
+        if ($method->isMagicCall() || $method->isMagicCallStatic()) {
             $method->setNumberOfOptionalParameters(FunctionInterface::INFINITE_PARAMETERS);
             $method->setNumberOfRequiredParameters(0);
         }
@@ -249,7 +249,7 @@ class FunctionFactory
             );
 
             if ($alternate_function instanceof Method) {
-                if ($alternate_function->getIsMagicCall() || $alternate_function->getIsMagicCallStatic()) {
+                if ($alternate_function->isMagicCall() || $alternate_function->isMagicCallStatic()) {
                     $alternate_function->setNumberOfOptionalParameters(999);
                     $alternate_function->setNumberOfRequiredParameters(0);
                 }

--- a/src/Phan/Language/Element/FunctionInterface.php
+++ b/src/Phan/Language/Element/FunctionInterface.php
@@ -136,7 +136,8 @@ interface FunctionInterface extends AddressableElementInterface
      * @return bool
      * True if this method returns a value
      */
-    public function getHasReturn() : bool;
+    public function hasReturn() : bool;
+
     /**
      * @param bool $has_return
      * Set to true to mark this method as having a

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -337,18 +337,38 @@ trait FunctionTrait
      * True if this method returns a value
      * (i.e. it has a return with an expression)
      */
-    public function getHasReturn() : bool
+    public function hasReturn() : bool
     {
         return $this->getPhanFlagsHasState(Flags::HAS_RETURN);
+    }
+
+    /**
+     * True if this method returns a value
+     * @deprecated use hasReturn
+     * @suppress PhanUnreferencedPublicMethod
+     */
+    public final function getHasReturn() : bool
+    {
+        return $this->hasReturn();
     }
 
     /**
      * @return bool
      * True if this method yields any value(i.e. it is a \Generator)
      */
-    public function getHasYield() : bool
+    public function hasYield() : bool
     {
         return $this->getPhanFlagsHasState(Flags::HAS_YIELD);
+    }
+
+    /**
+     * True if this method yields any value(i.e. it is a \Generator)
+     * @deprecated use hasYield
+     * @suppress PhanUnreferencedPublicMethod
+     */
+    public final function getHasYield() : bool
+    {
+        return $this->hasYield();
     }
 
     /**
@@ -1339,8 +1359,8 @@ trait FunctionTrait
                 }
             }
         }
-        if ($return_type->isEmpty() && !$this->getHasReturn()) {
-            if ($this instanceof Func || ($this instanceof Method && ($this->isPrivate() || $this->isEffectivelyFinal() || $this->getIsMagicAndVoid() || $this->getClass($code_base)->isFinal()))) {
+        if ($return_type->isEmpty() && !$this->hasReturn()) {
+            if ($this instanceof Func || ($this instanceof Method && ($this->isPrivate() || $this->isEffectivelyFinal() || $this->isMagicAndVoid() || $this->getClass($code_base)->isFinal()))) {
                 $this->setUnionType(VoidType::instance(false)->asUnionType());
             }
         }

--- a/src/Phan/Language/Element/MarkupDescription.php
+++ b/src/Phan/Language/Element/MarkupDescription.php
@@ -161,7 +161,7 @@ class MarkupDescription
         CodeBase $code_base,
         array &$checked_class_fqsens = []
     ) : ?string {
-        if (!$element->getIsOverride() && $element->getRealDefiningFQSEN() === $element->getFQSEN()) {
+        if (!$element->isOverride() && $element->getRealDefiningFQSEN() === $element->getFQSEN()) {
             return null;
         }
         $class_fqsen = $element->getDefiningClassFQSEN();

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -179,12 +179,21 @@ class Method extends ClassElement implements FunctionInterface
     }
 
     /**
-     * @return bool
-     * True if this element is overridden by at least one other element
+     * Returns true if this element is overridden by at least one other element
      */
-    public function getIsOverriddenByAnother() : bool
+    public function isOverriddenByAnother() : bool
     {
         return $this->getPhanFlagsHasState(Flags::IS_OVERRIDDEN_BY_ANOTHER);
+    }
+
+    /**
+     * Returns true if this element is overridden by at least one other element
+     * @deprecated use isOverriddenByAnother
+     * @suppress PhanUnreferencedPublicMethod
+     */
+    public final function getIsOverriddenByAnother() : bool
+    {
+        return $this->isOverriddenByAnother();
     }
 
     /**
@@ -232,7 +241,7 @@ class Method extends ClassElement implements FunctionInterface
             return true;
         }
         return Config::getValue('assume_no_external_class_overrides')
-            && !$this->getIsOverriddenByAnother()
+            && !$this->isOverriddenByAnother()
             && !$this->isAbstract();
     }
 
@@ -246,51 +255,66 @@ class Method extends ClassElement implements FunctionInterface
     }
 
     /**
-     * @return bool
-     * True if this is a magic method
+     * Returns true if this is a magic method
      * (Names are all normalized in FullyQualifiedMethodName::make())
      */
-    public function getIsMagic() : bool
+    public function isMagic() : bool
     {
         return \array_key_exists($this->getName(), FullyQualifiedMethodName::MAGIC_METHOD_NAME_SET);
     }
 
     /**
-     * @return bool
-     * True if this is a magic method which should have return type of void
+     * Returns true if this is a magic method
+     * @deprecated use isMagic
+     * @suppress PhanUnreferencedPublicMethod
+     */
+    public final function getIsMagic() : bool
+    {
+        return $this->isMagic();
+    }
+
+    /**
+     * Returns true if this is a magic method which should have return type of void
      * (Names are all normalized in FullyQualifiedMethodName::make())
      */
-    public function getIsMagicAndVoid() : bool
+    public function isMagicAndVoid() : bool
     {
         return \array_key_exists($this->getName(), FullyQualifiedMethodName::MAGIC_VOID_METHOD_NAME_SET);
     }
 
     /**
-     * @return bool
-     * True if this is the `__construct` method
+     * Returns true if this is a magic method which should have return type of void
+     * @deprecated use isMagicAndVoid
+     * @suppress PhanUnreferencedPublicMethod
+     */
+    public final function getIsMagicAndVoid() : bool
+    {
+        return $this->isMagicAndVoid();
+    }
+
+    /**
+     * Returns true if this is the `__construct` method
      * (Does not return true for php4 constructors)
      */
-    public function getIsNewConstructor() : bool
+    public function isNewConstructor() : bool
     {
-        return ($this->getName() === '__construct');
+        return $this->getName() === '__construct';
     }
 
     /**
-     * @return bool
-     * True if this is the magic `__call` method
+     * Returns true if this is the magic `__call` method
      */
-    public function getIsMagicCall() : bool
+    public function isMagicCall() : bool
     {
-        return ($this->getName() === '__call');
+        return $this->getName() === '__call';
     }
 
     /**
-     * @return bool
-     * True if this is the magic `__callStatic` method
+     * Returns true if this is the magic `__callStatic` method
      */
-    public function getIsMagicCallStatic() : bool
+    public function isMagicCallStatic() : bool
     {
-        return ($this->getName() === '__callStatic');
+        return $this->getName() === '__callStatic';
     }
 
     /**
@@ -513,7 +537,7 @@ class Method extends ClassElement implements FunctionInterface
         $method->setIsOverrideIntended($comment->isOverrideIntended());
         $method->setSuppressIssueSet($comment->getSuppressIssueSet());
 
-        if ($method->getIsMagicCall() || $method->getIsMagicCallStatic()) {
+        if ($method->isMagicCall() || $method->isMagicCallStatic()) {
             $method->setNumberOfOptionalParameters(FunctionInterface::INFINITE_PARAMETERS);
             $method->setNumberOfRequiredParameters(0);
         }

--- a/src/Phan/Language/Element/Parameter.php
+++ b/src/Phan/Language/Element/Parameter.php
@@ -491,7 +491,7 @@ class Parameter extends Variable
      *
      * This is needed to deal with edge cases of analysis.
      */
-    public function getIsUsingNullableSyntax() : bool
+    public function isUsingNullableSyntax() : bool
     {
         return $this->getPhanFlagsHasState(Flags::IS_PARAM_USING_NULLABLE_SYNTAX);
     }

--- a/src/Phan/Language/Element/Property.php
+++ b/src/Phan/Language/Element/Property.php
@@ -341,7 +341,7 @@ class Property extends ClassElement
     /**
      * Does this property contain `static` anywhere in the original union type?
      */
-    public function getHasStaticInUnionType() : bool
+    public function hasStaticInUnionType() : bool
     {
         return $this->getPhanFlagsHasState(Flags::HAS_STATIC_UNION_TYPE);
     }
@@ -393,7 +393,7 @@ class Property extends ClassElement
             if (FullyQualifiedClassName::fromType($type) === $old) {
                 $union_type = $union_type
                     ->withoutType($type)
-                    ->withType($new->asType()->withIsNullable($type->getIsNullable()));
+                    ->withType($new->asType()->withIsNullable($type->isNullable()));
             }
         }
         $this->setUnionType($union_type);

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -1503,15 +1503,35 @@ class Type
      *
      * E.g. returns true for `?array`, `null`, etc.
      */
-    public function getIsNullable() : bool
+    public function isNullable() : bool
+    {
+        return $this->is_nullable;
+    }
+
+    /**
+     * Is this nullable?
+     * @deprecated use isNullable
+     * @suppress PhanUnreferencedPublicMethod
+     */
+    public final function getIsNullable() : bool
+    {
+        return $this->isNullable();
+    }
+
+    /**
+     * Returns true if this has some possibly falsey values
+     */
+    public function isPossiblyFalsey() : bool
     {
         return $this->is_nullable;
     }
 
     /**
      * Returns true if this has some possibly falsey values
+     * @deprecated
+     * @suppress PhanUnreferencedPublicMethod
      */
-    public function getIsPossiblyFalsey() : bool
+    public final function getIsPossiblyFalsey() : bool
     {
         return $this->is_nullable;
     }
@@ -1519,17 +1539,37 @@ class Type
     /**
      * Returns true if this is guaranteed to be falsey
      */
-    public function getIsAlwaysFalsey() : bool
+    public function isAlwaysFalsey() : bool
     {
         return false;  // overridden in FalseType and NullType, as well as literal scalar types
     }
 
     /**
+     * Returns true if this is guaranteed to be falsey
+     * @deprecated use isAlwaysFalsey
+     * @suppress PhanUnreferencedPublicMethod
+     */
+    public final function getIsAlwaysFalsey() : bool
+    {
+        return $this->isAlwaysFalsey();
+    }
+
+    /**
      * Returns true if this is possibly truthy.
      */
-    public function getIsPossiblyTruthy() : bool
+    public function isPossiblyTruthy() : bool
     {
         return true;  // overridden in various types. This base class (Type) is implicitly the type of an object, which is always truthy.
+    }
+
+    /**
+     * Returns true if this is possibly truthy.
+     * @deprecated use isPossiblyTruthy
+     * @suppress PhanUnreferencedPublicMethod
+     */
+    public final function getIsPossiblyTruthy() : bool
+    {
+        return $this->isPossiblyTruthy();
     }
 
     /**
@@ -1540,58 +1580,128 @@ class Type
      * This base class (Type) is type of an object with a known FQSEN,
      * which is always truthy.
      */
-    public function getIsAlwaysTruthy() : bool
+    public function isAlwaysTruthy() : bool
     {
         return true;
     }
 
     /**
+     * Returns true if this is guaranteed to be truthy.
+     * @deprecated use isAlwaysTruthy
+     * @suppress PhanUnreferencedPublicMethod
+     */
+    public final function getIsAlwaysTruthy() : bool
+    {
+        return $this->isAlwaysTruthy();
+    }
+
+    /**
      * Returns true for types such as `mixed`, `bool`, `false`
      */
-    public function getIsPossiblyFalse() : bool
+    public function isPossiblyFalse() : bool
     {
         return false;
     }
 
     /**
+     * Returns true for types such as `mixed`, `bool`, `false`
+     * @deprecated use isPossiblyFalse
+     * @suppress PhanUnreferencedPublicMethod
+     */
+    public final function getIsPossiblyFalse() : bool
+    {
+        return $this->isPossiblyFalse();
+    }
+
+    /**
      * Returns true for non-nullable `FalseType`
      */
-    public function getIsAlwaysFalse() : bool
+    public function isAlwaysFalse() : bool
     {
         return false;  // overridden in FalseType
+    }
+
+    /**
+     * Returns true for non-nullable `FalseType`
+     * @deprecated
+     * @suppress PhanUnreferencedPublicMethod
+     */
+    public final function getIsAlwaysFalse() : bool
+    {
+        return $this->isAlwaysFalse();
     }
 
     /**
      * Returns true if this could include the type `true`
      * (e.g. for `mixed`, `bool`, etc.)
      */
-    public function getIsPossiblyTrue() : bool
+    public function isPossiblyTrue() : bool
+    {
+        return false;
+    }
+
+    /**
+     * Returns true if this could include the type `true`
+     * @deprecated use isPossiblyTrue
+     * @suppress PhanUnreferencedPublicMethod
+     */
+    public final function getIsPossiblyTrue() : bool
+    {
+        return $this->isPossiblyTrue();
+    }
+
+    /**
+     * Returns true for non-nullable `TrueType`
+     */
+    public function isAlwaysTrue() : bool
     {
         return false;
     }
 
     /**
      * Returns true for non-nullable `TrueType`
+     * @deprecated
+     * @suppress PhanUnreferencedPublicMethod
      */
-    public function getIsAlwaysTrue() : bool
+    public final function getIsAlwaysTrue() : bool
+    {
+        return $this->isAlwaysTrue();
+    }
+
+    /**
+     * Returns true for FalseType, TrueType, and BoolType
+     */
+    public function isInBoolFamily() : bool
     {
         return false;
     }
 
     /**
      * Returns true for FalseType, TrueType, and BoolType
+     * @deprecated use isInBoolFamily
+     * @suppress PhanUnreferencedPublicMethod
      */
-    public function getIsInBoolFamily() : bool
+    public final function getIsInBoolFamily() : bool
+    {
+        return $this->isInBoolFamily();
+    }
+
+    /**
+     * Returns true if this type may satisfy `is_numeric()`
+     */
+    public function isPossiblyNumeric() : bool
     {
         return false;
     }
 
     /**
      * Returns true if this type may satisfy `is_numeric()`
+     * @deprecated use isPossiblyNumeric
+     * @suppress PhanUnreferencedPublicMethod
      */
-    public function getIsPossiblyNumeric() : bool
+    public final function getIsPossiblyNumeric() : bool
     {
-        return false;
+        return $this->isPossiblyNumeric();
     }
 
     /**
@@ -1621,7 +1731,7 @@ class Type
      * Returns this type with any falsey types (e.g. false, null, 0, '') removed.
      *
      * Overridden by BoolType, etc.
-     * @see self::getIsAlwaysFalsey()
+     * @see self::isAlwaysFalsey()
      */
     public function asNonFalseyType() : Type
     {
@@ -1633,7 +1743,7 @@ class Type
      * Returns this type with any truthy types removed.
      *
      * Overridden by BoolType, etc.
-     * @see self::getIsAlwaysTruthy()
+     * @see self::isAlwaysTruthy()
      */
     public function asNonTruthyType() : Type
     {
@@ -1645,7 +1755,7 @@ class Type
      * Returns this type with the type `false` removed.
      *
      * Overridden by BoolType, etc.
-     * @see self::getIsAlwaysFalse()
+     * @see self::isAlwaysFalse()
      */
     public function asNonFalseType() : Type
     {
@@ -1656,7 +1766,7 @@ class Type
      * Returns this type with the type `true` removed.
      *
      * Overridden by BoolType, etc.
-     * @see self::getIsAlwaysTrue()
+     * @see self::isAlwaysTrue()
      */
     public function asNonTrueType() : Type
     {
@@ -2253,35 +2363,6 @@ class Type
     }
 
     /**
-     * @param CodeBase $code_base
-     *
-     * @param Type $parent
-     *
-     * @return bool
-     * True if this type represents a class which is a sub-type of
-     * the class represented by the passed type.
-     *
-     * @deprecated
-     * @suppress PhanUnreferencedPublicMethod
-     */
-    public function isSubclassOf(CodeBase $code_base, Type $parent) : bool
-    {
-        $fqsen = FullyQualifiedClassName::fromType($this);
-
-        $this_clazz = $code_base->getClassByFQSEN(
-            $fqsen
-        );
-
-        $parent_fqsen = FullyQualifiedClassName::fromType($parent);
-
-        $parent_clazz = $code_base->getClassByFQSEN(
-            $parent_fqsen
-        );
-
-        return $this_clazz->isSubclassOf($code_base, $parent_clazz);
-    }
-
-    /**
      * @param Type[] $target_type_set 1 or more types
      * @return bool
      * True if this Type can be cast to the given Type cleanly.
@@ -2569,7 +2650,7 @@ class Type
         if ($union_type->hasType($this)) {
             return true;
         }
-        if ($this->getIsNullable() && !$union_type->containsNullable()) {
+        if ($this->isNullable() && !$union_type->containsNullable()) {
             return false;
         }
         $this_resolved = $this->withStaticResolvedInContext($context);

--- a/src/Phan/Language/Type/ArrayShapeType.php
+++ b/src/Phan/Language/Type/ArrayShapeType.php
@@ -283,7 +283,7 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
                     $this_field_type = $this->field_types[$key] ?? null;
                     // Can't cast {a:int} to {a:int, other:string} if other is missing
                     if ($this_field_type === null) {
-                        if ($field_type->getIsPossiblyUndefined()) {
+                        if ($field_type->isPossiblyUndefined()) {
                             // ... unless the other field is allowed to be undefined.
                             continue;
                         }
@@ -340,7 +340,7 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
         $field_types = $this->field_types;
         $unique = [];
         foreach ($field_types as $value_union_type) {
-            if ($value_union_type->getIsPossiblyUndefined()) {
+            if ($value_union_type->isPossiblyUndefined()) {
                 continue;
             }
 
@@ -511,7 +511,7 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
                 } catch (RecursionDepthException $_) {
                     $expanded_field_type = MixedType::instance(false)->asUnionType();
                 }
-                if ($union_type->getIsPossiblyUndefined()) {
+                if ($union_type->isPossiblyUndefined()) {
                     // array{key?:string} should become array{key?:string}.
                     $expanded_field_type = $union_type->withIsPossiblyUndefined(true);
                 }
@@ -558,7 +558,7 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
                 } catch (RecursionDepthException $_) {
                     $expanded_field_type = MixedType::instance(false)->asUnionType();
                 }
-                if ($union_type->getIsPossiblyUndefined()) {
+                if ($union_type->isPossiblyUndefined()) {
                     // array{key?:string} should become array{key?:string}.
                     $expanded_field_type = $union_type->withIsPossiblyUndefined(true);
                 }
@@ -638,13 +638,13 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
      * @return bool true if there is guaranteed to be at least one property
      * @phan-override
      */
-    public function getIsAlwaysTruthy() : bool
+    public function isAlwaysTruthy() : bool
     {
         if ($this->is_nullable) {
             return false;
         }
         foreach ($this->field_types as $field) {
-            if (!$field->getIsPossiblyUndefined()) {
+            if (!$field->isPossiblyUndefined()) {
                 return true;
             }
         }

--- a/src/Phan/Language/Type/ArrayType.php
+++ b/src/Phan/Language/Type/ArrayType.php
@@ -17,7 +17,7 @@ class ArrayType extends IterableType
     /** @phan-override */
     const NAME = 'array';
 
-    public function getIsAlwaysTruthy() : bool
+    public function isAlwaysTruthy() : bool
     {
         return false;
     }

--- a/src/Phan/Language/Type/BoolType.php
+++ b/src/Phan/Language/Type/BoolType.php
@@ -15,7 +15,7 @@ final class BoolType extends ScalarType
 {
     /** @phan-override */
     const NAME = 'bool';
-    public function getIsPossiblyFalsey() : bool
+    public function isPossiblyFalsey() : bool
     {
         return true;  // it's always falsey, since this is conceptually a collection of FalseType and TrueType
     }
@@ -30,7 +30,7 @@ final class BoolType extends ScalarType
         return FalseType::instance($this->is_nullable);
     }
 
-    public function getIsPossiblyFalse() : bool
+    public function isPossiblyFalse() : bool
     {
         return true;  // it's possibly false, since this is conceptually a collection of FalseType and TrueType
     }
@@ -40,7 +40,7 @@ final class BoolType extends ScalarType
         return TrueType::instance($this->is_nullable);
     }
 
-    public function getIsPossiblyTrue() : bool
+    public function isPossiblyTrue() : bool
     {
         return true;  // it's possibly true, since this is conceptually a collection of FalseType and TrueType
     }
@@ -50,12 +50,12 @@ final class BoolType extends ScalarType
         return FalseType::instance($this->is_nullable);
     }
 
-    public function getIsInBoolFamily() : bool
+    public function isInBoolFamily() : bool
     {
         return true;
     }
 
-    public function getIsAlwaysTruthy() : bool
+    public function isAlwaysTruthy() : bool
     {
         return false;  // overridden in various types. This base class (Type) is implicitly the type of an object, which is always truthy.
     }

--- a/src/Phan/Language/Type/CallableStringType.php
+++ b/src/Phan/Language/Type/CallableStringType.php
@@ -41,7 +41,7 @@ final class CallableStringType extends StringType implements CallableInterface
     }
 
     /** @override */
-    public function getIsPossiblyNumeric() : bool
+    public function isPossiblyNumeric() : bool
     {
         return false;
     }

--- a/src/Phan/Language/Type/ClassStringType.php
+++ b/src/Phan/Language/Type/ClassStringType.php
@@ -19,7 +19,7 @@ final class ClassStringType extends StringType
     const NAME = 'class-string';
 
     /** @override */
-    public function getIsPossiblyNumeric() : bool
+    public function isPossiblyNumeric() : bool
     {
         return false;
     }

--- a/src/Phan/Language/Type/FalseType.php
+++ b/src/Phan/Language/Type/FalseType.php
@@ -16,32 +16,32 @@ final class FalseType extends ScalarType
     /** @phan-override */
     const NAME = 'false';
 
-    public function getIsPossiblyFalsey() : bool
+    public function isPossiblyFalsey() : bool
     {
         return true;  // it's always falsey, whether or not it's nullable.
     }
 
-    public function getIsAlwaysFalsey() : bool
+    public function isAlwaysFalsey() : bool
     {
         return true;  // FalseType is always falsey, whether or not it's nullable.
     }
 
-    public function getIsAlwaysFalse() : bool
+    public function isAlwaysFalse() : bool
     {
         return !$this->is_nullable;  // If it can be null, it's not **always** identical to false
     }
 
-    public function getIsPossiblyTruthy() : bool
+    public function isPossiblyTruthy() : bool
     {
         return false;
     }
 
-    public function getIsAlwaysTruthy() : bool
+    public function isAlwaysTruthy() : bool
     {
         return false;
     }
 
-    public function getIsPossiblyFalse() : bool
+    public function isPossiblyFalse() : bool
     {
         return true;
     }
@@ -54,7 +54,7 @@ final class FalseType extends ScalarType
         return NullType::instance(false);
     }
 
-    public function getIsInBoolFamily() : bool
+    public function isInBoolFamily() : bool
     {
         return true;
     }

--- a/src/Phan/Language/Type/FloatType.php
+++ b/src/Phan/Language/Type/FloatType.php
@@ -13,7 +13,7 @@ final class FloatType extends ScalarType
     const NAME = 'float';
 
     /** @override */
-    public function getIsPossiblyNumeric() : bool
+    public function isPossiblyNumeric() : bool
     {
         return true;
     }

--- a/src/Phan/Language/Type/FunctionLikeDeclarationType.php
+++ b/src/Phan/Language/Type/FunctionLikeDeclarationType.php
@@ -458,7 +458,7 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
     }
 
     /** @override */
-    public function getHasReturn() : bool
+    public function hasReturn() : bool
     {
         return true;
     }

--- a/src/Phan/Language/Type/IntType.php
+++ b/src/Phan/Language/Type/IntType.php
@@ -14,7 +14,7 @@ class IntType extends ScalarType
     const NAME = 'int';
 
     /** @override */
-    public function getIsPossiblyNumeric() : bool
+    public function isPossiblyNumeric() : bool
     {
         return true;
     }

--- a/src/Phan/Language/Type/LiteralIntType.php
+++ b/src/Phan/Language/Type/LiteralIntType.php
@@ -94,25 +94,25 @@ final class LiteralIntType extends IntType implements LiteralTypeInterface
     }
 
     /** @override */
-    public function getIsPossiblyFalsey() : bool
+    public function isPossiblyFalsey() : bool
     {
         return !$this->value;
     }
 
     /** @override */
-    public function getIsAlwaysFalsey() : bool
+    public function isAlwaysFalsey() : bool
     {
         return !$this->value;
     }
 
     /** @override */
-    public function getIsPossiblyTruthy() : bool
+    public function isPossiblyTruthy() : bool
     {
         return (bool)$this->value;
     }
 
     /** @override */
-    public function getIsAlwaysTruthy() : bool
+    public function isAlwaysTruthy() : bool
     {
         return (bool)$this->value;
     }

--- a/src/Phan/Language/Type/LiteralStringType.php
+++ b/src/Phan/Language/Type/LiteralStringType.php
@@ -193,25 +193,25 @@ final class LiteralStringType extends StringType implements LiteralTypeInterface
     }
 
     /** @override */
-    public function getIsPossiblyFalsey() : bool
+    public function isPossiblyFalsey() : bool
     {
         return !$this->value;
     }
 
     /** @override */
-    public function getIsAlwaysFalsey() : bool
+    public function isAlwaysFalsey() : bool
     {
         return !$this->value;
     }
 
     /** @override */
-    public function getIsPossiblyTruthy() : bool
+    public function isPossiblyTruthy() : bool
     {
         return (bool)$this->value;
     }
 
     /** @override */
-    public function getIsAlwaysTruthy() : bool
+    public function isAlwaysTruthy() : bool
     {
         return (bool)$this->value;
     }

--- a/src/Phan/Language/Type/NullType.php
+++ b/src/Phan/Language/Type/NullType.php
@@ -153,17 +153,17 @@ final class NullType extends ScalarType
         return $this->name;
     }
 
-    public function getIsNullable() : bool
+    public function isNullable() : bool
     {
         return true;
     }
 
-    public function getIsPossiblyFalsey() : bool
+    public function isPossiblyFalsey() : bool
     {
         return true;  // Null is always falsey.
     }
 
-    public function getIsAlwaysFalsey() : bool
+    public function isAlwaysFalsey() : bool
     {
         return true;  // Null is always falsey.
     }

--- a/src/Phan/Language/Type/ScalarType.php
+++ b/src/Phan/Language/Type/ScalarType.php
@@ -55,20 +55,6 @@ abstract class ScalarType extends NativeType
     }
 
     /**
-     * @param CodeBase $code_base (@phan-unused-param)
-     *
-     * @param Type $parent (@phan-unused-param)
-     *
-     * @return bool
-     * True if this type represents a class which is a sub-type of
-     * the class represented by the passed type.
-     */
-    public function isSubclassOf(CodeBase $code_base, Type $parent) : bool
-    {
-        return false;
-    }
-
-    /**
      * @return bool
      * True if this Type can be cast to the given Type
      * cleanly
@@ -111,7 +97,7 @@ abstract class ScalarType extends NativeType
         return $this->name;
     }
 
-    public function getIsAlwaysTruthy() : bool
+    public function isAlwaysTruthy() : bool
     {
         // Most scalars (Except ResourceType) have a false value, e.g. 0/""/"0"/0.0/false.
         // (But ResourceType isn't a subclass of ScalarType in Phan's implementation)

--- a/src/Phan/Language/Type/StringType.php
+++ b/src/Phan/Language/Type/StringType.php
@@ -22,7 +22,7 @@ class StringType extends ScalarType
     }
 
     /** @override */
-    public function getIsPossiblyNumeric() : bool
+    public function isPossiblyNumeric() : bool
     {
         return true;
     }

--- a/src/Phan/Language/Type/TrueType.php
+++ b/src/Phan/Language/Type/TrueType.php
@@ -16,22 +16,22 @@ final class TrueType extends ScalarType
     /** @phan-override */
     const NAME = 'true';
 
-    public function getIsPossiblyTruthy() : bool
+    public function isPossiblyTruthy() : bool
     {
         return true;
     }
 
-    public function getIsAlwaysTruthy() : bool
+    public function isAlwaysTruthy() : bool
     {
         return true;
     }
 
-    public function getIsPossiblyTrue() : bool
+    public function isPossiblyTrue() : bool
     {
         return true;
     }
 
-    public function getIsAlwaysTrue() : bool
+    public function isAlwaysTrue() : bool
     {
         return !$this->is_nullable;  // If it can be null, it's not **always** identical to true
     }
@@ -44,7 +44,7 @@ final class TrueType extends ScalarType
         return NullType::instance(true);
     }
 
-    public function getIsInBoolFamily() : bool
+    public function isInBoolFamily() : bool
     {
         return true;
     }

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -632,7 +632,7 @@ class UnionType implements Serializable
     public function hasTypeInBoolFamily() : bool
     {
         return $this->hasTypeMatchingCallback(static function (Type $type) : bool {
-            return $type->getIsInBoolFamily();
+            return $type->isInBoolFamily();
         });
     }
 
@@ -648,7 +648,7 @@ class UnionType implements Serializable
     public function getTypesInBoolFamily() : UnionType
     {
         return $this->makeFromFilter(static function (Type $type) : bool {
-            return $type->getIsInBoolFamily();
+            return $type->isInBoolFamily();
         });
     }
 
@@ -812,7 +812,7 @@ class UnionType implements Serializable
         $result = $this;
         foreach ($type_set as $type) {
             if ($type instanceof StaticOrSelfType) {
-                if ($type->getIsNullable()) {
+                if ($type->isNullable()) {
                     $is_nullable = true;
                 }
                 $result = $result->withoutType($type);
@@ -844,7 +844,7 @@ class UnionType implements Serializable
         $result = $this;
         foreach ($type_set as $type) {
             if ($type instanceof SelfType) {
-                if ($type->getIsNullable()) {
+                if ($type->isNullable()) {
                     $is_nullable = true;
                 }
                 $result = $result->withoutType($type);
@@ -876,7 +876,7 @@ class UnionType implements Serializable
         $result = $this;
         foreach ($type_set as $type) {
             if ($type instanceof SelfType) {
-                if ($type->getIsNullable()) {
+                if ($type->isNullable()) {
                     $is_nullable = true;
                 }
             }
@@ -984,7 +984,7 @@ class UnionType implements Serializable
     public function containsNullable() : bool
     {
         foreach ($this->type_set as $type) {
-            if ($type->getIsNullable()) {
+            if ($type->isNullable()) {
                 return true;
             }
         }
@@ -998,7 +998,7 @@ class UnionType implements Serializable
     public function containsNullableOrIsEmpty() : bool
     {
         foreach ($this->type_set as $type) {
-            if ($type->getIsNullable()) {
+            if ($type->isNullable()) {
                 return true;
             }
         }
@@ -1022,7 +1022,7 @@ class UnionType implements Serializable
         $builder = new UnionTypeBuilder();
         $did_change = false;
         foreach ($this->type_set as $type) {
-            if (!$type->getIsNullable()) {
+            if (!$type->isNullable()) {
                 $builder->addType($type);
                 continue;
             }
@@ -1045,7 +1045,7 @@ class UnionType implements Serializable
         $builder = new UnionTypeBuilder();
         $did_change = false;
         foreach ($this->type_set as $type) {
-            if ($type->getIsNullable()) {
+            if ($type->isNullable()) {
                 $builder->addType($type);
                 continue;
             }
@@ -1074,7 +1074,7 @@ class UnionType implements Serializable
     public function containsFalsey() : bool
     {
         foreach ($this->type_set as $type) {
-            if ($type->getIsPossiblyFalsey()) {
+            if ($type->isPossiblyFalsey()) {
                 return true;
             }
         }
@@ -1089,12 +1089,12 @@ class UnionType implements Serializable
         $builder = new UnionTypeBuilder();
         $did_change = false;
         foreach ($this->type_set as $type) {
-            if (!$type->getIsPossiblyFalsey()) {
+            if (!$type->isPossiblyFalsey()) {
                 $builder->addType($type);
                 continue;
             }
             $did_change = true;
-            if ($type->getIsAlwaysFalsey()) {
+            if ($type->isAlwaysFalsey()) {
                 // don't add null/false to the resulting type
                 continue;
             }
@@ -1113,7 +1113,7 @@ class UnionType implements Serializable
     public function containsTruthy() : bool
     {
         foreach ($this->type_set as $type) {
-            if ($type->getIsPossiblyTruthy()) {
+            if ($type->isPossiblyTruthy()) {
                 return true;
             }
         }
@@ -1126,7 +1126,7 @@ class UnionType implements Serializable
     public function hasNonNullIntType() : bool
     {
         foreach ($this->type_set as $type) {
-            if ($type instanceof IntType && !$type->getIsNullable()) {
+            if ($type instanceof IntType && !$type->isNullable()) {
                 return true;
             }
         }
@@ -1142,7 +1142,7 @@ class UnionType implements Serializable
             return false;
         }
         foreach ($this->type_set as $type) {
-            if (!($type instanceof IntType) || $type->getIsNullable()) {
+            if (!($type instanceof IntType) || $type->isNullable()) {
                 return false;
             }
         }
@@ -1158,7 +1158,7 @@ class UnionType implements Serializable
             return false;
         }
         foreach ($this->type_set as $type) {
-            if (!($type instanceof IntType || $type instanceof FloatType) || $type->getIsNullable()) {
+            if (!($type instanceof IntType || $type instanceof FloatType) || $type->isNullable()) {
                 return false;
             }
         }
@@ -1184,7 +1184,7 @@ class UnionType implements Serializable
     public function hasNonNullStringType() : bool
     {
         foreach ($this->type_set as $type) {
-            if ($type instanceof StringType && !$type->getIsNullable()) {
+            if ($type instanceof StringType && !$type->isNullable()) {
                 return true;
             }
         }
@@ -1200,7 +1200,7 @@ class UnionType implements Serializable
             return false;
         }
         foreach ($this->type_set as $type) {
-            if (!($type instanceof StringType) || $type->getIsNullable()) {
+            if (!($type instanceof StringType) || $type->isNullable()) {
                 return false;
             }
         }
@@ -1247,13 +1247,13 @@ class UnionType implements Serializable
         $did_change = false;
         $has_null = false;
         foreach ($this->type_set as $type) {
-            if (!$type->getIsPossiblyTruthy()) {
+            if (!$type->isPossiblyTruthy()) {
                 $builder->addType($type);
                 continue;
             }
             $did_change = true;
-            if ($type->getIsAlwaysTruthy()) {
-                if ($type->getIsNullable()) {
+            if ($type->isAlwaysTruthy()) {
+                if ($type->isNullable()) {
                     $has_null = true;
                 }
                 // don't add null/false to the resulting type
@@ -1278,7 +1278,7 @@ class UnionType implements Serializable
     public function containsFalse() : bool
     {
         foreach ($this->type_set as $type) {
-            if ($type->getIsPossiblyFalse()) {
+            if ($type->isPossiblyFalse()) {
                 return true;
             }
         }
@@ -1291,7 +1291,7 @@ class UnionType implements Serializable
     public function containsTrue() : bool
     {
         foreach ($this->type_set as $type) {
-            if ($type->getIsPossiblyTrue()) {
+            if ($type->isPossiblyTrue()) {
                 return true;
             }
         }
@@ -1307,12 +1307,12 @@ class UnionType implements Serializable
         $builder = new UnionTypeBuilder();
         $did_change = false;
         foreach ($this->type_set as $type) {
-            if (!$type->getIsPossiblyFalse()) {
+            if (!$type->isPossiblyFalse()) {
                 $builder->addType($type);
                 continue;
             }
             $did_change = true;
-            if ($type->getIsAlwaysFalse()) {
+            if ($type->isAlwaysFalse()) {
                 // don't add null/false to the resulting type
                 continue;
             }
@@ -1332,12 +1332,12 @@ class UnionType implements Serializable
         $builder = new UnionTypeBuilder();
         $did_change = false;
         foreach ($this->type_set as $type) {
-            if (!$type->getIsPossiblyTrue()) {
+            if (!$type->isPossiblyTrue()) {
                 $builder->addType($type);
                 continue;
             }
             $did_change = true;
-            if ($type->getIsAlwaysTrue()) {
+            if ($type->isAlwaysTrue()) {
                 // don't add null/false to the resulting type
                 continue;
             }
@@ -1595,7 +1595,7 @@ class UnionType implements Serializable
         if (\in_array($null_type, $target_type_set, true)) {
             foreach ($type_set as $source_type) {
                 // Only redo this check for the nullable types, we already failed the checks for non-nullable types.
-                if ($source_type->getIsNullable()) {
+                if ($source_type->isNullable()) {
                     // TODO: Add unit tests of nullable templates
                     return $source_type->withIsNullable(false)->canCastToAnyTypeInSetHandlingTemplates($target_type_set, $code_base);
                 }
@@ -1690,7 +1690,7 @@ class UnionType implements Serializable
         if (\in_array($null_type, $target_type_set, true)) {
             foreach ($type_set as $source_type) {
                 // Only redo this check for the nullable types, we already failed the checks for non-nullable types.
-                if ($source_type->getIsNullable()) {
+                if ($source_type->isNullable()) {
                     return $source_type->withIsNullable(false)->canCastToAnyTypeInSet($target_type_set);
                 }
             }
@@ -1924,7 +1924,7 @@ class UnionType implements Serializable
         }
 
         return !$this->hasTypeMatchingCallback(static function (Type $type) : bool {
-            return !$type->isArrayLike() || $type->getIsNullable();
+            return !$type->isArrayLike() || $type->isNullable();
         });
     }
 
@@ -1941,7 +1941,7 @@ class UnionType implements Serializable
         }
 
         return !$this->hasTypeMatchingCallback(static function (Type $type) : bool {
-            return !($type instanceof ArrayType) || $type->getIsNullable();
+            return !($type instanceof ArrayType) || $type->isNullable();
         });
     }
 
@@ -2272,7 +2272,7 @@ class UnionType implements Serializable
     {
         return $this->makeFromFilter(static function (Type $type) : bool {
             // IntType and LiteralStringType
-            return $type->getIsPossiblyNumeric();
+            return $type->isPossiblyNumeric();
         });
     }
 
@@ -2326,7 +2326,7 @@ class UnionType implements Serializable
             return false;
         }
         foreach ($this->type_set as $type) {
-            if (!$type->getIsInBoolFamily() || $type->getIsNullable()) {
+            if (!$type->isInBoolFamily() || $type->isNullable()) {
                 return false;
             }
         }
@@ -2584,7 +2584,7 @@ class UnionType implements Serializable
         return $this->asMappedUnionType(static function (Type $type) use ($closure) : Type {
             if ($type instanceof ArrayShapeType) {
                 $field_types = \array_map($closure, $type->getFieldTypes());
-                $result = ArrayShapeType::fromFieldTypes($field_types, $type->getIsNullable());
+                $result = ArrayShapeType::fromFieldTypes($field_types, $type->isNullable());
                 return $result;
             } elseif ($type instanceof GenericArrayType) {
                 $element_types = $closure($type->genericArrayElementType()->asUnionType());
@@ -2593,7 +2593,7 @@ class UnionType implements Serializable
                 } else {
                     $element_type = $element_types->getTypeSet()[0];
                 }
-                return GenericArrayType::fromElementType($element_type, $type->getIsNullable(), $type->getKeyType());
+                return GenericArrayType::fromElementType($element_type, $type->isNullable(), $type->getKeyType());
             }
             return ArrayType::instance(false);
         });
@@ -3040,7 +3040,7 @@ class UnionType implements Serializable
         if ($nullable) {
             if (\count($type_set) > 0) {
                 foreach ($type_set as $type) {
-                    if (!$type->getIsNullable()) {
+                    if (!$type->isNullable()) {
                         $builder->removeType($type);
                         $builder->addType($type->withIsNullable(true));
                     }
@@ -3266,7 +3266,7 @@ class UnionType implements Serializable
             }
         }
         if ($empty_array_shape_type && !$has_other_array_type) {
-            $result->addType(ArrayType::instance($empty_array_shape_type->getIsNullable()));
+            $result->addType(ArrayType::instance($empty_array_shape_type->isNullable()));
         }
         return $result->getUnionType();
     }
@@ -3303,7 +3303,7 @@ class UnionType implements Serializable
             }
         }
         if ($empty_array_shape_type && !$has_other_array_type) {
-            $result->addType(ArrayType::instance($empty_array_shape_type->getIsNullable()));
+            $result->addType(ArrayType::instance($empty_array_shape_type->isNullable()));
         }
         return $result->getUnionType();
     }
@@ -3364,9 +3364,18 @@ class UnionType implements Serializable
      *
      * This is distinct from null - The array shape offset potentially doesn't exist at all, which is different from existing and being null.
      */
-    public function getIsPossiblyUndefined() : bool
+    public function isPossiblyUndefined() : bool
     {
         return false;
+    }
+
+    /**
+     * @deprecated use isPossiblyUndefined
+     * @suppress PhanUnreferencedPublicMethod
+     */
+    public final function getIsPossiblyUndefined() : bool
+    {
+        return $this->isPossiblyUndefined();
     }
 
     /**
@@ -3477,7 +3486,7 @@ class UnionType implements Serializable
         foreach ($this->type_set as $type) {
             if ($type instanceof LiteralIntType) {
                 $type_set = $type_set->withType(LiteralIntType::instanceForValue(~$type->getValue(), false));
-                if ($type->getIsNullable()) {
+                if ($type->isNullable()) {
                     $type_set = $type_set->withType(LiteralIntType::instanceForValue(0, false));
                 }
             } elseif ($type instanceof StringType) {
@@ -3519,14 +3528,14 @@ class UnionType implements Serializable
         foreach ($this->type_set as $type) {
             if ($type instanceof LiteralIntType) {
                 $type_set = $type_set->withType($operation($type->getValue()));
-                if ($type->getIsNullable()) {
+                if ($type->isNullable()) {
                     $type_set = $type_set->withType(LiteralIntType::instanceForValue(0, false));
                 }
             } else {
                 if ($type instanceof LiteralStringType) {
                     if (\is_numeric($type->getValue())) {
                         $type_set = $type_set->withType($operation(+$type->getValue()));
-                        if ($type->getIsNullable()) {
+                        if ($type->isNullable()) {
                             $type_set = $type_set->withType(LiteralIntType::instanceForValue(0, false));
                         }
                         continue;
@@ -3575,9 +3584,9 @@ class UnionType implements Serializable
         // @phan-suppress-next-line PhanPossiblyFalseTypeArgumentInternal
         switch (\get_class($type)) {
             case LiteralIntType::class:
-                return $type->getIsNullable() ? null : $type->getValue();
+                return $type->isNullable() ? null : $type->getValue();
             case LiteralStringType::class:
-                return $type->getIsNullable() ? null : $type->getValue();
+                return $type->isNullable() ? null : $type->getValue();
             case FalseType::class:
                 return false;
             case TrueType::class:
@@ -3603,7 +3612,7 @@ class UnionType implements Serializable
         }
         $type = \reset($type_set);
         // @phan-suppress-next-line PhanPossiblyNonClassMethodCall
-        if ($type->getIsNullable()) {
+        if ($type->isNullable()) {
             return $type instanceof NullType ? null : $this;
         }
         // @phan-suppress-next-line PhanPossiblyFalseTypeArgumentInternal
@@ -3635,7 +3644,7 @@ class UnionType implements Serializable
         }
         $type = \reset($type_set);
         // @phan-suppress-next-line PhanPossiblyNonClassMethodCall
-        if ($type->getIsNullable()) {
+        if ($type->isNullable()) {
             return $type instanceof NullType ? null : $this;
         }
         // @phan-suppress-next-line PhanPossiblyFalseTypeArgumentInternal
@@ -3704,7 +3713,7 @@ class UnionType implements Serializable
         $has_false = false;
         $has_true = false;
         foreach ($this->type_set as $type) {
-            if ($type->getIsNullable()) {
+            if ($type->isNullable()) {
                 $has_null = true;
             }
             switch (\get_class($type)) {
@@ -3747,7 +3756,7 @@ class UnionType implements Serializable
     public function containsDefiniteNonObjectType() : bool
     {
         foreach ($this->type_set as $type) {
-            if ($type->getIsNullable() || $type->isDefiniteNonObjectType()) {
+            if ($type->isNullable() || $type->isDefiniteNonObjectType()) {
                 return true;
             }
         }
@@ -3762,7 +3771,7 @@ class UnionType implements Serializable
     public function containsDefiniteNonObjectAndNonClassType() : bool
     {
         foreach ($this->type_set as $type) {
-            if ($type->getIsNullable() || ($type->isDefiniteNonObjectType() && !$type instanceof StringType)) {
+            if ($type->isNullable() || ($type->isDefiniteNonObjectType() && !$type instanceof StringType)) {
                 return true;
             }
         }
@@ -3775,7 +3784,7 @@ class UnionType implements Serializable
     public function containsDefiniteNonCallableType() : bool
     {
         foreach ($this->type_set as $type) {
-            if ($type->getIsNullable() || $type->isDefiniteNonCallableType()) {
+            if ($type->isNullable() || $type->isDefiniteNonCallableType()) {
                 return true;
             }
         }

--- a/src/Phan/LanguageServer/CompletionResolver.php
+++ b/src/Phan/LanguageServer/CompletionResolver.php
@@ -28,7 +28,7 @@ class CompletionResolver
      * @return Closure(Context,Node, array<int,Node>):void
      * NOTE: The helper methods distinguish between "Go to definition"
      * and "go to type definition" in their implementations,
-     * based on $request->getIsTypeDefinitionRequest()
+     * based on $request->isTypeDefinitionRequest()
      */
     public static function createCompletionClosure(CompletionRequest $request, CodeBase $code_base) : \Closure
     {

--- a/src/Phan/LanguageServer/DefinitionResolver.php
+++ b/src/Phan/LanguageServer/DefinitionResolver.php
@@ -35,7 +35,7 @@ class DefinitionResolver
      * @return Closure(Context,Node,array<int,Node>):void
      * NOTE: The helper methods distinguish between "Go to definition"
      * and "go to type definition" in their implementations,
-     * based on $request->getIsTypeDefinitionRequest()
+     * based on $request->isTypeDefinitionRequest()
      */
     public static function createGoToDefinitionClosure(GoToDefinitionRequest $request, CodeBase $code_base) : \Closure
     {
@@ -315,7 +315,7 @@ class DefinitionResolver
         if (!is_string($name)) {
             return;
         }
-        if (!$request->getIsTypeDefinitionRequest() && !$request->getIsHoverRequest()) {
+        if (!$request->isTypeDefinitionRequest() && !$request->isHoverRequest()) {
             // TODO: Implement "Go To Definition" for variables with heuristics or create a new plugin
             return;
         }
@@ -359,7 +359,7 @@ class DefinitionResolver
             }
             $class = $code_base->getClassByFQSEN($class_fqsen);
             $method = $class->getMethodByName($code_base, '__construct');
-            if ($method->isPHPInternal() && !$class->isPHPInternal() && !$request->getIsHoverRequest()) {
+            if ($method->isPHPInternal() && !$class->isPHPInternal() && !$request->isHoverRequest()) {
                 $request->recordDefinitionElement($code_base, $class, false);
                 continue;
             }

--- a/src/Phan/LanguageServer/GoToDefinitionRequest.php
+++ b/src/Phan/LanguageServer/GoToDefinitionRequest.php
@@ -77,7 +77,7 @@ final class GoToDefinitionRequest extends NodeInfoRequest
         AddressableElementInterface $element,
         bool $resolve_type_definition_if_needed
     ) : void {
-        if ($this->getIsTypeDefinitionRequest() && $resolve_type_definition_if_needed) {
+        if ($this->isTypeDefinitionRequest() && $resolve_type_definition_if_needed) {
             if (!($element instanceof Clazz)) {
                 $this->recordTypeOfElement($code_base, $element->getContext(), $element);
                 return;
@@ -111,7 +111,7 @@ final class GoToDefinitionRequest extends NodeInfoRequest
     }
 
     /**
-     * Precondition: $this->getIsHoverRequest()
+     * Precondition: $this->isHoverRequest()
      * @return void
      */
     private function recordHoverTextForElementType(
@@ -148,7 +148,7 @@ final class GoToDefinitionRequest extends NodeInfoRequest
 
         // If there is exactly one known type, then if it is a class/interface type, show details about the class/interface for that type
         foreach ($type_set as $type) {
-            if ($type->getIsNullable()) {
+            if ($type->isNullable()) {
                 continue;
             }
             if ($type instanceof TemplateType) {
@@ -240,7 +240,7 @@ final class GoToDefinitionRequest extends NodeInfoRequest
         Context $context,
         TypedElementInterface $element
     ) : void {
-        if ($this->getIsHoverRequest()) {
+        if ($this->isHoverRequest()) {
             $this->recordHoverTextForElementType($code_base, $context, $element);
             return;
         }
@@ -279,7 +279,7 @@ final class GoToDefinitionRequest extends NodeInfoRequest
     ) : void {
         $record_definition = function (AddressableElementInterface $element) use ($code_base) : void {
             if (!$element->isPHPInternal()) {
-                if ($this->getIsHoverRequest()) {
+                if ($this->isHoverRequest()) {
                     $this->recordDefinitionElement($code_base, $element, false);
                 } else {
                     $this->recordDefinitionContext($element->getContext());
@@ -393,7 +393,7 @@ final class GoToDefinitionRequest extends NodeInfoRequest
     /**
      * Is this a "go to type definition" request?
      */
-    public function getIsTypeDefinitionRequest() : bool
+    public function isTypeDefinitionRequest() : bool
     {
         return $this->request_type === self::REQUEST_TYPE_DEFINITION;
     }
@@ -401,7 +401,7 @@ final class GoToDefinitionRequest extends NodeInfoRequest
     /**
      * Is this a hover request?
      */
-    public function getIsHoverRequest() : bool
+    public function isHoverRequest() : bool
     {
         return $this->request_type === self::REQUEST_HOVER;
     }

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -360,7 +360,7 @@ class ParseVisitor extends ScopeVisitor
             // TODO: More precise callable shape
             $class->addAdditionalType(CallableType::instance(false));
         } elseif ('__toString' === $method_name
-            && !$this->context->getIsStrictTypes()
+            && !$this->context->isStrictTypes()
         ) {
             $class->addAdditionalType(StringType::instance(false));
         }

--- a/src/Phan/Plugin/Internal/DumpPHPDocPlugin.php
+++ b/src/Phan/Plugin/Internal/DumpPHPDocPlugin.php
@@ -143,7 +143,7 @@ final class DumpPHPDocPlugin extends PluginV3 implements
             return;
         }
         $description = MarkupDescription::extractDescriptionFromDocComment($method);
-        if (!($method->getDocComment() || !$description) && $method->getIsOverride()) {
+        if (!($method->getDocComment() || !$description) && $method->isOverride()) {
             // Note: This deliberately avoids showing a summary for methods that are just overrides of other methods,
             // unless they have their own phpdoc.
             // Eventually, extractDescriptionFromDocComment will search ancestor classes for $description

--- a/src/Phan/Plugin/Internal/MethodSearcherPlugin.php
+++ b/src/Phan/Plugin/Internal/MethodSearcherPlugin.php
@@ -95,7 +95,7 @@ final class MethodSearcherPlugin extends PluginV3 implements
                 foreach ($replacement_element_types->getTypeSet() as $element_type) {
                     $replacement_type = GenericArrayType::fromElementType(
                         $element_type,
-                        $type->getIsNullable(),
+                        $type->isNullable(),
                         $type->getKeyType()
                     );
                     $union_type = $union_type->withType($replacement_type);
@@ -123,7 +123,7 @@ final class MethodSearcherPlugin extends PluginV3 implements
             exit(\EXIT_FAILURE);
         }
         return \array_map(static function (FullyQualifiedClassName $fqsen) use ($type) : Type {
-            return $fqsen->asType()->withIsNullable($type->getIsNullable());
+            return $fqsen->asType()->withIsNullable($type->isNullable());
         }, $fqsens);
     }
 
@@ -249,14 +249,14 @@ final class MethodSearcherPlugin extends PluginV3 implements
     {
         if ($function instanceof Method) {
             // TODO: convert __sleep to string[], etc.
-            if ($function->getIsMagicAndVoid()) {
+            if ($function->isMagicAndVoid()) {
                 return UnionType::fromFullyQualifiedString('void');
             }
-            if (!$function->isAbstract() && !$function->isPHPInternal() && !$function->getHasReturn()) {
+            if (!$function->isAbstract() && !$function->isPHPInternal() && !$function->hasReturn()) {
                 return UnionType::fromFullyQualifiedString('void');
             }
         } else {
-            if (!$function->isPHPInternal() && !$function->getHasReturn()) {
+            if (!$function->isPHPInternal() && !$function->hasReturn()) {
                 return UnionType::fromFullyQualifiedString('void');
             }
         }

--- a/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
+++ b/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
@@ -148,7 +148,7 @@ final class VariableTrackerElementVisitor extends PluginAwarePostAnalysisVisitor
                 return false;
             }
 
-            return $method->getIsOverride() || $method->getIsOverriddenByAnother();
+            return $method->isOverride() || $method->isOverriddenByAnother();
         } catch (Exception $_) {
             // should not happen
             return false;

--- a/tests/Phan/Language/EmptyUnionTypeTest.php
+++ b/tests/Phan/Language/EmptyUnionTypeTest.php
@@ -36,6 +36,7 @@ final class EmptyUnionTypeTest extends BaseTest
         // UnionType implementation can't be optimized
         'withIsPossiblyUndefined',
         'isPossiblyUndefined',
+        'getIsPossiblyUndefined',  // alias of isPossiblyUndefined
     ];
 
     public function testMethods() : void

--- a/tests/Phan/Language/EmptyUnionTypeTest.php
+++ b/tests/Phan/Language/EmptyUnionTypeTest.php
@@ -35,7 +35,7 @@ final class EmptyUnionTypeTest extends BaseTest
         '__construct',
         // UnionType implementation can't be optimized
         'withIsPossiblyUndefined',
-        'getIsPossiblyUndefined',
+        'isPossiblyUndefined',
     ];
 
     public function testMethods() : void

--- a/tests/Phan/Language/UnionTypeTest.php
+++ b/tests/Phan/Language/UnionTypeTest.php
@@ -619,7 +619,7 @@ final class UnionTypeTest extends BaseTest
         $this->assertSame('array<string,int>|array<string,string[]>', (string)$union_type->withFlattenedArrayShapeOrLiteralTypeInstances());
         $this->assertInstanceOf(ArrayShapeType::class, $type);
         $field_union_type = $type->getFieldTypes()['key'];
-        $this->assertFalse($field_union_type->getIsPossiblyUndefined());
+        $this->assertFalse($field_union_type->isPossiblyUndefined());
     }
 
     public function testFlattenEmptyArrayShape() : void
@@ -650,7 +650,7 @@ final class UnionTypeTest extends BaseTest
         $this->assertInstanceOf(ArrayShapeType::class, $type);
         $this->assertSame('array<string,int>|array<string,string>', (string)$union_type->withFlattenedArrayShapeOrLiteralTypeInstances());
         $field_union_type = $type->getFieldTypes()['key'];
-        $this->assertTrue($field_union_type->getIsPossiblyUndefined());
+        $this->assertTrue($field_union_type->isPossiblyUndefined());
         $this->assertSame('int|string=', (string)$field_union_type);
         $this->assertSame([IntType::instance(false), StringType::instance(false)], $field_union_type->getTypeSet());
     }
@@ -667,7 +667,7 @@ final class UnionTypeTest extends BaseTest
         $this->assertSame('array{key\n\\\\line\x3a:int}', (string)$type);
         $this->assertSame('array<string,int>', (string)$union_type->withFlattenedArrayShapeOrLiteralTypeInstances());
         $field_union_type = $type->getFieldTypes()["key\n\\line:"];
-        $this->assertFalse($field_union_type->getIsPossiblyUndefined());
+        $this->assertFalse($field_union_type->isPossiblyUndefined());
         $this->assertSame('int', (string)$field_union_type);
     }
 


### PR DESCRIPTION
Some methods were already using isFoo()/hasFoo() - Make this consistent.

Leave aliases for methods that are likely to be used externally

And remove a function deprecated in Phan v1