### PR TITLE
Add issue types for redundant/impossible checks in the global scope

### DIFF
--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -1849,6 +1849,12 @@ Using {CODE} of type {TYPE} as the left hand side of a null coalescing (??) oper
 
 e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0697_coalescing_always_never_null.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0697_coalescing_always_never_null.php#L5).
 
+## PhanCoalescingAlwaysNullInGlobalScope
+
+```
+Using {CODE} of type {TYPE} as the left hand side of a null coalescing (??) operation. The left hand side may be unnecessary. (in the global scope - this is likely a false positive)
+```
+
 ## PhanCoalescingAlwaysNullInLoop
 
 ```
@@ -1862,6 +1868,12 @@ Using non-null {CODE} of type {TYPE} as the left hand side of a null coalescing 
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0697_coalescing_always_never_null.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0697_coalescing_always_never_null.php#L4).
+
+## PhanCoalescingNeverNullInGlobalScope
+
+```
+Using non-null {CODE} of type {TYPE} as the left hand side of a null coalescing (??) operation. The right hand side may be unnecessary. (in the global scope - this is likely a false positive)
+```
 
 ## PhanCoalescingNeverNullInLoop
 
@@ -1877,10 +1889,18 @@ Impossible attempt to cast {CODE} of type {TYPE} to {TYPE}
 
 e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0265_ternary_guards.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0265_ternary_guards.php#L4).
 
+## PhanImpossibleConditionInGlobalScope
+
+```
+Impossible attempt to cast {CODE} of type {TYPE} to {TYPE} in the global scope (may be a false positive)
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0620_more_noop_expressions.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0620_more_noop_expressions.php#L3).
+
 ## PhanImpossibleConditionInLoop
 
 ```
-Impossible attempt to cast {CODE} of type {TYPE} to {TYPE} in a loop body
+Impossible attempt to cast {CODE} of type {TYPE} to {TYPE} in a loop body (may be a false positive)
 ```
 
 ## PhanImpossibleTypeComparison
@@ -1890,6 +1910,12 @@ Impossible attempt to check if {CODE} of type {TYPE} is identical to {CODE} of t
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0695_identity_no_type_overlap.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0695_identity_no_type_overlap.php#L5).
+
+## PhanImpossibleTypeComparisonInGlobalScope
+
+```
+Impossible attempt to check if {CODE} of type {TYPE} is identical to {CODE} of type {TYPE} in the global scope (likely a false positive)
+```
 
 ## PhanImpossibleTypeComparisonInLoop
 
@@ -2071,7 +2097,15 @@ e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/plugin_test/expe
 Redundant attempt to cast {CODE} of type {TYPE} to {TYPE}
 ```
 
-e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0516_literal_type_narrowing.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0516_literal_type_narrowing.php#L4).
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0696_redundant_from_branch.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0696_redundant_from_branch.php#L11).
+
+## PhanRedundantConditionInGlobalScope
+
+```
+Redundant attempt to cast {CODE} of type {TYPE} to {TYPE} in the global scope (likely a false positive)
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0620_more_noop_expressions.php.expected#L4) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0620_more_noop_expressions.php#L4).
 
 ## PhanRedundantConditionInLoop
 

--- a/src/Phan/Analysis/RedundantCondition.php
+++ b/src/Phan/Analysis/RedundantCondition.php
@@ -20,6 +20,14 @@ class RedundantCondition
         Issue::CoalescingAlwaysNull     => Issue::CoalescingAlwaysNullInLoop,
     ];
 
