### PR TITLE
Run language server with a single analysis process

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,7 @@ New features(Analysis):
 Language Server/Daemon mode:
 + Fix a crash - always run the language server or daemon with a single analysis process, regardless of CLI or config settings (#2898)
 + Properly locate the defining class for `MyClass::class` when the polyfill/fallback is used.
++ Don't emit color in responses from the daemon or language server unless the CLI flag `--color` is passed in.
 
 Maintenance:
 + Warn if running Phan with php 7.4+ when the installed php-ast version is older than 1.0.2.

--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,7 @@ New features(Analysis):
 + Include the deprecation reason for user-defined classes that were deprecated (#2807)
 
 Language Server/Daemon mode:
++ Fix a crash - always run the language server or daemon with a single analysis process, regardless of CLI or config settings (#2898)
 + Properly locate the defining class for `MyClass::class` when the polyfill/fallback is used.
 
 Maintenance:

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -791,6 +791,8 @@ class CLI
             && Config::getValue('dead_code_detection')) {
             throw new AssertionError("We cannot run dead code detection on more than one core.");
         }
+
+        self::ensureServerRunsSingleAnalysisProcess();
     }
 
     /**
@@ -894,6 +896,23 @@ class CLI
         if (!$all_plugins_exist) {
             \fwrite(STDERR, "Exiting due to invalid plugin config.\n");
             exit(1);
+        }
+    }
+
+    private static function ensureServerRunsSingleAnalysisProcess() : void
+    {
+        if (!self::isDaemonOrLanguageServer()) {
+            return;
+        }
+        // If the client has multiple files open at once (and requests analysis of multiple files),
+        // then there there would be multiple processes doing analysis.
+        //
+        // This would not work with Phan's current design - the socket used by the daemon can only be used by one process.
+        // Also, the implementation of some requests such as "Go to Definition", "Find References" (planned), etc. assume Phan runs as a single process.
+        $processes = Config::getValue('processes');
+        if ($processes !== 1) {
+            fprintf(STDERR, "Notice: Running with processes=1 instead of processes=%s - the daemon/language server assumes it will run as a single process" . \PHP_EOL, (string)json_encode($processes));
+            Config::setValue('processes', 1);
         }
     }
 

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -852,6 +852,9 @@ class CLI
      */
     public static function supportsColor($output) : bool
     {
+        if (self::isDaemonOrLanguageServer()) {
+            return false;
+        }
         if (\defined('PHP_WINDOWS_VERSION_BUILD')) {
             return (\function_exists('sapi_windows_vt100_support')
                 && \sapi_windows_vt100_support($output))

--- a/src/Phan/Language/Element/AddressableElement.php
+++ b/src/Phan/Language/Element/AddressableElement.php
@@ -338,7 +338,9 @@ abstract class AddressableElement extends TypedElement implements AddressableEle
                         return '';
                     }
                     $new_lines[0] = preg_replace('/^\s*@deprecated\b\s*/', '', $new_lines[0]);
-                    $reason = implode(' ', array_filter(array_map('trim', $new_lines), function (string $line) : bool { return $line !== ''; }));
+                    $reason = implode(' ', array_filter(array_map('trim', $new_lines), static function (string $line) : bool {
+                        return $line !== '';
+                    }));
                     if ($reason !== '') {
                         return ' (Deprecated because: ' . $reason . ')';
                     }


### PR DESCRIPTION
And don't set color in responses from the Phan daemon unless `--color` is set

Fixes #2898