### PR TITLE
Improve real type checks for conditions/operators

### DIFF
--- a/src/Phan/AST/ASTReverter.php
+++ b/src/Phan/AST/ASTReverter.php
@@ -173,8 +173,17 @@ class ASTReverter
                 return \sprintf(
                     "(%s %s %s)",
                     self::toShortString($node->children['left']),
-                    PostOrderAnalysisVisitor::NAME_FOR_BINARY_OP[$node->flags] ?? ' unknown ',
+                    PostOrderAnalysisVisitor::NAME_FOR_BINARY_OP[$node->flags] ?? 'unknown',
                     self::toShortString($node->children['right'])
+                );
+            },
+            /** @suppress PhanAccessClassConstantInternal */
+            ast\AST_ASSIGN_OP => static function (Node $node) : string {
+                return \sprintf(
+                    "(%s %s= %s)",
+                    self::toShortString($node->children['var']),
+                    PostOrderAnalysisVisitor::NAME_FOR_BINARY_OP[$node->flags] ?? 'unknown',
+                    self::toShortString($node->children['expr'])
                 );
             },
             ast\AST_UNARY_OP => static function (Node $node) : string {
@@ -205,6 +214,22 @@ class ASTReverter
                     $prop_node instanceof Node ? '{' . self::toShortString($prop_node) . '}' : (string)$prop_node
                 );
             },
+            ast\AST_INSTANCEOF => static function (Node $node) : string {
+                return \sprintf(
+                    '(%s instanceof %s)',
+                    self::toShortString($node->children['expr']),
+                    self::toShortString($node->children['class'])
+                );
+            },
+            ast\AST_CAST => static function (Node $node) : string {
+                return \sprintf(
+                    '(%s)(%s)',
+                    // @phan-suppress-next-line PhanAccessClassConstantInternal
+                    PostOrderAnalysisVisitor::AST_CAST_FLAGS_LOOKUP[$node->flags] ?? 'unknown',
+                    self::toShortString($node->children['expr'])
+                );
+
+            }
         ];
     }
 }

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -722,25 +722,6 @@ class ConditionVisitor extends KindVisitorImplementation implements ConditionVis
         };
 
         /**
-         * @param array<int,Node|mixed> $args
-         */
-        $scalar_callback = static function (CodeBase $unused_code_base, Context $unused_context, Variable $variable, array $args) : void {
-            // Change the type to match the is_a relationship
-            // If we already have possible scalar types, then keep those
-            // (E.g. T|false becomes bool, T becomes int|float|bool|string|null)
-            $new_type = $variable->getUnionType()->scalarTypes();
-            if ($new_type->containsNullable()) {
-                $new_type = $new_type->nonNullableClone();
-            }
-            if ($new_type->isEmpty()) {
-                // If there are no inferred types, or the only type we saw was 'null',
-                // assume there this can be any possible scalar.
-                // (Excludes `resource`, which is technically a scalar)
-                $new_type = UnionType::fromFullyQualifiedRealString('int|float|bool|string');
-            }
-            $variable->setUnionType($new_type);
-        };
-        /**
          * @param string $extract_types
          * @param UnionType $default_if_empty
          * @return Closure(CodeBase,Context,Variable,array):void
@@ -771,10 +752,11 @@ class ConditionVisitor extends KindVisitorImplementation implements ConditionVis
         };
         /** @return void */
         $callable_callback = $make_callback('callableTypes', CallableType::instance(false)->asRealUnionType());
-        $bool_callback = $make_callback('getTypesInBoolFamily', BoolType::instance(false)->asRealUnionType());
+        $bool_callback = $make_callback('boolTypes', BoolType::instance(false)->asRealUnionType());
         $int_callback = $make_callback('intTypes', IntType::instance(false)->asRealUnionType());
         $string_callback = $make_callback('stringTypes', StringType::instance(false)->asRealUnionType());
         $numeric_callback = $make_callback('numericTypes', UnionType::fromFullyQualifiedRealString('string|int|float'));
