### PR TITLE
Catch more types of redundant conditions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@ New features(CLI, Configs):
 
 New features(Analysis):
 + Reduce the number of false positives of `--redundant-condition-detection` for variables in loops
++ Warn about more types of expressions causing redundant conditions (#2534, #822).
 + Emit `PhanRedundantCondition` and `PhanImpossibleCondition` for `$x instanceof SomeClass` expressions.
 + Emit `PhanImpossibleCondition` for `is_array` and `is_object` checks.
 
@@ -18,6 +19,7 @@ Bug fixes:
 + Fix issue that would make Phan infer that a redundant/impossible condition outside a loop was in a loop.
 + Avoid false positives analyzing expressions within `assert()`.
 + Fix method signatures for php 7.4's `WeakReference`.
++ Fix false positives analyzing uses of `__call` and `__callStatic` (#702)
 
 Jun 14 2019, Phan 2.2.0
 -----------------------

--- a/src/Phan/AST/ASTReverter.php
+++ b/src/Phan/AST/ASTReverter.php
@@ -239,6 +239,13 @@ class ASTReverter
                     self::toShortString($node->children['args'])
                 );
             },
+            ast\AST_NEW => static function (Node $node) : string {
+                return \sprintf(
+                    'new %s%s',
+                    self::toShortString($node->children['class']),
+                    self::toShortString($node->children['args'])
+                );
+            },
         ];
     }
 }

