### PR TITLE
Check for uses of !== and === where types don't overlap

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,10 @@ New features(CLI, Configs):
   Supported values: `default`, `vim`, `eclipse_dark`
 + Be consistent about starting parameter/variable names with `$` in issue messages.
 + Add `--redundant-condition-detection` to attempt to detect redundant conditions/casts and impossible conditions based on the inferred real expression types.
-  New issue types: `PhanRedundantCondition`, `PhanImpossibleCondition` (e.g. `is_int(2)` and `boolval(true)` is redundant, `empty(2)` is impossible).
+
+New features(Analysis):
++ New issue types: `PhanRedundantCondition`, `PhanImpossibleCondition` (when `--redundant-condition-detection` is enabled)
+  (e.g. `is_int(2)` and `boolval(true)` is redundant, `empty(2)` is impossible).
 
   Note: This has many false positives involving loops, variables set in loops, and global variables.
   This will be split into more granular issue types later on.
@@ -16,8 +19,9 @@ New features(CLI, Configs):
   The real types are inferred separately (and more conservatively) from regular (phpdoc+real) expression types.
 
   (these checks can also be enabled with the config setting `redundant_condition_detection`)
-
-New features(Analysis):
++ New issue types: `PhanImpossibleTypeComparison` (when `--redundant-condition-detection` is enabled) (#1807)
+  (e.g. warns about `$x = new stdClass(); assert($x !== null)`)
++ Make Phan more accurately check if a loop may be executed 0 times.
 + Make Phan more accurately check if a loop may be executed 0 times.
 + Support the type `callable-object` in phpdoc and infer it from checks such as `is_callable($var) && is_object($var)` (#1336)
 + Support the type `callable-array` in phpdoc and infer it from checks such as `is_callable($var) && is_array($var)` (#2833)

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -721,7 +721,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/misc/fallback_te
 ## PhanNoopNumericLiteral
 
 ```
-Unused result of a numeric literal {STRING_LITERAL} near this line
+Unused result of a numeric literal {SCALAR} near this line
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/misc/fallback_test/expected/035_bad_switch_statement.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/2.0.0/tests/misc/fallback_test/src/035_bad_switch_statement.php#L1).
@@ -1550,7 +1550,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/files/expected/0
 ## PhanParamSpecial1
 
 ```
-Argument {INDEX} ({PARAMETER}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} when argument {INDEX} is {TYPE}
+Argument {INDEX} (${PARAMETER}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} when argument {INDEX} is {TYPE}
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/files/expected/0511_implode.php.expected#L3) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/2.0.0/tests/files/src/0511_implode.php#L8).
@@ -1558,7 +1558,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/files/expected/0
 ## PhanParamSpecial2
 
 ```
-Argument {INDEX} ({PARAMETER}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} when passed only one argument
+Argument {INDEX} (${PARAMETER}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} when passed only one argument
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/files/expected/0511_implode.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/2.0.0/tests/files/src/0511_implode.php#L4).
@@ -1841,6 +1841,22 @@ e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/files/expected/0
 
 This category of issue come from using incorrect types or types that cannot cast to the expected types.
 
+## PhanImpossibleCondition
+
+```
+Impossible attempt to cast {CODE} of type {TYPE} to {TYPE}
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0265_ternary_guards.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0265_ternary_guards.php#L4).
+
+## PhanImpossibleTypeComparison
+
+```
+Impossible attempt to check if {CODE} of type {TYPE} is identical to {CODE} of type {TYPE}
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0695_identity_no_type_overlap.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0695_identity_no_type_overlap.php#L5).
+
 ## PhanInfiniteRecursion
 
 NOTE: This is based on very simple heuristics. It has known false positives and false negatives.
@@ -1889,7 +1905,7 @@ This issue (and similar issues) may be emitted when `strict_param_checking` is t
 (when some types of the argument's union type match, but not others.)
 
 ```
-Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} ({TYPE} is incompatible) defined at {FILE}:{LINE}
+Argument {INDEX} (${PARAMETER}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} ({TYPE} is incompatible) defined at {FILE}:{LINE}
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/plugin_test/expected/088_possibly_invalid_argument.php.expected#L3) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/2.0.0/tests/plugin_test/src/088_possibly_invalid_argument.php#L10).
@@ -1899,7 +1915,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/plugin_test/expe
 This issue may be emitted when `strict_param_checking` is true, when analyzing an internal function.
 
 ```
-Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} ({TYPE} is incompatible)
+Argument {INDEX} (${PARAMETER}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} ({TYPE} is incompatible)
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/plugin_test/expected/025_strict_param_checks.php.expected#L3) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/2.0.0/tests/plugin_test/src/025_strict_param_checks.php#L8).
@@ -1930,7 +1946,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/plugin_test/expe
 This issue may be emitted when `strict_param_checking` is true
 
 ```
-Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} ({TYPE} is incompatible) defined at {FILE}:{LINE}
+Argument {INDEX} (${PARAMETER}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} ({TYPE} is incompatible) defined at {FILE}:{LINE}
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/plugin_test/expected/088_possibly_invalid_argument.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/2.0.0/tests/plugin_test/src/088_possibly_invalid_argument.php#L6).
@@ -1940,7 +1956,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/plugin_test/expe
 This issue may be emitted when `strict_param_checking` is true
 
 ```
-Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} ({TYPE} is incompatible)
+Argument {INDEX} (${PARAMETER}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} ({TYPE} is incompatible)
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/plugin_test/expected/078_merge_bool_and.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/2.0.0/tests/plugin_test/src/078_merge_bool_and.php#L3).
@@ -1976,7 +1992,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/plugin_test/expe
 This issue may be emitted when `strict_param_checking` is true
 
 ```
-Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} ({TYPE} is incompatible) defined at {FILE}:{LINE}
+Argument {INDEX} (${PARAMETER}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} ({TYPE} is incompatible) defined at {FILE}:{LINE}
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/plugin_test/expected/088_possibly_invalid_argument.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/2.0.0/tests/plugin_test/src/088_possibly_invalid_argument.php#L8).
@@ -1986,7 +2002,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/plugin_test/expe
 This issue may be emitted when `strict_param_checking` is true
 
 ```
-Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} ({TYPE} is incompatible)
+Argument {INDEX} (${PARAMETER}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} ({TYPE} is incompatible)
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/plugin_test/expected/025_strict_param_checks.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/2.0.0/tests/plugin_test/src/025_strict_param_checks.php#L6).
@@ -2008,6 +2024,14 @@ Returning type {TYPE} but {FUNCTIONLIKE} is declared to return {TYPE} ({TYPE} is
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/plugin_test/expected/026_strict_return_checks.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/2.0.0/tests/plugin_test/src/026_strict_return_checks.php#L16).
+
+## PhanRedundantCondition
+
+```
+Redundant attempt to cast {CODE} of type {TYPE} to {TYPE}
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0516_literal_type_narrowing.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0516_literal_type_narrowing.php#L4).
 
 ## PhanRelativePathUsed
 
