### PR TITLE
Emit critical errors for duplicate use

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,8 @@ New features(Analysis):
 + Be more accurate about inferring real union types from assertions that expressions are non-null. (#2901)
 + Support dumping Phan's internal representation of a variable's union type (and real union type) with `'@phan-debug-var $varName'` (useful for debugging)
 + Fix false positive `PhanRedundantCondition` analyzing `if ([$a] = (expr))` (#2904)
++ Emit critical errors for duplicate use for class/namespace, function, or constant (#2897)
+  New issue types: `PhanDuplicateUseNormal`, `PhanDuplicateUseFunction`, `PhanDuplicateUseConstant`
 
 Jun 17 2019, Phan 2.2.3
 -----------------------

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -3805,6 +3805,30 @@ This detects code causing a [warning in PHP 7.3](http://php.net/manual/en/migrat
 ```
 
 
+## PhanDuplicateUseConstant
+
+```
+Cannot use constant {CONST} as {CONST} because the name is already in use
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0723_duplicate_use.php.expected#L3) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0723_duplicate_use.php#L8).
+
+## PhanDuplicateUseFunction
+
+```
+Cannot use function {FUNCTION} as {FUNCTION} because the name is already in use
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0723_duplicate_use.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0723_duplicate_use.php#L6).
+
+## PhanDuplicateUseNormal
+
+```
+Cannot use {CLASSLIKE} as {CLASSLIKE} because the name is already in use
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0723_duplicate_use.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0723_duplicate_use.php#L4).
+
 ## PhanInvalidConstantExpression
 
 ```

--- a/src/Phan/Analysis/ScopeVisitor.php
+++ b/src/Phan/Analysis/ScopeVisitor.php
@@ -132,7 +132,8 @@ abstract class ScopeVisitor extends AnalysisVisitor
                 $flags,
                 $alias,
                 $target,
-                $lineno
+                $lineno,
+                $this->code_base
             );
         }
 
@@ -167,7 +168,8 @@ abstract class ScopeVisitor extends AnalysisVisitor
                 $flags,
                 $alias,
                 $target,
-                $lineno
+                $lineno,
+                $this->code_base
             );
         }
 

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -337,6 +337,9 @@ class Issue
     const UnreferencedUseNormal         = 'PhanUnreferencedUseNormal';
     const UnreferencedUseFunction       = 'PhanUnreferencedUseFunction';
     const UnreferencedUseConstant       = 'PhanUnreferencedUseConstant';
+    const DuplicateUseNormal            = 'PhanDuplicateUseNormal';
+    const DuplicateUseFunction          = 'PhanDuplicateUseFunction';
+    const DuplicateUseConstant          = 'PhanDuplicateUseConstant';
     const UseNormalNoEffect             = 'PhanUseNormalNoEffect';
     const UseNormalNamespacedNoEffect   = 'PhanUseNormalNamespacedNoEffect';
     const UseFunctionNoEffect           = 'PhanUseFunctionNoEffect';
@@ -748,6 +751,30 @@ class Issue
                 'Cannot \'{OPERATOR}\' {INDEX} levels.',
                 self::REMEDIATION_A,
                 17007
+            ),
+            new Issue(
+                self::DuplicateUseNormal,
+                self::CATEGORY_SYNTAX,
+                self::SEVERITY_CRITICAL,
+                "Cannot use {CLASSLIKE} as {CLASSLIKE} because the name is already in use",
+                self::REMEDIATION_B,
+                17008
+            ),
+            new Issue(
+                self::DuplicateUseFunction,
+                self::CATEGORY_SYNTAX,
+                self::SEVERITY_CRITICAL,
+                "Cannot use function {FUNCTION} as {FUNCTION} because the name is already in use",
+                self::REMEDIATION_B,
+                17009
+            ),
+            new Issue(
+                self::DuplicateUseConstant,
+                self::CATEGORY_SYNTAX,
+                self::SEVERITY_CRITICAL,
+                "Cannot use constant {CONST} as {CONST} because the name is already in use",
+                self::REMEDIATION_B,
+                17010
             ),
 
             // Issue::CATEGORY_UNDEFINED

--- a/tests/files/expected/0723_duplicate_use.php.expected
+++ b/tests/files/expected/0723_duplicate_use.php.expected
@@ -1,0 +1,4 @@
+%s:4 PhanDuplicateUseNormal Cannot use \Foo as foo because the name is already in use
+%s:6 PhanDuplicateUseFunction Cannot use function \ast\parse_file as parse_code because the name is already in use
+%s:8 PhanDuplicateUseConstant Cannot use constant \PHP_VERSION as PHP_VERSION because the name is already in use
+%s:11 PhanUndeclaredClassMethod Call to method __construct from undeclared class \Foo

--- a/tests/files/src/0723_duplicate_use.php
+++ b/tests/files/src/0723_duplicate_use.php
@@ -1,0 +1,12 @@
+<?php
+namespace NS;
+use \foo;
+use \foo;
+use function ast\parse_code;
+use function ast\parse_file as parse_code;
+use const PHP_VERSION;
+use const PHP_VERSION;
+
+var_export(parse_code('x.php', 50));
+var_export(new Foo());
+var_export(PHP_VERSION);


### PR DESCRIPTION
New issue types: `PhanDuplicateUseNormal`, `PhanDuplicateUseFunction`,
`PhanDuplicateUseConstant`

Fixes #2897