### PR TITLE
Support analysis of php 7.4's short arrow functions (fn()=>expr)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,9 +4,13 @@ Phan NEWS
 -----------------------
 
 New features(Analysis):
++ Support analysis of PHP 7.4's short arrow function syntax (`fn ($arg) => expr`) (#2714)
+  (requires php-ast 1.0.2dev or newer)
+
+  Note that the polyfill does not yet support this syntax.
 + Infer the return types of PHP 7.4's magic methods `__serialize()` and `__unserialize()`. (#2755)
   Improve analysis of return types of other magic methods such as `__sleep()`.
-+ Support more of PHP 7.4's function signatures (e.g. `WeakReference`)
++ Support more of PHP 7.4's function signatures (e.g. `WeakReference`) (#2756)
 
 Plugins:
 + Detect some new php 7.3 functions (`array_key_first`, etc.) in `UseReturnValuePlugin`.

--- a/src/Phan/AST/ArrowFunc.php
+++ b/src/Phan/AST/ArrowFunc.php
@@ -1,0 +1,100 @@
+<?php declare(strict_types=1);
+
+namespace Phan\AST;
+
+use ast;
+use ast\Node;
+use InvalidArgumentException;
+use function is_string;
+
+/**
+ * Utilities for computing uses of an ast\AST_ARROW_FUNC node.
+ */
+class ArrowFunc
+{
+    /** @var array<int|string, Node> maps variable names to the first Node where the variable was used.*/
+    private $uses = [];
+
+    private function __construct()
+    {
+    }
+
+    /**
+     * Returns the set of variables used by the arrow func $n
+     *
+     * @param Node $n a Node with kind ast\AST_ARROW_FUNC
+     * @return array<int|string, Node>
+     * @suppress PhanThrowTypeAbsent
+     */
+    public static function getUses(Node $n) : array
+    {
+        if ($n->kind !== ast\AST_ARROW_FUNC) {
+            throw new InvalidArgumentException("Expected node kind AST_ARROW_FUNC but got " . ast\get_kind_name($n->kind));
+        }
+        // @phan-suppress-next-line PhanUndeclaredProperty
+        return $n->phan_arrow_uses ?? $n->phan_arrow_uses = (new self())->computeUses($n);
+    }
+
+    /**
+     * @return array<string|int,Node>
+     */
+    private function computeUses(Node $n) : array
+    {
+        $stmts = $n->children['stmts'];
+        if ($stmts instanceof Node) {  // should always be a node
+            $this->buildUses($stmts);
+            // Iterate over the AST_PARAM nodes and remove their variables.
+            // They are variables used within the function, but are not uses from the outer scope.
+            foreach ($n->children['params']->children as $param) {
+                $name = $param->children['name'] ?? null;
+                if (\is_string($name)) {
+                    unset($this->uses[$name]);
+                }
+            }
+        }
+        return $this->uses;
+    }
+
+    /**
+     * @param int|string $name the name of the variable being used by this arrow func.
+     *                         may need to handle `${'0'}`?
+     */
+    private function recordUse($name, Node $n) : void
+    {
+        $this->uses[$name] = $this->uses[$name] ?? $n;
+    }
+
+    private function buildUses(Node $n) : void
+    {
+        switch ($n->kind) {
+            case ast\AST_VAR:
+                $name = $n->children['name'];
+                if (is_string($name)) {
+                    $this->recordUse($name, $n);
+                    return;
+                }
+                break;
+            case ast\AST_ARROW_FUNC:
+                foreach (self::getUses($n) as $name => $child_node) {
+                    $this->recordUse($name, $child_node);
+                }
+                return;
+            case ast\AST_CLOSURE:
+                foreach ($n->children['uses']->children ?? [] as $child_node) {
+                    if (!$child_node instanceof Node) {
+                        continue;
+                    }
+                    $name = $child_node->children['name'];
+                    if (is_string($name)) {
+                        $this->recordUse($name, $child_node);
+                    }
+                }
+                return;
+        }
+        foreach ($n->children as $child_node) {
+            if ($child_node instanceof Node) {
+                $this->buildUses($child_node);
+            }
+        }
+    }
+}

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1604,6 +1604,22 @@ class UnionTypeVisitor extends AnalysisVisitor
     }
 
     /**
+     * Visit a node with kind `\ast\AST_ARROW_FUNC`
+     *
+     * @param Node $node
+     * A node of the type indicated by the method name that we'd
+     * like to figure out the type that it produces.
+     *
+     * @return UnionType
+     * The set of types that are possibly produced by the
+     * given node
+     */
+    public function visitArrowFunc(Node $node) : UnionType
+    {
+        return $this->visitClosure($node);
+    }
+
+    /**
      * Visit a node with kind `\ast\AST_VAR`
      *
      * @param Node $node

--- a/src/Phan/AST/Visitor/Element.php
+++ b/src/Phan/AST/Visitor/Element.php
@@ -6,7 +6,10 @@ use AssertionError;
 use ast;
 use ast\flags;
 use ast\Node;
+use Phan\AST\TolerantASTConverter\Shim;
 use Phan\Debug;
+
+Shim::load();
 
 /**
  * This contains functionality needed by various visitor implementations
@@ -42,6 +45,7 @@ class Element
         ast\AST_ARG_LIST           => 'visitArgList',
         ast\AST_ARRAY              => 'visitArray',
         ast\AST_ARRAY_ELEM         => 'visitArrayElem',
+        ast\AST_ARROW_FUNC         => 'visitArrowFunc',
         ast\AST_ASSIGN             => 'visitAssign',
         ast\AST_ASSIGN_OP          => 'visitAssignOp',
         ast\AST_ASSIGN_REF         => 'visitAssignRef',

--- a/src/Phan/AST/Visitor/KindVisitor.php
+++ b/src/Phan/AST/Visitor/KindVisitor.php
@@ -27,6 +27,11 @@ interface KindVisitor
     public function visitArrayElem(Node $node);
 
     /**
+     * Visit a node with kind `ast\AST_ARROW_FUNC`
+     */
+    public function visitArrowFunc(Node $node);
+
+    /**
      * Visit a node with kind `\ast\AST_ASSIGN`
      */
     public function visitAssign(Node $node);

