### PR TITLE
Improve analysis of return types of magic methods

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@ Phan NEWS
 ?? ??? 2019, Phan 2.0.0 (dev)
 -----------------------
 
+New features(Analysis):
++ Infer the return types of PHP 7.4's magic methods `__serialize()` and `__unserialize()`. (#2755)
+  Improve analysis of return types of other magic methods such as `__sleep()`.
+
 Plugins:
 + Detect some new php 7.3 functions (array_key_first, etc.) in `UseReturnValuePlugin`.
 

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -1334,9 +1334,18 @@ trait FunctionTrait
                 }
             }
         }
-        if ($return_type->isEmpty() && !$this->hasReturn()) {
-            if ($this instanceof Func || ($this instanceof Method && ($this->isPrivate() || $this->isEffectivelyFinal() || $this->isMagicAndVoid() || $this->getClass($code_base)->isFinal()))) {
-                $this->setUnionType(VoidType::instance(false)->asUnionType());
+        if ($return_type->isEmpty()) {
+            if ($this->hasReturn()) {
+                if ($this instanceof Method) {
+                    $union_type = $this->getUnionTypeOfMagicIfKnown();
+                    if ($union_type) {
+                        $this->setUnionType($union_type);
+                    }
+                }
+            } else {
+                if ($this instanceof Func || ($this instanceof Method && ($this->isPrivate() || $this->isEffectivelyFinal() || $this->isMagicAndVoid() || $this->getClass($code_base)->isFinal()))) {
+                    $this->setUnionType(VoidType::instance(false)->asUnionType());
+                }
             }
         }
         foreach ($real_return_type->getTypeSet() as $type) {

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -259,6 +259,15 @@ class Method extends ClassElement implements FunctionInterface
     }
 
     /**
+     * Returns the return union type of this magic method, if known.
+     */
+    public function getUnionTypeOfMagicIfKnown() : ?UnionType
+    {
+        $type_string = FullyQualifiedMethodName::MAGIC_METHOD_TYPE_MAP[$this->getName()] ?? null;
+        return $type_string ? UnionType::fromFullyQualifiedString($type_string) : null;
+    }
+
+    /**
      * Returns true if this is a magic method
      * @deprecated use isMagic
      * @suppress PhanUnreferencedPublicMethod

--- a/src/Phan/Language/FQSEN/FullyQualifiedMethodName.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedMethodName.php
@@ -23,8 +23,10 @@ class FullyQualifiedMethodName extends FullyQualifiedClassElement implements Ful
         '__isset'       => '__isset',
         '__set'         => '__set',
         '__set_state'   => '__set_state',
+        '__serialize'   => '__serialize',
         '__sleep'       => '__sleep',
         '__tostring'    => '__toString',
+        '__unserialize' => '__unserialize',
         '__unset'       => '__unset',
         '__wakeup'      => '__wakeup',
     ];
@@ -39,12 +41,34 @@ class FullyQualifiedMethodName extends FullyQualifiedClassElement implements Ful
         '__get'         => true,
         '__invoke'      => true,
         '__isset'       => true,
+        '__serialize'   => true,
         '__set'         => true,
         '__set_state'   => true,
         '__sleep'       => true,
         '__toString'    => true,
+        '__unserialize' => true,
         '__unset'       => true,
         '__wakeup'      => true,
+    ];
+
+    /**
+     * Maps magic method names with known types to those types.
+     * Excludes values with mixed types.
+     */
+    const MAGIC_METHOD_TYPE_MAP = [
+        '__clone'       => 'void',
+        '__construct'   => 'void',
+        '__debugInfo'   => 'array<string,mixed>',
+        '__destruct'    => 'void',
+        '__isset'       => 'bool',
+        '__serialize'   => 'array',
+        '__set'         => 'void',
+        '__set_state'   => 'object',
+        '__sleep'       => 'string[]',
+        '__toString'    => 'string',
+        '__unserialize' => 'void',
+        '__unset'       => 'void',
+        '__wakeup'      => 'void',
     ];
 
     /**
@@ -56,6 +80,7 @@ class FullyQualifiedMethodName extends FullyQualifiedClassElement implements Ful
         '__destruct'    => true,
         '__set'         => true,
         '__unset'       => true,
+        '__unserialize' => true,
         '__wakeup'      => true,
     ];
 

--- a/src/Phan/Plugin/Internal/MethodSearcherPlugin.php
+++ b/src/Phan/Plugin/Internal/MethodSearcherPlugin.php
@@ -248,9 +248,10 @@ final class MethodSearcherPlugin extends PluginV3 implements
     private static function guessUnionType(FunctionInterface $function) : UnionType
     {
         if ($function instanceof Method) {
-            // TODO: convert __sleep to string[], etc.
-            if ($function->isMagicAndVoid()) {
-                return UnionType::fromFullyQualifiedString('void');
+            // convert __set to void, __sleep to string[], etc.
+            $union_type = $function->getUnionTypeOfMagicIfKnown();
+            if ($union_type) {
+                return $union_type;
             }
             if (!$function->isAbstract() && !$function->isPHPInternal() && !$function->hasReturn()) {
                 return UnionType::fromFullyQualifiedString('void');

--- a/tests/files/expected/0320_return_in_void_magic_method.php.expected
+++ b/tests/files/expected/0320_return_in_void_magic_method.php.expected
@@ -1,6 +1,13 @@
 %s:6 PhanTypeMagicVoidWithReturn Found a return statement with a value in the implementation of the magic method \MyClass::__construct, expected void return type
+%s:7 PhanTypeMismatchReturn Returning type false but __construct() is declared to return void
 %s:16 PhanTypeMagicVoidWithReturn Found a return statement with a value in the implementation of the magic method \MyClass::__clone, expected void return type
+%s:17 PhanTypeMismatchReturn Returning type false but __clone() is declared to return void
 %s:31 PhanTypeMagicVoidWithReturn Found a return statement with a value in the implementation of the magic method \MyClass::__destruct, expected void return type
+%s:32 PhanTypeMismatchReturn Returning type false but __destruct() is declared to return void
 %s:51 PhanTypeMagicVoidWithReturn Found a return statement with a value in the implementation of the magic method \MyClass::__set, expected void return type
+%s:52 PhanTypeMismatchReturn Returning type false but __set() is declared to return void
 %s:71 PhanTypeMagicVoidWithReturn Found a return statement with a value in the implementation of the magic method \MyClass::__unset, expected void return type
+%s:72 PhanTypeMismatchReturn Returning type false but __unset() is declared to return void
 %s:77 PhanTypeMagicVoidWithReturn Found a return statement with a value in the implementation of the magic method \MyClass::__wakeup, expected void return type
+%s:78 PhanTypeMismatchReturn Returning type false but __wakeup() is declared to return void
+%s:84 PhanTypeMismatchReturn Returning type 'data' but __set_state() is declared to return object

--- a/tests/files/expected/0673_serialize_unserialize_new.php.expected
+++ b/tests/files/expected/0673_serialize_unserialize_new.php.expected
@@ -1,0 +1,3 @@
+%s:19 PhanTypeMismatchReturn Returning type 'data' but __serialize() is declared to return array
+%s:22 PhanTypeMagicVoidWithReturn Found a return statement with a value in the implementation of the magic method \NewSerializeInvalid::__unserialize, expected void return type
+%s:24 PhanTypeMismatchReturn Returning type array{} but __unserialize() is declared to return void

--- a/tests/files/src/0320_return_in_void_magic_method.php
+++ b/tests/files/src/0320_return_in_void_magic_method.php
@@ -78,3 +78,9 @@ class MyClass {
         return false;
     }
 }
+
+class MyClass2 {
+    public function __SET_STATE($data) {
+        return 'data';
+    }
+}

--- a/tests/files/src/0673_serialize_unserialize_new.php
+++ b/tests/files/src/0673_serialize_unserialize_new.php
@@ -1,0 +1,26 @@
+<?php
+class NewSerialize {
+    public $prop;
+
+    public function __serialize() {
+        return ['prop' => $this->prop];
+    }
+
+    public function __unserialize($data) {
+        $this->prop = $data['prop'];
+    }
+}
+
+// Phan should detect incorrect return statements for __serialize/__unserialize
+class NewSerializeInvalid {
+    public $prop;
+
+    public function __serialize() {
+        return 'data';
+    }
+
+    public function __unserialize($data) {
+        $this->prop = $data['prop'];
+        return [];
+    }
+}

--- a/tests/plugin_test/expected/031_sleep.php.expected
+++ b/tests/plugin_test/expected/031_sleep.php.expected
@@ -1,4 +1,5 @@
 src/031_sleep.php:4 PhanUnreferencedPHPDocProperty Possibly zero references to PHPDoc @property \A31->z
+src/031_sleep.php:17 PhanTypeMismatchReturn Returning type array{0:'_x',1:'z',2:'_z',3:'A31',4:2,5:float,6:\stdClass} but __sleep() is declared to return string[]
 src/031_sleep.php:17 SleepCheckerInvalidPropNameType __sleep is returning an array with a value of type 2, expected string
 src/031_sleep.php:17 SleepCheckerInvalidPropNameType __sleep is returning an array with a value of type \stdClass, expected string
 src/031_sleep.php:17 SleepCheckerInvalidPropNameType __sleep is returning an array with a value of type float, expected string
@@ -8,7 +9,9 @@ src/031_sleep.php:17 SleepCheckerMagicPropName __sleep is returning an array tha
 src/031_sleep.php:19 SleepCheckerInvalidPropName __sleep is returning an array that includes _Z, which cannot be found
 src/031_sleep.php:22 PhanUnusedPublicNoOverrideMethodParameter Parameter $x is never used
 src/031_sleep.php:28 SleepCheckerPropertyMissingTransient Property public $_myProp that is not serialized by __sleep should be annotated with @transient or @phan-transient
+src/031_sleep.php:35 PhanTypeMismatchReturn Returning type 2 but __sleep() is declared to return string[]
 src/031_sleep.php:35 SleepCheckerInvalidReturnStatement __sleep must return an array of strings. This is definitely not an array.
+src/031_sleep.php:37 PhanTypeMismatchReturn Returning type void but __sleep() is declared to return string[]
 src/031_sleep.php:37 SleepCheckerInvalidReturnStatement __sleep must return an array of strings. This is definitely not an array.
 src/031_sleep.php:39 SleepCheckerInvalidPropName __sleep is returning an array that includes _myprop, which cannot be found
 src/031_sleep.php:39 SleepCheckerInvalidPropName __sleep is returning an array that includes x, which cannot be found


### PR DESCRIPTION
Support checking __serialize()/__unserialize()

Improve checks of return types of other methods such as __sleep()

Fixes #2755