### PR TITLE
Improve Phan's warnings about deprecations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,9 @@ New features(Analysis):
 + Emit critical errors for duplicate use for class/namespace, function, or constant (#2897)
   New issue types: `PhanDuplicateUseNormal`, `PhanDuplicateUseFunction`, `PhanDuplicateUseConstant`
 + Emit `PhanCompatibleUnsetCast` for uses of the deprecated `(unset)(expr)` cast. (#2871)
++ Emit `PhanDeprecatedClass`, `PhanDeprecatedTrait`, and `PhanDeprecatedInterface` on the class directly inheriting from the deprecated class, trait, or interface. (#972)
+  Stop emitting that issue when constructing a non-deprecated class inheriting from a deprecated class.
++ Include the deprecation reason for user-defined classes that were deprecated (#2807)
 
 Language Server/Daemon mode:
 + Properly locate the defining class for `MyClass::class` when the polyfill/fallback is used.

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -570,7 +570,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/files/expected/0
 ## PhanDeprecatedClass
 
 ```
-Call to deprecated class {CLASS} defined at {FILE}:{LINE}
+Using a deprecated class {CLASS} defined at {FILE}:{LINE}{DETAILS}
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/files/expected/0123_deprecated_class.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/2.0.0/tests/files/src/0123_deprecated_class.php#L12).
@@ -578,7 +578,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/files/expected/0
 ## PhanDeprecatedClassConstant
 
 ```
-Reference to deprecated property {PROPERTY} defined at {FILE}:{LINE}
+Reference to deprecated property {PROPERTY} defined at {FILE}:{LINE}{DETAILS}
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/php72_files/expected/0007_deprecated_class_constant.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/2.0.0/tests/php72_files/src/0007_deprecated_class_constant.php#L6).
@@ -588,7 +588,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/php72_files/expe
 If a class, method, function, property or constant is marked in its comment as `@deprecated`, any references to them will emit a deprecated error.
 
 ```
-Call to deprecated function {FUNCTIONLIKE} defined at {FILE}:{LINE}
+Call to deprecated function {FUNCTIONLIKE} defined at {FILE}:{LINE}{DETAILS}
 ```
 
 This will be emitted for the following code.
@@ -610,7 +610,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/php72_files/expe
 ## PhanDeprecatedInterface
 
 ```
-Using a deprecated interface {INTERFACE} defined at {FILE}:{LINE}
+Using a deprecated interface {INTERFACE} defined at {FILE}:{LINE}{DETAILS}
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/files/expected/0269_deprecated_interface.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/2.0.0/tests/files/src/0269_deprecated_interface.php#L7).
@@ -618,7 +618,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/files/expected/0
 ## PhanDeprecatedProperty
 
 ```
-Reference to deprecated property {PROPERTY} defined at {FILE}:{LINE}
+Reference to deprecated property {PROPERTY} defined at {FILE}:{LINE}{DETAILS}
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/files/expected/0171_deprecated_property.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/2.0.0/tests/files/src/0171_deprecated_property.php#L9).
@@ -626,7 +626,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/files/expected/0
 ## PhanDeprecatedTrait
 
 ```
-Using a deprecated trait {TRAIT} defined at {FILE}:{LINE}
+Using a deprecated trait {TRAIT} defined at {FILE}:{LINE}{DETAILS}
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/files/expected/0270_deprecated_trait.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/2.0.0/tests/files/src/0270_deprecated_trait.php#L7).

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -1372,7 +1372,8 @@ class ContextNode
                     $node->lineno,
                     $property->getRepresentationForIssue(),
                     $property->getFileRef()->getFile(),
-                    $property->getFileRef()->getLineNumberStart()
+                    $property->getFileRef()->getLineNumberStart(),
+                    $property->getDeprecationReason()
                 );
             }
 
@@ -1802,7 +1803,8 @@ class ContextNode
                     $node->lineno,
                     (string)$constant->getFQSEN(),
                     $constant->getFileRef()->getFile(),
-                    $constant->getFileRef()->getLineNumberStart()
+                    $constant->getFileRef()->getLineNumberStart(),
+                    $constant->getDeprecationReason()
                 );
             }
 

--- a/src/Phan/Analysis/ArgumentType.php
+++ b/src/Phan/Analysis/ArgumentType.php
@@ -188,7 +188,8 @@ final class ArgumentType
                     $context->getLineNumberStart(),
                     $method->getRepresentationForIssue(),
                     $method->getFileRef()->getFile(),
-                    $method->getFileRef()->getLineNumberStart()
+                    $method->getFileRef()->getLineNumberStart(),
+                    $method->getDeprecationReason()
                 );
             }
         }

--- a/src/Phan/Analysis/ClassInheritanceAnalyzer.php
+++ b/src/Phan/Analysis/ClassInheritanceAnalyzer.php
@@ -142,7 +142,7 @@ class ClassInheritanceAnalyzer
         ) {
             Issue::maybeEmit(
                 $code_base,
-                $source_class->getContext(),
+                $source_class->getInternalContext(),
                 Issue::AccessClassInternal,
                 $source_class->getFileRef()->getLineNumberStart(),
                 (string)$target_class,
@@ -150,19 +150,24 @@ class ClassInheritanceAnalyzer
                 (string)$target_class->getFileRef()->getLineNumberStart()
             );
         }
-
-        /*
         if ($target_class->isDeprecated()) {
+            if ($target_class->isTrait()) {
+                $issue_type = Issue::DeprecatedTrait;
+            } elseif ($target_class->isInterface()) {
+                $issue_type = Issue::DeprecatedInterface;
+            } else {
+                $issue_type = Issue::DeprecatedClass;
+            }
             Issue::maybeEmit(
                 $code_base,
-                $source_class->getContext(),
-                Issue::DeprecatedClass,
+                $source_class->getInternalContext(),
+                $issue_type,
                 $source_class->getFileRef()->getLineNumberStart(),
-                (string)$target_class->getFQSEN(),
-                $target_class->getFileRef()->getFile(),
-                (string)$target_class->getFileRef()->getLineNumberStart()
+                $target_class->getFQSEN(),
+                $target_class->getContext()->getFile(),
+                $target_class->getContext()->getLineNumberStart(),
+                $target_class->getDeprecationReason()
             );
         }
-        */
     }
 }

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -1950,32 +1950,9 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                         $node->lineno,
                         (string)$class->getFQSEN(),
                         $class->getContext()->getFile(),
-                        (string)$class->getContext()->getLineNumberStart()
+                        (string)$class->getContext()->getLineNumberStart(),
+                        $class->getDeprecationReason()
                     );
-                }
-                foreach ($class->getInterfaceFQSENList() as $interface) {
-                    $clazz = $this->code_base->getClassByFQSEN($interface);
-                    if ($clazz->isDeprecated()) {
-                        $this->emitIssue(
-                            Issue::DeprecatedInterface,
-                            $node->lineno,
-                            (string)$clazz->getFQSEN(),
-                            $clazz->getContext()->getFile(),
-                            (string)$clazz->getContext()->getLineNumberStart()
-                        );
-                    }
-                }
-                foreach ($class->getTraitFQSENList() as $trait) {
-                    $clazz = $this->code_base->getClassByFQSEN($trait);
-                    if ($clazz->isDeprecated()) {
-                        $this->emitIssue(
-                            Issue::DeprecatedTrait,
-                            $node->lineno,
-                            (string)$clazz->getFQSEN(),
-                            $clazz->getContext()->getFile(),
-                            (string)$clazz->getContext()->getLineNumberStart()
-                        );
-                    }
                 }
             }
 

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -2335,7 +2335,7 @@ class Issue
                 self::DeprecatedFunction,
                 self::CATEGORY_DEPRECATED,
                 self::SEVERITY_NORMAL,
-                "Call to deprecated function {FUNCTIONLIKE} defined at {FILE}:{LINE}",
+                "Call to deprecated function {FUNCTIONLIKE} defined at {FILE}:{LINE}{DETAILS}",
                 self::REMEDIATION_B,
                 5000
             ),
@@ -2351,7 +2351,7 @@ class Issue
                 self::DeprecatedClass,
                 self::CATEGORY_DEPRECATED,
                 self::SEVERITY_NORMAL,
-                "Call to deprecated class {CLASS} defined at {FILE}:{LINE}",
+                "Using a deprecated class {CLASS} defined at {FILE}:{LINE}{DETAILS}",
                 self::REMEDIATION_B,
                 5001
             ),
@@ -2359,7 +2359,7 @@ class Issue
                 self::DeprecatedProperty,
                 self::CATEGORY_DEPRECATED,
                 self::SEVERITY_NORMAL,
-                "Reference to deprecated property {PROPERTY} defined at {FILE}:{LINE}",
+                "Reference to deprecated property {PROPERTY} defined at {FILE}:{LINE}{DETAILS}",
                 self::REMEDIATION_B,
                 5002
             ),
@@ -2367,7 +2367,7 @@ class Issue
                 self::DeprecatedClassConstant,
                 self::CATEGORY_DEPRECATED,
                 self::SEVERITY_NORMAL,
-                "Reference to deprecated property {PROPERTY} defined at {FILE}:{LINE}",
+                "Reference to deprecated property {PROPERTY} defined at {FILE}:{LINE}{DETAILS}",
                 self::REMEDIATION_B,
                 5007
             ),
@@ -2375,7 +2375,7 @@ class Issue
                 self::DeprecatedInterface,
                 self::CATEGORY_DEPRECATED,
                 self::SEVERITY_NORMAL,
-                "Using a deprecated interface {INTERFACE} defined at {FILE}:{LINE}",
+                "Using a deprecated interface {INTERFACE} defined at {FILE}:{LINE}{DETAILS}",
                 self::REMEDIATION_B,
                 5003
             ),
@@ -2383,7 +2383,7 @@ class Issue
                 self::DeprecatedTrait,
                 self::CATEGORY_DEPRECATED,
                 self::SEVERITY_NORMAL,
-                "Using a deprecated trait {TRAIT} defined at {FILE}:{LINE}",
+                "Using a deprecated trait {TRAIT} defined at {FILE}:{LINE}{DETAILS}",
                 self::REMEDIATION_B,
                 5004
             ),

--- a/src/Phan/Language/Element/FunctionInterface.php
+++ b/src/Phan/Language/Element/FunctionInterface.php
@@ -349,6 +349,11 @@ interface FunctionInterface extends AddressableElementInterface
     public function getComment() : ?Comment;
 
     /**
+     * @return string - a suffix for an issue message indicating the cause for deprecation. This string is empty if the cause is unknown.
+     */
+    public function getDeprecationReason() : string;
+
+    /**
      * Set the comment data for this function/method
      */
     public function setComment(Comment $comment) : void;

--- a/src/Phan/Language/Element/MarkupDescription.php
+++ b/src/Phan/Language/Element/MarkupDescription.php
@@ -412,7 +412,11 @@ class MarkupDescription
         return $str;
     }
 
-    private static function trimLine(string $line) : string
+    /**
+     * Remove leading * and spaces (and trailing spaces) from the provided line of text.
+     * This is useful for trimming raw doc comment lines
+     */
+    public static function trimLine(string $line) : string
     {
         $line = \rtrim($line);
         $pos = \stripos($line, '*');

--- a/src/Phan/Language/Type/FunctionLikeDeclarationType.php
+++ b/src/Phan/Language/Type/FunctionLikeDeclarationType.php
@@ -416,6 +416,12 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
     }
 
     /** @override */
+    public function getDeprecationReason() : string
+    {
+        return '';
+    }
+
+    /** @override */
     public function getDependentReturnType(CodeBase $code_base, Context $context, array $args) : UnionType
     {
         throw new \AssertionError('unexpected call to ' . __METHOD__);

--- a/src/Phan/Library/FileCacheEntry.php
+++ b/src/Phan/Library/FileCacheEntry.php
@@ -12,6 +12,7 @@ use Phan\Plugin\Internal\IssueFixingPlugin\FileContents;
  * - Checking for (at)phan-suppress-line annotations at runtime - Many checks to the same file will often be in cache
  * - Checking the tokens/text of the file for purposes such as checking for expressions that are incompatible in PHP5.
  * - `--automatic-fix`
+ * @suppress PhanDeprecatedClass FileContents will be removed in a future release.
  */
 class FileCacheEntry extends FileContents
 {

--- a/src/Phan/PluginV2/PluginAwarePostAnalysisVisitor.php
+++ b/src/Phan/PluginV2/PluginAwarePostAnalysisVisitor.php
@@ -8,6 +8,7 @@ namespace Phan\PluginV2;
  * For plugins which define their own post-order analysis behaviors in the analysis phase.
  * Called on a node after PluginAwarePreAnalysisVisitor implementations.
  * @deprecated use PluginV3
+ * @suppress PhanDeprecatedClass
  */
 abstract class PluginAwarePostAnalysisVisitor extends PluginAwareBaseAnalysisVisitor
 {

--- a/src/Phan/PluginV2/PluginAwarePreAnalysisVisitor.php
+++ b/src/Phan/PluginV2/PluginAwarePreAnalysisVisitor.php
@@ -7,6 +7,7 @@ namespace Phan\PluginV2;
  * Called on a node before PluginAwarePreAnalysisVisitor implementations.
  *
  * @deprecated use PluginV3
+ * @suppress PhanDeprecatedClass
  */
 abstract class PluginAwarePreAnalysisVisitor extends PluginAwareBaseAnalysisVisitor
 {

--- a/src/Phan/PluginV3/AnalyzePropertyCapability.php
+++ b/src/Phan/PluginV3/AnalyzePropertyCapability.php
@@ -8,6 +8,7 @@ use Phan\Language\Element\Property;
 /**
  * Plugins can implement this to analyze (and modify) a property definition,
  * after parsing and before analyzing.
+ * @suppress PhanDeprecatedInterface
  */
 interface AnalyzePropertyCapability extends \Phan\PluginV2\AnalyzePropertyCapability
 {

--- a/tests/files/expected/0123_deprecated_class.php.expected
+++ b/tests/files/expected/0123_deprecated_class.php.expected
@@ -1,3 +1,3 @@
-%s:12 PhanDeprecatedClass Call to deprecated class \C defined at %s:5
+%s:12 PhanDeprecatedClass Using a deprecated class \C defined at %s:5
 %s:13 PhanDeprecatedFunction Call to deprecated function \C::f() defined at %s:9
 %s:20 PhanDeprecatedFunction Call to deprecated function \f() defined at %s:18

--- a/tests/files/expected/0269_deprecated_interface.php.expected
+++ b/tests/files/expected/0269_deprecated_interface.php.expected
@@ -1,1 +1,1 @@
-%s:7 PhanDeprecatedInterface Using a deprecated interface \I defined at %s:3
+%s:5 PhanDeprecatedInterface Using a deprecated interface \I defined at %s:3

--- a/tests/files/expected/0270_deprecated_trait.php.expected
+++ b/tests/files/expected/0270_deprecated_trait.php.expected
@@ -1,1 +1,1 @@
-%s:7 PhanDeprecatedTrait Using a deprecated trait \T defined at %s:3
+%s:5 PhanDeprecatedTrait Using a deprecated trait \T defined at %s:3

--- a/tests/files/expected/0726_deprecation_reason.php.expected
+++ b/tests/files/expected/0726_deprecation_reason.php.expected
@@ -1,0 +1,5 @@
+%s:7 PhanDeprecatedInterface Using a deprecated interface \TestDeprecationMessage\DeprecatedInterface defined at %s:5 (Deprecated because: single line reason.)
+%s:31 PhanDeprecatedClass Using a deprecated class \TestDeprecationMessage\ExampleClass defined at %s:15 (Deprecated because: deprecated since 1.3. Switch to otherAPI instead.)
+%s:32 PhanDeprecatedProperty Reference to deprecated property \TestDeprecationMessage\ExampleClass::$double defined at %s:23 (Deprecated because: use triple instead. More details.)
+%s:33 PhanDeprecatedFunction Call to deprecated function \TestDeprecationMessage\ExampleClass::deprecatedMethod() defined at %s:28 (Deprecated because: use *->otherMethod() instead)
+%s:40 PhanDeprecatedTrait Using a deprecated trait \TestDeprecationMessage\DeprecatedTrait defined at %s:39 (Deprecated because: this does nothing)

--- a/tests/files/src/0726_deprecation_reason.php
+++ b/tests/files/src/0726_deprecation_reason.php
@@ -1,0 +1,47 @@
+<?php
+namespace TestDeprecationMessage;
+
+/** @deprecated single line reason. */
+interface DeprecatedInterface{}
+
+class Foo implements DeprecatedInterface {}
+
+/**
+ * @deprecated deprecated since 1.3.
+ *
+ * Switch to otherAPI instead.
+ * @some-other-annotation
+ */
+class ExampleClass {
+    /** @deprecated just use null */
+    const NULL = null;
+
+    /** @deprecated use triple instead.
+      *
+      * More details.
+      */
+    public static $double = 2;
+
+    /**
+     * @deprecated use *->otherMethod() instead
+     */
+    public static function deprecatedMethod() {
+    }
+}
+$x = new ExampleClass();
+var_export(ExampleClass::$double);
+var_export(ExampleClass::deprecatedMethod());
+
+/**
+ * @deprecated
+ * this does nothing
+ */
+trait DeprecatedTrait {}
+class Other {
+    use DeprecatedTrait;
+}
+
+/**
+ * @suppress PhanDeprecatedInterface suppressions should work
+ */
+class OtherFoo implements DeprecatedInterface {}


### PR DESCRIPTION
Include user-defined reasons for deprecation (from doc comments)
in the issue message.

Warn about inherited deprecated elements at the place inheritance
occurs, not where the inheriting instance is constructed.

Fixes #2807
Fixes #972