--- a/src/Phan/AST/Visitor/KindVisitorImplementation.php
+++ b/src/Phan/AST/Visitor/KindVisitorImplementation.php
@@ -56,6 +56,11 @@ abstract class KindVisitorImplementation implements KindVisitor
         return $this->visit($node);
     }
 
+    public function visitArrowFunc(Node $node)
+    {
+        return $this->visit($node);
+    }
+
     public function visitAssign(Node $node)
     {
         return $this->visit($node);

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -1211,6 +1211,19 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
      * A new or an unchanged context resulting from
      * parsing the node
      */
+    public function visitArrowFunc(Node $node) : Context
+    {
+        return $this->visitClosure($node);
+    }
+
+    /**
+     * @param Node $node
+     * A node to parse
+     *
+     * @return Context
+     * A new or an unchanged context resulting from
+     * parsing the node
+     */
     public function visitReturn(Node $node) : Context
     {
         $context = $this->context;

--- a/src/Phan/Analysis/ReachabilityChecker.php
+++ b/src/Phan/Analysis/ReachabilityChecker.php
@@ -144,6 +144,15 @@ final class ReachabilityChecker extends KindVisitorImplementation
      * @return ?bool
      * @override
      */
+    public function visitArrowFunc(Node $_) : ?bool
+    {
+        return null;
+    }
+
+    /**
+     * @return ?bool
+     * @override
+     */
     public function visitFuncDecl(Node $_) : ?bool
     {
         return null;

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -1496,7 +1496,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
 
     /**
      * @param Node $node
-     * An AST node we'd like to analyze the statements for
+     * An AST node of kind ast\AST_FUNC_DECL we'd like to analyze the statements for
      *
      * @return Context
      * The updated context after visiting the node
@@ -1511,7 +1511,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
 
     /**
      * @param Node $node
-     * An AST node we'd like to analyze the statements for
+     * An AST node of kind ast\AST_CLOSURE we'd like to analyze the statements for
      *
      * @return Context
      * The updated context after visiting the node
@@ -1519,6 +1519,20 @@ class BlockAnalysisVisitor extends AnalysisVisitor
      * @see self::visitClosedContext()
      */
     public function visitClosure(Node $node) : Context
+    {
+        return $this->visitClosedContext($node);
+    }
+
+    /**
+     * @param Node $node
+     * An AST node of kind ast\AST_ARROW_FUNC we'd like to analyze the statements for
+     *
+     * @return Context
+     * The updated context after visiting the node
+     *
+     * @see self::visitClosedContext()
+     */
+    public function visitArrowFunc(Node $node) : Context
     {
         return $this->visitClosedContext($node);
     }

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -1635,7 +1635,7 @@ EOB;
     public static function doesTerminalSupportUtf8() : bool
     {
         if (\strtoupper(\substr(PHP_OS, 0, 3)) === 'WIN') {
-            if (!\function_exists('sapi_windows_cp_is_utf8') || !sapi_windows_cp_is_utf8()) {
+            if (!\function_exists('sapi_windows_cp_is_utf8') || !\sapi_windows_cp_is_utf8()) {
                 return false;
             }
         }

--- a/src/Phan/Debug.php
+++ b/src/Phan/Debug.php
@@ -129,7 +129,7 @@ class Debug
         }
 
         if (!\is_object($node)) {
-            return $string . $node . "\n";
+            return $string . (\is_array($node) ? \json_encode($node) : $node) . "\n";
         }
         $kind = $node->kind;
 

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -328,6 +328,7 @@ class Issue
     const UnusedPrivateMethodParameter          = 'PhanUnusedPrivateMethodParameter';
     const UnusedPrivateFinalMethodParameter     = 'PhanUnusedPrivateFinalMethodParameter';
     const UnusedClosureUseVariable              = 'PhanUnusedClosureUseVariable';
+    const ShadowedVariableInArrowFunc           = 'PhanShadowedVariableInArrowFunc';
     const UnusedClosureParameter                = 'PhanUnusedClosureParameter';
     const UnusedGlobalFunctionParameter         = 'PhanUnusedGlobalFunctionParameter';
     const UnusedVariableValueOfForeachWithKey   = 'PhanUnusedVariableValueOfForeachWithKey';  // has higher false positive rates than UnusedVariable
@@ -2902,6 +2903,14 @@ class Issue
                 'Closure use variable ${VARIABLE} is never used',
                 self::REMEDIATION_B,
                 6042
+            ),
+            new Issue(
+                self::ShadowedVariableInArrowFunc,
+                self::CATEGORY_NOOP,
+                self::SEVERITY_LOW,
+                'Short arrow function shadows variable ${VARIABLE} from the outer scope',
+                self::REMEDIATION_B,
+                6072
             ),
             new Issue(
                 self::UnusedClosureParameter,

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -857,6 +857,26 @@ class ParseVisitor extends ScopeVisitor
     }
 
     /**
+     * Visit a node with kind `\ast\AST_ARROW_FUNC`
+     *
+     * @param Node $node
+     * A node to parse
+     *
+     * @return Context
+     * A new or an unchanged context resulting from
+     * parsing the node
+     */
+    public function visitArrowFunc(Node $node) : Context
+    {
+        if (!isset($node->children['params'])) {
+            $msg = "php-ast 1.0.2dev or newer is required to correctly parse short arrow functions, but 1.0.1 is installed. A short arrow function was seen at $this->context";
+            \fwrite(\STDERR, $msg . \PHP_EOL);
+            throw new AssertionError($msg);
+        }
+        return $this->visitClosure($node);
+    }
+
+    /**
      * Visit a node with kind `\ast\AST_CALL`
      *
      * @param Node $node

--- a/tests/Phan/AST/TolerantASTConverter/ConversionTest.php
+++ b/tests/Phan/AST/TolerantASTConverter/ConversionTest.php
@@ -163,7 +163,6 @@ final class ConversionTest extends BaseTest
                 self::normalizeYieldFlags($v);
             }
         }
-
     }
 
     /** @dataProvider astValidFileExampleProvider */

--- a/tests/Phan/IntlTest.php
+++ b/tests/Phan/IntlTest.php
@@ -31,6 +31,6 @@ final class IntlTest extends AbstractPhanFileTest
      */
     public function getTestFiles() : array
     {
-        return $this->scanSourceFilesDir(INTL_TEST_FILE_DIR, INTL_EXPECTED_DIR);
+        return $this->scanSourceFilesDir(\INTL_TEST_FILE_DIR, \INTL_EXPECTED_DIR);
     }
 }

--- a/tests/Phan/PHP70Test.php
+++ b/tests/Phan/PHP70Test.php
@@ -33,6 +33,6 @@ class PHP70Test extends AbstractPhanFileTest
      */
     public function getTestFiles() : array
     {
-        return $this->scanSourceFilesDir(PHP70_TEST_FILE_DIR, PHP70_EXPECTED_DIR);
+        return $this->scanSourceFilesDir(\PHP70_TEST_FILE_DIR, \PHP70_EXPECTED_DIR);
     }
 }

--- a/tests/Phan/PHP72Test.php
+++ b/tests/Phan/PHP72Test.php
@@ -69,6 +69,6 @@ class PHP72Test extends AbstractPhanFileTest
      */
     public function getTestFiles() : array
     {
-        return $this->scanSourceFilesDir(PHP72_TEST_FILE_DIR, PHP72_EXPECTED_DIR);
+        return $this->scanSourceFilesDir(\PHP72_TEST_FILE_DIR, \PHP72_EXPECTED_DIR);
     }
 }

