### PR TITLE
Don't emit native syntax error in plugin for shebang

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@ New features(Analysis):
 
 Plugins:
 + Detect some new php 7.3 functions (`array_key_first`, etc.) in `UseReturnValuePlugin`.
++ Don't emit a `PhanNativePHPSyntaxCheckPlugin` error in `InvokePHPNativeSyntaxCheckPlugin` due to a shebang before `declare(strict_types=1)`
 
 Bug fixes:
 + Analyze the remaining expressions in a statement after emitting `PhanTraitParentReference` (#2750)

--- a/internal/dump_fallback_ast.php
+++ b/internal/dump_fallback_ast.php
@@ -25,7 +25,6 @@
  * SOFTWARE.
  */
 
-// @phan-file-suppress PhanNativePHPSyntaxCheckPlugin this does not expect "env php" header when the script is provided on stdin
 // @phan-file-suppress PhanMissingRequireFile this depends on where Phan is installed
 if (file_exists(__DIR__ . "/../../../../vendor/autoload.php")) {
     require __DIR__ . "/../../../../vendor/autoload.php";

--- a/internal/internalsignatures.php
+++ b/internal/internalsignatures.php
@@ -1,8 +1,6 @@
 #!/usr/bin/env php
 <?php declare(strict_types=1);
 
-// @phan-file-suppress PhanNativePHPSyntaxCheckPlugin caused by inline HTML before declare
-
 require_once dirname(__DIR__) . '/vendor/autoload.php';
 require_once __DIR__ . '/lib/IncompatibleXMLSignatureDetector.php';
 

--- a/internal/reflection_completeness_check.php
+++ b/internal/reflection_completeness_check.php
@@ -6,7 +6,6 @@ declare(strict_types=1);
  * This checks that the function signatures are complete.
  * TODO: Expand to checking classes (methods, and properties)
  * TODO: Refactor the scripts in internal/ to reuse more code.
- * @phan-file-suppress PhanNativePHPSyntaxCheckPlugin, UnusedPluginFileSuppression caused by inline HTML before declare
  * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  */
 require_once dirname(__DIR__) . '/vendor/autoload.php';

--- a/internal/sanitycheck.php
+++ b/internal/sanitycheck.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 require_once dirname(__DIR__) . '/vendor/autoload.php';
 require_once dirname(__DIR__) . '/internal/lib/IncompatibleSignatureDetectorBase.php';
 
-// @phan-file-suppress PhanNativePHPSyntaxCheckPlugin, UnusedPluginFileSuppression caused by inline HTML before declare
 /**
  * Loads the ReflectionFunction or ReflectionMethod for the given function or method name.
  * Method names must use '::' to separate the class and method names.

--- a/internal/update_wiki_config_types.php
+++ b/internal/update_wiki_config_types.php
@@ -2,8 +2,6 @@
 <?php
 declare(strict_types=1);
 
-// @phan-file-suppress PhanNativePHPSyntaxCheckPlugin, UnusedPluginFileSuppression caused by inline HTML before declare
-
 require_once dirname(__DIR__) . '/vendor/autoload.php';
 require_once __DIR__ . '/lib/WikiWriter.php';
 

--- a/internal/update_wiki_issue_types.php
+++ b/internal/update_wiki_issue_types.php
@@ -2,8 +2,6 @@
 <?php
 declare(strict_types=1);
 
-// @phan-file-suppress PhanNativePHPSyntaxCheckPlugin, UnusedPluginFileSuppression
-
 require_once dirname(__DIR__) . '/vendor/autoload.php';
 require_once __DIR__ . '/lib/WikiWriter.php';
 

--- a/plugins/codeclimate/engine
+++ b/plugins/codeclimate/engine
@@ -1,6 +1,5 @@
 #!/usr/bin/env php
 <?php declare(strict_types = 1);
-// @phan-file-suppress PhanNativePHPSyntaxCheckPlugin
 
 require_once(__DIR__ . '/../../src/requirements.php');
 

--- a/tests/plugin_test/test.sh
+++ b/tests/plugin_test/test.sh
@@ -29,12 +29,6 @@ sed -i 's,missing closing parenthesis,missing ),g' $ACTUAL_PATH
 echo
 echo "Comparing the output:"
 
-if [[ "$(php -r 'echo PHP_VERSION_ID;')" < 70100 ]]; then
-    echo "Skipping test cases that rely on Closure::fromCallable() or native syntax checks, the current php version is php 7.0";
-    # Ignore results of a subset of tests in php 7.0
-    # TODO: If we imitate the reflection of php 7.1 in php 7.0, we can restore this.
-    sed -i "/^.*PhanNativePHPSyntaxCheckPlugin.*unexpected '\\?'/d" $ACTUAL_PATH
-fi
 # Normalize PHP_VERSION_ID
 # and remove php 8.0 warnings
 sed -i -e 's/^\(src.020_bool.php.*of type\) [0-9]\+ \(evaluated\)/\1 int \2/g' \

--- a/tool/make_stubs
+++ b/tool/make_stubs
@@ -1,10 +1,6 @@
 #!/usr/bin/env php
 <?php declare(strict_types=1);
 
-/**
- * @phan-file-suppress PhanNativePHPSyntaxCheckPlugin, UnusedPluginFileSuppression php warns about declare() after the inline HTML /usr/bin/env php
- */
-
 use Phan\AST\TolerantASTConverter\Shim;
 use Phan\CodeBase;
 use Phan\Language\Element\Clazz;


### PR DESCRIPTION
(before some php code such as strict_types declarations)

Preserve the line numbers in error messages