### PR TITLE
Defer resolving static variables, inherit static return type

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,9 @@ New features(Analysis):
 + Improve analysis of some ways to initialize groups of static variables.
   e.g. `static $a = null; static $b = null; if ($a === null) { $a = $b = rand(0,10); } use($a, $b)`
   will now also infer that $b is non-null.
++ Infer from `return new static();` and `return $this;` that the return type of a method is `@return static`, not `@return self` (#2797)
+  (and propogate that to inherited methods)
++ Fix some false positives when casting array types containing `static` to types containing the class or its ancestors. (#2797)
 
 Language Server/Daemon mode:
 + Add `--language-server-min-diagnostics-delay-ms <ms>`, to work around race conditions in some language clients.

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@ New features(Analysis):
 + Infer from `return new static();` and `return $this;` that the return type of a method is `@return static`, not `@return self` (#2797)
   (and propogate that to inherited methods)
 + Fix some false positives when casting array types containing `static` to types containing the class or its ancestors. (#2797)
++ Add `PhanTypeInstantiateAbstractStatic` and `PhanTypeInstantiateTraitStaticOrSelf` as lower-severity warnings about `return new self()` and `return new static()` (#2797)
+  (emitted in static methods of abstract classes)
 
 Language Server/Daemon mode:
 + Add `--language-server-min-diagnostics-delay-ms <ms>`, to work around race conditions in some language clients.

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -2121,6 +2121,14 @@ Saw a call to an internal function {FUNCTION}() with what would be invalid argum
 
 e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/plugin_test/expected/101_extended_return_inferences.php.expected#L12) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/2.0.0/tests/plugin_test/src/101_extended_return_inferences.php#L22).
 
+## PhanTypeErrorInOperation
+
+```
+Saw an error when attempting to infer the type of expression {CODE}: {DETAILS}
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0678_invalid_operations.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0678_invalid_operations.php#L8).
+
 ## PhanTypeExpectedObject
 
 ```
@@ -2171,6 +2179,14 @@ This issue will be emitted for the following code
 abstract class D {} (new D);
 ```
 
+## PhanTypeInstantiateAbstractStatic
+
+```
+Potential instantiation of abstract class {CLASS} (not an issue if this method is only called from a non-abstract subclass)
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0679_static_from_type.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0679_static_from_type.php#L4).
+
 ## PhanTypeInstantiateInterface
 
 ```
@@ -2190,6 +2206,14 @@ Instantiation of trait {TRAIT}
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/files/expected/0624_instantiate_abstract.php.expected#L11) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/2.0.0/tests/files/src/0624_instantiate_abstract.php#L42).
+
+## PhanTypeInstantiateTraitStaticOrSelf
+
+```
+Potential instantiation of trait {TRAIT} (not an issue if this method is only called from a non-abstract class using the trait)
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0624_instantiate_abstract.php.expected#L12) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0624_instantiate_abstract.php#L43).
 
 ## PhanTypeInvalidBitwiseBinaryOperator
 

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1224,7 +1224,6 @@ class UnionTypeVisitor extends AnalysisVisitor
                 return $type;
             }
 
-
             $class = $this->code_base->getClassByFQSEN($fqsen);
 
             // If this class doesn't have any generics on it, we're
@@ -2441,8 +2440,10 @@ class UnionTypeVisitor extends AnalysisVisitor
 
         // If this is a straight-forward class name, recurse into the
         // class node and get its type
-        $is_static_type_string = Type::isStaticTypeString($class_name);
-        if (!($is_static_type_string || Type::isSelfTypeString($class_name))) {
+        if (Type::isStaticTypeString($class_name)) {
+            return StaticType::instance(false)->asUnionType();
+        }
+        if (!Type::isSelfTypeString($class_name)) {
             // @phan-suppress-next-line PhanThrowTypeAbsentForCall
             return self::unionTypeFromClassNode(
                 $this->code_base,
@@ -2484,9 +2485,6 @@ class UnionTypeVisitor extends AnalysisVisitor
 
         $result = $this->context->getClassFQSEN()->asUnionType();
 
-        if ($is_static_type_string) {
-            $result = $result->withType(StaticType::instance(false));
-        }
         return $result;
     }
 
@@ -2524,7 +2522,7 @@ class UnionTypeVisitor extends AnalysisVisitor
                     continue;
                 }
                 $result = $result->withType($fqsen->asType());
-            } elseif (\get_class($sub_type) === Type::class || $sub_type instanceof ClosureType) {
+            } elseif (\get_class($sub_type) === Type::class || $sub_type instanceof ClosureType || $sub_type instanceof StaticType) {
                 $result = $result->withType($sub_type);
             } elseif ($is_valid) {
                 if ($sub_type instanceof StringType) {

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -332,7 +332,9 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
                     $func_context->getLineNumberStart(),
                     (string)$class_fqsen
                 );
-                $closure_scope->overrideClassFQSEN(null);  // Avoid an uncaught CodeBaseException due to missing class for @phan-closure-scope
+                // Avoid an uncaught CodeBaseException due to missing class for @phan-closure-scope
+                // Just pretend it's the containing class instead of the missing class.
+                $closure_scope->overrideClassFQSEN($func_context->getScope()->getParentScope()->getClassFQSENOrNull());
                 return null;
             }
             return $class_fqsen;
@@ -676,7 +678,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
             $code_base,
             $context,
             $node->children['expr']
-        );
+        )->withStaticResolvedInContext($context);
 
         // Check the expression type to make sure it's
         // something we can iterate over

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -96,8 +96,10 @@ class Issue
     const TypeComparisonToArray     = 'PhanTypeComparisonToArray';
     const TypeConversionFromArray   = 'PhanTypeConversionFromArray';
     const TypeInstantiateAbstract   = 'PhanTypeInstantiateAbstract';
+    const TypeInstantiateAbstractStatic = 'PhanTypeInstantiateAbstractStatic';
     const TypeInstantiateInterface  = 'PhanTypeInstantiateInterface';
     const TypeInstantiateTrait      = 'PhanTypeInstantiateTrait';
+    const TypeInstantiateTraitStaticOrSelf = 'PhanTypeInstantiateTraitStaticOrSelf';
     const TypeInvalidCloneNotObject = 'PhanTypeInvalidCloneNotObject';
     const TypeInvalidClosureScope   = 'PhanTypeInvalidClosureScope';
     const TypeInvalidLeftOperand    = 'PhanTypeInvalidLeftOperand';
@@ -1447,6 +1449,14 @@ class Issue
                 10013
             ),
             new Issue(
+                self::TypeInstantiateAbstractStatic,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_LOW,
+                "Potential instantiation of abstract class {CLASS} (not an issue if this method is only called from a non-abstract subclass)",
+                self::REMEDIATION_B,
+                10111
+            ),
+            new Issue(
                 self::TypeInstantiateInterface,
                 self::CATEGORY_TYPE,
                 self::SEVERITY_NORMAL,
@@ -1461,6 +1471,14 @@ class Issue
                 "Instantiation of trait {TRAIT}",
                 self::REMEDIATION_B,
                 10074
+            ),
+            new Issue(
+                self::TypeInstantiateTraitStaticOrSelf,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_LOW,
+                "Potential instantiation of trait {TRAIT} (not an issue if this method is only called from a non-abstract class using the trait)",
+                self::REMEDIATION_B,
+                10112
             ),
             new Issue(
                 self::TypeInvalidClosureScope,

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -33,6 +33,7 @@ use Phan\Language\Type;
 use Phan\Language\Type\IterableType;
 use Phan\Language\Type\LiteralStringType;
 use Phan\Language\Type\MixedType;
+use Phan\Language\Type\StaticType;
 use Phan\Language\Type\TemplateType;
 use Phan\Language\UnionType;
 use Phan\Library\None;
@@ -2748,7 +2749,7 @@ class Clazz extends AddressableElement
             new Variable(
                 $this->getContext(),
                 'this',
-                $this->getUnionType(),
+                StaticType::instance(false)->asUnionType(),
                 0
             )
         );

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -608,6 +608,11 @@ class Method extends ClassElement implements FunctionInterface
         parent::setUnionType($union_type);
     }
 