+        $scalar_callback = $make_callback('scalarTypesStrict', UnionType::fromFullyQualifiedRealString('string|int|float|bool'));
 
         // Note: LiteralIntType exists, but LiteralFloatType doesn't, which is why these are different.
         $float_callback = $make_direct_assertion_callback('float');

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -740,7 +740,10 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
      */
     private function checkCanIterate(UnionType $union_type, Node $node) : void
     {
-        if ($union_type->isScalar()) {
+        if ($union_type->isEmpty()) {
+            return;
+        }
+        if (!$union_type->hasPossiblyObjectTypes() && !$union_type->hasIterable()) {
             $this->emitIssue(
                 Issue::TypeMismatchForeach,
                 $node->children['expr']->lineno ?? $node->lineno,

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -11,6 +11,7 @@ use Phan\Language\Element\Clazz;
 use Phan\Language\Element\FunctionInterface;
 use Phan\Language\FQSEN\FullyQualifiedClassName;
 use Phan\Language\Type\ArrayType;
+use Phan\Language\Type\BoolType;
 use Phan\Language\Type\IntType;
 use Phan\Language\Type\ObjectType;
 use Phan\Language\Type\TemplateType;
@@ -1376,5 +1377,23 @@ final class EmptyUnionType extends UnionType
     public function arrayTypesStrictCast() : UnionType
     {
         return ArrayType::instance(false)->asRealUnionType();
+    }
+
+    public function boolTypes() : UnionType
+    {
+        return BoolType::instance(false)->asRealUnionType();
+    }
+
+    public function scalarTypesStrict(bool $allow_empty = false) : UnionType
+    {
+        if ($allow_empty) {
+            return $this;
+        }
+        return UnionType::fromFullyQualifiedRealString('int|float|string|bool');
+    }
+
+    public function isExclusivelyRealTypes() : bool
+    {
+        return false;
     }
 }

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -3419,4 +3419,12 @@ class Type
     {
         return null;
     }
+
+    /**
+     * Convert this to a subtype that satisfies is_scalar(), or returns null
+     */
+    public function asScalarType() : ?Type
+    {
+        return null;
+    }
 }

--- a/src/Phan/Language/Type/ArrayShapeType.php
+++ b/src/Phan/Language/Type/ArrayShapeType.php
@@ -246,6 +246,7 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
                     // However, the scalar_array_key_cast config would make any cast of array keys a valid cast.
                     continue;
                 }
+                // @phan-suppress-next-line PhanImpossibleCondition known false positive in loop
                 if ($element_union_types) {
                     $element_union_types = $element_union_types->withType($target_type->genericArrayElementType());
                 } else {

--- a/src/Phan/Language/Type/CallableType.php
+++ b/src/Phan/Language/Type/CallableType.php
@@ -52,4 +52,9 @@ final class CallableType extends NativeType implements CallableInterface
     {
         return CallableArrayType::instance(false);
     }
+
+    public function asScalarType() : ?Type
+    {
+        return CallableStringType::instance(false);
+    }
 }

--- a/src/Phan/Language/Type/NullType.php
+++ b/src/Phan/Language/Type/NullType.php
@@ -163,9 +163,19 @@ final class NullType extends ScalarType
         return true;  // Null is always falsey.
     }
 
+    public function isPossiblyTruthy() : bool
+    {
+        return false;  // Null is always falsey.
+    }
+
     public function isAlwaysFalsey() : bool
     {
         return true;  // Null is always falsey.
+    }
+
+    public function isAlwaysTruthy() : bool
+    {
+        return false;  // Null is always falsey.
     }
 
     public function isPrintableScalar() : bool
@@ -205,6 +215,16 @@ final class NullType extends ScalarType
     }
 
     public function canUseInRealSignature() : bool
+    {
+        return false;
+    }
+
+    public function asScalarType() : ?Type
+    {
+        return null;
+    }
+
+    public function isScalar() : bool
     {
         return false;
     }

--- a/src/Phan/Language/Type/ScalarType.php
+++ b/src/Phan/Language/Type/ScalarType.php
@@ -142,6 +142,11 @@ abstract class ScalarType extends NativeType
     {
         return true;
     }
+
+    public function asScalarType() : ?Type
+    {
+        return $this->withIsNullable(false);
+    }
 }
 \class_exists(IntType::class);
 \class_exists(StringType::class);

--- a/src/Phan/Language/Type/VoidType.php
+++ b/src/Phan/Language/Type/VoidType.php
@@ -2,6 +2,9 @@
 
 namespace Phan\Language\Type;
 
