### PR TITLE
Track if a redundant/impossible check was made within a loop.

### DIFF
--- a/.phan/plugins/PregRegexCheckerPlugin.php
+++ b/.phan/plugins/PregRegexCheckerPlugin.php
@@ -151,7 +151,7 @@ class PregRegexCheckerPlugin extends PluginV3 implements AnalyzeFunctionCallCapa
         // > $replacement may contain references of the form \\n or $n, with the latter form being the preferred one.
         try {
             foreach ($replacement_templates as $replacement_template) {
-                // @phan-suppress-next-line PhanCoalescingAlwaysNull false positive in loop
+                // @phan-suppress-next-line PhanCoalescingAlwaysNullInLoop false positive in loop
                 $pattern_keys = $pattern_keys ?? self::computePatternKeys($patterns);
                 $regex_group_keys = self::extractTemplateKeys($replacement_template);
                 foreach ($regex_group_keys as $key => $reference_string) {

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@ New features(CLI, Configs):
 + Add `--redundant-condition-detection` to attempt to detect redundant conditions/casts and impossible conditions based on the inferred real expression types.
 
 New features(Analysis):
-+ New issue types: `PhanRedundantCondition`, `PhanImpossibleCondition` (when `--redundant-condition-detection` is enabled)
++ New issue types: `PhanRedundantCondition[InLoop]`, `PhanImpossibleCondition[InLoop]` (when `--redundant-condition-detection` is enabled)
   (e.g. `is_int(2)` and `boolval(true)` is redundant, `empty(2)` is impossible).
 
   Note: This has many false positives involving loops, variables set in loops, and global variables.
@@ -19,9 +19,9 @@ New features(Analysis):
   The real types are inferred separately (and more conservatively) from regular (phpdoc+real) expression types.
 
   (these checks can also be enabled with the config setting `redundant_condition_detection`)
-+ New issue types: `PhanImpossibleTypeComparison` (when `--redundant-condition-detection` is enabled) (#1807)
++ New issue types: `PhanImpossibleTypeComparison[InLoop]` (when `--redundant-condition-detection` is enabled) (#1807)
   (e.g. warns about `$x = new stdClass(); assert($x !== null)`)
-+ New issue types: `PhanCoalescingAlwaysNull`, `PhanCoalescingNeverNull` (when `--redundant-condition-detection` is enabled)
++ New issue types: `PhanCoalescingAlwaysNull[InLoop]`, `PhanCoalescingNeverNull[InLoop]` (when `--redundant-condition-detection` is enabled)
   (e.g. warns about `(null ?? 'other')`, `($a >= $b) ?? 'default'`)
 + Infer real return types from Reflection of php and the enabled extensions (affects `--redundant-condition-detection`)
 + Make Phan more accurately check if a loop may be executed 0 times.

--- a/composer.lock
+++ b/composer.lock
@@ -497,16 +497,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v4.3.0",
+            "version": "v4.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "707b619d2c3bedf0224d56f95f77dabc60102305"
+                "reference": "d50bbeeb0e17e6dd4124ea391eff235e932cbf64"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/707b619d2c3bedf0224d56f95f77dabc60102305",
-                "reference": "707b619d2c3bedf0224d56f95f77dabc60102305",
+                "url": "https://api.github.com/repos/symfony/console/zipball/d50bbeeb0e17e6dd4124ea391eff235e932cbf64",
+                "reference": "d50bbeeb0e17e6dd4124ea391eff235e932cbf64",
                 "shasum": ""
             },
             "require": {
@@ -568,7 +568,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2019-05-27T08:16:38+00:00"
+            "time": "2019-06-05T13:25:51+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -1385,16 +1385,16 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "2.1.1",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "8b389aebe1b8b0578430bda0c7c95a829608e059"
+                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/8b389aebe1b8b0578430bda0c7c95a829608e059",
-                "reference": "8b389aebe1b8b0578430bda0c7c95a829608e059",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/1038454804406b0b5f5f520358e78c1c2f71501e",
+                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e",
                 "shasum": ""
             },
             "require": {
@@ -1430,7 +1430,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2019-02-20T10:12:59+00:00"
+            "time": "2019-06-07T04:22:29+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -2133,16 +2133,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v4.3.0",
+            "version": "v4.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "a5e3dd4e93a364668034a3cb6efa963d0b33ab45"
+                "reference": "856d35814cf287480465bb7a6c413bb7f5f5e69c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/a5e3dd4e93a364668034a3cb6efa963d0b33ab45",
-                "reference": "a5e3dd4e93a364668034a3cb6efa963d0b33ab45",
+                "url": "https://api.github.com/repos/symfony/process/zipball/856d35814cf287480465bb7a6c413bb7f5f5e69c",
+                "reference": "856d35814cf287480465bb7a6c413bb7f5f5e69c",
                 "shasum": ""
             },
             "require": {
@@ -2178,7 +2178,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2019-05-26T20:47:49+00:00"
+            "time": "2019-05-30T16:10:05+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -1849,6 +1849,12 @@ Using {CODE} of type {TYPE} as the left hand side of a null coalescing (??) oper
 
 e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0697_coalescing_always_never_null.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0697_coalescing_always_never_null.php#L5).
 
+## PhanCoalescingAlwaysNullInLoop
+
+```
+Using {CODE} of type {TYPE} as the left hand side of a null coalescing (??) operation. The left hand side may be unnecessary. (in a loop body - this is likely a false positive)
+```
+
 ## PhanCoalescingNeverNull
 
 ```
@@ -1856,6 +1862,12 @@ Using non-null {CODE} of type {TYPE} as the left hand side of a null coalescing 
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0697_coalescing_always_never_null.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0697_coalescing_always_never_null.php#L4).
+
+## PhanCoalescingNeverNullInLoop
+
+```
+Using non-null {CODE} of type {TYPE} as the left hand side of a null coalescing (??) operation. The right hand side may be unnecessary. (in a loop body - this is likely a false positive)
+```
 
 ## PhanImpossibleCondition
 
@@ -1865,6 +1877,12 @@ Impossible attempt to cast {CODE} of type {TYPE} to {TYPE}
 
 e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0265_ternary_guards.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0265_ternary_guards.php#L4).
 
+## PhanImpossibleConditionInLoop
+
+```
+Impossible attempt to cast {CODE} of type {TYPE} to {TYPE} in a loop body
+```
+
 ## PhanImpossibleTypeComparison
 
 ```
@@ -1872,6 +1890,12 @@ Impossible attempt to check if {CODE} of type {TYPE} is identical to {CODE} of t
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0695_identity_no_type_overlap.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0695_identity_no_type_overlap.php#L5).
+
+## PhanImpossibleTypeComparisonInLoop
+
+```
+Impossible attempt to check if {CODE} of type {TYPE} is identical to {CODE} of type {TYPE} in a loop body (likely a false positive)
+```
 
 ## PhanInfiniteRecursion
 
@@ -2048,6 +2072,14 @@ Redundant attempt to cast {CODE} of type {TYPE} to {TYPE}
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0516_literal_type_narrowing.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0516_literal_type_narrowing.php#L4).
+
+## PhanRedundantConditionInLoop
+
+```
+Redundant attempt to cast {CODE} of type {TYPE} to {TYPE} in a loop body (likely a false positive)
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0698_loop_false_positive.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0698_loop_false_positive.php#L5).
 
 ## PhanRelativePathUsed
 

--- a/internal/sanitycheck.php
+++ b/internal/sanitycheck.php
@@ -46,7 +46,7 @@ function getParametersCountsFromPhan(array $fields) : array
             break;
         } elseif (strpos($type, '=') === false) {
             $num_required++;
-            // @phan-suppress-next-line PhanImpossibleCondition this is a known false positive in loops
+            // @phan-suppress-next-line PhanImpossibleConditionInLoop this is a known false positive in loops
             if ($saw_optional) {
                 $saw_optional_after_required = true;
             }

--- a/phan_client
+++ b/phan_client
@@ -276,7 +276,7 @@ class PhanPHPLinter
             }
             $pathInProject = $issue['location']['path'];  // relative path
             if (!isset($file_mapping[$pathInProject])) {
-                // @phan-suppress-next-line PhanImpossibleCondition this is a known false positive in loops
+                // @phan-suppress-next-line PhanRedundantConditionInLoop this is a known false positive in loops
                 if (!$did_debug) {
                     self::debugInfo(sprintf("Unexpected path for issue (expected %s): %s\n", json_encode($file_mapping) ?: 'invalid', json_encode($issue) ?: 'invalid'));
                 }

--- a/src/Phan/AST/ASTReverter.php
+++ b/src/Phan/AST/ASTReverter.php
@@ -112,7 +112,7 @@ class ASTReverter
         };
         self::$closure_map = [
             ast\AST_ARG_LIST => static function (Node $node) : string {
-                return '(' . implode(', ', array_map('self::toShortString', $node->children)) . ')';
+                return '(' . implode(', ', \array_map('self::toShortString', $node->children)) . ')';
             },
             ast\AST_CLASS_CONST => static function (Node $node) : string {
                 return self::toShortString($node->children['class']) . '::' . $node->children['const'];

--- a/src/Phan/AST/ASTSimplifier.php
+++ b/src/Phan/AST/ASTSimplifier.php
@@ -140,7 +140,7 @@ class ASTSimplifier
             // Run normalizeIfStatement again.
             \array_pop($new_statements);
             \array_push($new_statements, ...self::normalizeIfStatement($stmt));
-            // @phan-suppress-next-line PhanImpossibleCondition this is a known false positive in loops
+            // @phan-suppress-next-line PhanRedundantConditionInLoop this is a known false positive in loops
             $modified = $modified || \end($new_statements) !== $stmt;
             continue;
         }

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -2634,7 +2634,7 @@ class TolerantASTConverter
         $prev_was_element = false;
         foreach ($n->listElements->children ?? [] as $item) {
             if ($item instanceof Token) {
-                // @phan-suppress-next-line PhanImpossibleCondition this is a known false positive in loops
+                // @phan-suppress-next-line PhanRedundantConditionInLoop this is a known false positive in loops
                 if (!$prev_was_element) {
                     $ast_items[] = null;
                     continue;
@@ -2665,7 +2665,7 @@ class TolerantASTConverter
         $prev_was_element = false;
         foreach ($n->arrayElements->children ?? [] as $item) {
             if ($item instanceof Token) {
-                // @phan-suppress-next-line PhanImpossibleCondition this is a known false positive in loops
+                // @phan-suppress-next-line PhanRedundantConditionInLoop this is a known false positive in loops
                 if (!$prev_was_element) {
                     $ast_items[] = null;
                     continue;

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -2151,7 +2151,7 @@ class UnionTypeVisitor extends AnalysisVisitor
             } else {
                 $function_types = $function->getUnionType();
             }
-            // @phan-suppress-next-line PhanImpossibleCondition known false positive in loops
+            // @phan-suppress-next-line PhanImpossibleConditionInLoop known false positive in loops
             if ($possible_types) {
                 $possible_types = $possible_types->withUnionType($function_types);
             } else {
@@ -2548,7 +2548,7 @@ class UnionTypeVisitor extends AnalysisVisitor
                 $result = $result->withType($fqsen->asType());
             } elseif (\get_class($sub_type) === Type::class || $sub_type instanceof ClosureType || $sub_type instanceof StaticType) {
                 $result = $result->withType($sub_type);
-            } elseif ($is_valid) {  // @phan-suppress-current-line PhanRedundantCondition
+            } elseif ($is_valid) {  // @phan-suppress-current-line PhanRedundantConditionInLoop
                 if ($sub_type instanceof StringType) {
                     if ($sub_type instanceof ClassStringType) {
                         $result = $result->withUnionType($sub_type->getClassUnionType());

--- a/src/Phan/Analysis/ArgumentType.php
+++ b/src/Phan/Analysis/ArgumentType.php
@@ -58,7 +58,7 @@ final class ArgumentType
         self::checkIsDeprecatedOrInternal($code_base, $context, $method);
         if ($method->hasFunctionCallAnalyzer()) {
             try {
-                $method->analyzeFunctionCall($code_base, $context->withLineNumberStart($node->lineno ?? 0), $node->children['args']->children);
+                $method->analyzeFunctionCall($code_base, $context->withLineNumberStart($node->lineno), $node->children['args']->children);
             } catch (StopParamAnalysisException $_) {
                 return;
             }
@@ -72,7 +72,7 @@ final class ArgumentType
         if ($argcount < $method->getNumberOfRequiredParameters() && !self::isUnpack($arglist->children)) {
             $alternate_found = false;
             foreach ($method->alternateGenerator($code_base) as $alternate_method) {
-                // @phan-suppress-next-line PhanImpossibleCondition
+                // @phan-suppress-next-line PhanRedundantConditionInLoop
                 $alternate_found = $alternate_found || (
                     $argcount >=
                     $alternate_method->getNumberOfRequiredParameters()
@@ -277,7 +277,7 @@ final class ArgumentType
         if ($argcount < $method->getNumberOfRequiredParameters() && !self::isUnpack($arg_nodes)) {
             $alternate_found = false;
             foreach ($method->alternateGenerator($code_base) as $alternate_method) {
-                // @phan-suppress-next-line PhanImpossibleCondition known false positive in loop
+                // @phan-suppress-next-line PhanRedundantConditionInLoop known false positive in loop
                 $alternate_found = $alternate_found || (
                     $argcount >=
                     $alternate_method->getNumberOfRequiredParameters()

--- a/src/Phan/Analysis/NegatedConditionVisitor.php
+++ b/src/Phan/Analysis/NegatedConditionVisitor.php
@@ -500,11 +500,11 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
                         // Add types which are not instances of $base_class_name
                         foreach ($union_type->getTypeSet() as $type) {
                             if ($type instanceof $base_class_name) {
-                                // @phan-suppress-next-line PhanImpossibleCondition this is a known false positive in loops
+                                // @phan-suppress-next-line PhanRedundantConditionInLoop this is a known false positive in loops
                                 $has_null = $has_null || $type->isNullable();
                                 continue;
                             }
-                            // @phan-suppress-next-line PhanImpossibleCondition this is a known false positive in loops
+                            // @phan-suppress-next-line PhanRedundantConditionInLoop this is a known false positive in loops
                             $has_other_nullable_types = $has_other_nullable_types || $type->isNullable();
                             $new_type_builder->addType($type);
                         }
@@ -539,11 +539,11 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
                         // Add types which are not scalars
                         foreach ($union_type->getTypeSet() as $type) {
                             if ($type_filter($type)) {
-                                // @phan-suppress-next-line PhanImpossibleCondition this is a known false positive in loops
+                                // @phan-suppress-next-line PhanRedundantConditionInLoop this is a known false positive in loops
                                 $has_null = $has_null || $type->isNullable();
                                 continue;
                             }
-                            // @phan-suppress-next-line PhanImpossibleCondition this is a known false positive in loops
+                            // @phan-suppress-next-line PhanRedundantConditionInLoop this is a known false positive in loops
                             $has_other_nullable_types = $has_other_nullable_types || $type->isNullable();
                             $new_type_builder->addType($type);
                         }
@@ -584,11 +584,11 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
                     // Add types which are not callable
                     foreach ($union_type->getTypeSet() as $type) {
                         if ($type->isCallable()) {
-                            // @phan-suppress-next-line PhanImpossibleCondition this is a known false positive in loops
+                            // @phan-suppress-next-line PhanRedundantConditionInLoop this is a known false positive in loops
                             $has_null = $has_null || $type->isNullable();
                             continue;
                         }
-                        // @phan-suppress-next-line PhanImpossibleCondition this is a known false positive in loops
+                        // @phan-suppress-next-line PhanRedundantConditionInLoop this is a known false positive in loops
                         $has_other_nullable_types = $has_other_nullable_types || $type->isNullable();
                         $new_type_builder->addType($type);
                     }
@@ -621,12 +621,12 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
                     // Add types which are not callable
                     foreach ($union_type->getTypeSet() as $type) {
                         if ($type instanceof ArrayType) {
-                            // @phan-suppress-next-line PhanImpossibleCondition this is a known false positive in loops
+                            // @phan-suppress-next-line PhanRedundantConditionInLoop this is a known false positive in loops
                             $has_null = $has_null || $type->isNullable();
                             continue;
                         }
 
-                        // @phan-suppress-next-line PhanImpossibleCondition this is a known false positive in loops
+                        // @phan-suppress-next-line PhanRedundantConditionInLoop this is a known false positive in loops
                         $has_other_nullable_types = $has_other_nullable_types || $type->isNullable();
 
                         if (\get_class($type) === IterableType::class) {
@@ -661,11 +661,11 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
                     // Add types which are not callable
                     foreach ($union_type->getTypeSet() as $type) {
                         if ($type->isObject()) {
-                            // @phan-suppress-next-line PhanImpossibleCondition this is a known false positive in loops
+                            // @phan-suppress-next-line PhanRedundantConditionInLoop this is a known false positive in loops
                             $has_null = $has_null || $type->isNullable();
                             continue;
                         }
-                        // @phan-suppress-next-line PhanImpossibleCondition this is a known false positive in loops
+                        // @phan-suppress-next-line PhanRedundantConditionInLoop this is a known false positive in loops
                         $has_other_nullable_types = $has_other_nullable_types || $type->isNullable();
 
                         if (\get_class($type) === IterableType::class) {

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -79,7 +79,7 @@ class ParameterTypesAnalyzer
             if ($parameter->isOptional()) {
                 $is_optional_seen = true;
             } else {
-                // @phan-suppress-next-line PhanImpossibleCondition this is a known false positive in loops
+                // @phan-suppress-next-line PhanImpossibleConditionInLoop this is a known false positive in loops
                 if ($is_optional_seen) {
                     Issue::maybeEmit(
                         $code_base,
@@ -883,7 +883,7 @@ class ParameterTypesAnalyzer
             $parameter_type = $parameter->getNonVariadicUnionType();
             // If there is already a phpdoc parameter type, then don't bother inheriting the parameter type from $o_method
             if (!$parameter_type->isEmpty()) {
-                // @phan-suppress-next-line PhanCoalescingAlwaysNull false positive in loop
+                // @phan-suppress-next-line PhanCoalescingAlwaysNullInLoop false positive in loop
                 $comment_parameter_map = $comment_parameter_map ?? self::extractCommentParameterMap($method);
                 $comment_parameter = $comment_parameter_map[$parameter->getName()] ?? null;
                 if ($comment_parameter) {

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -124,7 +124,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
 
         return $clazz->getContext()->withScope(
             $clazz->getInternalScope()
-        );
+        )->withoutLoops();
     }
 
     /**
@@ -274,7 +274,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
 
         $context = $original_context->withScope(
             $function->getInternalScope()
-        );
+        )->withoutLoops();
 
         // Parse the comment above the function to get
         // extra meta information about the function.
@@ -394,7 +394,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
     public function visitClosure(Node $node) : Context
     {
         $code_base = $this->code_base;
-        $context = $this->context;
+        $context = $this->context->withoutLoops();
         $closure_fqsen = FullyQualifiedFunctionName::fromClosureInContext(
             $context->withLineNumberStart($node->lineno),
             $node
@@ -533,7 +533,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
     public function visitArrowFunc(Node $node) : Context
     {
         $code_base = $this->code_base;
-        $context = $this->context;
+        $context = $this->context->withoutLoops();
         $closure_fqsen = FullyQualifiedFunctionName::fromClosureInContext(
             $context->withLineNumberStart($node->lineno),
             $node

--- a/src/Phan/Analysis/RedundantCondition.php
+++ b/src/Phan/Analysis/RedundantCondition.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+namespace Phan\Analysis;
+
+use ast\Node;
+use Phan\Issue;
+use Phan\Language\Context;
+use Phan\Parse\ParseVisitor;
+
+/**
+ * Contains miscellaneous utilities for warning about redundant and impossible conditions
+ */
+class RedundantCondition
+{
+    private const LOOP_ISSUE_NAMES = [
+        Issue::RedundantCondition       => Issue::RedundantConditionInLoop,
+        Issue::ImpossibleCondition      => Issue::ImpossibleConditionInLoop,
+        Issue::ImpossibleTypeComparison => Issue::ImpossibleTypeComparisonInLoop,
+        Issue::CoalescingNeverNull      => Issue::CoalescingNeverNullInLoop,
+        Issue::CoalescingAlwaysNull     => Issue::CoalescingAlwaysNullInLoop,
+    ];
+
+    /**
+     * Choose a more specific issue name based on where the issue was emitted from.
+     * In loops, Phan's checks have higher false positives.
+     *
+     * @param Node|int|float|string $node
+     * @param string $issue_name
+     */
+    public static function chooseSpecificImpossibleOrRedundantIssueKind($node, Context $context, string $issue_name) : string
+    {
+        if (ParseVisitor::isConstExpr($node)) {
+            return $issue_name;
+        }
+        if ($context->isInLoop()) {
+            return self::LOOP_ISSUE_NAMES[$issue_name] ?? $issue_name;
+        }
+
+        return $issue_name;
+    }
+}

--- a/src/Phan/Daemon.php
+++ b/src/Phan/Daemon.php
@@ -91,7 +91,7 @@ class Daemon
                     self::debugf("Got signal");
                     \pcntl_signal_dispatch();
                     self::debugf("done processing signals");
-                    // @phan-suppress-next-line PhanImpossibleCondition this is a known false positive with references. TODO fix analysis
+                    // @phan-suppress-next-line PhanImpossibleConditionInLoop this is a known false positive with references. TODO fix analysis
                     if ($got_signal) {
                         continue;  // Ignore notices from stream_socket_accept if it's due to being interrupted by a child process terminating.
                     }

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -197,11 +197,16 @@ class Issue
     const TypeErrorInInternalCall = 'PhanTypeErrorInInternalCall';
     const TypeErrorInOperation = 'PhanTypeErrorInOperation';
     const TypeInvalidPropertyDefaultReal  = 'PhanTypeInvalidPropertyDefaultReal';
-    const ImpossibleCondition         = 'PhanImpossibleCondition';
-    const RedundantCondition          = 'PhanRedundantCondition';
-    const ImpossibleTypeComparison    = 'PhanImpossibleTypeComparison';
-    const CoalescingNeverNull         = 'PhanCoalescingNeverNull';
-    const CoalescingAlwaysNull        = 'PhanCoalescingAlwaysNull';
+    const ImpossibleCondition               = 'PhanImpossibleCondition';
+    const ImpossibleConditionInLoop         = 'PhanImpossibleConditionInLoop';
+    const RedundantCondition                = 'PhanRedundantCondition';
+    const RedundantConditionInLoop          = 'PhanRedundantConditionInLoop';
+    const ImpossibleTypeComparison          = 'PhanImpossibleTypeComparison';
+    const ImpossibleTypeComparisonInLoop    = 'PhanImpossibleTypeComparisonInLoop';
+    const CoalescingNeverNull               = 'PhanCoalescingNeverNull';
+    const CoalescingNeverNullInLoop         = 'PhanCoalescingNeverNullInLoop';
+    const CoalescingAlwaysNull              = 'PhanCoalescingAlwaysNull';
+    const CoalescingAlwaysNullInLoop        = 'PhanCoalescingAlwaysNullInLoop';
 
     // Issue::CATEGORY_ANALYSIS
     const Unanalyzable              = 'PhanUnanalyzable';
@@ -2063,12 +2068,28 @@ class Issue
                 10113
             ),
             new Issue(
+                self::ImpossibleConditionInLoop,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_LOW,
+                "Impossible attempt to cast {CODE} of type {TYPE} to {TYPE} in a loop body",
+                self::REMEDIATION_B,
+                10118
+            ),
+            new Issue(
                 self::RedundantCondition,
                 self::CATEGORY_TYPE,
                 self::SEVERITY_LOW,
                 "Redundant attempt to cast {CODE} of type {TYPE} to {TYPE}",
                 self::REMEDIATION_B,
                 10114
+            ),
+            new Issue(
+                self::RedundantConditionInLoop,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_LOW,
+                "Redundant attempt to cast {CODE} of type {TYPE} to {TYPE} in a loop body (likely a false positive)",
+                self::REMEDIATION_B,
+                10119
             ),
             new Issue(
                 self::ImpossibleTypeComparison,
@@ -2079,6 +2100,14 @@ class Issue
                 10115
             ),
             new Issue(
+                self::ImpossibleTypeComparisonInLoop,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_LOW,
+                "Impossible attempt to check if {CODE} of type {TYPE} is identical to {CODE} of type {TYPE} in a loop body (likely a false positive)",
+                self::REMEDIATION_B,
+                10120
+            ),
+            new Issue(
                 self::CoalescingNeverNull,
                 self::CATEGORY_TYPE,
                 self::SEVERITY_LOW,
@@ -2087,12 +2116,28 @@ class Issue
                 10116
             ),
             new Issue(
+                self::CoalescingNeverNullInLoop,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_LOW,
+                "Using non-null {CODE} of type {TYPE} as the left hand side of a null coalescing (??) operation. The right hand side may be unnecessary. (in a loop body - this is likely a false positive)",
+                self::REMEDIATION_B,
+                10121
+            ),
+            new Issue(
                 self::CoalescingAlwaysNull,
                 self::CATEGORY_TYPE,
                 self::SEVERITY_LOW,
                 "Using {CODE} of type {TYPE} as the left hand side of a null coalescing (??) operation. The left hand side may be unnecessary.",
                 self::REMEDIATION_B,
                 10117
+            ),
+            new Issue(
+                self::CoalescingAlwaysNullInLoop,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_LOW,
+                "Using {CODE} of type {TYPE} as the left hand side of a null coalescing (??) operation. The left hand side may be unnecessary. (in a loop body - this is likely a false positive)",
+                self::REMEDIATION_B,
+                10122
             ),
             // Issue::CATEGORY_VARIABLE
             new Issue(

--- a/src/Phan/Language/Type/ArrayShapeType.php
+++ b/src/Phan/Language/Type/ArrayShapeType.php
@@ -246,7 +246,7 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
                     // However, the scalar_array_key_cast config would make any cast of array keys a valid cast.
                     continue;
                 }
-                // @phan-suppress-next-line PhanImpossibleCondition known false positive in loop
+                // @phan-suppress-next-line PhanImpossibleConditionInLoop known false positive in loop
                 if ($element_union_types) {
                     $element_union_types = $element_union_types->withType($target_type->genericArrayElementType());
                 } else {

--- a/src/Phan/Language/Type/FunctionLikeDeclarationType.php
+++ b/src/Phan/Language/Type/FunctionLikeDeclarationType.php
@@ -369,7 +369,7 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
     }
 
     /** @override */
-    public function analyzeFunctionCall(CodeBase $unused_code_base, Context $unused_context, array $_) : void
+    public function analyzeFunctionCall(CodeBase $code_base, Context $context, array $args) : void
     {
         throw new \AssertionError('should not call ' . __METHOD__);
     }

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -3953,7 +3953,7 @@ class UnionType implements Serializable
                 // Not going to bother being more specific (this applies bitwise not to each character for LiteralStringType)
                 $type_set = $type_set->withType(StringType::instance(false));
             } else {
-                // @phan-suppress-next-line PhanImpossibleCondition this is a known false positive in loops
+                // @phan-suppress-next-line PhanImpossibleConditionInLoop this is a known false positive in loops
                 if ($added_fallbacks) {
                     continue;
                 }
@@ -4005,7 +4005,7 @@ class UnionType implements Serializable
                         return $type_set->withType(LiteralIntType::instanceForValue(0, false));
                     }
                 }
-                // @phan-suppress-next-line PhanImpossibleCondition this is a known false positive in loops
+                // @phan-suppress-next-line PhanImpossibleConditionInLoop this is a known false positive in loops
                 if ($added_fallbacks) {
                     continue;
                 }

--- a/src/Phan/LanguageServer/ProtocolStreamWriter.php
+++ b/src/Phan/LanguageServer/ProtocolStreamWriter.php
@@ -58,7 +58,7 @@ class ProtocolStreamWriter implements ProtocolWriter
     private function flush() : void
     {
         $keepWriting = true;
-        // @phan-suppress-next-line PhanRedundantCondition this is a known false positive in loops
+        // @phan-suppress-next-line PhanRedundantConditionInLoop this is a known false positive in loops
         while ($keepWriting) {
             $message = $this->messages[0]['message'];
             $promise = $this->messages[0]['promise'];

--- a/src/Phan/Plugin/Internal/IssueFixingPlugin/IssueFixer.php
+++ b/src/Phan/Plugin/Internal/IssueFixingPlugin/IssueFixer.php
@@ -301,7 +301,7 @@ class IssueFixer
         $new_contents = '';
         $prev_edit = null;
         foreach ($all_edits as $edit) {
-            // @phan-suppress-next-line PhanImpossibleCondition known false positive in loop
+            // @phan-suppress-next-line PhanImpossibleConditionInLoop known false positive in loop
             if ($prev_edit && $edit->isEqualTo($prev_edit)) {
                 continue;
             }

--- a/src/Phan/Plugin/Internal/RequireExistsPlugin.php
+++ b/src/Phan/Plugin/Internal/RequireExistsPlugin.php
@@ -134,7 +134,7 @@ class RequireExistsVisitor extends PluginAwarePostAnalysisVisitor
             if (file_exists($absolute_path)) {
                 return $absolute_path;
             }
-            // @phan-suppress-next-line PhanCoalescingAlwaysNull false positive in loop.
+            // @phan-suppress-next-line PhanCoalescingAlwaysNullInLoop false positive in loop.
             $first_absolute_path = $first_absolute_path ?? $absolute_path;
         }
         // If we searched every directory in include_paths, but none existed,

--- a/src/Phan/PluginV3/AnalyzeFunctionCallCapability.php
+++ b/src/Phan/PluginV3/AnalyzeFunctionCallCapability.php
@@ -17,6 +17,8 @@ interface AnalyzeFunctionCallCapability
      * maps FQSEN of function or method to a closure used to analyze the function in question.
      * '\A::foo' or 'A::foo' as a key will override a method, and '\foo' or 'foo' as a key will override a function.
      * Closure Type: function(CodeBase $code_base, Context $context, Func|Method $function, array $args) : void {...}
+     *
+     * Note that $function->getMostRecentParentNodeListForCall() can be used to get the parent node list of the current call (will be the empty array if fetching it failed).
      */
     public function getAnalyzeFunctionCallClosures(CodeBase $code_base) : array;
 }

--- a/src/Phan/PluginV3/PluginAwarePostAnalysisVisitor.php
+++ b/src/Phan/PluginV3/PluginAwarePostAnalysisVisitor.php
@@ -18,6 +18,8 @@ namespace Phan\PluginV3;
  *
  * - Phan is able to figure out which methods a subclass implements, and only call the plugin's visitor for those types,
  *   but only when the plugin's visitor does not override the fallback visit() method.
+ *
+ * Subclasses should declare protected $parent_node_list as an instance property if they need to know the list of parent nodes.
  */
 abstract class PluginAwarePostAnalysisVisitor extends PluginAwareBaseAnalysisVisitor
 {

--- a/tests/Phan/Language/Internal/FunctionSignatureMapTest.php
+++ b/tests/Phan/Language/Internal/FunctionSignatureMapTest.php
@@ -99,8 +99,8 @@ final class FunctionSignatureMapTest extends BaseTest implements CodeBaseAwareTe
                 $errors .= "Expected function name '$function_name' to be found in signatures for php 7.4\n";
                 continue;
             }
-            $return_type = UnionType::fromStringInContext(str_replace('void', 'null', $return_type_string), $context, Type::FROM_TYPE);
-            $phan_return_type = UnionType::fromStringInContext(str_replace('void', 'null', $real_signature[0]), $context, Type::FROM_TYPE);
+            $return_type = UnionType::fromStringInContext(\str_replace('void', 'null', $return_type_string), $context, Type::FROM_TYPE);
+            $phan_return_type = UnionType::fromStringInContext(\str_replace('void', 'null', $real_signature[0]), $context, Type::FROM_TYPE);
             if (!$phan_return_type->canStrictCastToUnionType($this->code_base, $return_type)) {
                 $errors .= "Expected $phan_return_type to be able to cast to $return_type (checking consistency of real and phpdoc return types for '$function_name')\n";
             }

--- a/tests/files/expected/0312_for_loop_loop_after_statements.php.expected
+++ b/tests/files/expected/0312_for_loop_loop_after_statements.php.expected
@@ -1,3 +1,3 @@
-%s:9 PhanRedundantCondition Redundant attempt to cast $node of type \Node312 to truthy
-%s:16 PhanRedundantCondition Redundant attempt to cast $node of type \Node312 to truthy
+%s:9 PhanRedundantConditionInLoop Redundant attempt to cast $node of type \Node312 to truthy in a loop body (likely a false positive)
+%s:16 PhanRedundantConditionInLoop Redundant attempt to cast $node of type \Node312 to truthy in a loop body (likely a false positive)
 %s:16 PhanTypeMismatchArgumentInternal Argument 1 ($string) is 0|\Node312 but \strlen() takes string

--- a/tests/files/expected/0426_inline_var_force.php.expected
+++ b/tests/files/expected/0426_inline_var_force.php.expected
@@ -1,6 +1,6 @@
 %s:6 PhanUndeclaredVariable Variable $prev is undeclared
-%s:9 PhanRedundantCondition Redundant attempt to cast $first of type true to truthy
+%s:9 PhanRedundantConditionInLoop Redundant attempt to cast $first of type true to truthy in a loop body (likely a false positive)
 %s:10 PhanUndeclaredVariable Variable $prev is undeclared
 %s:22 PhanUnextractableAnnotation Saw unextractable annotation for comment '@phan-example-annotation array<int,string> description :'
 %s:22 PhanUnextractableAnnotation Saw unextractable annotation for comment '@phan-param a value'
-%s:31 PhanRedundantCondition Redundant attempt to cast $first of type true to truthy
+%s:31 PhanRedundantConditionInLoop Redundant attempt to cast $first of type true to truthy in a loop body (likely a false positive)

--- a/tests/files/expected/0690_callable_not_false.php.expected
+++ b/tests/files/expected/0690_callable_not_false.php.expected
@@ -1,5 +1,8 @@
 %s:6 PhanImpossibleCondition Impossible attempt to cast $c of type callable to empty
+%s:6 PhanRedundantCondition Redundant attempt to cast $c of type callable to truthy
 %s:8 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is callable-string but \intdiv() takes int
 %s:10 PhanImpossibleCondition Impossible attempt to cast $c of type callable-string to empty
+%s:10 PhanRedundantCondition Redundant attempt to cast $c of type callable-string to truthy
 %s:14 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is callable-string but \intdiv() takes int
 %s:16 PhanImpossibleCondition Impossible attempt to cast $str of type callable-string to empty
+%s:16 PhanRedundantCondition Redundant attempt to cast $str of type callable-string to truthy

--- a/tests/files/expected/0691_callable_object.php.expected
+++ b/tests/files/expected/0691_callable_object.php.expected
@@ -3,5 +3,7 @@
 %s:24 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is object but \intdiv() takes int
 %s:26 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is callable-object but \intdiv() takes int
 %s:28 PhanImpossibleCondition Impossible attempt to cast $c of type callable-object to empty
+%s:28 PhanRedundantCondition Redundant attempt to cast $c of type callable-object to truthy
 %s:32 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is callable-object but \intdiv() takes int
 %s:34 PhanImpossibleCondition Impossible attempt to cast $o of type callable-object to empty
+%s:34 PhanRedundantCondition Redundant attempt to cast $o of type callable-object to truthy

--- a/tests/files/expected/0692_callable_array.php.expected
+++ b/tests/files/expected/0692_callable_array.php.expected
@@ -2,5 +2,7 @@
 %s:14 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is null but \intdiv() takes int
 %s:20 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is callable-array but \intdiv() takes int
 %s:22 PhanImpossibleCondition Impossible attempt to cast $c of type callable-array to empty
+%s:22 PhanRedundantCondition Redundant attempt to cast $c of type callable-array to truthy
 %s:26 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is callable-array but \intdiv() takes int
 %s:28 PhanImpossibleCondition Impossible attempt to cast $arr of type callable-array to empty
+%s:28 PhanRedundantCondition Redundant attempt to cast $arr of type callable-array to truthy

--- a/tests/files/expected/0698_loop_false_positive.php.expected
+++ b/tests/files/expected/0698_loop_false_positive.php.expected
@@ -1,0 +1,1 @@
+%s:5 PhanRedundantConditionInLoop Redundant attempt to cast $found of type false to falsey in a loop body (likely a false positive)

--- a/tests/files/src/0312_for_loop_loop_after_statements.php
+++ b/tests/files/src/0312_for_loop_loop_after_statements.php
@@ -6,15 +6,14 @@ class Node312 {
 }
 
 function test312(Node312 $head) {
-  for ($node = $head; $node; $node = $next) {  // TODO emit different types in loops or fix false positive
+  for ($node = $head; $node; $node = $next) {  // false positive PhanRedundantConditionInLoop
     $next = $node->next;
     $node->next = null;
   }
 }
 
 function test312Buggy(Node312 $head) {
-  for ($node = $head; $node; $node = strlen($next ?: 0)) {  // TODO emit different types in loops or fix false positive
-
+  for ($node = $head; $node; $node = strlen($next ?: 0)) {  // false positive PhanRedundantConditionInLoop
     $next = $node->next;
     $node->next = null;
   }

--- a/tests/files/src/0426_inline_var_force.php
+++ b/tests/files/src/0426_inline_var_force.php
@@ -6,11 +6,11 @@ function example(int ...$values) {
     $sum = 0;
     '@phan-var int $prev';
     foreach ($values as $value) {
-        if (!$first) {  // TODO emit different issue type for loops or fix this false positive.
+        if (!$first) {  // emits different issue type for loops (usually false positive)
             $sum += $prev * $value;
         } else {
             $first = false;
-            $prev = $value;  // FIXME should not warn about $prev being unused
+            $prev = $value;  // emits different issue type for loops (usually false positive)
         }
     }
     return $sum;

--- a/tests/files/src/0690_callable_not_false.php
+++ b/tests/files/src/0690_callable_not_false.php
@@ -3,7 +3,7 @@
 namespace TestNarrowing;
 
 function test_callable_not_null(callable $c, string $str) {
-    assert(!empty($c));
+    assert(!empty($c));  // TODO: Avoid warning twice for empty() checks?
     if (is_string($c)) {
         echo intdiv($c, 2);
         $c();

--- a/tests/files/src/0698_loop_false_positive.php
+++ b/tests/files/src/0698_loop_false_positive.php
@@ -1,0 +1,9 @@
+<?php
+
+function test_loop() {
+    $found = false;
+    while (!$found) {
+        $found = rand(0,10) > 0;
+        echo '.';
+    }
+}

--- a/tests/run_test
+++ b/tests/run_test
@@ -28,6 +28,7 @@ case "$TEST_SUITE" in
 		exit $?
 		;;
 	__FakeSelfFallbackTest)
+		# This usually requires 1 GB with all plugins enabled.
 		./phan --plugin PHPUnitNotDeadCodePlugin \
 			--plugin InvokePHPNativeSyntaxCheckPlugin \
 			--dead-code-detection \
@@ -35,7 +36,7 @@ case "$TEST_SUITE" in
 			--polyfill-parse-all-element-doc-comments \
 			--force-polyfill-parser \
 			--disable-cache \
-			--memory-limit 1G
+			--memory-limit 2G
 		exit $?
 		;;
 	__FakeRewritingTest)


### PR DESCRIPTION
Only warn if the expression it acts on is variable.