### PR TITLE
Implement --redundant-condition-detection for redundant/impossible conditions (currently has many false positives)

### DIFF
--- a/.phan/plugins/FFIAnalysisPlugin.php
+++ b/.phan/plugins/FFIAnalysisPlugin.php
@@ -133,7 +133,7 @@ class FFIPostAnalysisVisitor extends PluginAwarePostAnalysisVisitor
         if (!is_string($var_name)) {
             return;
         }
-        $cdata_type = UnionType::fromFullyQualifiedString('\FFI\CData');
+        $cdata_type = UnionType::fromFullyQualifiedPHPDocString('\FFI\CData');
         $scope = $this->context->getScope();
         // @phan-suppress-next-line PhanUndeclaredProperty
         if ($node->is_ffi !== FFIPreAnalysisVisitor::ENTIRELY_FFI_CDATA) {

--- a/.phan/plugins/PHPUnitAssertionPlugin.php
+++ b/.phan/plugins/PHPUnitAssertionPlugin.php
@@ -79,21 +79,22 @@ class PHPUnitAssertionPlugin extends PluginV3 implements AnalyzeFunctionCallCapa
                 );
                 // TODO: Rest of https://github.com/sebastianbergmann/phpunit/issues/3368
             case 'assertisstring':
+                // TODO: Could convert to real types?
                 return $method->createClosureForAssertion(
                     $code_base,
-                    new Assertion(UnionType::fromFullyQualifiedString('string'), 'unusedParamName', Assertion::IS_OF_TYPE),
+                    new Assertion(UnionType::fromFullyQualifiedPHPDocString('string'), 'unusedParamName', Assertion::IS_OF_TYPE),
                     0
                 );
             case 'assertnull':
                 return $method->createClosureForAssertion(
                     $code_base,
-                    new Assertion(UnionType::fromFullyQualifiedString('null'), 'unusedParamName', Assertion::IS_OF_TYPE),
+                    new Assertion(UnionType::fromFullyQualifiedPHPDocString('null'), 'unusedParamName', Assertion::IS_OF_TYPE),
                     0
                 );
             case 'assertnotnull':
                 return $method->createClosureForAssertion(
                     $code_base,
-                    new Assertion(UnionType::fromFullyQualifiedString('null'), 'unusedParamName', Assertion::IS_NOT_OF_TYPE),
+                    new Assertion(UnionType::fromFullyQualifiedPHPDocString('null'), 'unusedParamName', Assertion::IS_NOT_OF_TYPE),
                     0
                 );
             case 'assertsame':
@@ -139,51 +140,51 @@ class PHPUnitAssertionPlugin extends PluginV3 implements AnalyzeFunctionCallCapa
                         $original_type = (UnionTypeVisitor::unionTypeFromNode($code_base, $context, $args[1]));
                         switch ($string) {
                             case 'numeric':
-                                return UnionType::fromFullyQualifiedString('int|float|string');
+                                return UnionType::fromFullyQualifiedPHPDocString('int|float|string');
                             case 'integer':
                             case 'int':
-                                return UnionType::fromFullyQualifiedString('int');
+                                return UnionType::fromFullyQualifiedPHPDocString('int');
 
                             case 'double':
                             case 'float':
                             case 'real':
-                                return UnionType::fromFullyQualifiedString('float');
+                                return UnionType::fromFullyQualifiedPHPDocString('float');
 
                             case 'string':
-                                return UnionType::fromFullyQualifiedString('string');
+                                return UnionType::fromFullyQualifiedPHPDocString('string');
 
                             case 'boolean':
                             case 'bool':
-                                return UnionType::fromFullyQualifiedString('bool');
+                                return UnionType::fromFullyQualifiedPHPDocString('bool');
 
                             case 'null':
-                                return UnionType::fromFullyQualifiedString('null');
+                                return UnionType::fromFullyQualifiedPHPDocString('null');
 
                             case 'array':
                                 $result = $original_type->arrayTypes();
                                 if ($result->isEmpty()) {
-                                    return UnionType::fromFullyQualifiedString('array');
+                                    return UnionType::fromFullyQualifiedPHPDocString('array');
                                 }
                                 return $result;
                             case 'object':
                                 $result = $original_type->objectTypes();
                                 if ($result->isEmpty()) {
-                                    return UnionType::fromFullyQualifiedString('object');
+                                    return UnionType::fromFullyQualifiedPHPDocString('object');
                                 }
                                 return $result;
                             case 'resource':
-                                return UnionType::fromFullyQualifiedString('resource');
+                                return UnionType::fromFullyQualifiedPHPDocString('resource');
                             case 'scalar':
                                 $result = $original_type->scalarTypes();
                                 if ($result->isEmpty()) {
-                                    return UnionType::fromFullyQualifiedString('int|string|float|bool');
+                                    return UnionType::fromFullyQualifiedPHPDocString('int|string|float|bool');
                                 }
                                 return $result;
 
                             case 'callable':
                                 $result = $original_type->callableTypes();
                                 if ($result->isEmpty()) {
-                                    return UnionType::fromFullyQualifiedString('callable');
+                                    return UnionType::fromFullyQualifiedPHPDocString('callable');
                                 }
                                 return $result;
                         }
@@ -224,7 +225,7 @@ class PHPUnitAssertionPlugin extends PluginV3 implements AnalyzeFunctionCallCapa
                             return UnionType::empty();
                         }
                         try {
-                            return FullyQualifiedClassName::fromFullyQualifiedString($string)->asType()->asUnionType();
+                            return FullyQualifiedClassName::fromFullyQualifiedString($string)->asType()->asPHPDocUnionType();
                         } catch (\Exception $_) {
                             return UnionType::empty();
                         }

--- a/.phan/plugins/PrintfCheckerPlugin.php
+++ b/.phan/plugins/PrintfCheckerPlugin.php
@@ -161,7 +161,7 @@ class PrintfCheckerPlugin extends PluginV3 implements AnalyzeFunctionCallCapabil
 
     public function getReturnTypeOverrides(CodeBase $unused_code_base) : array
     {
-        $string_union_type = StringType::instance(false)->asUnionType();
+        $string_union_type = StringType::instance(false)->asPHPDocUnionType();
         /**
          * @param array<int,Node|string|int|float> $args the nodes for the arguments to the invocation
          */
@@ -172,7 +172,7 @@ class PrintfCheckerPlugin extends PluginV3 implements AnalyzeFunctionCallCapabil
             array $args
         ) use ($string_union_type) : UnionType {
             if (count($args) < 1) {
-                return FalseType::instance(false)->asUnionType();
+                return FalseType::instance(false)->asRealUnionType();
             }
             $union_type = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $args[0]);
             $format_strings = [];
@@ -534,7 +534,7 @@ class PrintfCheckerPlugin extends PluginV3 implements AnalyzeFunctionCallCapabil
                     $type_name = $spec->getExpectedUnionTypeName();
                     $expected_set[$type_name] = true;
                 }
-                $expected_union_type = new UnionType();
+                $expected_union_type = UnionType::empty();
                 foreach ($expected_set as $type_name => $_) {
                     // @phan-suppress-next-line PhanThrowTypeAbsentForCall getExpectedUnionTypeName should only return valid union types
                     $expected_union_type = $expected_union_type->withType(Type::fromFullyQualifiedString($type_name));
@@ -625,7 +625,7 @@ class PrintfCheckerPlugin extends PluginV3 implements AnalyzeFunctionCallCapabil
         if (isset($expected_set['string'])) {
             static $string_weak_types;
             if ($string_weak_types === null) {
-                $string_weak_types = UnionType::fromFullyQualifiedString('int|string|float');
+                $string_weak_types = UnionType::fromFullyQualifiedPHPDocString('int|string|float');
             }
             return $actual_union_type->canCastToUnionType($string_weak_types);
         }

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,19 @@ New features(CLI, Configs):
 + Be consistent about starting parameter/variable names with `$` in issue messages.
 + Fix false positives in more edge cases when analyzing variables with type `static` (e.g. `yield from $this;`) (#2825)
 + Properly emit `NonStaticCallToStatic` in more edge cases (#2826)
++ Add `--redundant-condition-detection` to attempt to detect redundant conditions/casts and impossible conditions based on the inferred real expression types.
+  New issue types: `PhanRedundantCondition`, `PhanImpossibleCondition` (e.g. `is_int(2)` and `boolval(true)` is redundant, `empty(2)` is impossible).
+
+  Note: This has many false positives involving loops, variables set in loops, and global variables.
+  This will be split into more granular issue types later on.
+
+  The real types are inferred separately (and more conservatively) from regular (phpdoc+real) expression types.
+
+  (these checks can also be enabled with the config setting `redundant_condition_detection`)
+
+New features(Analysis):
++ Infer that `<=>` is `-1|0|1` instead of `int`
++ Infer that eval with backticks is `?string` instead of `string`
 
 Maintenance:
 + Add updates to the function/method signature map from Psalm and PHPStan.

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1765,7 +1765,7 @@ class UnionTypeVisitor extends AnalysisVisitor
             $name_node_type = $this->__invoke($name_node);
             static $int_or_string_type;
             if ($int_or_string_type === null) {
-                $int_or_string_type = UnionType::fromFullyQualifiedString('int|string|null');
+                $int_or_string_type = UnionType::fromFullyQualifiedPHPDocString('int|string|null');
             }
             if (!$name_node_type->canCastToUnionType($int_or_string_type)) {
                 Issue::maybeEmit($this->code_base, $this->context, Issue::TypeSuspiciousIndirectVariable, $name_node->lineno, (string)$name_node_type);
@@ -3254,7 +3254,7 @@ class UnionTypeVisitor extends AnalysisVisitor
         if ($int_type === null) {
             $int_type = IntType::instance(false)->asPHPDocUnionType();
             $string_type = StringType::instance(false)->asPHPDocUnionType();
-            $int_or_string_type = UnionType::fromFullyQualifiedString('int|string');
+            $int_or_string_type = UnionType::fromFullyQualifiedPHPDocString('int|string');
         }
         $key_enum_type = GenericArrayType::keyTypeFromUnionTypeKeys($union_type);
         switch ($key_enum_type) {

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1270,7 +1270,7 @@ class UnionTypeVisitor extends AnalysisVisitor
             return Type::fromType($type, $template_type_list);
         }, $union_type->getTypeSet());
 
-        return UnionType::of($type_set, $class_node->kind === ast\AST_NAME ? $type_set : null);
+        return UnionType::of($type_set, $class_node->kind === ast\AST_NAME ? $type_set : []);
     }
 
     /**

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -2438,7 +2438,7 @@ class UnionTypeVisitor extends AnalysisVisitor
             );
 
             // Turn that into a union type
-            return $fqsen->asUnionType();
+            return $fqsen->asType()->asRealUnionType();
         }
 
         // Things of the form `new $className()`, `new $obj()`, `new (foo())()`, etc.
@@ -2494,9 +2494,7 @@ class UnionTypeVisitor extends AnalysisVisitor
             return $parent_type_option->get()->asRealUnionType();
         }
 
-        $result = $this->context->getClassFQSEN()->asUnionType();
-
-        return $result;
+        return $this->context->getClassFQSEN()->asType()->asRealUnionType();
     }
 
     private function classTypesForNonName(Node $node) : UnionType

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -935,7 +935,7 @@ class UnionTypeVisitor extends AnalysisVisitor
             }
             // TODO: Normalize value_types, e.g. false+true=bool, array<int,T>+array<string,T>=array<mixed,T>
             $key_type_enum = GenericArrayType::getKeyTypeOfArrayNode($this->code_base, $this->context, $node, $this->should_catch_issue_exception);
-            return $value_types_builder->getUnionType()->asNonEmptyGenericArrayTypes($key_type_enum);
+            return $value_types_builder->getPHPDocUnionType()->asNonEmptyGenericArrayTypes($key_type_enum)->withRealType(ArrayType::instance(false));
         }
 
         // TODO: Also return types such as array<int, mixed>?

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1532,12 +1532,19 @@ class UnionTypeVisitor extends AnalysisVisitor
             return null;
         }
         if ($resulting_element_type === false) {
-            $this->emitIssue(
-                Issue::TypeInvalidDimOffset,
-                $dim_node->lineno ?? $node->lineno,
-                StringUtil::jsonEncode($dim_value),
-                (string)$union_type
+            // XXX not sure what to do here. For now, just return null and only warn in cases where requested to.
+            $exception = new IssueException(
+                Issue::fromType(Issue::TypeInvalidDimOffset)(
+                    $this->context->getFile(),
+                    $dim_node->lineno ?? $node->lineno,
+                    [StringUtil::jsonEncode($dim_value), (string)$union_type]
+                )
             );
+            if ($this->should_catch_issue_exception) {
+                Issue::maybeEmitInstance($this->code_base, $this->context, $exception->getIssueInstance());
+            } else {
+                throw $exception;
+            }
             // $union_type is exclusively array shape types, but those don't contain the field $dim_value.
             // It's undefined (which becomes null)
             return NullType::instance(false)->asPHPDocUnionType();

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1375,7 +1375,7 @@ class UnionTypeVisitor extends AnalysisVisitor
         if ($union_type->hasTopLevelArrayShapeTypeInstances()) {
             $element_type = $this->resolveArrayShapeElementTypes($node, $union_type);
             if ($element_type !== null) {
-                return $element_type;
+                return $element_type->eraseRealTypeSet();
             }
         }
 
@@ -1388,7 +1388,7 @@ class UnionTypeVisitor extends AnalysisVisitor
 
         // Figure out what the types of accessed array
         // elements would be.
-        $generic_types = $union_type->genericArrayElementTypes();
+        $generic_types = $union_type->genericArrayElementTypes()->eraseRealTypeSet();
 
         // If we have generics, we're all set
         if (!$generic_types->isEmpty()) {

--- a/src/Phan/Analysis/AssignOperatorFlagVisitor.php
+++ b/src/Phan/Analysis/AssignOperatorFlagVisitor.php
@@ -99,18 +99,15 @@ class AssignOperatorFlagVisitor extends FlagVisitorImplementation
         } elseif ($left->hasNonNullIntType()
             && $right->hasNonNullIntType()
         ) {
-            return IntType::instance(false)->asUnionType();
+            return IntType::instance(false)->asPHPDocUnionType();
         } elseif ($left->hasType(FloatType::instance(false))
             && $right->hasType(FloatType::instance(false))
         ) {
-            return FloatType::instance(false)->asUnionType();
+            return FloatType::instance(false)->asPHPDocUnionType();
         }
 
         static $int_or_float;
-        return $int_or_float ?? ($int_or_float = new UnionType([
-            IntType::instance(false),
-            FloatType::instance(false)
-        ]));
+        return $int_or_float ?? ($int_or_float = UnionType::fromFullyQualifiedPHPDocString('int|float'));
     }
 
     public function visitBinaryCoalesce(Node $node) : UnionType
@@ -146,13 +143,13 @@ class AssignOperatorFlagVisitor extends FlagVisitorImplementation
         if ($left->hasNonNullIntType()
             && $right->hasNonNullIntType()
         ) {
-            return IntType::instance(false)->asUnionType();
+            return IntType::instance(false)->asPHPDocUnionType();
         } elseif ($left->hasNonNullStringType() &&
             $right->hasNonNullStringType()) {
             // $x = 'a'; $x &= 'c';
-            return StringType::instance(false)->asUnionType();
+            return StringType::instance(false)->asPHPDocUnionType();
         }
-        return IntType::instance(false)->asUnionType();
+        return IntType::instance(false)->asPHPDocUnionType();
     }
 
     /**
@@ -174,13 +171,13 @@ class AssignOperatorFlagVisitor extends FlagVisitorImplementation
         if ($left->hasNonNullIntType()
             && $right->hasNonNullIntType()
         ) {
-            return IntType::instance(false)->asUnionType();
+            return IntType::instance(false)->asPHPDocUnionType();
         } elseif ($left->hasNonNullStringType() &&
             $right->hasNonNullStringType()) {
             // $x = 'a'; $x |= 'c';
-            return StringType::instance(false)->asUnionType();
+            return StringType::instance(false)->asPHPDocUnionType();
         }
-        return IntType::instance(false)->asUnionType();
+        return IntType::instance(false)->asPHPDocUnionType();
     }
 
     /**
@@ -223,14 +220,14 @@ class AssignOperatorFlagVisitor extends FlagVisitorImplementation
         } elseif ($left->hasNonNullIntType()
             && $right->hasNonNullIntType()
         ) {
-            return IntType::instance(false)->asUnionType();
+            return IntType::instance(false)->asPHPDocUnionType();
         } elseif ($left->hasNonNullStringType()
             && $right->hasNonNullStringType()
         ) {
-            return StringType::instance(false)->asUnionType();
+            return StringType::instance(false)->asPHPDocUnionType();
         }
 
-        return IntType::instance(false)->asUnionType();
+        return IntType::instance(false)->asPHPDocUnionType();
     }
 
     /**
@@ -242,7 +239,7 @@ class AssignOperatorFlagVisitor extends FlagVisitorImplementation
      */
     public function visitBinaryConcat(Node $node) : UnionType
     {
-        return StringType::instance(false)->asUnionType();
+        return StringType::instance(false)->asRealUnionType();
     }
 
     /**
@@ -270,7 +267,7 @@ class AssignOperatorFlagVisitor extends FlagVisitorImplementation
         if ($left->isNonNullIntType()
             && $right->isNonNullIntType()
         ) {
-            return IntType::instance(false)->asUnionType();
+            return IntType::instance(false)->asPHPDocUnionType();
         }
 
         // If both left and right are arrays, then this is array
@@ -280,7 +277,7 @@ class AssignOperatorFlagVisitor extends FlagVisitorImplementation
                 return $left;
             }
 
-            return ArrayType::instance(false)->asUnionType();
+            return ArrayType::instance(false)->asPHPDocUnionType();
         }
 
         // TODO: isNonNullNumberType
@@ -289,7 +286,7 @@ class AssignOperatorFlagVisitor extends FlagVisitorImplementation
             && ($right->isNonNullIntType()
             || $right->isType(FloatType::instance(false)))
         ) {
-            return FloatType::instance(false)->asUnionType();
+            return FloatType::instance(false)->asPHPDocUnionType();
         }
 
         $left_is_array = (
@@ -304,7 +301,7 @@ class AssignOperatorFlagVisitor extends FlagVisitorImplementation
 
         if ($left_is_array
             && !$right->canCastToUnionType(
-                ArrayType::instance(false)->asUnionType()
+                ArrayType::instance(false)->asPHPDocUnionType()
             )
         ) {
             Issue::maybeEmit(
@@ -315,7 +312,7 @@ class AssignOperatorFlagVisitor extends FlagVisitorImplementation
             );
             return UnionType::empty();
         } elseif ($right_is_array
-            && !$left->canCastToUnionType(ArrayType::instance(false)->asUnionType())
+            && !$left->canCastToUnionType(ArrayType::instance(false)->asPHPDocUnionType())
         ) {
             Issue::maybeEmit(
                 $this->code_base,
@@ -327,46 +324,43 @@ class AssignOperatorFlagVisitor extends FlagVisitorImplementation
         } elseif ($left_is_array || $right_is_array) {
             // If it is a '+' and we know one side is an array
             // and the other is unknown, assume array
-            return ArrayType::instance(false)->asUnionType();
+            return ArrayType::instance(false)->asPHPDocUnionType();
         }
 
         static $int_or_float;
-        return $int_or_float ?? ($int_or_float = new UnionType([
-            IntType::instance(false),
-            FloatType::instance(false)
-        ]));
+        return $int_or_float ?? ($int_or_float = UnionType::fromFullyQualifiedPHPDocString('int|float'));
     }
 
     /** @override */
     public function visitBinaryDiv(Node $_) : UnionType
     {
         // analyzed in AssignOperatorAnalysisVisitor
-        return FloatType::instance(false)->asUnionType();
+        return FloatType::instance(false)->asPHPDocUnionType();
     }
 
     /** @override */
     public function visitBinaryMod(Node $_) : UnionType
     {
         // analyzed in AssignOperatorAnalysisVisitor
-        return IntType::instance(false)->asUnionType();
+        return IntType::instance(false)->asPHPDocUnionType();
     }
 
     /** @override */
     public function visitBinaryPow(Node $_) : UnionType
     {
         // analyzed in AssignOperatorAnalysisVisitor
-        return FloatType::instance(false)->asUnionType();
+        return FloatType::instance(false)->asPHPDocUnionType();
     }
 
     /** @override */
     public function visitBinaryShiftLeft(Node $_) : UnionType
     {
-        return IntType::instance(false)->asUnionType();
+        return IntType::instance(false)->asPHPDocUnionType();
     }
 
     /** @override */
     public function visitBinaryShiftRight(Node $_) : UnionType
     {
-        return IntType::instance(false)->asUnionType();
+        return IntType::instance(false)->asPHPDocUnionType();
     }
 }

--- a/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
+++ b/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
@@ -131,23 +131,17 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
                     return !($type instanceof FloatType);
                 }
             )) {
-                return $int_or_float ?? ($int_or_float = new UnionType([
-                    IntType::instance(false),
-                    FloatType::instance(false)
-                ]));
+                return $int_or_float ?? ($int_or_float = UnionType::fromFullyQualifiedPHPDocString('int|float'));
             }
 
-            return FloatType::instance(false)->asUnionType();
+            return FloatType::instance(false)->asPHPDocUnionType();
         } elseif ($left->hasNonNullIntType()
             && $right->hasNonNullIntType()
         ) {
-            return IntType::instance(false)->asUnionType();
+            return IntType::instance(false)->asPHPDocUnionType();
         }
 