+use Phan\Config;
+use Phan\Language\Type;
+
 /**
  * Represents the return type `void`
  */
@@ -29,4 +32,48 @@ final class VoidType extends NativeType
     {
         return true;
     }
+
+    public function asScalarType() : ?Type
+    {
+        return null;
+    }
+
+    public function isPossiblyFalsey() : bool
+    {
+        return true;  // Null is always falsey.
+    }
+
+    public function isPossiblyTruthy() : bool
+    {
+        return false;  // Null is always falsey.
+    }
+
+    public function isAlwaysFalsey() : bool
+    {
+        return true;  // Null is always falsey.
+    }
+
+    public function isAlwaysTruthy() : bool
+    {
+        return false;  // Null is always falsey.
+    }
+
+
+    public function isPrintableScalar() : bool
+    {
+        // This would be '', which is probably not intended. allow null in union types for `echo` if there are **other** valid types.
+        return Config::get_null_casts_as_any_type();
+    }
+
+    public function isValidBitwiseOperand() : bool
+    {
+        // Allow null in union types for bitwise operations if there are **other** valid types.
+        return Config::get_null_casts_as_any_type();
+    }
+
+    public function isValidNumericOperand() : bool
+    {
+        return Config::get_null_casts_as_any_type();
+    }
+
 }

