### PR TITLE
Fix PhanRedundantCondition analyzing `if ([$x] = expr)`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@ New features(Analysis):
 + Be more accurate about inferring real union types from array destructuring assignments. (#2901)
 + Be more accurate about inferring real union types from assertions that expressions are non-null. (#2901)
 + Support dumping Phan's internal representation of a variable's union type (and real union type) with `'@phan-debug-var $varName'` (useful for debugging)
++ Fix false positive `PhanRedundantCondition` analyzing `if ([$a] = (expr))` (#2904)
 
 Jun 17 2019, Phan 2.2.3
 -----------------------

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -990,6 +990,13 @@ class ConditionVisitor extends KindVisitorImplementation implements ConditionVis
             // Other code should warn about this invalid AST
             return $context;
         }
+        if ($left->kind === ast\AST_ARRAY) {
+            $expr_node = $node->children['expr'];
+            if ($expr_node instanceof Node) {
+                return (new self($this->code_base, $context))->__invoke($expr_node);
+            }
+            return $context;
+        }
         return (new self($this->code_base, $context))->__invoke($left);
     }
 

--- a/src/Phan/Analysis/NegatedConditionVisitor.php
+++ b/src/Phan/Analysis/NegatedConditionVisitor.php
@@ -991,6 +991,13 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
             // Other code should warn about this invalid AST
             return $context;
         }
+        if ($left->kind === ast\AST_ARRAY) {
+            $expr_node = $node->children['expr'];
+            if ($expr_node instanceof Node) {
+                return (new self($this->code_base, $context))->__invoke($expr_node);
+            }
+            return $context;
+        }
         return (new self($this->code_base, $context))->__invoke($left);
     }
 

--- a/tests/files/expected/0134_conditional_list_assign.php.expected
+++ b/tests/files/expected/0134_conditional_list_assign.php.expected
@@ -1,1 +1,1 @@
-%s:2 PhanRedundantConditionInGlobalScope Redundant attempt to cast list($a) of type array{0:1} to truthy in the global scope (likely a false positive)
+%s:2 PhanRedundantCondition Redundant attempt to cast [1,2,3] of type array{0:1,1:2,2:3} to truthy

--- a/tests/files/expected/0157_conditional_assignment.php.expected
+++ b/tests/files/expected/0157_conditional_assignment.php.expected
@@ -1,1 +1,1 @@
-%s:5 PhanRedundantCondition Redundant attempt to cast list($a) of type array{0:1} to truthy
+%s:5 PhanRedundantCondition Redundant attempt to cast [1] of type array{0:1} to truthy

--- a/tests/files/expected/0722_destructure_false_positive.php.expected
+++ b/tests/files/expected/0722_destructure_false_positive.php.expected
@@ -1,0 +1,6 @@
+%s:7 PhanRedundantCondition Redundant attempt to cast [2] of type array{0:2} to truthy
+%s:9 PhanTypeInvalidExpressionArrayDestructuring Invalid value of type 0 in an array destructuring assignment, expected array|ArrayAccess
+%s:10 PhanImpossibleCondition Impossible attempt to cast null of type null to truthy
+%s:10 PhanTypeInvalidExpressionArrayDestructuring Invalid value of type null in an array destructuring assignment, expected array|ArrayAccess
+%s:12 PhanImpossibleCondition Impossible attempt to cast [] of type array{} to truthy
+%s:12 PhanTypeInvalidDimOffsetArrayDestructuring Invalid offset 0 of array type array{} in an array destructuring assignment

--- a/tests/files/src/0722_destructure_false_positive.php
+++ b/tests/files/src/0722_destructure_false_positive.php
@@ -1,0 +1,13 @@
+<?php
+const ZERO = 0;
+function destructure(?array $values) {
+    // Observed: PhanRedundantCondition Redundant attempt to cast [$a] of type array{0:mixed|null} to truthy
+    // Expected: nothing
+    if ([$a] = $values) { echo "Saw $a\n"; }
+    if ([$b] = [2]) { echo "Saw $b\n"; }
+    // should not crash
+    if ([$c] = 0) { echo "Saw $c\n"; }
+    if (list($d) = null) { echo "Saw $d\n"; }
+    // should warn
+    if (list($e) = []) { echo "Saw $e\n"; }
+}


### PR DESCRIPTION
When the left hand side is an array, apply the condition to the right
hand side instead.

Fixes #2904