### PR TITLE
Treat compact('var1', ['var2']) as uses of those variables

### DIFF
--- a/.phan/plugins/PHPUnitAssertionPlugin.php
+++ b/.phan/plugins/PHPUnitAssertionPlugin.php
@@ -56,7 +56,7 @@ class PHPUnitAssertionPlugin extends PluginV3 implements AnalyzeFunctionCallCapa
     }
 
     /**
-     * @return ?Closure(CodeBase, Context, FunctionInterface, array):void
+     * @return ?Closure(CodeBase, Context, FunctionInterface, array, ?Node):void
      * @suppress PhanAccessClassConstantInternal, PhanAccessMethodInternal
      */
     private function createClosureForMethod(CodeBase $code_base, Method $method, string $name) : ?Closure

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,7 @@ New features(Analysis):
 + Fix failure to infer type when there is an assignment in a condition (#2964)
   (e.g. `return ($obj = maybeObj()) instanceof stdClass ? $obj : new stdClass();`)
 + Warn about no-ops in for loops (e.g. `for ($x; $x < 10, $x < 20; $x + 1) {}`) (#2926)
++ Treat `compact('var1', ['var2'])` as a usage of $var1 and $var2 in `--unused-variable-detection` (#1812)
 
 Bug fixes:
 + Fix crash in StringUtil seen in php 7.4-dev due to notice in `hexdec()` (affects polyfill/fallback parser).
@@ -30,6 +31,8 @@ Plugins:
   In the `plugin_config` config array, `inline_html_whitelist_regex` and `inline_html_blacklist_regex` can be used to limit the subset of analyzed files to check for inline HTML.
 + For `UnusedSuppressionPlugin`: `'plugin_config' => ['unused_suppression_whitelisted_only' => true]` will make this plugin report unused suppressions only for issues in `whitelist_issue_types`. (#2961)
 + For `UseReturnValuePlugin`: warn about unused results of function calls in loops (#2926)
++ Provide the `$node` causing the call as a 5th parameter to closures returned by `AnalyzeFunctionCallCapability->getAnalyzeFunctionCallClosuresStatic`
+  (this can be used to get the variable/expression for an instance method call, etc.)
 
 Maintenance:
 + Made `--polyfill-parse-all-element-doc-comments` a no-op, it was only needed for compatibility with running Phan with php 7.0.

--- a/src/Phan/Analysis/ArgumentType.php
+++ b/src/Phan/Analysis/ArgumentType.php
@@ -58,7 +58,7 @@ final class ArgumentType
         self::checkIsDeprecatedOrInternal($code_base, $context, $method);
         if ($method->hasFunctionCallAnalyzer()) {
             try {
-                $method->analyzeFunctionCall($code_base, $context->withLineNumberStart($node->lineno), $node->children['args']->children);
+                $method->analyzeFunctionCall($code_base, $context->withLineNumberStart($node->lineno), $node->children['args']->children, $node);
             } catch (StopParamAnalysisException $_) {
                 return;
             }

--- a/src/Phan/Language/Element/FunctionInterface.php
+++ b/src/Phan/Language/Element/FunctionInterface.php
@@ -319,8 +319,9 @@ interface FunctionInterface extends AddressableElementInterface
      * @param CodeBase $code_base
      * @param Context $context
      * @param array<int,Node|int|string> $args
+     * @param ?Node $node - the node causing the call. This may be dynamic, e.g. call_user_func_array. This will be required in Phan 3.
      */
-    public function analyzeFunctionCall(CodeBase $code_base, Context $context, array $args) : void;
+    public function analyzeFunctionCall(CodeBase $code_base, Context $context, array $args, Node $node = null) : void;
 
     /**
      * Make additional analysis logic of this function/method use $closure

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -1011,13 +1011,14 @@ trait FunctionTrait
      * @param CodeBase $code_base
      * @param Context $context
      * @param array<int,Node|int|string|float> $args
+     * @param ?Node $node - the node causing the call. This may be dynamic, e.g. call_user_func_array. This will be required in Phan 3.
      * @return void
      * @suppress PhanUnreferencedPublicMethod Phan knows FunctionInterface's method is referenced, but can't associate that yet.
      */
-    public function analyzeFunctionCall(CodeBase $code_base, Context $context, array $args) : void
+    public function analyzeFunctionCall(CodeBase $code_base, Context $context, array $args, Node $node = null) : void
     {
         // @phan-suppress-next-line PhanTypePossiblyInvalidCallable - Callers should check hasFunctionCallAnalyzer
-        ($this->function_call_analyzer_callback)($code_base, $context, $this, $args);
+        ($this->function_call_analyzer_callback)($code_base, $context, $this, $args, $node);
     }
 
     /**
@@ -1566,7 +1567,7 @@ trait FunctionTrait
 
     /**
      * @param int $i the index of the parameter which $assertion acts upon.
-     * @return ?Closure(CodeBase, Context, FunctionInterface, array):void
+     * @return ?Closure(CodeBase, Context, FunctionInterface, array, ?Node):void
      * @suppress PhanAccessPropertyInternal
      * @internal
      */
@@ -1593,7 +1594,7 @@ trait FunctionTrait
      * @internal
      * @suppress PhanAccessClassConstantInternal
      * @param Closure(CodeBase, Context, array):UnionType $union_type_extractor
-     * @return ?Closure(CodeBase, Context, FunctionInterface, array):void
+     * @return ?Closure(CodeBase, Context, FunctionInterface, array, ?Node):void
      */
     public static function createClosureForUnionTypeExtractorAndAssertionType(Closure $union_type_extractor, int $assertion_type, int $i) : ?Closure
     {
@@ -1602,7 +1603,7 @@ trait FunctionTrait
                 /**
                  * @param array<int,Node|mixed> $args
                  */
-                return static function (CodeBase $code_base, Context $context, FunctionInterface $unused_function, array $args) use ($i, $union_type_extractor) : void {
+                return static function (CodeBase $code_base, Context $context, FunctionInterface $unused_function, array $args, ?Node $unused_node) use ($i, $union_type_extractor) : void {
                     $arg = $args[$i] ?? null;
                     if (!($arg instanceof Node)) {
                         return;
@@ -1616,7 +1617,7 @@ trait FunctionTrait
                 /**
                  * @param array<int,Node|mixed> $args
                  */
-                return static function (CodeBase $code_base, Context $context, FunctionInterface $unused_function, array $args) use ($i, $union_type_extractor) : void {
+                return static function (CodeBase $code_base, Context $context, FunctionInterface $unused_function, array $args, ?Node $unused_node) use ($i, $union_type_extractor) : void {
                     $arg = $args[$i] ?? null;
                     if (!($arg instanceof Node)) {
                         return;
@@ -1630,7 +1631,7 @@ trait FunctionTrait
                 /**
                  * @param array<int,Node|mixed> $args
                  */
-                return static function (CodeBase $code_base, Context $context, FunctionInterface $unused_function, array $args) use ($i) : void {
+                return static function (CodeBase $code_base, Context $context, FunctionInterface $unused_function, array $args, ?Node $unused_node) use ($i) : void {
                     $arg = $args[$i] ?? null;
                     if (!($arg instanceof Node)) {
                         return;
@@ -1643,7 +1644,7 @@ trait FunctionTrait
                 /**
                  * @param array<int,Node|mixed> $args
                  */
-                return static function (CodeBase $code_base, Context $context, FunctionInterface $unused_function, array $args) use ($i) : void {
+                return static function (CodeBase $code_base, Context $context, FunctionInterface $unused_function, array $args, ?Node $unused_node) use ($i) : void {
                     $arg = $args[$i] ?? null;
                     if (!($arg instanceof Node)) {
                         return;

--- a/src/Phan/Language/Type/FunctionLikeDeclarationType.php
+++ b/src/Phan/Language/Type/FunctionLikeDeclarationType.php
@@ -2,6 +2,7 @@
 
 namespace Phan\Language\Type;
 
+use ast\Node;
 use Closure;
 use Generator;
 use Phan\CodeBase;
@@ -369,7 +370,7 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
     }
 
     /** @override */
-    public function analyzeFunctionCall(CodeBase $code_base, Context $context, array $args) : void
+    public function analyzeFunctionCall(CodeBase $code_base, Context $context, array $args, Node $node = null) : void
     {
         throw new \AssertionError('should not call ' . __METHOD__);
     }
@@ -474,7 +475,7 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
         throw new \AssertionError('unexpected call to ' . __METHOD__);
     }
 
-    public function getNode() : ?\ast\Node
+    public function getNode() : ?Node
     {
         return null;
     }

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -597,9 +597,9 @@ final class ConfigPluginSet extends PluginV3 implements
     }
 
     /**
-     * @param Closure(CodeBase, Context, FunctionInterface, array<int,Node|mixed>):void $a
-     * @param ?Closure(CodeBase, Context, FunctionInterface, array<int,Node|mixed>):void $b
-     * @return Closure(CodeBase, Context, FunctionInterface, array<int,Node|mixed>):void $b
+     * @param Closure(CodeBase, Context, FunctionInterface, array<int,Node|mixed>, ?Node):void $a
+     * @param ?Closure(CodeBase, Context, FunctionInterface, array<int,Node|mixed>, ?Node):void $b
+     * @return Closure(CodeBase, Context, FunctionInterface, array<int,Node|mixed>, ?Node):void $b
      */
     public static function mergeAnalyzeFunctionCallClosures(Closure $a, Closure $b = null) : Closure
     {
@@ -609,9 +609,9 @@ final class ConfigPluginSet extends PluginV3 implements
         /**
          * @param array<int,Node|mixed> $args
          */
-        return static function (CodeBase $code_base, Context $context, FunctionInterface $func, array $args) use ($a, $b) : void {
-            $a($code_base, $context, $func, $args);
-            $b($code_base, $context, $func, $args);
+        return static function (CodeBase $code_base, Context $context, FunctionInterface $func, array $args, ?Node $node) use ($a, $b) : void {
+            $a($code_base, $context, $func, $args, $node);
+            $b($code_base, $context, $func, $args, $node);
         };
     }
     /**

--- a/src/Phan/Plugin/Internal/CallableParamPlugin.php
+++ b/src/Phan/Plugin/Internal/CallableParamPlugin.php
@@ -33,7 +33,7 @@ final class CallableParamPlugin extends PluginV3 implements
     /**
      * @param array<int,int> $callable_params
      * @param array<int,int> $class_params
-     * @phan-return Closure(CodeBase,Context,FunctionInterface,array):void
+     * @phan-return Closure(CodeBase,Context,FunctionInterface,array,?Node):void
      */
     private static function generateClosure(array $callable_params, array $class_params) : Closure
     {
@@ -46,7 +46,7 @@ final class CallableParamPlugin extends PluginV3 implements
         /**
          * @param array<int,Node|int|float|string> $args
          */
-        $closure = static function (CodeBase $code_base, Context $context, FunctionInterface $unused_function, array $args) use ($callable_params, $class_params) : void {
+        $closure = static function (CodeBase $code_base, Context $context, FunctionInterface $unused_function, array $args, ?Node $_) use ($callable_params, $class_params) : void {
             // TODO: Implement support for variadic callable arguments.
             foreach ($callable_params as $i) {
                 $arg = $args[$i] ?? null;
@@ -96,7 +96,7 @@ final class CallableParamPlugin extends PluginV3 implements
     }
 
     /**
-     * @return ?Closure(CodeBase,Context,FunctionInterface,array):void
+     * @return ?Closure(CodeBase,Context,FunctionInterface,array,?Node):void
      */
     private static function generateClosureForFunctionInterface(FunctionInterface $function) : ?Closure
     {

--- a/src/Phan/Plugin/Internal/ClosureReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ClosureReturnTypeOverridePlugin.php
@@ -196,7 +196,8 @@ final class ClosureReturnTypeOverridePlugin extends PluginV3 implements
             CodeBase $code_base,
             Context $context,
             Func $unused_function,
-            array $args
+            array $args,
+            ?Node $_
         ) : void {
             if (\count($args) < 1) {
                 return;
@@ -216,7 +217,8 @@ final class ClosureReturnTypeOverridePlugin extends PluginV3 implements
             CodeBase $code_base,
             Context $context,
             Func $unused_function,
-            array $args
+            array $args,
+            ?Node $_
         ) : void {
             if (\count($args) < 2) {
                 return;

--- a/src/Phan/Plugin/Internal/MiscParamPlugin.php
+++ b/src/Phan/Plugin/Internal/MiscParamPlugin.php
@@ -41,8 +41,7 @@ final class MiscParamPlugin extends PluginV3 implements
     AnalyzeFunctionCallCapability
 {
     /**
-     * @return array<string,Closure>
-     * @phan-return array<string,Closure(CodeBase,Context,FunctionInterface,array):void>
+     * @return array<string,Closure(CodeBase,Context,FunctionInterface,array,?Node):void>
      */
     private static function getAnalyzeFunctionCallClosuresStatic() : array
     {
@@ -55,7 +54,8 @@ final class MiscParamPlugin extends PluginV3 implements
             CodeBase $code_base,
             Context $context,
             FunctionInterface $function,
-            array $args
+            array $args,
+            ?Node $_
         ) : void {
             if (\count($args) !== 1) {
                 return;
@@ -88,7 +88,8 @@ final class MiscParamPlugin extends PluginV3 implements
             CodeBase $code_base,
             Context $context,
             FunctionInterface $function,
-            array $args
+            array $args,
+            ?Node $_
         ) : void {
             $argcount = \count($args);
             if ($argcount < 3) {
@@ -145,7 +146,8 @@ final class MiscParamPlugin extends PluginV3 implements
             CodeBase $code_base,
             Context $context,
             FunctionInterface $function,
-            array $args
+            array $args,
+            ?Node $_
         ) use ($stop_exception) : void {
             $argcount = \count($args);
             // (string glue, string[] pieces),
@@ -259,7 +261,8 @@ final class MiscParamPlugin extends PluginV3 implements
             CodeBase $code_base,
             Context $context,
             FunctionInterface $function,
-            array $args
+            array $args,
+            ?Node $_
         ) : void {
             $argcount = \count($args);
             if ($argcount < 4) {
@@ -364,7 +367,8 @@ final class MiscParamPlugin extends PluginV3 implements
             CodeBase $code_base,
             Context $context,
             FunctionInterface $unused_function,
-            array $args
+            array $args,
+            ?Node $_
         ) : void {
             // TODO: support nested adds, like AssignmentVisitor
             // TODO: support properties, like AssignmentVisitor
@@ -409,7 +413,8 @@ final class MiscParamPlugin extends PluginV3 implements
             CodeBase $code_base,
             Context $context,
             FunctionInterface $unused_function,
-            array $args
+            array $args,
+            ?Node $_
         ) use ($get_variable) : void {
             // TODO: support nested adds, like AssignmentVisitor
             // TODO: Could be more specific for arrays with known length and order
@@ -430,7 +435,8 @@ final class MiscParamPlugin extends PluginV3 implements
             CodeBase $code_base,
             Context $context,
             FunctionInterface $unused_function,
-            array $args
+            array $args,
+            ?Node $_
         ) use ($get_variable) : void {
             // TODO: support nested adds, like AssignmentVisitor
             // TODO: Could be more specific for arrays with known length and order
@@ -454,12 +460,14 @@ final class MiscParamPlugin extends PluginV3 implements
 
         /**
          * @param array<int,Node|int|float|string> $args
+         * TODO: Could make unused variable detection more precise for https://github.com/phan/phan/issues/1812 , but low priority.
          */
         $extract_callback = static function (
             CodeBase $code_base,
             Context $context,
             FunctionInterface $unused_function,
-            array $args
+            array $args,
+            ?Node $_
         ) : void {
             // TODO: support nested adds, like AssignmentVisitor
             // TODO: Could be more specific for arrays with known length and order
@@ -570,7 +578,8 @@ final class MiscParamPlugin extends PluginV3 implements
             CodeBase $code_base,
             Context $context,
             FunctionInterface $unused_function,
-            array $args
+            array $args,
+            ?Node $_
         ) : void {
             if (count($args) < 2) {
                 return;
@@ -625,7 +634,8 @@ final class MiscParamPlugin extends PluginV3 implements
             CodeBase $code_base,
             Context $context,
             FunctionInterface $unused_function,
-            array $args
+            array $args,
+            ?Node $_
         ) : void {
             if (count($args) < 2) {
                 return;

--- a/src/Phan/Plugin/Internal/RedundantConditionCallPlugin.php
+++ b/src/Phan/Plugin/Internal/RedundantConditionCallPlugin.php
@@ -33,8 +33,6 @@ use function count;
 /**
  * NOTE: This is automatically loaded by phan. Do not include it in a config.
  *
- * TODO: Refactor this.
- *
  * TODO: Support real types (e.g. array_values() if the passed in real union type is an array, otherwise real type is ?array
  */
 final class RedundantConditionCallPlugin extends PluginV3 implements
@@ -53,13 +51,13 @@ final class RedundantConditionCallPlugin extends PluginV3 implements
         /**
          * @param Closure(UnionType):int $checker returns _IS_IMPOSSIBLE/_IS_REDUNDANT/_IS_REASONABLE_CONDITION
          * @param string $expected_type
-         * @return Closure(CodeBase, Context, FunctionInterface, array<int,mixed>):void
+         * @return Closure(CodeBase, Context, FunctionInterface, array<int,mixed>, ?Node):void
          */
         $make_first_arg_checker = static function (Closure $checker, string $expected_type) : Closure {
             /**
              * @param array<int,Node|int|float|string> $args
              */
-            return static function (CodeBase $code_base, Context $context, FunctionInterface $unused_function, array $args) use ($checker, $expected_type) : void {
+            return static function (CodeBase $code_base, Context $context, FunctionInterface $unused_function, array $args, ?Node $_) use ($checker, $expected_type) : void {
                 if (count($args) < 1) {
                     return;
                 }
@@ -169,7 +167,7 @@ final class RedundantConditionCallPlugin extends PluginV3 implements
 
         /**
          * @param Closure(UnionType):bool $condition
-         * @return Closure(CodeBase,Context,FunctionInterface,array<int,mixed>):void
+         * @return Closure(CodeBase, Context, FunctionInterface, array<int,mixed>, ?Node):void
          */
         $make_cast_callback = static function (Closure $condition, string $expected_type) use ($make_first_arg_checker) : Closure {
             return $make_first_arg_checker(static function (UnionType $union_type) use ($condition) : int {

--- a/src/Phan/Plugin/Internal/StringFunctionPlugin.php
+++ b/src/Phan/Plugin/Internal/StringFunctionPlugin.php
@@ -62,8 +62,7 @@ final class StringFunctionPlugin extends PluginV3 implements
     }
 
     /**
-     * @return array<string,Closure>
-     * @phan-return array<string,Closure(CodeBase,Context,FunctionInterface,array):void>
+     * @return array<string,Closure(CodeBase,Context,FunctionInterface,array,?Node):void>
      */
     private static function getAnalyzeFunctionCallClosuresStatic() : array
     {
@@ -76,7 +75,8 @@ final class StringFunctionPlugin extends PluginV3 implements
                 CodeBase $code_base,
                 Context $context,
                 FunctionInterface $function,
-                array $args
+                array $args,
+                ?Node $_
             ) use (
                 $expected_const_pos,
                 $expected_variable_pos,
@@ -196,7 +196,7 @@ final class StringFunctionPlugin extends PluginV3 implements
 
     /**
      * @param CodeBase $code_base @phan-unused-param
-     * @return array<string,\Closure>
+     * @return array<string,Closure(CodeBase,Context,FunctionInterface,array,?Node):void>
      * @override
      */
     public function getAnalyzeFunctionCallClosures(CodeBase $code_base) : array

--- a/src/Phan/PluginV3.php
+++ b/src/Phan/PluginV3.php
@@ -47,7 +47,7 @@ use Phan\PluginV3\IssueEmitter;
  *     Called after the analysis phase is complete.
  *     (implement \Phan\PluginV3\FinalizeProcessCapability)
  *
- *  8. public function getAnalyzeFunctionCallClosures(CodeBase $code_base) : array<string, Closure(CodeBase,Context,Func|Method,array):void>
+ *  8. public function getAnalyzeFunctionCallClosures(CodeBase $code_base) : array<string, Closure(CodeBase,Context,Func|Method,array,?Node):void>
  *     Maps FQSEN of function or method to a closure used to analyze the function in question.
  *     'MyClass::myMethod' can be used as the FQSEN of a static or instance method.
  *     See .phan/plugins/PregRegexCheckerPlugin.php as an example.

--- a/src/Phan/PluginV3/AnalyzeFunctionCallCapability.php
+++ b/src/Phan/PluginV3/AnalyzeFunctionCallCapability.php
@@ -2,7 +2,11 @@
 
 namespace Phan\PluginV3;
 
+use ast\Node;
+use Closure;
 use Phan\CodeBase;
+use Phan\Language\Context;
+use Phan\Language\Element\FunctionInterface;
 
 /**
  * AnalyzeFunctionCallCapability is used when you want to analyze the parameters passed to a function or method, whether or not the return value is used.
@@ -13,10 +17,12 @@ use Phan\CodeBase;
 interface AnalyzeFunctionCallCapability
 {
     /**
-     * @return array<string,\Closure>
+     * @return array<string,Closure(CodeBase,Context,FunctionInterface,array<int,mixed>,?Node)>
      * maps FQSEN of function or method to a closure used to analyze the function in question.
      * '\A::foo' or 'A::foo' as a key will override a method, and '\foo' or 'foo' as a key will override a function.
-     * Closure Type: function(CodeBase $code_base, Context $context, Func|Method $function, array $args) : void {...}
+     * Closure Type: function(CodeBase $code_base, Context $context, Func|Method $function, array $args, ?Node $node) : void {...}
+     *
+     * If compatibility with older Phan versions is needed, make the param for $node optional.
      *
      * Note that $function->getMostRecentParentNodeListForCall() can be used to get the parent node list of the current call (will be the empty array if fetching it failed).
      */

--- a/tests/plugin_test/expected/132_compact.php.expected
+++ b/tests/plugin_test/expected/132_compact.php.expected
@@ -1,0 +1,1 @@
+src/132_compact.php:2 PhanUnusedGlobalFunctionParameter Parameter $myUnusedVar is never used

--- a/tests/plugin_test/src/132_compact.php
+++ b/tests/plugin_test/src/132_compact.php
@@ -1,0 +1,7 @@
+<?php
+function returnsPackedArgs($myVar, $myOtherVar, $myUnusedVar) {
+    $nameToReturn = 'myOtherVar';
+    return compact('myVar', [$nameToReturn]);
+}
+// returns ['myVar' => 'a', 'myOtherVar' => 'b']
+var_export(returnsPackedArgs('a', 'b', 'c'));


### PR DESCRIPTION
For #1812