### PR TITLE
v2: Fix false positive PhanUndeclaredVariable within a closure

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,8 +3,9 @@ Phan NEWS
 ?? ??? 2019, Phan 2.0.0 (dev)
 -----------------------
 
-Bug fixes
+Bug fixes:
 + Analyze the remaining expressions in a statement after emitting `PhanTraitParentReference` (#2750)
++ Don't emit `PhanUndeclaredVariable` within a closure if a `use` variable was undefined outside of it. (#2716)
 
 09 May 2019, Phan 2.0.0-RC1
 -----------------------

--- a/tests/files/expected/0672_undef_in_closure.php.expected
+++ b/tests/files/expected/0672_undef_in_closure.php.expected
@@ -1,0 +1,2 @@
+%s:3 PhanUndeclaredVariable Variable $var is undeclared
+%s:4 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is null but \intdiv() takes int

--- a/tests/files/src/0672_undef_in_closure.php
+++ b/tests/files/src/0672_undef_in_closure.php
@@ -1,0 +1,9 @@
+<?php
+function test_undef_var_in_closure() {
+    $cb = function () use ($var) {
+        echo intdiv($var, 2);
+        var_dump($var);
+    };
+    $cb();
+}
+test_undef_var_in_closure();


### PR DESCRIPTION
Fixes #2716
Should not warn twice. It already warns within the use.