### PR TITLE
Improve inferred real types from weak equality checks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@ New features(Analysis):
   (affects redundant condition detection and unused variable detection)
 + Warn about adding fields to an unused array variable, if Phan infers the real variable type is an array. (#2933)
 + Check for `PhanInfiniteLoop` when the condition expression is omitted (e.g. `for (;;) {}`)
++ Avoid false positives in real condition checks from weak equality checks such as `if ($x == null) { if ($x !== null) {}}` (#2924)
 
 Jul 01 2019, Phan 2.2.4
 -----------------------

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -181,6 +181,8 @@ class ConditionVisitor extends KindVisitorImplementation implements ConditionVis
             case flags\BINARY_BOOL_OR:
                 return $this->analyzeShortCircuitingOr($node->children['left'], $node->children['right']);
             case flags\BINARY_IS_IDENTICAL:
+                $this->checkVariablesDefined($node);
+                return $this->analyzeAndUpdateToBeEqual($node->children['left'], $node->children['right']);
             case flags\BINARY_IS_EQUAL:
                 // TODO: Could be more precise, and preserve 0, [], etc. for `$x == null`
                 $this->checkVariablesDefined($node);

--- a/src/Phan/Analysis/ConditionVisitor/EqualsCondition.php
+++ b/src/Phan/Analysis/ConditionVisitor/EqualsCondition.php
@@ -10,9 +10,9 @@ use Phan\AST\UnionTypeVisitor;
 use Phan\Language\Context;
 
 /**
- * This represents an identical assertion implementation acting on two sides of a condition (===)
+ * This represents an equals assertion implementation acting on two sides of a condition (==)
  */
-class IdenticalCondition implements BinaryCondition
+class EqualsCondition implements BinaryCondition
 {
     /**
      * Assert that this condition applies to the variable $var (i.e. $var === $expr)
@@ -24,7 +24,7 @@ class IdenticalCondition implements BinaryCondition
      */
     public function analyzeVar(ConditionVisitorInterface $visitor, Node $var, $expr) : Context
     {
-        return $visitor->updateVariableToBeIdentical($var, $expr);
+        return $visitor->updateVariableToBeEqual($var, $expr);
     }
 
     /**
@@ -46,9 +46,7 @@ class IdenticalCondition implements BinaryCondition
         $code_base = $visitor->getCodeBase();
         $context = $visitor->getContext();
         $value = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $expr)->asSingleScalarValueOrNullOrSelf();
-        if (!\is_bool($value)) {
-            return null;
-        }
+        // Skip check for `if is_bool`, allow weaker comparisons such as `is_string($x) == 1`
         if ($value) {
             // e.g. `if (is_string($x) === true)`
             return (new ConditionVisitor($code_base, $context))->visitCall($call_node);

--- a/src/Phan/Analysis/ConditionVisitorInterface.php
+++ b/src/Phan/Analysis/ConditionVisitorInterface.php
@@ -32,6 +32,17 @@ interface ConditionVisitorInterface
      * @param Node|int|float|string $expr
      * @return Context - Constant after inferring type from an expression such as `if ($x === 'literal')`
      */
+    public function updateVariableToBeEqual(
+        Node $var_node,
+        $expr,
+        Context $context = null
+    ) : Context;
+
+    /**
+     * @param Node $var_node
+     * @param Node|int|float|string $expr
+     * @return Context - Constant after inferring type from an expression such as `if ($x === 'literal')`
+     */
     public function updateVariableToBeIdentical(
         Node $var_node,
         $expr,

--- a/src/Phan/Analysis/NegatedConditionVisitor.php
+++ b/src/Phan/Analysis/NegatedConditionVisitor.php
@@ -128,10 +128,11 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
                 $this->checkVariablesDefined($node);
                 return $this->analyzeAndUpdateToBeNotEqual($node->children['left'], $node->children['right']);
             case flags\BINARY_IS_NOT_IDENTICAL:
+                $this->checkVariablesDefined($node);
+                return $this->analyzeAndUpdateToBeIdentical($node->children['left'], $node->children['right']);
             case flags\BINARY_IS_NOT_EQUAL:
                 $this->checkVariablesDefined($node);
-                // TODO: Add a different function for IS_NOT_EQUAL, e.g. analysis of != null should be different from !== null (First would remove FalseType)
-                return $this->analyzeAndUpdateToBeIdentical($node->children['left'], $node->children['right']);
+                return $this->analyzeAndUpdateToBeEqual($node->children['left'], $node->children['right']);
             case flags\BINARY_IS_GREATER:
                 $this->checkVariablesDefined($node);
                 return $this->analyzeAndUpdateToBeCompared($node->children['left'], $node->children['right'], flags\BINARY_IS_SMALLER_OR_EQUAL);
@@ -722,8 +723,8 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
         if (($var_node->kind ?? null) !== ast\AST_VAR) {
             return $this->checkComplexIsset($var_node);
         }
-        // if (!isset($x))
-        return $this->updateVariableWithNewType($var_node, $this->context, NullType::instance(false)->asPHPDocUnionType(), true);
+        // if (!isset($x)) means that $x is definitely null
+        return $this->updateVariableWithNewType($var_node, $this->context, NullType::instance(false)->asRealUnionType(), true, false);
     }
 
     /**

--- a/tests/files/expected/0731_weak_equality.php.expected
+++ b/tests/files/expected/0731_weak_equality.php.expected
@@ -1,0 +1,3 @@
+%s:2 PhanCompatibleNullableTypePHP71 Type 'object' refers to any object starting in PHP 7.2. In PHP 7.1 and earlier, it refers to a class/interface with the name 'object'
+%s:6 PhanSuspiciousWeakTypeComparison Suspicious attempt to compare $o of type object to true of type true
+%s:7 PhanRedundantCondition Redundant attempt to cast $o of type object to object

--- a/tests/files/src/0731_weak_equality.php
+++ b/tests/files/src/0731_weak_equality.php
@@ -1,0 +1,11 @@
+<?php
+function weak_equality_731($value, bool $strict, object $o) {
+    if ($value != null || ($strict === true && $value !== null)) {
+        echo "This is non-null\n";
+    }
+    if ($o == true) {
+        if (is_object($o)) {
+            echo "Still an object\n";
+        }
+    }
+}


### PR DESCRIPTION
This is incomplete but an improvement over the old behavior of inferring
that the real type was certain.

This preserves truthy types and/or falsey types of the old union type,
depending on whether the right hand side is truthy and/or falsey.

Fixes #2924