--- a/src/Phan/Plugin/Internal/IssueFixingPlugin/IssueFixer.php
+++ b/src/Phan/Plugin/Internal/IssueFixingPlugin/IssueFixer.php
@@ -301,6 +301,7 @@ class IssueFixer
         $new_contents = '';
         $prev_edit = null;
         foreach ($all_edits as $edit) {
+            // @phan-suppress-next-line PhanImpossibleCondition known false positive in loop
             if ($prev_edit && $edit->isEqualTo($prev_edit)) {
                 continue;
             }

--- a/tests/files/expected/0101_one_of_each.php.expected
+++ b/tests/files/expected/0101_one_of_each.php.expected
@@ -34,6 +34,7 @@
 %s:129 PhanTypeMismatchArgument Argument 1 ($i) is 'string' but \f8() takes int defined at %s:128
 %s:132 PhanTypeMismatchArgumentInternal Argument 1 ($string) is 42 but \strlen() takes string
 %s:138 PhanTypeMismatchForeach null passed to foreach instead of array
+%s:139 PhanTypeMismatchForeach resource passed to foreach instead of array
 %s:141 PhanTypeMismatchDefault Default value for int $p can't be false
 %s:144 PhanTypeMismatchReturn Returning type 'string' but f() is declared to return int
 %s:147 PhanTypeMissingReturn Method \C9::f is declared to return int but has no return value

--- a/tests/files/expected/0299_binary_op.php.expected
+++ b/tests/files/expected/0299_binary_op.php.expected
@@ -31,6 +31,7 @@
 %s:42 PhanTypeMismatchArgument Argument 1 ($x) is int but \expect_string_298() takes string defined at %s:3
 %s:43 PhanTypeMismatchArgument Argument 1 ($x) is int but \expect_string_298() takes string defined at %s:3
 %s:44 PhanTypeMismatchArgument Argument 1 ($x) is int but \expect_string_298() takes string defined at %s:3
+%s:45 PhanTypeMismatchArgumentInternal Argument 1 ($string) is float|int but \strlen() takes string
 %s:45 PhanTypeMismatchArgument Argument 1 ($x) is float but \expect_string_298() takes string defined at %s:3
 %s:46 PhanTypeMismatchArgument Argument 1 ($x) is int but \expect_string_298() takes string defined at %s:3
 %s:47 PhanTypeMismatchArgument Argument 1 ($x) is float but \expect_string_298() takes string defined at %s:3

--- a/tests/files/expected/0693_redundant_cast_operations.php.expected
+++ b/tests/files/expected/0693_redundant_cast_operations.php.expected
@@ -1,0 +1,41 @@
+%s:5 PhanRedundantCondition Redundant attempt to cast ($a < $b) of type bool to bool
+%s:6 PhanRedundantCondition Redundant attempt to cast ($a <= $b) of type bool to bool
+%s:7 PhanRedundantCondition Redundant attempt to cast ($a > $b) of type bool to bool
+%s:8 PhanRedundantCondition Redundant attempt to cast ($a >= $b) of type bool to bool
+%s:9 PhanRedundantCondition Redundant attempt to cast ($a == $b) of type bool to bool
+%s:10 PhanRedundantCondition Redundant attempt to cast ($a === $b) of type bool to bool
+%s:11 PhanRedundantCondition Redundant attempt to cast ($a != $b) of type bool to bool
+%s:12 PhanRedundantCondition Redundant attempt to cast ($a != $b) of type bool to bool
+%s:13 PhanRedundantCondition Redundant attempt to cast ($a !== $b) of type bool to bool
+%s:14 PhanRedundantCondition Redundant attempt to cast !$a of type bool to bool
+%s:15 PhanRedundantCondition Redundant attempt to cast ($a <=> $b) of type -1|0|1 to int
+%s:16 PhanRedundantCondition Redundant attempt to cast ($a xor $b) of type bool to bool
+%s:17 PhanRedundantCondition Redundant attempt to cast ($a && $b) of type bool to bool
+%s:18 PhanRedundantCondition Redundant attempt to cast ($a || $b) of type bool to bool
+%s:19 PhanRedundantCondition Redundant attempt to cast ($a && $b) of type bool to bool
+%s:20 PhanRedundantCondition Redundant attempt to cast ($a || $b) of type bool to bool
+%s:23 PhanRedundantCondition Redundant attempt to cast (bool)($a) of type bool to bool
+%s:25 PhanRedundantCondition Redundant attempt to cast (int)($a) of type int to int
+%s:26 PhanRedundantCondition Redundant attempt to cast (float)($a) of type float to float
+%s:27 PhanRedundantCondition Redundant attempt to cast (int)($a) of type int to int
+%s:28 PhanRedundantCondition Redundant attempt to cast (array)($a) of type array to array
+%s:29 PhanRedundantCondition Redundant attempt to cast (object)($a) of type object to object
+%s:30 PhanRedundantCondition Redundant attempt to cast ($a * $b) of type float|int to float
+%s:32 PhanRedundantCondition Redundant attempt to cast ($a % $b) of type int to float
+%s:34 PhanRedundantCondition Redundant attempt to cast ($a - $b) of type float|int to float
+%s:35 PhanRedundantCondition Redundant attempt to cast ($a . $b) of type string to string
+%s:37 PhanRedundantCondition Redundant attempt to cast ($a >> $b) of type int to int
+%s:38 PhanRedundantCondition Redundant attempt to cast ($a << $b) of type int to int
+%s:39 PhanRedundantCondition Redundant attempt to cast (5 << 1) of type int to int
+%s:40 PhanRedundantCondition Redundant attempt to cast (5 >> 1) of type int to int
+%s:47 PhanRedundantCondition Redundant attempt to cast (3 & 6) of type 2 to int
+%s:48 PhanRedundantCondition Redundant attempt to cast (3 ^ 6) of type 5 to int
+%s:49 PhanRedundantCondition Redundant attempt to cast (3 | 6) of type 7 to int
+%s:52 PhanRedundantCondition Redundant attempt to cast ($x *= 3) of type float to float
+%s:58 PhanRedundantCondition Redundant attempt to cast ($x -= 3) of type float to float
+%s:60 PhanRedundantCondition Redundant attempt to cast ($x **= 3) of type float to float
+%s:63 PhanRedundantCondition Redundant attempt to cast ($x /= 3) of type float to float
+%s:66 PhanRedundantCondition Redundant attempt to cast ($x %= 3) of type int to int
+%s:69 PhanRedundantCondition Redundant attempt to cast ($x .= 'suffix') of type string to string
+%s:73 PhanRedundantCondition Redundant attempt to cast ($x <<= 3) of type int to int
+%s:77 PhanRedundantCondition Redundant attempt to cast ($x >>= 3) of type int to int

--- a/tests/files/expected/0694_callable_scalar.php.expected
+++ b/tests/files/expected/0694_callable_scalar.php.expected
@@ -1,0 +1,9 @@
+%s:4 PhanRedundantCondition Redundant attempt to cast $i of type int to scalar
+%s:6 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is string but \intdiv() takes int
+%s:8 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is null but \intdiv() takes int
+%s:10 PhanRedundantCondition Redundant attempt to cast $b of type bool to scalar
+%s:11 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is bool but \intdiv() takes int
+%s:12 PhanRedundantCondition Redundant attempt to cast $a of type bool|float|int|string to scalar
+%s:16 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is callable-string but \intdiv() takes int
+%s:19 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is callable but \intdiv() takes int
+%s:22 PhanImpossibleCondition Impossible attempt to cast $nil of type null to scalar

--- a/tests/files/src/0101_one_of_each.php
+++ b/tests/files/src/0101_one_of_each.php
@@ -136,7 +136,7 @@ strlen(42);
 
 // Issue::PhanTypeMismatchForeach
 foreach (null as $i) {}
-
+foreach (STDIN as $i) {}
 // Issue::PhanTypeMismatchProperty
 function f3(int $p = false) {}
 

--- a/tests/files/src/0299_binary_op.php
+++ b/tests/files/src/0299_binary_op.php
@@ -42,7 +42,7 @@ function test298() {
     expect_string_298($intVar |= 1);
     expect_string_298($intVar ^= 2);
     expect_string_298($intVar &= 0xffff);
-    expect_string_298($intVar /= 2);
+    expect_string_298($intVar /= 2); echo strlen($intVar);
     expect_string_298($intVar *= 2);  // TODO: Do a better job at carrying the result of the assignment operator out of the scope of the above argument
     expect_string_298($intVar **= 2);
     expect_string_298($intVar %= 5);

--- a/tests/files/src/0693_redundant_cast_operations.php
+++ b/tests/files/src/0693_redundant_cast_operations.php
@@ -1,0 +1,93 @@
+<?php
+namespace NSRedundant;
+
+function test($a, $b) {
+    var_export((bool)($a < $b));
+    var_export((bool)($a <= $b));
+    var_export((bool)($a > $b));
+    var_export((bool)($a >= $b));
+    var_export((bool)($a == $b));
+    var_export((bool)($a === $b));
+    var_export((bool)($a != $b));
+    var_export((bool)($a <> $b));
+    var_export((bool)($a !== $b));
+    var_export((bool)!$a);
+    var_export((int)($a <=> $b));
+    var_export((bool)($a xor $b));
+    var_export((bool)($a and $b));
+    var_export((bool)($a or $b));
+    var_export((bool)($a && $b));
+    var_export((bool)($a || $b));
+}
+function testops($a, $b) {
+    var_export((bool)(bool)$a);
+    //  ++ -- ~ (int) (float) (string) (array) (object) (bool) @
+    var_export((int)(int)$a);
+    var_export((float)(float)$a);
+    var_export((int)(int)$a);
+    var_export((array)(array)$a);
+    var_export((object)(object)$a);
+    var_export((float)($a * $b));
+    var_export((float)($a / $b));
+    var_export((float)($a % $b));
+    var_export((float)($a + $b));
+    var_export((float)($a - $b));
+    var_export((string)($a . $b));
+    var_export((float)($a . $b));  // not redundant
+    var_export((int)($a >> $b));
+    var_export((int)($a << $b));
+    var_export((int)(5 << 1));
+    var_export((int)(5 >> 1));
+    var_export((array)($a & $b));  // impossible. TODO: Warn about impossible casts.
+    // can be string/int, so not redundant
+    var_export((int)($a & $b));  // not redundant
+    var_export((int)($a ^ $b));  // can be string/int
+    var_export((int)($a | $b));  // not redundant
+
+    var_export((int)(3 & 6));
+    var_export((int)(3 ^ 6));
+    var_export((int)(3 | 6));
+    $y = 0;
+    $x = 2;
+    var_export((float)($x *= 3));
+    $y += $x;
+    $x = 2.5;
+    var_export((float)($x += 3));  // TODO: Be more precise about += when both sides have known real types.
+    $y += $x;
+    $x = 2.5;
+    var_export((float)($x -= 3));
+    $y += $x;
+    var_export((float)($x **= 3));
+    $y += $x;
+    $x = 2;
+    var_export((float)($x /= 3));
+    $y += $x;
+    $x = 2;
+    var_export((int)($x %= 3));
+    $y += $x;
+    $x = 'prefix';
+    var_export((string)($x .= 'suffix'));
+    $y += strlen($x);
+
+    $x = 124652;
+    var_export((int)($x <<= 3));
+    $y += $x;
+
+    $x = 124652;
+    var_export((int)($x >>= 3));
+    $y += $x;
+
+    // bitwise operators can act on int/string. TODO: Be more precise for ^=, etc. when real types are known.
+    $x = 124652;
+    var_export((int)($x ^= 3));
+    $y += $x;
+
+    $x = 124652;
+    var_export((int)($x |= 3));
+    $y += $x;
+
+    $x = 124652;
+    var_export((int)($x &= 3));
+    $y += $x;
+    var_export($y);
+}

--- a/tests/files/src/0694_callable_scalar.php
+++ b/tests/files/src/0694_callable_scalar.php
@@ -1,0 +1,23 @@
+<?php
+
+function test_scalar_cast(int $i, ?string $s, bool $b, array $a, callable $c) {
+    assert(is_scalar($i));  // redundant
+    if (is_scalar($s)) {
+        echo intdiv($s, 2);
+    } else {
+        echo intdiv($s, 3);
+    }
+    assert(is_scalar($b));
+    echo intdiv($b, 2);
+    assert(is_scalar($a));  // impossible
+    echo intdiv($a, 2);  // Phan gives up and infers the empty union type.
+    if (is_scalar($c)) {
+        $c();
+        echo intdiv($c, 2);  // callable-string
+    } else {
+        $c();
+        echo intdiv($c, 4);  // callable
+    }
+    $nil = null;
+    var_export(is_scalar($nil));
+}

--- a/tests/php74_files/expected/000_null_assign.php.expected
+++ b/tests/php74_files/expected/000_null_assign.php.expected
@@ -1,6 +1,6 @@
-%s:5 PhanTypeMismatchArgumentInternal Argument 1 ($var) is int|string but \count() takes \Countable|array
-%s:6 PhanTypeMismatchArgumentInternal Argument 1 ($var) is int|string but \count() takes \Countable|array
-%s:7 PhanTypeMismatchArgumentInternal Argument 1 ($var) is int|string but \count() takes \Countable|array
+%s:5 PhanTypeMismatchArgumentInternal Argument 1 ($var) is int|string but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array
+%s:6 PhanTypeMismatchArgumentInternal Argument 1 ($var) is int|string but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array
+%s:7 PhanTypeMismatchArgumentInternal Argument 1 ($var) is int|string but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array
 %s:8 PhanUndeclaredVariable Variable $missing is undeclared
 %s:9 PhanTypeMismatchArgumentInternal Argument 1 ($string) is array{0:2} but \strlen() takes string
 %s:12 PhanTypeMismatchArgumentInternal Argument 1 ($string) is array{0:int,1:2} but \strlen() takes string

--- a/tests/php74_files/expected/005_typed_properties.php.expected
+++ b/tests/php74_files/expected/005_typed_properties.php.expected
@@ -1,4 +1,4 @@
 %s:17 PhanParamTooFew Call with 0 arg(s) to \TypedProperties\A::__construct() which requires 3 arg(s) defined at %s:10
-%s:18 PhanTypeMismatchArgumentInternal Argument 1 ($var) is ?int but \count() takes \Countable|array
-%s:19 PhanTypeMismatchArgumentInternal Argument 1 ($var) is string but \count() takes \Countable|array
-%s:20 PhanTypeMismatchArgumentInternal Argument 1 ($var) is \TypedProperties\A|\TypedProperties\SubClass but \count() takes \Countable|array
+%s:18 PhanTypeMismatchArgumentInternal Argument 1 ($var) is ?int but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array
+%s:19 PhanTypeMismatchArgumentInternal Argument 1 ($var) is string but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array
+%s:20 PhanTypeMismatchArgumentInternal Argument 1 ($var) is \TypedProperties\A|\TypedProperties\SubClass but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array


### PR DESCRIPTION
Improve real type checks for is_scalar/is_bool/is_callable.

Aggressively infer the real union type for more php operators

And change the way the inline value of the assign operator expression is inferred.