### PR TITLE
Fix the way conditions handle unary/binary expressions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@ New features(CLI, Configs):
   This can be disabled by setting `PHAN_DISABLE_COLOR_OUTPUT=1` or by passing the flag `--no-color`.
 
 New features(Analysis):
++ Support unary and binary expressions on literals/constants in conditions. (#2812)
+  (e.g. `assert($x === -(1))` and `assert($x === 2+2)` now infer that $x is -1 and 4, respectively)
 + Infer that static variables with no default are `null`.
 + Improve control flow analysis of unconditionally true/false branches.
 + Improve analysis of some ways to initialize groups of static variables.

--- a/tests/files/expected/0684_unary_op_in_condition.php.expected
+++ b/tests/files/expected/0684_unary_op_in_condition.php.expected
@@ -1,0 +1,2 @@
+%s:35 PhanTypeMismatchArgumentInternal Argument 1 (var) is bool but \count() takes \Countable|array
+%s:60 PhanTypeMismatchArgumentInternal Argument 1 (var) is bool but \count() takes \Countable|array

--- a/tests/files/src/0684_unary_op_in_condition.php
+++ b/tests/files/src/0684_unary_op_in_condition.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+namespace NS684;
+
+/**
+ * @param string $s
+ *
+ * @return bool|int Returns -1 when $s is empty, false if it is bad word, or true if it is fine
+ */
+function checkString( string $s )
+{
+    if ( 'badword' === $s ) return false;
+    return '' === $s ? -1 : true;
+}
+
+/**
+ * Checks whether string is valid
+ *
+ * @param string $s String to check
+ *
+ * @return bool String is not empty and not a bad word
+ */
+function isValidString( $s ): bool
+{
+    $x = checkString( $s );
+
+    // Assuming we can't statically analyse checkString
+    // Here, $x can be -1, true or false
+    \assert( -1 === $x || \is_bool( $x ) );
+
+    if ( -1 === $x ) {
+        // Handling the case that $x is -1
+        return false;
+    }
+    echo count($x);
+
+    // At this point, $x can only be true or false so it is boolean
+    return $x;
+}
+
+/**
+ * Checks whether string is valid
+ *
+ * @param string $s String to check
+ *
+ * @return bool String is not empty and not a bad word
+ */
+function isValidString2( $s ): bool
+{
+    $x = checkString( $s );
+
+    // Assuming we can't statically analyse checkString
+    // Here, $x can be -1, true or false
+    \assert( 10 - 11 === $x || \is_bool( $x ) );
+
+    if ( -1 === $x ) {
+        // Handling the case that $x is -1
+        return false;
+    }
+    echo count($x);
+
+    // At this point, $x can only be true or false so it is boolean
+    return $x;
+}


### PR DESCRIPTION
Previously, `assert($x === -1)` failed, because `-1` wasn't a scalar, it
was a unary op on a scalar.
Also fix binary ops.

Fixes #2812