@@ -2527,7 +2551,7 @@ class A { public function __set() { return true; } }
 ## PhanTypeMismatchArgument
 
 ```
-Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} defined at {FILE}:{LINE}
+Argument {INDEX} (${PARAMETER}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} defined at {FILE}:{LINE}
 ```
 
 This will be emitted for the code
@@ -2540,7 +2564,7 @@ f8('string');
 ## PhanTypeMismatchArgumentInternal
 
 ```
-Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE}
+Argument {INDEX} (${PARAMETER}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE}
 ```
 
 This will be emitted for the code
@@ -2552,7 +2576,7 @@ strlen(42);
 ## PhanTypeMismatchArgumentNullable
 
 ```
-Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} defined at {FILE}:{LINE} (expected type to be non-nullable)
+Argument {INDEX} (${PARAMETER}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} defined at {FILE}:{LINE} (expected type to be non-nullable)
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/files/expected/0086_conditional_instanceof_type.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/2.0.0/tests/files/src/0086_conditional_instanceof_type.php#L14).
@@ -2560,7 +2584,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/files/expected/0
 ## PhanTypeMismatchArgumentNullableInternal
 
 ```
-Argument {INDEX} ({VARIABLE}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} (expected type to be non-nullable)
+Argument {INDEX} (${PARAMETER}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} (expected type to be non-nullable)
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/files/expected/0152_closure_casts_callable.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/2.0.0/tests/files/src/0152_closure_casts_callable.php#L4).
@@ -2584,7 +2608,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/files/expected/0
 ## PhanTypeMismatchDeclaredParam
 
 ```
-Doc-block of ${VARIABLE} in {METHOD} contains phpdoc param type {TYPE} which is incompatible with the param type {TYPE} declared in the signature
+Doc-block of ${PARAMETER} in {METHOD} contains phpdoc param type {TYPE} which is incompatible with the param type {TYPE} declared in the signature
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/files/expected/0334_reject_bad_narrowing.php.expected#L6) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/2.0.0/tests/files/src/0334_reject_bad_narrowing.php#L25).
@@ -2592,7 +2616,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/files/expected/0
 ## PhanTypeMismatchDeclaredParamNullable
 
 ```
