### PR TITLE
Phan v2: Add abstraction to support PluginV2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,11 +8,16 @@ New features(CLI, Configs):
   New CLI flags to disable features: `--language-server-disable-hover`, `--language-server-disable-go-to-definition`, `--language-server-disable-completion`
 
 Backwards Incompatible Changes:
++ Drop support for running Phan with PHP 7.0. (PHP 7.0 reached its end of life in December 2018)
+  Analyzing codebases with `--target-php-version 7.0` continues to be supported.
 + Require php-ast 1.0.1 or newer (or the absence of php-ast with `--allow-polyfill-parser`)
   Phan switched from using [AST version 50 to version 70](https://github.com/nikic/php-ast#ast-versioning).
 
 Plugins:
-+ Change `PluginV2` to `PluginV3` because type signatures are stricter (and incompatible with existing plugins) and some of Phan's methods will be removed, changed, or renamed.
++ Change `PluginV2` to `PluginV3`
+  `PluginV2` and its capabilities will continue to work to make migrating to Phan 2.x easier, but `PluginV2` is deprecated and will be removed in Phan 3.
+
+  `PluginV3` has the same APIs and capabilities as PluginV2, but uses PHP 7.1 signatures (`void`, `?MyClass`, etc.)
 + Third party plugins may need to be upgraded to support changes in AST version 70, e.g. the new node kinds `AST_PROP_GROUP` and `AST_CLASS_NAME`
 + Add `PHPDocToRealTypesPlugin` to suggest real types to replace (or use alongside) phpdoc return types.
   This does not check that the phpdoc types are correct.

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -41,19 +41,19 @@ use Phan\Plugin\Internal\RequireExistsPlugin;
 use Phan\Plugin\Internal\StringFunctionPlugin;
 use Phan\Plugin\Internal\ThrowAnalyzerPlugin;
 use Phan\Plugin\Internal\VariableTrackerPlugin;
+use Phan\PluginV2\AfterAnalyzeFileCapability;
+use Phan\PluginV2\AnalyzeClassCapability;
+use Phan\PluginV2\AnalyzeFunctionCapability;
+use Phan\PluginV2\AnalyzeMethodCapability;
+use Phan\PluginV2\AnalyzePropertyCapability;
+use Phan\PluginV2\BeforeAnalyzeCapability;
+use Phan\PluginV2\BeforeAnalyzeFileCapability;
+use Phan\PluginV2\FinalizeProcessCapability;
 use Phan\PluginV3;
-use Phan\PluginV3\AfterAnalyzeFileCapability;
-use Phan\PluginV3\AnalyzeClassCapability;
 use Phan\PluginV3\AnalyzeFunctionCallCapability;
-use Phan\PluginV3\AnalyzeFunctionCapability;
-use Phan\PluginV3\AnalyzeMethodCapability;
-use Phan\PluginV3\AnalyzePropertyCapability;
 use Phan\PluginV3\AutomaticFixCapability;
-use Phan\PluginV3\BeforeAnalyzeCapability;
-use Phan\PluginV3\BeforeAnalyzeFileCapability;
 use Phan\PluginV3\BeforeAnalyzePhaseCapability;
-use Phan\PluginV3\FinalizeProcessCapability;
-use Phan\PluginV3\HandleLazyLoadInternalFunctionCapability;
+use Phan\PluginV2\HandleLazyLoadInternalFunctionCapability;
 use Phan\PluginV3\PluginAwarePostAnalysisVisitor;
 use Phan\PluginV3\PluginAwarePreAnalysisVisitor;
 use Phan\PluginV3\PostAnalyzeNodeCapability;
@@ -82,16 +82,16 @@ use const STDERR;
  * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod TODO: Document
  */
 final class ConfigPluginSet extends PluginV3 implements
-    AfterAnalyzeFileCapability,
-    AnalyzeClassCapability,
-    AnalyzeFunctionCapability,
+    \Phan\PluginV3\AfterAnalyzeFileCapability,
+    \Phan\PluginV3\AnalyzeClassCapability,
+    \Phan\PluginV3\AnalyzeFunctionCapability,
     AnalyzeFunctionCallCapability,
-    AnalyzeMethodCapability,
-    AnalyzePropertyCapability,
-    BeforeAnalyzeCapability,
+    \Phan\PluginV3\AnalyzeMethodCapability,
+    \Phan\PluginV3\AnalyzePropertyCapability,
+    \Phan\PluginV3\BeforeAnalyzeCapability,
     BeforeAnalyzePhaseCapability,
-    BeforeAnalyzeFileCapability,
-    FinalizeProcessCapability,
+    \Phan\PluginV3\BeforeAnalyzeFileCapability,
+    \Phan\PluginV3\FinalizeProcessCapability,
     ReturnTypeOverrideCapability,
     SuppressionCapability
 {
@@ -875,7 +875,7 @@ final class ConfigPluginSet extends PluginV3 implements
         $this->analyze_class_plugin_set         = self::filterByClass($plugin_set, AnalyzeClassCapability::class);
         $this->finalize_process_plugin_set      = self::filterByClass($plugin_set, FinalizeProcessCapability::class);
         $this->return_type_override_plugin_set  = self::filterByClass($plugin_set, ReturnTypeOverrideCapability::class);
-        $this->suppression_plugin_set           = self::filterByClass($plugin_set, SuppressionCapability::class);
+        $this->suppression_plugin_set           = self::filterByClass($plugin_set, SuppressionCapability::class, \Phan\PluginV2\SuppressionCapability::class);
         $this->analyze_function_call_plugin_set = self::filterByClass($plugin_set, AnalyzeFunctionCallCapability::class);
         $this->handle_lazy_load_internal_function_plugin_set = self::filterByClass($plugin_set, HandleLazyLoadInternalFunctionCapability::class);
         $this->unused_suppression_plugin        = self::findUnusedSuppressionPlugin($plugin_set);
@@ -942,7 +942,7 @@ final class ConfigPluginSet extends PluginV3 implements
         PreAnalyzeNodeCapability $plugin
     ) : void {
         $plugin_analysis_class = $plugin->getPreAnalyzeNodeVisitorClassName();
-        if (!\is_subclass_of($plugin_analysis_class, PluginAwarePreAnalysisVisitor::class)) {
+        if (!\is_subclass_of($plugin_analysis_class, PluginAwarePreAnalysisVisitor::class) && !\is_subclass_of($plugin_analysis_class, \Phan\PluginV2\PluginAwarePreAnalysisVisitor::class)) {
             throw new \TypeError(
                 \sprintf(
                     "Result of %s::getAnalyzeNodeVisitorClassName must be the name of a subclass of '%s', but '%s' is not",
@@ -1045,7 +1045,7 @@ final class ConfigPluginSet extends PluginV3 implements
         PostAnalyzeNodeCapability $plugin
     ) : void {
         $plugin_analysis_class = $plugin->getPostAnalyzeNodeVisitorClassName();
-        if (!\is_subclass_of($plugin_analysis_class, PluginAwarePostAnalysisVisitor::class)) {
+        if (!\is_subclass_of($plugin_analysis_class, PluginAwarePostAnalysisVisitor::class) && !is_subclass_of($plugin_analysis_class, \Phan\PluginV2\PluginAwarePostAnalysisVisitor::class)) {
             throw new \TypeError(
                 \sprintf(
                     "Result of %s::getAnalyzeNodeVisitorClassName must be the name of a subclass of '%s', but '%s' is not",
@@ -1119,14 +1119,17 @@ final class ConfigPluginSet extends PluginV3 implements
      * @template T
      * @param array<int,PluginV3> $plugin_set
      * @param class-string<T> $interface_name
+     * @param ?class-string $alternate_interface_name a legacy inferface from PluginV2 accepting the same arguments
      * @return array<int,T>
      * @suppress PhanPartialTypeMismatchReturn unable to infer this
      */
-    private static function filterByClass(array $plugin_set, string $interface_name) : array
+    private static function filterByClass(array $plugin_set, string $interface_name, ?string $alternate_interface_name = null) : array
     {
         $result = [];
         foreach ($plugin_set as $plugin) {
             if ($plugin instanceof $interface_name) {
+                $result[] = $plugin;
+            } elseif ($alternate_interface_name && $plugin instanceof $alternate_interface_name) {
                 $result[] = $plugin;
             }
         }

--- a/src/Phan/PluginV2.php
+++ b/src/Phan/PluginV2.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Phan;
+
+/**
+ * @deprecated - External plugins should migrate to Phan V2 and PluginV3.
+ * @suppress PhanUnreferencedClass this is deprecated and provided to make migrating to PluginV3 easier
+ */
+class PluginV2 extends PluginV3
+{
+}

--- a/src/Phan/PluginV2/AfterAnalyzeFileCapability.php
+++ b/src/Phan/PluginV2/AfterAnalyzeFileCapability.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Phan\PluginV2;
+
+use ast\Node;
+use Phan\CodeBase;
+use Phan\Language\Context;
+
+/**
+ * Plugins should move to PluginV3 to indicate that they support PhanV2, AST version 70 and its APIs
+ *
+ * @see \Phan\PluginV3\AfterAnalyzeFileCapability
+ */
+interface AfterAnalyzeFileCapability
+{
+    /**
+     * Use PluginV3 instead.
+     * @return void
+     */
+    public function afterAnalyzeFile(
+        CodeBase $code_base,
+        Context $context,
+        string $file_contents,
+        Node $node
+    );
+}

--- a/src/Phan/PluginV2/AnalyzeClassCapability.php
+++ b/src/Phan/PluginV2/AnalyzeClassCapability.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Phan\PluginV2;
+
+use Phan\CodeBase;
+use Phan\Language\Element\Clazz;
+
+/**
+ * Plugins should move to PluginV3
+ * @see \Phan\PluginV3\AnalyzeClassCapability
+ */
+interface AnalyzeClassCapability
+{
+    /** @return void deprecated */
+    public function analyzeClass(
+        CodeBase $code_base,
+        Clazz $class
+    );
+}

--- a/src/Phan/PluginV2/AnalyzeFunctionCallCapability.php
+++ b/src/Phan/PluginV2/AnalyzeFunctionCallCapability.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Phan\PluginV2;
+
+/**
+ * @deprecated use PluginV3
+ */
+interface AnalyzeFunctionCallCapability extends \Phan\PluginV3\AnalyzeFunctionCallCapability
+{
+}

--- a/src/Phan/PluginV2/AnalyzeFunctionCapability.php
+++ b/src/Phan/PluginV2/AnalyzeFunctionCapability.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace Phan\PluginV2;
+
+use Phan\CodeBase;
+use Phan\Language\Element\Func;
+
+/**
+ * Use PluginV3 instead.
+ * @see \Phan\PluginV3\AnalyzeFunctionCapability
+ */
+interface AnalyzeFunctionCapability
+{
+    /**
+     * @return void use pluginv3 instead
+     */
+    public function analyzeFunction(
+        CodeBase $code_base,
+        Func $function
+    );
+}

--- a/src/Phan/PluginV2/AnalyzeMethodCapability.php
+++ b/src/Phan/PluginV2/AnalyzeMethodCapability.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace Phan\PluginV2;
+
+use Phan\CodeBase;
+use Phan\Language\Element\Method;
+
+/**
+ * Use PluginV3 instead
+ */
+interface AnalyzeMethodCapability
+{
+    /**
+     * Analyze (and modify) a method definition, after parsing and before analyzing.
+     *
+     * @return void
+     */
+    public function analyzeMethod(
+        CodeBase $code_base,
+        Method $method
+    );
+}

--- a/src/Phan/PluginV2/AnalyzePropertyCapability.php
+++ b/src/Phan/PluginV2/AnalyzePropertyCapability.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace Phan\PluginV2;
+
+use Phan\CodeBase;
+use Phan\Language\Element\Property;
+
+/**
+ * @deprecated use PluginV3 instead
+ */
+interface AnalyzePropertyCapability
+{
+    /**
+     * Analyze (and modify) a property definition,
+     * after parsing and before analyzing.
+     *
+     * @return void
+     */
+    public function analyzeProperty(
+        CodeBase $code_base,
+        Property $property
+    );
+}

--- a/src/Phan/PluginV2/AutomaticFixCapability.php
+++ b/src/Phan/PluginV2/AutomaticFixCapability.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Phan\PluginV2;
+
+/**
+ * @deprecated use PluginV3
+ */
+interface AutomaticFixCapability extends \Phan\PluginV3\AutomaticFixCapability
+{
+}

--- a/src/Phan/PluginV2/BeforeAnalyzeCapability.php
+++ b/src/Phan/PluginV2/BeforeAnalyzeCapability.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace Phan\PluginV2;
+
+use Phan\CodeBase;
+
+/**
+ * Use PluginV3 instead.
+ */
+interface BeforeAnalyzeCapability
+{
+    /**
+     * This method is called before analyzing a project and before analyzing methods.
+     *
+     * @return void
+     */
+    public function beforeAnalyze(
+        CodeBase $code_base
+    );
+}

--- a/src/Phan/PluginV2/BeforeAnalyzeFileCapability.php
+++ b/src/Phan/PluginV2/BeforeAnalyzeFileCapability.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Phan\PluginV2;
+
+use ast\Node;
+use Phan\CodeBase;
+use Phan\Language\Context;
+
+/**
+ * Use PluginV3 instead
+ */
+interface BeforeAnalyzeFileCapability
+{
+    /**
+     * This method is called before analyzing a file.
+     *
+     * @return void
+     */
+    public function beforeAnalyzeFile(
+        CodeBase $code_base,
+        Context $context,
+        string $file_contents,
+        Node $node
+    );
+}

--- a/src/Phan/PluginV2/FinalizeProcessCapability.php
+++ b/src/Phan/PluginV2/FinalizeProcessCapability.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace Phan\PluginV2;
+
+use Phan\CodeBase;
+
+/**
+ * Use PluginV2 instead
+ */
+interface FinalizeProcessCapability
+{
+    /**
+     * This is called after the other forms of analysis are finished running.
+     *
+     * @return void
+     */
+    public function finalizeProcess(CodeBase $code_base);
+}

--- a/src/Phan/PluginV2/HandleLazyLoadInternalFunctionCapability.php
+++ b/src/Phan/PluginV2/HandleLazyLoadInternalFunctionCapability.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace Phan\PluginV2;
+
+use Phan\CodeBase;
+use Phan\Language\Element\Func;
+
+/**
+ * Use PluginV3 instead.
+ */
+interface HandleLazyLoadInternalFunctionCapability
+{
+    /**
+     * This method is called after Phan lazily loads a global internal function.
+     *
+     * @return void
+     */
+    public function handleLazyLoadInternalFunction(
+        CodeBase $code_base,
+        Func $function
+    );
+}

--- a/src/Phan/PluginV2/PluginAwareBaseAnalysisVisitor.php
+++ b/src/Phan/PluginV2/PluginAwareBaseAnalysisVisitor.php
@@ -1,0 +1,86 @@
+<?php declare(strict_types=1);
+
+namespace Phan\PluginV2;
+
+use ast\Node;
+use Phan\AST\AnalysisVisitor;
+use Phan\AST\Visitor\Element;
+use Phan\Issue;
+use Phan\PluginV3\IssueEmitter;
+
+/**
+ * This augments AnalysisVisitor with public and internal methods.
+ * @deprecated use PluginV3
+ */
+abstract class PluginAwareBaseAnalysisVisitor extends AnalysisVisitor
+{
+    use IssueEmitter;  // defines emitPluginIssue
+
+    /**
+     * This is an empty visit() body.
+     * Don't override this unless you need to, analysis is more efficient if Phan knows it doesn't need to call a plugin on a node type.
+     * @see self::isDefinedInSubclass()
+     * @param Node $node @phan-unused-param (unused because the body is empty)
+     *
+     * @return void
+     */
+    public function visit(Node $node)
+    {
+    }
+
+    /**
+     * See documentation for PluginV3
+     * @param array<int,string> $issue_message_args
+     * @return void
+     * @suppress PhanPluginCanUsePHP71Void
+     * @suppress PhanUnreferencedPublicMethod
+     */
+    public function emit(
+        string $issue_type,
+        string $issue_message_fmt,
+        array $issue_message_args = [],
+        int $severity = Issue::SEVERITY_NORMAL,
+        int $remediation_difficulty = Issue::REMEDIATION_B,
+        int $issue_type_id = Issue::TYPE_ID_UNKNOWN
+    ) {
+        $this->emitPluginIssue(
+            $this->code_base,
+            $this->context,
+            $issue_type,
+            $issue_message_fmt,
+            $issue_message_args,
+            $severity,
+            $remediation_difficulty,
+            $issue_type_id
+        );
+    }
+
+    // Internal methods used by ConfigPluginSet are below.
+    // They aren't useful for plugins.
+
+    /**
+     * @return array<int,int> The list of $node->kind values this plugin is capable of analyzing.
+     */
+    final public static function getHandledNodeKinds() : array
+    {
+        $defines_visit = self::isDefinedInSubclass('visit');
+        $kinds = [];
+        foreach (Element::VISIT_LOOKUP_TABLE as $kind => $method_name) {
+            if ($defines_visit || self::isDefinedInSubclass($method_name)) {
+                $kinds[] = $kind;
+            }
+        }
+        return $kinds;
+    }
+
+    /**
+     * @return bool true if $method_name is defined by the subclass of PluginAwareBaseAnalysisVisitor,
+     * and not by PluginAwareBaseAnalysisVisitor or one of its parents.
+     */
+    private static function isDefinedInSubclass(string $method_name) : bool
+    {
+        $method = new \ReflectionMethod(static::class, $method_name);
+        return \is_subclass_of($method->getDeclaringClass()->name, self::class);
+    }
+    // End of methods for internal use.
+}

--- a/src/Phan/PluginV2/PluginAwarePostAnalysisVisitor.php
+++ b/src/Phan/PluginV2/PluginAwarePostAnalysisVisitor.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace Phan\PluginV2;
+
+// use ast\Node;
+
+/**
+ * For plugins which define their own post-order analysis behaviors in the analysis phase.
+ * Called on a node after PluginAwarePreAnalysisVisitor implementations.
+ * @deprecated use PluginV3
+ */
+abstract class PluginAwarePostAnalysisVisitor extends PluginAwareBaseAnalysisVisitor
+{
+    // Subclasses should declare protected $parent_node_list as an instance property if they need to know the list.
+
+    // @var array<int,Node> - Set after the constructor is called if an instance property with this name is declared
+    // protected $parent_node_list;
+
+    // Implementations should omit the constructor or call parent::__construct(CodeBase $code_base, Context $context)
+}

--- a/src/Phan/PluginV2/PluginAwarePreAnalysisVisitor.php
+++ b/src/Phan/PluginV2/PluginAwarePreAnalysisVisitor.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Phan\PluginV2;
+
+/**
+ * For plugins which define their own pre-order analysis behaviors in the analysis phase.
+ * Called on a node before PluginAwarePreAnalysisVisitor implementations.
+ *
+ * @deprecated use PluginV3
+ */
+abstract class PluginAwarePreAnalysisVisitor extends PluginAwareBaseAnalysisVisitor
+{
+    // Subclasses should declare protected $parent_node_list as an instance property if they need to know the list.
+
+    // @var array<int,Node> - Set after the constructor is called if an instance property with this name is declared
+    // protected $parent_node_list;
+
+    // Implementations should omit the constructor or call parent::__construct(CodeBase $code_base, Context $context)
+}

--- a/src/Phan/PluginV2/PostAnalyzeNodeCapability.php
+++ b/src/Phan/PluginV2/PostAnalyzeNodeCapability.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Phan\PluginV2;
+
+/**
+ * Use PluginV3
+ * @deprecated
+ */
+interface PostAnalyzeNodeCapability extends \Phan\PluginV3\PostAnalyzeNodeCapability
+{
+}

--- a/src/Phan/PluginV2/PreAnalyzeNodeCapability.php
+++ b/src/Phan/PluginV2/PreAnalyzeNodeCapability.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Phan\PluginV2;
+
+/**
+ * Use PluginV3
+ * @deprecated
+ */
+interface PreAnalyzeNodeCapability extends \Phan\PluginV3\PreAnalyzeNodeCapability
+{
+}

--- a/src/Phan/PluginV2/ReturnTypeOverrideCapability.php
+++ b/src/Phan/PluginV2/ReturnTypeOverrideCapability.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Phan\PluginV2;
+
+/**
+ * @deprecated use PluginV3
+ */
+interface ReturnTypeOverrideCapability extends \Phan\PluginV3\ReturnTypeOverrideCapability
+{
+}

--- a/src/Phan/PluginV2/StopParamAnalysisException.php
+++ b/src/Phan/PluginV2/StopParamAnalysisException.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace Phan\PluginV2;
+
+/**
+ * Use PluginV3
+ * @deprecated use PluginV3
+ * @see \Phan\PluginV3\StopParamAnalysisException
+ * @suppress PhanUnreferencedClass
+ */
+class StopParamAnalysisException extends \Phan\PluginV3\StopParamAnalysisException
+{
+}

--- a/src/Phan/PluginV2/SuppressionCapability.php
+++ b/src/Phan/PluginV2/SuppressionCapability.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace Phan\PluginV2;
+
+use Phan\CodeBase;
+use Phan\Language\Context;
+use Phan\Language\Element\TypedElement;
+use Phan\Language\Element\UnaddressableTypedElement;
+use Phan\Language\FQSEN;
+use Phan\Language\Type;
+use Phan\Language\UnionType;
+use Phan\Suggestion;
+
+/**
+ * Plugins can implement this to suppress issues in additional ways.
+ *
+ * @see \Phan\Plugin\Internal\BuiltinSuppressionPlugin for an example of how to implement a plugin with this functionality
+ * @deprecated Use PluginV3 instead.
+ */
+interface SuppressionCapability
+{
+    /**
+     * @param array<int,string|int|float|bool|Type|UnionType|FQSEN|TypedElement|UnaddressableTypedElement> $parameters
+     *
+     * @param ?Suggestion $suggestion Phan's suggestion for how to fix the issue, if any.
+     *
+     * @return bool true if the given issue instance should be suppressed, given the current file contents.
+     * @deprecated use PluginV3
+     * @suppress PhanPluginCanUseNullableParamType provided for legacy PluginV2 plugins
+     */
+    public function shouldSuppressIssue(
+        CodeBase $code_base,
+        Context $context,
+        string $issue_type,
+        int $lineno,
+        array $parameters,
+        $suggestion
+    ) : bool;
+}

--- a/src/Phan/PluginV3/AfterAnalyzeFileCapability.php
+++ b/src/Phan/PluginV3/AfterAnalyzeFileCapability.php
@@ -10,7 +10,7 @@ use Phan\Language\Context;
  * AfterAnalyzeFileCapability is used when you want to perform checks after analyzing a file
  * NOTE: This does not run on empty files.
  */
-interface AfterAnalyzeFileCapability
+interface AfterAnalyzeFileCapability extends \Phan\PluginV2\AfterAnalyzeFileCapability
 {
     /**
      * This method is called after Phan analyzes a file.

--- a/src/Phan/PluginV3/AnalyzeClassCapability.php
+++ b/src/Phan/PluginV3/AnalyzeClassCapability.php
@@ -9,7 +9,7 @@ use Phan\Language\Element\Clazz;
  * Plugins should implement this to be called to
  * analyze (and possibly modify) a class definition, after parsing and before analyzing.
  */
-interface AnalyzeClassCapability
+interface AnalyzeClassCapability extends \Phan\PluginV2\AnalyzeClassCapability
 {
     /**
      * Analyze (and modify) a class definition, after parsing and before analyzing.

--- a/src/Phan/PluginV3/AnalyzeFunctionCapability.php
+++ b/src/Phan/PluginV3/AnalyzeFunctionCapability.php
@@ -9,7 +9,7 @@ use Phan\Language\Element\Func;
  * Plugins should implement this to analyze (and modify) a function definition,
  * after parsing and before analyzing.
  */
-interface AnalyzeFunctionCapability
+interface AnalyzeFunctionCapability extends \Phan\PluginV2\AnalyzeFunctionCapability
 {
     /**
      * Analyze (and modify) a function definition, after parsing and before analyzing.

--- a/src/Phan/PluginV3/AnalyzeMethodCapability.php
+++ b/src/Phan/PluginV3/AnalyzeMethodCapability.php
@@ -9,7 +9,7 @@ use Phan\Language\Element\Method;
  * Plugins can implement this to analyze (and modify) a method definition,
  * after parsing and before analyzing.
  */
-interface AnalyzeMethodCapability
+interface AnalyzeMethodCapability extends \Phan\PluginV2\AnalyzeMethodCapability
 {
     /**
      * Analyze (and modify) a method definition, after parsing and before analyzing.

--- a/src/Phan/PluginV3/AnalyzePropertyCapability.php
+++ b/src/Phan/PluginV3/AnalyzePropertyCapability.php
@@ -9,7 +9,7 @@ use Phan\Language\Element\Property;
  * Plugins can implement this to analyze (and modify) a property definition,
  * after parsing and before analyzing.
  */
-interface AnalyzePropertyCapability
+interface AnalyzePropertyCapability extends \Phan\PluginV2\AnalyzePropertyCapability
 {
     /**
      * Analyze (and modify) a property definition,

--- a/src/Phan/PluginV3/BeforeAnalyzeCapability.php
+++ b/src/Phan/PluginV3/BeforeAnalyzeCapability.php
@@ -12,7 +12,7 @@ use Phan\CodeBase;
  * @see BeforeAnalyzePhaseCapability to run plugins **after** analyzing methods.
  * (use BeforeAnalyzePhaseCapability if you're not sure)
  */
-interface BeforeAnalyzeCapability
+interface BeforeAnalyzeCapability extends \Phan\PluginV2\BeforeAnalyzeCapability
 {
     /**
      * This method is called before analyzing a project and before analyzing methods.

--- a/src/Phan/PluginV3/BeforeAnalyzeFileCapability.php
+++ b/src/Phan/PluginV3/BeforeAnalyzeFileCapability.php
@@ -10,7 +10,7 @@ use Phan\Language\Context;
  * BeforeAnalyzeFileCapability is used when you want to perform checks before analyzing a file
  * NOTE: This does not run on empty files.
  */
-interface BeforeAnalyzeFileCapability
+interface BeforeAnalyzeFileCapability extends \Phan\PluginV2\BeforeAnalyzeFileCapability
 {
     /**
      * This method is called before analyzing a file.

--- a/src/Phan/PluginV3/FinalizeProcessCapability.php
+++ b/src/Phan/PluginV3/FinalizeProcessCapability.php
@@ -7,7 +7,7 @@ use Phan\CodeBase;
 /**
  * Plugins can implement this to be called after other forms of analysis are finished running
  */
-interface FinalizeProcessCapability
+interface FinalizeProcessCapability extends \Phan\PluginV2\FinalizeProcessCapability
 {
     /**
      * This is called after the other forms of analysis are finished running.

--- a/src/Phan/PluginV3/HandleLazyLoadInternalFunctionCapability.php
+++ b/src/Phan/PluginV3/HandleLazyLoadInternalFunctionCapability.php
@@ -9,7 +9,7 @@ use Phan\Language\Element\Func;
  * HandleLazyLoadInternalFunctionCapability is used when you want to modify some subset of global functions used in the program,
  * when some global functions (such as register_shutdown_function) won't be loaded until the analysis phase.
  */
-interface HandleLazyLoadInternalFunctionCapability
+interface HandleLazyLoadInternalFunctionCapability extends \Phan\PluginV2\HandleLazyLoadInternalFunctionCapability
 {
     /**
      * This method is called after Phan lazily loads a global internal function.


### PR DESCRIPTION
Many PluginV2 plugins would continue working in Phan v2.
This makes it easier to test them and to migrate to Phan v2 before
updating those plugins.

- However, due to changes in Phan's APIs, migration from AST version 50 to
  70, etc., those plugins might have subtle bugs.
- Various APIs were renamed or removed (e.g. `getIsNullable()` to `isNullable()`).
  Some method aliases were provided for compatibility, but those will
  probably be dropped in Phan V3
- Plugins that exclusively target PluginV3 can safely drop PHP 7.0 support and
  update dependencies.

The PluginV2 compatibility support will be deprecated and removed in the future.