-        return $int_or_float ?? ($int_or_float = new UnionType([
-            IntType::instance(false),
-            FloatType::instance(false)
-        ]));
+        return $int_or_float ?? ($int_or_float = UnionType::fromFullyQualifiedPHPDocString('int|float'));
     }
 
     /**
@@ -164,7 +158,7 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
         // TODO: Any sanity checks should go here.
 
         // <=> returns -1, 0, or 1
-        return IntType::instance(false)->asUnionType();
+        return UnionType::fromFullyQualifiedPHPDocString('-1|0|1');
     }
 
     /**
@@ -179,7 +173,7 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
     public function visitBinaryShiftLeft(Node $node) : UnionType
     {
         // TODO: Any sanity checks should go here.
-        return IntType::instance(false)->asUnionType();
+        return IntType::instance(false)->asRealUnionType();
     }
 
     /**
@@ -194,7 +188,7 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
     public function visitBinaryShiftRight(Node $node) : UnionType
     {
         // TODO: Any sanity checks should go here.
-        return IntType::instance(false)->asUnionType();
+        return IntType::instance(false)->asRealUnionType();
     }
 
     /**
@@ -253,7 +247,7 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
             }
         } elseif ($left->hasNonNullStringType()) {
             if ($right->hasNonNullStringType()) {
-                return StringType::instance(false)->asUnionType();
+                return StringType::instance(false)->asPHPDocUnionType();
             }
             if ($right->hasNonNullIntType()) {
                 $this->emitIssue(
@@ -275,9 +269,10 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
             );
         }
 
-        return IntType::instance(false)->asUnionType();
+        return IntType::instance(false)->asPHPDocUnionType();
     }
 
+    // TODO: Switch to asRealUnionType when both operands are real
     private static function computeIntegerOperationResult(
         Node $node,
         UnionType $left,
@@ -289,32 +284,32 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
             if (is_int($right_value)) {
                 switch ($node->flags) {
                     case ast\flags\BINARY_BITWISE_OR:
-                        return LiteralIntType::instanceForValue($left_value | $right_value, false)->asUnionType();
+                        return LiteralIntType::instanceForValue($left_value | $right_value, false)->asPHPDocUnionType();
                     case ast\flags\BINARY_BITWISE_AND:
-                        return LiteralIntType::instanceForValue($left_value & $right_value, false)->asUnionType();
+                        return LiteralIntType::instanceForValue($left_value & $right_value, false)->asPHPDocUnionType();
                     case ast\flags\BINARY_BITWISE_XOR:
-                        return LiteralIntType::instanceForValue($left_value ^ $right_value, false)->asUnionType();
+                        return LiteralIntType::instanceForValue($left_value ^ $right_value, false)->asPHPDocUnionType();
                     case ast\flags\BINARY_MUL:
                         $value = $left_value * $right_value;
-                        return is_int($value) ? LiteralIntType::instanceForValue($value, false)->asUnionType()
-                                              : FloatType::instance(false)->asUnionType();
+                        return is_int($value) ? LiteralIntType::instanceForValue($value, false)->asPHPDocUnionType()
+                                              : FloatType::instance(false)->asPHPDocUnionType();
                     case ast\flags\BINARY_SUB:
                         $value = $left_value - $right_value;
-                        return is_int($value) ? LiteralIntType::instanceForValue($value, false)->asUnionType()
-                                              : FloatType::instance(false)->asUnionType();
+                        return is_int($value) ? LiteralIntType::instanceForValue($value, false)->asPHPDocUnionType()
+                                              : FloatType::instance(false)->asPHPDocUnionType();
                     case ast\flags\BINARY_ADD:
                         $value = $left_value + $right_value;
-                        return is_int($value) ? LiteralIntType::instanceForValue($value, false)->asUnionType()
-                                              : FloatType::instance(false)->asUnionType();
+                        return is_int($value) ? LiteralIntType::instanceForValue($value, false)->asPHPDocUnionType()
+                                              : FloatType::instance(false)->asPHPDocUnionType();
                     case ast\flags\BINARY_POW:
                         $value = $left_value ** $right_value;
-                        return is_int($value) ? LiteralIntType::instanceForValue($value, false)->asUnionType()
-                                              : FloatType::instance(false)->asUnionType();
+                        return is_int($value) ? LiteralIntType::instanceForValue($value, false)->asPHPDocUnionType()
+                                              : FloatType::instance(false)->asPHPDocUnionType();
                 }
             }
         }
 
-        return IntType::instance(false)->asUnionType();
+        return IntType::instance(false)->asPHPDocUnionType();
     }
 
     /**
@@ -350,7 +345,7 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
      */
     public function visitBinaryBoolAnd(Node $unused_node) : UnionType
     {
-        return BoolType::instance(false)->asUnionType();
+        return BoolType::instance(false)->asRealUnionType();
     }
 
     /**
@@ -362,7 +357,7 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
      */
     public function visitBinaryBoolXor(Node $unused_node) : UnionType
     {
-        return BoolType::instance(false)->asUnionType();
+        return BoolType::instance(false)->asRealUnionType();
     }
 
     /**
@@ -374,7 +369,7 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
      */
     public function visitBinaryBoolOr(Node $unused_node) : UnionType
     {
-        return BoolType::instance(false)->asUnionType();
+        return BoolType::instance(false)->asRealUnionType();
     }
 
     /**
@@ -395,7 +390,7 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
             $this->should_catch_issue_exception
         )->asSingleScalarValueOrNullOrSelf() : $left_node;
         if (\is_object($left_value)) {
-            return StringType::instance(false)->asUnionType();
+            return StringType::instance(false)->asRealUnionType();
         }
         $right_node = $node->children['right'];
         $right_value = $right_node instanceof Node ? UnionTypeVisitor::unionTypeFromNode(
@@ -405,9 +400,9 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
             $this->should_catch_issue_exception
         )->asSingleScalarValueOrNullOrSelf() : $right_node;
         if (\is_object($right_value)) {
-            return StringType::instance(false)->asUnionType();
+            return StringType::instance(false)->asRealUnionType();
         }
-        return LiteralStringType::instanceForValue($left_value . $right_value, false)->asUnionType();
+        return LiteralStringType::instanceForValue($left_value . $right_value, false)->asRealUnionType();
     }
 
     /**
@@ -437,11 +432,11 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
         $right_is_array_like = $right->isExclusivelyArrayLike();
 
         $left_can_cast_to_array = $left->canCastToUnionType(
-            ArrayType::instance(false)->asUnionType()
+            ArrayType::instance(false)->asPHPDocUnionType()
         );
 
         $right_can_cast_to_array = $right->canCastToUnionType(
-            ArrayType::instance(false)->asUnionType()
+            ArrayType::instance(false)->asPHPDocUnionType()
         );
 
         if ($left_is_array_like
@@ -471,7 +466,7 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
             );
         }
 
-        return BoolType::instance(false)->asUnionType();
+        return BoolType::instance(false)->asRealUnionType();
     }
 
     /**
@@ -660,16 +655,13 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
         if ($int_or_float_union_type === null) {
             $float_type = FloatType::instance(false);
             $array_type = ArrayType::instance(false);
-            $int_or_float_union_type = new UnionType([
-                IntType::instance(false),
-                $float_type
-            ]);
+            $int_or_float_union_type = UnionType::fromFullyQualifiedPHPDocString('int|float');
         }
 
         if ($left->isNonNullNumberType() && $right->isNonNullNumberType()) {
             if (!$left->hasNonNullIntType() || !$right->hasNonNullIntType()) {
                 // Heuristic: If one or more of the sides is a float, the result is always a float.
-                return $float_type->asUnionType();
+                return $float_type->asPHPDocUnionType();
             }
             return $int_or_float_union_type;
         }
@@ -692,7 +684,7 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
 
             if ($left_is_array
                 && !$right->canCastToUnionType(
-                    ArrayType::instance(false)->asUnionType()
+                    ArrayType::instance(false)->asPHPDocUnionType()
                 )
             ) {
                 $this->emitIssue(
@@ -700,7 +692,7 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
                     $node->lineno ?? 0
                 );
                 return UnionType::empty();
-            } elseif ($right_is_array && !$left->canCastToUnionType($array_type->asUnionType())) {
+            } elseif ($right_is_array && !$left->canCastToUnionType($array_type->asPHPDocUnionType())) {
                 $this->emitIssue(
                     Issue::TypeInvalidLeftOperand,
                     $node->lineno ?? 0
@@ -709,7 +701,7 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
             }
             // If it is a '+' and we know one side is an array
             // and the other is unknown, assume array
-            return $array_type->asUnionType();
+            return $array_type->asPHPDocUnionType();
         }
 
         return $int_or_float_union_type;
@@ -764,16 +756,13 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
         static $int_or_float_union_type = null;
         if ($int_or_float_union_type === null) {
             $float_type = FloatType::instance(false);
-            $int_or_float_union_type = new UnionType([
-                IntType::instance(false),
-                $float_type
-            ]);
+            $int_or_float_union_type = UnionType::fromFullyQualifiedPHPDocString('int|float');
         }
 
         if ($left->isNonNullNumberType() && $right->isNonNullNumberType()) {
             if (!$left->hasNonNullIntType() || !$right->hasNonNullIntType()) {
                 // Heuristic: If one or more of the sides is a float, the result is always a float.
-                return $float_type->asUnionType();
+                return UnionType::fromFullyQualifiedPHPDocString('int|float');
             }
             return $int_or_float_union_type;
         }
@@ -826,7 +815,7 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
     public function visitBinaryMod(Node $unused_node) : UnionType
     {
         // TODO: Warn about invalid left or right side
-        return IntType::instance(false)->asUnionType();
+        return IntType::instance(false)->asRealUnionType();
     }
 
     /**

--- a/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
+++ b/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
@@ -762,7 +762,7 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
         if ($left->isNonNullNumberType() && $right->isNonNullNumberType()) {
             if (!$left->hasNonNullIntType() || !$right->hasNonNullIntType()) {
                 // Heuristic: If one or more of the sides is a float, the result is always a float.
-                return UnionType::fromFullyQualifiedPHPDocString('int|float');
+                return $float_type->asPHPDocUnionType();
             }
             return $int_or_float_union_type;
         }

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -793,36 +793,8 @@ class ConditionVisitor extends KindVisitorImplementation implements ConditionVis
                     //
                     // FIXME move this to PostOrderAnalysisVisitor so that all expressions can be analyzed, not just variables?
                     $new_type = $default_if_empty;
-                    if ($union_type->hasRealTypeSet() && !$union_type->getRealUnionType()->hasAnyTypeOverlap($code_base, $default_if_empty)) {
-                        Issue::maybeEmit(
-                            $code_base,
-                            $context,
-                            Issue::TypeImpossibleCondition,
-                            $context->getLineNumberStart(),
-                            $variable->getName(),
-                            $union_type->getRealUnionType(),
-                            $default_if_empty
-                        );
-                    }
                 } else {
-                    if ($new_type->containsNullable()) {
-                        $new_type = $new_type->nonNullableClone();
-                    }
-                    if ($check_redundant && $union_type->hasRealTypeSet() && $new_type->isEqualTo($union_type)) {
-                        $real_type = $union_type->getRealUnionType();
-                        $new_real_type = $method->invoke($real_type)->nonNullableClone();
-                        if ($real_type->isEqualTo($new_real_type)) {
-                            Issue::maybeEmit(
-                                $code_base,
-                                $context,
-                                Issue::TypeRedundantCondition,
-                                $context->getLineNumberStart(),
-                                $variable->getName(),
-                                $union_type->getRealUnionType(),
-                                $default_if_empty
-                            );
-                        }
-                    }
+                    $new_type = $new_type->nonNullableClone();
                 }
                 $variable->setUnionType($new_type);
             };

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -639,7 +639,9 @@ class ConditionVisitor extends KindVisitorImplementation implements ConditionVis
                 $new_type_builder->addType(Type::traversableInstance());
             }
         }
-        $variable->setUnionType($new_type_builder->isEmpty() ? ObjectType::instance(false)->asRealUnionType() : $new_type_builder->getUnionType());
+        $variable->setUnionType(
+            $new_type_builder->isEmpty() ? ObjectType::instance(false)->asRealUnionType()
+                                         : UnionType::of($new_type_builder->getTypeSet(), [ObjectType::instance(false)]));
     }
 
     /**

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -794,11 +794,11 @@ class ConditionVisitor extends KindVisitorImplementation implements ConditionVis
             };
         };
         /** @return void */
-        $callable_callback = $make_callback('callableTypes', CallableType::instance(false)->asUnionType());
-        $bool_callback = $make_callback('getTypesInBoolFamily', BoolType::instance(false)->asUnionType());
-        $int_callback = $make_callback('intTypes', IntType::instance(false)->asUnionType());
-        $string_callback = $make_callback('stringTypes', StringType::instance(false)->asUnionType());
-        $numeric_callback = $make_callback('numericTypes', UnionType::fromFullyQualifiedString('string|int|float'));
+        $callable_callback = $make_callback('callableTypes', CallableType::instance(false)->asRealUnionType());
+        $bool_callback = $make_callback('getTypesInBoolFamily', BoolType::instance(false)->asRealUnionType());
+        $int_callback = $make_callback('intTypes', IntType::instance(false)->asRealUnionType());
+        $string_callback = $make_callback('stringTypes', StringType::instance(false)->asRealUnionType());
+        $numeric_callback = $make_callback('numericTypes', UnionType::fromFullyQualifiedRealString('string|int|float'));
 
         // Note: LiteralIntType exists, but LiteralFloatType doesn't, which is why these are different.
         $float_callback = $make_direct_assertion_callback('float');

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -776,11 +776,10 @@ class ConditionVisitor extends KindVisitorImplementation implements ConditionVis
          */
         $make_callback = static function (string $extract_types, UnionType $default_if_empty) : Closure {
             $method = new ReflectionMethod(UnionType::class, $extract_types);
-            $check_redundant = $extract_types !== 'numericTypes';
             /**
              * @param array<int,Node|mixed> $args
              */
-            return static function (CodeBase $code_base, Context $context, Variable $variable, array $args) use ($method, $default_if_empty, $check_redundant) : void {
+            return static function (CodeBase $code_base, Context $context, Variable $variable, array $args) use ($method, $default_if_empty) : void {
                 // Change the type to match the is_a relationship
                 // If we already have possible callable types, then keep those
                 // (E.g. Closure|false becomes Closure)

--- a/src/Phan/Analysis/ConditionVisitorUtil.php
+++ b/src/Phan/Analysis/ConditionVisitorUtil.php
@@ -24,13 +24,11 @@ use Phan\Language\Element\Variable;
 use Phan\Language\FQSEN\FullyQualifiedClassName;
 use Phan\Language\Type;
 use Phan\Language\Type\FalseType;
-use Phan\Language\Type\IntType;
 use Phan\Language\Type\LiteralIntType;
 use Phan\Language\Type\LiteralStringType;
 use Phan\Language\Type\LiteralTypeInterface;
 use Phan\Language\Type\MixedType;
 use Phan\Language\Type\NullType;
-use Phan\Language\Type\StringType;
 use Phan\Language\Type\TrueType;
 use Phan\Language\UnionType;
 use Phan\Library\StringUtil;
@@ -672,7 +670,7 @@ trait ConditionVisitorUtil
         }
         if (!is_string($expr_value)) {
             $expr_type = UnionTypeVisitor::unionTypeFromNode($this->code_base, $this->context, $expr_node);
-            if (!$expr_type->canCastToUnionType(UnionType::fromFullyQualifiedString('string|false'))) {
+            if (!$expr_type->canCastToUnionType(UnionType::fromFullyQualifiedPHPDocString('string|false'))) {
                 Issue::maybeEmit(
                     $this->code_base,
                     $this->context,

--- a/src/Phan/Analysis/ConditionVisitorUtil.php
+++ b/src/Phan/Analysis/ConditionVisitorUtil.php
@@ -156,7 +156,7 @@ trait ConditionVisitorUtil
                 }
                 if ($has_nullable) {
                     if ($union_type->isEmpty()) {
-                        return NullType::instance(false)->asUnionType();
+                        return NullType::instance(false)->asPHPDocUnionType();
                     }
                     return $union_type->nullableClone();
                 }
@@ -699,7 +699,7 @@ trait ConditionVisitorUtil
 
             return null;
         }
-        $expr_type = $fqsen->asType()->asUnionType();
+        $expr_type = \is_string($expr_node) ? $fqsen->asType()->asRealUnionType() : $fqsen->asType()->asPHPDocUnionType();
 
         $var_name = $object_node->children['name'] ?? null;
         // Don't analyze variables such as $$a
@@ -778,11 +778,7 @@ trait ConditionVisitorUtil
             $name_node_type = UnionTypeVisitor::unionTypeFromNode($this->code_base, $context, $var_name_node, true);
             static $int_or_string_type;
             if ($int_or_string_type === null) {
-                $int_or_string_type = new UnionType([
-                    StringType::instance(false),
-                    IntType::instance(false),
-                    NullType::instance(false),
-                ]);
+                $int_or_string_type = UnionType::fromFullyQualifiedPHPDocString('?int|?string');
             }
             if (!$name_node_type->canCastToUnionType($int_or_string_type)) {
                 Issue::maybeEmit($this->code_base, $context, Issue::TypeSuspiciousIndirectVariable, $var_name_node->lineno ?? 0, (string)$name_node_type);

--- a/src/Phan/Analysis/NegatedConditionVisitor.php
+++ b/src/Phan/Analysis/NegatedConditionVisitor.php
@@ -507,7 +507,7 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
                         if ($has_null && !$has_other_nullable_types) {
                             $new_type_builder->addType(NullType::instance(false));
                         }
-                        return $new_type_builder->getUnionType();
+                        return $new_type_builder->getPHPDocUnionType();
                     },
                     false
                 );
@@ -544,7 +544,7 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
                         if ($has_null && !$has_other_nullable_types) {
                             $new_type_builder->addType(NullType::instance(false));
                         }
-                        return $new_type_builder->getUnionType();
+                        return $new_type_builder->getPHPDocUnionType();
                     },
                     false
                 );
@@ -782,7 +782,7 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
         } else {
             static $null_and_possibly_undefined = null;
             if ($null_and_possibly_undefined === null) {
-                $null_and_possibly_undefined = NullType::instance(false)->asUnionType()->withIsPossiblyUndefined(true);
+                $null_and_possibly_undefined = NullType::instance(false)->asPHPDocUnionType()->withIsPossiblyUndefined(true);
             }
 
             return ArrayType::combineArrayShapeTypesWithField($union_type, $dim_value, $null_and_possibly_undefined);
@@ -851,11 +851,11 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
                 }
                 if (!$context->getScope()->hasVariableWithName($var_name)) {
                     // Support analyzing cases such as `if (!empty($x['key'])) { use($x); }`, or `assert(!empty($x['key']))`
-                    // (Assume that this is an array, not ArrayAccess, as a heuristic)
+                    // (Assume that this is an array, not ArrayAccess or a string, as a heuristic)
                     $context->setScope($context->getScope()->withVariable(new Variable(
                         $context->withLineNumberStart($expr_node->lineno ?? 0),
                         $var_name,
-                        ArrayType::instance(false)->asUnionType(),
+                        ArrayType::instance(false)->asPHPDocUnionType(),
                         0
                     )));
                     return $context;
@@ -896,7 +896,7 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
             if (!$union_type->hasTopLevelArrayShapeTypeInstances()) {
                 return $context;
             }
-            $new_union_type = ArrayType::combineArrayShapeTypesWithField($union_type, $dim_value, MixedType::instance(false)->asUnionType());
+            $new_union_type = ArrayType::combineArrayShapeTypesWithField($union_type, $dim_value, MixedType::instance(false)->asPHPDocUnionType());
             $variable = clone($variable);
             $variable->setUnionType($new_union_type);
             return $context->withScopeVariable(

--- a/src/Phan/Analysis/NegatedConditionVisitor.php
+++ b/src/Phan/Analysis/NegatedConditionVisitor.php
@@ -587,7 +587,8 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
                     if ($has_null && !$has_other_nullable_types) {
                         $new_type_builder->addType(NullType::instance(false));
                     }
-                    return $new_type_builder->getUnionType();
+                    // TODO: Could try to track real types here and elsewhere
+                    return $new_type_builder->getPHPDocUnionType();
                 },
                 false
             );
@@ -628,7 +629,7 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
                     if ($has_null && !$has_other_nullable_types) {
                         $new_type_builder->addType(NullType::instance(false));
                     }
-                    return $new_type_builder->getUnionType();
+                    return $new_type_builder->getPHPDocUnionType();
                 },
                 false
             );
@@ -665,7 +666,7 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
                     if ($has_null && !$has_other_nullable_types) {
                         $new_type_builder->addType(NullType::instance(false));
                     }
-                    return $new_type_builder->getUnionType();
+                    return $new_type_builder->getPHPDocUnionType();
                 },
                 false
             );
@@ -709,7 +710,7 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
             return $this->checkComplexIsset($var_node);
         }
         // if (!isset($x))
