### PR TITLE
v2: Make Phan's automatically added type annotations non-fully qualified 

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -469,12 +469,13 @@ return [
         // Plugins for Phan's self-analysis
         ////////////////////////////////////////////////////////////////////////
 
-        // TODO: warn about the usage of assert() for Phan's self-analysis. See https://github.com/phan/phan/issues/288
+        // Warns about the usage of assert() for Phan's self-analysis. See https://github.com/phan/phan/issues/288
         'NoAssertPlugin',
 
         'HasPHPDocPlugin',
-        'PHPDocToRealTypesPlugin',
+        'PHPDocToRealTypesPlugin',  // suggests replacing (at)return void with `: void` in the declaration, etc.
         'PHPDocRedundantPlugin',
+        'PreferNamespaceUsePlugin',
 
         // This should only be enabled if the code being analyzed contains Phan plugins.
         'PhanSelfCheckPlugin',

--- a/.phan/plugins/AlwaysReturnPlugin.php
+++ b/.phan/plugins/AlwaysReturnPlugin.php
@@ -126,7 +126,7 @@ final class AlwaysReturnPlugin extends PluginV3 implements
      * @param Func|Method $func
      * @return ?Node - returns null if there's no statement list to analyze
      */
-    private static function getStatementListToAnalyze($func) : ?\ast\Node
+    private static function getStatementListToAnalyze($func) : ?Node
     {
         if (!$func->hasNode()) {
             return null;

--- a/.phan/plugins/NotFullyQualifiedUsagePlugin/fixers.php
+++ b/.phan/plugins/NotFullyQualifiedUsagePlugin/fixers.php
@@ -22,7 +22,7 @@ call_user_func(static function () : void {
      * @return ?FileEditSet
      * @suppress PhanAccessMethodInternal
      */
-    $fix = static function (CodeBase $code_base, FileCacheEntry $contents, IssueInstance $instance) : ?\Phan\Plugin\Internal\IssueFixingPlugin\FileEditSet {
+    $fix = static function (CodeBase $code_base, FileCacheEntry $contents, IssueInstance $instance) : ?FileEditSet {
         $line = $instance->getLine();
         $expected_name = $instance->getTemplateParameters()[0];
         $edits = [];

--- a/.phan/plugins/PHPDocRedundantPlugin/Fixers.php
+++ b/.phan/plugins/PHPDocRedundantPlugin/Fixers.php
@@ -32,7 +32,7 @@ class Fixers
         CodeBase $unused_code_base,
         FileCacheEntry $contents,
         IssueInstance $instance
-    ) : ?\Phan\Plugin\Internal\IssueFixingPlugin\FileEditSet {
+    ) : ?FileEditSet {
         $params = $instance->getTemplateParameters();
         $name = $params[0];
         $encoded_comment = $params[1];
@@ -121,7 +121,7 @@ class Fixers
         FileCacheEntry $contents,
         int $line,
         string $name
-    ) : ?\Microsoft\PhpParser\FunctionLike {
+    ) : ?FunctionLike {
         $candidates = [];
         foreach ($contents->getNodesAtLine($line) as $node) {
             if ($node instanceof FunctionDeclaration || $node instanceof MethodDeclaration) {

--- a/.phan/plugins/PHPDocToRealTypesPlugin.php
+++ b/.phan/plugins/PHPDocToRealTypesPlugin.php
@@ -18,6 +18,8 @@ use PHPDocToRealTypesPlugin\Fixers;
  * This plugin suggests real types that can be used instead of phpdoc types.
  *
  * It does not check if the change is safe to make.
+ *
+ * TODO: Always use the same type representation as phpdoc if possible in this plugin
  */
 class PHPDocToRealTypesPlugin extends PluginV3 implements
     AnalyzeFunctionCapability,

--- a/.phan/plugins/PHPDocToRealTypesPlugin/Fixers.php
+++ b/.phan/plugins/PHPDocToRealTypesPlugin/Fixers.php
@@ -28,7 +28,7 @@ class Fixers
         CodeBase $unused_code_base,
         FileCacheEntry $contents,
         IssueInstance $instance
-    ) : ?\Phan\Plugin\Internal\IssueFixingPlugin\FileEditSet {
+    ) : ?FileEditSet {
         $params = $instance->getTemplateParameters();
         $return_type = $params[0];
         $name = $params[1];
@@ -104,7 +104,7 @@ class Fixers
         FileCacheEntry $contents,
         int $line,
         string $name
-    ) : ?\Microsoft\PhpParser\FunctionLike {
+    ) : ?FunctionLike {
         $candidates = [];
         foreach ($contents->getNodesAtLine($line) as $node) {
             if ($node instanceof FunctionDeclaration || $node instanceof MethodDeclaration) {

--- a/.phan/plugins/PHPUnitAssertionPlugin.php
+++ b/.phan/plugins/PHPUnitAssertionPlugin.php
@@ -59,7 +59,7 @@ class PHPUnitAssertionPlugin extends PluginV3 implements AnalyzeFunctionCallCapa
      * @return ?Closure(CodeBase, Context, FunctionInterface, array):void
      * @suppress PhanAccessClassConstantInternal, PhanAccessMethodInternal
      */
-    private function createClosureForMethod(CodeBase $code_base, Method $method, string $name) : ?\Closure
+    private function createClosureForMethod(CodeBase $code_base, Method $method, string $name) : ?Closure
     {
         // TODO: Add a helper method which will convert a doc comment and a stub php function source code to a closure for a param index (or indices)
         switch (\strtolower($name)) {

--- a/.phan/plugins/PhanSelfCheckPlugin.php
+++ b/.phan/plugins/PhanSelfCheckPlugin.php
@@ -44,7 +44,7 @@ class PhanSelfCheckPlugin extends PluginV3 implements AnalyzeFunctionCallCapabil
         /**
          * @return Closure(CodeBase, Context, FunctionInterface, array<int,mixed>):void
          */
-        $make_array_issue_callback = static function (int $fmt_index, int $arg_index) : \Closure {
+        $make_array_issue_callback = static function (int $fmt_index, int $arg_index) : Closure {
             /**
              * @param array<int,Node|string|int|float> $args the nodes for the arguments to the invocation
              * @return void
@@ -81,7 +81,7 @@ class PhanSelfCheckPlugin extends PluginV3 implements AnalyzeFunctionCallCapabil
          * @param int $arg_index the index of an array parameter expecting sequential arguments. This is >= $type_index.
          * @return Closure(CodeBase, Context, FunctionInterface, array<int,mixed>):void
          */
-        $make_type_and_parameters_callback = static function (int $type_index, int $arg_index) : \Closure {
+        $make_type_and_parameters_callback = static function (int $type_index, int $arg_index) : Closure {
             /**
              * @param array<int,Node|string|int|float> $args the nodes for the arguments to the invocation
              * @return void
@@ -122,7 +122,7 @@ class PhanSelfCheckPlugin extends PluginV3 implements AnalyzeFunctionCallCapabil
          * @param int $arg_index the index of an array parameter expecting variable arguments. This is >= $type_index.
          * @return Closure(CodeBase, Context, FunctionInterface, array<int,mixed>):void
          */
-        $make_type_and_varargs_callback = static function (int $type_index, int $arg_index) : \Closure {
+        $make_type_and_varargs_callback = static function (int $type_index, int $arg_index) : Closure {
             /**
              * @param array<int,Node|string|int|float> $args the nodes for the arguments to the invocation
              * @return void
@@ -195,7 +195,7 @@ class PhanSelfCheckPlugin extends PluginV3 implements AnalyzeFunctionCallCapabil
         return $results;
     }
 
-    private static function getIssueOrWarn(CodeBase $code_base, Context $context, FunctionInterface $function, string $issue_type) : ?\Phan\Issue
+    private static function getIssueOrWarn(CodeBase $code_base, Context $context, FunctionInterface $function, string $issue_type) : ?Issue
     {
         try {
             return Issue::fromType($issue_type);

--- a/.phan/plugins/PossiblyStaticMethodPlugin.php
+++ b/.phan/plugins/PossiblyStaticMethodPlugin.php
@@ -87,7 +87,7 @@ final class PossiblyStaticMethodPlugin extends PluginV3 implements
      * @param Method $method
      * @return ?Node - returns null if there's no statement list to analyze
      */
-    private static function getStatementListToAnalyze(Method $method) : ?\ast\Node
+    private static function getStatementListToAnalyze(Method $method) : ?Node
     {
         if (!$method->hasNode()) {
             return null;

--- a/.phan/plugins/PreferNamespaceUsePlugin.php
+++ b/.phan/plugins/PreferNamespaceUsePlugin.php
@@ -1,0 +1,181 @@
+<?php declare(strict_types=1);
+
+use ast\Node;
+use Phan\CodeBase;
+use Phan\IssueInstance;
+use Phan\Language\Context;
+use Phan\Language\Element\Func;
+use Phan\Language\Element\FunctionInterface;
+use Phan\Language\Element\Method;
+use Phan\Library\FileCacheEntry;
+use Phan\Plugin\Internal\IssueFixingPlugin\FileEditSet;
+use Phan\PluginV3;
+use Phan\PluginV3\AnalyzeFunctionCapability;
+use Phan\PluginV3\AnalyzeMethodCapability;
+use Phan\PluginV3\AutomaticFixCapability;
+use PreferNamespaceUsePlugin\Fixers;
+
+/**
+ * This plugin checks for redundant doc comments on functions, closures, and methods.
+ *
+ * This treats a doc comment as redundant if
+ *
+ * 1. It is exclusively annotations (0 or more), e.g. (at)return void
+ * 2. Every annotation repeats the real information in the signature.
+ *
+ * It does not check if the change is safe to make.
+ */
+class PreferNamespaceUsePlugin extends PluginV3 implements
+    AnalyzeFunctionCapability,
+    AnalyzeMethodCapability,
+    AutomaticFixCapability
+{
+    const PreferNamespaceUseParamType = 'PhanPluginPreferNamespaceUseParamType';
+    const PreferNamespaceUseReturnType = 'PhanPluginPreferNamespaceUseReturnType';
+
+    public function analyzeFunction(CodeBase $code_base, Func $function) : void
+    {
+        $this->analyzeFunctionLike($code_base, $function);
+    }
+
+    public function analyzeMethod(CodeBase $code_base, Method $method) : void
+    {
+        if ($method->isMagic() || $method->isPHPInternal()) {
+            return;
+        }
+        if ($method->getFQSEN() !== $method->getDefiningFQSEN()) {
+            return;
+        }
+        $this->analyzeFunctionLike($code_base, $method);
+    }
+
+    private function analyzeFunctionLike(CodeBase $code_base, FunctionInterface $method) : void
+    {
+        $node = $method->getNode();
+        if (!$node) {
+            return;
+        }
+        $return_type = $node->children['returnType'];
+        if ($return_type instanceof Node) {
+            $this->analyzeFunctionLikeReturn($code_base, $method, $return_type);
+        }
+        foreach ($node->children['params']->children ?? [] as $param_node) {
+            if (!($param_node instanceof Node)) {
+                // impossible?
+                continue;
+            }
+            $this->analyzeFunctionLikeParam($code_base, $method, $param_node);
+        }
+    }
+
+    private function analyzeFunctionLikeReturn(CodeBase $code_base, FunctionInterface $method, Node $return_type) : void
+    {
+        $is_nullable = false;
+        if ($return_type->kind === ast\AST_NULLABLE_TYPE) {
+            $return_type = $return_type->children['type'];
+            if (!($return_type instanceof Node)) {
+                // should not happen
+                return;
+            }
+            $is_nullable = true;
+        }
+        $shorter_return_type = self::determineShorterType($method->getContext(), $return_type);
+        if (is_string($shorter_return_type)) {
+            $prefix = $is_nullable ? '?' : '';
+            self::emitIssue(
+                $code_base,
+                $method->getContext(),
+                self::PreferNamespaceUseReturnType,
+                'Could write return type of {FUNCTION} as {TYPE} instead of {TYPE}',
+                [$method->getName(), $prefix . $shorter_return_type, $prefix . '\\' . $return_type->children['name']]
+            );
+        }
+    }
+
+    private function analyzeFunctionLikeParam(CodeBase $code_base, FunctionInterface $method, Node $param_node) : void
+    {
+        $param_type = $param_node->children['type'];
+        if (!$param_type instanceof Node) {
+            return;
+        }
+        $is_nullable = false;
+        if ($param_type->kind === ast\AST_NULLABLE_TYPE) {
+            $param_type = $param_type->children['type'];
+            if (!($param_type instanceof Node)) {
+                // should not happen
+                return;
+            }
+            $is_nullable = true;
+        }
+        $shorter_param_type = self::determineShorterType($method->getContext(), $param_type);
+        if (is_string($shorter_param_type)) {
+            $param_name = $param_node->children['name'];
+            if (!is_string($param_name)) {
+                // should be impossible
+                return;
+            }
+
+            $prefix = $is_nullable ? '?' : '';
+            self::emitIssue(
+                $code_base,
+                $method->getContext(),
+                self::PreferNamespaceUseParamType,
+                'Could write param type of ${PARAMETER} of {FUNCTION} as {TYPE} instead of {TYPE}',
+                [$param_name, $method->getName(), $prefix . $shorter_param_type, $prefix . '\\' . $param_type->children['name']]
+            );
+        }
+    }
+
+    /**
+     * Given a node with a parameter or return type, return a string with a shorter represented of the type (if possible), or return null if this is not possible.
+     *
+     * This does not try all possibilities, and only affects fully qualified types.
+     */
+    private static function determineShorterType(Context $context, Node $type_node) : ?string
+    {
+        if ($type_node->kind !== ast\AST_NAME) {
+            return null;
+        }
+
+        if ($type_node->flags !== ast\flags\NAME_FQ) {
+            return null;
+        }
+        $name = $type_node->children['name'];
+        if (!is_string($name)) {
+            return null;
+        }
+        $parts = explode('\\', $name);
+        $name_end = (string)array_pop($parts);
+        $namespace = implode('\\', $parts);
+
+        if ($context->hasNamespaceMapFor(ast\flags\USE_NORMAL, $name_end)) {
+            $fqsen = $context->getNamespaceMapFor(ast\flags\USE_NORMAL, $name_end);
+            if ($fqsen->getName() === $name_end && strcasecmp(ltrim($fqsen->getNamespace(), '\\'), $namespace) === 0) {
+                // found `use Bar\Something` when looking for `\Bar\Something`, so suggest `Something`
+                return $name_end;
+            }
+            // TODO: Could look for `use \Foo\Bar as FB;`
+        } elseif (strcasecmp($namespace, ltrim($context->getNamespace(), "\\")) === 0) {
+            // Foo\Bar\Baz in Foo\Bar is Baz unless there is another namespace use shadowing it.
+            return $name_end;
+        }
+        return null;
+    }
+
+    /**
+     * @return array<string,Closure(CodeBase,FileCacheEntry,IssueInstance):(?FileEditSet)>
+     */
+    public function getAutomaticFixers() : array
+    {
+        require_once __DIR__ .  '/PreferNamespaceUsePlugin/Fixers.php';
+        return [
+            self::PreferNamespaceUseReturnType => Closure::fromCallable([Fixers::class, 'fixReturnType']),
+            self::PreferNamespaceUseParamType => Closure::fromCallable([Fixers::class, 'fixParamType']),
+            //self::RedundantClosureComment => $function_like_fixer,
+        ];
+    }
+}
+
+// Every plugin needs to return an instance of itself at the
+// end of the file in which it's defined.
+return new PreferNamespaceUsePlugin();

--- a/.phan/plugins/PreferNamespaceUsePlugin/Fixers.php
+++ b/.phan/plugins/PreferNamespaceUsePlugin/Fixers.php
@@ -1,0 +1,142 @@
+<?php declare(strict_types=1);
+
+namespace PreferNamespaceUsePlugin;
+
+use Microsoft\PhpParser;
+use Microsoft\PhpParser\FunctionLike;
+use Microsoft\PhpParser\Node\Expression\AnonymousFunctionCreationExpression;
+use Microsoft\PhpParser\Node\MethodDeclaration;
+use Microsoft\PhpParser\Node\Statement\FunctionDeclaration;
+use Phan\AST\TolerantASTConverter\NodeUtils;
+use Phan\CodeBase;
+use Phan\IssueInstance;
+use Phan\Library\FileCacheEntry;
+use Phan\Plugin\Internal\IssueFixingPlugin\FileEdit;
+use Phan\Plugin\Internal\IssueFixingPlugin\FileEditSet;
+
+/**
+ * This plugin implements --automatic-fix for PreferNamespaceUsePlugin
+ */
+class Fixers
+{
+
+    /**
+     * Generate an edit to replace a fully qualified return type with a shorter equivalent representation.
+     * @return ?FileEditSet
+     */
+    public static function fixReturnType(
+        CodeBase $unused_code_base,
+        FileCacheEntry $contents,
+        IssueInstance $instance
+    ) : ?FileEditSet {
+        $params = $instance->getTemplateParameters();
+        $shorter_return_type = ltrim((string)$params[1], '?');
+        $method_name = $params[0];
+        // @phan-suppress-next-line PhanPartialTypeMismatchArgument
+        $declaration = self::findFunctionLikeDeclaration($contents, $instance->getLine(), $method_name);
+        if (!$declaration) {
+            return null;
+        }
+        return self::computeEditsForReturnTypeDeclaration($declaration, (string)$shorter_return_type);
+    }
+
+    /**
+     * Generate an edit to replace a fully qualified param type with a shorter equivalent representation.
+     * @return ?FileEditSet
+     */
+    public static function fixParamType(
+        CodeBase $unused_code_base,
+        FileCacheEntry $contents,
+        IssueInstance $instance
+    ) : ?FileEditSet {
+        $params = $instance->getTemplateParameters();
+        $shorter_return_type = ltrim((string)$params[2], '?');
+        $method_name = (string)$params[1];
+        $param_name = (string)$params[0];
+        // @phan-suppress-next-line PhanPartialTypeMismatchArgument
+        $declaration = self::findFunctionLikeDeclaration($contents, $instance->getLine(), $method_name);
+        if (!$declaration) {
+            return null;
+        }
+        return self::computeEditsForParamTypeDeclaration($contents, $declaration, $param_name, (string)$shorter_return_type);
+    }
+
+    private static function computeEditsForReturnTypeDeclaration(
+        FunctionLike $declaration,
+        string $shorter_return_type
+    ) : ?FileEditSet {
+        // @phan-suppress-next-line PhanUndeclaredProperty
+        $return_type_node = $declaration->returnType;
+        if (!$return_type_node) {
+            return null;
+        }
+        // Generate an edit to replace the long return type with the shorter return type
+        $file_edit = new FileEdit(
+            $return_type_node->getStart(),
+            $return_type_node->getEndPosition(),
+            $shorter_return_type
+        );
+        return new FileEditSet([$file_edit]);
+    }
+
+    private static function computeEditsForParamTypeDeclaration(
+        FileCacheEntry $contents,
+        FunctionLike $declaration,
+        string $param_name,
+        string $shorter_param_type
+    ) : ?FileEditSet {
+        // @phan-suppress-next-line PhanUndeclaredProperty
+        $return_type_node = $declaration->returnType;
+        if (!$return_type_node) {
+            return null;
+        }
+        // @phan-suppress-next-line PhanUndeclaredProperty
+        $parameter_node_list = $declaration->parameters->children ?? [];
+        foreach ($parameter_node_list as $param) {
+            if (!$param instanceof PhpParser\Node\Parameter) {
+                continue;
+            }
+            $declaration_name = (new NodeUtils($contents->getContents()))->tokenToString($param->variableName);
+            if ($declaration_name !== $param_name) {
+                continue;
+            }
+            $token = $param->typeDeclaration;
+            if (!$token) {
+                return null;
+            }
+            // @phan-suppress-next-line PhanThrowTypeAbsentForCall php-parser is not expected to throw here
+            $file_edit = new FileEdit($token->getStart(), $token->getEndPosition(), $shorter_param_type);
+            return new FileEditSet([$file_edit]);
+        }
+        return null;
+    }
+
+    // TODO: Move this into a reusable function
+    private static function findFunctionLikeDeclaration(
+        FileCacheEntry $contents,
+        int $line,
+        string $name
+    ) : ?FunctionLike {
+        $candidates = [];
+        foreach ($contents->getNodesAtLine($line) as $node) {
+            if ($node instanceof FunctionDeclaration || $node instanceof MethodDeclaration) {
+                $name_node = $node->name;
+                if (!$name_node) {
+                    continue;
+                }
+                $declaration_name = (new NodeUtils($contents->getContents()))->tokenToString($name_node);
+                if ($declaration_name === $name) {
+                    $candidates[] = $node;
+                }
+            } elseif ($node instanceof AnonymousFunctionCreationExpression) {
+                if ($name === '{closure}') {
+                    $candidates[] = $node;
+                }
+            }
+        }
+        if (\count($candidates) === 1) {
+            return $candidates[0];
+        }
+        return null;
+    }
+}

--- a/.phan/plugins/PrintfCheckerPlugin.php
+++ b/.phan/plugins/PrintfCheckerPlugin.php
@@ -83,7 +83,7 @@ class PrintfCheckerPlugin extends PluginV3 implements AnalyzeFunctionCallCapabil
      * @param bool|int|string|float|Node|array|null $ast_node
      * @return ?PrimitiveValue
      */
-    protected function astNodeToPrimitive(CodeBase $code_base, Context $context, $ast_node) : ?\Phan\Plugin\PrintfCheckerPlugin\PrimitiveValue
+    protected function astNodeToPrimitive(CodeBase $code_base, Context $context, $ast_node) : ?PrimitiveValue
     {
         // Base case: convert primitive tokens such as numbers and strings.
         if (!($ast_node instanceof Node)) {
@@ -148,7 +148,7 @@ class PrintfCheckerPlugin extends PluginV3 implements AnalyzeFunctionCallCapabil
      * @param PrimitiveValue $right the value on the right.
      * @return ?PrimitiveValue
      */
-    protected static function concatenateToPrimitive(PrimitiveValue $left, PrimitiveValue $right) : ?\Phan\Plugin\PrintfCheckerPlugin\PrimitiveValue
+    protected static function concatenateToPrimitive(PrimitiveValue $left, PrimitiveValue $right) : ?PrimitiveValue
     {
         // Combining untranslated strings with anything will cause problems.
         if ($left->is_translated) {

--- a/.phan/plugins/README.md
+++ b/.phan/plugins/README.md
@@ -327,12 +327,40 @@ Warnings may need to be completely disabled due to the large number of method de
 #### PHPDocToRealTypesPlugin.php
 
 This plugin suggests real types that can be used instead of phpdoc types.
-Currently, this just checks return types.
-This also supports `--automatic-fix` to add those types.
+Currently, this just checks param and return types.
+Some of the suggestions made by this plugin will cause inheritance errors.
+
+This doesn't suggest changes if classes have subclasses (but this check doesn't work when inheritance involves traits).
+`PHPDOC_TO_REAL_TYPES_IGNORE_INHERITANCE=1` can be used to force this to check **all** methods and emit issues.
+
+This also supports `--automatic-fix` to add the types to the real type signatures.
 
 - **PhanPluginCanUseReturnType**: `Can use {TYPE} as a return type of {METHOD}`
 - **PhanPluginCanUseNullableReturnType**: `Can use {TYPE} as a return type of {METHOD}` (useful if there is a minimum php version of 7.1)
 - **PhanPluginCanUsePHP71Void**: `Can use php 7.1's void as a return type of {METHOD}` (useful if there is a minimum php version of 7.1)
+
+This supports `--automatic-fix`.
+- `PHPDocRedundantPlugin` will be useful for cleaning up redundant phpdoc after real types were added.
+- `PreferNamespaceUsePlugin` can be used to convert types from fully qualified types back to unqualified types ()
+
+#### PHPDocRedundantPlugin.php
+
+This plugin warns about function/method/closure phpdoc that does nothing but repeat the information in the type signature.
+E.g. this will warn about `/** @return void */ function () : void {}` and `/** */`, but not `/** @return void description of what it does or other annotations */`
+
+This supports `--automatic-fix`
+
+- **PhanPluginRedundantFunctionComment**: `Redundant doc comment on function {FUNCTION}(): {COMMENT}`
+- **PhanPluginRedundantMethodComment**: `Redundant doc comment on method {METHOD}(): {COMMENT}`
+- **PhanPluginRedundantClosureComment**: `Redundant doc comment on closure {FUNCTION}: {COMMENT}`
+
+#### PreferNamespaceUsePlugin.php
+
+This plugin suggests using `ClassName` instead of `\My\Ns\ClassName` when there is a `use My\Ns\ClassName` annotation (or for uses in namespace `\My\Ns`)
+Currently, this only checks **real** (not phpdoc) param/return annotations.
+
+- **PhanPluginPreferNamespaceUseParamType**: `Could write param type of ${PARAMETER} of {FUNCTION} as {TYPE} instead of {TYPE}`
+- **PhanPluginPreferNamespaceUseReturnType**: `Could write return type of {FUNCTION} as {TYPE} instead of {TYPE}`
 
 ### 4. Demo plugins:
 

--- a/.phan/plugins/UseReturnValuePlugin.php
+++ b/.phan/plugins/UseReturnValuePlugin.php
@@ -870,7 +870,7 @@ class UseReturnValueVisitor extends PluginAwarePostAnalysisVisitor
      * For `$x = +foo();` the parent node is AST_ASSIGN.
      * @return ?Node
      */
-    private function findNonUnaryParentNodeNode() : ?\ast\Node
+    private function findNonUnaryParentNodeNode() : ?Node
     {
         $parent = end($this->parent_node_list);
         if (!$parent) {

--- a/.phan/plugins/WhitespacePlugin/fixers.php
+++ b/.phan/plugins/WhitespacePlugin/fixers.php
@@ -16,7 +16,7 @@ return [
      * @return ?FileEditSet
      * @suppress PhanAccessMethodInternal
      */
-    WhitespacePlugin::Tab => static function (CodeBase $unused_code_base, FileCacheEntry $contents, IssueInstance $instance) : ?\Phan\Plugin\Internal\IssueFixingPlugin\FileEditSet {
+    WhitespacePlugin::Tab => static function (CodeBase $unused_code_base, FileCacheEntry $contents, IssueInstance $instance) : ?FileEditSet {
         $spaces_per_tab = (int)(Config::getValue('plugin_config')['spaces_per_tab'] ?? 4);
         if ($spaces_per_tab <= 0) {
             $spaces_per_tab = 4;
@@ -25,7 +25,7 @@ return [
         /**
          * @return Generator<FileEdit>
          */
-        $compute_edits = static function (string $line_contents, int $byte_offset) use ($spaces_per_tab) : \Generator {
+        $compute_edits = static function (string $line_contents, int $byte_offset) use ($spaces_per_tab) : Generator {
             preg_match_all('/\t+/', $line_contents, $matches, PREG_OFFSET_CAPTURE);
 
             $effective_space_count = 0;
@@ -69,7 +69,7 @@ return [
      * @return ?FileEditSet
      * @suppress PhanAccessMethodInternal
      */
-    WhitespacePlugin::WhitespaceTrailing => static function (CodeBase $unused_code_base, FileCacheEntry $contents, IssueInstance $instance) : ?\Phan\Plugin\Internal\IssueFixingPlugin\FileEditSet {
+    WhitespacePlugin::WhitespaceTrailing => static function (CodeBase $unused_code_base, FileCacheEntry $contents, IssueInstance $instance) : ?FileEditSet {
         IssueFixer::debug("Calling trailing whitespace fixer {$instance->getFile()}\n");
         $raw_contents = $contents->getContents();
         $byte_offset = 0;
@@ -97,7 +97,7 @@ return [
      * @return ?FileEditSet
      * @suppress PhanAccessMethodInternal
      */
-    WhitespacePlugin::CarriageReturn => static function (CodeBase $unused_code_base, FileCacheEntry $contents, IssueInstance $instance) : ?\Phan\Plugin\Internal\IssueFixingPlugin\FileEditSet {
+    WhitespacePlugin::CarriageReturn => static function (CodeBase $unused_code_base, FileCacheEntry $contents, IssueInstance $instance) : ?FileEditSet {
         IssueFixer::debug("Calling trailing whitespace fixer {$instance->getFile()}\n");
         $raw_contents = $contents->getContents();
         $byte_offset = 0;

--- a/composer.lock
+++ b/composer.lock
@@ -1681,16 +1681,16 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "4.2.1",
+            "version": "4.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "3095910f0f0fb155ac4021fc51a4a7a39ac04e8a"
+                "reference": "f2a2c8e1c97c11ace607a7a667d73d47c19fe404"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/3095910f0f0fb155ac4021fc51a4a7a39ac04e8a",
-                "reference": "3095910f0f0fb155ac4021fc51a4a7a39ac04e8a",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/f2a2c8e1c97c11ace607a7a667d73d47c19fe404",
+                "reference": "f2a2c8e1c97c11ace607a7a667d73d47c19fe404",
                 "shasum": ""
             },
             "require": {
@@ -1730,7 +1730,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2019-04-25T07:55:20+00:00"
+            "time": "2019-05-05T09:05:15+00:00"
         },
         {
             "name": "sebastian/exporter",

--- a/internal/PHP_CodeSniffer/composer.lock
+++ b/internal/PHP_CodeSniffer/composer.lock
@@ -8,28 +8,29 @@
     "packages": [
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "0.3.1",
+            "version": "0.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "2cc49f47c69b023eaf05b48e6529389893b13d74"
+                "reference": "472d3161d289f652713a5e353532fa4592663a57"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/2cc49f47c69b023eaf05b48e6529389893b13d74",
-                "reference": "2cc49f47c69b023eaf05b48e6529389893b13d74",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/472d3161d289f652713a5e353532fa4592663a57",
+                "reference": "472d3161d289f652713a5e353532fa4592663a57",
                 "shasum": ""
             },
             "require": {
                 "php": "~7.1"
             },
             "require-dev": {
-                "consistence/coding-standard": "^2.0.0",
+                "consistence/coding-standard": "^3.5",
                 "jakub-onderka/php-parallel-lint": "^0.9.2",
                 "phing/phing": "^2.16.0",
                 "phpstan/phpstan": "^0.10",
                 "phpunit/phpunit": "^6.3",
-                "slevomat/coding-standard": "^3.3.0",
+                "slevomat/coding-standard": "^4.7.2",
+                "squizlabs/php_codesniffer": "^3.3.2",
                 "symfony/process": "^3.4 || ^4.0"
             },
             "type": "library",
@@ -50,7 +51,7 @@
                 "MIT"
             ],
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
-            "time": "2019-01-14T12:26:23+00:00"
+            "time": "2019-04-23T20:26:19+00:00"
         },
         {
             "name": "slevomat/coding-standard",
@@ -58,12 +59,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "971b856b0a2c06d86996465b98b7d069b39574a6"
+                "reference": "1ff7cfb8e8df3af138cd04793ca1fbfea254cd50"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/971b856b0a2c06d86996465b98b7d069b39574a6",
-                "reference": "971b856b0a2c06d86996465b98b7d069b39574a6",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/1ff7cfb8e8df3af138cd04793ca1fbfea254cd50",
+                "reference": "1ff7cfb8e8df3af138cd04793ca1fbfea254cd50",
                 "shasum": ""
             },
             "require": {
@@ -90,7 +91,7 @@
                 "MIT"
             ],
             "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
-            "time": "2019-04-20T05:53:19+00:00"
+            "time": "2019-05-01T13:36:10+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",

--- a/internal/lib/IncompatibleStubsSignatureDetector.php
+++ b/internal/lib/IncompatibleStubsSignatureDetector.php
@@ -101,7 +101,7 @@ class IncompatibleStubsSignatureDetector extends IncompatibleSignatureDetectorBa
                     \RecursiveDirectoryIterator::FOLLOW_SYMLINKS
                 )
             ),
-            static function (\SplFileInfo $file_info) : bool {
+            static function (SplFileInfo $file_info) : bool {
                 if ($file_info->getExtension() !== 'php') {
                     return false;
                 }

--- a/internal/lib/IncompatibleXMLSignatureDetector.php
+++ b/internal/lib/IncompatibleXMLSignatureDetector.php
@@ -237,7 +237,7 @@ class IncompatibleXMLSignatureDetector extends IncompatibleSignatureDetectorBase
     /**
      * @return Generator<string>
      */
-    private function getPossibleFilesInReferenceDirectory(string $folder_in_reference_directory) : \Generator
+    private function getPossibleFilesInReferenceDirectory(string $folder_in_reference_directory) : Generator
     {
         $file = $this->reference_directory . '/' . $folder_in_reference_directory . '.xml';
         yield $file;
@@ -393,7 +393,7 @@ class IncompatibleXMLSignatureDetector extends IncompatibleSignatureDetectorBase
     /**
      * @return ?SimpleXMLElement the simple xml for the global function $function_name
      */
-    public function getSimpleXMLForFunctionSignature(string $function_name) : ?\SimpleXMLElement
+    public function getSimpleXMLForFunctionSignature(string $function_name) : ?SimpleXMLElement
     {
         $function_name_lc = strtolower($function_name);
         $function_name_file_map = $this->getFilesForFunctionNameList();
@@ -502,7 +502,7 @@ class IncompatibleXMLSignatureDetector extends IncompatibleSignatureDetectorBase
     /** @var array<string,?SimpleXMLElement> maps file paths to cached parsed XML elements */
     private $simple_xml_cache = [];
 
-    private function getSimpleXMLForFile(string $file_path) : ?\SimpleXMLElement
+    private function getSimpleXMLForFile(string $file_path) : ?SimpleXMLElement
     {
         if (array_key_exists($file_path, $this->simple_xml_cache)) {
             return $this->simple_xml_cache[$file_path];
@@ -518,7 +518,7 @@ class IncompatibleXMLSignatureDetector extends IncompatibleSignatureDetectorBase
         });
     }
 
-    private function getSimpleXMLForFileUncached(string $file_path) : ?\SimpleXMLElement
+    private function getSimpleXMLForFileUncached(string $file_path) : ?SimpleXMLElement
     {
         $signature_file_contents = $this->fileGetContents($file_path);
         if (!is_string($signature_file_contents)) {
@@ -528,7 +528,7 @@ class IncompatibleXMLSignatureDetector extends IncompatibleSignatureDetectorBase
         return $this->getSimpleXMLForFileContents($signature_file_contents, $file_path);
     }
 
-    private function getSimpleXMLForFileContents(string $signature_file_contents, string $file_path) : ?\SimpleXMLElement
+    private function getSimpleXMLForFileContents(string $signature_file_contents, string $file_path) : ?SimpleXMLElement
     {
         // Not sure if there's a good way of using an external entity file in PHP.
         $signature_file_contents = $this->normalizeEntityFile($signature_file_contents);
@@ -588,7 +588,7 @@ class IncompatibleXMLSignatureDetector extends IncompatibleSignatureDetectorBase
      * @param ?SimpleXMLElement $xml
      * @return ?array<mixed,string>
      */
-    private function parseFunctionLikeSignatureForXML(string $function_name, ?\SimpleXMLElement $xml) : ?array
+    private function parseFunctionLikeSignatureForXML(string $function_name, ?SimpleXMLElement $xml) : ?array
     {
         if (!$xml) {
             return null;

--- a/internal/package.php
+++ b/internal/package.php
@@ -27,7 +27,7 @@ foreach (['src', 'vendor', '.phan'] as $subdir) {
 // Include all files with suffix .php, excluding those found in the tests folder.
 $iterator = new CallbackFilterIterator(
     $iterators,
-    static function (\SplFileInfo $file_info) : bool {
+    static function (SplFileInfo $file_info) : bool {
         if ($file_info->getExtension() !== 'php') {
             return false;
         }

--- a/src/Phan/AST/ASTHasher.php
+++ b/src/Phan/AST/ASTHasher.php
@@ -53,7 +53,7 @@ class ASTHasher
      * @param Node $node
      * @return string a 16-byte binary key
      */
-    private static function computeHash(\ast\Node $node) : string
+    private static function computeHash(Node $node) : string
     {
         $str = 'N' . $node->kind . ':' . ($node->flags & 0xfffff);
         foreach ($node->children as $key => $child) {

--- a/src/Phan/AST/AnalysisVisitor.php
+++ b/src/Phan/AST/AnalysisVisitor.php
@@ -93,7 +93,7 @@ abstract class AnalysisVisitor extends KindVisitorImplementation
         string $issue_type,
         int $lineno,
         array $parameters,
-        ?\Phan\Suggestion $suggestion
+        ?Suggestion $suggestion
     ) : void {
         Issue::maybeEmitWithParameters(
             $this->code_base,

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -169,7 +169,7 @@ class ContextNode
      * @return ?FullyQualifiedClassName (If this returns null, the caller is responsible for emitting an issue or falling back)
      * @throws FQSENException hopefully impossible
      */
-    public function getTraitFQSEN(array $adaptations_map) : ?\Phan\Language\FQSEN\FullyQualifiedClassName
+    public function getTraitFQSEN(array $adaptations_map) : ?FullyQualifiedClassName
     {
         // TODO: In a subsequent PR, try to make trait analysis work when $adaptations_map has multiple possible traits.
         $trait_fqsen_string = $this->getQualifiedName();
@@ -1206,7 +1206,7 @@ class ContextNode
      * @throws NodeException
      * An exception is thrown if we can't understand the node
      */
-    public function getOrCreateVariableForReferenceParameter(Parameter $parameter, ?\Phan\Language\Element\Parameter $real_parameter) : Variable
+    public function getOrCreateVariableForReferenceParameter(Parameter $parameter, ?Parameter $real_parameter) : Variable
     {
         try {
             return $this->getVariable();
@@ -2012,7 +2012,7 @@ class ContextNode
      * @return ?FullyQualifiedClassName
      * @throws IssueException if the list of possible classes couldn't be determined.
      */
-    public function resolveClassNameInContext() : ?\Phan\Language\FQSEN\FullyQualifiedClassName
+    public function resolveClassNameInContext() : ?FullyQualifiedClassName
     {
         // A function argument to resolve into an FQSEN
         $arg = $this->node;

--- a/src/Phan/AST/Parser.php
+++ b/src/Phan/AST/Parser.php
@@ -37,7 +37,7 @@ class Parser
      *
      * @return ?Cache<ParseResult>
      */
-    private static function maybeGetCache(CodeBase $code_base) : ?\Phan\Library\Cache
+    private static function maybeGetCache(CodeBase $code_base) : ?Cache
     {
         if ($code_base->getExpectChangesToFileContents()) {
             return null;
@@ -90,11 +90,11 @@ class Parser
     public static function parseCode(
         CodeBase $code_base,
         Context $context,
-        ?\Phan\Daemon\Request $request,
+        ?Request $request,
         string $file_path,
         string $file_contents,
         bool $suppress_parse_errors
-    ) : ?\ast\Node {
+    ) : ?Node {
         try {
             // This will choose the parser to use based on the config and $file_path
             // (For "Go To Definition", one of the files will have a slower parser which records the requested AST node)
@@ -148,7 +148,7 @@ class Parser
         string $file_contents,
         bool $suppress_parse_errors,
         Error $native_parse_error
-    ) : ?\ast\Node {
+    ) : ?Node {
         if (!$suppress_parse_errors) {
             Issue::maybeEmit(
                 $code_base,
@@ -198,7 +198,7 @@ class Parser
      * @return ?Node
      * @throws ParseException
      */
-    public static function parseCodePolyfill(CodeBase $code_base, Context $context, string $file_path, string $file_contents, bool $suppress_parse_errors, ?\Phan\Daemon\Request $request) : ?\ast\Node
+    public static function parseCodePolyfill(CodeBase $code_base, Context $context, string $file_path, string $file_contents, bool $suppress_parse_errors, ?Request $request) : ?Node
     {
         $converter = self::createConverter($file_path, $file_contents, $request);
         $converter->setPHPVersionId(Config::get_closest_target_php_version_id());

--- a/src/Phan/AST/PhanAnnotationAdder.php
+++ b/src/Phan/AST/PhanAnnotationAdder.php
@@ -74,7 +74,7 @@ class PhanAnnotationAdder
      * @param Node $node
      * @param int $bit_set the bits to add to the flags
      */
-    private static function markNode(\ast\Node $node, int $bit_set) : void
+    private static function markNode(Node $node, int $bit_set) : void
     {
         $kind = $node->kind;
         if (\array_key_exists($kind, self::FLAGS_NODE_TYPE_SET)) {
@@ -93,7 +93,7 @@ class PhanAnnotationAdder
          * @param Node $node
          * @return void
          */
-        $binary_op_handler = static function (\ast\Node $node) : void {
+        $binary_op_handler = static function (Node $node) : void {
             if ($node->flags === flags\BINARY_COALESCE) {
                 $inner_node = $node->children['left'];
                 if ($inner_node instanceof Node) {
@@ -105,7 +105,7 @@ class PhanAnnotationAdder
          * @param Node $node
          * @return void
          */
-        $dim_handler = static function (\ast\Node $node) : void {
+        $dim_handler = static function (Node $node) : void {
             if ($node->flags & self::FLAG_IGNORE_NULLABLE_AND_UNDEF) {
                 $inner_node = $node->children['expr'];
                 if ($inner_node instanceof Node) {
@@ -118,7 +118,7 @@ class PhanAnnotationAdder
          * @param Node $node
          * @return void
          */
-        $ignore_nullable_and_undef_handler = static function (\ast\Node $node) : void {
+        $ignore_nullable_and_undef_handler = static function (Node $node) : void {
             $inner_node = $node->children['var'];
             if ($inner_node instanceof Node) {
                 self::markNode($inner_node, self::FLAG_IGNORE_NULLABLE_AND_UNDEF);
@@ -129,7 +129,7 @@ class PhanAnnotationAdder
          * @param Node $node
          * @return void
          */
-        $ignore_nullable_and_undef_expr_handler = static function (\ast\Node $node) : void {
+        $ignore_nullable_and_undef_expr_handler = static function (Node $node) : void {
             $inner_node = $node->children['expr'];
             if ($inner_node instanceof Node) {
                 self::markNode($inner_node, self::FLAG_IGNORE_NULLABLE_AND_UNDEF);
@@ -139,7 +139,7 @@ class PhanAnnotationAdder
          * @param Node $node
          * @return void
          */
-        $ast_array_elem_handler = static function (\ast\Node $node) : void {
+        $ast_array_elem_handler = static function (Node $node) : void {
             // Handle [$a1, $a2] = $array; - Don't warn about $node
             $bit = $node->flags & self::FLAG_IGNORE_UNDEF;
             if ($bit) {

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -2017,7 +2017,7 @@ class TolerantASTConverter
      * @param ?Token $flags
      * @throws InvalidArgumentException if the class flags were unexpected
      */
-    private static function phpParserClassModifierToAstClassFlags(?\Microsoft\PhpParser\Token $flags) : int
+    private static function phpParserClassModifierToAstClassFlags(?Token $flags) : int
     {
         if ($flags === null) {
             return 0;

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -485,7 +485,7 @@ class UnionTypeVisitor extends AnalysisVisitor
      * @return ?Type
      * @throws IssueException if the parent type could not be resolved
      */
-    public static function findParentType(Context $context, CodeBase $code_base) : ?\Phan\Language\Type
+    public static function findParentType(Context $context, CodeBase $code_base) : ?Type
     {
         if (!$context->isInClassScope()) {
             throw new IssueException(
@@ -637,7 +637,7 @@ class UnionTypeVisitor extends AnalysisVisitor
      * @param int|float|string|Node $node
      * @return ?UnionType
      */
-    public static function unionTypeFromLiteralOrConstant(CodeBase $code_base, Context $context, $node) : ?\Phan\Language\UnionType
+    public static function unionTypeFromLiteralOrConstant(CodeBase $code_base, Context $context, $node) : ?UnionType
     {
         if ($node instanceof Node) {
             // TODO: Could check for arrays of constants or literals, and convert those to the generic array types
@@ -662,7 +662,7 @@ class UnionTypeVisitor extends AnalysisVisitor
      * This preserves `self` and `static`
      * @param Node $node
      */
-    public function fromTypeInSignature(\ast\Node $node) : UnionType
+    public function fromTypeInSignature(Node $node) : UnionType
     {
         $is_nullable = $node->kind === ast\AST_NULLABLE_TYPE;
         if ($is_nullable) {
@@ -1427,7 +1427,7 @@ class UnionTypeVisitor extends AnalysisVisitor
         return false;
     }
 
-    private function resolveArrayShapeElementTypes(Node $node, UnionType $union_type) : ?\Phan\Language\UnionType
+    private function resolveArrayShapeElementTypes(Node $node, UnionType $union_type) : ?UnionType
     {
         $dim_node = $node->children['dim'];
         $dim_value = $dim_node instanceof Node ? (new ContextNode($this->code_base, $this->context, $dim_node))->getEquivalentPHPScalarValue() : $dim_node;
@@ -2821,7 +2821,7 @@ class UnionTypeVisitor extends AnalysisVisitor
      * @return ?FullyQualifiedClassName
      * @throws FQSENException
      */
-    private function lookupClassOfCallableByName(string $class_name) : ?\Phan\Language\FQSEN\FullyQualifiedClassName
+    private function lookupClassOfCallableByName(string $class_name) : ?FullyQualifiedClassName
     {
         switch (\strtolower($class_name)) {
             case 'self':
@@ -3086,7 +3086,7 @@ class UnionTypeVisitor extends AnalysisVisitor
      * @return ?UnionType (Returns null when mixed)
      * TODO: Add an equivalent for Traversable and subclasses, once we have template support for Traversable<Key,T>
      */
-    public static function unionTypeOfArrayKeyForNode(CodeBase $code_base, Context $context, $node) : ?\Phan\Language\UnionType
+    public static function unionTypeOfArrayKeyForNode(CodeBase $code_base, Context $context, $node) : ?UnionType
     {
         $arg_type = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $node);
         return self::arrayKeyUnionTypeOfUnionType($arg_type);
@@ -3097,7 +3097,7 @@ class UnionTypeVisitor extends AnalysisVisitor
      * TODO: Add an equivalent for Traversable and subclasses, once we have template support for Traversable<Key,T>
      * TODO: Move into UnionType?
      */
-    public static function arrayKeyUnionTypeOfUnionType(UnionType $union_type) : ?\Phan\Language\UnionType
+    public static function arrayKeyUnionTypeOfUnionType(UnionType $union_type) : ?UnionType
     {
         if ($union_type->isEmpty()) {
             return null;

--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -183,7 +183,7 @@ class Analysis
      * @return Context
      * The context from within the node is returned
      */
-    public static function parseNodeInContext(CodeBase $code_base, Context $context, Node $node) : \Phan\Language\Context
+    public static function parseNodeInContext(CodeBase $code_base, Context $context, Node $node) : Context
     {
         $kind = $node->kind;
         $context->setLineNumberStart($node->lineno);
@@ -483,7 +483,7 @@ class Analysis
     public static function analyzeFile(
         CodeBase $code_base,
         string $file_path,
-        ?\Phan\Daemon\Request $request,
+        ?Request $request,
         string $override_contents = null
     ) : Context {
         // Set the file on the context

--- a/src/Phan/Analysis/Analyzable.php
+++ b/src/Phan/Analysis/Analyzable.php
@@ -64,7 +64,7 @@ trait Analyzable
      * NOTE: This is non-null if hasNode is true
      * @suppress PhanTypeMismatchDeclaredReturnNullable
      */
-    public function getNode() : ?\ast\Node
+    public function getNode() : ?Node
     {
         return $this->node;
     }

--- a/src/Phan/Analysis/AssignOperatorAnalysisVisitor.php
+++ b/src/Phan/Analysis/AssignOperatorAnalysisVisitor.php
@@ -73,7 +73,7 @@ class AssignOperatorAnalysisVisitor extends FlagVisitorImplementation
      *
      * @return Context
      */
-    public function visit(Node $node) : \Phan\Language\Context
+    public function visit(Node $node) : Context
     {
         Issue::maybeEmit(
             $this->code_base,
@@ -89,7 +89,7 @@ class AssignOperatorAnalysisVisitor extends FlagVisitorImplementation
      * @param Closure(UnionType):UnionType $get_type
      * @return Context
      */
-    private function updateTargetVariableWithType(Node $node, Closure $get_type) : \Phan\Language\Context
+    private function updateTargetVariableWithType(Node $node, Closure $get_type) : Context
     {
         try {
             $variable_name = (new ContextNode(
@@ -158,7 +158,7 @@ class AssignOperatorAnalysisVisitor extends FlagVisitorImplementation
      *
      * @see BinaryOperatorFlagVisitor::visitBinaryAdd() for analysis of "+", which is similar to "+="
      */
-    public function visitBinaryAdd(Node $node) : \Phan\Language\Context
+    public function visitBinaryAdd(Node $node) : Context
     {
         return $this->updateTargetWithType($node, function (UnionType $left) use ($node) : UnionType {
             $code_base = $this->code_base;
@@ -267,7 +267,7 @@ class AssignOperatorAnalysisVisitor extends FlagVisitorImplementation
         });
     }
 
-    public function visitBinaryCoalesce(Node $node) : \Phan\Language\Context
+    public function visitBinaryCoalesce(Node $node) : Context
     {
         $var_node = $node->children['var'];
         $new_node = new ast\Node(ast\AST_BINARY_OP, $node->lineno, [
@@ -404,22 +404,22 @@ class AssignOperatorAnalysisVisitor extends FlagVisitorImplementation
         });
     }
 
-    public function visitBinaryBitwiseAnd(Node $node) : \Phan\Language\Context
+    public function visitBinaryBitwiseAnd(Node $node) : Context
     {
         return $this->analyzeBitwiseOperation($node);
     }
 
-    public function visitBinaryBitwiseOr(Node $node) : \Phan\Language\Context
+    public function visitBinaryBitwiseOr(Node $node) : Context
     {
         return $this->analyzeBitwiseOperation($node);
     }
 
-    public function visitBinaryBitwiseXor(Node $node) : \Phan\Language\Context
+    public function visitBinaryBitwiseXor(Node $node) : Context
     {
         return $this->analyzeBitwiseOperation($node);
     }
 
-    public function visitBinaryConcat(Node $node) : \Phan\Language\Context
+    public function visitBinaryConcat(Node $node) : Context
     {
         return $this->updateTargetWithType($node, static function (UnionType $unused_left) : UnionType {
             // TODO: Check if both sides can cast to string and warn if they can't.
@@ -427,12 +427,12 @@ class AssignOperatorAnalysisVisitor extends FlagVisitorImplementation
         });
     }
 
-    public function visitBinaryDiv(Node $node) : \Phan\Language\Context
+    public function visitBinaryDiv(Node $node) : Context
     {
         return $this->analyzeNumericArithmeticOp($node, false);
     }
 
-    public function visitBinaryMod(Node $node) : \Phan\Language\Context
+    public function visitBinaryMod(Node $node) : Context
     {
         $this->warnForInvalidOperandsOfNumericOp($node);
         return $this->updateTargetWithType($node, static function (UnionType $unused_left) : UnionType {
@@ -441,12 +441,12 @@ class AssignOperatorAnalysisVisitor extends FlagVisitorImplementation
         });
     }
 
-    public function visitBinaryMul(Node $node) : \Phan\Language\Context
+    public function visitBinaryMul(Node $node) : Context
     {
         return $this->analyzeNumericArithmeticOp($node, true);
     }
 
-    public function visitBinaryPow(Node $node) : \Phan\Language\Context
+    public function visitBinaryPow(Node $node) : Context
     {
         // TODO: 2 ** (-2)  is a float
         return $this->analyzeNumericArithmeticOp($node, true);
@@ -456,7 +456,7 @@ class AssignOperatorAnalysisVisitor extends FlagVisitorImplementation
      * @return Context
      * TODO: There's an RFC to make binary shift left/right apply to strings.
      */
-    public function visitBinaryShiftLeft(Node $node) : \Phan\Language\Context
+    public function visitBinaryShiftLeft(Node $node) : Context
     {
         $this->analyzeBinaryShift($node);
         return $this->updateTargetWithType($node, static function (UnionType $unused_left) : UnionType {
@@ -466,7 +466,7 @@ class AssignOperatorAnalysisVisitor extends FlagVisitorImplementation
         });
     }
 
-    public function visitBinaryShiftRight(Node $node) : \Phan\Language\Context
+    public function visitBinaryShiftRight(Node $node) : Context
     {
         $this->analyzeBinaryShift($node);
         return $this->updateTargetWithType($node, static function (UnionType $unused_left) : UnionType {
@@ -526,7 +526,7 @@ class AssignOperatorAnalysisVisitor extends FlagVisitorImplementation
         );
     }
 
-    public function visitBinarySub(Node $node) : \Phan\Language\Context
+    public function visitBinarySub(Node $node) : Context
     {
         return $this->analyzeNumericArithmeticOp($node, true);
     }

--- a/src/Phan/Analysis/AssignOperatorFlagVisitor.php
+++ b/src/Phan/Analysis/AssignOperatorFlagVisitor.php
@@ -113,7 +113,7 @@ class AssignOperatorFlagVisitor extends FlagVisitorImplementation
         ]));
     }
 
-    public function visitBinaryCoalesce(Node $node) : \Phan\Language\UnionType
+    public function visitBinaryCoalesce(Node $node) : UnionType
     {
         $var_node = $node->children['var'];
         $new_node = new ast\Node(ast\AST_BINARY_OP, $node->lineno, [
@@ -130,7 +130,7 @@ class AssignOperatorFlagVisitor extends FlagVisitorImplementation
     /**
      * @return UnionType for the `&` operator
      */
-    public function visitBinaryBitwiseAnd(Node $node) : \Phan\Language\UnionType
+    public function visitBinaryBitwiseAnd(Node $node) : UnionType
     {
         $left = UnionTypeVisitor::unionTypeFromNode(
             $this->code_base,
@@ -158,7 +158,7 @@ class AssignOperatorFlagVisitor extends FlagVisitorImplementation
     /**
      * @return UnionType for the `|` operator
      */
-    public function visitBinaryBitwiseOr(Node $node) : \Phan\Language\UnionType
+    public function visitBinaryBitwiseOr(Node $node) : UnionType
     {
         $left = UnionTypeVisitor::unionTypeFromNode(
             $this->code_base,
@@ -190,7 +190,7 @@ class AssignOperatorFlagVisitor extends FlagVisitorImplementation
      *
      * @return UnionType for the `^` operator
      */
-    public function visitBinaryBitwiseXor(Node $node) : \Phan\Language\UnionType
+    public function visitBinaryBitwiseXor(Node $node) : UnionType
     {
         $left = UnionTypeVisitor::unionTypeFromNode(
             $this->code_base,

--- a/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
+++ b/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
@@ -418,7 +418,7 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
      * @return UnionType
      * The resulting type(s) of the binary operation
      */
-    private function visitBinaryOpCommon(Node $node) : \Phan\Language\UnionType
+    private function visitBinaryOpCommon(Node $node) : UnionType
     {
         $left = UnionTypeVisitor::unionTypeFromNode(
             $this->code_base,
@@ -832,7 +832,7 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
      * @return UnionType
      * The resulting type(s) of the binary operation
      */
-    public function visitBinaryMod(Node $unused_node) : \Phan\Language\UnionType
+    public function visitBinaryMod(Node $unused_node) : UnionType
     {
         // TODO: Warn about invalid left or right side
         return IntType::instance(false)->asUnionType();

--- a/src/Phan/Analysis/ConditionVisitor/BinaryCondition.php
+++ b/src/Phan/Analysis/ConditionVisitor/BinaryCondition.php
@@ -36,5 +36,5 @@ interface BinaryCondition
      * @param Node|string|int|float $expr
      * @return ?Context
      */
-    public function analyzeCall(ConditionVisitorInterface $visitor, \ast\Node $call_node, $expr) : ?\Phan\Language\Context;
+    public function analyzeCall(ConditionVisitorInterface $visitor, Node $call_node, $expr) : ?Context;
 }

--- a/src/Phan/Analysis/ConditionVisitor/ComparisonCondition.php
+++ b/src/Phan/Analysis/ConditionVisitor/ComparisonCondition.php
@@ -48,7 +48,7 @@ class ComparisonCondition implements BinaryCondition
     /**
      * @suppress PhanUnusedPublicMethodParameter
      */
-    public function analyzeCall(ConditionVisitorInterface $visitor, \ast\Node $call_node, $expr) : ?\Phan\Language\Context
+    public function analyzeCall(ConditionVisitorInterface $visitor, Node $call_node, $expr) : ?Context
     {
         return null;
     }

--- a/src/Phan/Analysis/ConditionVisitor/HasTypeCondition.php
+++ b/src/Phan/Analysis/ConditionVisitor/HasTypeCondition.php
@@ -71,7 +71,7 @@ class HasTypeCondition implements BinaryCondition
     /**
      * @suppress PhanUnusedPublicMethodParameter
      */
-    public function analyzeCall(ConditionVisitorInterface $visitor, \ast\Node $call_node, $expr) : ?\Phan\Language\Context
+    public function analyzeCall(ConditionVisitorInterface $visitor, Node $call_node, $expr) : ?Context
     {
         return null;
     }

--- a/src/Phan/Analysis/ConditionVisitor/IdenticalCondition.php
+++ b/src/Phan/Analysis/ConditionVisitor/IdenticalCondition.php
@@ -39,7 +39,7 @@ class IdenticalCondition implements BinaryCondition
         return $visitor->analyzeClassAssertion($object, $expr) ?? $visitor->getContext();
     }
 
-    public function analyzeCall(ConditionVisitorInterface $visitor, \ast\Node $call_node, $expr) : ?\Phan\Language\Context
+    public function analyzeCall(ConditionVisitorInterface $visitor, Node $call_node, $expr) : ?Context
     {
         if (!$expr instanceof Node) {
             return null;

--- a/src/Phan/Analysis/ConditionVisitor/NotEqualsCondition.php
+++ b/src/Phan/Analysis/ConditionVisitor/NotEqualsCondition.php
@@ -44,7 +44,7 @@ class NotEqualsCondition implements BinaryCondition
     /**
      * @suppress PhanUnusedPublicMethodParameter
      */
-    public function analyzeCall(ConditionVisitorInterface $visitor, \ast\Node $call_node, $expr) : ?\Phan\Language\Context
+    public function analyzeCall(ConditionVisitorInterface $visitor, Node $call_node, $expr) : ?Context
     {
         if (!$expr instanceof Node) {
             return null;

--- a/src/Phan/Analysis/ConditionVisitor/NotHasTypeCondition.php
+++ b/src/Phan/Analysis/ConditionVisitor/NotHasTypeCondition.php
@@ -69,7 +69,7 @@ class NotHasTypeCondition implements BinaryCondition
         return $visitor->getContext();
     }
 
-    public function analyzeCall(ConditionVisitorInterface $unused_visitor, \ast\Node $unused_call_node, $unused_expr) : ?\Phan\Language\Context
+    public function analyzeCall(ConditionVisitorInterface $unused_visitor, Node $unused_call_node, $unused_expr) : ?Context
     {
         return null;
     }

--- a/src/Phan/Analysis/ConditionVisitor/NotIdenticalCondition.php
+++ b/src/Phan/Analysis/ConditionVisitor/NotIdenticalCondition.php
@@ -40,7 +40,7 @@ class NotIdenticalCondition implements BinaryCondition
         return $visitor->getContext();
     }
 
-    public function analyzeCall(ConditionVisitorInterface $visitor, \ast\Node $call_node, $expr) : ?\Phan\Language\Context
+    public function analyzeCall(ConditionVisitorInterface $visitor, Node $call_node, $expr) : ?Context
     {
         if (!$expr instanceof Node) {
             return null;

--- a/src/Phan/Analysis/ConditionVisitorInterface.php
+++ b/src/Phan/Analysis/ConditionVisitorInterface.php
@@ -79,7 +79,7 @@ interface ConditionVisitorInterface
      * @param Node|string|int|float|bool $expr_node
      * @return ?Context
      */
-    public function analyzeClassAssertion($object_node, $expr_node) : ?\Phan\Language\Context;
+    public function analyzeClassAssertion($object_node, $expr_node) : ?Context;
 
     /**
      * @return ?Variable - Returns null if the variable is undeclared and ignore_undeclared_variables_in_global_scope applies.
@@ -89,5 +89,5 @@ interface ConditionVisitorInterface
      *
      * TODO: support assertions on superglobals, within the current file scope?
      */
-    public function getVariableFromScope(Node $var_node, Context $context) : ?\Phan\Language\Element\Variable;
+    public function getVariableFromScope(Node $var_node, Context $context) : ?Variable;
 }

--- a/src/Phan/Analysis/ConditionVisitorUtil.php
+++ b/src/Phan/Analysis/ConditionVisitorUtil.php
@@ -619,7 +619,7 @@ trait ConditionVisitorUtil
      * @return ?Context
      * @suppress PhanPartialTypeMismatchArgument
      */
-    private function analyzeBinaryConditionSide(Node $var_node, $expr_node, BinaryCondition $condition) : ?\Phan\Language\Context
+    private function analyzeBinaryConditionSide(Node $var_node, $expr_node, BinaryCondition $condition) : ?Context
     {
         '@phan-var ConditionVisitorUtil|ConditionVisitorInterface $this';
         $kind = $var_node->kind;
@@ -666,7 +666,7 @@ trait ConditionVisitorUtil
      * @return ?Context
      * @suppress PhanUnreferencedPublicMethod referenced in ConditionVisitorInterface
      */
-    public function analyzeClassAssertion($object_node, $expr_node) : ?\Phan\Language\Context
+    public function analyzeClassAssertion($object_node, $expr_node) : ?Context
     {
         if (!($object_node instanceof Node)) {
             return null;
@@ -771,7 +771,7 @@ trait ConditionVisitorUtil
      *
      * TODO: support assertions on superglobals, within the current file scope?
      */
-    final public function getVariableFromScope(Node $var_node, Context $context) : ?\Phan\Language\Element\Variable
+    final public function getVariableFromScope(Node $var_node, Context $context) : ?Variable
     {
         if ($var_node->kind !== ast\AST_VAR) {
             return null;

--- a/src/Phan/Analysis/ContextMergeVisitor.php
+++ b/src/Phan/Analysis/ContextMergeVisitor.php
@@ -299,7 +299,7 @@ class ContextMergeVisitor extends KindVisitorImplementation
         // Get the intersection of all types for all versions of
         // the variable from every side of the branch
         $union_type =
-            static function (string $variable_name) use ($scope_list) : \Phan\Language\UnionType {
+            static function (string $variable_name) use ($scope_list) : UnionType {
                 $previous_type = null;
                 $type_list = [];
                 // Get a list of all variables with the given name from

--- a/src/Phan/Analysis/NegatedConditionVisitor.php
+++ b/src/Phan/Analysis/NegatedConditionVisitor.php
@@ -260,7 +260,7 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitCall(Node $node) : \Phan\Language\Context
+    public function visitCall(Node $node) : Context
     {
         $raw_function_name = self::getFunctionName($node);
         if (!\is_string($raw_function_name)) {
@@ -301,7 +301,7 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
         return $context;
     }
 
-    public function visitVar(Node $node) : \Phan\Language\Context
+    public function visitVar(Node $node) : Context
     {
         $this->checkVariablesDefined($node);
         return $this->removeTruthyFromVariable($node, $this->context, false);
@@ -448,7 +448,7 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
      * @param Node|mixed $class_node
      * @return ?UnionType
      */
-    private function computeNegatedInstanceofType(UnionType $union_type, $class_node) : ?\Phan\Language\UnionType
+    private function computeNegatedInstanceofType(UnionType $union_type, $class_node) : ?UnionType
     {
         $right_hand_union_type = UnionTypeVisitor::unionTypeFromNode(
             $this->code_base,
@@ -718,7 +718,7 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
      * Analyze expressions such as $x['offset'] inside of a negated isset type check
      * @return Context
      */
-    public function checkComplexIsset(Node $var_node) : \Phan\Language\Context
+    public function checkComplexIsset(Node $var_node) : Context
     {
         $context = $this->context;
         if ($var_node->kind === ast\AST_DIM) {
@@ -833,7 +833,7 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
         return $context;
     }
 
-    private function checkComplexNegatedEmpty(Node $var_node) : \Phan\Language\Context
+    private function checkComplexNegatedEmpty(Node $var_node) : Context
     {
         $context = $this->context;
         // TODO: !empty($obj->prop['offset']) should imply $obj is not null (removeNullFromVariable)

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -1146,7 +1146,7 @@ class ParameterTypesAnalyzer
      *           if Phan should proceed using phpdoc type instead of real types. (Converting T|null to ?T)
      *         - null if the type is an invalid narrowing, and Phan should warn.
      */
-    public static function normalizeNarrowedParamType(UnionType $phpdoc_param_union_type, UnionType $real_param_type) : ?\Phan\Language\UnionType
+    public static function normalizeNarrowedParamType(UnionType $phpdoc_param_union_type, UnionType $real_param_type) : ?UnionType
     {
         // "@param null $x" is almost always a mistake. Forbid it for now.
         // But allow "@param T|null $x"

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -2330,7 +2330,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
      * @param string $method_name - NOTE: The caller should convert constants/class constants/etc in $node->children['method'] to a string.
      * @return ?Method
      */
-    private function getStaticMethodOrEmitIssue(Node $node, string $method_name) : ?\Phan\Language\Element\Method
+    private function getStaticMethodOrEmitIssue(Node $node, string $method_name) : ?Method
     {
         try {
             // Get a reference to the method being called
@@ -3095,7 +3095,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
      *
      * @param ?Parameter $real_parameter the real parameter type from the type signature
      */
-    private function createPassByReferenceArgumentInCall(Node $argument, Parameter $parameter, ?\Phan\Language\Element\Parameter $real_parameter) : void
+    private function createPassByReferenceArgumentInCall(Node $argument, Parameter $parameter, ?Parameter $real_parameter) : void
     {
         if ($argument->kind == ast\AST_VAR) {
             // We don't do anything with the new variable; just create it
@@ -3157,7 +3157,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         array $argument_list,
         FunctionInterface $method,
         Parameter $parameter,
-        ?\Phan\Language\Element\Parameter $real_parameter
+        ?Parameter $real_parameter
     ) : void {
         $variable = null;
         $kind = $argument->kind;
@@ -3343,7 +3343,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         try {
             // Even though we don't modify the parameter list, we still need to know the types
             // -- as an optimization, we don't run quick mode again if the types didn't change?
-            $parameter_list = \array_map(static function (Parameter $parameter) : \Phan\Language\Element\Parameter {
+            $parameter_list = \array_map(static function (Parameter $parameter) : Parameter {
                 return clone($parameter);
             }, $method->getParameterList());
 

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -310,7 +310,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
         return $context;
     }
 
-    private static function getOverrideClassFQSEN(CodeBase $code_base, Func $func) : ?\Phan\Language\FQSEN\FullyQualifiedClassName
+    private static function getOverrideClassFQSEN(CodeBase $code_base, Func $func) : ?FullyQualifiedClassName
     {
         $closure_scope = $func->getInternalScope();
         if ($closure_scope instanceof ClosureScope) {

--- a/src/Phan/Analysis/ReferenceCountsAnalyzer.php
+++ b/src/Phan/Analysis/ReferenceCountsAnalyzer.php
@@ -467,7 +467,7 @@ class ReferenceCountsAnalyzer
     public static function findAlternateReferencedElementDeclaration(
         CodeBase $code_base,
         AddressableElement $element
-    ) : ?\Phan\Language\Element\AddressableElement {
+    ) : ?AddressableElement {
         $old_fqsen = $element->getFQSEN();
         if ($old_fqsen instanceof FullyQualifiedGlobalStructuralElement) {
             $fqsen = $old_fqsen->getCanonicalFQSEN();

--- a/src/Phan/Analysis/ThrowsTypesAnalyzer.php
+++ b/src/Phan/Analysis/ThrowsTypesAnalyzer.php
@@ -128,7 +128,7 @@ class ThrowsTypesAnalyzer
         CodeBase $code_base,
         Context $context,
         FullyQualifiedClassName $type_fqsen
-    ) : ?\Phan\Suggestion {
+    ) : ?Suggestion {
         return IssueFixSuggester::suggestSimilarClass(
             $code_base,
             $context,

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -440,7 +440,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
      *
      * @return Context (The unmodified $context, or a different Context instance with modifications)
      */
-    private function analyzeAndGetUpdatedContext(\Phan\Language\Context $context, \ast\Node $node, \ast\Node $child_node) : \Phan\Language\Context
+    private function analyzeAndGetUpdatedContext(Context $context, Node $node, Node $child_node) : Context
     {
         // Modify the original object instead of creating a new BlockAnalysisVisitor.
         // this is slightly more efficient, especially if a large number of unchanged parameters would exist.

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -275,7 +275,7 @@ class CLI
      * @throws UsageException
      * @internal - used for unit tests only
      */
-    public static function fromRawValues(array $opts, array $argv) : \Phan\CLI
+    public static function fromRawValues(array $opts, array $argv) : CLI
     {
         return new self($opts, $argv);
     }

--- a/src/Phan/CodeBase/UndoTracker.php
+++ b/src/Phan/CodeBase/UndoTracker.php
@@ -131,7 +131,7 @@ class UndoTracker
      *
      * @return void
      */
-    public function recordUndo(\Closure $undo_operation) : void
+    public function recordUndo(Closure $undo_operation) : void
     {
         $file = $this->current_parsed_file;
         if (!\is_string($file)) {

--- a/src/Phan/Config/Initializer.php
+++ b/src/Phan/Config/Initializer.php
@@ -255,7 +255,7 @@ EOT;
      * @return ?InitializedSettings
      * @internal
      */
-    public static function createPhanSettingsForComposerSettings(array $composer_settings, ?string $vendor_path, array $opts) : ?\Phan\Config\InitializedSettings
+    public static function createPhanSettingsForComposerSettings(array $composer_settings, ?string $vendor_path, array $opts) : ?InitializedSettings
     {
         $level = $opts['init-level'] ?? 3;
         $level = self::LEVEL_MAP[\strtolower((string)$level)] ?? $level;

--- a/src/Phan/Daemon.php
+++ b/src/Phan/Daemon.php
@@ -36,7 +36,7 @@ class Daemon
      *
      * @throws Exception if analysis fails unexpectedly
      */
-    public static function run(CodeBase $code_base, Closure $file_path_lister) : ?\Phan\Daemon\Request
+    public static function run(CodeBase $code_base, Closure $file_path_lister) : ?Request
     {
         if (Config::getValue('language_server_use_pcntl_fallback')) {
             self::runWithoutPcntl($code_base, $file_path_lister);

--- a/src/Phan/Daemon/Request.php
+++ b/src/Phan/Daemon/Request.php
@@ -184,7 +184,7 @@ class Request
         CodeBase $code_base,
         Closure $file_path_lister,
         FileMapping $file_mapping,
-        ?\Phan\LanguageServer\NodeInfoRequest $most_recent_node_info_request,
+        ?NodeInfoRequest $most_recent_node_info_request,
         bool $should_exit
     ) : Request {
         FileCache::clear();
@@ -372,7 +372,7 @@ class Request
         return $mapping;
     }
 
-    public function getMostRecentNodeInfoRequest() : ?\Phan\LanguageServer\NodeInfoRequest
+    public function getMostRecentNodeInfoRequest() : ?NodeInfoRequest
     {
         return $this->most_recent_node_info_request;
     }
@@ -474,7 +474,7 @@ class Request
      * @param Responder $responder
      * @return ?Request - non-null if this is a worker process with work to do. null if request failed or this is the master.
      */
-    public static function accept(CodeBase $code_base, \Closure $file_path_lister, Responder $responder, bool $fork) : ?\Phan\Daemon\Request
+    public static function accept(CodeBase $code_base, Closure $file_path_lister, Responder $responder, bool $fork) : ?Request
     {
         FileCache::clear();
 
@@ -615,7 +615,7 @@ class Request
      * @param ?array<int,string> $file_names
      * @return void
      */
-    public static function reloadFilePathListForDaemon(CodeBase $code_base, \Closure $file_path_lister, array $file_mapping_contents, array $file_names = null) : void
+    public static function reloadFilePathListForDaemon(CodeBase $code_base, Closure $file_path_lister, array $file_mapping_contents, array $file_names = null) : void
     {
         $old_count = $code_base->getParsedFilePathCount();
 

--- a/src/Phan/IssueFixSuggester.php
+++ b/src/Phan/IssueFixSuggester.php
@@ -43,12 +43,12 @@ class IssueFixSuggester
      * @param Closure(Clazz):bool $class_closure
      * @return Closure(FullyQualifiedClassName):bool
      */
-    public static function createFQSENFilterFromClassFilter(CodeBase $code_base, Closure $class_closure) : \Closure
+    public static function createFQSENFilterFromClassFilter(CodeBase $code_base, Closure $class_closure) : Closure
     {
         /**
          * @param FullyQualifiedClassName $alternate_fqsen
          */
-        return static function (\Phan\Language\FQSEN\FullyQualifiedClassName $alternate_fqsen) use ($code_base, $class_closure) : bool {
+        return static function (FullyQualifiedClassName $alternate_fqsen) use ($code_base, $class_closure) : bool {
             if (!$code_base->hasClassWithFQSEN($alternate_fqsen)) {
                 return false;
             }
@@ -59,7 +59,7 @@ class IssueFixSuggester
     /**
      * @return Closure(FullyQualifiedClassName):bool
      */
-    public static function createFQSENFilterForClasslikeCategories(CodeBase $code_base, bool $allow_class, bool $allow_trait, bool $allow_interface) : \Closure
+    public static function createFQSENFilterForClasslikeCategories(CodeBase $code_base, bool $allow_class, bool $allow_trait, bool $allow_interface) : Closure
     {
         return self::createFQSENFilterFromClassFilter($code_base, static function (Clazz $class) use ($allow_class, $allow_trait, $allow_interface) : bool {
             if ($class->isTrait()) {
@@ -72,7 +72,7 @@ class IssueFixSuggester
         });
     }
 
-    public static function suggestSimilarClassForMethod(CodeBase $code_base, Context $context, FullyQualifiedClassName $class_fqsen, string $method_name, bool $is_static) : ?\Phan\Suggestion
+    public static function suggestSimilarClassForMethod(CodeBase $code_base, Context $context, FullyQualifiedClassName $class_fqsen, string $method_name, bool $is_static) : ?Suggestion
     {
         $filter = null;
         if (strtolower($method_name) === '__construct') {
@@ -91,7 +91,7 @@ class IssueFixSuggester
         FullyQualifiedFunctionName $function_fqsen,
         bool $suggest_in_global_namespace = true,
         string $prefix = ""
-    ) : ?\Phan\Suggestion {
+    ) : ?Suggestion {
         if (!$prefix) {
             $prefix = self::DEFAULT_FUNCTION_SUGGESTION_PREFIX;
         }
@@ -134,10 +134,10 @@ class IssueFixSuggester
         CodeBase $code_base,
         Context $context,
         FullyQualifiedClassName $class_fqsen,
-        ?\Closure $filter = null,
+        ?Closure $filter = null,
         string $prefix = null,
         int $class_suggest_type = self::CLASS_SUGGEST_ONLY_CLASSES
-    ) : ?\Phan\Suggestion {
+    ) : ?Suggestion {
         if (!$prefix) {
             $prefix = self::DEFAULT_CLASS_SUGGESTION_PREFIX;
         }
@@ -177,7 +177,7 @@ class IssueFixSuggester
         return Suggestion::fromString($suggestion_text);
     }
 
-    public static function suggestSimilarMethod(CodeBase $code_base, Context $context, Clazz $class, string $wanted_method_name, bool $is_static) : ?\Phan\Suggestion
+    public static function suggestSimilarMethod(CodeBase $code_base, Context $context, Clazz $class, string $wanted_method_name, bool $is_static) : ?Suggestion
     {
         if (Config::getValue('disable_suggestions')) {
             return null;
@@ -215,7 +215,7 @@ class IssueFixSuggester
      * @return ?FullyQualifiedClassName
      * @internal
      */
-    public static function maybeGetClassInCurrentScope(Context $context) : ?\Phan\Language\FQSEN\FullyQualifiedClassName
+    public static function maybeGetClassInCurrentScope(Context $context) : ?FullyQualifiedClassName
     {
         if ($context->isInClassScope()) {
             return $context->getClassFQSEN();
@@ -251,7 +251,7 @@ class IssueFixSuggester
      * @param ?\Closure(FullyQualifiedClassName):bool $filter
      * @return ?Suggestion
      */
-    public static function suggestSimilarClassForGenericFQSEN(CodeBase $code_base, Context $context, FQSEN $fqsen, ?\Closure $filter = null, string $prefix = 'Did you mean') : ?\Phan\Suggestion
+    public static function suggestSimilarClassForGenericFQSEN(CodeBase $code_base, Context $context, FQSEN $fqsen, ?Closure $filter = null, string $prefix = 'Did you mean') : ?Suggestion
     {
         if (Config::getValue('disable_suggestions')) {
             return null;
@@ -262,7 +262,7 @@ class IssueFixSuggester
         return self::suggestSimilarClass($code_base, $context, $fqsen, $filter, $prefix);
     }
 
-    public static function suggestSimilarProperty(CodeBase $code_base, Context $context, Clazz $class, string $wanted_property_name, bool $is_static) : ?\Phan\Suggestion
+    public static function suggestSimilarProperty(CodeBase $code_base, Context $context, Clazz $class, string $wanted_property_name, bool $is_static) : ?Suggestion
     {
         if (Config::getValue('disable_suggestions')) {
             return null;
@@ -339,7 +339,7 @@ class IssueFixSuggester
         return $candidates;
     }
 
-    public static function suggestSimilarClassConstant(CodeBase $code_base, Context $context, FullyQualifiedClassConstantName $class_constant_fqsen) : ?\Phan\Suggestion
+    public static function suggestSimilarClassConstant(CodeBase $code_base, Context $context, FullyQualifiedClassConstantName $class_constant_fqsen) : ?Suggestion
     {
         if (Config::getValue('disable_suggestions')) {
             return null;
@@ -370,7 +370,7 @@ class IssueFixSuggester
     /**
      * @return ?Suggestion with values similar to the given constant
      */
-    public static function suggestSimilarGlobalConstant(CodeBase $code_base, Context $context, FullyQualifiedGlobalConstantName $fqsen) : ?\Phan\Suggestion
+    public static function suggestSimilarGlobalConstant(CodeBase $code_base, Context $context, FullyQualifiedGlobalConstantName $fqsen) : ?Suggestion
     {
         if (Config::getValue('disable_suggestions')) {
             return null;
@@ -519,7 +519,7 @@ class IssueFixSuggester
         return $candidates;
     }
 
-    public static function suggestVariableTypoFix(CodeBase $code_base, Context $context, string $variable_name, string $prefix = 'Did you mean') : ?\Phan\Suggestion
+    public static function suggestVariableTypoFix(CodeBase $code_base, Context $context, string $variable_name, string $prefix = 'Did you mean') : ?Suggestion
     {
         if (Config::getValue('disable_suggestions')) {
             return null;

--- a/src/Phan/IssueInstance.php
+++ b/src/Phan/IssueInstance.php
@@ -129,7 +129,7 @@ class IssueInstance
     /**
      * @return ?Suggestion If this is non-null, this contains suggestions on how to resolve the error.
      */
-    public function getSuggestion() : ?\Phan\Suggestion
+    public function getSuggestion() : ?Suggestion
     {
         return $this->suggestion;
     }

--- a/src/Phan/Language/AnnotatedUnionType.php
+++ b/src/Phan/Language/AnnotatedUnionType.php
@@ -80,7 +80,7 @@ class AnnotatedUnionType extends UnionType
      * @return UnionType
      * @override
      */
-    public function withType(Type $type) : \Phan\Language\UnionType
+    public function withType(Type $type) : UnionType
     {
         return parent::withType($type)->withIsPossiblyUndefined(false);
     }
@@ -91,7 +91,7 @@ class AnnotatedUnionType extends UnionType
      * @return UnionType
      * @override
      */
-    public function withoutType(Type $type) : \Phan\Language\UnionType
+    public function withoutType(Type $type) : UnionType
     {
         return parent::withoutType($type)->withIsPossiblyUndefined(false);
     }
@@ -102,7 +102,7 @@ class AnnotatedUnionType extends UnionType
      * @return UnionType
      * @override
      */
-    public function withUnionType(UnionType $union_type) : \Phan\Language\UnionType
+    public function withUnionType(UnionType $union_type) : UnionType
     {
         return parent::withUnionType($union_type)->withIsPossiblyUndefined(false);
     }

--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -418,7 +418,7 @@ class Context extends FileRef
         return $this->scope->getClassFQSEN();
     }
 
-    public function getClassFQSENOrNull() : ?\Phan\Language\FQSEN\FullyQualifiedClassName
+    public function getClassFQSENOrNull() : ?FullyQualifiedClassName
     {
         return $this->scope->getClassFQSENOrNull();
     }
@@ -672,7 +672,7 @@ class Context extends FileRef
      * @param bool $should_catch_issue_exception the value passed to UnionTypeVisitor
      * @return ?UnionType
      */
-    public function getUnionTypeOfNodeIfCached(int $node_id, bool $should_catch_issue_exception) : ?\Phan\Language\UnionType
+    public function getUnionTypeOfNodeIfCached(int $node_id, bool $should_catch_issue_exception) : ?UnionType
     {
         if ($should_catch_issue_exception) {
             return $this->cache[$node_id] ?? null;
@@ -889,7 +889,7 @@ class Context extends FileRef
         return $override_type;
     }
 
-    public function getThisPropertyIfOverridden(string $name) : ?\Phan\Language\UnionType
+    public function getThisPropertyIfOverridden(string $name) : ?UnionType
     {
         if (!$this->scope->hasVariableWithName(self::VAR_NAME_THIS_PROPERTIES)) {
             return null;

--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -270,7 +270,7 @@ class Context extends FileRef
      * @deprecated use isStrictTypes
      * @suppress PhanUnreferencedPublicMethod
      */
-    public final function getIsStrictTypes() : bool
+    final public function getIsStrictTypes() : bool
     {
         return $this->isStrictTypes();
     }

--- a/src/Phan/Language/Element/AddressableElement.php
+++ b/src/Phan/Language/Element/AddressableElement.php
@@ -305,7 +305,7 @@ abstract class AddressableElement extends TypedElement implements AddressableEle
      * @internal
      * @return ?Closure
      */
-    abstract public function createRestoreCallback() : ?\Closure;
+    abstract public function createRestoreCallback() : ?Closure;
 
     /**
      * @param ?string $doc_comment the 'docComment' for this element, if any exists.

--- a/src/Phan/Language/Element/ClassElement.php
+++ b/src/Phan/Language/Element/ClassElement.php
@@ -247,7 +247,7 @@ abstract class ClassElement extends AddressableElement
      *                                    null if in the global scope.
      * @return bool true if this can be accessed from the scope of $accessing_class_fqsen
      */
-    public function isAccessibleFromClass(CodeBase $code_base, ?\Phan\Language\FQSEN\FullyQualifiedClassName $accessing_class_fqsen) : bool
+    public function isAccessibleFromClass(CodeBase $code_base, ?FullyQualifiedClassName $accessing_class_fqsen) : bool
     {
         if ($this->isPublic()) {
             return true;

--- a/src/Phan/Language/Element/ClassElement.php
+++ b/src/Phan/Language/Element/ClassElement.php
@@ -189,7 +189,7 @@ abstract class ClassElement extends AddressableElement
      * @deprecated use isOverride
      * @suppress PhanUnreferencedPublicMethod
      */
-    public final function getIsOverride() : bool
+    final public function getIsOverride() : bool
     {
         return $this->isOverride();
     }

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -1839,7 +1839,7 @@ class Clazz extends AddressableElement
      * @deprecated use hasDynamicProperties
      * @suppress PhanUnreferencedPublicMethod
      */
-    public final function getHasDynamicProperties(CodeBase $code_base) : bool
+    final public function getHasDynamicProperties(CodeBase $code_base) : bool
     {
         return $this->hasDynamicProperties($code_base);
     }

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -449,7 +449,7 @@ class Clazz extends AddressableElement
      * @return Option<Type>
      * If a parent type is defined, get Some<Type>, else None.
      */
-    public function getParentTypeOption() : \Phan\Library\Option
+    public function getParentTypeOption() : Option
     {
         if ($this->parent_type !== null) {
             return new Some($this->parent_type);
@@ -1101,7 +1101,7 @@ class Clazz extends AddressableElement
      *
      * @param ?Node $node
      */
-    public static function isAccessToElementOfThis(?\ast\Node $node) : bool
+    public static function isAccessToElementOfThis(?Node $node) : bool
     {
         if (!($node instanceof Node)) {
             return false;
@@ -1623,7 +1623,7 @@ class Clazz extends AddressableElement
      * @return Method
      * The magic `__call` method
      */
-    public function getCallMethod(CodeBase $code_base) : \Phan\Language\Element\Method
+    public function getCallMethod(CodeBase $code_base) : Method
     {
         return $this->getMethodByName($code_base, '__call');
     }
@@ -1664,7 +1664,7 @@ class Clazz extends AddressableElement
      * @return Method
      * The magic `__callStatic` method
      */
-    public function getCallStaticMethod(CodeBase $code_base) : \Phan\Language\Element\Method
+    public function getCallStaticMethod(CodeBase $code_base) : Method
     {
         return $this->getMethodByName($code_base, '__callStatic');
     }
@@ -2969,7 +2969,7 @@ class Clazz extends AddressableElement
      * Used by daemon mode to restore an element to the state it had before parsing.
      * @return Closure
      */
-    public function createRestoreCallback() : \Closure
+    public function createRestoreCallback() : Closure
     {
         // NOTE: Properties, Methods, and closures are restored separately.
         $original_this = clone($this);
@@ -2990,7 +2990,7 @@ class Clazz extends AddressableElement
         $this->additional_union_types = ($this->additional_union_types ?? UnionType::empty())->withType($type);
     }
 
-    public function getAdditionalTypes() : ?\Phan\Language\UnionType
+    public function getAdditionalTypes() : ?UnionType
     {
         return $this->additional_union_types;
     }
@@ -3127,7 +3127,7 @@ class Clazz extends AddressableElement
      *
      * @return ?ClassElement if non-null, this is of the same type as $element
      */
-    public static function getAncestorElement(CodeBase $code_base, FullyQualifiedClassName $ancestor_fqsen, ClassElement $element) : ?\Phan\Language\Element\ClassElement
+    public static function getAncestorElement(CodeBase $code_base, FullyQualifiedClassName $ancestor_fqsen, ClassElement $element) : ?ClassElement
     {
         if (!$code_base->hasClassWithFQSEN($ancestor_fqsen)) {
             return null;

--- a/src/Phan/Language/Element/Comment/Builder.php
+++ b/src/Phan/Language/Element/Comment/Builder.php
@@ -130,7 +130,7 @@ final class Builder
         string $line,
         bool $is_var,
         int $i
-    ) : \Phan\Language\Element\Comment\Parameter {
+    ) : Parameter {
         $matched = \preg_match(self::PARAM_COMMENT_REGEX, $line, $match);
         // Parse https://docs.phpdoc.org/references/phpdoc/tags/param.html
         // Exceptions: Deliberately allow "&" in "@param int &$x" when documenting references.
@@ -209,7 +209,7 @@ final class Builder
     private function returnTypeFromCommentLine(
         string $line,
         int $i
-    ) : \Phan\Language\UnionType {
+    ) : UnionType {
         $return_union_type_string = '';
 
         if (\preg_match(self::RETURN_COMMENT_REGEX, $line, $match)) {
@@ -478,7 +478,7 @@ final class Builder
      * @internal
      */
     const ASSERT_REGEX = '/@phan-assert(?:(-true-condition|-false-condition)|\s+(!?)(' . UnionType::union_type_regex . '))\s+\$' . self::WORD_REGEX . '/';
-    private function assertFromCommentLine(string $line) : ?\Phan\Language\Element\Comment\Assertion
+    private function assertFromCommentLine(string $line) : ?Assertion
     {
         if (!\preg_match(self::ASSERT_REGEX, $line, $match)) {
             return null;
@@ -690,7 +690,7 @@ final class Builder
         }
     }
 
-    private static function generateSuggestionForMisspelledAnnotation(string $annotation) : ?\Phan\Suggestion
+    private static function generateSuggestionForMisspelledAnnotation(string $annotation) : ?Suggestion
     {
         $suggestions = IssueFixSuggester::getSuggestionsForStringSet('@' . $annotation, self::SUPPORTED_ANNOTATIONS);
         if (!$suggestions) {
@@ -822,7 +822,7 @@ final class Builder
      */
     private static function templateTypeFromCommentLine(
         string $line
-    ) : ?\Phan\Language\Type\TemplateType {
+    ) : ?TemplateType {
         // Backslashes or nested templates wouldn't make sense, so use WORD_REGEX.
         if (\preg_match('/@(?:phan-)?template\s+(' . self::WORD_REGEX . ')/', $line, $match)) {
             $template_type_identifier = $match[1];
@@ -841,7 +841,7 @@ final class Builder
      */
     private function inheritsFromCommentLine(
         string $line
-    ) : \Phan\Library\Option {
+    ) : Option {
         $match = [];
         if (\preg_match('/@(?:phan-)?(?:inherits|extends)\s+(' . Type::type_regex . ')/', $line, $match)) {
             $type_string = $match[1];
@@ -914,7 +914,7 @@ final class Builder
         string $param_string,
         int $param_index,
         int $comment_line_offset
-    ) : ?\Phan\Language\Element\Comment\Parameter {
+    ) : ?Parameter {
         $param_string = \trim($param_string);
         // Don't support trailing commas, or omitted params. Provide at least one of [type] or [parameter]
         if ($param_string === '') {
@@ -962,7 +962,7 @@ final class Builder
     private function magicMethodFromCommentLine(
         string $line,
         int $comment_line_offset
-    ) : ?\Phan\Language\Element\Comment\Method {
+    ) : ?Method {
         // https://phpdoc.org/docs/latest/references/phpdoc/tags/method.html
         // > Going to assume "static" is a magic keyword, based on https://github.com/phpDocumentor/phpDocumentor2/issues/822
         // > TODO: forbid in trait?
@@ -1105,7 +1105,7 @@ final class Builder
     private function magicPropertyFromCommentLine(
         string $line,
         int $i
-    ) : ?\Phan\Language\Element\Comment\Property {
+    ) : ?Property {
         // Note that the type of a property can be left out (@property $myVar) - This is equivalent to @property mixed $myVar
         // TODO: properly handle duplicates...
         if (\preg_match('/@(?:phan-)?(property|property-read|property-write)(?:\s+(' . UnionType::union_type_regex . '))?(?:\s+(?:\\$' . self::WORD_REGEX . '))/', $line, $match)) {

--- a/src/Phan/Language/Element/ConstantTrait.php
+++ b/src/Phan/Language/Element/ConstantTrait.php
@@ -55,7 +55,7 @@ trait ConstantTrait
      * @internal
      * @return ?Closure
      */
-    public function createRestoreCallback() : ?\Closure
+    public function createRestoreCallback() : ?Closure
     {
         $future_union_type = $this->future_union_type;
         if ($future_union_type === null) {

--- a/src/Phan/Language/Element/ElementFutureUnionType.php
+++ b/src/Phan/Language/Element/ElementFutureUnionType.php
@@ -65,7 +65,7 @@ trait ElementFutureUnionType
      * on this object or null if there is no future
      * union type.
      */
-    public function getFutureUnionType() : ?\Phan\Language\UnionType
+    public function getFutureUnionType() : ?UnionType
     {
         $future_union_type = $this->future_union_type;
         if ($future_union_type === null) {

--- a/src/Phan/Language/Element/Func.php
+++ b/src/Phan/Language/Element/Func.php
@@ -104,7 +104,7 @@ class Func extends AddressableElement implements FunctionInterface
         Context $context,
         Type $closure_scope_type,
         Node $node
-    ) : ?\Phan\Language\FQSEN\FullyQualifiedClassName {
+    ) : ?FullyQualifiedClassName {
         if ($node->kind !== ast\AST_CLOSURE) {
             return null;
         }

--- a/src/Phan/Language/Element/FunctionInterface.php
+++ b/src/Phan/Language/Element/FunctionInterface.php
@@ -173,7 +173,7 @@ interface FunctionInterface extends AddressableElementInterface
      * @param int $i - offset of the parameter.
      * @return Parameter|null The parameter type that the **caller** observes.
      */
-    public function getParameterForCaller(int $i) : ?\Phan\Language\Element\Parameter;
+    public function getParameterForCaller(int $i) : ?Parameter;
 
     /**
      * Gets the $ith real parameter for the **caller**.
@@ -184,7 +184,7 @@ interface FunctionInterface extends AddressableElementInterface
      * @param int $i - offset of the parameter.
      * @return Parameter|null The parameter type that the **caller** observes.
      */
-    public function getRealParameterForCaller(int $i) : ?\Phan\Language\Element\Parameter;
+    public function getRealParameterForCaller(int $i) : ?Parameter;
 
     /**
      * @param Parameter $parameter
@@ -297,7 +297,7 @@ interface FunctionInterface extends AddressableElementInterface
     /**
      * @return ?UnionType the raw phpdoc union type
      */
-    public function getPHPDocReturnType() : ?\Phan\Language\UnionType;
+    public function getPHPDocReturnType() : ?UnionType;
 
     /**
      * @return bool
@@ -322,7 +322,7 @@ interface FunctionInterface extends AddressableElementInterface
      * Make calculation of the return type of this function/method use $closure
      * @return void
      */
-    public function setDependentReturnTypeClosure(\Closure $closure) : void;
+    public function setDependentReturnTypeClosure(Closure $closure) : void;
 
     /**
      * Returns true if this function or method has additional analysis logic for invocations (From internal and user defined plugins)
@@ -345,13 +345,13 @@ interface FunctionInterface extends AddressableElementInterface
      * If callers need to invoke multiple closures, they should pass in a closure to invoke multiple closures or use addFunctionCallAnalyzer.
      * @return void
      */
-    public function setFunctionCallAnalyzer(\Closure $closure) : void;
+    public function setFunctionCallAnalyzer(Closure $closure) : void;
 
     /**
      * If callers need to invoke multiple closures, they should pass in a closure to invoke multiple closures.
      * @return void
      */
-    public function addFunctionCallAnalyzer(\Closure $closure) : void;
+    public function addFunctionCallAnalyzer(Closure $closure) : void;
 
     /**
      * Initialize the inner scope of this method with variables created from the parameters.
@@ -362,12 +362,12 @@ interface FunctionInterface extends AddressableElementInterface
      */
     public function ensureScopeInitialized(CodeBase $code_base) : void;
 
-    public function getNode() : ?\ast\Node;
+    public function getNode() : ?Node;
 
     /**
      * @return ?Comment - Not set for internal functions/methods
      */
-    public function getComment() : ?\Phan\Language\Element\Comment;
+    public function getComment() : ?Comment;
 
     public function setComment(Comment $comment) : void;
 
@@ -440,5 +440,5 @@ interface FunctionInterface extends AddressableElementInterface
      * @return ?Closure(CodeBase, Context, array):UnionType
      * @internal
      */
-    public function getCommentParamAssertionClosure(CodeBase $code_base) : ?\Closure;
+    public function getCommentParamAssertionClosure(CodeBase $code_base) : ?Closure;
 }

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -347,7 +347,7 @@ trait FunctionTrait
      * @deprecated use hasReturn
      * @suppress PhanUnreferencedPublicMethod
      */
-    public final function getHasReturn() : bool
+    final public function getHasReturn() : bool
     {
         return $this->hasReturn();
     }
@@ -366,7 +366,7 @@ trait FunctionTrait
      * @deprecated use hasYield
      * @suppress PhanUnreferencedPublicMethod
      */
-    public final function getHasYield() : bool
+    final public function getHasYield() : bool
     {
         return $this->hasYield();
     }

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -76,7 +76,7 @@ trait FunctionTrait
      * The fully-qualified structural element name of this
      * structural element
      */
-    abstract public function getFQSEN() : \Phan\Language\FQSEN;
+    abstract public function getFQSEN() : FQSEN;
 
     /**
      * @return string
@@ -455,7 +455,7 @@ trait FunctionTrait
      * @param int $i - offset of the parameter.
      * @return Parameter|null The parameter type that the **caller** observes.
      */
-    public function getParameterForCaller(int $i) : ?\Phan\Language\Element\Parameter
+    public function getParameterForCaller(int $i) : ?Parameter
     {
         $list = $this->parameter_list;
         if (count($list) === 0) {
@@ -482,7 +482,7 @@ trait FunctionTrait
      * @return Parameter|null The real parameter type (from php signature) that the **caller** observes.
      * @suppress PhanUnreferencedPublicMethod false positive - this is referenced in FunctionInterface.
      */
-    public function getRealParameterForCaller(int $i) : ?\Phan\Language\Element\Parameter
+    public function getRealParameterForCaller(int $i) : ?Parameter
     {
         $list = $this->real_parameter_list;
         if (count($list) === 0) {
@@ -568,7 +568,7 @@ trait FunctionTrait
     public function getRealParameterList()
     {
         // Excessive cloning, to ensure that this stays immutable.
-        return \array_map(static function (Parameter $param) : \Phan\Language\Element\Parameter {
+        return \array_map(static function (Parameter $param) : Parameter {
             return clone($param);
         }, $this->real_parameter_list);
     }
@@ -581,7 +581,7 @@ trait FunctionTrait
      */
     public function setRealParameterList(array $parameter_list) : void
     {
-        $this->real_parameter_list = \array_map(static function (Parameter $param) : \Phan\Language\Element\Parameter {
+        $this->real_parameter_list = \array_map(static function (Parameter $param) : Parameter {
             return clone($param);
         }, $parameter_list);
 
@@ -896,7 +896,7 @@ trait FunctionTrait
      * @param ?UnionType $type the raw phpdoc union type
      * @return void
      */
-    public function setPHPDocReturnType(?\Phan\Language\UnionType $type) : void
+    public function setPHPDocReturnType(?UnionType $type) : void
     {
         $this->phpdoc_return_type = $type;
     }
@@ -905,7 +905,7 @@ trait FunctionTrait
      * @return ?UnionType the raw phpdoc union type
      * @suppress PhanUnreferencedPublicMethod Phan knows FunctionInterface's method is referenced, but can't associate that yet.
      */
-    public function getPHPDocReturnType() : ?\Phan\Language\UnionType
+    public function getPHPDocReturnType() : ?UnionType
     {
         return $this->phpdoc_return_type;
     }
@@ -979,7 +979,7 @@ trait FunctionTrait
     abstract public function getRecursionDepth() : int;
 
     /** @return Node|null the node of this function-like's declaration, if any exist and were kept for recursive non-quick analysis. */
-    abstract public function getNode() : ?\ast\Node;
+    abstract public function getNode() : ?Node;
 
     /** @return Context location and scope where this was declared. */
     abstract public function getContext() : Context;
@@ -1063,7 +1063,7 @@ trait FunctionTrait
     /**
      * @return ?Comment - Not set for internal functions/methods
      */
-    public function getComment() : ?\Phan\Language\Element\Comment
+    public function getComment() : ?Comment
     {
         return $this->comment;
     }
@@ -1500,7 +1500,7 @@ trait FunctionTrait
      *
      * @return ?Closure(array<int,Node|string|int|float|UnionType>, Context):UnionType
      */
-    public function getTemplateTypeExtractorClosure(CodeBase $code_base, TemplateType $template_type, int $skip_index = null) : ?\Closure
+    public function getTemplateTypeExtractorClosure(CodeBase $code_base, TemplateType $template_type, int $skip_index = null) : ?Closure
     {
         $closure = null;
         foreach ($this->parameter_list as $i => $parameter) {
@@ -1556,7 +1556,7 @@ trait FunctionTrait
      * @return ?Closure(CodeBase, Context, FunctionInterface, array):void
      * @internal
      */
-    private function getPluginForParamAssertionMap(CodeBase $code_base, array $param_assertion_map) : ?\Closure
+    private function getPluginForParamAssertionMap(CodeBase $code_base, array $param_assertion_map) : ?Closure
     {
         $closure = null;
         foreach ($param_assertion_map as $param_name => $assertion) {
@@ -1586,7 +1586,7 @@ trait FunctionTrait
      * @suppress PhanAccessPropertyInternal
      * @internal
      */
-    public function createClosureForAssertion(CodeBase $code_base, Assertion $assertion, int $i) : ?\Closure
+    public function createClosureForAssertion(CodeBase $code_base, Assertion $assertion, int $i) : ?Closure
     {
         $union_type = $assertion->union_type;
         if ($union_type->hasTemplateTypeRecursive()) {
@@ -1611,7 +1611,7 @@ trait FunctionTrait
      * @param Closure(CodeBase, Context, array):UnionType $union_type_extractor
      * @return ?Closure(CodeBase, Context, FunctionInterface, array):void
      */
-    public static function createClosureForUnionTypeExtractorAndAssertionType(Closure $union_type_extractor, int $assertion_type, int $i) : ?\Closure
+    public static function createClosureForUnionTypeExtractorAndAssertionType(Closure $union_type_extractor, int $assertion_type, int $i) : ?Closure
     {
         switch ($assertion_type) {
             case Assertion::IS_OF_TYPE:
@@ -1678,7 +1678,7 @@ trait FunctionTrait
      *
      * @return ?Closure(CodeBase, Context, array):UnionType
      */
-    private function makeAssertionUnionTypeExtractor(CodeBase $code_base, UnionType $type, int $asserted_param_index) : ?\Closure
+    private function makeAssertionUnionTypeExtractor(CodeBase $code_base, UnionType $type, int $asserted_param_index) : ?Closure
     {
         $comment = $this->getComment();
         if (!$comment) {
@@ -1718,7 +1718,7 @@ trait FunctionTrait
      * @internal
      * @suppress PhanUnreferencedPublicMethod referenced in FunctionTrait
      */
-    public function getCommentParamAssertionClosure(CodeBase $code_base) : ?\Closure
+    public function getCommentParamAssertionClosure(CodeBase $code_base) : ?Closure
     {
         $comment = $this->getComment();
         if (!$comment) {

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -191,7 +191,7 @@ class Method extends ClassElement implements FunctionInterface
      * @deprecated use isOverriddenByAnother
      * @suppress PhanUnreferencedPublicMethod
      */
-    public final function getIsOverriddenByAnother() : bool
+    final public function getIsOverriddenByAnother() : bool
     {
         return $this->isOverriddenByAnother();
     }
@@ -268,7 +268,7 @@ class Method extends ClassElement implements FunctionInterface
      * @deprecated use isMagic
      * @suppress PhanUnreferencedPublicMethod
      */
-    public final function getIsMagic() : bool
+    final public function getIsMagic() : bool
     {
         return $this->isMagic();
     }
@@ -287,7 +287,7 @@ class Method extends ClassElement implements FunctionInterface
      * @deprecated use isMagicAndVoid
      * @suppress PhanUnreferencedPublicMethod
      */
-    public final function getIsMagicAndVoid() : bool
+    final public function getIsMagicAndVoid() : bool
     {
         return $this->isMagicAndVoid();
     }

--- a/src/Phan/Language/Element/Parameter.php
+++ b/src/Phan/Language/Element/Parameter.php
@@ -234,7 +234,7 @@ class Parameter extends Variable
      * @param Node|string|float|int $node
      * @return ?UnionType - Returns if we know the exact type of $node and can easily resolve it
      */
-    private static function maybeGetKnownDefaultValueForNode($node) : ?\Phan\Language\UnionType
+    private static function maybeGetKnownDefaultValueForNode($node) : ?UnionType
     {
         if (!($node instanceof Node)) {
             return Type::nonLiteralFromObject($node)->asUnionType();

--- a/src/Phan/Language/Element/Property.php
+++ b/src/Phan/Language/Element/Property.php
@@ -211,7 +211,7 @@ class Property extends ClassElement
      * @internal
      * @return ?Closure
      */
-    public function createRestoreCallback() : ?\Closure
+    public function createRestoreCallback() : ?Closure
     {
         $future_union_type = $this->future_union_type;
         if ($future_union_type === null) {

--- a/src/Phan/Language/Element/Variable.php
+++ b/src/Phan/Language/Element/Variable.php
@@ -195,7 +195,7 @@ class Variable extends UnaddressableTypedElement implements TypedElementInterfac
      */
     public static function getUnionTypeOfHardcodedGlobalVariableWithName(
         string $name
-    ) : ?\Phan\Language\UnionType {
+    ) : ?UnionType {
         if (\array_key_exists($name, self::_BUILTIN_GLOBAL_TYPES)) {
             // More efficient than using context.
             return UnionType::fromFullyQualifiedString(self::_BUILTIN_GLOBAL_TYPES[$name]);

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -55,7 +55,7 @@ final class EmptyUnionType extends UnionType
      * @return UnionType
      * @override
      */
-    public function withType(Type $type) : \Phan\Language\UnionType
+    public function withType(Type $type) : UnionType
     {
         return $type->asUnionType();
     }
@@ -70,7 +70,7 @@ final class EmptyUnionType extends UnionType
      * @return UnionType
      * @override
      */
-    public function withoutType(Type $type) : \Phan\Language\UnionType
+    public function withoutType(Type $type) : UnionType
     {
         return $this;
     }
@@ -92,7 +92,7 @@ final class EmptyUnionType extends UnionType
      * @return UnionType
      * @override
      */
-    public function withUnionType(UnionType $union_type) : \Phan\Language\UnionType
+    public function withUnionType(UnionType $union_type) : UnionType
     {
         return $union_type;
     }
@@ -634,7 +634,7 @@ final class EmptyUnionType extends UnionType
      */
     public function asClassFQSENList(
         Context $context
-    ) : \Generator {
+    ) : Generator {
         if (false) {
             yield;
         }
@@ -664,7 +664,7 @@ final class EmptyUnionType extends UnionType
     public function asClassList(
         CodeBase $code_base,
         Context $context
-    ) : \Generator {
+    ) : Generator {
         yield from [];
     }
 
@@ -1277,7 +1277,7 @@ final class EmptyUnionType extends UnionType
         return $this;
     }
 
-    public function getTemplateTypeExtractorClosure(CodeBase $code_base, TemplateType $template_type) : ?\Closure
+    public function getTemplateTypeExtractorClosure(CodeBase $code_base, TemplateType $template_type) : ?Closure
     {
         return null;
     }

--- a/src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php
@@ -134,7 +134,7 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN
         $key = static::class . '|' .
             static::toString(\strtolower($namespace), static::canonicalLookupKey($name), $alternate_id);
 
-        $fqsen = self::memoizeStatic($key, static function () use ($namespace, $name, $alternate_id) : \Phan\Language\FQSEN\FullyQualifiedGlobalStructuralElement {
+        $fqsen = self::memoizeStatic($key, static function () use ($namespace, $name, $alternate_id) : FullyQualifiedGlobalStructuralElement {
             return new static(
                 $namespace,
                 $name,
@@ -165,7 +165,7 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN
              * @return FullyQualifiedGlobalStructuralElement
              * @throws FQSENException
              */
-            static function () use ($fully_qualified_string) : \Phan\Language\FQSEN\FullyQualifiedGlobalStructuralElement {
+            static function () use ($fully_qualified_string) : FullyQualifiedGlobalStructuralElement {
                 // Split off the alternate_id
                 $parts = \explode(',', $fully_qualified_string);
                 $fqsen_string = $parts[0];

--- a/src/Phan/Language/Scope.php
+++ b/src/Phan/Language/Scope.php
@@ -115,7 +115,7 @@ abstract class Scope
      * (e.g. a FullyQualifiedFunctionName, FullyQualifiedClassName, etc.)
      * @suppress PhanPossiblyNullTypeReturn, PhanPartialTypeMismatchReturn callers should call hasFQSEN
      */
-    public function getFQSEN() : \Phan\Language\FQSEN
+    public function getFQSEN() : FQSEN
     {
         return $this->fqsen;
     }
@@ -176,7 +176,7 @@ abstract class Scope
      * @return ?FullyQualifiedClassName
      * Crawl the scope hierarchy to get a class FQSEN.
      */
-    public function getClassFQSENOrNull() : ?\Phan\Language\FQSEN\FullyQualifiedClassName
+    public function getClassFQSENOrNull() : ?FullyQualifiedClassName
     {
         return $this->parent_scope->getClassFQSENOrNull();
     }

--- a/src/Phan/Language/Scope/BranchScope.php
+++ b/src/Phan/Language/Scope/BranchScope.php
@@ -65,7 +65,7 @@ class BranchScope extends Scope
      * Crawl the scope hierarchy to get a class FQSEN.
      * Return null if there is no class FQSEN.
      */
-    public function getClassFQSENOrNull() : ?\Phan\Language\FQSEN\FullyQualifiedClassName
+    public function getClassFQSENOrNull() : ?FullyQualifiedClassName
     {
         return $this->parent_scope->getClassFQSENOrNull();
     }

--- a/src/Phan/Language/Scope/ClassScope.php
+++ b/src/Phan/Language/Scope/ClassScope.php
@@ -70,7 +70,7 @@ class ClassScope extends ClosedScope
      * Get the FullyQualifiedClassName of the class whose scope
      * we're in. This subclass does not return null.
      */
-    public function getClassFQSENOrNull() : \Phan\Language\FQSEN\FullyQualifiedClassName
+    public function getClassFQSENOrNull() : FullyQualifiedClassName
     {
         $fqsen = $this->getFQSEN();
 

--- a/src/Phan/Language/Scope/ClosureScope.php
+++ b/src/Phan/Language/Scope/ClosureScope.php
@@ -47,7 +47,7 @@ class ClosureScope extends FunctionLikeScope
      * If the (at)phan-closure-scope annotation is used, returns the corresponding override class FQSEN.
      * Returns the class FQSEN inside this closure's scope (with an (at)phan-closure-scope annotation).
      */
-    public function getOverrideClassFQSEN() : ?\Phan\Language\FQSEN\FullyQualifiedClassName
+    public function getOverrideClassFQSEN() : ?FullyQualifiedClassName
     {
         return $this->override_class_fqsen;
     }
@@ -65,7 +65,7 @@ class ClosureScope extends FunctionLikeScope
      * @return ?FullyQualifiedClassName
      * Crawl the scope hierarchy to get a class FQSEN.
      */
-    public function getClassFQSENOrNull() : ?\Phan\Language\FQSEN\FullyQualifiedClassName
+    public function getClassFQSENOrNull() : ?FullyQualifiedClassName
     {
         return $this->override_class_fqsen ?? parent::getClassFQSENOrNull();
     }

--- a/src/Phan/Language/Scope/FunctionLikeScope.php
+++ b/src/Phan/Language/Scope/FunctionLikeScope.php
@@ -37,7 +37,7 @@ class FunctionLikeScope extends ClosedScope
      * Crawl the scope hierarchy to get a class FQSEN.
      * Return null if there is no class FQSEN.
      */
-    public function getClassFQSENOrNull() : ?\Phan\Language\FQSEN\FullyQualifiedClassName
+    public function getClassFQSENOrNull() : ?FullyQualifiedClassName
     {
         return $this->parent_scope->getClassFQSENOrNull();
     }

--- a/src/Phan/Language/Scope/PropertyScope.php
+++ b/src/Phan/Language/Scope/PropertyScope.php
@@ -71,7 +71,7 @@ class PropertyScope extends ClosedScope
      * Crawl the scope hierarchy to get a class FQSEN.
      * Return null if there is no class FQSEN.
      */
-    public function getClassFQSENOrNull() : ?\Phan\Language\FQSEN\FullyQualifiedClassName
+    public function getClassFQSENOrNull() : ?FullyQualifiedClassName
     {
         return $this->parent_scope->getClassFQSENOrNull();
     }

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -608,7 +608,7 @@ class Type
                  * @param mixed $value
                  * @return UnionType
                  */
-                static function ($value) : \Phan\Language\UnionType {
+                static function ($value) : UnionType {
                     return self::fromObjectExtended($value)->asUnionType();
                 },
                 $array
@@ -2031,7 +2031,7 @@ class Type
     /**
      * @return ?UnionType returns the iterable key's union type, if this is a subtype of iterable. null otherwise.
      */
-    public function iterableKeyUnionType(CodeBase $unused_code_base) : ?\Phan\Language\UnionType
+    public function iterableKeyUnionType(CodeBase $unused_code_base) : ?UnionType
     {
         if ($this->namespace === '\\') {
             $name = strtolower($this->name);
@@ -2059,7 +2059,7 @@ class Type
      *
      * This is overridden by the array subclasses
      */
-    public function iterableValueUnionType(CodeBase $unused_code_base) : ?\Phan\Language\UnionType
+    public function iterableValueUnionType(CodeBase $unused_code_base) : ?UnionType
     {
         if ($this->namespace === '\\') {
             $name = strtolower($this->name);
@@ -2076,7 +2076,7 @@ class Type
     }
 
     // TODO: Use a template-based abstraction so that this boilerplate can be removed
-    private function keyTypeOfTraversable() : ?\Phan\Language\UnionType
+    private function keyTypeOfTraversable() : ?UnionType
     {
         $template_type_list = $this->template_parameter_type_list;
         if (count($template_type_list) === 2) {
@@ -2085,7 +2085,7 @@ class Type
         return null;
     }
 
-    private function valueTypeOfTraversable() : ?\Phan\Language\UnionType
+    private function valueTypeOfTraversable() : ?UnionType
     {
         $template_type_list = $this->template_parameter_type_list;
         $count = count($template_type_list);
@@ -2096,7 +2096,7 @@ class Type
     }
 
 
-    private function keyTypeOfGenerator() : ?\Phan\Language\UnionType
+    private function keyTypeOfGenerator() : ?UnionType
     {
         $template_type_list = $this->template_parameter_type_list;
         if (count($template_type_list) >= 2 && count($template_type_list) <= 4) {
@@ -2105,7 +2105,7 @@ class Type
         return null;
     }
 
-    private function valueTypeOfGenerator() : ?\Phan\Language\UnionType
+    private function valueTypeOfGenerator() : ?UnionType
     {
         $template_type_list = $this->template_parameter_type_list;
         if (count($template_type_list) >= 2 && count($template_type_list) <= 4) {
@@ -2208,7 +2208,7 @@ class Type
         if ($recursion_depth >= 20) {
             throw new RecursionDepthException("Recursion has gotten out of hand: " . Frame::getExpandedTypesDetails());
         }
-        $union_type = $this->memoize(__METHOD__, function () use ($code_base, $recursion_depth) : \Phan\Language\UnionType {
+        $union_type = $this->memoize(__METHOD__, function () use ($code_base, $recursion_depth) : UnionType {
             $union_type = $this->asUnionType();
 
             $class_fqsen = $this->asFQSEN();
@@ -2290,7 +2290,7 @@ class Type
         if ($recursion_depth >= 20) {
             throw new RecursionDepthException("Recursion has gotten out of hand: " . Frame::getExpandedTypesDetails());
         }
-        $union_type = $this->memoize(__METHOD__, function () use ($code_base, $recursion_depth) : \Phan\Language\UnionType {
+        $union_type = $this->memoize(__METHOD__, function () use ($code_base, $recursion_depth) : UnionType {
             $union_type = $this->asUnionType();
 
             $class_fqsen = $this->asFQSEN();
@@ -2767,7 +2767,7 @@ class Type
      */
     private static function typeStringComponents(
         string $type_string
-    ) : \Phan\Library\Tuple5 {
+    ) : Tuple5 {
         // This doesn't depend on any configs; the result can be safely cached.
         static $cache = [];
         return $cache[$type_string] ?? ($cache[$type_string] = self::typeStringComponentsInner($type_string));
@@ -2785,7 +2785,7 @@ class Type
      */
     private static function typeStringComponentsInner(
         string $type_string
-    ) : \Phan\Library\Tuple5 {
+    ) : Tuple5 {
         // Check to see if we have template parameter types
         $template_parameter_type_name_list = [];
         $shape_components = null;
@@ -3237,7 +3237,7 @@ class Type
      * @return ?Closure(UnionType, Context):UnionType a closure to determine the union type(s) that are in the same position(s) as the template type.
      * This is overridden in subclasses.
      */
-    public function getTemplateTypeExtractorClosure(CodeBase $code_base, TemplateType $template_type) : ?\Closure
+    public function getTemplateTypeExtractorClosure(CodeBase $code_base, TemplateType $template_type) : ?Closure
     {
         if (!$this->template_parameter_type_list) {
             return null;
@@ -3276,7 +3276,7 @@ class Type
      * @param Context $context the context where the function interface is referenced (for emitting issues) @phan-unused-param
      * @return ?FunctionInterface
      */
-    public function asFunctionInterfaceOrNull(CodeBase $code_base, Context $context) : ?\Phan\Language\Element\FunctionInterface
+    public function asFunctionInterfaceOrNull(CodeBase $code_base, Context $context) : ?FunctionInterface
     {
         if (static::class !== self::class) {
             // Overridden in other subclasses

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -1513,7 +1513,7 @@ class Type
      * @deprecated use isNullable
      * @suppress PhanUnreferencedPublicMethod
      */
-    public final function getIsNullable() : bool
+    final public function getIsNullable() : bool
     {
         return $this->isNullable();
     }
@@ -1531,7 +1531,7 @@ class Type
      * @deprecated
      * @suppress PhanUnreferencedPublicMethod
      */
-    public final function getIsPossiblyFalsey() : bool
+    final public function getIsPossiblyFalsey() : bool
     {
         return $this->is_nullable;
     }
@@ -1549,7 +1549,7 @@ class Type
      * @deprecated use isAlwaysFalsey
      * @suppress PhanUnreferencedPublicMethod
      */
-    public final function getIsAlwaysFalsey() : bool
+    final public function getIsAlwaysFalsey() : bool
     {
         return $this->isAlwaysFalsey();
     }
@@ -1567,7 +1567,7 @@ class Type
      * @deprecated use isPossiblyTruthy
      * @suppress PhanUnreferencedPublicMethod
      */
-    public final function getIsPossiblyTruthy() : bool
+    final public function getIsPossiblyTruthy() : bool
     {
         return $this->isPossiblyTruthy();
     }
@@ -1590,7 +1590,7 @@ class Type
      * @deprecated use isAlwaysTruthy
      * @suppress PhanUnreferencedPublicMethod
      */
-    public final function getIsAlwaysTruthy() : bool
+    final public function getIsAlwaysTruthy() : bool
     {
         return $this->isAlwaysTruthy();
     }
@@ -1608,7 +1608,7 @@ class Type
      * @deprecated use isPossiblyFalse
      * @suppress PhanUnreferencedPublicMethod
      */
-    public final function getIsPossiblyFalse() : bool
+    final public function getIsPossiblyFalse() : bool
     {
         return $this->isPossiblyFalse();
     }
@@ -1626,7 +1626,7 @@ class Type
      * @deprecated
      * @suppress PhanUnreferencedPublicMethod
      */
-    public final function getIsAlwaysFalse() : bool
+    final public function getIsAlwaysFalse() : bool
     {
         return $this->isAlwaysFalse();
     }
@@ -1645,7 +1645,7 @@ class Type
      * @deprecated use isPossiblyTrue
      * @suppress PhanUnreferencedPublicMethod
      */
-    public final function getIsPossiblyTrue() : bool
+    final public function getIsPossiblyTrue() : bool
     {
         return $this->isPossiblyTrue();
     }
@@ -1663,7 +1663,7 @@ class Type
      * @deprecated
      * @suppress PhanUnreferencedPublicMethod
      */
-    public final function getIsAlwaysTrue() : bool
+    final public function getIsAlwaysTrue() : bool
     {
         return $this->isAlwaysTrue();
     }
@@ -1681,7 +1681,7 @@ class Type
      * @deprecated use isInBoolFamily
      * @suppress PhanUnreferencedPublicMethod
      */
-    public final function getIsInBoolFamily() : bool
+    final public function getIsInBoolFamily() : bool
     {
         return $this->isInBoolFamily();
     }
@@ -1699,7 +1699,7 @@ class Type
      * @deprecated use isPossiblyNumeric
      * @suppress PhanUnreferencedPublicMethod
      */
-    public final function getIsPossiblyNumeric() : bool
+    final public function getIsPossiblyNumeric() : bool
     {
         return $this->isPossiblyNumeric();
     }

--- a/src/Phan/Language/Type/ArrayShapeType.php
+++ b/src/Phan/Language/Type/ArrayShapeType.php
@@ -191,7 +191,7 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
      * @return UnionType
      * @phan-override
      */
-    public function iterableKeyUnionType(CodeBase $unused_code_base) : \Phan\Language\UnionType
+    public function iterableKeyUnionType(CodeBase $unused_code_base) : UnionType
     {
         return $this->getKeyUnionType();
     }
@@ -214,7 +214,7 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
      * @return UnionType
      * @override
      */
-    public function iterableValueUnionType(CodeBase $unused_code_base) : \Phan\Language\UnionType
+    public function iterableValueUnionType(CodeBase $unused_code_base) : UnionType
     {
         return $this->genericArrayElementUnionType();
     }
@@ -704,7 +704,7 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
      * @param CodeBase $code_base
      * @return ?Closure(UnionType, Context):UnionType
      */
-    public function getTemplateTypeExtractorClosure(CodeBase $code_base, TemplateType $template_type) : ?\Closure
+    public function getTemplateTypeExtractorClosure(CodeBase $code_base, TemplateType $template_type) : ?Closure
     {
         $closure = null;
         foreach ($this->field_types as $key => $type) {
@@ -757,7 +757,7 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
      * Returns the function interface this references
      * @return ?FunctionInterface
      */
-    public function asFunctionInterfaceOrNull(CodeBase $code_base, Context $context) : ?\Phan\Language\Element\FunctionInterface
+    public function asFunctionInterfaceOrNull(CodeBase $code_base, Context $context) : ?FunctionInterface
     {
         if (\count($this->field_types) !== 2) {
             Issue::maybeEmit(

--- a/src/Phan/Language/Type/ArrayType.php
+++ b/src/Phan/Language/Type/ArrayType.php
@@ -186,7 +186,7 @@ class ArrayType extends IterableType
     /**
      * @return UnionType int|string for arrays
      */
-    public function iterableKeyUnionType(CodeBase $unused_code_base) : \Phan\Language\UnionType
+    public function iterableKeyUnionType(CodeBase $unused_code_base) : UnionType
     {
         // Reduce false positive partial type mismatch errors
         return UnionType::empty();

--- a/src/Phan/Language/Type/ClassStringType.php
+++ b/src/Phan/Language/Type/ClassStringType.php
@@ -67,7 +67,7 @@ final class ClassStringType extends StringType
      * @return ?Closure(UnionType):UnionType a closure to determine the union type(s) that are in the same position(s) as the template type.
      * This is overridden in subclasses.
      */
-    public function getTemplateTypeExtractorClosure(CodeBase $code_base, TemplateType $template_type) : ?\Closure
+    public function getTemplateTypeExtractorClosure(CodeBase $code_base, TemplateType $template_type) : ?Closure
     {
         $template_union_type = $this->template_parameter_type_list[0] ?? null;
         if (!$template_union_type) {

--- a/src/Phan/Language/Type/ClosureType.php
+++ b/src/Phan/Language/Type/ClosureType.php
@@ -174,12 +174,12 @@ final class ClosureType extends Type
      * @deprecated use asFunctionInterfaceOrNull
      * @suppress PhanUnreferencedPublicMethod
      */
-    public function getFunctionLikeOrNull() : ?\Phan\Language\Element\FunctionInterface
+    public function getFunctionLikeOrNull() : ?FunctionInterface
     {
         return $this->func;
     }
 
-    public function asFunctionInterfaceOrNull(CodeBase $unused_codebase, Context $unused_context) : ?\Phan\Language\Element\FunctionInterface
+    public function asFunctionInterfaceOrNull(CodeBase $unused_codebase, Context $unused_context) : ?FunctionInterface
     {
         return $this->func;
     }

--- a/src/Phan/Language/Type/FunctionLikeDeclarationType.php
+++ b/src/Phan/Language/Type/FunctionLikeDeclarationType.php
@@ -136,7 +136,7 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
     /**
      * @return ?ClosureDeclarationParameter the parameter which the argument at the index $i would be passed in as
      */
-    public function getClosureParameterForArgument(int $i) : ?\Phan\Language\Type\ClosureDeclarationParameter
+    public function getClosureParameterForArgument(int $i) : ?ClosureDeclarationParameter
     {
         $result = $this->params[$i] ?? null;
         if (!$result) {
@@ -280,7 +280,7 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
         return false;
     }
 
-    public function asFunctionInterfaceOrNull(CodeBase $unused_codebase, Context $unused_context) : ?\Phan\Language\Element\FunctionInterface
+    public function asFunctionInterfaceOrNull(CodeBase $unused_codebase, Context $unused_context) : ?FunctionInterface
     {
         return $this;
     }
@@ -358,7 +358,7 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
      * @phan-return \Generator<FunctionLikeDeclarationType>
      * @override
      */
-    public function alternateGenerator(CodeBase $_) : \Generator
+    public function alternateGenerator(CodeBase $_) : Generator
     {
         yield $this;
     }
@@ -411,7 +411,7 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
     }
 
     /** @override */
-    public function getComment() : ?\Phan\Language\Element\Comment
+    public function getComment() : ?Comment
     {
         return null;
     }
@@ -518,7 +518,7 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
     }
 
     /** @override */
-    public function getPHPDocReturnType() : ?\Phan\Language\UnionType
+    public function getPHPDocReturnType() : ?UnionType
     {
         return $this->return_type;
     }
@@ -527,7 +527,7 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
      * @return Parameter|null
      * @override
      */
-    public function getParameterForCaller(int $i) : ?\Phan\Language\Element\Parameter
+    public function getParameterForCaller(int $i) : ?Parameter
     {
         $list = $this->params;
         if (\count($list) === 0) {
@@ -545,7 +545,7 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
      * @return Parameter|null
      * @override
      */
-    public function getRealParameterForCaller(int $i) : ?\Phan\Language\Element\Parameter
+    public function getRealParameterForCaller(int $i) : ?Parameter
     {
         // FunctionLikeDeclarationType doesn't know if the phpdoc type is the real union type.
         //
@@ -852,7 +852,7 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
         return false;
     }
 
-    public function getTemplateTypeExtractorClosure(CodeBase $code_base, TemplateType $template_type) : ?\Closure
+    public function getTemplateTypeExtractorClosure(CodeBase $code_base, TemplateType $template_type) : ?Closure
     {
         // Create a closure to extract types for the template type from the return type and param types.
         $closure = $this->getReturnTemplateTypeExtractorClosure($code_base, $template_type);
@@ -889,7 +889,7 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
      * Extracts a closure to extract the template type from the return type, or returns null
      * @return ?Closure(UnionType,Context):UnionType
      */
-    private function getReturnTemplateTypeExtractorClosure(CodeBase $code_base, TemplateType $template_type) : ?\Closure
+    private function getReturnTemplateTypeExtractorClosure(CodeBase $code_base, TemplateType $template_type) : ?Closure
     {
         $return_closure = $this->getUnionType()->getTemplateTypeExtractorClosure($code_base, $template_type);
         if (!$return_closure) {
@@ -925,7 +925,7 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
         return (new static($this->file_ref, $new_params, $new_return_type, $this->returns_reference, $this->is_nullable))->asUnionType();
     }
 
-    public function getCommentParamAssertionClosure(CodeBase $code_base) : ?\Closure
+    public function getCommentParamAssertionClosure(CodeBase $code_base) : ?Closure
     {
         return null;
     }

--- a/src/Phan/Language/Type/GenericArrayTemplateKeyType.php
+++ b/src/Phan/Language/Type/GenericArrayTemplateKeyType.php
@@ -72,7 +72,7 @@ class GenericArrayTemplateKeyType extends GenericArrayType
      * @param CodeBase $code_base
      * @return ?Closure(UnionType, Context):UnionType
      */
-    public function getTemplateTypeExtractorClosure(CodeBase $code_base, TemplateType $template_type) : ?\Closure
+    public function getTemplateTypeExtractorClosure(CodeBase $code_base, TemplateType $template_type) : ?Closure
     {
         $element_closure = parent::getTemplateTypeExtractorClosure($code_base, $template_type);
         $key_closure = $this->template_key_type->getTemplateTypeExtractorClosure($code_base, $template_type);

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -240,7 +240,7 @@ class GenericArrayType extends ArrayType implements GenericArrayInterface
      * @return UnionType returns the array value's union type
      * @phan-override
      */
-    public function iterableValueUnionType(CodeBase $unused_codebase) : \Phan\Language\UnionType
+    public function iterableValueUnionType(CodeBase $unused_codebase) : UnionType
     {
         return $this->element_type->asUnionType();
     }
@@ -249,7 +249,7 @@ class GenericArrayType extends ArrayType implements GenericArrayInterface
      * @return UnionType the array key's union type
      * @phan-override
      */
-    public function iterableKeyUnionType(CodeBase $unused_codebase) : \Phan\Language\UnionType
+    public function iterableKeyUnionType(CodeBase $unused_codebase) : UnionType
     {
         return self::unionTypeForKeyType($this->key_type);
     }
@@ -687,7 +687,7 @@ class GenericArrayType extends ArrayType implements GenericArrayInterface
      * @param CodeBase $code_base
      * @return ?Closure(UnionType,Context):UnionType
      */
-    public function getTemplateTypeExtractorClosure(CodeBase $code_base, TemplateType $template_type) : ?\Closure
+    public function getTemplateTypeExtractorClosure(CodeBase $code_base, TemplateType $template_type) : ?Closure
     {
         $closure = $this->element_type->getTemplateTypeExtractorClosure($code_base, $template_type);
         if (!$closure) {

--- a/src/Phan/Language/Type/GenericIterableType.php
+++ b/src/Phan/Language/Type/GenericIterableType.php
@@ -58,7 +58,7 @@ final class GenericIterableType extends IterableType
      *
      * @see self::getKeyUnionType()
      */
-    public function iterableKeyUnionType(CodeBase $unused_code_base) : \Phan\Language\UnionType
+    public function iterableKeyUnionType(CodeBase $unused_code_base) : UnionType
     {
         return $this->key_union_type;
     }
@@ -69,7 +69,7 @@ final class GenericIterableType extends IterableType
      *
      * @see self::getElementUnionType()
      */
-    public function iterableValueUnionType(CodeBase $unused_code_base) : \Phan\Language\UnionType
+    public function iterableValueUnionType(CodeBase $unused_code_base) : UnionType
     {
         return $this->element_union_type;
     }
@@ -151,7 +151,7 @@ final class GenericIterableType extends IterableType
      * @param CodeBase $code_base
      * @return ?Closure(UnionType, Context):UnionType
      */
-    public function getTemplateTypeExtractorClosure(CodeBase $code_base, TemplateType $template_type) : ?\Closure
+    public function getTemplateTypeExtractorClosure(CodeBase $code_base, TemplateType $template_type) : ?Closure
     {
         $closure = $this->element_union_type->getTemplateTypeExtractorClosure($code_base, $template_type);
         if ($closure) {

--- a/src/Phan/Language/Type/LiteralIntType.php
+++ b/src/Phan/Language/Type/LiteralIntType.php
@@ -33,7 +33,7 @@ final class LiteralIntType extends IntType implements LiteralTypeInterface
     /**
      * @return LiteralIntType a unique LiteralIntType for $value (and the nullability)
      */
-    public static function instanceForValue(int $value, bool $is_nullable) : \Phan\Language\Type\LiteralIntType
+    public static function instanceForValue(int $value, bool $is_nullable) : LiteralIntType
     {
         if ($is_nullable) {
             static $nullable_cache = [];

--- a/src/Phan/Language/Type/LiteralStringType.php
+++ b/src/Phan/Language/Type/LiteralStringType.php
@@ -309,7 +309,7 @@ final class LiteralStringType extends StringType implements LiteralTypeInterface
      *
      * @return ?FunctionInterface
      */
-    public function asFunctionInterfaceOrNull(CodeBase $code_base, Context $context) : ?\Phan\Language\Element\FunctionInterface
+    public function asFunctionInterfaceOrNull(CodeBase $code_base, Context $context) : ?FunctionInterface
     {
         // parse 'function_name' or 'class_name::method_name'
         // NOTE: In other subclasses of Type, calling this might recurse.

--- a/src/Phan/Language/Type/NativeType.php
+++ b/src/Phan/Language/Type/NativeType.php
@@ -245,7 +245,7 @@ abstract class NativeType extends Type
     /**
      * @return ?UnionType returns the iterable value's union type if this is a subtype of iterable, null otherwise.
      */
-    public function iterableKeyUnionType(CodeBase $unused_code_base) : ?\Phan\Language\UnionType
+    public function iterableKeyUnionType(CodeBase $unused_code_base) : ?UnionType
     {
         return null;
     }
@@ -253,7 +253,7 @@ abstract class NativeType extends Type
     /**
      * @return ?UnionType returns the iterable value's union type if this is a subtype of iterable, null otherwise.
      */
-    public function iterableValueUnionType(CodeBase $unused_code_base) : ?\Phan\Language\UnionType
+    public function iterableValueUnionType(CodeBase $unused_code_base) : ?UnionType
     {
         return null;
     }

--- a/src/Phan/Language/Type/TemplateType.php
+++ b/src/Phan/Language/Type/TemplateType.php
@@ -139,7 +139,7 @@ final class TemplateType extends Type
      * @param ?Closure(mixed, Context):UnionType $right
      * @return ?Closure(mixed, Context):UnionType
      */
-    public static function combineParameterClosures(?\Closure $left, ?\Closure $right) : ?\Closure
+    public static function combineParameterClosures(?Closure $left, ?Closure $right) : ?Closure
     {
         if (!$left) {
             return $right;
@@ -161,7 +161,7 @@ final class TemplateType extends Type
      *
      * @return ?Closure(UnionType, Context):UnionType a closure to map types to the template type wherever it was in the original union type
      */
-    public function getTemplateTypeExtractorClosure(CodeBase $unused_code_base, TemplateType $template_type) : ?\Closure
+    public function getTemplateTypeExtractorClosure(CodeBase $unused_code_base, TemplateType $template_type) : ?Closure
     {
         if ($this === $template_type) {
             return static function (UnionType $type, Context $_) : UnionType {

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -108,7 +108,7 @@ class UnionType implements Serializable
      * @param Type[] $type_list
      * @return UnionType
      */
-    public static function of(array $type_list) : \Phan\Language\UnionType
+    public static function of(array $type_list) : UnionType
     {
         $n = \count($type_list);
         if ($n === 0) {
@@ -126,7 +126,7 @@ class UnionType implements Serializable
      * @return UnionType
      * @suppress PhanPossiblyNonClassMethodCall
      */
-    protected static function ofUniqueTypes(array $type_list) : \Phan\Language\UnionType
+    protected static function ofUniqueTypes(array $type_list) : UnionType
     {
         $n = \count($type_list);
         if ($n === 0) {
@@ -144,7 +144,7 @@ class UnionType implements Serializable
     /**
      * @return EmptyUnionType (Real return type omitted for performance)
      */
-    public static function empty() : \Phan\Language\EmptyUnionType
+    public static function empty() : EmptyUnionType
     {
         return self::$empty_instance;
     }
@@ -472,7 +472,7 @@ class UnionType implements Serializable
          * @param string|null $type_name
          * @return UnionType|null
          */
-        $get_for_global_context = static function (?string $type_name) : ?\Phan\Language\UnionType {
+        $get_for_global_context = static function (?string $type_name) : ?UnionType {
             if (!$type_name) {
                 return null;
             }
@@ -535,7 +535,7 @@ class UnionType implements Serializable
      *
      * @return UnionType
      */
-    public function withType(Type $type) : \Phan\Language\UnionType
+    public function withType(Type $type) : UnionType
     {
         $type_set = $this->type_set;
         if (\count($type_set) === 0) {
@@ -558,7 +558,7 @@ class UnionType implements Serializable
      *
      * @return UnionType
      */
-    public function withoutType(Type $type) : \Phan\Language\UnionType
+    public function withoutType(Type $type) : UnionType
     {
         // Copy the array $this->type_set
         $type_set = $this->type_set;
@@ -588,7 +588,7 @@ class UnionType implements Serializable
      *
      * @return UnionType
      */
-    public function withUnionType(UnionType $union_type) : \Phan\Language\UnionType
+    public function withUnionType(UnionType $union_type) : UnionType
     {
         // Precondition: Both UnionTypes have lists of unique types.
         $type_set = $this->type_set;
@@ -1997,7 +1997,7 @@ class UnionType implements Serializable
      */
     public function asClassFQSENList(
         Context $context
-    ) : \Generator {
+    ) : Generator {
         // Iterate over each viable class type to see if any
         // have the constant we're looking for
         foreach ($this->type_set as $class_type) {
@@ -2050,7 +2050,7 @@ class UnionType implements Serializable
     public function asClassList(
         CodeBase $code_base,
         Context $context
-    ) : \Generator {
+    ) : Generator {
         // Iterate over each viable class type to see if any
         // have the constant we're looking for
         foreach ($this->type_set as $class_type) {
@@ -3821,7 +3821,7 @@ class UnionType implements Serializable
      *
      * @return ?Closure(UnionType, Context):UnionType a closure to map types to the template type wherever it was in the original union type
      */
-    public function getTemplateTypeExtractorClosure(CodeBase $code_base, TemplateType $template_type) : ?\Closure
+    public function getTemplateTypeExtractorClosure(CodeBase $code_base, TemplateType $template_type) : ?Closure
     {
         $closure = null;
         foreach ($this->type_set as $type) {

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -3373,7 +3373,7 @@ class UnionType implements Serializable
      * @deprecated use isPossiblyUndefined
      * @suppress PhanUnreferencedPublicMethod
      */
-    public final function getIsPossiblyUndefined() : bool
+    final public function getIsPossiblyUndefined() : bool
     {
         return $this->isPossiblyUndefined();
     }

--- a/src/Phan/LanguageServer/CompletionResolver.php
+++ b/src/Phan/LanguageServer/CompletionResolver.php
@@ -30,7 +30,7 @@ class CompletionResolver
      * and "go to type definition" in their implementations,
      * based on $request->isTypeDefinitionRequest()
      */
-    public static function createCompletionClosure(CompletionRequest $request, CodeBase $code_base) : \Closure
+    public static function createCompletionClosure(CompletionRequest $request, CodeBase $code_base) : Closure
     {
         // TODO: Could use the parent node list
         // (e.g. don't use a method with a void return as an argument to another function)

--- a/src/Phan/LanguageServer/DefinitionResolver.php
+++ b/src/Phan/LanguageServer/DefinitionResolver.php
@@ -37,7 +37,7 @@ class DefinitionResolver
      * and "go to type definition" in their implementations,
      * based on $request->isTypeDefinitionRequest()
      */
-    public static function createGoToDefinitionClosure(GoToDefinitionRequest $request, CodeBase $code_base) : \Closure
+    public static function createGoToDefinitionClosure(GoToDefinitionRequest $request, CodeBase $code_base) : Closure
     {
         /**
          * @param array<int,Node> $parent_node_list

--- a/src/Phan/LanguageServer/GoToDefinitionRequest.php
+++ b/src/Phan/LanguageServer/GoToDefinitionRequest.php
@@ -353,7 +353,7 @@ final class GoToDefinitionRequest extends NodeInfoRequest
         return \array_values($this->locations);
     }
 
-    public function getHoverResponse() : ?\Phan\LanguageServer\Protocol\Hover
+    public function getHoverResponse() : ?Hover
     {
         return $this->hover_response;
     }

--- a/src/Phan/LanguageServer/LanguageServer.php
+++ b/src/Phan/LanguageServer/LanguageServer.php
@@ -261,7 +261,7 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
      *
      * @suppress PhanUndeclaredConstant, UnusedSuppression (pcntl unavailable on Windows)
      */
-    public static function run(CodeBase $code_base, \Closure $file_path_lister, array $options) : ?\Phan\Daemon\Request
+    public static function run(CodeBase $code_base, Closure $file_path_lister, array $options) : ?Request
     {
         if (!$code_base->isUndoTrackingEnabled()) {
             throw new AssertionError("Expected undo tracking to be enabled");

--- a/src/Phan/LanguageServer/NodeInfoRequest.php
+++ b/src/Phan/LanguageServer/NodeInfoRequest.php
@@ -67,7 +67,7 @@ abstract class NodeInfoRequest
         return $this->position;
     }
 
-    final public function getPromise() : \Sabre\Event\Promise
+    final public function getPromise() : Promise
     {
         return $this->promise;
     }

--- a/src/Phan/LanguageServer/Server/TextDocument.php
+++ b/src/Phan/LanguageServer/Server/TextDocument.php
@@ -187,7 +187,7 @@ class TextDocument
      * @return ?Promise <Location|Location[]|null>
      * @suppress PhanUnreferencedPublicMethod called by client via AdvancedJsonRpc
      */
-    public function definition(TextDocumentIdentifier $textDocument, Position $position) : ?\Sabre\Event\Promise
+    public function definition(TextDocumentIdentifier $textDocument, Position $position) : ?Promise
     {
         Logger::logInfo("Called textDocument/definition, uri={$textDocument->uri} position={$position->line}:{$position->character}");
         try {
@@ -208,7 +208,7 @@ class TextDocument
      * @return ?Promise <Location|Location[]|null>
      * @suppress PhanUnreferencedPublicMethod called by client via AdvancedJsonRpc
      */
-    public function typeDefinition(TextDocumentIdentifier $textDocument, Position $position) : ?\Sabre\Event\Promise
+    public function typeDefinition(TextDocumentIdentifier $textDocument, Position $position) : ?Promise
     {
         Logger::logInfo("Called textDocument/typeDefinition, uri={$textDocument->uri} position={$position->line}:{$position->character}");
         try {
@@ -231,7 +231,7 @@ class TextDocument
      * @suppress PhanUnreferencedPublicMethod called by client via AdvancedJsonRpc
      * @return ?Promise
      */
-    public function hover(TextDocumentIdentifier $textDocument, Position $position) : ?\Sabre\Event\Promise
+    public function hover(TextDocumentIdentifier $textDocument, Position $position) : ?Promise
     {
         // Some clients (e.g. emacs-lsp, the last time I checked)
         // don't respect the server's reported hover capability, and send this unconditionally.
@@ -261,7 +261,7 @@ class TextDocument
      * @suppress PhanUnreferencedPublicMethod called by client via AdvancedJsonRpc
      * @return ?Promise <CompletionItem[]|CompletionList>
      */
-    public function completion(TextDocumentIdentifier $textDocument, Position $position, CompletionContext $context = null) : ?\Sabre\Event\Promise
+    public function completion(TextDocumentIdentifier $textDocument, Position $position, CompletionContext $context = null) : ?Promise
     {
         if (!Config::getValue('language_server_enable_completion')) {
             // Placeholder to avoid a performance degradation on clients

--- a/src/Phan/Library/FileCache.php
+++ b/src/Phan/Library/FileCache.php
@@ -62,7 +62,7 @@ final class FileCache
      * @return ?FileCacheEntry if the entry exists in cache, return it.
      * Otherwise, return null.
      */
-    public static function getEntry(string $file_name) : ?\Phan\Library\FileCacheEntry
+    public static function getEntry(string $file_name) : ?FileCacheEntry
     {
         $entry = self::$cache_entries[$file_name] ?? null;
         if ($entry) {

--- a/src/Phan/Library/Map.php
+++ b/src/Phan/Library/Map.php
@@ -53,7 +53,7 @@ class Map extends SplObjectStorage
      * A new map containing the mapped keys and
      * values
      */
-    public function keyValueMap(Closure $key_closure, Closure $value_closure) : \Phan\Library\Map
+    public function keyValueMap(Closure $key_closure, Closure $value_closure) : Map
     {
         $map = new Map();
         foreach ($this as $key => $value) {

--- a/src/Phan/Library/Set.php
+++ b/src/Phan/Library/Set.php
@@ -168,7 +168,7 @@ class Set extends \SplObjectStorage
      * closure return true
      * @suppress PhanUnreferencedPublicMethod potentially useful but currently unused
      */
-    public function filter(Closure $closure) : \Phan\Library\Set
+    public function filter(Closure $closure) : Set
     {
         $set = new Set();
         foreach ($this as $element) {

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -1409,35 +1409,35 @@ class ParseVisitor extends ScopeVisitor
     }
 
     // common no-ops
-    public function visitArrayElem(Node $node) : \Phan\Language\Context
+    public function visitArrayElem(Node $node) : Context
     {
         return $this->context;
     }
-    public function visitVar(Node $node) : \Phan\Language\Context
+    public function visitVar(Node $node) : Context
     {
         return $this->context;
     }
-    public function visitName(Node $node) : \Phan\Language\Context
+    public function visitName(Node $node) : Context
     {
         return $this->context;
     }
-    public function visitArgList(Node $node) : \Phan\Language\Context
+    public function visitArgList(Node $node) : Context
     {
         return $this->context;
     }
-    public function visitStmtList(Node $node) : \Phan\Language\Context
+    public function visitStmtList(Node $node) : Context
     {
         return $this->context;
     }
-    public function visitProp(Node $node) : \Phan\Language\Context
+    public function visitProp(Node $node) : Context
     {
         return $this->context;
     }
-    public function visitArray(Node $node) : \Phan\Language\Context
+    public function visitArray(Node $node) : Context
     {
         return $this->context;
     }
-    public function visitBinaryOp(Node $node) : \Phan\Language\Context
+    public function visitBinaryOp(Node $node) : Context
     {
         return $this->context;
     }

--- a/src/Phan/Phan.php
+++ b/src/Phan/Phan.php
@@ -323,7 +323,7 @@ class Phan implements IgnoredFilesFilterInterface
      */
     public static function finishAnalyzingRemainingStatements(
         CodeBase $code_base,
-        ?\Phan\Daemon\Request $request,
+        ?Request $request,
         array $analyze_file_path_list,
         array $temporary_file_mapping
     ) : bool {

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -455,7 +455,7 @@ final class ConfigPluginSet extends PluginV3 implements
         string $issue_type,
         int $lineno,
         array $parameters,
-        ?\Phan\Suggestion $suggestion
+        ?Suggestion $suggestion
     ) : bool {
         foreach ($this->suppression_plugin_set as $plugin) {
             if ($plugin->shouldSuppressIssue(
@@ -604,7 +604,7 @@ final class ConfigPluginSet extends PluginV3 implements
      * @param ?Closure(CodeBase, Context, FunctionInterface, array<int,Node|mixed>):void $b
      * @return Closure(CodeBase, Context, FunctionInterface, array<int,Node|mixed>):void $b
      */
-    public static function mergeAnalyzeFunctionCallClosures(Closure $a, Closure $b = null) : \Closure
+    public static function mergeAnalyzeFunctionCallClosures(Closure $a, Closure $b = null) : Closure
     {
         if (!$b) {
             return $a;
@@ -687,7 +687,7 @@ final class ConfigPluginSet extends PluginV3 implements
         $this->addNodeSelectionClosureForKind($node->kind, $closure);
     }
 
-    public function addTemporaryAnalysisPlugin(CodeBase $code_base, ?\Phan\Daemon\Request $request) : ?\Phan\Library\RAII
+    public function addTemporaryAnalysisPlugin(CodeBase $code_base, ?\Phan\Daemon\Request $request) : ?RAII
     {
         if (!$request) {
             return null;
@@ -928,7 +928,7 @@ final class ConfigPluginSet extends PluginV3 implements
         /**
          * @param array<int,Closure> $closure_list
          */
-        return $closures_for_kind->getFlattenedClosures(static function (array $closure_list) : \Closure {
+        return $closures_for_kind->getFlattenedClosures(static function (array $closure_list) : Closure {
             return static function (CodeBase $code_base, Context $context, Node $node) use ($closure_list) : void {
                 foreach ($closure_list as $closure) {
                     $closure($code_base, $context, $node);
@@ -1025,7 +1025,7 @@ final class ConfigPluginSet extends PluginV3 implements
         /**
          * @param array<int,Closure> $closure_list
          */
-        return $closures_for_kind->getFlattenedClosures(static function (array $closure_list) : \Closure {
+        return $closures_for_kind->getFlattenedClosures(static function (array $closure_list) : Closure {
             /**
              * @param array<int,Node> $parent_node_list
              */
@@ -1137,7 +1137,7 @@ final class ConfigPluginSet extends PluginV3 implements
      * @param PluginV3[] $plugin_set
      * @return ?UnusedSuppressionPlugin
      */
-    private static function findUnusedSuppressionPlugin(array $plugin_set) : ?\UnusedSuppressionPlugin
+    private static function findUnusedSuppressionPlugin(array $plugin_set) : ?UnusedSuppressionPlugin
     {
         foreach ($plugin_set as $plugin) {
             // Don't use instanceof, avoid triggering class autoloader unnecessarily.

--- a/src/Phan/Plugin/Internal/BuiltinSuppressionPlugin.php
+++ b/src/Phan/Plugin/Internal/BuiltinSuppressionPlugin.php
@@ -64,7 +64,7 @@ final class BuiltinSuppressionPlugin extends PluginV3 implements
         string $issue_type,
         int $lineno,
         array $parameters,
-        ?\Phan\Suggestion $suggestion
+        ?Suggestion $suggestion
     ) : bool {
         $issue_suppression_list = $this->getRawIssueSuppressionList($code_base, $context->getFile());
         $suppressions_for_issue_type = $issue_suppression_list[$issue_type] ?? null;
@@ -197,7 +197,7 @@ final class BuiltinSuppressionPlugin extends PluginV3 implements
      */
     private static function yieldSuppressionComments(
         string $file_contents
-    ) : \Generator {
+    ) : Generator {
         foreach (\token_get_all($file_contents) as $token) {
             if (!\is_array($token)) {
                 continue;

--- a/src/Phan/Plugin/Internal/CallableParamPlugin.php
+++ b/src/Phan/Plugin/Internal/CallableParamPlugin.php
@@ -97,7 +97,7 @@ final class CallableParamPlugin extends PluginV3 implements
     /**
      * @return ?Closure(CodeBase,Context,FunctionInterface,array):void
      */
-    private static function generateClosureForFunctionInterface(FunctionInterface $function) : ?\Closure
+    private static function generateClosureForFunctionInterface(FunctionInterface $function) : ?Closure
     {
         $callable_params = [];
         $class_params = [];

--- a/src/Phan/Plugin/Internal/IssueFixingPlugin/IssueFixer.php
+++ b/src/Phan/Plugin/Internal/IssueFixingPlugin/IssueFixer.php
@@ -91,7 +91,7 @@ class IssueFixer
         string $file_contents,
         NamespaceUseDeclaration $declaration,
         IssueInstance $issue_instance
-    ) : ?\Phan\Plugin\Internal\IssueFixingPlugin\FileEdit {
+    ) : ?FileEdit {
         if (!self::isMatchingNamespaceUseDeclaration($file_contents, $declaration, $issue_instance)) {
             return null;
         }
@@ -146,7 +146,7 @@ class IssueFixer
             CodeBase $unused_code_base,
             FileCacheEntry $file_contents,
             IssueInstance $issue_instance
-        ) : ?\Phan\Plugin\Internal\IssueFixingPlugin\FileEditSet {
+        ) : ?FileEditSet {
             // 1-based line
             $line = $issue_instance->getLine();
             $edits = [];
@@ -212,7 +212,7 @@ class IssueFixer
                 ) use (
                     $closure,
                     $instance
-) : ?\Phan\Plugin\Internal\IssueFixingPlugin\FileEditSet {
+) : ?FileEditSet {
                     self::debug("Calling for $instance\n");
                     return $closure($code_base, $file_contents, $instance);
                 };

--- a/src/Phan/Plugin/Internal/MiscParamPlugin.php
+++ b/src/Phan/Plugin/Internal/MiscParamPlugin.php
@@ -338,7 +338,7 @@ final class MiscParamPlugin extends PluginV3 implements
             CodeBase $code_base,
             Context $context,
             $node
-        ) : ?\Phan\Language\Element\Variable {
+        ) : ?Variable {
             if (!$node instanceof Node) {
                 return null;
             }

--- a/src/Phan/Plugin/Internal/NodeSelectionPlugin.php
+++ b/src/Phan/Plugin/Internal/NodeSelectionPlugin.php
@@ -19,7 +19,7 @@ class NodeSelectionPlugin extends PluginV3 implements PostAnalyzeNodeCapability
      * @return void
      * TODO: Fix false positive TypeMismatchDeclaredParam with Closure $closure = null in this method
      */
-    public function setNodeSelectorClosure(?\Closure $closure) : void
+    public function setNodeSelectorClosure(?Closure $closure) : void
     {
         NodeSelectionVisitor::$closure = $closure;
     }

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
@@ -62,7 +62,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
      * @return VariableTrackingScope
      * @override
      */
-    public function visit(Node $node) : \Phan\Plugin\Internal\VariableTracker\VariableTrackingScope
+    public function visit(Node $node) : VariableTrackingScope
     {
         foreach ($node->children as $child_node) {
             if (!($child_node instanceof Node)) {
@@ -79,7 +79,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
      * @return VariableTrackingScope
      * @override
      */
-    public function visitStmtList(Node $node) : \Phan\Plugin\Internal\VariableTracker\VariableTrackingScope
+    public function visitStmtList(Node $node) : VariableTrackingScope
     {
         $top_level_statement = $this->top_level_statement;
         foreach ($node->children as $child_node) {
@@ -99,7 +99,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
      * @return VariableTrackingScope
      * @override
      */
-    public function visitAssignRef(Node $node) : \Phan\Plugin\Internal\VariableTracker\VariableTrackingScope
+    public function visitAssignRef(Node $node) : VariableTrackingScope
     {
         $expr = $node->children['expr'];
         if ($expr instanceof Node) {
@@ -120,7 +120,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
      * @override
      * @return VariableTrackingScope
      */
-    public function visitPostInc(Node $node) : \Phan\Plugin\Internal\VariableTracker\VariableTrackingScope
+    public function visitPostInc(Node $node) : VariableTrackingScope
     {
         return $this->analyzeIncDec($node);
     }
@@ -130,7 +130,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
      * @override
      * @return VariableTrackingScope
      */
-    public function visitPostDec(Node $node) : \Phan\Plugin\Internal\VariableTracker\VariableTrackingScope
+    public function visitPostDec(Node $node) : VariableTrackingScope
     {
         return $this->analyzeIncDec($node);
     }
@@ -140,7 +140,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
      * @override
      * @return VariableTrackingScope
      */
-    public function visitPreInc(Node $node) : \Phan\Plugin\Internal\VariableTracker\VariableTrackingScope
+    public function visitPreInc(Node $node) : VariableTrackingScope
     {
         return $this->analyzeIncDec($node);
     }
@@ -150,12 +150,12 @@ final class VariableTrackerVisitor extends AnalysisVisitor
      * @override
      * @return VariableTrackingScope
      */
-    public function visitPreDec(Node $node) : \Phan\Plugin\Internal\VariableTracker\VariableTrackingScope
+    public function visitPreDec(Node $node) : VariableTrackingScope
     {
         return $this->analyzeIncDec($node);
     }
 
-    private function analyzeIncDec(Node $node) : \Phan\Plugin\Internal\VariableTracker\VariableTrackingScope
+    private function analyzeIncDec(Node $node) : VariableTrackingScope
     {
         $var_node = $node->children['var'];
         if ($var_node instanceof Node && $var_node->kind === ast\AST_VAR) {
@@ -180,7 +180,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
      * @return VariableTrackingScope
      * @override
      */
-    public function visitAssignOp(Node $node) : \Phan\Plugin\Internal\VariableTracker\VariableTrackingScope
+    public function visitAssignOp(Node $node) : VariableTrackingScope
     {
         $expr = $node->children['expr'];
         if ($expr instanceof Node) {
@@ -220,7 +220,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
      * @return VariableTrackingScope
      * @override
      */
-    public function visitAssign(Node $node) : \Phan\Plugin\Internal\VariableTracker\VariableTrackingScope
+    public function visitAssign(Node $node) : VariableTrackingScope
     {
         $expr = $node->children['expr'];
         if ($expr instanceof Node) {
@@ -339,7 +339,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
         // return $this->analyzeAssignmentTarget($expr, false);
     }
 
-    public function handleMissingNodeKind(Node $unused_node) : \Phan\Plugin\Internal\VariableTracker\VariableTrackingScope
+    public function handleMissingNodeKind(Node $unused_node) : VariableTrackingScope
     {
         // do nothing
         return $this->scope;
@@ -349,7 +349,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
      * @param Node|string|int|float|null $child_node
      * @return VariableTrackingScope
      */
-    private function analyzeWhenValidNode(VariableTrackingScope $scope, $child_node) : \Phan\Plugin\Internal\VariableTracker\VariableTrackingScope
+    private function analyzeWhenValidNode(VariableTrackingScope $scope, $child_node) : VariableTrackingScope
     {
         if ($child_node instanceof Node) {
             return $this->analyze($scope, $child_node);
@@ -363,7 +363,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
      * @param Node $child_node - The node which will be analyzed to create the updated context.
      * @return VariableTrackingScope
      */
-    private function analyze(VariableTrackingScope $scope, Node $child_node) : \Phan\Plugin\Internal\VariableTracker\VariableTrackingScope
+    private function analyze(VariableTrackingScope $scope, Node $child_node) : VariableTrackingScope
     {
         // Modify the original object instead of creating a new BlockAnalysisVisitor.
         // this is slightly more efficient, especially if a large number of unchanged parameters would exist.
@@ -381,7 +381,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
      * @return VariableTrackingScope
      * @override
      */
-    public function visitFuncDecl(Node $unused_node) : \Phan\Plugin\Internal\VariableTracker\VariableTrackingScope
+    public function visitFuncDecl(Node $unused_node) : VariableTrackingScope
     {
         return $this->scope;
     }
@@ -391,7 +391,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
      * @return VariableTrackingScope
      * @override
      */
-    public function visitClass(Node $unused_node) : \Phan\Plugin\Internal\VariableTracker\VariableTrackingScope
+    public function visitClass(Node $unused_node) : VariableTrackingScope
     {
         return $this->scope;
     }
@@ -403,7 +403,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
      * @return VariableTrackingScope
      * @override
      */
-    public function visitClosure(Node $node) : \Phan\Plugin\Internal\VariableTracker\VariableTrackingScope
+    public function visitClosure(Node $node) : VariableTrackingScope
     {
         foreach ($node->children['uses']->children ?? [] as $closure_use) {
             if (!($closure_use instanceof Node)) {
@@ -430,7 +430,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
      * @return VariableTrackingScope
      * Common no-op
      */
-    public function visitName(Node $unused_node) : \Phan\Plugin\Internal\VariableTracker\VariableTrackingScope
+    public function visitName(Node $unused_node) : VariableTrackingScope
     {
         return $this->scope;
     }
@@ -440,7 +440,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
      * @return VariableTrackingScope
      * @override
      */
-    public function visitVar(Node $node) : \Phan\Plugin\Internal\VariableTracker\VariableTrackingScope
+    public function visitVar(Node $node) : VariableTrackingScope
     {
         $name = $node->children['name'];
         if (\is_string($name)) {
@@ -460,7 +460,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
      * @return VariableTrackingScope
      * @override
      */
-    public function visitStatic(Node $node) : \Phan\Plugin\Internal\VariableTracker\VariableTrackingScope
+    public function visitStatic(Node $node) : VariableTrackingScope
     {
         $name = $node->children['var']->children['name'] ?? null;
         if (\is_string($name)) {
@@ -474,7 +474,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
      * @return VariableTrackingScope
      * @override
      */
-    public function visitGlobal(Node $node) : \Phan\Plugin\Internal\VariableTracker\VariableTrackingScope
+    public function visitGlobal(Node $node) : VariableTrackingScope
     {
         $name = $node->children['var']->children['name'] ?? null;
         if (\is_string($name)) {
@@ -487,7 +487,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
      * Analyzes `foreach ($expr as $key => $value) { stmts }
      * @return VariableTrackingScope
      */
-    public function visitForeach(Node $node) : \Phan\Plugin\Internal\VariableTracker\VariableTrackingScope
+    public function visitForeach(Node $node) : VariableTrackingScope
     {
         $expr_node = $node->children['expr'];
         $outer_scope_unbranched = $this->analyzeWhenValidNode($this->scope, $expr_node);
@@ -521,7 +521,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
      * @return VariableTrackingScope
      * @override
      */
-    public function visitWhile(Node $node) : \Phan\Plugin\Internal\VariableTracker\VariableTrackingScope
+    public function visitWhile(Node $node) : VariableTrackingScope
     {
         $outer_scope_unbranched = $this->analyzeWhenValidNode($this->scope, $node->children['cond']);
         $outer_scope = new VariableTrackingBranchScope($outer_scope_unbranched);
@@ -545,7 +545,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
      * @return VariableTrackingScope
      * @override
      */
-    public function visitDoWhile(Node $node) : \Phan\Plugin\Internal\VariableTracker\VariableTrackingScope
+    public function visitDoWhile(Node $node) : VariableTrackingScope
     {
         $outer_scope_unbranched = $this->scope;
         $outer_scope = new VariableTrackingBranchScope($outer_scope_unbranched);
@@ -567,7 +567,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
      * @return VariableTrackingScope
      * @override
      */
-    public function visitFor(Node $node) : \Phan\Plugin\Internal\VariableTracker\VariableTrackingScope
+    public function visitFor(Node $node) : VariableTrackingScope
     {
         $top_level_statement = $this->top_level_statement;
         $init_node = $node->children['init'];
@@ -618,7 +618,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
      * @see BlockAnalysisVisitor::visitIf()
      * @override
      */
-    public function visitIf(Node $node) : \Phan\Plugin\Internal\VariableTracker\VariableTrackingScope
+    public function visitIf(Node $node) : VariableTrackingScope
     {
         $outer_scope = $this->scope;
 
@@ -670,7 +670,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
      *
      * @override
      */
-    public function visitSwitchList(Node $node) : \Phan\Plugin\Internal\VariableTracker\VariableTrackingScope
+    public function visitSwitchList(Node $node) : VariableTrackingScope
     {
         $outer_scope = $this->scope;
 
@@ -721,7 +721,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
      *
      * @override
      */
-    public function visitTry(Node $node) : \Phan\Plugin\Internal\VariableTracker\VariableTrackingScope
+    public function visitTry(Node $node) : VariableTrackingScope
     {
         $outer_scope = $this->scope;
 
@@ -754,7 +754,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
      *
      * @override
      */
-    public function visitCatchList(Node $node) : \Phan\Plugin\Internal\VariableTracker\VariableTrackingScope
+    public function visitCatchList(Node $node) : VariableTrackingScope
     {
         $outer_scope = $this->scope;
 
@@ -783,7 +783,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
      *
      * @override
      */
-    public function visitCatch(Node $node) : \Phan\Plugin\Internal\VariableTracker\VariableTrackingScope
+    public function visitCatch(Node $node) : VariableTrackingScope
     {
         $var_node = $node->children['var'];
 

--- a/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
+++ b/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
@@ -329,7 +329,7 @@ final class VariableTrackerElementVisitor extends PluginAwarePostAnalysisVisitor
         );
     }
 
-    private static function makeSuggestion(VariableGraph $graph, string $variable_name, string $issue_type) : ?\Phan\Suggestion
+    private static function makeSuggestion(VariableGraph $graph, string $variable_name, string $issue_type) : ?Suggestion
     {
         if ($issue_type !== Issue::UnusedVariable) {
             return null;

--- a/src/Phan/PluginV3/SuppressionCapability.php
+++ b/src/Phan/PluginV3/SuppressionCapability.php
@@ -51,7 +51,7 @@ interface SuppressionCapability
         string $issue_type,
         int $lineno,
         array $parameters,
-        ?\Phan\Suggestion $suggestion
+        ?Suggestion $suggestion
     ) : bool;
 
     /**

--- a/tests/Phan/AST/TolerantASTConverter/TolerantASTConverterWithNodeMappingTest.php
+++ b/tests/Phan/AST/TolerantASTConverter/TolerantASTConverterWithNodeMappingTest.php
@@ -76,7 +76,7 @@ final class TolerantASTConverterWithNodeMappingTest extends BaseTest
         }
     }
 
-    private function parseASTWithDefaultOptions(string $file_contents, int $byte_offset) : \ast\Node
+    private function parseASTWithDefaultOptions(string $file_contents, int $byte_offset) : Node
     {
         $converter = new TolerantASTConverterWithNodeMapping($byte_offset);
         $errors = [];


### PR DESCRIPTION
Those were added by PHPDocToRealTypesPlugin, which always adds the fully-qualified type right now.

The code converting those from FQ to non-FQ is PreferNamespaceUsePlugin, which also supports `--automatic-fix`

