### PR TITLE
Fix a false positive PhanRedundantCondition on array fields

### DIFF
--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -914,7 +914,7 @@ class ConditionVisitor extends KindVisitorImplementation implements ConditionVis
         }
         // Should always be a node for valid ASTs, tolerant-php-parser may produce invalid nodes
         if (\in_array($var_node->kind, [ast\AST_VAR, ast\AST_PROP, ast\AST_DIM], true)) {
-            // Don't emit notices for if (empty($x)) {}, etc.
+            // Don't emit notices for if (empty($x)) {}, etc. We already do that in RedundantConditionPlugin.
             return $this->removeTruthyFromVariable($var_node, $this->context, true);
         }
         $this->checkVariablesDefinedInIsset($var_node);

--- a/src/Phan/Analysis/ConditionVisitorUtil.php
+++ b/src/Phan/Analysis/ConditionVisitorUtil.php
@@ -71,9 +71,9 @@ trait ConditionVisitorUtil
             /**
              * @suppress PhanUndeclaredProperty did_check_redundant_condition
              */
-            function (UnionType $type) use ($var_node, $context) : bool {
+            function (UnionType $type) use ($var_node, $context, $suppress_issues) : bool {
                 $contains_truthy = $type->containsTruthy();
-                if (Config::getValue('redundant_condition_detection') && $type->hasRealTypeSet()) {
+                if (!$suppress_issues && Config::getValue('redundant_condition_detection') && $type->hasRealTypeSet()) {
                     // Here, we only perform the redundant condition checks on whichever ran first, to avoid warning about both impossible and redundant conditions
                     if (isset($var_node->did_check_redundant_condition)) {
                         return $contains_truthy;
@@ -125,9 +125,9 @@ trait ConditionVisitorUtil
             /**
              * @suppress PhanUndeclaredProperty did_check_redundant_condition
              */
-            function (UnionType $type) use ($context, $var_node) : bool {
+            function (UnionType $type) use ($context, $var_node, $suppress_issues) : bool {
                 $contains_falsey = $type->containsFalsey();
-                if (Config::getValue('redundant_condition_detection') && $type->hasRealTypeSet()) {
+                if (!$suppress_issues && Config::getValue('redundant_condition_detection') && $type->hasRealTypeSet()) {
                     // Here, we only perform the redundant condition checks on whichever ran first, to avoid warning about both impossible and redundant conditions
                     if (isset($var_node->did_check_redundant_condition)) {
                         return $contains_falsey;

--- a/tests/files/expected/0690_callable_not_false.php.expected
+++ b/tests/files/expected/0690_callable_not_false.php.expected
@@ -1,8 +1,5 @@
 %s:6 PhanImpossibleCondition Impossible attempt to cast $c of type callable to empty
-%s:6 PhanRedundantCondition Redundant attempt to cast $c of type callable to truthy
 %s:8 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is callable-string but \intdiv() takes int
 %s:10 PhanImpossibleCondition Impossible attempt to cast $c of type callable-string to empty
-%s:10 PhanRedundantCondition Redundant attempt to cast $c of type callable-string to truthy
 %s:14 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is callable-string but \intdiv() takes int
 %s:16 PhanImpossibleCondition Impossible attempt to cast $str of type callable-string to empty
-%s:16 PhanRedundantCondition Redundant attempt to cast $str of type callable-string to truthy

--- a/tests/files/expected/0691_callable_object.php.expected
+++ b/tests/files/expected/0691_callable_object.php.expected
@@ -3,7 +3,5 @@
 %s:24 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is object but \intdiv() takes int
 %s:26 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is callable-object but \intdiv() takes int
 %s:28 PhanImpossibleCondition Impossible attempt to cast $c of type callable-object to empty
-%s:28 PhanRedundantCondition Redundant attempt to cast $c of type callable-object to truthy
 %s:32 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is callable-object but \intdiv() takes int
 %s:34 PhanImpossibleCondition Impossible attempt to cast $o of type callable-object to empty
-%s:34 PhanRedundantCondition Redundant attempt to cast $o of type callable-object to truthy

--- a/tests/files/expected/0692_callable_array.php.expected
+++ b/tests/files/expected/0692_callable_array.php.expected
@@ -2,7 +2,5 @@
 %s:14 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is null but \intdiv() takes int
 %s:20 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is callable-array but \intdiv() takes int
 %s:22 PhanImpossibleCondition Impossible attempt to cast $c of type callable-array to empty
-%s:22 PhanRedundantCondition Redundant attempt to cast $c of type callable-array to truthy
 %s:26 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is callable-array but \intdiv() takes int
 %s:28 PhanImpossibleCondition Impossible attempt to cast $arr of type callable-array to empty
-%s:28 PhanRedundantCondition Redundant attempt to cast $arr of type callable-array to truthy

--- a/tests/files/expected/0706_false_positive_empty_dim.php.expected
+++ b/tests/files/expected/0706_false_positive_empty_dim.php.expected
@@ -1,0 +1,1 @@
+%s:9 PhanRedundantCondition Redundant attempt to cast $v of type null to empty

--- a/tests/files/src/0690_callable_not_false.php
+++ b/tests/files/src/0690_callable_not_false.php
@@ -3,7 +3,7 @@
 namespace TestNarrowing;
 
 function test_callable_not_null(callable $c, string $str) {
-    assert(!empty($c));  // TODO: Avoid warning twice for empty() checks?
+    assert(!empty($c));  // should only warn once about the empty()
     if (is_string($c)) {
         echo intdiv($c, 2);
         $c();

--- a/tests/files/src/0706_false_positive_empty_dim.php
+++ b/tests/files/src/0706_false_positive_empty_dim.php
@@ -1,0 +1,11 @@
+<?php
+
+function test_array_object706(ArrayObject $o) {
+    // should not emit "PhanRedundantCondition Redundant attempt to cast $o of type \ArrayObject to truthy"
+    if (!empty($o['field'])) {
+        echo "has field\n";
+    }
+    $v = null;
+    if (empty($v)) {
+    }
+}

--- a/tests/files/src/0707_scope_pollution.php
+++ b/tests/files/src/0707_scope_pollution.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace NS705;
+
+class Subclass {
+    /**
+     * @param string $name
+     * @param mixed|null $default
+     */
+    public function getOption($name, $default = null) : string {
+        var_export($default);
+        $name = (string)$name;  // should not emit PhanRedundantCondition because this was a phpdoc type
+        return $name;
+    }
+}
+class Other extends Subclass {
+    public function test() {
+        $this->getOption('something');
+    }
+}


### PR DESCRIPTION
and avoid duplicate warning for uses of empty()

Fixes #2858