--- a/tests/Phan/PHP73Test.php
+++ b/tests/Phan/PHP73Test.php
@@ -54,6 +54,6 @@ final class PHP73Test extends AbstractPhanFileTest
      */
     public function getTestFiles() : array
     {
-        return $this->scanSourceFilesDir(PHP73_TEST_FILE_DIR, PHP73_EXPECTED_DIR);
+        return $this->scanSourceFilesDir(\PHP73_TEST_FILE_DIR, \PHP73_EXPECTED_DIR);
     }
 }

--- a/tests/Phan/PHP74Test.php
+++ b/tests/Phan/PHP74Test.php
@@ -3,6 +3,7 @@
 namespace Phan\Tests;
 
 use Phan\Config;
+use Phan\Plugin\ConfigPluginSet;
 
 /**
  * Unit tests of Phan analysis targeting PHP 7.4 codebases.
@@ -12,15 +13,17 @@ final class PHP74Test extends AbstractPhanFileTest
 {
     const OVERRIDES = [
         'allow_method_param_type_widening' => true,
+        'unused_variable_detection' => true,  // for use with tests of arrow functions
         'target_php_version' => '7.4',
     ];
 
-    public function setUp() : void
+    public static function setUpBeforeClass() : void
     {
-        parent::setUp();
+        parent::setUpBeforeClass();
         foreach (self::OVERRIDES as $key => $value) {
             Config::setValue($key, $value);
         }
+        ConfigPluginSet::reset();  // @phan-suppress-current-line PhanAccessMethodInternal
     }
 
     /**
@@ -55,6 +58,6 @@ final class PHP74Test extends AbstractPhanFileTest
      */
     public function getTestFiles() : array
     {
-        return $this->scanSourceFilesDir(PHP74_TEST_FILE_DIR, PHP74_EXPECTED_DIR);
+        return $this->scanSourceFilesDir(\PHP74_TEST_FILE_DIR, \PHP74_EXPECTED_DIR);
     }
 }

