### PR TITLE
Fix false positive PhanRedundantCondition for $assert()

### DIFF
--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -947,9 +947,13 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
      */
     public function visitCall(Node $node) : Context
     {
-        $name = $node->children['expr']->children['name'] ?? null;
+        $expr_node = $node->children['expr'];
+        if (($expr_node->kind ?? null) !== ast\AST_NAME) {
+            return $this->context;
+        }
+        $name = $expr_node->children['name'];
         // Look only at nodes of the form `assert(expr, ...)`.
-        if ($name !== 'assert') {
+        if (!\is_string($name) || \strcasecmp($name, 'assert') !== 0) {
             return $this->context;
         }
         $args_first_child = $node->children['args']->children[0] ?? null;

--- a/tests/files/expected/0704_not_assert.php.expected
+++ b/tests/files/expected/0704_not_assert.php.expected
@@ -1,0 +1,2 @@
+%s:5 PhanRedundantCondition Redundant attempt to cast $this of type static to truthy
+%s:5 PhanTypeMismatchArgumentInternal Argument 1 ($assertion) is static but \assert() takes bool|string

--- a/tests/files/src/0704_not_assert.php
+++ b/tests/files/src/0704_not_assert.php
@@ -1,0 +1,8 @@
+<?php
+class X704 {
+    function test_array_object(callable $assert) {
+        $assert($this);
+        ASSERT($this);  // should be case-insensitive
+    }
+}
+(new X704())->test_array_object('is_object');


### PR DESCRIPTION
Don't mix it up with assert()

Fixes #2859