+    private const GLOBAL_ISSUE_NAMES = [
+        Issue::RedundantCondition       => Issue::RedundantConditionInGlobalScope,
+        Issue::ImpossibleCondition      => Issue::ImpossibleConditionInGlobalScope,
+        Issue::ImpossibleTypeComparison => Issue::ImpossibleTypeComparisonInGlobalScope,
+        Issue::CoalescingNeverNull      => Issue::CoalescingNeverNullInGlobalScope,
+        Issue::CoalescingAlwaysNull     => Issue::CoalescingAlwaysNullInGlobalScope,
+    ];
+
     /**
      * Choose a more specific issue name based on where the issue was emitted from.
      * In loops, Phan's checks have higher false positives.
@@ -31,6 +39,9 @@ class RedundantCondition
     {
         if (ParseVisitor::isConstExpr($node)) {
             return $issue_name;
+        }
+        if ($context->isInGlobalScope()) {
+            return self::GLOBAL_ISSUE_NAMES[$issue_name] ?? $issue_name;
         }
         if ($context->isInLoop()) {
             return self::LOOP_ISSUE_NAMES[$issue_name] ?? $issue_name;

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -199,14 +199,19 @@ class Issue
     const TypeInvalidPropertyDefaultReal  = 'PhanTypeInvalidPropertyDefaultReal';
     const ImpossibleCondition               = 'PhanImpossibleCondition';
     const ImpossibleConditionInLoop         = 'PhanImpossibleConditionInLoop';
+    const ImpossibleConditionInGlobalScope  = 'PhanImpossibleConditionInGlobalScope';
     const RedundantCondition                = 'PhanRedundantCondition';
     const RedundantConditionInLoop          = 'PhanRedundantConditionInLoop';
+    const RedundantConditionInGlobalScope   = 'PhanRedundantConditionInGlobalScope';
     const ImpossibleTypeComparison          = 'PhanImpossibleTypeComparison';
     const ImpossibleTypeComparisonInLoop    = 'PhanImpossibleTypeComparisonInLoop';
+    const ImpossibleTypeComparisonInGlobalScope    = 'PhanImpossibleTypeComparisonInGlobalScope';
     const CoalescingNeverNull               = 'PhanCoalescingNeverNull';
     const CoalescingNeverNullInLoop         = 'PhanCoalescingNeverNullInLoop';
+    const CoalescingNeverNullInGlobalScope  = 'PhanCoalescingNeverNullInGlobalScope';
     const CoalescingAlwaysNull              = 'PhanCoalescingAlwaysNull';
     const CoalescingAlwaysNullInLoop        = 'PhanCoalescingAlwaysNullInLoop';
+    const CoalescingAlwaysNullInGlobalScope = 'PhanCoalescingAlwaysNullInGlobalScope';
 
     // Issue::CATEGORY_ANALYSIS
     const Unanalyzable              = 'PhanUnanalyzable';
@@ -2071,9 +2076,17 @@ class Issue
                 self::ImpossibleConditionInLoop,
                 self::CATEGORY_TYPE,
                 self::SEVERITY_LOW,
-                "Impossible attempt to cast {CODE} of type {TYPE} to {TYPE} in a loop body",
+                "Impossible attempt to cast {CODE} of type {TYPE} to {TYPE} in a loop body (may be a false positive)",
                 self::REMEDIATION_B,
                 10118
+            ),
+            new Issue(
+                self::ImpossibleConditionInGlobalScope,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_LOW,
+                "Impossible attempt to cast {CODE} of type {TYPE} to {TYPE} in the global scope (may be a false positive)",
+                self::REMEDIATION_B,
+                10123
             ),
             new Issue(
                 self::RedundantCondition,
@@ -2092,6 +2105,14 @@ class Issue
                 10119
             ),
             new Issue(
+                self::RedundantConditionInGlobalScope,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_LOW,
+                "Redundant attempt to cast {CODE} of type {TYPE} to {TYPE} in the global scope (likely a false positive)",
+                self::REMEDIATION_B,
+                10124
+            ),
+            new Issue(
                 self::ImpossibleTypeComparison,
                 self::CATEGORY_TYPE,
                 self::SEVERITY_LOW,
@@ -2106,6 +2127,14 @@ class Issue
                 "Impossible attempt to check if {CODE} of type {TYPE} is identical to {CODE} of type {TYPE} in a loop body (likely a false positive)",
                 self::REMEDIATION_B,
                 10120
+            ),
+            new Issue(
+                self::ImpossibleTypeComparisonInGlobalScope,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_LOW,
+                "Impossible attempt to check if {CODE} of type {TYPE} is identical to {CODE} of type {TYPE} in the global scope (likely a false positive)",
+                self::REMEDIATION_B,
+                10125
             ),
             new Issue(
                 self::CoalescingNeverNull,
@@ -2124,6 +2153,14 @@ class Issue
                 10121
             ),
             new Issue(
+                self::CoalescingNeverNullInGlobalScope,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_LOW,
+                "Using non-null {CODE} of type {TYPE} as the left hand side of a null coalescing (??) operation. The right hand side may be unnecessary. (in the global scope - this is likely a false positive)",
+                self::REMEDIATION_B,
+                10126
+            ),
+            new Issue(
                 self::CoalescingAlwaysNull,
                 self::CATEGORY_TYPE,
                 self::SEVERITY_LOW,
@@ -2138,6 +2175,14 @@ class Issue
                 "Using {CODE} of type {TYPE} as the left hand side of a null coalescing (??) operation. The left hand side may be unnecessary. (in a loop body - this is likely a false positive)",
                 self::REMEDIATION_B,
                 10122
+            ),
+            new Issue(
+                self::CoalescingAlwaysNullInGlobalScope,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_LOW,
+                "Using {CODE} of type {TYPE} as the left hand side of a null coalescing (??) operation. The left hand side may be unnecessary. (in the global scope - this is likely a false positive)",
+                self::REMEDIATION_B,
+                10127
             ),
             // Issue::CATEGORY_VARIABLE
             new Issue(

--- a/tests/files/expected/0300_misc_types.php.expected
+++ b/tests/files/expected/0300_misc_types.php.expected
@@ -21,5 +21,5 @@
 %s:34 PhanTypeMismatchArgument Argument 1 ($x) is string but \expect_int_300() takes int defined at %s:4
 %s:35 PhanUnusedVariable Unused definition of variable $definedStrVar
 %s:37 PhanContextNotObject Cannot access self when not in object context
-%s:38 PhanRedundantCondition Redundant attempt to cast (unknown) of type \ArrayObject to object
+%s:38 PhanRedundantConditionInGlobalScope Redundant attempt to cast (unknown) of type \ArrayObject to object in the global scope (likely a false positive)
 %s:38 PhanTypeMismatchArgument Argument 1 ($x) is object but \expect_string_300() takes string defined at %s:3

--- a/tests/files/expected/0620_more_noop_expressions.php.expected
+++ b/tests/files/expected/0620_more_noop_expressions.php.expected
@@ -1,14 +1,14 @@
-%s:3 PhanImpossibleCondition Impossible attempt to cast $a of type 2 to empty
+%s:3 PhanImpossibleConditionInGlobalScope Impossible attempt to cast $a of type 2 to empty in the global scope (may be a false positive)
 %s:3 PhanNoopEmpty Unused result of an empty(expr) check
 %s:4 PhanNoopIsset Unused result of an isset(expr) check
-%s:4 PhanRedundantCondition Redundant attempt to cast $a of type 2 to isset
+%s:4 PhanRedundantConditionInGlobalScope Redundant attempt to cast $a of type 2 to isset in the global scope (likely a false positive)
 %s:7 PhanNoopCast Unused result of a (string)(expr) cast
 %s:8 PhanNoopCast Unused result of a (int)(expr) cast
-%s:8 PhanRedundantCondition Redundant attempt to cast $a of type 2 to int
+%s:8 PhanRedundantConditionInGlobalScope Redundant attempt to cast $a of type 2 to int in the global scope (likely a false positive)
 %s:9 PhanNoopCast Unused result of a (bool)(expr) cast
 %s:10 PhanNoopCast Unused result of a (unset)(expr) cast
 %s:11 PhanNoopCast Unused result of a (float)(expr) cast
-%s:11 PhanRedundantCondition Redundant attempt to cast $a of type 2 to float
+%s:11 PhanRedundantConditionInGlobalScope Redundant attempt to cast $a of type 2 to float in the global scope (likely a false positive)
 %s:12 PhanNoopCast Unused result of a (array)(expr) cast
 %s:13 PhanNoopCast Unused result of a (object)(expr) cast
 %s:22 PhanNoopBinaryOperator Unused result of a binary '??' operator


### PR DESCRIPTION
(These tend to have higher false positives due to using variables from
other files, etc.)