-        return $this->updateVariableWithNewType($var_node, $this->context, NullType::instance(false)->asUnionType(), true);
+        return $this->updateVariableWithNewType($var_node, $this->context, NullType::instance(false)->asPHPDocUnionType(), true);
     }
 
     /**
@@ -752,7 +753,7 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
             }
         } elseif ($var_node->kind === ast\AST_PROP) {
             $context = $this->modifyPropertySimple($var_node, static function (UnionType $_) : UnionType {
-                return NullType::instance(false)->asUnionType();
+                return NullType::instance(false)->asPHPDocUnionType();
             }, $context);
         }
         return $context;

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -880,6 +880,7 @@ class ParameterTypesAnalyzer
         $comment_parameter_map = null;
         foreach ($phpdoc_parameter_list as $i => $parameter) {
             $parameter_type = $parameter->getNonVariadicUnionType();
+            // If there is already a phpdoc parameter type, then don't bother inheriting the parameter type from $o_method
             if (!$parameter_type->isEmpty()) {
                 $comment_parameter_map = $comment_parameter_map ?? self::extractCommentParameterMap($method);
                 $comment_parameter = $comment_parameter_map[$parameter->getName()] ?? null;
@@ -897,7 +898,7 @@ class ParameterTypesAnalyzer
                     continue;
                 }
                 if ($parameter_type->isEmpty() || $parent_parameter_type->isExclusivelyNarrowedFormOf($code_base, $parameter_type)) {
-                    $parameter->setUnionType($parent_parameter_type);
+                    $parameter->setUnionType($parent_parameter_type->eraseRealTypeSet());
                 }
             }
         }
@@ -1057,7 +1058,7 @@ class ParameterTypesAnalyzer
                 $param_to_modify = $method->getParameterList()[$i] ?? null;
                 if ($param_to_modify) {
                     // TODO: Maybe have two different sets of methods for setUnionType and setCallerUnionType, this is easy to mix up for variadics.
-                    $param_to_modify->setUnionType($normalized_phpdoc_param_union_type);
+                    $param_to_modify->setUnionType($normalized_phpdoc_param_union_type->withRealTypeSet($real_param_type->getRealTypeSet()));
                 }
             } else {
                 $comment = $method->getComment();

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -580,7 +580,8 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             $default_type = NullType::instance(false)->asRealUnionType();
         }
 
-        $variable->setUnionType($default_type);
+        // NOTE: Phan can't be sure that the type the static type starts with is the same as what it has later. Avoid false positive PhanTypeRedundantCondition.
+        $variable->setUnionType($default_type->eraseRealTypeSet());
         // TODO: Probably not true in a loop?
         // TODO: Expand this to assigning to variables? (would need to make references invalidate that, and skip this in the global scope)
         $variable->enablePhanFlagBits(\Phan\Language\Element\Flags::IS_CONSTANT_DEFINITION);

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -2303,7 +2303,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
 
             if (!$possible_ancestor_type->isEmpty()) {
                 // but forbid 'self::__construct', 'static::__construct'
-                $type = $this->context->getClassFQSEN()->asUnionType();
+                $type = $this->context->getClassFQSEN()->asRealUnionType();
                 if ($possible_ancestor_type->hasStaticType()) {
                     $this->emitIssue(
                         Issue::AccessOwnConstructor,

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -3115,11 +3115,15 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             // We don't do anything with the new variable; just create it
             // if it doesn't exist
             try {
-                (new ContextNode(
+                $variable = (new ContextNode(
                     $this->code_base,
                     $this->context,
                     $argument
                 ))->getOrCreateVariableForReferenceParameter($parameter, $real_parameter);
+                $variable_union_type = $variable->getUnionType();
+                if ($variable_union_type->hasRealTypeSet()) {
+                    $variable->setUnionType($variable->getUnionType()->eraseRealTypeSet());
+                }
             } catch (NodeException $_) {
                 return;
             }
@@ -3470,10 +3474,10 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                     if ($parameter_type->isType(NullType::instance(false))) {
                         // Treat a parameter default of null the same way as passing null to that parameter
                         // (Add null to the list of possibilities)
-                        $parameter_clone->addUnionType($parameter_type);
+                        $parameter_clone->addUnionType($parameter_type->eraseRealTypeSet());
                     } else {
                         // For other types (E.g. string), just replace the union type.
-                        $parameter_clone->setUnionType($parameter_type);
+                        $parameter_clone->setUnionType($parameter_type->eraseRealTypeSet());
                     }
                 }
 
@@ -3580,7 +3584,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         array &$parameter_list,
         int $parameter_offset
     ) : void {
-        $argument_type = $argument_types[$parameter_offset];
+        $argument_type = $argument_types[$parameter_offset]->eraseRealTypeSet();
         if ($parameter->isVariadic()) {
             for ($i = $parameter_offset + 1; $i < \count($argument_types); $i++) {
                 $argument_type = $argument_type->withUnionType($argument_types[$i]);

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -577,7 +577,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 $node->children['default']
             );
         } else {
-            $default_type = NullType::instance(false)->asUnionType();
+            $default_type = NullType::instance(false)->asRealUnionType();
         }
 
         $variable->setUnionType($default_type);
@@ -1029,7 +1029,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
     {
         $var = $node->children['var'];
         $old_type = UnionTypeVisitor::unionTypeFromNode($this->code_base, $this->context, $var)->withFlattenedArrayShapeOrLiteralTypeInstances();
-        if (!$old_type->canCastToUnionType(UnionType::fromFullyQualifiedString('int|string|float'))) {
+        if (!$old_type->canCastToUnionType(UnionType::fromFullyQualifiedPHPDocString('int|string|float'))) {
             $this->emitIssue(
                 Issue::TypeInvalidUnaryOperandIncOrDec,
                 $node->lineno,
@@ -1404,7 +1404,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
 
         $yield_value_node = $node->children['value'];
         if ($yield_value_node === null) {
-            $yield_value_type = VoidType::instance(false)->asUnionType();
+            $yield_value_type = VoidType::instance(false)->asRealUnionType();
         } else {
             $yield_value_type = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $yield_value_node);
         }
@@ -1426,7 +1426,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         if ($type_list_count > 1) {
             $yield_key_node = $node->children['key'];
             if ($yield_key_node === null) {
-                $yield_key_type = VoidType::instance(false)->asUnionType();
+                $yield_key_type = VoidType::instance(false)->asRealUnionType();
             } else {
                 $yield_key_type = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $yield_key_node);
             }
@@ -1661,7 +1661,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
     {
         if (!($node instanceof Node)) {
             if (null === $node) {
-                yield $return_lineno => VoidType::instance(false)->asUnionType();
+                yield $return_lineno => VoidType::instance(false)->asRealUnionType();
                 return;
             }
             yield $return_lineno => UnionTypeVisitor::unionTypeFromNode(
@@ -1800,7 +1800,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
     {
         if (\count($node->children) === 0) {
             // Possibly unreachable (array shape would be returned instead)
-            yield $node->lineno => MixedType::instance(false)->asUnionType();
+            yield $node->lineno => MixedType::instance(false)->asPHPDocUnionType();
             return;
         }
         foreach ($node->children as $elem) {
@@ -1830,7 +1830,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             } else {
                 yield $elem->lineno => Type::fromObject(
                     $value_node
-                )->asUnionType();
+                )->asRealUnionType();
             }
         }
     }
@@ -2149,7 +2149,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             }
             if (!\is_string($method_name)) {
                 $method_name_type = UnionTypeVisitor::unionTypeFromNode($this->code_base, $this->context, $node->children['method']);
-                if (!$method_name_type->canCastToUnionType(StringType::instance(false)->asUnionType())) {
+                if (!$method_name_type->canCastToUnionType(StringType::instance(false)->asPHPDocUnionType())) {
                     Issue::maybeEmit(
                         $this->code_base,
                         $this->context,
@@ -2547,7 +2547,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             }
             if (!\is_string($method_name)) {
                 $method_name_type = UnionTypeVisitor::unionTypeFromNode($this->code_base, $this->context, $node->children['method']);
-                if (!$method_name_type->canCastToUnionType(StringType::instance(false)->asUnionType())) {
+                if (!$method_name_type->canCastToUnionType(StringType::instance(false)->asPHPDocUnionType())) {
                     Issue::maybeEmit(
                         $this->code_base,
                         $this->context,

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -580,7 +580,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             $default_type = NullType::instance(false)->asRealUnionType();
         }
 
-        // NOTE: Phan can't be sure that the type the static type starts with is the same as what it has later. Avoid false positive PhanTypeRedundantCondition.
+        // NOTE: Phan can't be sure that the type the static type starts with is the same as what it has later. Avoid false positive PhanRedundantCondition.
         $variable->setUnionType($default_type->eraseRealTypeSet());
         // TODO: Probably not true in a loop?
         // TODO: Expand this to assigning to variables? (would need to make references invalidate that, and skip this in the global scope)

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -447,7 +447,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
                             [$variable_name],
                             IssueFixSuggester::suggestVariableTypoFix($this->code_base, $context, $variable_name)
                         );
-                        $variable = new Variable($context, $variable_name, NullType::instance(false)->asRealUnionType(), 0);
+                        $variable = new Variable($context, $variable_name, NullType::instance(false)->asPHPDocUnionType(), 0);
                     } else {
                         // If the variable doesn't exist, but it's
                         // a pass-by-reference variable, we can
@@ -471,6 +471,11 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
                     // doesn't update the outer scope
                     if (!($use->flags & ast\flags\PARAM_REF)) {
                         $variable = clone($variable);
+                    } else {
+                        $union_type = $variable->getUnionType();
+                        if ($union_type->hasRealTypeSet()) {
+                            $variable->setUnionType($union_type->eraseRealTypeSet());
+                        }
                     }
                 }
 

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -306,7 +306,8 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
             $this->setReturnTypeOfGenerator($function, $node);
         }
         if (!$function->hasReturn() && $function->getUnionType()->isEmpty()) {
-            $function->setUnionType(VoidType::instance(false)->asUnionType());
+            // TODO: This is a global function - also guarantee that it's a real type elsewhere if phpdoc matches the implementation.
+            $function->setUnionType(VoidType::instance(false)->asRealUnionType());
         }
 
         return $context;
@@ -446,7 +447,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
                             [$variable_name],
                             IssueFixSuggester::suggestVariableTypoFix($this->code_base, $context, $variable_name)
                         );
-                        $variable = new Variable($context, $variable_name, NullType::instance(false)->asUnionType(), 0);
+                        $variable = new Variable($context, $variable_name, NullType::instance(false)->asRealUnionType(), 0);
                     } else {
                         // If the variable doesn't exist, but it's
                         // a pass-by-reference variable, we can
@@ -565,7 +566,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
             }
         }
         if (!$func->hasReturn() && $func->getUnionType()->isEmpty()) {
-            $func->setUnionType(VoidType::instance(false)->asUnionType());
+            $func->setUnionType(VoidType::instance(false)->asRealUnionType());
         }
 
         // Add parameters to the context.
@@ -620,7 +621,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
             $func_return_type = $func->getUnionType();
             try {
                 $func_return_type_can_cast = $func_return_type->canCastToExpandedUnionType(
-                    Type::fromNamespaceAndName('\\', 'Generator', false)->asUnionType(),
+                    Type::fromNamespaceAndName('\\', 'Generator', false)->asPHPDocUnionType(),
                     $this->code_base
                 );
             } catch (RecursionDepthException $_) {

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -365,7 +365,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
                     new Variable(
                         $context,
                         'this',
-                        $override_this_fqsen->asUnionType(),
+                        $override_this_fqsen->asRealUnionType(),
                         0
                     )
                 );
@@ -479,7 +479,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
             }
         }
         if (!$func->hasReturn() && $func->getUnionType()->isEmpty()) {
-            $func->setUnionType(VoidType::instance(false)->asUnionType());
+            $func->setUnionType(VoidType::instance(false)->asRealUnionType());
         }
 
         // Add parameters to the context.

--- a/src/Phan/Analysis/RegexAnalyzer.php
+++ b/src/Phan/Analysis/RegexAnalyzer.php
@@ -38,11 +38,11 @@ class RegexAnalyzer
         static $shape_array_inner_type = null;
         if ($string_array_type === null) {
             // Note: Patterns **can** have named subpatterns
-            $string_array_type = UnionType::fromFullyQualifiedString('string[]');
-            $string_type       = UnionType::fromFullyQualifiedString('string');
-            $array_type        = UnionType::fromFullyQualifiedString('array');
-            $shape_array_type  = UnionType::fromFullyQualifiedString('array{0:string,1:int}[]');
-            $shape_array_inner_type  = UnionType::fromFullyQualifiedString('array{0:string,1:int}');
+            $string_array_type = UnionType::fromFullyQualifiedPHPDocString('string[]');
+            $string_type       = UnionType::fromFullyQualifiedPHPDocString('string');
+            $array_type        = UnionType::fromFullyQualifiedPHPDocString('array');
+            $shape_array_type  = UnionType::fromFullyQualifiedPHPDocString('array{0:string,1:int}[]');
+            $shape_array_inner_type  = UnionType::fromFullyQualifiedPHPDocString('array{0:string,1:int}');
         }
         $regex_node = $argument_list[0];
         $regex = $regex_node instanceof Node ? (new ContextNode($code_base, $context, $regex_node))->getEquivalentPHPScalarValue() : $regex_node;
@@ -94,7 +94,7 @@ class RegexAnalyzer
         }
 
         if (!\is_int($bit)) {
-            return UnionType::fromFullyQualifiedString('array[]');
+            return UnionType::fromFullyQualifiedPHPDocString('array[]');
         }
 
         $shape_array_type = self::getPregMatchUnionType($code_base, $context, $argument_list);
@@ -120,6 +120,7 @@ class RegexAnalyzer
             },
             $regex_group_keys
         );
-        return ArrayShapeType::fromFieldTypes($field_types, false)->asUnionType();
+        // NOTE: This is treated as not 100% guaranteed to be an array to avoid false positives about comparing to non-arrays
+        return ArrayShapeType::fromFieldTypes($field_types, false)->asPHPDocUnionType();
     }
 }

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -141,6 +141,7 @@ class CLI
         'progress-bar',
         'project-root-directory:',
         'quick',
+        'redundant-condition-detection',
         'require-config-exists',
         'signature-compatibility',
         'strict-method-checking',
@@ -699,6 +700,9 @@ class CLI
                     Config::setValue('constant_variable_detection', true);
                     Config::setValue('unused_variable_detection', true);
                     break;
+                case 'redundant-condition-detection':
+                    Config::setValue('redundant_condition_detection', true);
+                    break;
                 case 'allow-polyfill-parser':
                     // Just check if it's installed and of a new enough version.
                     // Assume that if there is an installation, it works, and warn later in ensureASTParserExists()
@@ -1247,6 +1251,12 @@ Extended help:
   (i.e. they are declared once (as a constant expression) and never modified).
   This is almost entirely false positives for most coding styles.
   Implies --unused-variable-detection
+
+ --redundant-condition-detection
+  Emit issues for conditions such as is_int(expr) that are redundant or impossible.
+
+  This has many known false positives for loops, variables set in loops,
+  and global variables.
 
  --language-server-on-stdin
   Start the language server (For the Language Server protocol).

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -423,6 +423,12 @@ class Config
         // This has a few known false positives, e.g. for loops or branches.
         'unused_variable_detection' => false,
 
+        // Set to true in order to attempt to detect redundant and impossible conditions.
+        //
+        // This has a large number of false positives involving loops,
+        // variables set in branches of loops, and global variables.
+        'redundant_condition_detection' => false,
+
         // Set to true in order to attempt to detect variables that could be replaced with constants or literals.
         // (i.e. they are declared once (as a constant expression) and never modified)
         // This is almost entirely false positives for most coding styles.
@@ -1322,6 +1328,7 @@ class Config
             'suppress_issue_types' => $is_string_list,
             'target_php_version' => $is_scalar,
             'unused_variable_detection' => $is_bool,
+            'redundant_condition_detection' => $is_bool,
             'use_fallback_parser' => $is_bool,
             'use_polyfill_parser' => $is_bool,
             'warn_about_redundant_use_namespaced_class' => $is_bool,

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -196,7 +196,9 @@ class Issue
     const TypeInvalidStaticPropertyName = 'PhanTypeInvalidStaticPropertyName';
     const TypeErrorInInternalCall = 'PhanTypeErrorInInternalCall';
     const TypeErrorInOperation = 'PhanTypeErrorInOperation';
-    const TypeInvalidPropertyDefaultReal = 'PhanTypeInvalidPropertyDefaultReal';
+    const TypeInvalidPropertyDefaultReal  = 'PhanTypeInvalidPropertyDefaultReal';
+    const TypeImpossibleCondition         = 'PhanTypeImpossibleCondition';
+    const TypeRedundantCondition          = 'PhanTypeRedundantCondition';
 
     // Issue::CATEGORY_ANALYSIS
     const Unanalyzable              = 'PhanUnanalyzable';
@@ -2048,6 +2050,22 @@ class Issue
                 "Default value for {TYPE} \${PROPERTY} can't be {TYPE}",
                 self::REMEDIATION_B,
                 10108
+            ),
+            new Issue(
+                self::TypeImpossibleCondition,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_CRITICAL,
+                "Impossible attempt to cast \${VARIABLE} of type {TYPE} to {TYPE}",
+                self::REMEDIATION_B,
+                10113
+            ),
+            new Issue(
+                self::TypeRedundantCondition,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_CRITICAL,
+                "Redundant attempt to cast \${VARIABLE} of type {TYPE} to {TYPE}",
+                self::REMEDIATION_B,
+                10114
             ),
             // Issue::CATEGORY_VARIABLE
             new Issue(

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -2055,7 +2055,7 @@ class Issue
                 self::TypeImpossibleCondition,
                 self::CATEGORY_TYPE,
                 self::SEVERITY_CRITICAL,
-                "Impossible attempt to cast \${VARIABLE} of type {TYPE} to {TYPE}",
+                "Impossible attempt to cast {CODE} of type {TYPE} to {TYPE}",
                 self::REMEDIATION_B,
                 10113
             ),
@@ -2063,7 +2063,7 @@ class Issue
                 self::TypeRedundantCondition,
                 self::CATEGORY_TYPE,
                 self::SEVERITY_CRITICAL,
-                "Redundant attempt to cast \${VARIABLE} of type {TYPE} to {TYPE}",
+                "Redundant attempt to cast {CODE} of type {TYPE} to {TYPE}",
                 self::REMEDIATION_B,
                 10114
             ),

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -197,8 +197,8 @@ class Issue
     const TypeErrorInInternalCall = 'PhanTypeErrorInInternalCall';
     const TypeErrorInOperation = 'PhanTypeErrorInOperation';
     const TypeInvalidPropertyDefaultReal  = 'PhanTypeInvalidPropertyDefaultReal';
-    const TypeImpossibleCondition         = 'PhanTypeImpossibleCondition';
-    const TypeRedundantCondition          = 'PhanTypeRedundantCondition';
+    const ImpossibleCondition         = 'PhanImpossibleCondition';
+    const RedundantCondition          = 'PhanRedundantCondition';
 
     // Issue::CATEGORY_ANALYSIS
     const Unanalyzable              = 'PhanUnanalyzable';
@@ -2052,7 +2052,7 @@ class Issue
                 10108
             ),
             new Issue(
-                self::TypeImpossibleCondition,
+                self::ImpossibleCondition,
                 self::CATEGORY_TYPE,
                 self::SEVERITY_CRITICAL,
                 "Impossible attempt to cast {CODE} of type {TYPE} to {TYPE}",
@@ -2060,7 +2060,7 @@ class Issue
                 10113
             ),
             new Issue(
-                self::TypeRedundantCondition,
+                self::RedundantCondition,
                 self::CATEGORY_TYPE,
                 self::SEVERITY_CRITICAL,
                 "Redundant attempt to cast {CODE} of type {TYPE} to {TYPE}",

--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -808,7 +808,7 @@ class Context extends FileRef
             $override_type = ArrayShapeType::fromFieldTypes([$property->getName() => $type], false);
             $override_type = self::addArrayShapeTypes($override_type, $old_type->getTypeSet());
 
-            $variable->setUnionType($override_type->asUnionType());
+            $variable->setUnionType($override_type->asPHPDocUnionType());
         } else {
             // There is nothing inferred about any type
 
@@ -820,7 +820,7 @@ class Context extends FileRef
             $variable = new Variable(
                 $this,
                 self::VAR_NAME_THIS_PROPERTIES,
-                $override_type->asUnionType(),
+                $override_type->asPHPDocUnionType(),
                 0
             );
         }
@@ -840,7 +840,7 @@ class Context extends FileRef
             $override_type = ArrayShapeType::fromFieldTypes([$property_name => $type], false);
             $override_type = self::addArrayShapeTypes($override_type, $old_type->getTypeSet());
 
-            $variable->setUnionType($override_type->asUnionType());
+            $variable->setUnionType($override_type->asPHPDocUnionType());
         } else {
             // There is nothing inferred about any type
 
@@ -848,7 +848,7 @@ class Context extends FileRef
             $variable = new Variable(
                 $this,
                 self::VAR_NAME_THIS_PROPERTIES,
-                $override_type->asUnionType(),
+                $override_type->asPHPDocUnionType(),
                 0
             );
         }

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -425,7 +425,7 @@ class Clazz extends AddressableElement
                             \array_map(static function (Type $type) use ($template_type_map) : Type {
                                 return $template_type_map[$type->getName()] ?? $type;
                             }, $union_type->getTypeSet()),
-                            null
+                            []
                         );
                     }, $parent_type->getTemplateParameterTypeList())
                 );

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -230,7 +230,7 @@ class Clazz extends AddressableElement
         $clazz = new Clazz(
             $context,
             $class_name,
-            UnionType::fromFullyQualifiedString('\\' . $class_name),
+            UnionType::fromFullyQualifiedRealString('\\' . $class_name),
             $flags,
             $class_fqsen
         );
@@ -325,7 +325,7 @@ class Clazz extends AddressableElement
             $property = new Property(
                 $property_context,
                 $name,
-                Type::fromObject($default_value)->asUnionType(),
+                Type::fromObject($default_value)->asPHPDocUnionType(),
                 $flags,
                 $property_fqsen,
                 UnionType::empty()
@@ -363,7 +363,7 @@ class Clazz extends AddressableElement
             $constant = new ClassConstant(
                 $context,
                 $name,
-                Type::fromObject($value)->asUnionType(),
+                Type::fromObject($value)->asRealUnionType(),  // TODO: These can vary based on OS/build flags
                 0,
                 $constant_fqsen
             );
@@ -424,7 +424,8 @@ class Clazz extends AddressableElement
                         return UnionType::of(
                             \array_map(static function (Type $type) use ($template_type_map) : Type {
                                 return $template_type_map[$type->getName()] ?? $type;
-                            }, $union_type->getTypeSet())
+                            }, $union_type->getTypeSet()),
+                            null
                         );
                     }, $parent_type->getTemplateParameterTypeList())
                 );
@@ -1483,7 +1484,7 @@ class Clazz extends AddressableElement
         }
         if ($method->hasYield()) {
             // There's no phpdoc standard for template types of Generators at the moment.
-            $new_type = UnionType::fromFullyQualifiedString('\\Generator');
+            $new_type = UnionType::fromFullyQualifiedRealString('\\Generator');
             if (!$new_type->canCastToUnionType($method->getUnionType())) {
                 $method->setUnionType($new_type);
             }
@@ -2734,7 +2735,7 @@ class Clazz extends AddressableElement
             LiteralStringType::instanceForValue(
                 $class_constant_value,
                 false
-            )->asUnionType(),
+            )->asRealUnionType(),
             0,
             FullyQualifiedClassConstantName::make(
                 $this->getFQSEN(),
@@ -2749,7 +2750,7 @@ class Clazz extends AddressableElement
             new Variable(
                 $this->getContext(),
                 'this',
-                StaticType::instance(false)->asUnionType(),
+                StaticType::instance(false)->asRealUnionType(),
                 0
             )
         );
@@ -3000,7 +3001,7 @@ class Clazz extends AddressableElement
         if (!$changed) {
             return UnionType::empty();
         }
-        return Type::fromType($this->parent_type, $parent_template_parameter_type_list)->asUnionType();
+        return Type::fromType($this->parent_type, $parent_template_parameter_type_list)->asPHPDocUnionType();
     }
 
     /**
@@ -3087,7 +3088,7 @@ class Clazz extends AddressableElement
                         }
                         /** @param array<int,\ast\Node|mixed> $unused_arg_list */
                         $template_type_resolver = static function (array $unused_arg_list) : UnionType {
-                            return MixedType::instance(false)->asUnionType();
+                            return MixedType::instance(false)->asPHPDocUnionType();
                         };
                     }
                     $template_type_resolvers[] = $template_type_resolver;

--- a/src/Phan/Language/Element/Comment/Builder.php
+++ b/src/Phan/Language/Element/Comment/Builder.php
@@ -1038,7 +1038,7 @@ final class Builder
             } else {
                 // From https://phpdoc.org/docs/latest/references/phpdoc/tags/method.html
                 // > When the intended method does not have a return value then the return type MAY be omitted; in which case 'void' is implied.
-                $return_union_type = VoidType::instance(false)->asUnionType();
+                $return_union_type = VoidType::instance(false)->asPHPDocUnionType();
             }
             $method_name = $match[22];
 

--- a/src/Phan/Language/Element/FunctionFactory.php
+++ b/src/Phan/Language/Element/FunctionFactory.php
@@ -220,7 +220,7 @@ class FunctionFactory
                     // TODO: could check isDefaultValueAvailable and getDefaultValue, for a better idea.
                     // I don't see any cases where this will be used for internal types, though.
                     $parameter->setDefaultValueType(
-                        NullType::instance(false)->asUnionType()
+                        NullType::instance(false)->asPHPDocUnionType()
                     );
                 }
 

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -791,7 +791,7 @@ trait FunctionTrait
             // to null
             if ($default_is_null) {
                 if ($was_empty) {
-                    $parameter->addUnionType(MixedType::instance(false)->asUnionType());
+                    $parameter->addUnionType(MixedType::instance(false)->asPHPDocUnionType());
                 }
                 // The parameter constructor or above check for wasEmpty already took care of null default case
             } else {
@@ -799,7 +799,7 @@ trait FunctionTrait
                 if ($was_empty) {
                     $parameter->addUnionType(self::inferNormalizedTypesOfDefault($default_type));
                     if (!Config::getValue('guess_unknown_parameter_type_using_default')) {
-                        $parameter->addUnionType(MixedType::instance(false)->asUnionType());
+                        $parameter->addUnionType(MixedType::instance(false)->asPHPDocUnionType());
                     }
                 } else {
                     // Don't add both `int` and `?int` to the same set.
@@ -823,7 +823,7 @@ trait FunctionTrait
         $normalized_default_type = UnionType::empty();
         foreach ($type_set as $type) {
             if ($type instanceof FalseType || $type instanceof NullType) {
-                return MixedType::instance(false)->asUnionType();
+                return MixedType::instance(false)->asPHPDocUnionType();
             } elseif ($type instanceof GenericArrayType) {
                 // Ideally should be the **only** type.
                 $normalized_default_type = $normalized_default_type->withType(ArrayType::instance(false));
@@ -1158,7 +1158,7 @@ trait FunctionTrait
 
         $return_type = $this->getUnionType();
         if ($return_type->isEmpty()) {
-            $return_type = MixedType::instance(false)->asUnionType();
+            $return_type = MixedType::instance(false)->asPHPDocUnionType();
         }
         return new ClosureDeclarationType(
             $this->getFileRef(),
@@ -1345,7 +1345,7 @@ trait FunctionTrait
                 }
             } else {
                 if ($this instanceof Func || ($this instanceof Method && ($this->isPrivate() || $this->isEffectivelyFinal() || $this->isMagicAndVoid() || $this->getClass($code_base)->isFinal()))) {
-                    $this->setUnionType(VoidType::instance(false)->asUnionType());
+                    $this->setUnionType(VoidType::instance(false)->asRealUnionType());
                 }
             }
         }

--- a/src/Phan/Language/Element/GlobalConstant.php
+++ b/src/Phan/Language/Element/GlobalConstant.php
@@ -68,7 +68,7 @@ class GlobalConstant extends AddressableElement implements ConstantInterface
         $result = new self(
             new Context(),
             $name,
-            Type::fromObject($value)->asUnionType(),
+            Type::fromObject($value)->asRealUnionType(),
             0,
             $constant_fqsen
         );

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -264,7 +264,7 @@ class Method extends ClassElement implements FunctionInterface
     public function getUnionTypeOfMagicIfKnown() : ?UnionType
     {
         $type_string = FullyQualifiedMethodName::MAGIC_METHOD_TYPE_MAP[$this->getName()] ?? null;
-        return $type_string ? UnionType::fromFullyQualifiedString($type_string) : null;
+        return $type_string ? UnionType::fromFullyQualifiedPHPDocString($type_string) : null;
     }
 
     /**

--- a/src/Phan/Language/Element/Parameter.php
+++ b/src/Phan/Language/Element/Parameter.php
@@ -14,14 +14,10 @@ use Phan\Language\Element\Comment\Builder;
 use Phan\Language\FutureUnionType;
 use Phan\Language\Type;
 use Phan\Language\Type\ArrayType;
-use Phan\Language\Type\BoolType;
 use Phan\Language\Type\ClosureDeclarationParameter;
 use Phan\Language\Type\FalseType;
-use Phan\Language\Type\FloatType;
-use Phan\Language\Type\IntType;
 use Phan\Language\Type\MixedType;
 use Phan\Language\Type\NullType;
-use Phan\Language\Type\StringType;
 use Phan\Language\Type\TrueType;
 use Phan\Language\UnionType;
 use Phan\Parse\ParseVisitor;
@@ -216,7 +212,7 @@ class Parameter extends Variable
         );
         if ($reflection_parameter->isOptional()) {
             $parameter->setDefaultValueType(
-                NullType::instance(false)->asUnionType()
+                NullType::instance(false)->asPHPDocUnionType()
             );
         }
         return $parameter;
@@ -589,7 +585,7 @@ class Parameter extends Variable
     {
         $param_type = $this->getNonVariadicUnionType();
         if ($param_type->isEmpty()) {
-            $param_type = MixedType::instance(false)->asUnionType();
+            $param_type = MixedType::instance(false)->asPHPDocUnionType();
         }
         return new ClosureDeclarationParameter(
             $param_type,

--- a/src/Phan/Language/Element/Variable.php
+++ b/src/Phan/Language/Element/Variable.php
@@ -198,7 +198,8 @@ class Variable extends UnaddressableTypedElement implements TypedElementInterfac
     ) : ?UnionType {
         if (\array_key_exists($name, self::_BUILTIN_GLOBAL_TYPES)) {
             // More efficient than using context.
-            return UnionType::fromFullyQualifiedString(self::_BUILTIN_GLOBAL_TYPES[$name]);
+            // Note that global constants can be modified by user code
+            return UnionType::fromFullyQualifiedPHPDocString(self::_BUILTIN_GLOBAL_TYPES[$name]);
         }
 
         if (\array_key_exists($name, Config::getValue('globals_type_map'))

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -27,7 +27,7 @@ final class EmptyUnionType extends UnionType
      */
     public function __construct()
     {
-        parent::__construct([], true, null);
+        parent::__construct([], true, []);
     }
 
     /**
@@ -1316,9 +1316,9 @@ final class EmptyUnionType extends UnionType
         return $type->asRealUnionType();
     }
 
-    public function getRealTypeSet() : ?array
+    public function getRealTypeSet() : array
     {
-        return null;
+        return [];
     }
 
     public function hasRealTypeSet() : bool

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -27,7 +27,7 @@ final class EmptyUnionType extends UnionType
      */
     public function __construct()
     {
-        parent::__construct([], true);
+        parent::__construct([], true, null);
     }
 
     /**
@@ -58,7 +58,7 @@ final class EmptyUnionType extends UnionType
      */
     public function withType(Type $type) : UnionType
     {
-        return $type->asUnionType();
+        return $type->asPHPDocUnionType();
     }
 
     /**
@@ -95,7 +95,7 @@ final class EmptyUnionType extends UnionType
      */
     public function withUnionType(UnionType $union_type) : UnionType
     {
-        return $union_type;
+        return $union_type->eraseRealTypeSet();
     }
 
     /**
@@ -965,7 +965,7 @@ final class EmptyUnionType extends UnionType
      */
     public function asNonEmptyGenericArrayTypes(int $key_type) : UnionType
     {
-        return ArrayType::instance(false)->asUnionType();
+        return ArrayType::instance(false)->asPHPDocUnionType();
     }
 
     /**
@@ -1223,12 +1223,12 @@ final class EmptyUnionType extends UnionType
 
     public function applyUnaryBitwiseNotOperator() : UnionType
     {
-        return IntType::instance(false)->asUnionType();
+        return IntType::instance(false)->asPHPDocUnionType();
     }
 
     public function applyUnaryPlusOperator() : UnionType
     {
-        return UnionType::fromFullyQualifiedString('int|float');
+        return UnionType::fromFullyQualifiedPHPDocString('int|float');
     }
 
     /** @return null */

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -1311,4 +1311,32 @@ final class EmptyUnionType extends UnionType
     {
         return null;
     }
+
+    public function hasRealTypeSet() : bool
+    {
+        return false;
+    }
+
+    public function eraseRealTypeSet() : UnionType
+    {
+        return $this;
+    }
+
+    public function hasAnyTypeOverlap(CodeBase $code_base, UnionType $other) : bool
+    {
+        return true;
+    }
+
+    public function withRealTypeSet(?array $real_type_set) : UnionType
+    {
+        if (!$real_type_set) {
+            return $this;
+        }
+        return UnionType::of($real_type_set, $real_type_set);
+    }
+
+    public function getRealUnionType() : UnionType
+    {
+        return $this;
+    }
 }

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -1010,7 +1010,7 @@ final class EmptyUnionType extends UnionType
 
     public function replaceWithTemplateTypes(UnionType $template_union_type) : UnionType
     {
-        return $template_union_type;
+        return $template_union_type->eraseRealTypeSet();
     }
 
     public function hasTypeWithFQSEN(Type $other) : bool
@@ -1300,5 +1300,15 @@ final class EmptyUnionType extends UnionType
     public function isVoidType() : bool
     {
         return false;
+    }
+
+    public function withRealType(Type $type) : UnionType
+    {
+        return $type->asRealUnionType();
+    }
+
+    public function getRealTypeSet() : ?array
+    {
+        return null;
     }
 }

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -803,6 +803,11 @@ final class EmptyUnionType extends UnionType
         return $this;
     }
 