--- a/tests/Phan/PhanTestCommon.php
+++ b/tests/Phan/PhanTestCommon.php
@@ -34,6 +34,6 @@ abstract class PhanTestCommon extends AbstractPhanFileTest
     final public function getAllTestFiles() : array
     {
         static $results = null;
-        return $results ?? $results = $this->scanSourceFilesDir(TEST_FILE_DIR, EXPECTED_DIR);
+        return $results ?? $results = $this->scanSourceFilesDir(\TEST_FILE_DIR, \EXPECTED_DIR);
     }
 }

--- a/tests/Phan/RasmusTest.php
+++ b/tests/Phan/RasmusTest.php
@@ -12,6 +12,6 @@ class RasmusTest extends AbstractPhanFileTest
      */
     public function getTestFiles() : array
     {
-        return $this->scanSourceFilesDir(RASMUS_TEST_FILE_DIR, RASMUS_EXPECTED_DIR);
+        return $this->scanSourceFilesDir(\RASMUS_TEST_FILE_DIR, \RASMUS_EXPECTED_DIR);
     }
 }

--- a/tests/Phan/SoapTest.php
+++ b/tests/Phan/SoapTest.php
@@ -31,6 +31,6 @@ final class SoapTest extends AbstractPhanFileTest
      */
     public function getTestFiles() : array
     {
-        return $this->scanSourceFilesDir(SOAP_TEST_FILE_DIR, SOAP_EXPECTED_DIR);
+        return $this->scanSourceFilesDir(\SOAP_TEST_FILE_DIR, \SOAP_EXPECTED_DIR);
     }
 }