-Doc-block of ${VARIABLE} in {METHOD} is phpdoc param type {TYPE} which is not a permitted replacement of the nullable param type {TYPE} declared in the signature ('?T' should be documented as 'T|null' or '?T')
+Doc-block of ${PARAMETER} in {METHOD} is phpdoc param type {TYPE} which is not a permitted replacement of the nullable param type {TYPE} declared in the signature ('?T' should be documented as 'T|null' or '?T')
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/files/expected/0005_compat.php.expected#L3) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/2.0.0/tests/files/src/0005_compat.php#L21).
@@ -2616,7 +2640,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/files/expected/0
 ## PhanTypeMismatchDefault
 
 ```
-Default value for {TYPE} ${VARIABLE} can't be {TYPE}
+Default value for {TYPE} ${PARAMETER} can't be {TYPE}
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/rasmus_files/expected/0030_def_arg_type.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/2.0.0/tests/rasmus_files/src/0030_def_arg_type.php#L4).
@@ -3520,7 +3544,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/files/expected/0
 ## PhanCommentParamAssertionWithoutRealParam
 
 ```
-Saw an @phan-assert annotation for {VARIABLE}, but it was not found in the param list of {FUNCTIONLIKE}
+Saw an @phan-assert annotation for ${PARAMETER}, but it was not found in the param list of {FUNCTIONLIKE}
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/plugin_test/expected/086_comment_param_assertions.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/2.0.0/tests/plugin_test/src/086_comment_param_assertions.php#L14).
@@ -3528,7 +3552,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/plugin_test/expe
 ## PhanCommentParamOnEmptyParamList
 
 ```
-Saw an @param annotation for {VARIABLE}, but the param list of {FUNCTIONLIKE} is empty
+Saw an @param annotation for ${PARAMETER}, but the param list of {FUNCTIONLIKE} is empty
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/plugin_test/expected/086_comment_param_assertions.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/2.0.0/tests/plugin_test/src/086_comment_param_assertions.php#L3).
@@ -3536,7 +3560,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/plugin_test/expe
 ## PhanCommentParamOutOfOrder
 
 ```