+    public function floatTypes() : UnionType
+    {
+        return $this;
+    }
+
     /**
      * Returns the types for which is_string($x) would be true.
      *
@@ -1327,6 +1332,9 @@ final class EmptyUnionType extends UnionType
         return true;
     }
 
+    /**
+     * @param ?array<int,Type> $real_type_set
+     */
     public function withRealTypeSet(?array $real_type_set) : UnionType
     {
         if (!$real_type_set) {

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -322,6 +322,10 @@ final class EmptyUnionType extends UnionType
         return true;
     }
 
+    public function isNull() : bool {
+        return false;
+    }
+
     /**
      * @return bool - True if not empty, not possibly undefined, and at least one type is NullType or nullable.
      */

--- a/src/Phan/Language/FQSEN/FullyQualifiedClassName.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedClassName.php
@@ -77,9 +77,9 @@ class FullyQualifiedClassName extends FullyQualifiedGlobalStructuralElement
      * @return UnionType
      * The union type of just this class type
      */
-    public function asUnionType() : UnionType
+    public function asPHPDocUnionType() : UnionType
     {
-        return $this->asType()->asUnionType();
+        return $this->asType()->asPHPDocUnionType();
     }
 
     /**

--- a/src/Phan/Language/FQSEN/FullyQualifiedClassName.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedClassName.php
@@ -76,6 +76,17 @@ class FullyQualifiedClassName extends FullyQualifiedGlobalStructuralElement
     /**
      * @return UnionType
      * The union type of just this class type
+     * @deprecated use asPHPDocUnionType()
+     * @suppress PhanUnreferencedPublicMethod
+     */
+    public function asUnionType() : UnionType
+    {
+        return $this->asType()->asPHPDocUnionType();
+    }
+
+    /**
+     * @return UnionType
+     * The union type of just this class type
      */
     public function asPHPDocUnionType() : UnionType
     {

--- a/src/Phan/Language/FQSEN/FullyQualifiedClassName.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedClassName.php
@@ -83,6 +83,15 @@ class FullyQualifiedClassName extends FullyQualifiedGlobalStructuralElement
     }
 
     /**
+     * @return UnionType
+     * The union type of just this class type
+     */
+    public function asRealUnionType() : UnionType
+    {
+        return $this->asType()->asRealUnionType();
+    }
+
+    /**
      * @return FullyQualifiedClassName
      * The FQSEN for \stdClass.
      */

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -607,7 +607,8 @@ class Type
                  * @param mixed $value
                  */
                 static function ($value) : UnionType {
-                    return self::fromObjectExtended($value)->asUnionType();
+                    // TODO: Look into how this is used and add real equivalent?
+                    return self::fromObjectExtended($value)->asPHPDocUnionType();
                 },
                 $array
             ),
@@ -890,7 +891,7 @@ class Type
     private static function createTemplateParameterTypeList(array $template_parameter_type_name_list) : array
     {
         return \array_map(static function (string $type_name) : UnionType {
-            return UnionType::fromFullyQualifiedString($type_name);
+            return UnionType::fromFullyQualifiedPHPDocString($type_name);
         }, $template_parameter_type_name_list);
     }
 
@@ -1466,7 +1467,7 @@ class Type
     {
         // return new UnionType([$this]);
         // Memoize the set of types. The constructed UnionType object can be modified later, so it isn't memoized.
-        return $this->singleton_union_type ?? ($this->singleton_union_type = new UnionType([$this], true));
+        return $this->singleton_union_type ?? ($this->singleton_union_type = new UnionType([$this], true, null));
     }
 
     /**
@@ -2217,6 +2218,8 @@ class Type
      * @return UnionType
      * Expands class types to all inherited classes returning
      * a superset of this type.
+     *
+     * TODO: Add equivalent to preserve the real type
      */
     public function asExpandedTypes(
         CodeBase $code_base,
@@ -2228,8 +2231,8 @@ class Type
         if ($recursion_depth >= 20) {
             throw new RecursionDepthException("Recursion has gotten out of hand: " . Frame::getExpandedTypesDetails());
         }
-        $union_type = $this->memoize(__METHOD__, function () use ($code_base, $recursion_depth) : UnionType {
-            $union_type = $this->asUnionType();
+        return $this->memoize(__METHOD__, function () use ($code_base, $recursion_depth) : UnionType {
+            $union_type = $this->asPHPDocUnionType();
 
             $class_fqsen = $this->asFQSEN();
 
@@ -2282,9 +2285,8 @@ class Type
                 );
             }
 
-            return $recursive_union_type_builder->getUnionType();
+            return $recursive_union_type_builder->getPHPDocUnionType();
         });
-        return $union_type;
     }
 
     /**
@@ -2310,8 +2312,8 @@ class Type
         if ($recursion_depth >= 20) {
             throw new RecursionDepthException("Recursion has gotten out of hand: " . Frame::getExpandedTypesDetails());
         }
-        $union_type = $this->memoize(__METHOD__, function () use ($code_base, $recursion_depth) : UnionType {
-            $union_type = $this->asUnionType();
+        return $this->memoize(__METHOD__, function () use ($code_base, $recursion_depth) : UnionType {
+            $union_type = $this->asPHPDocUnionType();
 
             $class_fqsen = $this->asFQSEN();
 
@@ -2373,13 +2375,12 @@ class Type
                 );
             }
 
-            $result = $recursive_union_type_builder->getUnionType();
+            $result = $recursive_union_type_builder->getPHPDocUnionType();
             if (!$template_union_type->isEmpty()) {
                 return $result->replaceWithTemplateTypes($template_union_type);
             }
             return $result;
         });
-        return $union_type;
     }
 
     /**
@@ -3162,10 +3163,10 @@ class Type
     {
         if ($this->is_nullable) {
             // ++null is 1
-            return UnionType::of([$this->withIsNullable(false), IntType::instance(false)]);
+            return UnionType::of([$this->withIsNullable(false), IntType::instance(false)], null);
         }
         // ++$obj; doesn't change the object.
-        return $this->asUnionType();
+        return $this->asPHPDocUnionType();
     }
 
     /**
@@ -3230,16 +3231,16 @@ class Type
         array $template_parameter_type_map
     ) : UnionType {
         if (!$this->template_parameter_type_list) {
-            return $this->asUnionType();
+            return $this->asPHPDocUnionType();
         }
         $new_type_list = [];
         foreach ($this->template_parameter_type_list as $i => $type) {
             $new_type_list[$i] = $type->withTemplateParameterTypeMap($template_parameter_type_map);
         }
         if ($new_type_list === $this->template_parameter_type_list) {
-            return $this->asUnionType();
+            return $this->asPHPDocUnionType();
         }
-        return self::fromType($this, $new_type_list)->asUnionType();
+        return self::fromType($this, $new_type_list)->asPHPDocUnionType();
     }
 
     /**

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -1448,21 +1448,43 @@ class Type
         return $result;
     }
 
-
     /**
      * @var ?UnionType of [$this]
      */
     protected $singleton_union_type;
 
     /**
+     * @var ?UnionType of [$this] with an identical real type set
+     */
+    protected $singleton_real_union_type;
+
+    /**
      * @return UnionType
      * A UnionType representing this and only this type
      */
-    public function asUnionType() : UnionType
+    public function asPHPDocUnionType() : UnionType
     {
         // return new UnionType([$this]);
         // Memoize the set of types. The constructed UnionType object can be modified later, so it isn't memoized.
         return $this->singleton_union_type ?? ($this->singleton_union_type = new UnionType([$this], true));
+    }
+
+    /**
+     * @param ?array<int,string> $type_set
+     * @return UnionType
+     * A UnionType representing this and only this type
+     */
+    public function asRealUnionType() : UnionType
+    {
+        // return new UnionType([$this]);
+        // Memoize the set of types. The constructed UnionType object can be modified later, so it isn't memoized.
+        return $this->singleton_real_union_type ?? ($this->singleton_real_union_type = $this->computeRealUnionType());
+    }
+
+    private function computeRealUnionType() : UnionType
+    {
+        $type_set = [$this];
+        return new UnionType($type_set, true, $type_set);
     }
 
     /**

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -1460,14 +1460,26 @@ class Type
     protected $singleton_real_union_type;
 
     /**
+     * A UnionType representing this and only this type (from phpdoc or real types)
+     *
+     * @deprecated use self::asPHPDocUnionType()
+     * @suppress PhanUnreferencedPublicMethod
+     */
+    public function asUnionType() : UnionType
+    {
+        return $this->singleton_union_type ?? ($this->singleton_union_type = new UnionType([$this], true, []));
+    }
+
+    /**
      * @return UnionType
-     * A UnionType representing this and only this type
+     * A UnionType representing this and only this type (from phpdoc or real types)
+     * @see asRealUnionType() if you are certain this is the real type of the expression.
      */
     public function asPHPDocUnionType() : UnionType
     {
         // return new UnionType([$this]);
         // Memoize the set of types. The constructed UnionType object can be modified later, so it isn't memoized.
-        return $this->singleton_union_type ?? ($this->singleton_union_type = new UnionType([$this], true, null));
+        return $this->singleton_union_type ?? ($this->singleton_union_type = new UnionType([$this], true, []));
     }
 
     /**
@@ -3162,7 +3174,7 @@ class Type
     {
         if ($this->is_nullable) {
             // ++null is 1
-            return UnionType::of([$this->withIsNullable(false), IntType::instance(false)], null);
+            return UnionType::of([$this->withIsNullable(false), IntType::instance(false)], []);
         }
         // ++$obj; doesn't change the object.
         return $this->asPHPDocUnionType();

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -1471,7 +1471,6 @@ class Type
     }
 
     /**
-     * @param ?array<int,string> $type_set
      * @return UnionType
      * A UnionType representing this and only this type
      */

--- a/src/Phan/Language/Type/ArrayShapeType.php
+++ b/src/Phan/Language/Type/ArrayShapeType.php
@@ -554,7 +554,7 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
                 try {
                     $expanded_field_type = $union_type->asExpandedTypesPreservingTemplate($code_base, $recursion_depth);
                 } catch (RecursionDepthException $_) {
-                    $expanded_field_type = MixedType::instance(false)->asUnionType();
+                    $expanded_field_type = MixedType::instance(false)->asPHPDocUnionType();
                 }
                 if ($union_type->isPossiblyUndefined()) {
                     // array{key?:string} should become array{key?:string}.
@@ -562,7 +562,7 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
                 }
                 $result_fields[$key] = $expanded_field_type;
             }
-            return ArrayShapeType::fromFieldTypes($result_fields, $this->is_nullable)->asUnionType();
+            return ArrayShapeType::fromFieldTypes($result_fields, $this->is_nullable)->asPHPDocUnionType();
         });
     }
 
@@ -659,11 +659,11 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
         if (\array_keys($this->field_types) !== [0, 1]) {
             return true;
         }
-        if (!$this->field_types[0]->canCastToUnionType(UnionType::fromFullyQualifiedString('string|object'))) {
+        if (!$this->field_types[0]->canCastToUnionType(UnionType::fromFullyQualifiedPHPDocString('string|object'))) {
             // First field of callable array should be a string or object. (the expression or class)
             return true;
         }
-        if (!$this->field_types[1]->canCastToUnionType(StringType::instance(false)->asUnionType())) {
+        if (!$this->field_types[1]->canCastToUnionType(StringType::instance(false)->asPHPDocUnionType())) {
             // Second field of callable array should be the method name.
             return true;
         }
@@ -691,9 +691,9 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
             }
         }
         if ($field_types === $this->field_types) {
-            return $this->asUnionType();
+            return $this->asPHPDocUnionType();
         }
-        return self::fromFieldTypes($field_types, $this->is_nullable)->asUnionType();
+        return self::fromFieldTypes($field_types, $this->is_nullable)->asPHPDocUnionType();
     }
 
     /**

--- a/src/Phan/Language/Type/ArrayShapeType.php
+++ b/src/Phan/Language/Type/ArrayShapeType.php
@@ -507,7 +507,7 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
                 try {
                     $expanded_field_type = $union_type->asExpandedTypes($code_base, $recursion_depth);
                 } catch (RecursionDepthException $_) {
-                    $expanded_field_type = MixedType::instance(false)->asUnionType();
+                    $expanded_field_type = MixedType::instance(false)->asPHPDocUnionType();
                 }
                 if ($union_type->isPossiblyUndefined()) {
                     // array{key?:string} should become array{key?:string}.
@@ -515,7 +515,7 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
                 }
                 $result_fields[$key] = $expanded_field_type;
             }
-            return ArrayShapeType::fromFieldTypes($result_fields, $this->is_nullable)->asUnionType();
+            return ArrayShapeType::fromFieldTypes($result_fields, $this->is_nullable)->asPHPDocUnionType();
         });
     }
 

--- a/src/Phan/Language/Type/ArrayShapeType.php
+++ b/src/Phan/Language/Type/ArrayShapeType.php
@@ -649,6 +649,21 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
         return false;
     }
 
+    public function isAlwaysFalsey() : bool
+    {
+        return \count($this->field_types) === 0;
+    }
+
+    public function isPossiblyTruthy() : bool
+    {
+        return \count($this->field_types) > 0;
+    }
+
+    public function isPossiblyFalsey() : bool
+    {
+        return !$this->isAlwaysTruthy();
+    }
+
     /**
      * Returns true if this contains a type that is definitely non-callable
      * e.g. returns true for false, array, int

--- a/src/Phan/Language/Type/ArrayType.php
+++ b/src/Phan/Language/Type/ArrayType.php
@@ -33,6 +33,16 @@ class ArrayType extends IterableType
         return false;  // Overrides IterableType returning true
     }
 
+    public function isPossiblyTruthy() : bool
+    {
+        return true;
+    }
+
+    public function isPossiblyFalsey() : bool
+    {
+        return true;
+    }
+
     public function isArrayLike() : bool
     {
         return true;  // Overrides Type

--- a/src/Phan/Language/Type/ArrayType.php
+++ b/src/Phan/Language/Type/ArrayType.php
@@ -60,18 +60,18 @@ class ArrayType extends IterableType
                     $result->addType($type);
                 }
             } elseif ($type instanceof ArrayType) {
-                return $type->asUnionType();
+                return UnionType::of([$type], $union_type->getRealTypeSet());
             }
         }
         if ($result->isEmpty()) {
-            return ArrayShapeType::union($array_shape_types)->asUnionType();
+            return UnionType::of([ArrayShapeType::union($array_shape_types)], $union_type->getRealTypeSet());
         }
         foreach ($array_shape_types as $type) {
             foreach ($type->withFlattenedArrayShapeOrLiteralTypeInstances() as $type_part) {
                 $result->addType($type_part);
             }
         }
-        return $result->getUnionType();
+        return UnionType::of($result->getTypeSet(), $union_type->getRealTypeSet());
     }
 
     /**
@@ -94,7 +94,7 @@ class ArrayType extends IterableType
                     $result->addType($type);
                 }
             } elseif ($type instanceof ArrayType) {
-                return $type->asUnionType();
+                return $type->asPHPDocUnionType();
             }
         }
         $right_array_shape_types = [];
@@ -107,28 +107,28 @@ class ArrayType extends IterableType
                     $result->addType($type);
                 }
             } elseif ($type instanceof ArrayType) {
-                return $type->asUnionType();
+                return $type->asPHPDocUnionType();
             }
         }
         if ($result->isEmpty()) {
             if (\count($left_array_shape_types) === 0) {
-                return ArrayShapeType::union($right_array_shape_types)->asUnionType();
+                return ArrayShapeType::union($right_array_shape_types)->asPHPDocUnionType();
             }
             if (\count($right_array_shape_types) === 0) {
-                return ArrayShapeType::union($left_array_shape_types)->asUnionType();
+                return ArrayShapeType::union($left_array_shape_types)->asPHPDocUnionType();
             }
             // fields from the left take precedence (e.g. [0, false] + ['string'] becomes [0, false])
             return ArrayShapeType::combineWithPrecedence(
                 ArrayShapeType::union($left_array_shape_types),
                 ArrayShapeType::union($right_array_shape_types)
-            )->asUnionType();
+            )->asPHPDocUnionType();
         }
         foreach (\array_merge($left_array_shape_types, $right_array_shape_types) as $type) {
             foreach ($type->withFlattenedArrayShapeOrLiteralTypeInstances() as $type_part) {
                 $result->addType($type_part);
             }
         }
-        return $result->getUnionType();
+        return $result->getPHPDocUnionType();
     }
 
     /**
@@ -157,7 +157,7 @@ class ArrayType extends IterableType
             // TODO: Add possibly_undefined annotations in union
             ArrayShapeType::union($left_array_shape_types)
         ));
-        return $result->getUnionType();
+        return $result->getPHPDocUnionType();
     }
 
     /**

--- a/src/Phan/Language/Type/CallableStringType.php
+++ b/src/Phan/Language/Type/CallableStringType.php
@@ -51,7 +51,7 @@ final class CallableStringType extends StringType implements CallableInterface
      */
     public function getTypeAfterIncOrDec() : UnionType
     {
-        return UnionType::fromFullyQualifiedString('string');
+        return UnionType::fromFullyQualifiedPHPDocString('string');
     }
 
     public function canUseInRealSignature() : bool

--- a/src/Phan/Language/Type/ClassStringType.php
+++ b/src/Phan/Language/Type/ClassStringType.php
@@ -29,7 +29,7 @@ final class ClassStringType extends StringType
      */
     public function getTypeAfterIncOrDec() : UnionType
     {
-        return UnionType::fromFullyQualifiedString('string');
+        return UnionType::fromFullyQualifiedPHPDocString('string');
     }
 
     public function hasTemplateTypeRecursive() : bool

--- a/src/Phan/Language/Type/ClosureDeclarationParameter.php
+++ b/src/Phan/Language/Type/ClosureDeclarationParameter.php
@@ -183,7 +183,7 @@ final class ClosureDeclarationParameter
             $flags
         );
         if ($this->is_optional && !$this->is_variadic) {
-            $result->setDefaultValueType(MixedType::instance(false)->asUnionType());
+            $result->setDefaultValueType(MixedType::instance(false)->asPHPDocUnionType());
         }
         return $result;
     }

--- a/src/Phan/Language/Type/ClosureType.php
+++ b/src/Phan/Language/Type/ClosureType.php
@@ -63,6 +63,7 @@ final class ClosureType extends Type
             throw new AssertionError('should only clone null fqsen');
         }
         $this->singleton_union_type = null;
+        $this->singleton_real_union_type = null;
         // same as new static($this->namespace, $this->name, $this->template_parameter_type_list, $this->is_nullable);
     }
 

--- a/src/Phan/Language/Type/FunctionLikeDeclarationType.php
+++ b/src/Phan/Language/Type/FunctionLikeDeclarationType.php
@@ -231,7 +231,7 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
         CodeBase $unused_code_base,
         int $unused_recursion_depth = 0
     ) : UnionType {
-        return $this->asUnionType();
+        return $this->asPHPDocUnionType();
     }
 
     /**
@@ -241,7 +241,7 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
         CodeBase $unused_code_base,
         int $unused_recursion_depth = 0
     ) : UnionType {
-        return $this->asUnionType();
+        return $this->asPHPDocUnionType();
     }
 
     /**
@@ -918,10 +918,10 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
         $new_return_type = $this->return_type->withTemplateParameterTypeMap($template_parameter_type_map);
         if ($new_params === $this->params && $new_return_type === $this->return_type) {
             // no change
-            return $this->asUnionType();
+            return $this->asPHPDocUnionType();
         }
         // Create ClosureDeclarationType or CallableDeclarationType
-        return (new static($this->file_ref, $new_params, $new_return_type, $this->returns_reference, $this->is_nullable))->asUnionType();
+        return (new static($this->file_ref, $new_params, $new_return_type, $this->returns_reference, $this->is_nullable))->asPHPDocUnionType();
     }
 
     public function getCommentParamAssertionClosure(CodeBase $code_base) : ?Closure

--- a/src/Phan/Language/Type/GenericArrayTemplateKeyType.php
+++ b/src/Phan/Language/Type/GenericArrayTemplateKeyType.php
@@ -45,11 +45,11 @@ class GenericArrayTemplateKeyType extends GenericArrayType
         $new_element_type = $element_type->withTemplateParameterTypeMap($template_parameter_type_map);
         $new_key_type = $this->template_key_type->withTemplateParameterTypeMap($template_parameter_type_map);
         if ($element_type === $new_element_type && $new_key_type === $this->template_key_type) {
-            return $this->asUnionType();
+            return $this->asPHPDocUnionType();
         }
         if ($this->template_key_type !== $new_key_type) {
             if ($new_element_type->isEmpty()) {
-                $new_element_type = MixedType::instance(false)->asUnionType();
+                $new_element_type = MixedType::instance(false)->asPHPDocUnionType();
             }
             return $new_element_type->asGenericArrayTypes(
                 GenericArrayType::keyTypeFromUnionTypeValues($new_key_type)

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -167,7 +167,7 @@ class GenericArrayType extends ArrayType implements GenericArrayInterface
     private function canCastToGenericIterableType(
         GenericIterableType $iterable_type
     ) : bool {
-        if (!$this->element_type->asUnionType()->canCastToUnionType($iterable_type->getElementUnionType())) {
+        if (!$this->element_type->asPHPDocUnionType()->canCastToUnionType($iterable_type->getElementUnionType())) {
             return false;
         }
         // TODO: Account for scalar key casting config
@@ -242,7 +242,7 @@ class GenericArrayType extends ArrayType implements GenericArrayInterface
      */
     public function iterableValueUnionType(CodeBase $unused_codebase) : UnionType
     {
-        return $this->element_type->asUnionType();
+        return $this->element_type->asPHPDocUnionType();
     }
 
     /**
@@ -261,7 +261,7 @@ class GenericArrayType extends ArrayType implements GenericArrayInterface
      */
     public function genericArrayElementUnionType() : UnionType
     {
-        return $this->element_type->asUnionType();
+        return $this->element_type->asPHPDocUnionType();
     }
 
     public function __toString() : string
@@ -314,7 +314,7 @@ class GenericArrayType extends ArrayType implements GenericArrayInterface
         }
 
         return $this->memoize(__METHOD__, function () use ($code_base, $recursion_depth) : UnionType {
-            $union_type = $this->asUnionType();
+            $union_type = $this->asPHPDocUnionType();
 
             $element_type = $this->genericArrayElementType();
             if (!$element_type->isObjectWithKnownFQSEN()) {
@@ -355,7 +355,7 @@ class GenericArrayType extends ArrayType implements GenericArrayInterface
                     }
                 }
             } catch (RecursionDepthException $_) {
-                return ArrayType::instance($this->is_nullable)->asUnionType();
+                return ArrayType::instance($this->is_nullable)->asPHPDocUnionType();
             }
 
             // Add in aliases
@@ -363,7 +363,7 @@ class GenericArrayType extends ArrayType implements GenericArrayInterface
             if (Config::getValue('enable_class_alias_support')) {
                 self::addClassAliases($code_base, $recursive_union_type_builder, $class_fqsen);
             }
-            return $recursive_union_type_builder->getUnionType();
+            return $recursive_union_type_builder->getPHPDocUnionType();
         });
     }
 
@@ -393,7 +393,7 @@ class GenericArrayType extends ArrayType implements GenericArrayInterface
         }
 
         return $this->memoize(__METHOD__, function () use ($code_base, $recursion_depth) : UnionType {
-            $union_type = $this->asUnionType();
+            $union_type = $this->asPHPDocUnionType();
 
             $class_fqsen = FullyQualifiedClassName::fromType($this->genericArrayElementType());
 
@@ -431,7 +431,7 @@ class GenericArrayType extends ArrayType implements GenericArrayInterface
                     }
                 }
             } catch (RecursionDepthException $_) {
-                return ArrayType::instance($this->is_nullable)->asUnionType();
+                return ArrayType::instance($this->is_nullable)->asPHPDocUnionType();
             }
 
             // Add in aliases