--- a/tests/php74_files/expected/003_arrow_func.php.expected
+++ b/tests/php74_files/expected/003_arrow_func.php.expected
@@ -1,0 +1,13 @@
+%s:10 PhanUnusedPublicNoOverrideMethodParameter Parameter $x is never used
+%s:14 PhanTypeInvalidLeftOperandOfNumericOp Invalid operator: left operand of % is string (expected number)
+%s:17 PhanParamTooFew Call with 0 arg(s) to Closure(array $x) which requires 1 arg(s) defined at %s:5
+%s:17 PhanTypeMismatchArgumentInternal Argument 1 (string) is array but \strlen() takes string
+%s:19 PhanParamTooMany Call with 1 arg(s) to Closure() : int which only takes 0 arg(s) defined at %s:6
+%s:19 PhanTypeMismatchArgumentInternal Argument 1 (string) is int but \strlen() takes string
+%s:20 PhanTypeMismatchArgumentInternal Argument 1 (string) is \Generator|\Iterator|\Traversable|iterable but \strlen() takes string
+%s:23 PhanTypeNonVarPassByRef Only variables can be passed by reference at argument 1 of Closure(&$x)
+%s:28 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is bool but \intdiv() takes int
+%s:30 PhanNoopClosure Unused closure
+%s:32 PhanUndeclaredVariable Variable $undef is undeclared
+%s:36 PhanUnusedVariable Unused definition of variable $argUnused
+%s:41 PhanTypeMismatchArgumentInternal Argument 1 (string) is array{0:2} but \strlen() takes string

--- a/tests/php74_files/src/003_arrow_func.php
+++ b/tests/php74_files/src/003_arrow_func.php
@@ -1,0 +1,42 @@
+<?php
+// Tests functionality from https://wiki.php.net/rfc/arrow_functions_v2
+function test_arrow_func() {
+    $x = 123;
+    $fn1 = fn(array $x) => $x;
+    $fn2 = fn(): int => $x;
+    $fn3 = fn($x = 42) => yield $x;
+    $fn4 = fn(&$x) => $x;
+    $fn5 = fn&($x) => $x;
+    $fn6 = fn($x, ...$rest) => $rest;
+    $fn7 = static fn() => 1;
+
+    $regex = '/(fo*)/';
+    $fn = fn($str) => preg_match($regex, $str, $matches) && ($matches[1] % 7 == 0);
+
+    var_export($fn1([]));
+    echo strlen($fn1());
+
+    echo strlen($fn2('extra'));  // Too many parameters, actually int
+    echo strlen($fn3());  // should infer generator
+    $arg = 'arg';
+    echo strlen($fn4($arg));  // works
+    echo strlen($fn4('not a reference'));  // emits PhanTypeNonVarPassByRef
+    $fn5($arg) = 2;  // should not warn, doesn't properly infer that $arg is set
+
+    echo strlen($fn6('arg'));  // TODO: should infer array<int,mixed> and warn
+    echo intdiv($fn7(), 2);
+    echo intdiv($fn('foooooooooooooooo'), 2);
+
+    fn() => 2;  // PhanNoopClosure
+
+    $cb = fn() => fn() => $undef;  // PhanUndeclaredVariable
+    var_export($cb()());
+
+    $arg = [2];
+    $argUnused = [3];  // phan will warn that this is unused (it does not begin with raii, unused, or _)
+    $fn = fn() => call_user_func(function () use ($arg) {
+        var_export($arg);
+        return $arg;
+    });
+    echo strlen($fn());  // PhanTypeMismatchArgumentInternal
+}


### PR DESCRIPTION
This requires php-ast 1.0.2-dev, which is not yet released.

Fixes #2714