+    protected function getUnionTypeWithStatic() : UnionType
+    {
+        return parent::getUnionType();
+    }
+
     /**
      * @return UnionType
      * The return type of this method in its given context.
@@ -615,9 +620,10 @@ class Method extends ClassElement implements FunctionInterface
     public function getUnionType() : UnionType
     {
         if ($this->defining_method_for_type_fetching) {
-            return $this->defining_method_for_type_fetching->getUnionType();
+            $union_type = $this->defining_method_for_type_fetching->getUnionTypeWithStatic();
+        } else {
+            $union_type = parent::getUnionType();
         }
-        $union_type = parent::getUnionType();
 
         // If the type is 'static', add this context's class
         // to the return type

--- a/src/Phan/Language/FQSEN/FullyQualifiedClassElement.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedClassElement.php
@@ -64,7 +64,7 @@ abstract class FullyQualifiedClassElement extends AbstractFQSEN
      * there are multiple definitions of the element
      *
      * @return static
-     * @suppress PhanTypeInstantiateAbstract this error is correct, but this should never be called directly
+     * @suppress PhanTypeInstantiateAbstractStatic this error is correct, but this should never be called directly
      */
     public static function make(
         FullyQualifiedClassName $fully_qualified_class_name,

--- a/src/Phan/Language/Scope/ClosureScope.php
+++ b/src/Phan/Language/Scope/ClosureScope.php
@@ -33,10 +33,15 @@ class ClosureScope extends FunctionLikeScope
      */
     public function overrideClassFQSEN(FullyQualifiedClassName $fqsen = null) : void
     {
+        // If there is an FQSEN override, then this is in a class scope.
+        // If there is no override, then this inherits the class of the parent
         if ($fqsen) {
             $this->flags |= Scope::IN_CLASS_SCOPE;
         } else {
-            $this->flags &= ~Scope::IN_CLASS_SCOPE;
+            if (!($this->parent_scope->flags & Scope::IN_CLASS_SCOPE)) {
+                // This is probably a closure FQSEN with an missing class override outside of a method scope.
+                $this->flags &= ~Scope::IN_CLASS_SCOPE;
+            }
         }
         $this->override_class_fqsen = $fqsen;
     }

--- a/src/Phan/Language/Type/ArrayShapeType.php
+++ b/src/Phan/Language/Type/ArrayShapeType.php
@@ -870,4 +870,21 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
     {
         return ArrayType::instance($this->is_nullable);
     }
+
+    public function withStaticResolvedInContext(Context $context) : Type
+    {
+        $did_change = false;
+        $new_field_types = $this->field_types;
+        foreach ($new_field_types as $i => $field_type) {
+            $new_field_type = $field_type->withStaticResolvedInContext($context);
+            if ($new_field_type !== $field_type) {
+                $did_change = true;
+                $new_field_types[$i] = $new_field_type;
+            }
+        }
+        if (!$did_change) {
+            return $this;
+        }
+        return self::fromFieldTypes($new_field_types, $this->is_nullable);
+    }
 }

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -719,4 +719,21 @@ class GenericArrayType extends ArrayType implements GenericArrayInterface
     {
         return ArrayType::instance($this->is_nullable);
     }