@@ -439,7 +439,7 @@ class GenericArrayType extends ArrayType implements GenericArrayInterface
             if (Config::getValue('enable_class_alias_support')) {
                 self::addClassAliases($code_base, $recursive_union_type_builder, $class_fqsen);
             }
-            return $recursive_union_type_builder->getUnionType();
+            return $recursive_union_type_builder->getPHPDocUnionType();
         });
     }
 
@@ -493,9 +493,9 @@ class GenericArrayType extends ArrayType implements GenericArrayInterface
         static $string_union_type = null;
         static $int_or_string_union_type = null;
         if ($int_union_type === null) {
-            $int_union_type = UnionType::fromFullyQualifiedString('int');
-            $string_union_type = UnionType::fromFullyQualifiedString('string');
-            $int_or_string_union_type = UnionType::fromFullyQualifiedString('int|string');
+            $int_union_type = UnionType::fromFullyQualifiedPHPDocString('int');
+            $string_union_type = UnionType::fromFullyQualifiedPHPDocString('string');
+            $int_or_string_union_type = UnionType::fromFullyQualifiedPHPDocString('int|string');
         }
         switch ($key_type) {
             case self::KEY_INT:
@@ -671,7 +671,7 @@ class GenericArrayType extends ArrayType implements GenericArrayInterface
         $element_type = $this->genericArrayElementUnionType();
         $new_element_type = $element_type->withTemplateParameterTypeMap($template_parameter_type_map);
         if ($element_type === $new_element_type) {
-            return $this->asUnionType();
+            return $this->asPHPDocUnionType();
         }
         // TODO: Override in array shape subclass
         return $new_element_type->asGenericArrayTypes($this->getKeyType());

--- a/src/Phan/Language/Type/GenericIterableType.php
+++ b/src/Phan/Language/Type/GenericIterableType.php
@@ -125,9 +125,9 @@ final class GenericIterableType extends IterableType
         $new_element_type = $this->element_union_type->withTemplateParameterTypeMap($template_parameter_type_map);
         if ($new_element_type === $this->element_union_type &&
             $new_key_type === $this->key_union_type) {
-            return $this->asUnionType();
+            return $this->asPHPDocUnionType();
         }
-        return self::fromKeyAndValueTypes($new_key_type, $new_element_type, $this->is_nullable)->asUnionType();
+        return self::fromKeyAndValueTypes($new_key_type, $new_element_type, $this->is_nullable)->asPHPDocUnionType();
     }
 
     public function __toString() : string

--- a/src/Phan/Language/Type/GenericMultiArrayType.php
+++ b/src/Phan/Language/Type/GenericMultiArrayType.php
@@ -156,7 +156,8 @@ final class GenericMultiArrayType extends ArrayType implements MultiType, Generi
     {
         return $this->element_types_union_type
             ?? ($this->element_types_union_type = UnionType::of(
-                UnionType::normalizeMultiTypes($this->element_types)
+                UnionType::normalizeMultiTypes($this->element_types),
+                null
             ));
     }
 
@@ -207,9 +208,9 @@ final class GenericMultiArrayType extends ArrayType implements MultiType, Generi
                 );
             }
         } catch (RecursionDepthException $_) {
-            return ArrayType::instance($this->is_nullable)->asUnionType();
+            return ArrayType::instance($this->is_nullable)->asPHPDocUnionType();
         }
-        return $result->getUnionType();
+        return $result->getPHPDocUnionType();
     }
 
     /**
@@ -250,8 +251,8 @@ final class GenericMultiArrayType extends ArrayType implements MultiType, Generi
                 );
             }
         } catch (RecursionDepthException $_) {
-            return ArrayType::instance($this->is_nullable)->asUnionType();
+            return ArrayType::instance($this->is_nullable)->asPHPDocUnionType();
         }
-        return $result->getUnionType();
+        return $result->getPHPDocUnionType();
     }
 }

--- a/src/Phan/Language/Type/GenericMultiArrayType.php
+++ b/src/Phan/Language/Type/GenericMultiArrayType.php
@@ -157,7 +157,7 @@ final class GenericMultiArrayType extends ArrayType implements MultiType, Generi
         return $this->element_types_union_type
             ?? ($this->element_types_union_type = UnionType::of(
                 UnionType::normalizeMultiTypes($this->element_types),
-                null
+                []
             ));
     }
 

--- a/src/Phan/Language/Type/IntType.php
+++ b/src/Phan/Language/Type/IntType.php
@@ -21,6 +21,6 @@ class IntType extends ScalarType
 
     public function getTypeAfterIncOrDec() : UnionType
     {
-        return IntType::instance(false)->asUnionType();
+        return IntType::instance(false)->asPHPDocUnionType();
     }
 }

--- a/src/Phan/Language/Type/LiteralStringType.php
+++ b/src/Phan/Language/Type/LiteralStringType.php
@@ -294,11 +294,14 @@ final class LiteralStringType extends StringType implements LiteralTypeInterface
         return self::performComparison($this->value, $scalar, $flags);
     }
 
+    /**
+     * If a literal string is numeric, then it will have a numeric type (int/float) after being incremented/decremented
+     */
     public function getTypeAfterIncOrDec() : UnionType
     {
         $v = $this->value;
         ++$v;
-        return Type::nonLiteralFromObject($v)->asUnionType();
+        return Type::nonLiteralFromObject($v)->asPHPDocUnionType();
     }
 
     /**

--- a/src/Phan/Language/Type/NativeType.php
+++ b/src/Phan/Language/Type/NativeType.php
@@ -214,7 +214,7 @@ abstract class NativeType extends Type
         CodeBase $code_base,
         int $recursion_depth = 0
     ) : UnionType {
-        return $this->asUnionType();
+        return $this->asPHPDocUnionType();
     }
 
     /**
@@ -234,7 +234,7 @@ abstract class NativeType extends Type
         CodeBase $code_base,
         int $recursion_depth = 0
     ) : UnionType {
-        return $this->asUnionType();
+        return $this->asPHPDocUnionType();
     }
 
     public function hasTemplateParameterTypes() : bool
@@ -265,7 +265,7 @@ abstract class NativeType extends Type
     public function withTemplateParameterTypeMap(
         array $unused_template_parameter_type_map
     ) : UnionType {
-        return $this->asUnionType();
+        return $this->asPHPDocUnionType();
     }
 
     public function isTemplateSubtypeOf(Type $unused_type) : bool

--- a/src/Phan/Language/Type/NullType.php
+++ b/src/Phan/Language/Type/NullType.php
@@ -201,7 +201,7 @@ final class NullType extends ScalarType
      */
     public function getTypeAfterIncOrDec() : UnionType
     {
-        return IntType::instance(false)->asUnionType();
+        return IntType::instance(false)->asPHPDocUnionType();
     }
 
     public function canUseInRealSignature() : bool

--- a/src/Phan/Language/Type/ScalarType.php
+++ b/src/Phan/Language/Type/ScalarType.php
@@ -86,7 +86,7 @@ abstract class ScalarType extends NativeType
         Context $unused_context,
         CodeBase $unused_code_base
     ) : bool {
-        return $union_type->hasType($this) || $this->asUnionType()->canCastToUnionType($union_type);
+        return $union_type->hasType($this) || $this->asPHPDocUnionType()->canCastToUnionType($union_type);
     }
 
     /**

--- a/src/Phan/Language/Type/StringType.php
+++ b/src/Phan/Language/Type/StringType.php
@@ -42,7 +42,7 @@ class StringType extends ScalarType
      */
     public function getTypeAfterIncOrDec() : UnionType
     {
-        return UnionType::fromFullyQualifiedString('int|string|float');
+        return UnionType::fromFullyQualifiedPHPDocString('int|string|float');
     }
 
     public function isValidNumericOperand() : bool

--- a/src/Phan/Language/Type/TemplateType.php
+++ b/src/Phan/Language/Type/TemplateType.php
@@ -130,7 +130,7 @@ final class TemplateType extends Type
     public function withTemplateParameterTypeMap(
         array $template_parameter_type_map
     ) : UnionType {
-        return $template_parameter_type_map[$this->template_type_identifier] ?? $this->asUnionType();
+        return $template_parameter_type_map[$this->template_type_identifier] ?? $this->asPHPDocUnionType();
     }
 
     /**

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -1943,6 +1943,7 @@ class UnionType implements Serializable
      * (e.g. mixed <-> string, etc.)
      *
      * TODO: Make this work for callable <-> string, etc.
+     * @suppress PhanUnreferencedPublicMethod
      */
     public function hasAnyTypeOverlap(CodeBase $code_base, UnionType $other) : bool {
         return $this->canStrictCastToUnionType($code_base, $other) || $other->canStrictCastToUnionType($code_base, $this);

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -107,7 +107,7 @@ class UnionType implements Serializable
      * @param ?array<int,Type> $real_type_set
      * @see UnionType::of() for a more memory efficient equivalent.
      */
-    public function __construct(array $type_list, bool $is_unique, ?array $real_type_set)
+    public function __construct(array $type_list, bool $is_unique = false, array $real_type_set = [])
     {
         $this->type_set = ($is_unique || \count($type_list) <= 1) ? $type_list : self::getUniqueTypes($type_list);
         $this->real_type_set = $real_type_set;

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -2397,6 +2397,23 @@ class UnionType implements Serializable
     }
 
     /**
+     * Returns the types for which is_float($x) would be true.
+     *
+     * @return UnionType
+     * A UnionType with known int types kept, other types filtered out.
+     *
+     * @see nonGenericArrayTypes
+     * @suppress PhanUnreferencedPublicMethod
+     */
+    public function floatTypes() : UnionType
+    {
+        return $this->makeFromFilter(static function (Type $type) : bool {
+            // IntType and LiteralIntType and FloatType
+            return $type instanceof IntType || $type instanceof FloatType;
+        });
+    }
+
+    /**
      * Returns the types for which is_string($x) would be true.
      *
      * @return UnionType

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -1143,6 +1143,18 @@ class UnionType implements Serializable
     }
 
     /**
+     * Returns true if is_null(expr) is unconditionally true for this type
+     */
+    public function isNull() : bool {
+        foreach ($this->type_set as $type) {
+            if (!($type instanceof NullType) && !($type instanceof VoidType)) {
+                return false;
+            }
+        }
+        return \count($this->type_set) !== 0;
+    }
+
+    /**
      * @return UnionType a clone of this that does not include null,
      *                   and has the non-null equivalents of any nullable types in this UnionType
      */

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -3158,8 +3158,8 @@ class UnionType implements Serializable
 
     /**
      * @param Type[] $type_set
-     * @param ?array<int,Type> $real_type_set
      * @param int $flags non-zero
+     * @param ?array<int,Type> $real_type_set
      */
     public static function asNormalizedTypesInner(array $type_set, int $flags, ?array $real_type_set) : UnionType
     {
@@ -3985,6 +3985,9 @@ class UnionType implements Serializable
         return \reset($type_set) instanceof VoidType;
     }
 
+    /**
+     * Shorter version of `UnionType::of($this->getTypeSet(), [$type])`
+     */
     public function withRealType(Type $type) : UnionType
     {
         $real_type_set = [$type];

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -91,12 +91,12 @@ class UnionType implements Serializable
         . '(\s*\|\s*' . Type::type_regex_or_this . ')*';
 
     /**
-     * @var array<int,Type> * This is an immutable list of unique types.
+     * @var array<int,Type> This is an immutable list of unique types.
      */
     private $type_set;
 
     /**
-     * @var ?array<int,Type> * This is an immutable list of unique types.
+     * @var array<int,Type> * This is an immutable list of unique types.
      */
     private $real_type_set;
 
@@ -104,7 +104,7 @@ class UnionType implements Serializable
      * @param array<int,Type> $type_list
      * An optional list of types represented by this union
      * @param bool $is_unique - Whether or not this is already unique. Only set to true within UnionType code.
-     * @param ?array<int,Type> $real_type_set
+     * @param array<int,Type> $real_type_set
      * @see UnionType::of() for a more memory efficient equivalent.
      */
     public function __construct(array $type_list, bool $is_unique = false, array $real_type_set = [])
@@ -115,9 +115,9 @@ class UnionType implements Serializable
 
     /**
      * @param Type[] $type_list
-     * @param ?array<int,Type> $real_type_set
+     * @param array<int,Type> $real_type_set
      */
-    public static function of(array $type_list, ?array $real_type_set) : UnionType
+    public static function of(array $type_list, array $real_type_set = []) : UnionType
     {
         $n = \count($type_list);
         if ($n === 0) {
@@ -149,7 +149,7 @@ class UnionType implements Serializable
         } elseif ($n === 1) {
             return \reset($type_list)->asPHPDocUnionType();
         } else {
-            return new self($type_list, true, null);
+            return new self($type_list, true, []);
         }
     }
 
@@ -178,6 +178,15 @@ class UnionType implements Serializable
     // And clone isn't necessary anymore now that type_set is immutable
 
     /**
+     * @deprecated use self::fromFullyQualifiedPHPDocString() instead.
+     */
+    public static function fromFullyQualifiedString(
+        string $fully_qualified_string
+    ) : UnionType {
+        return self::fromFullyQualifiedPHPDocString($fully_qualified_string);
+    }
+
+    /**
      * @param string $fully_qualified_string
      * A '|' delimited string representing a type in the form
      * 'int|string|null|ClassName'.
@@ -185,6 +194,8 @@ class UnionType implements Serializable
      * @return UnionType
      *
      * @throws InvalidArgumentException if any type name in the union type was invalid
+     *
+     * @see self::fromFullyQualifiedRealString() if you are absolutely sure this is the real type of the expression.
      */
     public static function fromFullyQualifiedPHPDocString(
         string $fully_qualified_string
@@ -212,8 +223,7 @@ class UnionType implements Serializable
                 // TODO: Support template types within <> and test?
                 $union_type = new UnionType(
                     $unique_types,
-                    true,
-                    null
+                    true
                 );
             }
             $memoize_map[$fully_qualified_string] = $union_type;
@@ -318,7 +328,7 @@ class UnionType implements Serializable
                 $code_base
             );
         }
-        return UnionType::of(self::normalizeMultiTypes($types), null);
+        return UnionType::of(self::normalizeMultiTypes($types));
     }
 
     /**
@@ -598,11 +608,13 @@ class UnionType implements Serializable
     }
 
     /**
-     * @return ?array<int,Type>
+     * @return array<int,Type>
      * The list of real simple types associated with this
      * union type. Keys are consecutive.
+     *
+     * If this is empty, the real union type is unknown
      */
-    public function getRealTypeSet() : ?array
+    public function getRealTypeSet() : array
     {
         return $this->real_type_set;
     }
@@ -622,7 +634,7 @@ class UnionType implements Serializable
         }
         // 2 or more types in type_set
         $type_set[] = $type;
-        return new UnionType($type_set, true, null);
+        return new UnionType($type_set, true, []);
     }
 
     /**
@@ -666,7 +678,7 @@ class UnionType implements Serializable
                 // @phan-suppress-next-line PhanPossiblyNonClassMethodCall
                 return \reset($this->type_set)->asPHPDocUnionType();
             }
-            return new UnionType($this->type_set, true, null);
+            return new UnionType($this->type_set, true, []);
         }
         return $this;
     }
@@ -700,7 +712,7 @@ class UnionType implements Serializable
                 }
             }
         } else {
-            $real_type_set = null;
+            $real_type_set = [];
         }
         return new UnionType($new_type_set, true, $real_type_set);
     }
@@ -807,7 +819,7 @@ class UnionType implements Serializable
             }
         }
 
-        return $has_template ? UnionType::of($concrete_type_list, null) : $this;
+        return $has_template ? UnionType::of($concrete_type_list, []) : $this;
     }
 
     /**
@@ -1538,6 +1550,11 @@ class UnionType implements Serializable
         $this_resolved_type_set =
             $this->withStaticResolvedInContext($context)->type_set;
 
+        // Convert this type to an array of resolved
+        // types.
+        $type_set =
+            $this->withStaticResolvedInContext($context)
+            ->getTypeSet();
         // TODO: Need to resolve expanded union types (parents, interfaces) of classes *before* this is called.
 
         // Test to see if every single type in this union
@@ -1793,18 +1810,18 @@ class UnionType implements Serializable
 
         if (Config::get_null_casts_as_any_type()) {
             // null <-> null
-            if ($this->isType($null_type)
-                || $target->isType($null_type)
+            // (this fork has weaker type casting rules than phan/phan, using hasType instead of isType)
+            if ($this->hasType(NullType::instance(false))
+                || $target->isType(NullType::instance(false))
             ) {
                 return true;
             }
-        } else {
-            // If null_casts_as_any_type isn't set, then try the other two fallbacks.
-            if (Config::get_null_casts_as_array() && $this->isType($null_type) && $target->hasArrayLike()) {
-                return true;
-            } elseif (Config::get_array_casts_as_null() && $target->isType($null_type) && $this->hasArrayLike()) {
-                return true;
-            }
+        } elseif (Config::get_null_casts_as_array() && $this->hasType(NullType::instance(false)) && $target->hasArrayLike()) {
+            // null->array
+            return true;
+        } elseif (Config::get_array_casts_as_null() && $target->isType(NullType::instance(false)) && $this->hasArrayLike()) {
+            // array -> null
+            return true;
         }
 
         // mixed <-> mixed
@@ -2132,7 +2149,7 @@ class UnionType implements Serializable
             return $this;
         }
         // TODO: look into filtering real_type_set
-        return new UnionType($new_type_list, true, $this->real_type_set && $this->allTypesMatchRealTypeSet($cb) ? $this->real_type_set : null);
+        return new UnionType($new_type_list, true, $this->real_type_set && $this->allTypesMatchRealTypeSet($cb) ? $this->real_type_set : []);
     }
 
     private function allTypesMatchRealTypeSet(Closure $cb) : bool
@@ -2732,7 +2749,7 @@ class UnionType implements Serializable
             // @phan-suppress-next-line PhanPossiblyNonClassMethodCall
             return \count($parts) === 1 ? \reset($parts)->asPHPDocUnionType() : self::$empty_instance;
         }
-        return new UnionType($parts, false, null);
+        return new UnionType($parts, false, []);
     }
 
     /**
@@ -2749,7 +2766,7 @@ class UnionType implements Serializable
         if (\count($parts) <= 1) {
             return \count($parts) === 1 ? \reset($parts)->asPHPDocUnionType() : self::$empty_instance;
         }
-        return new UnionType($parts, false, null);
+        return new UnionType($parts, false, []);
     }
 
     /**
@@ -3516,7 +3533,7 @@ class UnionType implements Serializable
         if ($types === $this->type_set) {
             return $this;
         }
-        return UnionType::of($types, null);
+        return UnionType::of($types, []);
     }
 
     /**
@@ -3530,7 +3547,7 @@ class UnionType implements Serializable
         if ($is_possibly_undefined === false) {
             return $this;
         }
-        $result = new AnnotatedUnionType($this->getTypeSet(), true, null);
+        $result = new AnnotatedUnionType($this->getTypeSet(), true, []);
         $result->is_possibly_undefined = $is_possibly_undefined;
         return $result;
     }

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -2696,7 +2696,7 @@ class UnionType implements Serializable
     {
         $parts = \array_map($closure, $this->type_set);
         if (\count($parts) <= 1) {
-            return \count($parts) === 1 ? \reset($parts)->asUnionType() : self::$empty_instance;
+            return \count($parts) === 1 ? \reset($parts)->asPHPDocUnionType() : self::$empty_instance;
         }
         return new UnionType($parts, false, null);
     }

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -2861,10 +2861,10 @@ class UnionType implements Serializable
     public function replaceWithTemplateTypes(UnionType $template_union_type) : UnionType
     {
         // TODO: Preserve nullable
+        $result = $this->eraseRealTypeSet();
         if ($template_union_type->isEmpty()) {
-            return $this;
+            return $result;
         }
-        $result = $this;
         foreach ($this->getTypeSet() as $type) {
             // TODO: Handle recursion
             if ($template_union_type->hasTypeWithFQSEN($type)) {
@@ -3993,6 +3993,9 @@ class UnionType implements Serializable
         $real_type_set = [$type];
         if ($this->real_type_set === $real_type_set) {
             return $this;
+        }
+        if (!$this->type_set) {
+            return $type->asRealUnionType();
         }
         $new_type = clone($this);
         $new_type->real_type_set = $real_type_set;

--- a/src/Phan/Language/UnionTypeBuilder.php
+++ b/src/Phan/Language/UnionTypeBuilder.php
@@ -73,8 +73,16 @@ final class UnionTypeBuilder
     /**
      * Build and return the UnionType for the unique type set that this was building.
      */
-    public function getUnionType() : UnionType
+    public function getRealUnionType() : UnionType
     {
-        return UnionType::of($this->type_set);
+        return UnionType::of($this->type_set, false, $this->type_set);
+    }
+
+    /**
+     * Build and return the UnionType for the unique type set that this was building.
+     */
+    public function getPHPDocUnionType() : UnionType
+    {
+        return UnionType::of($this->type_set, false, null);
     }
 }

--- a/src/Phan/Language/UnionTypeBuilder.php
+++ b/src/Phan/Language/UnionTypeBuilder.php
@@ -75,7 +75,7 @@ final class UnionTypeBuilder
      */
     public function getRealUnionType() : UnionType
     {
-        return UnionType::of($this->type_set, false, $this->type_set);
+        return UnionType::of($this->type_set, $this->type_set);
     }
 
     /**
@@ -83,6 +83,6 @@ final class UnionTypeBuilder
      */
     public function getPHPDocUnionType() : UnionType
     {
-        return UnionType::of($this->type_set, false, null);
+        return UnionType::of($this->type_set, null);
     }
 }

--- a/src/Phan/Language/UnionTypeBuilder.php
+++ b/src/Phan/Language/UnionTypeBuilder.php
@@ -73,14 +73,6 @@ final class UnionTypeBuilder
     /**
      * Build and return the UnionType for the unique type set that this was building.
      */
-    public function getRealUnionType() : UnionType
-    {
-        return UnionType::of($this->type_set, $this->type_set);
-    }
-
-    /**
-     * Build and return the UnionType for the unique type set that this was building.
-     */
     public function getPHPDocUnionType() : UnionType
     {
         return UnionType::of($this->type_set, null);

--- a/src/Phan/Language/UnionTypeBuilder.php
+++ b/src/Phan/Language/UnionTypeBuilder.php
@@ -75,6 +75,15 @@ final class UnionTypeBuilder
      */
     public function getPHPDocUnionType() : UnionType
     {
-        return UnionType::of($this->type_set, null);
+        return UnionType::of($this->type_set, []);
+    }
+
+    /**
+     * Build and return the UnionType for the unique type set that this was building.
+     * @deprecated use self::getPHPDocUnionType()
+     */
+    public function getUnionType() : UnionType
+    {
+        return self::getPHPDocUnionType();
     }
 }

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -129,7 +129,7 @@ class ParseVisitor extends ScopeVisitor
         $class = new Clazz(
             $class_context,
             $class_name,
-            $class_fqsen->asUnionType(),
+            $class_fqsen->asRealUnionType(),
             $node->flags ?? 0,
             $class_fqsen
         );
@@ -463,9 +463,9 @@ class ParseVisitor extends ScopeVisitor
                 } else {
                     // Get the type of the default (not a literal)
                     if ($variable_has_literals) {
-                        $union_type = Type::fromObject($default_node)->asUnionType();
+                        $union_type = Type::fromObject($default_node)->asPHPDocUnionType();
                     } else {
-                        $union_type = Type::nonLiteralFromObject($default_node)->asUnionType();
+                        $union_type = Type::nonLiteralFromObject($default_node)->asPHPDocUnionType();
                     }
                 }
                 if (!$real_union_type->isEmpty() && !$union_type->canStrictCastToUnionType($this->code_base, $real_union_type)) {
@@ -544,7 +544,7 @@ class ParseVisitor extends ScopeVisitor
                     }
                     if ($future_union_type === null) {
                         if ($original_union_type->isType(ArrayShapeType::empty())) {
-                            $union_type = ArrayType::instance(false)->asUnionType();
+                            $union_type = ArrayType::instance(false)->asPHPDocUnionType();
                         } elseif ($original_union_type->isType(NullType::instance(false))) {
                             $union_type = UnionType::empty();
                         } else {
@@ -718,14 +718,14 @@ class ParseVisitor extends ScopeVisitor
                         )
                     );
                 } catch (InvalidArgumentException $_) {
-                    $constant->setUnionType(MixedType::instance(false)->asUnionType());
+                    $constant->setUnionType(MixedType::instance(false)->asPHPDocUnionType());
                     $this->emitIssue(
                         Issue::InvalidConstantExpression,
                         $value_node->lineno
                     );
                 }
             } else {
-                $constant->setUnionType(Type::fromObject($value_node)->asUnionType());
+                $constant->setUnionType(Type::fromObject($value_node)->asPHPDocUnionType());
             }
             $constant->setNodeForValue($value_node);
 