--- a/src/Phan/Analysis/LoopConditionVisitor.php
+++ b/src/Phan/Analysis/LoopConditionVisitor.php
@@ -1,0 +1,86 @@
+<?php declare(strict_types=1);
+
+namespace Phan\Analysis;
+
+use ast;
+use ast\Node;
+use Phan\CodeBase;
+use Phan\Config;
+use Phan\Language\Context;
+use Phan\Language\UnionType;
+
+/**
+ * Used to avoid false positives analyzing loop conditions for redundant conditions.
+ */
+class LoopConditionVisitor extends ConditionVisitor
+{
+    /** @var Node|string|int|false the node for the condition of the loop */
+    protected $loop_condition_node;
+
+    /** @var bool whether to allow conditions that are always false */
+    protected $allow_false;
+
+    /** @param Node|string|int|false $loop_condition_node the node for the condition of the loop */
+    public function __construct(CodeBase $code_base, Context $context, $loop_condition_node, bool $allow_false)
+    {
+        parent::__construct($code_base, $context);
+        $this->loop_condition_node = $loop_condition_node;
+        $this->allow_false = $allow_false;
+    }
+
+    public function checkRedundantOrImpossibleTruthyCondition($node, Context $context, ?UnionType $type, bool $is_negated) : void
+    {
+        if ($node === $this->loop_condition_node) {
+            // Don't warn about `while (1)` or `while (true)`
+            if ($node instanceof Node) {
+                if ($node->kind === ast\AST_CONST) {
+                    // @phan-suppress-next-line PhanPartialTypeMismatchArgumentInternal
+                    $node_name = \strtolower($node->children['name']->children['name']);
+                    if ($node_name === 'true' || ($this->allow_false && $node_name === 'false')) {
+                        return;
+                    }
+                }
+            } elseif (\is_int($node)) {
+                if ($node || $this->allow_false) {
+                    return;
+                }
+            }
+        }
+        parent::checkRedundantOrImpossibleTruthyCondition($node, $context, $type, $is_negated);
+    }
+
+    /**
+     * @param Node $node
+     * A node to parse
+     *
+     * @return Context
+     * A new or an unchanged context resulting from
+     * parsing the node
+     */
+    public function visitExprList(Node $node) : Context
+    {
+        $children = $node->children;
+        $count = \count($children);
+        if ($count > 1) {
+            foreach ($children as $sub_node) {
+                --$count;
+                if ($count > 0 && $sub_node instanceof Node) {
+                    $this->checkVariablesDefined($sub_node);
+                }
+            }
+        }
+        // Only analyze the last expression in the expression list for conditions.
+        $last_expression = \end($node->children);
+        if ($node === $this->loop_condition_node) {
+            // @phan-suppress-next-line PhanPartialTypeMismatchProperty
+            $this->loop_condition_node = $last_expression;
+        }
+        if ($last_expression instanceof Node) {
+            return $this->__invoke($last_expression);
+        } elseif (Config::getValue('redundant_condition_detection')) {
+            // @phan-suppress-next-line PhanPartialTypeMismatchArgument
+            $this->checkRedundantOrImpossibleTruthyCondition($last_expression, $this->context, null, false);
+        }
+        return $this->context;
+    }
+}

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -1622,7 +1622,21 @@ class Clazz extends AddressableElement
      */
     public function getCallMethod(CodeBase $code_base) : Method
     {
-        return $this->getMethodByName($code_base, '__call');
+        return self::makeCallMethodCloneForCaller($this->getMethodByName($code_base, '__call'));
+    }
+
+    private static function makeCallMethodCloneForCaller(Method $method) : Method
+    {
+        return new Method(
+            $method->getContext(),
+            $method->getName(),
+            $method->getUnionType(),
+            $method->getFlags(),
+            $method->getFQSEN(),
+            [
+                new VariadicParameter($method->getContext(), 'args', UnionType::empty(), 0)
+            ]
+        );
     }
 
     /**
@@ -1663,7 +1677,7 @@ class Clazz extends AddressableElement
      */
     public function getCallStaticMethod(CodeBase $code_base) : Method
     {
-        return $this->getMethodByName($code_base, '__callStatic');
+        return self::makeCallMethodCloneForCaller($this->getMethodByName($code_base, '__callStatic'));
     }
 
     /**

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -651,6 +651,7 @@ final class EmptyUnionType extends UnionType
      * context
      *
      * TODO: Add a method to ContextNode to directly get FQSEN instead?
+     * @suppress PhanImpossibleCondition deliberately making a generator yielding nothing
      */
     public function asClassFQSENList(
         Context $context
@@ -1210,6 +1211,7 @@ final class EmptyUnionType extends UnionType
      * @return Generator<Type,Type>
      * @suppress PhanTypeMismatchGeneratorYieldValue (deliberate empty stub code)
      * @suppress PhanTypeMismatchGeneratorYieldKey (deliberate empty stub code)
+     * @suppress PhanImpossibleCondition
      */
     public function getReferencedClasses() : Generator
     {

--- a/src/Phan/Language/Type/NativeType.php
+++ b/src/Phan/Language/Type/NativeType.php
@@ -300,6 +300,7 @@ abstract class NativeType extends Type
 
     /**
      * @return Generator<mixed,Type>
+     * @suppress PhanImpossibleCondition deliberately creating empty generator
      */
     public function getReferencedClasses() : Generator
     {

--- a/src/Phan/LanguageServer/LanguageServer.php
+++ b/src/Phan/LanguageServer/LanguageServer.php
@@ -941,6 +941,7 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
     {
         return coroutine(function () : \Generator {
             // Eventually, this might block on something. Leave it as a generator.
+            // @phan-suppress-next-line PhanImpossibleCondition deliberately unreachable yield
             if (false) {
                 yield;
             }

--- a/src/Phan/Plugin/Internal/RedundantConditionCallPlugin.php
+++ b/src/Phan/Plugin/Internal/RedundantConditionCallPlugin.php
@@ -383,6 +383,54 @@ class RedundantConditionVisitor extends PluginAwarePostAnalysisVisitor
     }
 
     /**
+     * Checks if the conditional of a ternary conditional is always true/false
+     * @override
+     */
+    /*
+    public function visitConditional(Node $node) : void
+    {
+        $cond_node = $node->children['cond'];
+        $cond_type = UnionTypeVisitor::unionTypeFromNode($this->code_base, $this->context, $cond_node);
+        if (!$cond_type->hasRealTypeSet()) {
+            return;
+        }
+        $cond_type = $cond_type->getRealUnionType();
+
+        if (!$cond_type->containsFalsey()) {
+            RedundantCondition::emitInstance(
+                $cond_node,
+                $this->code_base,
+                $this->context,
+                Issue::RedundantCondition,
+                [
+                    ASTReverter::toShortString($cond_node),
+                    $cond_type->getRealUnionType(),
+                    'truthy',
+                ],
+                static function (UnionType $type) : bool {
+                    return !$type->containsFalsey();
+                }
+            );
+        } elseif (!$cond_type->containsTruthy()) {
+            RedundantCondition::emitInstance(
+                $cond_node,
+                $this->code_base,
+                $this->context,
+                Issue::ImpossibleCondition,
+                [
+                    ASTReverter::toShortString($cond_node),
+                    $cond_type->getRealUnionType(),
+                    'truthy',
+                ],
+                static function (UnionType $type) : bool {
+                    return !$type->containsTruthy();
+                }
+            );
+        }
+    }
+     */
+
+    /**
      * Checks if the left hand side of a null coalescing operator is never null or always null
      */
     public function analyzeBinaryCoalesce(Node $node) : void

--- a/tests/files/expected/0056_aggressive_return_types.php.expected
+++ b/tests/files/expected/0056_aggressive_return_types.php.expected
@@ -1,1 +1,2 @@
 %s:3 PhanUnusedProtectedMethodParameter Parameter $data is never used
+%s:4 PhanRedundantCondition Redundant attempt to cast true of type true to truthy

--- a/tests/files/expected/0084_branch_scope.php.expected
+++ b/tests/files/expected/0084_branch_scope.php.expected
@@ -1,1 +1,2 @@
+%s:6 PhanRedundantCondition Redundant attempt to cast true of type true to truthy
 %s:17 PhanTypeMismatchArgument Argument 1 ($v) is 'str' but \f() takes int defined at %s:16

--- a/tests/files/expected/0085_double_branch.php.expected
+++ b/tests/files/expected/0085_double_branch.php.expected
@@ -1,0 +1,2 @@
+%s:3 PhanRedundantCondition Redundant attempt to cast true of type true to truthy
+%s:4 PhanImpossibleCondition Impossible attempt to cast false of type false to truthy

--- a/tests/files/expected/0119_var_type_override.php.expected
+++ b/tests/files/expected/0119_var_type_override.php.expected
@@ -1,0 +1,1 @@
+%s:6 PhanImpossibleCondition Impossible attempt to cast false of type false to truthy

--- a/tests/files/expected/0134_conditional_list_assign.php.expected
+++ b/tests/files/expected/0134_conditional_list_assign.php.expected
@@ -1,0 +1,1 @@
+%s:2 PhanRedundantConditionInGlobalScope Redundant attempt to cast list($a) of type array{0:1} to truthy in the global scope (likely a false positive)

--- a/tests/files/expected/0156_global_scope_leak.php.expected
+++ b/tests/files/expected/0156_global_scope_leak.php.expected
@@ -1,1 +1,2 @@
+%s:9 PhanImpossibleCondition Impossible attempt to cast false of type false to truthy
 %s:12 PhanUndeclaredVariable Variable $c is undeclared

--- a/tests/files/expected/0157_conditional_assignment.php.expected
+++ b/tests/files/expected/0157_conditional_assignment.php.expected
@@ -1,0 +1,1 @@
+%s:5 PhanRedundantCondition Redundant attempt to cast list($a) of type array{0:1} to truthy

--- a/tests/files/expected/0173_primitive_condition.php.expected
+++ b/tests/files/expected/0173_primitive_condition.php.expected
@@ -1,0 +1,2 @@
+%s:3 PhanRedundantCondition Redundant attempt to cast 1 of type 1 to truthy
+%s:4 PhanRedundantCondition Redundant attempt to cast 2 of type 2 to truthy

--- a/tests/files/expected/0254_array_bool_comparison.php.expected
+++ b/tests/files/expected/0254_array_bool_comparison.php.expected
@@ -1,4 +1,8 @@
+%s:3 PhanRedundantCondition Redundant attempt to cast true of type true to truthy
+%s:4 PhanRedundantCondition Redundant attempt to cast true of type true to truthy
 %s:5 PhanTypeComparisonFromArray array to string comparison
 %s:6 PhanTypeComparisonToArray string to array comparison
+%s:13 PhanRedundantCondition Redundant attempt to cast true of type true to truthy
+%s:14 PhanRedundantCondition Redundant attempt to cast true of type true to truthy
 %s:15 PhanTypeComparisonFromArray array to string comparison
 %s:16 PhanTypeComparisonToArray string to array comparison

--- a/tests/files/expected/0277_literal_conditional.php.expected
+++ b/tests/files/expected/0277_literal_conditional.php.expected
@@ -1,8 +1,22 @@
+%s:8 PhanImpossibleCondition Impossible attempt to cast 0 of type 0 to truthy
+%s:9 PhanImpossibleCondition Impossible attempt to cast 0 of type 0 to truthy
+%s:10 PhanImpossibleCondition Impossible attempt to cast 0 of type 0 to truthy
 %s:10 PhanTypeArraySuspicious Suspicious array access to 3
+%s:11 PhanRedundantCondition Redundant attempt to cast 1 of type 1 to truthy
 %s:11 PhanTypeArraySuspicious Suspicious array access to 3
+%s:12 PhanRedundantCondition Redundant attempt to cast true of type true to truthy
 %s:12 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is true but \intdiv() takes int
+%s:13 PhanRedundantCondition Redundant attempt to cast \true of type true to truthy
 %s:13 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is true but \intdiv() takes int
+%s:14 PhanImpossibleCondition Impossible attempt to cast false of type false to truthy
+%s:15 PhanImpossibleCondition Impossible attempt to cast \false of type false to truthy
+%s:16 PhanImpossibleCondition Impossible attempt to cast false of type false to truthy
+%s:17 PhanRedundantCondition Redundant attempt to cast TRUE of type true to truthy
 %s:17 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is true but \intdiv() takes int
+%s:18 PhanRedundantCondition Redundant attempt to cast 'key' of type 'key' to truthy
 %s:18 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is 'key' but \intdiv() takes int
+%s:19 PhanRedundantCondition Redundant attempt to cast '1' of type '1' to truthy
 %s:19 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is '1' but \intdiv() takes int
+%s:20 PhanImpossibleCondition Impossible attempt to cast '' of type '' to truthy
+%s:21 PhanImpossibleCondition Impossible attempt to cast '0' of type '0' to truthy
 %s:22 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is float but \intdiv() takes int

--- a/tests/files/expected/0279_void_return.php.expected
+++ b/tests/files/expected/0279_void_return.php.expected
@@ -1,3 +1,5 @@
+%s:9 PhanRedundantCondition Redundant attempt to cast true of type true to truthy
 %s:9 PhanTypeMismatchReturn Returning type void but f() is declared to return \DateTime
+%s:10 PhanRedundantCondition Redundant attempt to cast true of type true to truthy
 %s:10 PhanTypeMismatchReturn Returning type 42 but f() is declared to return \DateTime
 %s:15 PhanTypeMismatchReturn Returning type void but g() is declared to return int

--- a/tests/files/expected/0300_misc_types.php.expected
+++ b/tests/files/expected/0300_misc_types.php.expected
@@ -11,9 +11,12 @@
 %s:21 PhanUnusedVariable Unused definition of variable $undefIntVar
 %s:22 PhanTypeMismatchArgument Argument 1 ($x) is 42 but \expect_string_300() takes string defined at %s:3
 %s:22 PhanUnusedVariableReference Unused definition of variable $refIntVar as a reference
+%s:23 PhanImpossibleCondition Impossible attempt to cast false of type false to truthy
 %s:23 PhanTypeMismatchArgument Argument 1 ($x) is ?string but \expect_int_300() takes int defined at %s:4
 %s:25 PhanTypeMismatchArgument Argument 1 ($x) is \stdClass but \expect_string_300() takes string defined at %s:3
+%s:26 PhanImpossibleCondition Impossible attempt to cast null of type null to truthy
 %s:26 PhanTypeMismatchArgument Argument 1 ($x) is 3 but \expect_string_300() takes string defined at %s:3
+%s:27 PhanImpossibleCondition Impossible attempt to cast null of type null to truthy
 %s:27 PhanTypeMismatchArgument Argument 1 ($x) is 3 but \expect_string_300() takes string defined at %s:3
 %s:28 PhanUndeclaredFunction Call to undeclared function \expect_default_int_300()
 %s:31 PhanTypeMismatchArgument Argument 1 ($x) is int but \expect_string_300() takes string defined at %s:3
@@ -21,5 +24,5 @@
 %s:34 PhanTypeMismatchArgument Argument 1 ($x) is string but \expect_int_300() takes int defined at %s:4
 %s:35 PhanUnusedVariable Unused definition of variable $definedStrVar
 %s:37 PhanContextNotObject Cannot access self when not in object context
-%s:38 PhanRedundantConditionInGlobalScope Redundant attempt to cast (unknown) of type \ArrayObject to object in the global scope (likely a false positive)
+%s:38 PhanRedundantConditionInGlobalScope Redundant attempt to cast new ArrayObject() of type \ArrayObject to object in the global scope (likely a false positive)
 %s:38 PhanTypeMismatchArgument Argument 1 ($x) is object but \expect_string_300() takes string defined at %s:3

--- a/tests/files/expected/0311_condition_visitor_throw.php.expected
+++ b/tests/files/expected/0311_condition_visitor_throw.php.expected
@@ -1,3 +1,11 @@
+%s:8 PhanImpossibleCondition Impossible attempt to cast 0 of type 0 to truthy
+%s:9 PhanRedundantCondition Redundant attempt to cast STDERR of type resource to truthy
+%s:10 PhanImpossibleCondition Impossible attempt to cast 0 of type 0 to truthy
+%s:11 PhanRedundantCondition Redundant attempt to cast 1 of type 1 to truthy
+%s:12 PhanImpossibleCondition Impossible attempt to cast null of type null to truthy
+%s:13 PhanRedundantCondition Redundant attempt to cast 1 of type 1 to truthy
+%s:14 PhanImpossibleCondition Impossible attempt to cast '' of type '' to truthy
+%s:15 PhanRedundantCondition Redundant attempt to cast 'aa' of type 'aa' to truthy
 %s:17 PhanUndeclaredVariable Variable $x is undeclared
 %s:18 PhanUndeclaredVariable Variable $x2 is undeclared
 %s:19 PhanUndeclaredVariable Variable $z is undeclared

--- a/tests/files/expected/0678_invalid_operations.php.expected
+++ b/tests/files/expected/0678_invalid_operations.php.expected
@@ -1,2 +1,3 @@
 %s:5 PhanTypeConversionFromArray array to string conversion
 %s:8 PhanTypeErrorInOperation Saw an error when attempting to infer the type of expression +$arr: Unsupported operand types
+%s:8 PhanTypeInvalidUnaryOperandNumeric Invalid operator: unary operand of + is array{} (expected number)

--- a/tests/files/expected/0711_other_redundant_expressions.php.expected
+++ b/tests/files/expected/0711_other_redundant_expressions.php.expected
@@ -1,0 +1,3 @@
+%s:2 PhanImpossibleCondition Impossible attempt to cast false of type false to truthy
+%s:3 PhanImpossibleCondition Impossible attempt to cast [] of type array{} to truthy
+%s:6 PhanRedundantConditionInGlobalScope Redundant attempt to cast new stdClass() of type \stdClass to truthy in the global scope (likely a false positive)

--- a/tests/files/expected/0712_redundant_in_loops.php.expected
+++ b/tests/files/expected/0712_redundant_in_loops.php.expected
@@ -1,0 +1,4 @@
+%s:20 PhanImpossibleCondition Impossible attempt to cast false of type false to truthy
+%s:23 PhanImpossibleCondition Impossible attempt to cast 0 of type 0 to truthy
+%s:26 PhanImpossibleCondition Impossible attempt to cast false of type false to truthy
+%s:29 PhanImpossibleCondition Impossible attempt to cast 0 of type 0 to truthy

--- a/tests/files/src/0311_condition_visitor_throw.php
+++ b/tests/files/src/0311_condition_visitor_throw.php
@@ -5,7 +5,7 @@
  * @param int $str
  */
 function testcondition311($y, $str) {
-    if (!0) { }
+    if (!0) { }  // These all warn about having known truthiness
     if (!STDERR) { }
     if (!!0) { }
     if (!1) { }
@@ -13,7 +13,7 @@ function testcondition311($y, $str) {
     if (!!1) { }
     if (!'') { }
     if (!'aa') { }
-    if (!0.0) { }
+    if (!0.0) { }  // TODO: warn
     if ($y && !$x) { }  // should emit undefined
     if ($y && $x2) { }  // should emit undefined
     if (!$z) { }  // should emit undefined

--- a/tests/files/src/0710_call_static.php
+++ b/tests/files/src/0710_call_static.php
@@ -1,0 +1,18 @@
+<?php
+
+class Foo {
+
+    public function __call($method, $args_array) {
+        return method_exists('DateTime', $method);
+    }
+
+    public function __callStatic($method, $args_array) {
+        return method_exists('DateTime', $method);
+    }
+
+    public function test() {
+        $dateTimeZone = new DateTimeZone('UTC-0000');
+        var_export($this->setTimezone($dateTimeZone));
+        var_export(self::setGlobalTimezone($dateTimeZone, true, 'ignored'));
+    }
+}

--- a/tests/files/src/0711_other_redundant_expressions.php
+++ b/tests/files/src/0711_other_redundant_expressions.php
@@ -1,0 +1,8 @@
+<?php
+$x = false ? 'x' : 'y';
+if ([]) {
+    echo "Impossible\n";
+}
+if (new stdClass()) {
+    echo "Redundant\n";
+}

--- a/tests/files/src/0712_redundant_in_loops.php
+++ b/tests/files/src/0712_redundant_in_loops.php
@@ -1,0 +1,33 @@
+<?php
+
+function testLoop() {
+    do {
+        echo ".";
+        if (rand() % 2 > 0) {
+            break;
+        }
+        echo "other";
+    } while (false);  // should not warn
+
+    do {
+        echo ".";
+        if (rand() % 2 > 0) {
+            break;
+        }
+        echo "other";
+    } while (true);  // should not warn
+
+    while (false) {  // should warn
+        echo "unreachable\n";
+    }
+    while (0) {  // should warn
+        echo "unreachable\n";
+    }
+    for (;false;) {  // should warn
+        echo "unreachable\n";
+    }
+    for (;0;) {  // should warn
+        echo "unreachable\n";
+    }
+
+}


### PR DESCRIPTION
and fix analysis of inner body of __call and __callStatic

Fixes #702

Improve redundant/impossible condition detection. Handle previously
unhandled node types, as well as scalars

Fixes #2534
Fixes #822