+
+    /**
+     * Given a type such as array<int,static>, return array<int,SomeClass>
+     * @override
+     */
+    public function withStaticResolvedInContext(Context $context) : Type
+    {
+        $resolved_element_type = $this->element_type->withStaticResolvedInContext($context);
+        if ($this->element_type === $resolved_element_type) {
+            return $this;
+        }
+        return GenericArrayType::fromElementType(
+            $resolved_element_type,
+            $this->is_nullable,
+            $this->key_type
+        );
+    }
 }

--- a/tests/files/expected/0236_assign_ref_analyzed.php.expected
+++ b/tests/files/expected/0236_assign_ref_analyzed.php.expected
@@ -1,2 +1,2 @@
-%s:10 PhanTypeMismatchProperty Assigning \A236 to property but \A236->badDoc is string
-%s:12 PhanTypeMismatchProperty Assigning \A236 to property but \A236->badDoc is string
+%s:10 PhanTypeMismatchProperty Assigning \A236|static to property but \A236->badDoc is string
+%s:12 PhanTypeMismatchProperty Assigning \A236|static to property but \A236->badDoc is string

--- a/tests/files/expected/0575_nullable_self.php.expected
+++ b/tests/files/expected/0575_nullable_self.php.expected
@@ -1,3 +1,2 @@
 %s:16 PhanTypeMismatchProperty Assigning 2 to property but \PhanBug\Foo->parent is ?\PhanBug\Foo|\PhanBug\Foo|null
-%s:22 PhanTypeMismatchProperty Assigning array{0:\PhanBug\Foo} to property but \PhanBug\Foo->other is array<int,self>|self[]
-%s:23 PhanTypeMismatchProperty Assigning array{0:null} to property but \PhanBug\Foo->other is array<int,self>|self[]
+%s:23 PhanTypeMismatchProperty Assigning array{0:null} to property but \PhanBug\Foo->other is \PhanBug\Foo[]

--- a/tests/files/expected/0624_instantiate_abstract.php.expected
+++ b/tests/files/expected/0624_instantiate_abstract.php.expected
@@ -6,8 +6,10 @@
 %s:20 PhanTypeExpectedObjectOrClassName Expected an object instance or the name of a class but saw expression with type '..'
 %s:25 PhanTypeInstantiateAbstract Instantiation of abstract class \NS624\AbstractExample
 %s:26 PhanTypeInstantiateAbstract Instantiation of abstract class \NS624\AbstractExample
-%s:31 PhanTypeInstantiateAbstract Instantiation of abstract class \NS624\AbstractExample
+%s:31 PhanTypeInstantiateAbstractStatic Potential instantiation of abstract class \NS624\AbstractExample (not an issue if this method is only called from a non-abstract subclass)
 %s:33 PhanTypeInstantiateAbstract Instantiation of abstract class \NS624\AbstractExample
 %s:42 PhanTypeInstantiateTrait Instantiation of trait \NS624\T