@@ -1413,7 +1413,7 @@ class ParseVisitor extends ScopeVisitor
                     )
                 );
             } else {
-                $constant->setUnionType(Type::fromObject($value)->asUnionType());
+                $constant->setUnionType(Type::fromObject($value)->asPHPDocUnionType());
             }
         } else {
             $constant->setUnionType(UnionTypeVisitor::unionTypeFromNode($code_base, $context, $value));

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -839,7 +839,8 @@ final class ConfigPluginSet extends PluginV3 implements
                 \array_unshift($internal_return_type_plugins, new ExtendedDependentReturnTypeOverridePlugin());
             }
             $plugin_set = \array_merge($internal_return_type_plugins, $plugin_set);
-            // TODO: Add config option (on by default)
+        }
+        if (Config::getValue('redundant_condition_detection')) {
             $plugin_set[] = new RedundantConditionCallPlugin();
         }
         if (Config::getValue('enable_include_path_checks')) {

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -37,6 +37,7 @@ use Phan\Plugin\Internal\IssueFixingPlugin\IssueFixer;
 use Phan\Plugin\Internal\MiscParamPlugin;
 use Phan\Plugin\Internal\NodeSelectionPlugin;
 use Phan\Plugin\Internal\NodeSelectionVisitor;
+use Phan\Plugin\Internal\RedundantConditionCallPlugin;
 use Phan\Plugin\Internal\RequireExistsPlugin;
 use Phan\Plugin\Internal\StringFunctionPlugin;
 use Phan\Plugin\Internal\ThrowAnalyzerPlugin;
@@ -838,6 +839,8 @@ final class ConfigPluginSet extends PluginV3 implements
                 \array_unshift($internal_return_type_plugins, new ExtendedDependentReturnTypeOverridePlugin());
             }
             $plugin_set = \array_merge($internal_return_type_plugins, $plugin_set);
+            // TODO: Add config option (on by default)
+            $plugin_set[] = new RedundantConditionCallPlugin();
         }
         if (Config::getValue('enable_include_path_checks')) {
             $plugin_set[] = new RequireExistsPlugin();

--- a/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
@@ -370,7 +370,7 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
                 }
                 $array_shape_type = ArrayShapeType::fromFieldTypes([$key_type, $element_types], false);
 
-                return new UnionType([$array_shape_type, $false_type], false, [$array_type, $false_type]);
+                return new UnionType([$array_shape_type, $false_type], false, [ArrayType::instance(false), $false_type]);
             }
             return $mixed_type->asPHPDocUnionType();
         };

--- a/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
@@ -14,10 +14,8 @@ use Phan\Language\Type\ArrayShapeType;
 use Phan\Language\Type\ArrayType;
 use Phan\Language\Type\FalseType;
 use Phan\Language\Type\GenericArrayType;
-use Phan\Language\Type\IntType;
 use Phan\Language\Type\MixedType;
 use Phan\Language\Type\NullType;
-use Phan\Language\Type\StringType;
 use Phan\Language\UnionType;
 use Phan\PluginV3;
 use Phan\PluginV3\ReturnTypeOverrideCapability;
@@ -27,6 +25,8 @@ use function count;
  * NOTE: This is automatically loaded by phan. Do not include it in a config.
  *
  * TODO: Refactor this.
+ *
+ * TODO: Support real types (e.g. array_values() if the passed in real union type is an array, otherwise real type is ?array
  *
  * @phan-file-suppress PhanUnusedClosureParameter
  */
@@ -42,12 +42,10 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
         $mixed_type  = MixedType::instance(false);
         $false_type  = FalseType::instance(false);
         $array_type  = ArrayType::instance(false);
-        $int_type    = IntType::instance(false);
-        $string_type = StringType::instance(false);
         $null_type   = NullType::instance(false);
-        $int_or_string_or_false = new UnionType([$int_type, $string_type, $false_type]);
-        $int_or_string_or_null = new UnionType([$int_type, $string_type, $null_type]);
-        $int_or_string = new UnionType([$int_type, $string_type]);
+        $int_or_string_or_false = UnionType::fromFullyQualifiedPHPDocString('int|string|false');
+        $int_or_string_or_null = UnionType::fromFullyQualifiedPHPDocString('int|string|null');
+        $int_or_string = UnionType::fromFullyQualifiedPHPDocString('int|string');
 
         /**
          * @param array<int,Node|int|float|string> $args
@@ -60,7 +58,7 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
                     return $element_types->withType($false_type);
                 }
             }
-            return $mixed_type->asUnionType();
+            return $mixed_type->asPHPDocUnionType();
         };
         /**
          * @param array<int,Node|int|float|string> $args
@@ -114,7 +112,7 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
                     return $element_types->withFlattenedArrayShapeOrLiteralTypeInstances();
                 }
             }
-            return $array_type->asUnionType();
+            return $array_type->asPHPDocUnionType();
         };
         /**
          * @param array<int,Node|int|float|string> $args
@@ -126,13 +124,13 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
                 $element_types = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $args[1]);
                 if ($element_types->isEmpty()) {
                     if ($key_type_enum === GenericArrayType::KEY_MIXED) {
-                        return $array_type->asUnionType();
+                        return $array_type->asPHPDocUnionType();
                     }
-                    $element_types = $mixed_type->asUnionType();
+                    $element_types = $mixed_type->asPHPDocUnionType();
                 }
                 return $element_types->asNonEmptyGenericArrayTypes($key_type_enum);
             }
-            return $array_type->asUnionType();
+            return $array_type->asPHPDocUnionType();
         };
 
         /**
@@ -143,7 +141,7 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
                 $element_types = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $args[2]);
                 return $element_types->asNonEmptyGenericArrayTypes(GenericArrayType::KEY_INT);
             }
-            return $array_type->asUnionType();
+            return $array_type->asPHPDocUnionType();
         };
 
         /**
@@ -190,7 +188,7 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
                     return $generic_passed_array_type->withFlattenedArrayShapeOrLiteralTypeInstances();
                 }
             }
-            return $array_type->asUnionType();
+            return $array_type->asPHPDocUnionType();
         };
 
         /**
@@ -198,11 +196,11 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
          */
         $array_reduce_callback = static function (CodeBase $code_base, Context $context, Func $function, array $args) use ($mixed_type) : UnionType {
             if (\count($args) < 2) {
-                return $mixed_type->asUnionType();
+                return $mixed_type->asPHPDocUnionType();
             }
             $function_like_list = UnionTypeVisitor::functionLikeListFromNodeAndContext($code_base, $context, $args[1], true);
             if (\count($function_like_list) === 0) {
-                return $mixed_type->asUnionType();
+                return $mixed_type->asPHPDocUnionType();
             }
             $function_return_types = UnionType::empty();
             foreach ($function_like_list as $function_like) {
@@ -241,11 +239,11 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
             array $args
         ) use ($array_type) : UnionType {
             if (\count($args) < 2) {
-                return $array_type->asUnionType();
+                return $array_type->asPHPDocUnionType();
             }
             $function_like_list = UnionTypeVisitor::functionLikeListFromNodeAndContext($code_base, $context, $args[0], true);
             if (\count($function_like_list) === 0) {
-                return $array_type->asUnionType();
+                return $array_type->asPHPDocUnionType();
             }
             $arguments = \array_slice($args, 1);
             $possible_return_types = UnionType::empty();
@@ -307,7 +305,7 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
                 }
             }
             if ($possible_return_types->isEmpty()) {
-                return $array_type->asUnionType();
+                return $array_type->asPHPDocUnionType();
             }
             if (count($arguments) >= 2) {
                 // There were two or more arrays passed to the closure
@@ -323,7 +321,7 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
          */
         $array_pad_callback = static function (CodeBase $code_base, Context $context, Func $function, array $args) use ($array_type) : UnionType {
             if (\count($args) != 3) {
-                return $array_type->asUnionType();
+                return $array_type->asPHPDocUnionType();
             }
             $padded_array_type = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $args[0]);
             $result_types = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $args[2])->asGenericArrayTypes(GenericArrayType::KEY_INT);
@@ -336,13 +334,13 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
         /**
          * @param array<int,Node|int|string|float> $args
          */
-        $array_keys_callback = static function (CodeBase $code_base, Context $context, Func $function, array $args) use ($array_type, $int_type, $string_type) : UnionType {
+        $array_keys_callback = static function (CodeBase $code_base, Context $context, Func $function, array $args) use ($array_type) : UnionType {
             if (\count($args) != 1) {
-                return $array_type->asUnionType();
+                return $array_type->asPHPDocUnionType();
             }
             $key_union_type = UnionTypeVisitor::unionTypeOfArrayKeyForNode($code_base, $context, $args[0]);
             if ($key_union_type === null) {
-                $key_union_type = new UnionType([$int_type, $string_type], true);
+                $key_union_type = UnionType::fromFullyQualifiedPHPDocString('int|string');
             }
             return $key_union_type->asGenericArrayTypes(GenericArrayType::KEY_INT);
         };
@@ -351,7 +349,7 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
          */
         $array_values_callback = static function (CodeBase $code_base, Context $context, Func $function, array $args) use ($array_type) : UnionType {
             if (\count($args) != 1) {
-                return $array_type->asUnionType();
+                return $array_type->asPHPDocUnionType();
             }
             $union_type = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $args[0]);
             $element_type = $union_type->genericArrayElementTypes();
@@ -372,16 +370,16 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
                 }
                 $array_shape_type = ArrayShapeType::fromFieldTypes([$key_type, $element_types], false);
 
-                return new UnionType([$array_shape_type, $false_type]);
+                return new UnionType([$array_shape_type, $false_type], false, [$array_type, $false_type]);
             }
-            return $mixed_type->asUnionType();
+            return $mixed_type->asPHPDocUnionType();
         };
         /**
          * @param array<int,Node|int|float|string> $args
          */
         $array_combine_callback = static function (CodeBase $code_base, Context $context, Func $function, array $args) use ($array_type) : UnionType {
             if (\count($args) < 2) {
-                return $array_type->asUnionType();
+                return $array_type->asPHPDocUnionType();
             }
             $keys_type = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $args[0]);
             $values_type = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $args[1]);

--- a/src/Phan/Plugin/Internal/ClosureReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ClosureReturnTypeOverridePlugin.php
@@ -15,6 +15,7 @@ use Phan\Language\Element\FunctionInterface;
 use Phan\Language\Element\Method;
 use Phan\Language\Type;
 use Phan\Language\Type\ClosureType;
+use Phan\Language\Type\NullType;
 use Phan\Language\UnionType;
 use Phan\PluginV3;
 use Phan\PluginV3\AnalyzeFunctionCallCapability;
@@ -134,11 +135,12 @@ final class ClosureReturnTypeOverridePlugin extends PluginV3 implements
             array $args
         ) : UnionType {
             if (\count($args) < 1) {
-                return ClosureType::instance(false)->asUnionType();
+                // Emits warning and returns null if 0 args given
+                return NullType::instance(false)->asRealUnionType();
             }
             $function_like_list = UnionTypeVisitor::functionLikeListFromNodeAndContext($code_base, $context, $args[0], true);
             if (\count($function_like_list) === 0) {
-                return ClosureType::instance(false)->asUnionType();
+                return ClosureType::instance(false)->asPHPDocUnionType();
             }
             $closure_types = UnionType::empty();
             foreach ($function_like_list as $function_like) {
@@ -156,7 +158,7 @@ final class ClosureReturnTypeOverridePlugin extends PluginV3 implements
             array $args
         ) : UnionType {
             if (\count($args) < 1) {
-                return ClosureType::instance(false)->asUnionType();
+                return NullType::instance(false)->asRealUnionType();
             }
             $types = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $args[0], true);
             $types = $types->makeFromFilter(static function (Type $type) : bool {
@@ -167,7 +169,7 @@ final class ClosureReturnTypeOverridePlugin extends PluginV3 implements
             });
 
             if ($types->isEmpty()) {
-                return ClosureType::instance(false)->asUnionType();
+                return ClosureType::instance(false)->asPHPDocUnionType();
             }
             return $types;
         };

--- a/src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php
@@ -31,6 +31,8 @@ use function is_string;
  * or regex function appear to have arguments in the wrong order,
  *
  * e.g. explode($var, ':') or strpos(':', $x)
+ *
+ * TODO: Make these have corresponding real type sets in the union type.
  */
 final class DependentReturnTypeOverridePlugin extends PluginV3 implements
     ReturnTypeOverrideCapability
@@ -44,12 +46,12 @@ final class DependentReturnTypeOverridePlugin extends PluginV3 implements
      */
     public static function getReturnTypeOverridesStatic(CodeBase $code_base) : array
     {
-        $string_union_type = StringType::instance(false)->asUnionType();
-        $true_union_type = TrueType::instance(false)->asUnionType();
+        $string_union_type = StringType::instance(false)->asPHPDocUnionType();
+        $true_union_type = TrueType::instance(false)->asPHPDocUnionType();
         $string_or_true_union_type = $string_union_type->withUnionType($true_union_type);
-        $void_union_type = VoidType::instance(false)->asUnionType();
-        $nullable_string_union_type = StringType::instance(true)->asUnionType();
-        $float_union_type = FloatType::instance(false)->asUnionType();
+        $void_union_type = VoidType::instance(false)->asPHPDocUnionType();
+        $nullable_string_union_type = StringType::instance(true)->asPHPDocUnionType();
+        $float_union_type = FloatType::instance(false)->asPHPDocUnionType();
         $string_or_float_union_type = $string_union_type->withUnionType($float_union_type);
 
         /**
@@ -92,8 +94,8 @@ final class DependentReturnTypeOverridePlugin extends PluginV3 implements
          * @phan-return Closure(CodeBase,Context,Func,array):UnionType
          */
         $make_arg_existence_dependent_type_method = static function (int $arg_pos, string $type_if_exists_string, string $type_if_missing_string) : Closure {
-            $type_if_exists = UnionType::fromFullyQualifiedString($type_if_exists_string);
-            $type_if_missing = UnionType::fromFullyQualifiedString($type_if_missing_string);
+            $type_if_exists = UnionType::fromFullyQualifiedPHPDocString($type_if_exists_string);
+            $type_if_missing = UnionType::fromFullyQualifiedPHPDocString($type_if_missing_string);
             /**
              * @param array<int,Node|int|float|string> $args
              */
@@ -111,9 +113,9 @@ final class DependentReturnTypeOverridePlugin extends PluginV3 implements
             };
         };
 
-        $json_decode_array_types = UnionType::fromFullyQualifiedString('array|string|float|int|bool|null');
-        $json_decode_object_types = UnionType::fromFullyQualifiedString('\stdClass|array<int,mixed>|string|float|int|bool|null');
-        $json_decode_array_or_object_types = UnionType::fromFullyQualifiedString('\stdClass|array|string|float|int|bool|null');
+        $json_decode_array_types = UnionType::fromFullyQualifiedPHPDocString('array|string|float|int|bool|null');
+        $json_decode_object_types = UnionType::fromFullyQualifiedPHPDocString('\stdClass|array<int,mixed>|string|float|int|bool|null');
+        $json_decode_array_or_object_types = UnionType::fromFullyQualifiedPHPDocString('\stdClass|array|string|float|int|bool|null');
 
         $string_if_2_true           = $make_dependent_type_method(1, $string_union_type, $void_union_type, $nullable_string_union_type);
         $string_if_2_true_else_true = $make_dependent_type_method(1, $string_union_type, $true_union_type, $string_or_true_union_type);
@@ -161,8 +163,8 @@ final class DependentReturnTypeOverridePlugin extends PluginV3 implements
             return ($options_result & \JSON_OBJECT_AS_ARRAY) !== 0 ? $json_decode_array_types : $json_decode_object_types;
         };
 
-        $str_replace_types = UnionType::fromFullyQualifiedString('string|string[]');
-        $str_array_type = UnionType::fromFullyQualifiedString('string[]');
+        $str_replace_types = UnionType::fromFullyQualifiedPHPDocString('string|string[]');
+        $str_array_type = UnionType::fromFullyQualifiedPHPDocString('string[]');
 
         /**
          * @param array<int,Node|int|float|string> $args
@@ -190,7 +192,7 @@ final class DependentReturnTypeOverridePlugin extends PluginV3 implements
             }
             return $has_array ? $str_array_type : $str_replace_types;
         };
-        $string_or_false = UnionType::fromFullyQualifiedString('string|false');
+        $string_or_false = UnionType::fromFullyQualifiedPHPDocString('string|false');
         /**
          * @param array<int,Node|int|float|string> $args
          */
@@ -201,7 +203,7 @@ final class DependentReturnTypeOverridePlugin extends PluginV3 implements
             array $args
         ) use ($string_or_false) : UnionType {
             if (count($args) === 0 && Config::get_closest_target_php_version_id() >= 70100) {
-                return UnionType::fromFullyQualifiedString('array<string,string>');
+                return UnionType::fromFullyQualifiedPHPDocString('array<string,string>');
             }
             return $string_or_false;
         };
@@ -252,7 +254,7 @@ final class DependentReturnTypeOverridePlugin extends PluginV3 implements
                 }
                 if ($levels <= 0) {
                     // TODO: Could warn but not common
-                    return NullType::instance(false)->asUnionType();
+                    return NullType::instance(false)->asPHPDocUnionType();
                 }
             } else {
                 $levels = 1;
@@ -263,7 +265,7 @@ final class DependentReturnTypeOverridePlugin extends PluginV3 implements
             }
 
             $result = \dirname($arg, $levels);
-            return Type::fromObject($result)->asUnionType();
+            return Type::fromObject($result)->asPHPDocUnionType();
         };
 
         // TODO: Handle flags of preg_split.
@@ -294,7 +296,7 @@ final class DependentReturnTypeOverridePlugin extends PluginV3 implements
      */
     private static function makeStringFunctionHandler(callable $callable) : Closure
     {
-        $string_union_type = StringType::instance(false)->asUnionType();
+        $string_union_type = StringType::instance(false)->asPHPDocUnionType();
         /**
          * @param array<int,Node|int|float|string> $args
          */
@@ -317,7 +319,7 @@ final class DependentReturnTypeOverridePlugin extends PluginV3 implements
             }
 
             $result = $callable($arg);
-            return Type::fromObject($result)->asUnionType();
+            return Type::fromObject($result)->asPHPDocUnionType();
         };
     }
 

