### PR TITLE
Track real array types for $x['field'] = 'bar';

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,11 @@ New features(CLI, Configs):
 
 New features(Analysis):
 + Fix false positive PhanSuspiciousValueComparisonInLoop when both sides change in a loop. (#2919)
++ Detect potential infinite loops such as `while (true) { does_not_exit_loop(); }`. (Requires `--redundant-condition-detection`)
+  New issue types: `PhanInfiniteRecursion`.
++ Track that the **real** type of an array variable is an array after adding fields to it (#2932)
+  (affects redundant condition detection and unused variable detection)
++ Warn about adding fields to an unused array variable, if Phan infers the real variable type is an array. (#2933)
 
 Jul 01 2019, Phan 2.2.4
 -----------------------

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -1943,6 +1943,14 @@ e.g. [this issue](https://github.com/phan/phan/tree/2.2.3/tests/files/expected/0
 Impossible attempt to check if {CODE} of type {TYPE} is identical to {CODE} of type {TYPE} in a loop body (likely a false positive)
 ```
 
+## PhanInfiniteLoop
+
+```
+The loop condition {CODE} of type {TYPE} is always {TYPE} and nothing seems to exit the loop
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0728_infinite_loops.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0728_infinite_loops.php#L4).
+
 ## PhanInfiniteRecursion
 
 NOTE: This is based on very simple heuristics. It has known false positives and false negatives.
@@ -2161,7 +2169,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/
 Suspicious attempt to compare {CODE} of type {TYPE} to {CODE} of type {TYPE} with operator '{OPERATOR}'
 ```
 
-e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0526_crash.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0526_crash.php#L2).
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0697_coalescing_always_never_null.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0697_coalescing_always_never_null.php#L4).
 
 ## PhanSuspiciousValueComparisonInGlobalScope
 
@@ -2176,6 +2184,8 @@ e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/
 ```
 Suspicious attempt to compare {CODE} of type {TYPE} to {CODE} of type {TYPE} with operator '{OPERATOR}' in a loop (likely a false positive)
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0728_suspicious_value_comparison_in_loop_false_positive.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0728_suspicious_value_comparison_in_loop_false_positive.php#L30).
 
 ## PhanSuspiciousWeakTypeComparison
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -50,9 +50,13 @@
             <file>tests/Phan/ForkPoolTest.php</file>
         </testsuite>
         <testsuite name="PhanTest">
+            <file>tests/Phan/PhanTest0.php</file>
             <file>tests/Phan/PhanTest1.php</file>
             <file>tests/Phan/PhanTest2.php</file>
             <file>tests/Phan/PhanTest3.php</file>
+            <file>tests/Phan/PhanTest4.php</file>
+            <file>tests/Phan/PhanTest5.php</file>
+            <file>tests/Phan/PhanTest6.php</file>
             <file>tests/Phan/PhanTestNew.php</file>
         </testsuite>
         <testsuite name="RasmusTest">

--- a/src/Phan/Config/Initializer.php
+++ b/src/Phan/Config/Initializer.php
@@ -320,7 +320,7 @@ EOT;
             'phpdoc_type_mapping' => [],
             'dead_code_detection' => false,  // this is slow
             'unused_variable_detection' => !$is_average_level,
-            'redundant_condition_detection' => $is_strongest_level,
+            'redundant_condition_detection' => !$is_average_level,
             'quick_mode' => $is_weakest_level,
             'simplify_ast' => true,
             'generic_types_enabled' => true,

--- a/tests/Phan/CLITest.php
+++ b/tests/Phan/CLITest.php
@@ -100,7 +100,11 @@ final class CLITest extends BaseTest
         }
         $this->assertSame($expected_changed_options, $changed);
 
-        $this->assertSame(['src' . \DIRECTORY_SEPARATOR . 'empty.php'], $cli->getFileList());
+        $this->assertSame([
+            'src' . \DIRECTORY_SEPARATOR . 'a.php',
+            'src' . \DIRECTORY_SEPARATOR . 'b.php',
+            'src' . \DIRECTORY_SEPARATOR . 'empty.php',
+        ], $cli->getFileList());
 
         $printer_class = $extra['printer_class'] ?? null;
         unset($extra['printer_class']);

--- a/tests/Phan/PhanTest0.php
+++ b/tests/Phan/PhanTest0.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+namespace Phan\Tests;
+
+/**
+ * Runs tests/files/src/0000-0099
+ */
+class PhanTest0 extends PhanTestRange
+{
+    const START_RANGE = '0000';
+    const END_RANGE   = '0100';
+}

--- a/tests/Phan/PhanTest1.php
+++ b/tests/Phan/PhanTest1.php
@@ -3,10 +3,10 @@
 namespace Phan\Tests;
 
 /**
- * Runs tests/files/src/0000-0199
+ * Runs tests/files/src/0100-0199
  */
 class PhanTest1 extends PhanTestRange
 {
-    const START_RANGE = '0000';
+    const START_RANGE = '0100';
     const END_RANGE   = '0200';
 }

--- a/tests/Phan/PhanTest2.php
+++ b/tests/Phan/PhanTest2.php
@@ -3,10 +3,10 @@
 namespace Phan\Tests;
 
 /**
- * Runs tests/files/src/0200-0400
+ * Runs tests/files/src/0200-0299
  */
 class PhanTest2 extends PhanTestRange
 {
     const START_RANGE = '0200';
-    const END_RANGE   = '0400';
+    const END_RANGE   = '0300';
 }

--- a/tests/Phan/PhanTest3.php
+++ b/tests/Phan/PhanTest3.php
@@ -3,10 +3,10 @@
 namespace Phan\Tests;
 
 /**
- * Runs tests/files/src/0400-0599
+ * Runs tests/files/src/0300-0399
  */
 class PhanTest3 extends PhanTestRange
 {
-    const START_RANGE = '0400';
-    const END_RANGE   = '0600';
+    const START_RANGE = '0300';
+    const END_RANGE   = '0400';
 }

--- a/tests/Phan/PhanTest4.php
+++ b/tests/Phan/PhanTest4.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+namespace Phan\Tests;
+
+/**
+ * Runs tests/files/src/0400-0499
+ */
+class PhanTest4 extends PhanTestRange
+{
+    const START_RANGE = '0400';
+    const END_RANGE   = '0500';
+}

--- a/tests/Phan/PhanTest5.php
+++ b/tests/Phan/PhanTest5.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+namespace Phan\Tests;
+
+/**
+ * Runs tests/files/src/0500-0599
+ */
+class PhanTest5 extends PhanTestRange
+{
+    const START_RANGE = '0500';
+    const END_RANGE   = '0600';
+}

--- a/tests/Phan/PhanTest6.php
+++ b/tests/Phan/PhanTest6.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+namespace Phan\Tests;
+
+/**
+ * Runs tests/files/src/0600-0699
+ */
+class PhanTest6 extends PhanTestRange
+{
+    const START_RANGE = '0600';
+    const END_RANGE   = '0700';
+}

--- a/tests/Phan/PhanTestNew.php
+++ b/tests/Phan/PhanTestNew.php
@@ -3,7 +3,7 @@
 namespace Phan\Tests;
 
 /**
- * Runs tests/files/src/0600+
+ * Runs tests/files/src/0700+
  *
  * The default type of test for Phan
  *
@@ -20,8 +20,8 @@ class PhanTestNew extends PhanTestCommon
              */
             static function (array $data) : bool {
                 $expected_file = \basename($data[1]);
-                // Run everything except 0000-0599 (including tests starting with punctuation/letters if needed)
-                return !(\strcmp($expected_file, '0000') >= 0 && \strcmp($expected_file, '0600') < 0);
+                // Run everything except 0000-0699 (including tests starting with punctuation/letters if needed)
+                return !(\strcmp($expected_file, '0000') >= 0 && \strcmp($expected_file, '0700') < 0);
             }
         );
     }

--- a/tests/files/expected/0596_array_dim_branch.php.expected
+++ b/tests/files/expected/0596_array_dim_branch.php.expected
@@ -1,1 +1,2 @@
+%s:6 PhanUnusedVariable Unused definition of variable $x
 %s:9 PhanTypeSuspiciousEcho Suspicious argument \ArrayObject for an echo/print statement

--- a/tests/files/expected/0729_preserve_real_type.php.expected
+++ b/tests/files/expected/0729_preserve_real_type.php.expected
@@ -1,0 +1,1 @@
+%s:5 PhanRedundantCondition Redundant attempt to cast $x of type array{field:2} to array

--- a/tests/files/expected/0730_unused_field_added_to_array.php.expected
+++ b/tests/files/expected/0730_unused_field_added_to_array.php.expected
@@ -1,0 +1,2 @@
+%s:4 PhanUnusedVariable Unused definition of variable $arg
+%s:9 PhanUnusedVariable Unused definition of variable $result

--- a/tests/files/src/0596_array_dim_branch.php
+++ b/tests/files/src/0596_array_dim_branch.php
@@ -1,9 +1,9 @@
 <?php
-
+// Tests that assignments in branches don't affect unrelated branches.
 call_user_func(function () {
     $x = ['key' => new ArrayObject()];
     if (rand() % 2) {
-        $x['key'] = new stdClass();
+        $x['key'] = new stdClass();  // this warns because Phan infers the value is definitely an array and doesn't detect any uses elsewhere.
         return;
     } else {
         echo $x['key'];

--- a/tests/files/src/0729_preserve_real_type.php
+++ b/tests/files/src/0729_preserve_real_type.php
@@ -1,0 +1,15 @@
+<?php
+call_user_func(function () {
+    $x = [];
+    $x['field'] = 2;
+    if (is_array($x)) {
+        echo "The result was an array";
+    }
+});
+/** @param array $x */
+function addfield729($x) {
+    $x['field'] = 2;
+    if (is_array($x)) {
+        echo "The result was an array";
+    }
+}

--- a/tests/files/src/0730_unused_field_added_to_array.php
+++ b/tests/files/src/0730_unused_field_added_to_array.php
@@ -1,0 +1,24 @@
+<?php
+function append_values(array $arg) {
+    $arg[] = 2;
+    $arg[] = 3;
+}
+function double_values(array $input) : void {
+    $result = [];
+    foreach ($input as $e) {
+        $result[] = $e * 2;
+    }
+    echo "Result is: not used\n";
+}
+/** @param array $arg */
+function append_values_phpdoc($arg) {
+    $arg[] = 2;
+    $arg[] = 3;
+}
+/** @param array $result */
+function double_values_phpdoc(array $input, $result) : void {
+    foreach ($input as $e) {
+        $result[] = $e * 2;
+    }
+    echo "Result is: not used\n";
+}

--- a/tests/misc/config/src/a.php
+++ b/tests/misc/config/src/a.php
@@ -1,0 +1,2 @@
+<?php
+// Placeholder to avoid warning in CLITest.php

--- a/tests/misc/config/src/b.php
+++ b/tests/misc/config/src/b.php
@@ -1,0 +1,2 @@
+<?php
+// Placeholder to avoid warning in tests/Phan/CLITest.php

--- a/tests/plugin_test/expected/038_unused_loop_var.php.expected
+++ b/tests/plugin_test/expected/038_unused_loop_var.php.expected
@@ -1,1 +1,2 @@
+src/038_unused_loop_var.php:12 PhanUnusedVariable Unused definition of variable $ast_items
 src/038_unused_loop_var.php:16 PhanUnusedVariable Unused definition of variable $myUnusedVariable

--- a/tests/plugin_test/src/038_unused_loop_var.php
+++ b/tests/plugin_test/src/038_unused_loop_var.php
@@ -7,9 +7,9 @@ class ExampleLoopUnused {
         $prev_was_element = false;
         foreach ([2,3] as $item) {
             if ($item > 2) {
-                // should not warn
+                // should not warn about $prev_was_element being unused in subsequent definitions
                 if (!$prev_was_element) {
-                    $ast_items[] = null;
+                    $ast_items[] = null;  // warns because ast_items isn't used
                     continue;
                 }
                 $prev_was_element = false;


### PR DESCRIPTION
Previously, only the phpdoc type was tracked, and PhanRedundantCondition
would not be emitted.

Avoid warning to stderr in phpunit test CLITest.php

Fixes #2932

Also, warn about adding fields to an array variable
if the array variable isn't used afterwards.

Fixes #2933