-%s:43 PhanTypeInstantiateTrait Instantiation of trait \NS624\T
-%s:46 PhanTypeInstantiateTrait Instantiation of trait \NS624\T
+%s:43 PhanTypeInstantiateTraitStaticOrSelf Potential instantiation of trait \NS624\T (not an issue if this method is only called from a non-abstract class using the trait)
+%s:44 PhanTypeInstantiateTraitStaticOrSelf Potential instantiation of trait \NS624\T (not an issue if this method is only called from a non-abstract class using the trait)
+%s:47 PhanTypeInstantiateTrait Instantiation of trait \NS624\T
+%s:48 PhanTypeInstantiateTraitStaticOrSelf Potential instantiation of trait \NS624\T (not an issue if this method is only called from a non-abstract class using the trait)

--- a/tests/files/expected/0668_return_type_inherit.php.expected
+++ b/tests/files/expected/0668_return_type_inherit.php.expected
@@ -1,3 +1,3 @@
 %s:30 PhanTypeMismatchArgument Argument 1 (arg) is \NS668\A but \NS668\test() takes string defined at %s:26
-%s:31 PhanTypeMismatchArgument Argument 1 (arg) is \NS668\A but \NS668\test() takes string defined at %s:26
-%s:32 PhanTypeMismatchArgument Argument 1 (arg) is \NS668\A but \NS668\test() takes string defined at %s:26
+%s:31 PhanTypeMismatchArgument Argument 1 (arg) is \NS668\A|\NS668\B but \NS668\test() takes string defined at %s:26
+%s:32 PhanTypeMismatchArgument Argument 1 (arg) is \NS668\A|\NS668\B|\NS668\C but \NS668\test() takes string defined at %s:26

--- a/tests/files/expected/0679_static_from_type.php.expected
+++ b/tests/files/expected/0679_static_from_type.php.expected
@@ -1,3 +1,3 @@
-%s:4 PhanTypeInstantiateAbstract Instantiation of abstract class \NS679\T
+%s:4 PhanTypeInstantiateAbstractStatic Potential instantiation of abstract class \NS679\T (not an issue if this method is only called from a non-abstract subclass)
 %s:14 PhanUndeclaredMethod Call to undeclared method \NS679\C::missing
 %s:17 PhanUndeclaredMethod Call to undeclared method \NS679\C::missing

--- a/tests/files/expected/0679_static_from_type.php.expected
+++ b/tests/files/expected/0679_static_from_type.php.expected
@@ -1,0 +1,3 @@
+%s:4 PhanTypeInstantiateAbstract Instantiation of abstract class \NS679\T
+%s:14 PhanUndeclaredMethod Call to undeclared method \NS679\C::missing
+%s:17 PhanUndeclaredMethod Call to undeclared method \NS679\C::missing

--- a/tests/files/src/0575_nullable_self.php
+++ b/tests/files/src/0575_nullable_self.php
@@ -18,8 +18,8 @@ trait Foo
 
     public function setOther(self $other)
     {
-        $this->other = [$other];
-        $this->other = [$this];
+        $this->other = [$other];  // should not warn
+        $this->other = [$this];  // should not warn, static is self or a subtype of self
         $this->other = [null];
     }
 }

--- a/tests/files/src/0624_instantiate_abstract.php
+++ b/tests/files/src/0624_instantiate_abstract.php
@@ -39,10 +39,12 @@ trait T {
     }
 
     public static function staticTraitMethod() {
-        var_export(new self());
+        var_export(new T());  // This is always a bug
+        var_export(new self());  // This would be a bug if T::staticTraitMethod() was called directly instead of on the class inheriting the method from T
         var_export(new static());
     }
     public function traitMethod() {
+        var_export(new T());  // This is always a bug
         var_export(new self());
         var_export(new static());  // should not emit PhanTypeInstantiateTrait, this is a valid instance of something
     }

--- a/tests/files/src/0679_static_from_type.php
+++ b/tests/files/src/0679_static_from_type.php
@@ -1,0 +1,17 @@
+<?php
+namespace NS679;
+abstract class T {
+    public static function f() { return new static; }  // should warn for now about implementation but infer @return static
+    public function f2() { return $this; }  // should infer @return static
+}
+
+class C extends T {
+    public function fn() { echo 'hi'; }
+}
+
+$p = C::f();
+$p->fn();
+$p->missing();
+$p2 = $p->f2();
+$p2->fn();
+$p2->missing();


### PR DESCRIPTION
And automatically infer `@return static` from `return new static()`
and `return $this`

Fixes #2797

Make $this have a type of static instead of self, fix edge cases.
There may be more edge cases involving `static` in Phan and its plugins.