--- a/src/Phan/Plugin/Internal/ExtendedDependentReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ExtendedDependentReturnTypeOverridePlugin.php
@@ -36,8 +36,8 @@ final class ExtendedDependentReturnTypeOverridePlugin extends PluginV3 implement
      */
     private static function getReturnTypeOverridesStatic(CodeBase $code_base) : array
     {
-        $string_union_type = StringType::instance(false)->asUnionType();
-        $mixed_union_type = MixedType::instance(false)->asUnionType();
+        $string_union_type = StringType::instance(false)->asPHPDocUnionType();
+        $mixed_union_type = MixedType::instance(false)->asPHPDocUnionType();
         /**
          * @param callable-string $function
          * @return Closure(CodeBase,Context,Func,array):UnionType
@@ -90,7 +90,7 @@ final class ExtendedDependentReturnTypeOverridePlugin extends PluginV3 implement
                     );
                     return $default_type;
                 }
-                return Type::fromObjectExtended($result)->asUnionType();
+                return Type::fromObjectExtended($result)->asPHPDocUnionType();
             };
         };
         $basic_return_type_overrides = (new DependentReturnTypeOverridePlugin())->getReturnTypeOverrides($code_base);
@@ -120,7 +120,7 @@ final class ExtendedDependentReturnTypeOverridePlugin extends PluginV3 implement
                 return $cb_fallback($code_base, $context, $function_decl, $args);
             };
         };
-        $int_union_type = IntType::instance(false)->asUnionType();
+        $int_union_type = IntType::instance(false)->asPHPDocUnionType();
 
         return [
             // commonly used functions where the return type depends only on the passed in arguments
@@ -128,11 +128,11 @@ final class ExtendedDependentReturnTypeOverridePlugin extends PluginV3 implement
             'abs'          => $wrap_n_argument_function('abs', 1, 1, $int_union_type),
             'addcslashes'  => $wrap_n_argument_function('addcslashes', 2),
             'addslashes'   => $wrap_n_argument_function('addslashes', 1),
-            'explode'      => $wrap_n_argument_function('explode', 2, 3, UnionType::fromFullyQualifiedString('array<int,string>')),
+            'explode'      => $wrap_n_argument_function('explode', 2, 3, UnionType::fromFullyQualifiedPHPDocString('array<int,string>')),
             'implode'      => $wrap_n_argument_function('implode', 1, 2),
             // TODO: Improve this to warn about invalid json with json_error_last()
             'json_decode'  => $wrap_n_argument_function_with_fallback('json_decode', 1, 4),
-            'json_encode'  => $wrap_n_argument_function('json_encode', 1, 3, UnionType::fromFullyQualifiedString('string|false')),
+            'json_encode'  => $wrap_n_argument_function('json_encode', 1, 3, UnionType::fromFullyQualifiedRealString('string|false')),
             'substr'       => $wrap_n_argument_function('substr', 1, 3),
             'strlen'       => $wrap_n_argument_function('strlen', 1, 3),
             'join'         => $wrap_n_argument_function('join', 1),

--- a/src/Phan/Plugin/Internal/MethodSearcherPlugin.php
+++ b/src/Phan/Plugin/Internal/MethodSearcherPlugin.php
@@ -84,7 +84,7 @@ final class MethodSearcherPlugin extends PluginV3 implements
                 if ($replacements === [$type]) {
                     continue;
                 }
-                $union_type = $union_type->withoutType($type)->withUnionType(UnionType::of($replacements, null));
+                $union_type = $union_type->withoutType($type)->withUnionType(UnionType::of($replacements, []));
             } elseif ($type instanceof GenericArrayType) {
                 $element_type = $type->genericArrayElementType();
                 $replacement_element_types = self::addMissingNamespaces($code_base, $element_type->asPHPDocUnionType());

--- a/src/Phan/Plugin/Internal/MethodSearcherPlugin.php
+++ b/src/Phan/Plugin/Internal/MethodSearcherPlugin.php
@@ -84,10 +84,10 @@ final class MethodSearcherPlugin extends PluginV3 implements
                 if ($replacements === [$type]) {
                     continue;
                 }
-                $union_type = $union_type->withoutType($type)->withUnionType(UnionType::of($replacements));
+                $union_type = $union_type->withoutType($type)->withUnionType(UnionType::of($replacements, null));
             } elseif ($type instanceof GenericArrayType) {
                 $element_type = $type->genericArrayElementType();
-                $replacement_element_types = self::addMissingNamespaces($code_base, $element_type->asUnionType());
+                $replacement_element_types = self::addMissingNamespaces($code_base, $element_type->asPHPDocUnionType());
                 if ($replacement_element_types->isType($element_type)) {
                     continue;
                 }
@@ -213,7 +213,7 @@ final class MethodSearcherPlugin extends PluginV3 implements
         }
         // TODO: Set strict type casting rules here?
         if ($function instanceof Method && \in_array(\strtolower($function->getName()), ['__construct', '__clone'], true)) {
-            $return_type = $function->getFQSEN()->getFullyQualifiedClassName()->asType()->asUnionType();
+            $return_type = $function->getFQSEN()->getFullyQualifiedClassName()->asType()->asPHPDocUnionType();
         } else {
             $return_type = $function->getUnionType();
         }
@@ -233,7 +233,7 @@ final class MethodSearcherPlugin extends PluginV3 implements
             $signature_param_types[] = $param->getUnionType();
         }
         if ($function instanceof Method) {
-            $signature_param_types[] = $function->getFQSEN()->getFullyQualifiedClassName()->asType()->asUnionType();
+            $signature_param_types[] = $function->getFQSEN()->getFullyQualifiedClassName()->asType()->asPHPDocUnionType();
         }
         if (count($signature_param_types) < count(self::$param_types)) {
             return 0;
@@ -254,11 +254,11 @@ final class MethodSearcherPlugin extends PluginV3 implements
                 return $union_type;
             }
             if (!$function->isAbstract() && !$function->isPHPInternal() && !$function->hasReturn()) {
-                return UnionType::fromFullyQualifiedString('void');
+                return UnionType::fromFullyQualifiedPHPDocString('void');
             }
         } else {
             if (!$function->isPHPInternal() && !$function->hasReturn()) {
-                return UnionType::fromFullyQualifiedString('void');
+                return UnionType::fromFullyQualifiedRealString('void');
             }
         }
         return UnionType::empty();
@@ -289,13 +289,13 @@ final class MethodSearcherPlugin extends PluginV3 implements
                 if ($inner_type->isObjectWithKnownFQSEN()) {
                     $result += 5;
                 } else {
-                    if ($inner_type->isScalar() && !$actual_signature_type->canCastToUnionType($inner_type->asUnionType())) {
+                    if ($inner_type->isScalar() && !$actual_signature_type->canCastToUnionType($inner_type->asPHPDocUnionType())) {
                         $result += 0.5;
                         continue;
                     }
                     $result += 1;
                 }
-            } elseif ($expanded_actual_signature_type->canCastToUnionType($inner_type->asUnionType())) {
+            } elseif ($expanded_actual_signature_type->canCastToUnionType($inner_type->asPHPDocUnionType())) {
                 $result += 0.5;
             }
         }

--- a/src/Phan/Plugin/Internal/MiscParamPlugin.php
+++ b/src/Phan/Plugin/Internal/MiscParamPlugin.php
@@ -64,7 +64,7 @@ final class MiscParamPlugin extends PluginV3 implements
                 $args[0],
                 $context,
                 $code_base,
-                ArrayType::instance(false)->asUnionType(),
+                ArrayType::instance(false)->asPHPDocUnionType(),
                 static function (UnionType $node_type) use ($context, $function) : IssueInstance {
                     // "arg#1(values) is %s but {$function->getFQSEN()}() takes array when passed only one arg"
                     return Issue::fromType(Issue::ParamSpecial2)(
@@ -98,7 +98,7 @@ final class MiscParamPlugin extends PluginV3 implements
                 $args[$argcount - 1],
                 $context,
                 $code_base,
-                CallableType::instance(false)->asUnionType(),
+                CallableType::instance(false)->asPHPDocUnionType(),
                 static function (UnionType $unused_node_type) use ($context, $function) : IssueInstance {
                     // "The last argument to {$function->getFQSEN()} must be a callable"
                     return Issue::fromType(Issue::ParamSpecial3)(
@@ -117,7 +117,7 @@ final class MiscParamPlugin extends PluginV3 implements
                     $args[$i],
                     $context,
                     $code_base,
-                    ArrayType::instance(false)->asUnionType(),
+                    ArrayType::instance(false)->asPHPDocUnionType(),
                     static function (UnionType $node_type) use ($context, $function, $i) : IssueInstance {
                         // "arg#".($i+1)." is %s but {$function->getFQSEN()}() takes array"
                         return Issue::fromType(Issue::ParamTypeMismatch)(
@@ -188,7 +188,7 @@ final class MiscParamPlugin extends PluginV3 implements
                 // TODO: better array checks
                 if ($arg1_type->isExclusivelyArray()) {
                     if (!$arg2_type->canCastToUnionType(
-                        StringType::instance(false)->asUnionType()
+                        StringType::instance(false)->asPHPDocUnionType()
                     )) {
                         Issue::maybeEmit(
                             $code_base,
@@ -220,7 +220,7 @@ final class MiscParamPlugin extends PluginV3 implements
                     throw $stop_exception;
                 } elseif ($arg1_type->isNonNullStringType()) {
                     if (!$arg2_type->canCastToUnionType(
-                        ArrayType::instance(false)->asUnionType()
+                        ArrayType::instance(false)->asPHPDocUnionType()
                     )) {
                         Issue::maybeEmit(
                             $code_base,
@@ -272,7 +272,7 @@ final class MiscParamPlugin extends PluginV3 implements
                 $args[$argcount - 1],
                 $context,
                 $code_base,
-                CallableType::instance(false)->asUnionType(),
+                CallableType::instance(false)->asPHPDocUnionType(),
                 static function (UnionType $unused_node_type) use ($context, $function) : IssueInstance {
                     // "The last argument to {$function->getFQSEN()} must be a callable"
                     return Issue::fromType(Issue::ParamSpecial3)(
@@ -290,7 +290,7 @@ final class MiscParamPlugin extends PluginV3 implements
                 $args[$argcount - 2],
                 $context,
                 $code_base,
-                CallableType::instance(false)->asUnionType(),
+                CallableType::instance(false)->asPHPDocUnionType(),
                 static function (UnionType $unused_node_type) use ($context, $function) : IssueInstance {
                     // "The second last argument to {$function->getFQSEN()} must be a callable"
                     return Issue::fromType(Issue::ParamSpecial4)(
@@ -309,7 +309,7 @@ final class MiscParamPlugin extends PluginV3 implements
                     $args[$i],
                     $context,
                     $code_base,
-                    ArrayType::instance(false)->asUnionType(),
+                    ArrayType::instance(false)->asPHPDocUnionType(),
                     static function (UnionType $node_type) use ($context, $function, $i) : IssueInstance {
                     // "arg#".($i+1)." is %s but {$function->getFQSEN()}() takes array"
                         return Issue::fromType(Issue::ParamTypeMismatch)(
@@ -792,7 +792,7 @@ final class MiscParamPlugin extends PluginV3 implements
     private static function canCastToStringArrayLike(CodeBase $code_base, Context $context, UnionType $union_type) : bool
     {
         if ($union_type->canCastToUnionType(
-            UnionType::fromFullyQualifiedString('string[]|int[]')
+            UnionType::fromFullyQualifiedPHPDocString('string[]|int[]')
         )) {
             return true;
         }

--- a/src/Phan/Plugin/Internal/RedundantConditionCallPlugin.php
+++ b/src/Phan/Plugin/Internal/RedundantConditionCallPlugin.php
@@ -74,7 +74,7 @@ final class RedundantConditionCallPlugin extends PluginV3 implements
                     Issue::maybeEmit(
                         $code_base,
                         $context,
-                        Issue::TypeRedundantCondition,
+                        Issue::RedundantCondition,
                         $args[0]->lineno ?? $context->getLineNumberStart(),
                         ASTReverter::toShortString($args[0]),
                         $union_type->getRealUnionType(),
@@ -84,7 +84,7 @@ final class RedundantConditionCallPlugin extends PluginV3 implements
                     Issue::maybeEmit(
                         $code_base,
                         $context,
-                        Issue::TypeImpossibleCondition,
+                        Issue::ImpossibleCondition,
                         $args[0]->lineno ?? $context->getLineNumberStart(),
                         ASTReverter::toShortString($args[0]),
                         $union_type->getRealUnionType(),
@@ -259,7 +259,7 @@ class RedundantConditionVisitor extends PluginAwarePostAnalysisVisitor {
         $real_type = $type->getRealUnionType();
         if (!$real_type->containsTruthy()) {
             $this->emitIssue(
-                Issue::TypeRedundantCondition,
+                Issue::RedundantCondition,
                 $node->lineno ?? $var_node->lineno,
                 ASTReverter::toShortString($var_node),
                 $real_type,
@@ -267,7 +267,7 @@ class RedundantConditionVisitor extends PluginAwarePostAnalysisVisitor {
             );
         } elseif (!$real_type->containsFalsey()) {
             $this->emitIssue(
-                Issue::TypeImpossibleCondition,
+                Issue::ImpossibleCondition,
                 $node->lineno ?? $var_node->lineno,
                 ASTReverter::toShortString($var_node),
                 $real_type,
@@ -293,7 +293,7 @@ class RedundantConditionVisitor extends PluginAwarePostAnalysisVisitor {
         $real_type = $type->getRealUnionType();
         if (!$type->containsNullableOrUndefined()) {
             $this->emitIssue(
-                Issue::TypeRedundantCondition,
+                Issue::RedundantCondition,
                 $node->lineno ?? $var_node->lineno,
                 ASTReverter::toShortString($var_node),
                 $real_type,
@@ -301,7 +301,7 @@ class RedundantConditionVisitor extends PluginAwarePostAnalysisVisitor {
             );
         } elseif ($type->isNull()) {
             $this->emitIssue(
-                Issue::TypeImpossibleCondition,
+                Issue::ImpossibleCondition,
                 $node->lineno ?? $var_node->lineno,
                 ASTReverter::toShortString($var_node),
                 $real_type,

--- a/src/Phan/Plugin/Internal/RedundantConditionCallPlugin.php
+++ b/src/Phan/Plugin/Internal/RedundantConditionCallPlugin.php
@@ -172,10 +172,10 @@ final class RedundantConditionCallPlugin extends PluginV3 implements
         }, 'bool');
         $doubleval_callback = $make_cast_callback(static function (UnionType $union_type) : bool {
             return $union_type->floatTypes()->isEqualTo($union_type);
-        }, 'bool');
+        }, 'float');
         $strval_callback = $make_cast_callback(static function (UnionType $union_type) : bool {
             return $union_type->stringTypes()->isEqualTo($union_type);
-        }, 'bool');
+        }, 'string');
 
         $int_callback = $make_simple_first_arg_checker('intTypes', 'int');
         // $callable_callback = $make_simple_first_arg_checker('callableTypes', 'callable');

--- a/src/Phan/Plugin/Internal/RedundantConditionCallPlugin.php
+++ b/src/Phan/Plugin/Internal/RedundantConditionCallPlugin.php
@@ -1,0 +1,200 @@
+<?php declare(strict_types=1);
+
+namespace Phan\Plugin\Internal;
+
+use ast\Node;
+use Closure;
+use Exception;
+use Phan\AST\ASTReverter;
+use Phan\AST\UnionTypeVisitor;
+use Phan\CodeBase;
+use Phan\Issue;
+use Phan\Language\Context;
+use Phan\Language\Element\FunctionInterface;
+use Phan\Language\Type;
+use Phan\Language\Type\FloatType;
+use Phan\Language\Type\IntType;
+use Phan\Language\Type\NullType;
+use Phan\Language\Type\ResourceType;
+use Phan\Language\Type\VoidType;
+use Phan\Language\UnionType;
+use Phan\PluginV3;
+use Phan\PluginV3\AnalyzeFunctionCallCapability;
+use ReflectionMethod;
+use function count;
+
+/**
+ * NOTE: This is automatically loaded by phan. Do not include it in a config.
+ *
+ * TODO: Refactor this.
+ *
+ * TODO: Support real types (e.g. array_values() if the passed in real union type is an array, otherwise real type is ?array
+ *
+ * @phan-file-suppress PhanUnusedClosureParameter
+ */
+final class RedundantConditionCallPlugin extends PluginV3 implements
+    AnalyzeFunctionCallCapability
+{
+    private const _IS_IMPOSSIBLE = 1;
+    private const _IS_REDUNDANT = 2;
+    private const _IS_REASONABLE_CONDITION = 3;
+
+    /**
+     * @return array<string,\Closure>
+     */
+    private static function getAnalyzeFunctionCallClosuresStatic() : array
+    {
+        /**
+         * @param Closure(UnionType):int $checker returns _IS_IMPOSSIBLE/_IS_REDUNDANT/_IS_REASONABLE_CONDITION
+         * @param string $expected_type
+         * @return Closure(CodeBase, Context, FunctionInterface, array<int,mixed>):void
+         */
+        $make_first_arg_checker = static function (Closure $checker, string $expected_type) : Closure {
+            /**
+             * @param array<int,Node|int|float|string> $args
+             */
+            return static function (CodeBase $code_base, Context $context, FunctionInterface $unused_function, array $args) use ($checker, $expected_type) : void {
+                if (count($args) < 1) {
+                    return;
+                }
+                try {
+                    $union_type = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $args[0], false);
+                } catch (Exception $_) {
+                    return;
+                }
+                if (!$union_type->hasRealTypeSet()) {
+                    return;
+                }
+                $result = $checker($union_type->getRealUnionType());
+                if ($result === null) {
+                    return;
+                }
+                if ($result === self::_IS_REDUNDANT) {
+                    Issue::maybeEmit(
+                        $code_base,
+                        $context,
+                        Issue::TypeRedundantCondition,
+                        $context->getLineNumberStart(),
+                        ASTReverter::toShortString($args[0]),
+                        $union_type->getRealUnionType(),
+                        $expected_type
+                    );
+                } elseif ($result === self::_IS_IMPOSSIBLE)  {
+                    Issue::maybeEmit(
+                        $code_base,
+                        $context,
+                        Issue::TypeImpossibleCondition,
+                        $context->getLineNumberStart(),
+                        ASTReverter::toShortString($args[0]),
+                        $union_type->getRealUnionType(),
+                        $expected_type
+                    );
+                }
+            };
+        };
+        $make_simple_first_arg_checker = static function (string $extract_types_method, string $expected_type) use ($make_first_arg_checker) : Closure {
+            $method = new ReflectionMethod(UnionType::class, $extract_types_method);
+            return $make_first_arg_checker(static function (UnionType $type) use ($method) : int {
+                $new_real_type = $method->invoke($type)->nonNullableClone();
+                if ($new_real_type->isEmpty()) {
+                    return self::_IS_IMPOSSIBLE;
+                }
+                if ($new_real_type->isEqualTo($type)) {
+                    return self::_IS_REDUNDANT;
+                }
+                return self::_IS_REASONABLE_CONDITION;
+            }, $expected_type);
+        };
+        $resource_callback = $make_first_arg_checker(static function (UnionType $type) : int {
+            $new_real_type = $type->makeFromFilter(static function (Type $type) : bool {
+                return $type instanceof ResourceType;
+            })->nonNullableClone();
+            if ($new_real_type->isEmpty()) {
+                return self::_IS_IMPOSSIBLE;
+            }
+            if ($new_real_type->isEqualTo($type)) {
+                return self::_IS_REDUNDANT;
+            }
+            return self::_IS_REASONABLE_CONDITION;
+        }, 'resource');
+        $null_callback = $make_first_arg_checker(static function (UnionType $type) : int {
+            if (!$type->containsNullable()) {
+                return self::_IS_IMPOSSIBLE;
+            }
+            if ($type->hasTypeMatchingCallback(function (Type $type) : bool {
+                return !($type instanceof NullType || $type instanceof VoidType);
+            })) {
+                return self::_IS_REASONABLE_CONDITION;
+            }
+            return self::_IS_REDUNDANT;
+        }, 'null');
+        $numeric_callback = $make_first_arg_checker(static function (UnionType $union_type) : int {
+            $has_non_numeric = false;
+            $has_numeric = false;
+            foreach ($union_type->getTypeSet() as $type) {
+                if ($type->isNullable()) {
+                    $has_non_numeric = true;
+                }
+                if ($type instanceof IntType || $type instanceof FloatType) {
+                    $has_numeric = true;
+                } elseif ($type->isPossiblyNumeric()) {
+                    return self::_IS_REASONABLE_CONDITION;
+                } else {
+                    $has_non_numeric = true;
+                }
+            }
+            if ($has_numeric) {
+                if ($has_non_numeric) {
+                    return self::_IS_REASONABLE_CONDITION;
+                }
+                return self::_IS_REDUNDANT;
+            }
+            return self::_IS_IMPOSSIBLE;
+        }, 'numeric');
+
+        $int_callback = $make_simple_first_arg_checker('intTypes', 'int');
+        $callable_callback = $make_simple_first_arg_checker('callableTypes', 'callable');
+        $bool_callback = $make_simple_first_arg_checker('getTypesInBoolFamily', 'bool');
+        $float_callback = $make_simple_first_arg_checker('floatTypes', 'float');
+        $string_callback = $make_simple_first_arg_checker('stringTypes', 'string');
+
+        // TODO: Implement checks for the commented out conditions.
+        // TODO: Check intval, boolval, etc.
+        return [
+            // 'is_a' => $is_a_callback,
+            // 'is_array' => $array_callback,
+            'is_bool' => $bool_callback,
+            // TODO: Don't emit false positives for arrays/strings
+            // 'is_callable' => $callable_callback,
+            'is_double' => $float_callback,
+            'is_float' => $float_callback,
+            'is_int' => $int_callback,
+            'is_integer' => $int_callback,
+            // 'is_iterable' => $make_basic_assertion_callback('iterable'),  // TODO: Could keep basic array types and classes extending iterable
+            'is_long' => $int_callback,
+            'is_null' => $null_callback,
+            'is_numeric' => $numeric_callback,
+            // 'is_object' => $object_callback,
+            'is_real' => $float_callback,
+            'is_resource' => $resource_callback,
+            // TODO: Don't warn about CallableType, which can be string/scalar
+            // 'is_scalar' => $scalar_callback,
+            'is_string' => $string_callback,
+            // 'empty' => $null_callback,
+        ];
+    }
+
+    /**
+     * @param CodeBase $code_base @phan-unused-param
+     * @return array<string,\Closure>
+     */
+    public function getAnalyzeFunctionCallClosures(CodeBase $code_base) : array
+    {
+        // Unit tests invoke this repeatedly. Cache it.
+        static $overrides = null;
+        if ($overrides === null) {
+            $overrides = self::getAnalyzeFunctionCallClosuresStatic();
+        }
+        return $overrides;
+    }
+}

