### PR TITLE
Check if `expr instanceof SomeClass` is redundant/impossible

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,9 +9,11 @@ New features(CLI, Configs):
 
 New features(Analysis):
 + Reduce the number of false positives of `--redundant-condition-detection` for variables in loops
++ Emit `PhanRedundantCondition` and `PhanImpossibleCondition` for `$x instanceof SomeClass` expressions.
 
 Bug fixes:
 + Fix issue that would make Phan infer that a redundant/impossible condition outside a loop was in a loop.
++ Avoid false positives analyzing expressions within `assert()`
 
 Jun 14 2019, Phan 2.2.0
 -----------------------

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -2297,7 +2297,7 @@ class ContextNode
      */
     public function isVarWithConstantDefinition(Node $node) : bool
     {
-        if (!$node instanceof Node || $node->kind !== ast\AST_VAR) {
+        if ($node->kind !== ast\AST_VAR) {
             return false;
         }
         $name = $node->children['name'];

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -2037,7 +2037,7 @@ class TolerantASTConverter
         }
     }
 
-    private static function interfaceBaseClauseToNode(?\Microsoft\PhpParser\node\interfacebaseclause $node) : ?\ast\Node
+    private static function interfaceBaseClauseToNode(?\Microsoft\PhpParser\Node\InterfaceBaseClause $node) : ?\ast\Node
     {
         if (!$node instanceof PhpParser\Node\InterfaceBaseClause) {
             // TODO: real placeholder?

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -799,35 +799,16 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
     }
 
     /**
-     * @param Node $node
+     * @param Node $_
      * A node to parse
      *
      * @return Context
      * A new or an unchanged context resulting from
      * parsing the node
      */
-    public function visitCall(Node $node) : Context
+    public function visitCall(Node $_) : Context
     {
-        $expr_node = $node->children['expr'];
-        if (($expr_node->kind ?? null) !== ast\AST_NAME) {
-            return $this->context;
-        }
-        $name = $expr_node->children['name'];
-        // Look only at nodes of the form `assert(expr, ...)`.
-        if (!\is_string($name) || \strcasecmp($name, 'assert') !== 0) {
-            return $this->context;
-        }
-        $args_first_child = $node->children['args']->children[0] ?? null;
-        if (!($args_first_child instanceof Node)) {
-            return $this->context;
-        }
-
-        // Look to see if the asserted expression says anything about
-        // the types of any variables.
-        return (new ConditionVisitor(
-            $this->code_base,
-            $this->context
-        ))->__invoke($args_first_child);
+        return $this->context;
     }
 
     /**

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -1879,6 +1879,15 @@ class Clazz extends AddressableElement
 
     /**
      * @return bool
+     * True if this is a class (i.e. neither a trait nor an interface)
+     */
+    public function isClass() : bool
+    {
+        return ($this->getFlags() & (ast\flags\CLASS_INTERFACE | ast\flags\CLASS_TRAIT)) === 0;
+    }
+
+    /**
+     * @return bool
      * True if this class is a trait
      */
     public function isTrait() : bool
@@ -2135,7 +2144,7 @@ class Clazz extends AddressableElement
         // Get the parent class
         $parent = $this->getParentClass($code_base);
 
-        if ($parent->isTrait() || $parent->isInterface()) {
+        if (!$parent->isClass()) {
             $this->emitWrongInheritanceCategoryWarning($code_base, $parent, 'Class', $this->parent_type_lineno);
         }
         if ($parent->isFinal()) {

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -1407,4 +1407,14 @@ final class EmptyUnionType extends UnionType
     {
         return '';
     }
+
+    public function canPossiblyCastToClass(CodeBase $code_base, Type $class_type) : bool
+    {
+        return true;
+    }
+
+    public function isExclusivelySubclassesOf(CodeBase $code_base, Type $class_type) : bool
+    {
+        return false;
+    }
 }

--- a/src/Phan/Language/Type/ArrayType.php
+++ b/src/Phan/Language/Type/ArrayType.php
@@ -246,6 +246,12 @@ class ArrayType extends IterableType
     {
         return null;
     }
+
+    public function canPossiblyCastToClass(CodeBase $unused_code_base, Type $unused_other) : bool
+    {
+        // arrays can't cast to object.
+        return false;
+    }
 }
 // Trigger the autoloader for GenericArrayType so that it won't be called
 // before ArrayType.

--- a/src/Phan/Language/Type/ScalarType.php
+++ b/src/Phan/Language/Type/ScalarType.php
@@ -148,6 +148,11 @@ abstract class ScalarType extends NativeType
     {
         return $this->withIsNullable(false);
     }
+
+    public function canPossiblyCastToClass(CodeBase $unused_codebase, Type $unused_class_type) : bool
+    {
+        return false;
+    }
 }
 \class_exists(IntType::class);
 \class_exists(StringType::class);

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -2476,6 +2476,31 @@ class UnionType implements Serializable
     }
 
     /**
+     * Returns true if this union type is empty, or if it's possible for any type (or sub-type) of this union type to be able to cast to $class_type
+     */
+    public function canPossiblyCastToClass(CodeBase $code_base, Type $class_type) : bool
+    {
+        foreach ($this->type_set as $type) {
+            if ($type->withIsNullable(false)->canPossiblyCastToClass($code_base, $class_type)) {
+                return true;
+            }
+        }
+        return \count($this->type_set) === 0;
+    }
+
+    /**
+     * Returns true if this union type is non-empty and all types inherit this class/trait/interface.
+     */
+    public function isExclusivelySubclassesOf(CodeBase $code_base, Type $class_type) : bool
+    {
+        foreach ($this->type_set as $type) {
+            if ($type->isNullable() || !$type->asExpandedTypes($code_base)->hasType($class_type)) {
+                return false;
+            }
+        }
+        return \count($this->type_set) > 0;
+    }
+    /**
      * Returns the types for which is_scalar($x) would be true.
      * This means null/nullable is removed.
      * Takes `MyClass|int|?bool|array|?object` and returns `int|bool`

--- a/tests/files/expected/0086_conditional_instanceof_type.php.expected
+++ b/tests/files/expected/0086_conditional_instanceof_type.php.expected
@@ -1,2 +1,3 @@
 %s:8 PhanNonClassMethodCall Call to method f on non-class type null
+%s:10 PhanImpossibleConditionInGlobalScope Impossible attempt to cast $x of type null to \A in the global scope (may be a false positive)
 %s:14 PhanTypeMismatchArgumentNullable Argument 1 ($p) is ?\A but \A::f() takes \A defined at %s:3 (expected type to be non-nullable)

--- a/tests/files/expected/0098_undef.php.expected
+++ b/tests/files/expected/0098_undef.php.expected
@@ -1,5 +1,6 @@
 %s:6 PhanUndeclaredClassCatch Catching undeclared class \Undef
 %s:9 PhanUndeclaredStaticMethod Static call to undeclared method \C98::staticMethod
+%s:13 PhanImpossibleConditionInGlobalScope Impossible attempt to cast $v of type null to \Undef in the global scope (may be a false positive)
 %s:13 PhanUndeclaredClassInstanceof Checking instanceof against undeclared class \Undef
 %s:16 PhanUndeclaredTypeParameter Parameter $p has undeclared type \Undef
 %s:19 PhanUndeclaredTypeProperty Property \D98->p has undeclared type \Undef

--- a/tests/files/expected/0101_one_of_each.php.expected
+++ b/tests/files/expected/0101_one_of_each.php.expected
@@ -45,6 +45,7 @@
 %s:164 PhanTraitParentReference Reference to parent from trait \T1
 %s:172 PhanUndeclaredClassCatch Catching undeclared class \Undef
 %s:176 PhanUndeclaredConstant Reference to undeclared constant \C16::C
+%s:180 PhanImpossibleConditionInGlobalScope Impossible attempt to cast $v5 of type null to \Undef in the global scope (may be a false positive)
 %s:180 PhanUndeclaredClassInstanceof Checking instanceof against undeclared class \Undef
 %s:183 PhanUndeclaredClassMethod Call to method f5 from undeclared class \Undef
 %s:183 PhanUndeclaredTypeParameter Parameter $p has undeclared type \Undef

--- a/tests/files/expected/0211_assertion_cast.php.expected
+++ b/tests/files/expected/0211_assertion_cast.php.expected
@@ -1,0 +1,1 @@
+%s:4 PhanImpossibleConditionInGlobalScope Impossible attempt to cast $v of type \C211 to \DateTime in the global scope (may be a false positive)

--- a/tests/files/expected/0478_undeclared_classlike_suggestions.php.expected
+++ b/tests/files/expected/0478_undeclared_classlike_suggestions.php.expected
@@ -5,4 +5,5 @@
 %s:7 PhanUndeclaredTrait Class uses undeclared trait \ExampleTrait (Did you mean trait \NS2\ExampleTrait)
 %s:16 PhanUndeclaredClassConstant Reference to constant class from undeclared class \NS3\ClassWithRepeatedName (Did you mean class \ClassWithRepeatedName or class \NS2\ClassWithRepeatedName)
 %s:23 PhanUndeclaredClassCatch Catching undeclared class \NS2\Exception (Did you mean %Sclass \Exception%S)
+%s:26 PhanImpossibleConditionInGlobalScope Impossible attempt to cast $x of type null to \NS2\InvalidArgumentException in the global scope (may be a false positive)
 %s:26 PhanUndeclaredClassInstanceof Checking instanceof against undeclared class \NS2\InvalidArgumentException (Did you mean %Sclass \InvalidArgumentException%S)

--- a/tests/files/expected/0578_narrow_types.php.expected
+++ b/tests/files/expected/0578_narrow_types.php.expected
@@ -1,4 +1,5 @@
 %s:22 PhanTypeSuspiciousEcho Suspicious argument \BaseInterface578 for an echo/print statement
+%s:24 PhanRedundantCondition Redundant attempt to cast $b of type \Subclass578A to \BaseInterface578
 %s:25 PhanTypeSuspiciousEcho Suspicious argument \Subclass578A for an echo/print statement
 %s:28 PhanTypeSuspiciousEcho Suspicious argument \Subclass578A for an echo/print statement
 %s:31 PhanTypeSuspiciousEcho Suspicious argument \Subclass578A for an echo/print statement

--- a/tests/files/expected/0694_callable_scalar.php.expected
+++ b/tests/files/expected/0694_callable_scalar.php.expected
@@ -3,7 +3,7 @@
 %s:8 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is null but \intdiv() takes int
 %s:10 PhanRedundantCondition Redundant attempt to cast $b of type bool to scalar
 %s:11 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is bool but \intdiv() takes int
-%s:12 PhanRedundantCondition Redundant attempt to cast $a of type bool|float|int|string to scalar
+%s:12 PhanImpossibleCondition Impossible attempt to cast $a of type array to scalar
 %s:16 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is callable-string but \intdiv() takes int
 %s:19 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is callable but \intdiv() takes int
 %s:22 PhanImpossibleCondition Impossible attempt to cast $nil of type null to scalar

--- a/tests/files/expected/0709_redundant_instanceof.php.expected
+++ b/tests/files/expected/0709_redundant_instanceof.php.expected
@@ -1,0 +1,8 @@
+%s:24 PhanRedundantCondition Redundant attempt to cast $x of type \NS709\MyFinalClass to \NS709\MyFinalClass
+%s:25 PhanImpossibleCondition Impossible attempt to cast $x2 of type \NS709\MyFinalClass to \NS709\MyClass
+%s:26 PhanImpossibleCondition Impossible attempt to cast $x3 of type \NS709\MyFinalClass to \NS709\MyInterface
+%s:27 PhanRedundantCondition Redundant attempt to cast $x4 of type \NS709\MyFinalClass to \NS709\ValidInterface
+%s:28 PhanImpossibleCondition Impossible attempt to cast $y of type int to \NS709\MyFinalClass
+%s:30 PhanImpossibleCondition Impossible attempt to cast $m1 of type \NS709\MyClass to \NS709\MyFinalClass
+%s:38 PhanImpossibleCondition Impossible attempt to cast $a1 of type array to \NS709\MyClass
+%s:39 PhanImpossibleCondition Impossible attempt to cast $a2 of type array to object

--- a/tests/files/src/0129_suppress_stmts.php
+++ b/tests/files/src/0129_suppress_stmts.php
@@ -21,6 +21,7 @@ class C {
      * @suppress PhanUndeclaredClassMethod
      * @suppress PhanUndeclaredVariable
      * @suppress PhanUndeclaredVariable
+     * @suppress PhanImpossibleCondition
      */
     function f() {
         $v = Undef::undef();

--- a/tests/files/src/0709_redundant_instanceof.php
+++ b/tests/files/src/0709_redundant_instanceof.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace NS709;
+
+class MyClass {}
+interface ValidInterface {}
+interface MyInterface {}
+final class MyFinalClass implements ValidInterface {}
+
+function test_redundant_instanceof(
+    MyFinalClass $x,
+    MyFinalClass $x2,
+    MyFinalClass $x3,
+    MyFinalClass $x4,
+    int $y,
+    MyClass $m1,
+    MyClass $m2,
+    iterable $i1,
+    iterable $i2,
+    array $a1,
+    array $a2,
+    string $className
+) {
+    assert($x instanceof MyFinalClass);  // redundant
+    assert($x2 instanceof MyClass);  // impossible because MyFinalClass is final
+    assert($x3 instanceof MyInterface);  // impossible because MyFinalClass is final
+    assert($x4 instanceof ValidInterface);  // redundant
+    assert($y instanceof MyFinalClass);  // impossible
+
+    if ($m1 instanceof MyFinalClass) {
+        echo 'Impossible';
+    }
+    if ($m2 instanceof \Traversable) {
+        echo 'possible';
+    }
+    assert($i1 instanceof MyFinalClass);
+    assert($i2 instanceof MyClass);  // possible because MyClass can have subclasses. TODO: intersection type support.
+    assert($a1 instanceof MyClass);  // impossible because an array can't be an object
+    assert($a2 instanceof $className);  // impossible because an array can't be an object
+}


### PR DESCRIPTION
And improve the way expressions within assert() are analyzed