### PR TITLE
Respect '--allow-polyfill-parser' in Bootstrap.php

### DIFF
--- a/src/Phan/Bootstrap.php
+++ b/src/Phan/Bootstrap.php
@@ -27,7 +27,6 @@ if (extension_loaded('ast')) {
             STDERR,
             "Exiting without analyzing files." . PHP_EOL
         );
-        exit(1);
     } elseif (PHP_VERSION_ID >= 70400 && version_compare($ast_version, '1.0.2') < 0) {
         fprintf(
             STDERR,

--- a/src/Phan/Bootstrap.php
+++ b/src/Phan/Bootstrap.php
@@ -23,10 +23,6 @@ if (extension_loaded('ast')) {
             "ERROR: Phan 2.x requires php-ast 1.0.1+ because it depends on AST version 70. php-ast %s is installed." . PHP_EOL,
             $ast_version
         );
-        fwrite(
-            STDERR,
-            "Exiting without analyzing files." . PHP_EOL
-        );
     } elseif (PHP_VERSION_ID >= 70400 && version_compare($ast_version, '1.0.2') < 0) {
         fprintf(
             STDERR,


### PR DESCRIPTION
`ensureASTParserExists()` exits the cli if polyfill is not used and ast extension is too old.