--- a/src/Phan/Plugin/Internal/RequireExistsPlugin.php
+++ b/src/Phan/Plugin/Internal/RequireExistsPlugin.php
@@ -53,7 +53,7 @@ class RequireExistsVisitor extends PluginAwarePostAnalysisVisitor
 
         if (!\is_string($path)) {
             $type = UnionTypeVisitor::unionTypeFromNode($this->code_base, $this->context, $expr);
-            if (!$type->canCastToUnionType(StringType::instance(false)->asUnionType())) {
+            if (!$type->canCastToUnionType(StringType::instance(false)->asPHPDocUnionType())) {
                 $this->emitIssue(
                     Issue::TypeInvalidRequire,
                     $expr->lineno ?? $node->lineno,
@@ -69,7 +69,7 @@ class RequireExistsVisitor extends PluginAwarePostAnalysisVisitor
     {
         $expr = $node->children['expr'];
         $type = UnionTypeVisitor::unionTypeFromNode($this->code_base, $this->context, $expr);
-        if (!$type->canCastToUnionType(StringType::instance(false)->asUnionType())) {
+        if (!$type->canCastToUnionType(StringType::instance(false)->asPHPDocUnionType())) {
             $this->emitIssue(
                 Issue::TypeInvalidEval,
                 $expr->lineno ?? $node->lineno,

--- a/tests/.phan_for_test/config.php
+++ b/tests/.phan_for_test/config.php
@@ -63,6 +63,8 @@ return [
     // Note: This does not affect warnings about redundant uses in the global namespace.
     'warn_about_redundant_use_namespaced_class' => true,
 
+    'redundant_condition_detection' => true,
+
     // If true, Phan will read `class_alias` calls in the global scope,
     // then (1) create aliases from the *parsed* files if no class definition was found,
     // and (2) emit issues in the global scope if the source or target class is invalid.

--- a/tests/Phan/Analysis/ParameterTypesAnalyzerTest.php
+++ b/tests/Phan/Analysis/ParameterTypesAnalyzerTest.php
@@ -24,9 +24,9 @@ final class ParameterTypesAnalyzerTest extends BaseTest
         string $phpdoc_return_type_string,
         string $real_return_type_string
     ) : void {
-        $expected_type = UnionType::fromFullyQualifiedString($expected_type_string);
-        $phpdoc_return_type = UnionType::fromFullyQualifiedString($phpdoc_return_type_string);
-        $real_return_type = UnionType::fromFullyQualifiedString($real_return_type_string);
+        $expected_type = UnionType::fromFullyQualifiedPHPDocString($expected_type_string);
+        $phpdoc_return_type = UnionType::fromFullyQualifiedPHPDocString($phpdoc_return_type_string);
+        $real_return_type = UnionType::fromFullyQualifiedPHPDocString($real_return_type_string);
 
         $actual_normalized_type = ParameterTypesAnalyzer::normalizeNarrowedParamType($phpdoc_return_type, $real_return_type);
 
@@ -43,8 +43,8 @@ final class ParameterTypesAnalyzerTest extends BaseTest
         string $phpdoc_return_type_string,
         string $real_return_type_string
     ) : void {
-        $phpdoc_return_type = UnionType::fromFullyQualifiedString($phpdoc_return_type_string);
-        $real_return_type = UnionType::fromFullyQualifiedString($real_return_type_string);
+        $phpdoc_return_type = UnionType::fromFullyQualifiedPHPDocString($phpdoc_return_type_string);
+        $real_return_type = UnionType::fromFullyQualifiedPHPDocString($real_return_type_string);
 
         $actual_normalized_type = ParameterTypesAnalyzer::normalizeNarrowedParamType($phpdoc_return_type, $real_return_type);
 

--- a/tests/Phan/Debug/FrameTest.php
+++ b/tests/Phan/Debug/FrameTest.php
@@ -41,7 +41,7 @@ final class FrameTest extends BaseTest
         $this->assertHasEncodedValue('stdClass({"key":"value","2":"other"})', (object)['key' => 'value', '2' => 'other']);
         $this->assertHasEncodedValue('Phan\Language\FQSEN\FullyQualifiedClassName(\ast\Node)', FullyQualifiedClassName::fromFullyQualifiedString('ast\Node'));
         $this->assertHasEncodedValue('Phan\Language\Type(\stdClass)', Type::fromFullyQualifiedString('\stdClass'));
-        $this->assertHasEncodedValue('Phan\Language\UnionType(array<int,string>|false)', UnionType::fromFullyQualifiedString('array<int,string>|false'));
+        $this->assertHasEncodedValue('Phan\Language\UnionType(array<int,string>|false)', UnionType::fromFullyQualifiedPHPDocString('array<int,string>|false'));
         $code_base = new CodeBase([], [], [], [], []);
         $context = (new Context())->withFile('src/somefile.php')->withLineNumberStart(15);
         $this->assertHasEncodedValue('[Phan\CodeBase({}), Phan\Language\Context(src/somefile.php:15)]', [$code_base, $context]);

--- a/tests/Phan/Language/EmptyUnionTypeTest.php
+++ b/tests/Phan/Language/EmptyUnionTypeTest.php
@@ -89,11 +89,26 @@ final class EmptyUnionTypeTest extends BaseTest
                 $expected_result = \iterator_to_array($expected_result);
                 $actual_result = \iterator_to_array($actual_result);
             }
-            if ($expected_result !== $actual_result) {
-                $failures .= "Expected $method_name implementation to be the same for " . \serialize($arg_list) . "\n";
+            if (!self::isSameResult($expected_result, $actual_result)) {
+                $failures .= "Expected $method_name implementation to be the same for " . \serialize($arg_list) . ": " . serialize($expected_result) . ' !== ' . serialize($actual_result) . "\n";
             }
         }
         return $failures;
+    }
+
+    /**
+     * @param mixed $expected_result
+     * @param mixed $actual_result
+     */
+    private static function isSameResult($expected_result, $actual_result) : bool
+    {
+        if ($expected_result === $actual_result) {
+            return true;
+        }
+        if ($expected_result instanceof UnionType && $actual_result instanceof UnionType) {
+            return (string)$expected_result === (string)$actual_result;
+        }
+        return false;
     }
 
     /**

--- a/tests/Phan/Language/EmptyUnionTypeTest.php
+++ b/tests/Phan/Language/EmptyUnionTypeTest.php
@@ -75,7 +75,7 @@ final class EmptyUnionTypeTest extends BaseTest
             return '';
         }
 
-        $empty_regular = new UnionType([]);
+        $empty_regular = new UnionType([], true, null);
 
         $candidate_arg_lists = $this->generateArgLists($method);
         if (count($candidate_arg_lists) === 0) {
@@ -161,15 +161,19 @@ final class EmptyUnionTypeTest extends BaseTest
                     Type::fromFullyQualifiedString('\stdClass'),
                 ];
             case UnionType::class:
+                // TODO: Add tests of real union types
                 return [
-                    IntType::instance(false)->asUnionType(),
+                    IntType::instance(false)->asPHPDocUnionType(),
+                    IntType::instance(false)->asRealUnionType(),
                     UnionType::empty(),
-                    new UnionType([FalseType::instance(false), ArrayType::instance(false)]),
-                    ArrayType::instance(false)->asUnionType(),
-                    FalseType::instance(true)->asUnionType(),
-                    ObjectType::instance(false)->asUnionType(),
-                    MixedType::instance(false)->asUnionType(),
-                    Type::fromFullyQualifiedString('\stdClass')->asUnionType(),
+                    new UnionType([FalseType::instance(false), ArrayType::instance(false)], true, null),
+                    new UnionType([FalseType::instance(false), ArrayType::instance(false)], true, [FalseType::instance(false), ArrayType::instance(false)]),
+                    ArrayType::instance(false)->asPHPDocUnionType(),
+                    FalseType::instance(true)->asPHPDocUnionType(),
+                    ObjectType::instance(false)->asPHPDocUnionType(),
+                    ObjectType::instance(false)->asRealUnionType(),
+                    MixedType::instance(false)->asPHPDocUnionType(),
+                    Type::fromFullyQualifiedString('\stdClass')->asPHPDocUnionType(),
                 ];
             case Closure::class:
                 return [

--- a/tests/Phan/Language/EmptyUnionTypeTest.php
+++ b/tests/Phan/Language/EmptyUnionTypeTest.php
@@ -75,7 +75,7 @@ final class EmptyUnionTypeTest extends BaseTest
             return '';
         }
 
-        $empty_regular = new UnionType([], true, null);
+        $empty_regular = new UnionType([], true, []);
 
         $candidate_arg_lists = $this->generateArgLists($method);
         if (count($candidate_arg_lists) === 0) {
@@ -181,7 +181,7 @@ final class EmptyUnionTypeTest extends BaseTest
                     IntType::instance(false)->asPHPDocUnionType(),
                     IntType::instance(false)->asRealUnionType(),
                     UnionType::empty(),
-                    new UnionType([FalseType::instance(false), ArrayType::instance(false)], true, null),
+                    new UnionType([FalseType::instance(false), ArrayType::instance(false)], true),
                     new UnionType([FalseType::instance(false), ArrayType::instance(false)], true, [FalseType::instance(false), ArrayType::instance(false)]),
                     ArrayType::instance(false)->asPHPDocUnionType(),
                     FalseType::instance(true)->asPHPDocUnionType(),

--- a/tests/Phan/Language/TypeTest.php
+++ b/tests/Phan/Language/TypeTest.php
@@ -221,15 +221,15 @@ final class TypeTest extends BaseTest
         $string_iterable_type = self::makePHPDocType('iterable<string>');
         $expected_string_iterable_type = GenericIterableType::fromKeyAndValueTypes(
             UnionType::empty(),
-            StringType::instance(false)->asUnionType(),
+            StringType::instance(false)->asPHPDocUnionType(),
             false
         );
         $this->assertSameType($expected_string_iterable_type, $string_iterable_type);
 
         $string_to_stdclass_array_type = self::makePHPDocType('iterable<string,stdClass>');
         $expectedstring_to_std_class_array_type = GenericIterableType::fromKeyAndValueTypes(
-            StringType::instance(false)->asUnionType(),
-            UnionType::fromFullyQualifiedString('\stdClass'),
+            StringType::instance(false)->asPHPDocUnionType(),
+            UnionType::fromFullyQualifiedPHPDocString('\stdClass'),
             false
         );
         $this->assertSameType($expectedstring_to_std_class_array_type, $string_to_stdclass_array_type);
@@ -318,7 +318,7 @@ final class TypeTest extends BaseTest
     {
         // is_variadic, is_reference, is_optional
         return new ClosureDeclarationParameter(
-            UnionType::fromFullyQualifiedString($type_string),
+            UnionType::fromFullyQualifiedPHPDocString($type_string),
             false,
             false,
             false
@@ -341,7 +341,7 @@ final class TypeTest extends BaseTest
         $expected_closure_void_type = new ClosureDeclarationType(
             new Context(),
             [],
-            VoidType::instance(false)->asUnionType(),
+            VoidType::instance(false)->asPHPDocUnionType(),
             false,
             false
         );
@@ -355,7 +355,7 @@ final class TypeTest extends BaseTest
         $expected_closure_void_type = new CallableDeclarationType(
             new Context(),
             [self::makeBasicClosureParam('string')],
-            IntType::instance(false)->asUnionType(),
+            IntType::instance(false)->asPHPDocUnionType(),
             false,
             false
         );
@@ -369,7 +369,7 @@ final class TypeTest extends BaseTest
         $expected_closure_void_type = new CallableDeclarationType(
             new Context(),
             [self::makeBasicClosureParam('string')],
-            VoidType::instance(false)->asUnionType(),
+            VoidType::instance(false)->asPHPDocUnionType(),
             false,
             true
         );
@@ -383,7 +383,7 @@ final class TypeTest extends BaseTest
         $expected_closure_type = new ClosureDeclarationType(
             new Context(),
             [self::makeBasicClosureParam('int'), self::makeBasicClosureParam('mixed')],
-            IntType::instance(false)->asUnionType(),
+            IntType::instance(false)->asPHPDocUnionType(),
             false,
             false
         );
@@ -399,7 +399,7 @@ final class TypeTest extends BaseTest
         $expected_closure_scalar_type = new ClosureDeclarationType(
             new Context(),
             [$nullable_scalar_param],
-            UnionType::fromFullyQualifiedString('?int|?string'),
+            UnionType::fromFullyQualifiedPHPDocString('?int|?string'),
             false,
             false
         );
@@ -414,13 +414,13 @@ final class TypeTest extends BaseTest
     public function testClosureRefVariadicAnnotations() : void
     {
         // is_variadic, is_reference, is_optional
-        $string_ref_annotation = new ClosureDeclarationParameter(UnionType::fromFullyQualifiedString('string'), false, true, false);
-        $variadic_bool_annotation = new ClosureDeclarationParameter(UnionType::fromFullyQualifiedString('bool'), true, true, false);
+        $string_ref_annotation = new ClosureDeclarationParameter(UnionType::fromFullyQualifiedPHPDocString('string'), false, true, false);
+        $variadic_bool_annotation = new ClosureDeclarationParameter(UnionType::fromFullyQualifiedPHPDocString('bool'), true, true, false);
 
         $expected_closure_type = new ClosureDeclarationType(
             new Context(),
             [$string_ref_annotation, $variadic_bool_annotation],
-            UnionType::fromFullyQualifiedString('void'),
+            UnionType::fromFullyQualifiedPHPDocString('void'),
             false,
             false
         );
@@ -432,13 +432,13 @@ final class TypeTest extends BaseTest
     public function testClosureOptionalParam() : void
     {
         // is_variadic, is_reference, is_optional
-        $optional_string_annotation = new ClosureDeclarationParameter(UnionType::fromFullyQualifiedString('?string'), false, false, true);
-        $optional_int_annotation = new ClosureDeclarationParameter(UnionType::fromFullyQualifiedString('int'), false, false, true);
+        $optional_string_annotation = new ClosureDeclarationParameter(UnionType::fromFullyQualifiedPHPDocString('?string'), false, false, true);
+        $optional_int_annotation = new ClosureDeclarationParameter(UnionType::fromFullyQualifiedPHPDocString('int'), false, false, true);
 
         $expected_closure_type = new ClosureDeclarationType(
             new Context(),
             [$optional_string_annotation, $optional_int_annotation],
-            UnionType::fromFullyQualifiedString('void'),
+            UnionType::fromFullyQualifiedPHPDocString('void'),
             false,
             false
         );
@@ -540,7 +540,7 @@ final class TypeTest extends BaseTest
         if (!$actual_type instanceof ArrayShapeType) {
             throw new \RuntimeException(\sprintf("Failed to create expected class for %s: saw %s instead of %s", $type_string, get_class($actual_type), ArrayShapeType::class));
         }
-        $actual_flattened_type = UnionType::of($actual_type->withFlattenedArrayShapeOrLiteralTypeInstances());
+        $actual_flattened_type = UnionType::of($actual_type->withFlattenedArrayShapeOrLiteralTypeInstances(), null);
         $this->assertTrue($expected_flattened_type->isEqualTo($actual_flattened_type), "expected $actual_flattened_type to equal $expected_flattened_type");
     }
 

--- a/tests/Phan/Language/TypeTest.php
+++ b/tests/Phan/Language/TypeTest.php
@@ -540,7 +540,7 @@ final class TypeTest extends BaseTest
         if (!$actual_type instanceof ArrayShapeType) {
             throw new \RuntimeException(\sprintf("Failed to create expected class for %s: saw %s instead of %s", $type_string, get_class($actual_type), ArrayShapeType::class));
         }
-        $actual_flattened_type = UnionType::of($actual_type->withFlattenedArrayShapeOrLiteralTypeInstances(), null);
+        $actual_flattened_type = UnionType::of($actual_type->withFlattenedArrayShapeOrLiteralTypeInstances());
         $this->assertTrue($expected_flattened_type->isEqualTo($actual_flattened_type), "expected $actual_flattened_type to equal $expected_flattened_type");
     }
 

--- a/tests/Phan/Language/UnionTypeTest.php
+++ b/tests/Phan/Language/UnionTypeTest.php
@@ -312,11 +312,11 @@ final class UnionTypeTest extends BaseTest
     {
         $this->assertSame(
             '\Exception[]|\Throwable[]',
-            UnionType::fromFullyQualifiedString('\Exception[]')->asExpandedTypes(self::$code_base)->__toString()
+            UnionType::fromFullyQualifiedPHPDocString('\Exception[]')->asExpandedTypes(self::$code_base)->__toString()
         );
         $this->assertSame(
             'array<int,\Exception>|array<int,\Throwable>',
-            UnionType::fromFullyQualifiedString('array<int,\Exception>')->asExpandedTypes(self::$code_base)->__toString()
+            UnionType::fromFullyQualifiedPHPDocString('array<int,\Exception>')->asExpandedTypes(self::$code_base)->__toString()
         );
     }
 

--- a/tests/Phan/Plugin/Internal/MethodSearcherPluginTest.php
+++ b/tests/Phan/Plugin/Internal/MethodSearcherPluginTest.php
@@ -27,8 +27,8 @@ final class MethodSearcherPluginTest extends BaseTest implements CodeBaseAwareTe
      */
     public function testGetTypeMatchingBonus(float $expected_score, string $actual, string $desired) : void
     {
-        $actual_signature_type = UnionType::fromFullyQualifiedString($actual);
-        $desired_signature_type = UnionType::fromFullyQualifiedString($desired);
+        $actual_signature_type = UnionType::fromFullyQualifiedPHPDocString($actual);
+        $desired_signature_type = UnionType::fromFullyQualifiedPHPDocString($desired);
         // @phan-suppress-next-line PhanAccessMethodInternal
         $this->assertSame($expected_score, MethodSearcherPlugin::getTypeMatchingBonus($this->code_base, $actual_signature_type, $desired_signature_type));
     }
@@ -55,8 +55,8 @@ final class MethodSearcherPluginTest extends BaseTest implements CodeBaseAwareTe
      */
     public function testMatchesParamTypes(float $expected_score, array $actual, array $desired) : void
     {
-        $actual_signature_types = \array_map('\Phan\Language\UnionType::fromFullyQualifiedString', $actual);
-        $desired_signature_types = \array_map('\Phan\Language\UnionType::fromFullyQualifiedString', $desired);
+        $actual_signature_types = \array_map('\Phan\Language\UnionType::fromFullyQualifiedPHPDocString', $actual);
+        $desired_signature_types = \array_map('\Phan\Language\UnionType::fromFullyQualifiedPHPDocString', $desired);
         // @phan-suppress-next-line PhanAccessMethodInternal
         $this->assertSame($expected_score, MethodSearcherPlugin::matchesParamTypes($this->code_base, $actual_signature_types, $desired_signature_types));
     }

--- a/tests/files/expected/0265_ternary_guards.php.expected
+++ b/tests/files/expected/0265_ternary_guards.php.expected
@@ -1,1 +1,3 @@
+%s:4 PhanTypeImpossibleCondition Impossible attempt to cast $x of type array{} to string
+%s:9 PhanTypeImpossibleCondition Impossible attempt to cast $x of type array{} to int
 %s:9 PhanTypeMismatchArgumentInternal Argument 1 ($str) is int but \urldecode() takes string

--- a/tests/files/expected/0265_ternary_guards.php.expected
+++ b/tests/files/expected/0265_ternary_guards.php.expected
@@ -1,3 +1,3 @@
-%s:4 PhanTypeImpossibleCondition Impossible attempt to cast $x of type array{} to string
-%s:9 PhanTypeImpossibleCondition Impossible attempt to cast $x of type array{} to int
+%s:4 PhanImpossibleCondition Impossible attempt to cast $x of type array{} to string
+%s:9 PhanImpossibleCondition Impossible attempt to cast $x of type array{} to int
 %s:9 PhanTypeMismatchArgumentInternal Argument 1 ($str) is int but \urldecode() takes string

--- a/tests/files/expected/0299_binary_op.php.expected
+++ b/tests/files/expected/0299_binary_op.php.expected
@@ -17,7 +17,7 @@
 %s:25 PhanTypeMismatchArgument Argument 1 ($x) is 16384 but \expect_string_298() takes string defined at %s:3
 %s:26 PhanTypeMismatchArgument Argument 1 ($x) is int but \expect_string_298() takes string defined at %s:3
 %s:27 PhanTypeMismatchArgument Argument 1 ($x) is int but \expect_string_298() takes string defined at %s:3
-%s:28 PhanTypeMismatchArgument Argument 1 ($x) is int but \expect_string_298() takes string defined at %s:3
+%s:28 PhanTypeMismatchArgument Argument 1 ($x) is -1|0|1 but \expect_string_298() takes string defined at %s:3
 %s:30 PhanTypeMismatchArgument Argument 1 ($x) is 2 but \expect_string_298() takes string defined at %s:3
 %s:31 PhanTypeMismatchArgument Argument 1 ($x) is 4 but \expect_string_298() takes string defined at %s:3
 %s:32 PhanTypeMismatchArgument Argument 1 ($x) is 7 but \expect_string_298() takes string defined at %s:3

--- a/tests/files/expected/0300_misc_types.php.expected
+++ b/tests/files/expected/0300_misc_types.php.expected
@@ -11,7 +11,7 @@
 %s:21 PhanUnusedVariable Unused definition of variable $undefIntVar
 %s:22 PhanTypeMismatchArgument Argument 1 ($x) is 42 but \expect_string_300() takes string defined at %s:3
 %s:22 PhanUnusedVariableReference Unused definition of variable $refIntVar as a reference
-%s:23 PhanTypeMismatchArgument Argument 1 ($x) is string but \expect_int_300() takes int defined at %s:4
+%s:23 PhanTypeMismatchArgument Argument 1 ($x) is ?string but \expect_int_300() takes int defined at %s:4
 %s:25 PhanTypeMismatchArgument Argument 1 ($x) is \stdClass but \expect_string_300() takes string defined at %s:3
 %s:26 PhanTypeMismatchArgument Argument 1 ($x) is 3 but \expect_string_300() takes string defined at %s:3
 %s:27 PhanTypeMismatchArgument Argument 1 ($x) is 3 but \expect_string_300() takes string defined at %s:3

--- a/tests/files/expected/0364_extended_array_analyze.php.expected
+++ b/tests/files/expected/0364_extended_array_analyze.php.expected
@@ -30,6 +30,6 @@
 %s:38 PhanTypeMismatchArgument Argument 1 ($x) is array<int,\stdClass> but \p364() takes \stdClass defined at %s:45
 %s:39 PhanTypeMismatchArgument Argument 1 ($x) is array<int,string> but \p364() takes \stdClass defined at %s:45
 %s:40 PhanTypeMismatchArgument Argument 1 ($x) is array<int,string> but \p364() takes \stdClass defined at %s:45
-%s:41 PhanParamTypeMismatch Argument 3 is Closure(mixed,mixed):int but \array_uintersect_assoc() takes array
+%s:41 PhanParamTypeMismatch Argument 3 is Closure(mixed,mixed):(-1|0|1) but \array_uintersect_assoc() takes array
 %s:41 PhanTypeMismatchArgument Argument 1 ($x) is array<int,string> but \p364() takes \stdClass defined at %s:45
 %s:42 PhanTypeMismatchArgument Argument 1 ($x) is array<int,string> but \p364() takes \stdClass defined at %s:45

--- a/tests/files/expected/0414_print.php.expected
+++ b/tests/files/expected/0414_print.php.expected
@@ -1,1 +1,1 @@
-%s:3 PhanTypeMismatchArgumentInternal Argument 1 ($string) is int but \strlen() takes string
+%s:3 PhanTypeMismatchArgumentInternal Argument 1 ($string) is 1 but \strlen() takes string

--- a/tests/files/expected/0516_literal_type_narrowing.php.expected
+++ b/tests/files/expected/0516_literal_type_narrowing.php.expected
@@ -1,5 +1,5 @@
-%s:4 PhanTypeRedundantCondition Redundant attempt to cast $x of type 2 to int
-%s:5 PhanTypeRedundantCondition Redundant attempt to cast $x of type 2 to numeric
+%s:4 PhanRedundantCondition Redundant attempt to cast $x of type 2 to int
+%s:5 PhanRedundantCondition Redundant attempt to cast $x of type 2 to numeric
 %s:6 PhanTypeMismatchArgumentInternal Argument 1 ($string) is 2 but \strlen() takes string
-%s:9 PhanTypeRedundantCondition Redundant attempt to cast $y of type 'a string' to string
+%s:9 PhanRedundantCondition Redundant attempt to cast $y of type 'a string' to string
 %s:10 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is 'a string' but \intdiv() takes int

--- a/tests/files/expected/0516_literal_type_narrowing.php.expected
+++ b/tests/files/expected/0516_literal_type_narrowing.php.expected
@@ -1,4 +1,5 @@
 %s:4 PhanTypeRedundantCondition Redundant attempt to cast $x of type 2 to int
+%s:5 PhanTypeRedundantCondition Redundant attempt to cast $x of type 2 to numeric
 %s:6 PhanTypeMismatchArgumentInternal Argument 1 ($string) is 2 but \strlen() takes string
 %s:9 PhanTypeRedundantCondition Redundant attempt to cast $y of type 'a string' to string
 %s:10 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is 'a string' but \intdiv() takes int

--- a/tests/files/expected/0516_literal_type_narrowing.php.expected
+++ b/tests/files/expected/0516_literal_type_narrowing.php.expected
@@ -1,2 +1,4 @@
+%s:4 PhanTypeRedundantCondition Redundant attempt to cast $x of type 2 to int
 %s:6 PhanTypeMismatchArgumentInternal Argument 1 ($string) is 2 but \strlen() takes string
+%s:9 PhanTypeRedundantCondition Redundant attempt to cast $y of type 'a string' to string
 %s:10 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is 'a string' but \intdiv() takes int

--- a/tests/files/expected/0564_global_namespace_functions_constants.php.expected
+++ b/tests/files/expected/0564_global_namespace_functions_constants.php.expected
@@ -1,6 +1,6 @@
 %s:4 PhanUnreferencedUseNormal Possibly zero references to use statement for classlike/namespace uselessimport (\uselessimport)
 %s:4 PhanUseNormalNoEffect The use statement for class/namespace \uselessimport in the global namespace has no effect
-%s:12 PhanTypeRedundantCondition Redundant attempt to cast 'a string' of type 'a string' to string
+%s:12 PhanRedundantCondition Redundant attempt to cast 'a string' of type 'a string' to string
 %s:21 PhanUndeclaredClassMethod Call to method __construct from undeclared class \a\Missing
 %s:22 PhanUndeclaredConstant Reference to undeclared constant \ast\MISSING_CONST
 %s:23 PhanUndeclaredFunction Call to undeclared function \ast\missing_function()

--- a/tests/files/expected/0564_global_namespace_functions_constants.php.expected
+++ b/tests/files/expected/0564_global_namespace_functions_constants.php.expected
@@ -1,5 +1,6 @@
 %s:4 PhanUnreferencedUseNormal Possibly zero references to use statement for classlike/namespace uselessimport (\uselessimport)
 %s:4 PhanUseNormalNoEffect The use statement for class/namespace \uselessimport in the global namespace has no effect
+%s:12 PhanTypeRedundantCondition Redundant attempt to cast 'a string' of type 'a string' to string
 %s:21 PhanUndeclaredClassMethod Call to method __construct from undeclared class \a\Missing
 %s:22 PhanUndeclaredConstant Reference to undeclared constant \ast\MISSING_CONST
 %s:23 PhanUndeclaredFunction Call to undeclared function \ast\missing_function()

--- a/tests/files/expected/0620_more_noop_expressions.php.expected
+++ b/tests/files/expected/0620_more_noop_expressions.php.expected
@@ -1,5 +1,7 @@
 %s:3 PhanNoopEmpty Unused result of an empty(expr) check
+%s:3 PhanTypeImpossibleCondition Impossible attempt to cast $a of type 2 to empty
 %s:4 PhanNoopIsset Unused result of an isset(expr) check
+%s:4 PhanTypeRedundantCondition Redundant attempt to cast $a of type 2 to isset
 %s:7 PhanNoopCast Unused result of a (string)(expr) cast
 %s:8 PhanNoopCast Unused result of a (int)(expr) cast
 %s:9 PhanNoopCast Unused result of a (bool)(expr) cast

--- a/tests/files/expected/0620_more_noop_expressions.php.expected
+++ b/tests/files/expected/0620_more_noop_expressions.php.expected
@@ -1,7 +1,7 @@
+%s:3 PhanImpossibleCondition Impossible attempt to cast $a of type 2 to empty
 %s:3 PhanNoopEmpty Unused result of an empty(expr) check
-%s:3 PhanTypeImpossibleCondition Impossible attempt to cast $a of type 2 to empty
 %s:4 PhanNoopIsset Unused result of an isset(expr) check
-%s:4 PhanTypeRedundantCondition Redundant attempt to cast $a of type 2 to isset
+%s:4 PhanRedundantCondition Redundant attempt to cast $a of type 2 to isset
 %s:7 PhanNoopCast Unused result of a (string)(expr) cast
 %s:8 PhanNoopCast Unused result of a (int)(expr) cast
 %s:9 PhanNoopCast Unused result of a (bool)(expr) cast

--- a/tests/files/expected/0681_static_array_assign.php.expected
+++ b/tests/files/expected/0681_static_array_assign.php.expected
@@ -1,3 +1,4 @@
 %s:51 PhanTypeArraySuspicious Suspicious array access to static
 %s:54 PhanTypeArraySuspicious Suspicious array access to \Y681
 %s:57 PhanTypeArrayUnsetSuspicious Suspicious attempt to unset an offset of a value of type \Y681
+%s:60 PhanTypeArraySuspicious Suspicious array access to \Y681

--- a/tests/files/src/0516_literal_type_narrowing.php
+++ b/tests/files/src/0516_literal_type_narrowing.php
@@ -1,8 +1,8 @@
 <?php
 call_user_func(function() {
     $x = 2;
-    assert(is_int($x));
-    assert(is_numeric($x));  // TODO: Emit PhanTypeRedundantCondition for int/float
+    assert(is_int($x));  // Emits PhanRedundantCondition
+    assert(is_numeric($x));  // Emits PhanRedundantCondition
     echo strlen($x);
 
     $y = 'a string';

--- a/tests/files/src/0516_literal_type_narrowing.php
+++ b/tests/files/src/0516_literal_type_narrowing.php
@@ -2,7 +2,7 @@
 call_user_func(function() {
     $x = 2;
     assert(is_int($x));
-    assert(is_numeric($x));
+    assert(is_numeric($x));  // TODO: Emit PhanTypeRedundantCondition for int/float
     echo strlen($x);
 
     $y = 'a string';

--- a/tests/files/src/0681_static_array_assign.php
+++ b/tests/files/src/0681_static_array_assign.php
@@ -57,6 +57,6 @@ class Y681 {
         unset($this['myField']);
     }
     public function testIsset() {
-        var_export(isset($this['otherField']));  // NOTE: Phan currently does not type check isset checks
+        var_export(isset($this['otherField']));  // Warns as a side effect of checking if isset is redundant.
     }
 }

--- a/tests/fixer_test/expected/001_not_fully_qualified.php.expected
+++ b/tests/fixer_test/expected/001_not_fully_qualified.php.expected
@@ -1,4 +1,4 @@
 src_copy/001_not_fully_qualified.php:4 PhanPluginNotFullyQualifiedFunctionCall Expected function call to var_export() to be fully qualified or have a use statement but none were found in namespace \ns
 src_copy/001_not_fully_qualified.php:5 PhanPluginNotFullyQualifiedOptimizableFunctionCall Expected function call to is_string() to be fully qualified or have a use statement but none were found in namespace \ns (opcache can optimize fully qualified calls to this function in recent php versions)
-src_copy/001_not_fully_qualified.php:5 PhanTypeRedundantCondition Redundant attempt to cast 'test' of type 'test' to string
+src_copy/001_not_fully_qualified.php:5 PhanRedundantCondition Redundant attempt to cast 'test' of type 'test' to string
 src_copy/001_not_fully_qualified.php:6 PhanPluginNotFullyQualifiedGlobalConstant Expected usage of PHP_VERSION_ID to be fully qualified or have a use statement but none were found in namespace \ns

--- a/tests/fixer_test/expected/001_not_fully_qualified.php.expected
+++ b/tests/fixer_test/expected/001_not_fully_qualified.php.expected
@@ -1,3 +1,4 @@
 src_copy/001_not_fully_qualified.php:4 PhanPluginNotFullyQualifiedFunctionCall Expected function call to var_export() to be fully qualified or have a use statement but none were found in namespace \ns
 src_copy/001_not_fully_qualified.php:5 PhanPluginNotFullyQualifiedOptimizableFunctionCall Expected function call to is_string() to be fully qualified or have a use statement but none were found in namespace \ns (opcache can optimize fully qualified calls to this function in recent php versions)
+src_copy/001_not_fully_qualified.php:5 PhanTypeRedundantCondition Redundant attempt to cast 'test' of type 'test' to string
 src_copy/001_not_fully_qualified.php:6 PhanPluginNotFullyQualifiedGlobalConstant Expected usage of PHP_VERSION_ID to be fully qualified or have a use statement but none were found in namespace \ns

--- a/tests/fixer_test/test.sh
+++ b/tests/fixer_test/test.sh
@@ -20,7 +20,7 @@ rm -rf src_copy
 cp -r src src_copy
 
 # We use the polyfill parser because it behaves consistently in all php versions.
-../../phan --automatic-fix --dead-code-detection --force-polyfill-parser --memory-limit 1G | tee $ACTUAL_PATH
+../../phan --redundant-condition-detection --automatic-fix --dead-code-detection --force-polyfill-parser --memory-limit 1G | tee $ACTUAL_PATH
 
 # diff returns a non-zero exit code if files differ or are missing
 # This outputs the difference between actual and expected output.

--- a/tests/run_test
+++ b/tests/run_test
@@ -31,6 +31,7 @@ case "$TEST_SUITE" in
 		./phan --plugin PHPUnitNotDeadCodePlugin \
 			--plugin InvokePHPNativeSyntaxCheckPlugin \
 			--dead-code-detection \
+			--redundant-condition-detection \
 			--polyfill-parse-all-element-doc-comments \
 			--force-polyfill-parser \
 			--disable-cache \


### PR DESCRIPTION
More types of detection will be added in subsequent PRs.

This has many false positives involving loops, variables set in loops, and the global scope.

This check is disabled by default.