### PR TITLE
Fix false positive seen when non-template class extends template class

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,7 @@ New features(Analysis):
 + Emit `PhanDeprecatedClass`, `PhanDeprecatedTrait`, and `PhanDeprecatedInterface` on the class directly inheriting from the deprecated class, trait, or interface. (#972)
   Stop emitting that issue when constructing a non-deprecated class inheriting from a deprecated class.
 + Include the deprecation reason for user-defined classes that were deprecated (#2807)
++ Fix false positives seen when non-template class extends a template class (#2573)
 
 Language Server/Daemon mode:
 + Properly locate the defining class for `MyClass::class` when the polyfill/fallback is used.

--- a/tests/files/expected/0727_generic_array.php.expected
+++ b/tests/files/expected/0727_generic_array.php.expected
@@ -1,0 +1,1 @@
+%s:45 PhanTypeMismatchArgument Argument 1 ($item) is string[] but \Main::one() takes string defined at %s:51

--- a/tests/files/src/0727_generic_array.php
+++ b/tests/files/src/0727_generic_array.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+/**
+ * @template T
+ */
+class Base {
+
+    /**
+     * @var T
+     */
+    private $item;
+
+    /**
+     * @param T $item
+     */
+    public function __construct($item) {
+        $this->item = $item;
+    }
+
+    /**
+     * @return T[]
+     */
+    public function getArray() {
+        return [$this->item, $this->item];
+    }
+
+    public function getOne() {
+        return $this->item;
+    }
+}
+
+/**
+ * @inherits Base<string>
+ */
+class ItemBase extends Base {
+}
+
+class Main {
+
+    public function run() {
+        $base = new ItemBase("asd");
+
+        $this->one($base->getOne());
+        $this->two($base->getArray());
+        $this->one($base->getArray());
+    }
+
+    /**
+     * @param string $item
+     */
+    private function one($item) {
+        echo $item;
+    }
+
+    /**
+     * @param string[] $items
+     */
+    private function two($items) {
+        foreach ($items as $item) {
+            echo $item;
+        }
+    }
+}
+
+$m = new Main();
+$m->run();


### PR DESCRIPTION
e.g. `@inherits Base<string>` should make all methods on the inheriting
class act as though the template `T` was a string.

Fixes #2573