### PR TITLE
Properly check for PhanUnusedVariableGlobal

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@ Phan NEWS
 New features(Analysis):
 + Add early support for PHP 7.4's typed properties. (#2314)
   (This is incomplete, and does not support inheritance, assignment, impossible conditions, etc.)
++ Change warnings about undeclared `$this` into a critical `PhanUndeclaredThis` issue. (#2751)
++ Fix the check for `PhanUnusedVariableGlobal` (#2768)
 
 13 May 2019, Phan 2.0.0-RC2
 -----------------------
@@ -19,7 +21,6 @@ New features(Analysis):
   Improve analysis of return types of other magic methods such as `__sleep()`.
 + Support more of PHP 7.4's function signatures (e.g. `WeakReference`) (#2756)
 + Improve detection of unused variables inside of loops/branches.
-+ Change warnings about undeclared `$this` into a critical `PhanUndeclaredThis` issue. (#2751)
 
 Plugins:
 + Detect some new php 7.3 functions (`array_key_first`, etc.) in `UseReturnValuePlugin`.
@@ -80,7 +81,7 @@ New features(Analysis):
 + Improve unused variable detection: Detect more unused variables for expressions such as `$x++` and `$x -= 2` (#2715)
 + Fix false positive `PhanUnusedVariable` after assignment by reference (#2730)
 + Warn about references, static variables, and uses of global variables that are probably unnecessary (never used/assigned to afterwards) (#2733)
-  New issue types: `PhanUnusedVariableReference`, `PhanUnusedVariableGlobal`,  `PhanUnusedVariableGlobal`
+  New issue types: `PhanUnusedVariableReference`, `PhanUnusedVariableGlobal`,  `PhanUnusedVariableStatic`
 + Warn about invalid AST nodes for defaults of properties and static variables. (#2732)
 + Warn about union types on properties that might have an incomplete suffix. (e.g. `/** @var array<int, */`) (#2708)
 

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -1112,7 +1112,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/1.1.2/tests/plugin_test/expe
 Unreferenced definition of variable ${VARIABLE} as a global variable
 ```
 
-e.g. [this issue](https://github.com/phan/phan/tree/master/tests/plugin_test/expected/121_unused_reference.php.expected#L5) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/plugin_test/src/121_unused_reference.php#L28).
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0676_unused_global.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0676_unused_global.php#L4).
 
 ## PhanUnusedVariableReference
 
@@ -1128,7 +1128,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/master/tests/plugin_test/exp
 Unreferenced definition of variable ${VARIABLE} as a static variable
 ```
 
-e.g. [this issue](https://github.com/phan/phan/tree/master/tests/plugin_test/expected/121_unused_reference.php.expected#L3) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/plugin_test/src/121_unused_reference.php#L10).
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0669_invalid_static.php.expected#L4) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0669_invalid_static.php#L6).
 
 ## PhanUnusedVariableValueOfForeachWithKey
 

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
@@ -483,7 +483,8 @@ final class VariableTrackerVisitor extends AnalysisVisitor
     }
 
     /**
-     * TODO: Check if the current context is a function call passing an argument by reference
+     * Analyzes `static $var [ = default ];`
+     *
      * @return VariableTrackingScope
      * @override
      */
@@ -499,16 +500,14 @@ final class VariableTrackerVisitor extends AnalysisVisitor
     }
 
     /**
-     * TODO: Check if the current context is a function call passing an argument by reference
+     * Analyzes `global $var;` (analyzed like it was declared with the value from the global scope).
+     *
      * @return VariableTrackingScope
      * @override
      */
     public function visitGlobal(Node $node) : VariableTrackingScope
     {
-        $name = $node->children['var']->children['name'] ?? null;
-        if (\is_string($name)) {
-            self::$variable_graph->markAsGlobalVariable($name);
-        }
+        self::$variable_graph->markAsGlobal($node, $this->scope);
         return $this->scope;
     }
 

--- a/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
+++ b/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
@@ -343,13 +343,15 @@ final class VariableTrackerElementVisitor extends PluginAwarePostAnalysisVisitor
                 [$variable_name]
             );
         } elseif ($type_bitmask === VariableGraph::IS_GLOBAL) {
-            Issue::maybeEmitWithParameters(
-                $this->code_base,
-                $this->context,
-                Issue::UnusedVariableGlobal,
-                $line,
-                [$variable_name]
-            );
+            if ($definition_id !== false && $graph->isGlobal($definition_id)) {
+                Issue::maybeEmitWithParameters(
+                    $this->code_base,
+                    $this->context,
+                    Issue::UnusedVariableGlobal,
+                    $line,
+                    [$variable_name]
+                );
+            }
         }
     }
 

--- a/tests/files/expected/0569_switch_not_null.php.expected
+++ b/tests/files/expected/0569_switch_not_null.php.expected
@@ -1,3 +1,4 @@
+%s:4 PhanUnusedVariableGlobal Unreferenced definition of variable $argv as a global variable
 %s:8 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is string but \intdiv() takes int
 %s:11 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is ?string but \intdiv() takes int
 %s:26 PhanTypeMismatchArgumentInternal Argument 1 (numerator) is 'a'|'v1'|'v3' but \intdiv() takes int

--- a/tests/files/expected/0676_unused_global.php.expected
+++ b/tests/files/expected/0676_unused_global.php.expected
@@ -1,0 +1,1 @@
+%s:4 PhanUnusedVariableGlobal Unreferenced definition of variable $global as a global variable

--- a/tests/files/src/0676_unused_global.php
+++ b/tests/files/src/0676_unused_global.php
@@ -1,0 +1,7 @@
+<?php
+
+function test() {
+    global $global;
+    global $global2;
+    $global2 = 'other';
+}

--- a/tests/plugin_test/expected/121_unused_reference.php.expected
+++ b/tests/plugin_test/expected/121_unused_reference.php.expected
@@ -2,5 +2,5 @@ src/121_unused_reference.php:3 PhanUnusedVariableReference Unused definition of 
 src/121_unused_reference.php:9 PhanUndeclaredVariable Variable $staticVar is undeclared
 src/121_unused_reference.php:10 PhanUnusedVariableStatic Unreferenced definition of variable $staticVar as a static variable
 src/121_unused_reference.php:11 PhanUnusedVariableStatic Unreferenced definition of variable $staticUnreferencedVar as a static variable
-src/121_unused_reference.php:28 PhanUnusedVariableGlobal Unreferenced definition of variable $global121 as a global variable
+src/121_unused_reference.php:26 PhanUnusedVariableGlobal Unreferenced definition of variable $global121b as a global variable
 src/121_unused_reference.php:39 PhanUnusedVariableReference Unused definition of variable $dir_path as a reference

--- a/tests/plugin_test/src/121_unused_reference.php
+++ b/tests/plugin_test/src/121_unused_reference.php
@@ -21,9 +21,9 @@ test121(2);
 test121StaticVar();
 
 function test121GlobalVar() {
-    // This should warn - it's undefined
+
     global $global121;
-    global $global121b;
+    global $global121b;  // This should warn
     global $global121c;
     $global121 = 'new value';
     var_export($global121c);

--- a/tool/make_stubs
+++ b/tool/make_stubs
@@ -55,7 +55,6 @@ EOT;
      */
     public static function main() : void
     {
-        global $argv;
         $options = getopt('he:', ['help', 'extension:']);
         if (isset($options['h']) || isset($options['help'])) {
             self::printHelpAndExit('', 0);


### PR DESCRIPTION
Fixes #2768

Phan was warning about the wrong declarations.
Redeclarations affected the global scope, so they weren't unused.