-Expected @param annotation for {VARIABLE} to be before the @param annotation for {VARIABLE}
+Expected @param annotation for ${PARAMETER} to be before the @param annotation for ${PARAMETER}
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/files/expected/0520_spaces_in_union_type.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/2.0.0/tests/files/src/0520_spaces_in_union_type.php#L5).
@@ -3544,7 +3568,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/files/expected/0
 ## PhanCommentParamWithoutRealParam
 
 ```
-Saw an @param annotation for {VARIABLE}, but it was not found in the param list of {FUNCTIONLIKE}
+Saw an @param annotation for ${PARAMETER}, but it was not found in the param list of {FUNCTIONLIKE}
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/files/expected/0373_reject_bad_type_narrowing.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/2.0.0/tests/files/src/0373_reject_bad_type_narrowing.php#L4).

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -199,6 +199,7 @@ class Issue
     const TypeInvalidPropertyDefaultReal  = 'PhanTypeInvalidPropertyDefaultReal';
     const ImpossibleCondition         = 'PhanImpossibleCondition';
     const RedundantCondition          = 'PhanRedundantCondition';
+    const ImpossibleTypeComparison    = 'PhanImpossibleTypeComparison';
 
     // Issue::CATEGORY_ANALYSIS
     const Unanalyzable              = 'PhanUnanalyzable';
@@ -2066,6 +2067,14 @@ class Issue
                 "Redundant attempt to cast {CODE} of type {TYPE} to {TYPE}",
                 self::REMEDIATION_B,
                 10114
+            ),
+            new Issue(
+                self::ImpossibleTypeComparison,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_CRITICAL,
+                "Impossible attempt to check if {CODE} of type {TYPE} is identical to {CODE} of type {TYPE}",
+                self::REMEDIATION_B,
+                10115
             ),
             // Issue::CATEGORY_VARIABLE
             new Issue(

--- a/src/Phan/Language/Element/GlobalConstant.php
+++ b/src/Phan/Language/Element/GlobalConstant.php
@@ -65,10 +65,11 @@ class GlobalConstant extends AddressableElement implements ConstantInterface
         $constant_fqsen = FullyQualifiedGlobalConstantName::fromFullyQualifiedString(
             '\\' . $name
         );
+        $type = Type::fromObject($value);
         $result = new self(
             new Context(),
             $name,
-            Type::fromObject($value)->asRealUnionType(),
+            UnionType::of([$type], [$type->asNonLiteralType()]),
             0,
             $constant_fqsen
         );

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -1164,6 +1164,11 @@ final class EmptyUnionType extends UnionType
         return $this;
     }
 
+    public function canAnyTypeStrictCastToUnionType(CodeBase $code_base, UnionType $target) : bool
+    {
+        return true;
+    }
+
     public function canStrictCastToUnionType(CodeBase $code_base, UnionType $target) : bool
     {
         return true;

--- a/tests/files/expected/0299_binary_op.php.expected
+++ b/tests/files/expected/0299_binary_op.php.expected
@@ -7,8 +7,10 @@
 %s:15 PhanTypeMismatchArgument Argument 1 ($x) is '01' but \expect_int_298() takes int defined at %s:4
 %s:16 PhanTypeMismatchArgument Argument 1 ($x) is int but \expect_string_298() takes string defined at %s:3
 %s:17 PhanTypeMismatchArgument Argument 1 ($x) is bool but \expect_string_298() takes string defined at %s:3
+%s:18 PhanImpossibleTypeComparison Impossible attempt to check if 4 of type 4 is identical to 2 of type 2
 %s:18 PhanTypeMismatchArgument Argument 1 ($x) is bool but \expect_string_298() takes string defined at %s:3
 %s:19 PhanTypeMismatchArgument Argument 1 ($x) is bool but \expect_string_298() takes string defined at %s:3
+%s:20 PhanImpossibleTypeComparison Impossible attempt to check if 4 of type 4 is identical to 2 of type 2
 %s:20 PhanTypeMismatchArgument Argument 1 ($x) is bool but \expect_string_298() takes string defined at %s:3
 %s:21 PhanTypeMismatchArgument Argument 1 ($x) is bool but \expect_string_298() takes string defined at %s:3
 %s:22 PhanTypeMismatchArgument Argument 1 ($x) is bool but \expect_string_298() takes string defined at %s:3

--- a/tests/files/expected/0695_identity_no_type_overlap.php.expected
+++ b/tests/files/expected/0695_identity_no_type_overlap.php.expected
@@ -1,0 +1,8 @@
+%s:5 PhanImpossibleTypeComparison Impossible attempt to check if $obj of type \stdClass is identical to null of type null
+%s:6 PhanImpossibleTypeComparison Impossible attempt to check if $obj of type \stdClass is identical to null of type null
+%s:7 PhanImpossibleTypeComparison Impossible attempt to check if $obj of type \stdClass is identical to true of type true
+%s:8 PhanImpossibleTypeComparison Impossible attempt to check if $obj of type \stdClass is identical to $bool of type bool
+%s:9 PhanImpossibleTypeComparison Impossible attempt to check if $obj of type \stdClass is identical to $bool of type bool
+%s:10 PhanImpossibleTypeComparison Impossible attempt to check if $obj of type \stdClass is identical to $nullableBool of type ?bool
+%s:12 PhanImpossibleTypeComparison Impossible attempt to check if $bool of type bool is identical to null of type null
+%s:16 PhanImpossibleTypeComparison Impossible attempt to check if $nullableObj of type ?\stdClass is identical to true of type true

--- a/tests/files/src/0695_identity_no_type_overlap.php
+++ b/tests/files/src/0695_identity_no_type_overlap.php
@@ -1,0 +1,19 @@
+<?php
+
+function test_impossible_type_comparison695(stdClass $obj, ?stdClass $nullableObj, bool $bool, ?bool $nullableBool) {
+    // All of these checks on $obj are nullable
+    var_export($obj === null);
+    var_export($obj !== null);
+    var_export($obj === true);
+    var_export($obj === $bool);
+    var_export($obj !== $bool);
+    var_export($obj !== $nullableBool);
+
+    var_export($bool === null);  // impossible
+
+    var_export($nullableObj === null);
+    var_export($nullableObj !== null);
+    var_export($nullableObj === true);
+    var_export($nullableObj === $obj);
+    var_export($nullableObj === $nullableBool);
+}


### PR DESCRIPTION
Fixes #1807

Emit PhanImpossibleTypeComparison in those cases.
TODO: permit casting interfaces to other object types, in a subsequent PR