### PR TITLE
Fix real type inference when a method has phpdoc `@return`

### DIFF
--- a/.phan/plugins/AlwaysReturnPlugin.php
+++ b/.phan/plugins/AlwaysReturnPlugin.php
@@ -51,8 +51,6 @@ final class AlwaysReturnPlugin extends PluginV3 implements
      * @param Method $method
      * A method being analyzed
      *
-     * @return void
-     *
      * @override
      */
     public function analyzeMethod(
@@ -91,8 +89,6 @@ final class AlwaysReturnPlugin extends PluginV3 implements
      *
      * @param Func $function
      * A function or closure being analyzed
-     *
-     * @return void
      *
      * @override
      */

--- a/.phan/plugins/DemoPlugin.php
+++ b/.phan/plugins/DemoPlugin.php
@@ -75,8 +75,6 @@ class DemoPlugin extends PluginV3 implements
      * @param Clazz $class
      * A class being analyzed
      *
-     * @return void
-     *
      * @override
      */
     public function analyzeClass(
@@ -105,8 +103,6 @@ class DemoPlugin extends PluginV3 implements
      * @param Method $method
      * A method being analyzed
      *
-     * @return void
-     *
      * @override
      */
     public function analyzeMethod(
@@ -134,8 +130,6 @@ class DemoPlugin extends PluginV3 implements
      * @param Func $function
      * A function being analyzed
      *
-     * @return void
-     *
      * @override
      */
     public function analyzeFunction(
@@ -161,8 +155,6 @@ class DemoPlugin extends PluginV3 implements
      *
      * @param Property $property
      * A property being analyzed
-     *
-     * @return void
      *
      * @override
      */
@@ -203,8 +195,6 @@ class DemoNodeVisitor extends PluginAwarePostAnalysisVisitor
     /**
      * @param Node $node
      * A node to analyze
-     *
-     * @return void
      *
      * @override
      */

--- a/.phan/plugins/DollarDollarPlugin.php
+++ b/.phan/plugins/DollarDollarPlugin.php
@@ -55,8 +55,6 @@ class DollarDollarVisitor extends PluginAwarePostAnalysisVisitor
     /**
      * @param Node $node
      * A node to analyze
-     *
-     * @return void
      * @override
      */
     public function visitVar(Node $node) : void

--- a/.phan/plugins/DuplicateArrayKeyPlugin.php
+++ b/.phan/plugins/DuplicateArrayKeyPlugin.php
@@ -44,9 +44,6 @@ class DuplicateArrayKeyVisitor extends PluginAwarePostAnalysisVisitor
     /**
      * @param Node $node
      * A switch statement's case statement(AST_SWITCH_LIST) node to analyze
-     *
-     * @return void
-     *
      * @override
      */
     public function visitSwitchList(Node $node) : void
@@ -141,8 +138,6 @@ class DuplicateArrayKeyVisitor extends PluginAwarePostAnalysisVisitor
      * This is intended to perform well for large arrays.
      *
      * TODO: Do a better job for small arrays.
-     *
-     * @return void
      * @param array<int,mixed> $values_to_check
      * @param array<int,mixed> $children an array of scalars
      */
@@ -181,9 +176,6 @@ class DuplicateArrayKeyVisitor extends PluginAwarePostAnalysisVisitor
     /**
      * @param Node $node
      * An array literal(AST_ARRAY) node to analyze
-     *
-     * @return void
-     *
      * @override
      */
     public function visitArray(Node $node) : void

--- a/.phan/plugins/DuplicateArrayKeyPlugin.php
+++ b/.phan/plugins/DuplicateArrayKeyPlugin.php
@@ -88,7 +88,7 @@ class DuplicateArrayKeyVisitor extends PluginAwarePostAnalysisVisitor
                     clone($this->context)->withLineNumberStart($case_node->lineno),
                     'PhanPluginDuplicateSwitchCase',
                     "Duplicate/Equivalent switch case({STRING_LITERAL}) detected in switch statement - the later entry will be ignored.",
-                    [(string)$normalized_case_cond],
+                    [$normalized_case_cond],
                     Issue::SEVERITY_NORMAL,
                     Issue::REMEDIATION_A,
                     15071
@@ -250,7 +250,7 @@ class DuplicateArrayKeyVisitor extends PluginAwarePostAnalysisVisitor
             clone($this->context)->withLineNumberStart($entry->lineno ?? $node->lineno),
             'PhanPluginDuplicateArrayKey',
             "Duplicate/Equivalent array key value({STRING_LITERAL}) detected in array - the earlier entry will be ignored.",
-            [(string)$normalized_key],
+            [$normalized_key],
             Issue::SEVERITY_NORMAL,
             Issue::REMEDIATION_A,
             15071

--- a/.phan/plugins/DuplicateExpressionPlugin.php
+++ b/.phan/plugins/DuplicateExpressionPlugin.php
@@ -120,8 +120,6 @@ class RedundantNodePostAnalysisVisitor extends PluginAwarePostAnalysisVisitor
     /**
      * @param Node $node
      * A binary operation node to analyze
-     *
-     * @return void
      * @override
      * @suppress PhanAccessClassConstantInternal
      */
@@ -185,8 +183,6 @@ class RedundantNodePostAnalysisVisitor extends PluginAwarePostAnalysisVisitor
     /**
      * @param Node $node
      * An assignment operation node to analyze
-     *
-     * @return void
      * @override
      */
     public function visitAssignRef(Node $node) : void
@@ -197,8 +193,6 @@ class RedundantNodePostAnalysisVisitor extends PluginAwarePostAnalysisVisitor
     /**
      * @param Node $node
      * An assignment operation node to analyze
-     *
-     * @return void
      * @override
      */
     public function visitAssign(Node $node) : void
@@ -244,8 +238,6 @@ class RedundantNodePostAnalysisVisitor extends PluginAwarePostAnalysisVisitor
     /**
      * @param Node $node
      * A binary operation node to analyze
-     *
-     * @return void
      * @override
      */
     public function visitConditional(Node $node) : void

--- a/.phan/plugins/FFIAnalysisPlugin.php
+++ b/.phan/plugins/FFIAnalysisPlugin.php
@@ -116,7 +116,6 @@ class FFIPreAnalysisVisitor extends PluginAwarePreAnalysisVisitor
 class FFIPostAnalysisVisitor extends PluginAwarePostAnalysisVisitor
 {
     /**
-     * @return void
      * @override
      */
     public function visitAssign(Node $node) : void

--- a/.phan/plugins/HasPHPDocPlugin.php
+++ b/.phan/plugins/HasPHPDocPlugin.php
@@ -53,9 +53,6 @@ final class HasPHPDocPlugin extends PluginV3 implements
      *
      * @param Clazz $class
      * A class being analyzed
-     *
-     * @return void
-     *
      * @override
      */
     public function analyzeClass(
@@ -99,9 +96,6 @@ final class HasPHPDocPlugin extends PluginV3 implements
      *
      * @param Property $property
      * A property being analyzed
-     *
-     * @return void
-     *
      * @override
      */
     public function analyzeProperty(
@@ -153,9 +147,6 @@ final class HasPHPDocPlugin extends PluginV3 implements
      *
      * @param Method $method
      * A method being analyzed
-     *
-     * @return void
-     *
      * @override
      */
     public function analyzeMethod(
@@ -220,9 +211,6 @@ final class HasPHPDocPlugin extends PluginV3 implements
      *
      * @param Func $function
      * A function being analyzed
-     *
-     * @return void
-     *
      * @override
      */
     public function analyzeFunction(

--- a/.phan/plugins/InlineHTMLPlugin.php
+++ b/.phan/plugins/InlineHTMLPlugin.php
@@ -63,7 +63,6 @@ class InlineHTMLPlugin extends PluginV3 implements
      *
      * @param string $file_contents the unmodified file contents @phan-unused-param
      * @param Node $node the node @phan-unused-param
-     * @return void
      * @override
      * @throws Error if a process fails to shut down
      */

--- a/.phan/plugins/InvokePHPNativeSyntaxCheckPlugin.php
+++ b/.phan/plugins/InvokePHPNativeSyntaxCheckPlugin.php
@@ -54,7 +54,6 @@ class InvokePHPNativeSyntaxCheckPlugin extends PluginV3 implements
      *
      * @param string $file_contents the unmodified file contents @phan-unused-param
      * @param Node $node the node @phan-unused-param
-     * @return void
      * @override
      */
     public function beforeAnalyzeFile(
@@ -79,7 +78,6 @@ class InvokePHPNativeSyntaxCheckPlugin extends PluginV3 implements
      *
      * @param string $file_contents the unmodified file contents @phan-unused-param
      * @param Node $node the node @phan-unused-param
-     * @return void
      * @override
      * @throws Error if a process fails to shut down
      */
@@ -348,7 +346,6 @@ class InvokeExecutionPromise
     }
 
     /**
-     * @return void
      * @throws Error if reading failed
      */
     public function blockingRead() : void
@@ -365,7 +362,6 @@ class InvokeExecutionPromise
     }
 
     /**
-     * @return ?string
      * @throws RangeException if this was called before the process finished
      */
     public function getError() : ?string

--- a/.phan/plugins/NoAssertPlugin.php
+++ b/.phan/plugins/NoAssertPlugin.php
@@ -56,8 +56,6 @@ class NoAssertVisitor extends PluginAwarePostAnalysisVisitor
     /**
      * @param Node $node
      * A node to analyze
-     *
-     * @return void
      * @override
      */
     public function visitCall(Node $node) : void

--- a/.phan/plugins/NotFullyQualifiedUsagePlugin.php
+++ b/.phan/plugins/NotFullyQualifiedUsagePlugin.php
@@ -91,9 +91,6 @@ class NotFullyQualifiedUsageVisitor extends PluginAwarePostAnalysisVisitor
     /**
      * @param Node $node
      * A node to analyze of type ast\AST_CALL (call to a global function)
-     *
-     * @return void
-     *
      * @override
      */
     public function visitCall(Node $node) : void
@@ -145,9 +142,6 @@ class NotFullyQualifiedUsageVisitor extends PluginAwarePostAnalysisVisitor
     /**
      * @param Node $node
      * A node to analyze of type ast\AST_CONST (reference to a constant)
-     *
-     * @return void
-     *
      * @override
      */
     public function visitConst(Node $node) : void

--- a/.phan/plugins/PHPDocRedundantPlugin.php
+++ b/.phan/plugins/PHPDocRedundantPlugin.php
@@ -191,7 +191,7 @@ class PHPDocRedundantPlugin extends PluginV3 implements
                 return;
             }
             if (!preg_match('/^@(phan-)?return\s/', $line)) {
-                return;
+                continue;
             }
             // @phan-suppress-next-line PhanAccessClassConstantInternal
             if (!preg_match(Builder::RETURN_COMMENT_REGEX, $line, $matches)) {

--- a/.phan/plugins/PHPUnitNotDeadCodePlugin.php
+++ b/.phan/plugins/PHPUnitNotDeadCodePlugin.php
@@ -51,7 +51,6 @@ class PHPUnitNotDeadPluginVisitor extends PluginAwarePostAnalysisVisitor
 
     /**
      * This is called after the parse phase is completely finished, so $this->code_base contains all class definitions
-     * @return void
      * @override
      */
     public function visitClass(Node $unused_node) : void
@@ -135,7 +134,6 @@ class PHPUnitNotDeadPluginVisitor extends PluginAwarePostAnalysisVisitor
 
     /**
      * Static initializer for this plugin - Gets called below before any methods can be used
-     * @return void
      * @suppress PhanThrowTypeAbsentForCall this FQSEN is valid
      */
     public static function init() : void

--- a/.phan/plugins/PossiblyStaticMethodPlugin.php
+++ b/.phan/plugins/PossiblyStaticMethodPlugin.php
@@ -188,9 +188,6 @@ final class PossiblyStaticMethodPlugin extends PluginV3 implements
      *
      * @param Method $method
      * A method being analyzed
-     *
-     * @return void
-     *
      * @override
      */
     public function analyzeMethod(

--- a/.phan/plugins/PrintfCheckerPlugin.php
+++ b/.phan/plugins/PrintfCheckerPlugin.php
@@ -343,7 +343,6 @@ class PrintfCheckerPlugin extends PluginV3 implements AnalyzeFunctionCallCapabil
      * @param FunctionInterface $function
      * @param Node|array|string|float|int|bool|resource|null $pattern_node
      * @param ?(Node|string|int|float)[] $arg_nodes arguments following the format string. Null if the arguments could not be determined.
-     * @return void
      * @suppress PhanPartialTypeMismatchArgument TODO: refactor into smaller functions
      */
     protected function analyzePrintfPattern(CodeBase $code_base, Context $context, FunctionInterface $function, $pattern_node, $arg_nodes) : void

--- a/.phan/plugins/SleepCheckerPlugin.php
+++ b/.phan/plugins/SleepCheckerPlugin.php
@@ -46,8 +46,6 @@ class SleepCheckerVisitor extends PluginAwarePostAnalysisVisitor
     /**
      * @param Node $node
      * A node to analyze
-     *
-     * @return void
      * @override
      */
     public function visitMethod(Node $node) : void

--- a/.phan/plugins/SuspiciousParamOrderPlugin.php
+++ b/.phan/plugins/SuspiciousParamOrderPlugin.php
@@ -38,7 +38,6 @@ class SuspiciousParamOrderVisitor extends PluginAwarePostAnalysisVisitor
 
     /**
      * @param Node $node a node of type AST_CALL
-     * @return void
      * @override
      */
     public function visitCall(Node $node) : void
@@ -266,7 +265,6 @@ class SuspiciousParamOrderVisitor extends PluginAwarePostAnalysisVisitor
 
     /**
      * @param Node $node a node of type AST_METHOD_CALL
-     * @return void
      * @override
      */
     public function visitMethodCall(Node $node) : void
@@ -297,7 +295,6 @@ class SuspiciousParamOrderVisitor extends PluginAwarePostAnalysisVisitor
 
     /**
      * @param Node $node a node of type AST_STATIC_CALL
-     * @return void
      * @override
      */
     public function visitStaticCall(Node $node) : void

--- a/.phan/plugins/UnknownElementTypePlugin.php
+++ b/.phan/plugins/UnknownElementTypePlugin.php
@@ -41,9 +41,6 @@ class UnknownElementTypePlugin extends PluginV3 implements
      *
      * @param Method $method
      * A method being analyzed
-     *
-     * @return void
-     *
      * @override
      */
     public function analyzeMethod(
@@ -118,9 +115,6 @@ class UnknownElementTypePlugin extends PluginV3 implements
      *
      * @param Func $function
      * A function being analyzed
-     *
-     * @return void
-     *
      * @override
      */
     public function analyzeFunction(
@@ -200,9 +194,6 @@ class UnknownElementTypePlugin extends PluginV3 implements
      *
      * @param Property $property
      * A property being analyzed
-     *
-     * @return void
-     *
      * @override
      */
     public function analyzeProperty(

--- a/.phan/plugins/UnknownElementTypePlugin.php
+++ b/.phan/plugins/UnknownElementTypePlugin.php
@@ -135,7 +135,7 @@ class UnknownElementTypePlugin extends PluginV3 implements
                 $function->getContext(),
                 $issue,
                 $message,
-                [(string)$function->getNameForIssue()]
+                [$function->getNameForIssue()]
             );
         } elseif (self::isRegularArray($function->getUnionType())) {
             if ($function->getFQSEN()->isClosure()) {
@@ -150,7 +150,7 @@ class UnknownElementTypePlugin extends PluginV3 implements
                 $function->getContext(),
                 $issue,
                 $message,
-                [(string)$function->getNameForIssue()]
+                [$function->getNameForIssue()]
             );
         }
         foreach ($function->getParameterList() as $parameter) {
@@ -167,7 +167,7 @@ class UnknownElementTypePlugin extends PluginV3 implements
                     $parameter->createContext($function),
                     $issue,
                     $message,
-                    [(string)$function->getNameForIssue(), $parameter->getName()]
+                    [$function->getNameForIssue(), $parameter->getName()]
                 );
             } elseif (self::isRegularArray($parameter->getUnionType())) {
                 if ($function->getFQSEN()->isClosure()) {
@@ -182,7 +182,7 @@ class UnknownElementTypePlugin extends PluginV3 implements
                     $parameter->createContext($function),
                     $issue,
                     $message,
-                    [(string)$function->getNameForIssue(), $parameter->getName()]
+                    [$function->getNameForIssue(), $parameter->getName()]
                 );
             }
         }

--- a/.phan/plugins/UnreachableCodePlugin.php
+++ b/.phan/plugins/UnreachableCodePlugin.php
@@ -60,9 +60,6 @@ final class UnreachableCodeVisitor extends PluginAwarePostAnalysisVisitor
     /**
      * @param Node $node
      * A node to analyze
-     *
-     * @return void
-     *
      * @override
      */
     public function visitStmtList(Node $node) : void

--- a/.phan/plugins/UnusedSuppressionPlugin.php
+++ b/.phan/plugins/UnusedSuppressionPlugin.php
@@ -114,9 +114,6 @@ class UnusedSuppressionPlugin extends PluginV3 implements
      *
      * @param Clazz $class
      * A class being analyzed
-     *
-     * @return void
-     *
      * @override
      */
     public function analyzeClass(
@@ -132,9 +129,6 @@ class UnusedSuppressionPlugin extends PluginV3 implements
      *
      * @param Method $method
      * A method being analyzed
-     *
-     * @return void
-     *
      * @override
      */
     public function analyzeMethod(
@@ -156,9 +150,6 @@ class UnusedSuppressionPlugin extends PluginV3 implements
      *
      * @param Func $function
      * A function being analyzed
-     *
-     * @return void
-     *
      * @override
      */
     public function analyzeFunction(
@@ -174,9 +165,6 @@ class UnusedSuppressionPlugin extends PluginV3 implements
      *
      * @param Property $property
      * A property being analyzed
-     *
-     * @return void
-     *
      * @override
      */
     public function analyzeProperty(
@@ -295,8 +283,6 @@ class UnusedSuppressionPlugin extends PluginV3 implements
 
     /**
      * Record the fact that $plugin caused suppressions in $file_path for issue $issue_type due to an annotation around $line
-     *
-     * @return void
      * @internal
      */
     public function recordPluginSuppression(

--- a/.phan/plugins/UseReturnValuePlugin.php
+++ b/.phan/plugins/UseReturnValuePlugin.php
@@ -78,7 +78,6 @@ class UseReturnValuePlugin extends PluginV3 implements PostAnalyzeNodeCapability
     }
 
     /**
-     * @return void
      * @override
      */
     public function finalizeProcess(CodeBase $code_base) : void
@@ -905,7 +904,6 @@ class UseReturnValueVisitor extends PluginAwarePostAnalysisVisitor
 
     /**
      * @param Node $node a node of type AST_CALL
-     * @return void
      * @override
      */
     public function visitCall(Node $node) : void
@@ -954,7 +952,6 @@ class UseReturnValueVisitor extends PluginAwarePostAnalysisVisitor
 
     /**
      * @param Node $node a node of type AST_METHOD_CALL
-     * @return void
      * @override
      */
     public function visitMethodCall(Node $node) : void
@@ -1002,7 +999,6 @@ class UseReturnValueVisitor extends PluginAwarePostAnalysisVisitor
 
     /**
      * @param Node $node a node of type AST_METHOD_CALL
-     * @return void
      * @override
      */
     public function visitStaticCall(Node $node) : void

--- a/.phan/plugins/WhitespacePlugin.php
+++ b/.phan/plugins/WhitespacePlugin.php
@@ -35,7 +35,6 @@ class WhitespacePlugin extends PluginV3 implements
      *
      * @param string $file_contents the unmodified file contents @phan-unused-param
      * @param Node $node the node @phan-unused-param
-     * @return void
      * @override
      * @throws Error if a process fails to shut down
      */

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,12 @@ Phan NEWS
 ??? ?? 2019, Phan 2.2.7 (dev)
 -----------------------
 
+New features(Analysis):
++ Fix failure to infer real types when an invoked function or method had a phpdoc `@return` in addition to the real type.
+
+Plugins:
++ Properly warn about redundant `@return` annotations followed by other annotation lines in `PHPDocRedundantPlugin`.
+
 Jul 17 2019, Phan 2.2.6
 -----------------------
 

--- a/internal/dump_fallback_ast.php
+++ b/internal/dump_fallback_ast.php
@@ -37,7 +37,6 @@ dump_main();
 
 /**
  * Dumps a snippet provided as a command line argument
- * @return void
  * @throws Exception if it can't render the AST
  */
 function dump_main() : void
@@ -128,7 +127,6 @@ function dump_expr_as_ast(string $expr, bool $with_placeholders, bool $native) :
 
 /**
  * Parses $expr and echoes the tolerant-php-parser AST to stdout.
- * @return void
  * @throws Exception
  */
 function dump_expr(string $expr) : void

--- a/internal/lib/IncompatibleStubsSignatureDetector.php
+++ b/internal/lib/IncompatibleStubsSignatureDetector.php
@@ -57,7 +57,6 @@ class IncompatibleStubsSignatureDetector extends IncompatibleSignatureDetectorBa
 
     /**
      * Check that this extracts the correct signature types from the folder.
-     * @return void
      * @suppress PhanPluginMixedKeyNoKey
      */
     public function selfTest() : void

--- a/internal/sanitycheck.php
+++ b/internal/sanitycheck.php
@@ -191,7 +191,6 @@ function getUnionTypeStringForReflectionType(ReflectionType $reflection_type = n
  *
  * @param array<int|string,string> $fields the signature from Phan being checked for contradictions
  * @param array<string,array<int|string,string>> $signatures the set of all signatures (to check for existence of alternates)
- * @return void
  * @throws InvalidArgumentException for invalid return types
  */
 function check_fields(string $function_name, array $fields, array $signatures) : void

--- a/internal/update_wiki_config_types.php
+++ b/internal/update_wiki_config_types.php
@@ -333,8 +333,6 @@ EOT;
 
     /**
      * Updates the markdown document of issue types with minimal documentation of missing issue types.
-     *
-     * @return void
      * @throws InvalidArgumentException (uncaught) if the documented issue types can't be found.
      */
     public static function main() : void

--- a/internal/update_wiki_issue_types.php
+++ b/internal/update_wiki_issue_types.php
@@ -81,8 +81,6 @@ EOT;
 
     /**
      * Updates the markdown document of issue types with minimal documentation of missing issue types.
-     *
-     * @return void
      * @throws InvalidArgumentException (uncaught) if the documented issue types can't be found.
      */
     public static function main() : void

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -116,9 +116,6 @@ class ContextNode
 
     /**
      * Get a fully qualified name from a node
-     *
-     * @return string
-     *
      * @throws FQSENException if the node is invalid
      * @internal TODO: Stop using this
      */
@@ -327,7 +324,6 @@ class ContextNode
      * Handles a node of kind ast\AST_TRAIT_PRECEDENCE, modifying the corresponding TraitAdaptations instance
      * @param array<string,TraitAdaptations> $adaptations_map
      * @param Node $adaptation_node
-     * @return void
      * @throws UnanalyzableException (should be caught and emitted as an issue)
      */
     private function handleTraitPrecedence(array $adaptations_map, Node $adaptation_node) : void
@@ -1853,7 +1849,6 @@ class ContextNode
     }
 
     /**
-     * @return Func
      * @throws CodeBaseException if the closure could not be found
      */
     public function getClosure() : Func
@@ -2010,7 +2005,6 @@ class ContextNode
     }
 
     /**
-     * @return ?FullyQualifiedClassName
      * @throws IssueException if the list of possible classes couldn't be determined.
      */
     public function resolveClassNameInContext() : ?FullyQualifiedClassName

--- a/src/Phan/AST/Parser.php
+++ b/src/Phan/AST/Parser.php
@@ -83,7 +83,6 @@ class Parser
      * @param string $file_path file path for error reporting
      * @param string $file_contents file contents to pass to parser. This may deliberately differ from what is currently on disk (e.g. for the language server mode or daemon mode)
      * @param bool $suppress_parse_errors (If true, don't emit SyntaxError)
-     * @return ?Node
      * @throws ParseError
      * @throws CompileError (possible in php 7.3)
      * @throws ParseException
@@ -138,7 +137,6 @@ class Parser
      * @param string $file_path file path for error reporting
      * @param string $file_contents file contents to pass to parser. May be overridden to ignore what is currently on disk.
      * @param ParseError|CompileError $native_parse_error (can be CompileError in 7.3, will be ParseError in most cases)
-     * @return ?Node
      * @throws ParseError most of the time
      * @throws CompileError in PHP 7.3+
      */
@@ -195,7 +193,6 @@ class Parser
      * @param string $file_contents file contents to pass to parser. May be overridden to ignore what is currently on disk.
      * @param bool $suppress_parse_errors (If true, don't emit SyntaxError)
      * @param ?Request $request - May affect the parser used for $file_path
-     * @return ?Node
      * @throws ParseException
      */
     public static function parseCodePolyfill(CodeBase $code_base, Context $context, string $file_path, string $file_contents, bool $suppress_parse_errors, ?Request $request) : ?Node

--- a/src/Phan/AST/TolerantASTConverter/NodeDumper.php
+++ b/src/Phan/AST/TolerantASTConverter/NodeDumper.php
@@ -75,7 +75,6 @@ class NodeDumper
 
     /**
      * Sets the text used for indentation (e.g. 4 spaces)
-     * @return void
      * @suppress PhanUnreferencedPublicMethod
      */
     public function setIndent(string $indent) : void
@@ -114,7 +113,6 @@ class NodeDumper
     /**
      * @param Node|Token|null $ast_node
      * @param string $padding (to be echoed before the current node
-     * @return string
      * @throws Exception for invalid $ast_node values
      */
     public function dumpTreeAsString($ast_node, string $key = '', string $padding = '') : string
@@ -155,7 +153,6 @@ class NodeDumper
     /**
      * @param Node|Token $ast_node
      * @param string $padding (to be echoed before the current node
-     * @return void
      * @throws Exception for invalid $ast_node values
      * @suppress PhanUnreferencedPublicMethod
      */

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -176,7 +176,6 @@ class TolerantASTConverter
      *
      * @param Diagnostic[] &$errors @phan-output-reference
      * @param ?Cache<ParseResult> $cache
-     * @return ast\Node
      * @throws InvalidArgumentException if the requested AST version is invalid.
      */
     public function parseCodeAsPHPAST(string $file_contents, int $version, array &$errors = [], Cache $cache = null) : \ast\Node
@@ -205,7 +204,6 @@ class TolerantASTConverter
      * Generates an ast\Node with this converter's current settings.
      *
      * @param Diagnostic[] &$errors @phan-output-reference
-     * @return ast\Node
      * @throws InvalidArgumentException if the requested AST version is invalid.
      */
     public function parseCodeAsPHPASTUncached(string $file_contents, int $version, array &$errors = []) : \ast\Node
@@ -232,7 +230,6 @@ class TolerantASTConverter
      * @param PhpParser\Node $parser_node
      * @param int $ast_version
      * @param string $file_contents
-     * @return ast\Node
      * @throws InvalidArgumentException if the provided AST version isn't valid
      */
     public function phpParserToPhpast(PhpParser\Node $parser_node, int $ast_version, string $file_contents) : \ast\Node
@@ -722,7 +719,6 @@ class TolerantASTConverter
                 );
             },
             /**
-             * @return ?ast\Node
              * @throws InvalidNodeException if the resulting AST would not be analyzable by Phan
              */
             'Microsoft\PhpParser\Node\Expression\ScopedPropertyAccessExpression' => static function (PhpParser\Node\Expression\ScopedPropertyAccessExpression $n, int $start_line) : ?\ast\Node {
@@ -1607,8 +1603,6 @@ class TolerantASTConverter
      * @param PhpParser\Node\NamespaceUseClause $use_clause
      * @param ?int $parser_use_kind
      * @param int $start_line
-     * @return ast\Node
-     *
      * @throws InvalidNodeException
      */
     protected static function astStmtUseOrGroupUseFromUseClause(PhpParser\Node\NamespaceUseClause $use_clause, ?int $parser_use_kind, int $start_line) : ast\Node
@@ -2828,7 +2822,6 @@ class TolerantASTConverter
     }
 
     /**
-     * @return string
      * @throws InvalidNodeException if the qualified type name could not be converted to a valid php-ast type name
      */
     private static function phpParserNameToString(PhpParser\Node\QualifiedName $name) : string

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverterWithNodeMapping.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverterWithNodeMapping.php
@@ -88,9 +88,6 @@ class TolerantASTConverterWithNodeMapping extends TolerantASTConverter
 
     /**
      * @param Diagnostic[] &$errors @phan-output-reference
-     *
-     * @return \ast\Node
-     *
      * @throws InvalidArgumentException for invalid $version
      * @throws Throwable (after logging) if anything is thrown by the parser
      */
@@ -426,7 +423,6 @@ class TolerantASTConverterWithNodeMapping extends TolerantASTConverter
 
     /**
      * @param PhpParser\Node\QualifiedName|Token|null $type
-     * @return ?ast\Node
      * @override
      */
     protected static function phpParserTypeToAstNode($type, int $line) : ?\ast\Node

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -487,7 +487,6 @@ class UnionTypeVisitor extends AnalysisVisitor
     }
 
     /**
-     * @return ?Type
      * @throws IssueException if the parent type could not be resolved
      */
     public static function findParentType(Context $context, CodeBase $code_base) : ?Type
@@ -2980,7 +2979,6 @@ class UnionTypeVisitor extends AnalysisVisitor
 
     /**
      * @param string $class_name (may also be 'self', 'parent', or 'static')
-     * @return ?FullyQualifiedClassName
      * @throws FQSENException
      */
     private function lookupClassOfCallableByName(string $class_name) : ?FullyQualifiedClassName

--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -63,9 +63,6 @@ class Analysis
      * @param bool $is_php_internal_stub
      * If this is true, this function will act as though the parsed constants, functions, and classes are actually part of PHP or it's extension's internals.
      * See autoload_internal_extension_signatures.
-     *
-     * @return Context
-     *
      * @throws InvalidArgumentException for invalid stub files
      */
     public static function parseFile(CodeBase $code_base, string $file_path, bool $suppress_parse_errors = false, string $override_contents = null, bool $is_php_internal_stub = false) : Context

--- a/src/Phan/Analysis/Analyzable.php
+++ b/src/Phan/Analysis/Analyzable.php
@@ -70,8 +70,6 @@ trait Analyzable
 
     /**
      * Ensure that annotations about what flags a function declaration has have been added
-     *
-     * @return void
      * @suppress PhanUndeclaredProperty deliberately using dynamic properties
      */
     public static function ensureDidAnnotate(Node $node) : void

--- a/src/Phan/Analysis/AssignOperatorAnalysisVisitor.php
+++ b/src/Phan/Analysis/AssignOperatorAnalysisVisitor.php
@@ -150,8 +150,6 @@ class AssignOperatorAnalysisVisitor extends FlagVisitorImplementation
     }
 
     /**
-     * @return Context
-     *
      * @see BinaryOperatorFlagVisitor::visitBinaryAdd() for analysis of "+", which is similar to "+="
      */
     public function visitBinaryAdd(Node $node) : Context

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -237,7 +237,6 @@ class AssignmentVisitor extends AnalysisVisitor
 
     /**
      * Analyzes code such as list($a) = [1, 2, 3];
-     * @return void
      * @see self::visitArray()
      */
     private function analyzeShapedArrayAssignment(Node $node) : void
@@ -424,7 +423,6 @@ class AssignmentVisitor extends AnalysisVisitor
 
     /**
      * Analyzes code such as list($a) = function_returning_array();
-     * @return void
      * @see self::visitArray()
      */
     private function analyzeGenericArrayAssignment(Node $node) : void

--- a/src/Phan/Analysis/ConditionVisitor/ComparisonCondition.php
+++ b/src/Phan/Analysis/ConditionVisitor/ComparisonCondition.php
@@ -24,7 +24,6 @@ class ComparisonCondition implements BinaryCondition
      *
      * @param Node $var
      * @param Node|int|string|float $expr
-     * @return Context
      * @override
      */
     public function analyzeVar(ConditionVisitorInterface $visitor, Node $var, $expr) : Context
@@ -37,7 +36,6 @@ class ComparisonCondition implements BinaryCondition
      *
      * @param Node|int|string|float $object
      * @param Node|int|string|float $expr
-     * @return Context
      * @suppress PhanUnusedPublicMethodParameter
      */
     public function analyzeClassCheck(ConditionVisitorInterface $visitor, $object, $expr) : Context

--- a/src/Phan/Analysis/ConditionVisitor/EqualsCondition.php
+++ b/src/Phan/Analysis/ConditionVisitor/EqualsCondition.php
@@ -19,7 +19,6 @@ class EqualsCondition implements BinaryCondition
      *
      * @param Node $var
      * @param Node|int|string|float $expr
-     * @return Context
      * @override
      */
     public function analyzeVar(ConditionVisitorInterface $visitor, Node $var, $expr) : Context

--- a/src/Phan/Analysis/ConditionVisitor/HasTypeCondition.php
+++ b/src/Phan/Analysis/ConditionVisitor/HasTypeCondition.php
@@ -24,7 +24,6 @@ class HasTypeCondition implements BinaryCondition
      *
      * @param Node $var
      * @param Node|int|string|float $unused_expr
-     * @return Context
      * @override
      */
     public function analyzeVar(ConditionVisitorInterface $visitor, Node $var, $unused_expr) : Context

--- a/src/Phan/Analysis/ConditionVisitor/IdenticalCondition.php
+++ b/src/Phan/Analysis/ConditionVisitor/IdenticalCondition.php
@@ -19,7 +19,6 @@ class IdenticalCondition implements BinaryCondition
      *
      * @param Node $var
      * @param Node|int|string|float $expr
-     * @return Context
      * @override
      */
     public function analyzeVar(ConditionVisitorInterface $visitor, Node $var, $expr) : Context

--- a/src/Phan/Analysis/ConditionVisitor/NotEqualsCondition.php
+++ b/src/Phan/Analysis/ConditionVisitor/NotEqualsCondition.php
@@ -19,7 +19,6 @@ class NotEqualsCondition implements BinaryCondition
      *
      * @param Node $var
      * @param Node|int|string|float $expr
-     * @return Context
      * @override
      */
     public function analyzeVar(ConditionVisitorInterface $visitor, Node $var, $expr) : Context
@@ -32,7 +31,6 @@ class NotEqualsCondition implements BinaryCondition
      *
      * @param Node|int|string|float $object
      * @param Node|int|string|float $expr
-     * @return Context
      * @override
      * @suppress PhanUnusedPublicMethodParameter
      */

--- a/src/Phan/Analysis/ConditionVisitor/NotHasTypeCondition.php
+++ b/src/Phan/Analysis/ConditionVisitor/NotHasTypeCondition.php
@@ -26,7 +26,6 @@ class NotHasTypeCondition implements BinaryCondition
      *
      * @param Node $var
      * @param Node|int|string|float $unused_expr
-     * @return Context
      * @override
      */
     public function analyzeVar(ConditionVisitorInterface $visitor, Node $var, $unused_expr) : Context

--- a/src/Phan/Analysis/ConditionVisitor/NotIdenticalCondition.php
+++ b/src/Phan/Analysis/ConditionVisitor/NotIdenticalCondition.php
@@ -19,7 +19,6 @@ class NotIdenticalCondition implements BinaryCondition
      *
      * @param Node $var
      * @param Node|int|string|float $expr
-     * @return Context
      * @override
      */
     public function analyzeVar(ConditionVisitorInterface $visitor, Node $var, $expr) : Context
@@ -32,7 +31,6 @@ class NotIdenticalCondition implements BinaryCondition
      *
      * @param Node|int|string|float $object
      * @param Node|int|string|float $expr
-     * @return Context
      * @suppress PhanUnusedPublicMethodParameter
      */
     public function analyzeClassCheck(ConditionVisitorInterface $visitor, $object, $expr) : Context

--- a/src/Phan/Analysis/ConditionVisitorUtil.php
+++ b/src/Phan/Analysis/ConditionVisitorUtil.php
@@ -809,7 +809,6 @@ trait ConditionVisitorUtil
      * @param Node $var_node
      * @param Node|int|string|float $expr_node
      * @param BinaryCondition $condition
-     * @return ?Context
      * @suppress PhanPartialTypeMismatchArgument
      */
     private function analyzeBinaryConditionSide(Node $var_node, $expr_node, BinaryCondition $condition) : ?Context
@@ -856,7 +855,6 @@ trait ConditionVisitorUtil
      *
      * @param Node|string|int|float $object_node
      * @param Node|string|int|float|bool $expr_node
-     * @return ?Context
      * @suppress PhanUnreferencedPublicMethod referenced in ConditionVisitorInterface
      */
     public function analyzeClassAssertion($object_node, $expr_node) : ?Context

--- a/src/Phan/Analysis/NegatedConditionVisitor.php
+++ b/src/Phan/Analysis/NegatedConditionVisitor.php
@@ -406,7 +406,6 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
                 $expr_node,
                 /**
                  * @param array<int,mixed> $args
-                 * @return void
                  * @suppress PhanUnusedClosureParameter
                  */
                 function (CodeBase $code_base, Context $context, Variable $variable, array $args) use ($class_node) : void {

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -1099,8 +1099,6 @@ class ParameterTypesAnalyzer
     /**
      * Guesses the return number of a method's PHPDoc's (at)return statement.
      * Returns null if that could not be found.
-     *
-     * @return ?int
      * @internal
      */
     public static function guessCommentReturnLineNumber(FunctionInterface $method) : ?int

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -231,7 +231,6 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
 
     /**
      * @param Node $node a node of type AST_DIM in unset()
-     * @return void
      * @see UnionTypeVisitor::resolveArrayShapeElementTypes()
      * @see UnionTypeVisitor::visitDim()
      */
@@ -287,7 +286,6 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
 
     /**
      * @param Node $node a node of type AST_PROP in unset()
-     * @return void
      * @see UnionTypeVisitor::resolveArrayShapeElementTypes()
      * @see UnionTypeVisitor::visitDim()
      */
@@ -3345,9 +3343,6 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
      *
      * @param FunctionInterface $method
      * The method or function being called
-     *
-     * @return void
-     *
      * @see analyzeMethodWithArgumentTypes (Which takes AST nodes)
      */
     public function analyzeCallableWithArgumentTypes(

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -2783,6 +2783,8 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
     public function analyzeProp(Node $node, bool $is_static) : Context
     {
         $exception_or_null = null;
+        // TODO fix #2985
+        $property = null;
 
         try {
             $property = (new ContextNode(

--- a/src/Phan/Analysis/ReachabilityChecker.php
+++ b/src/Phan/Analysis/ReachabilityChecker.php
@@ -132,7 +132,6 @@ final class ReachabilityChecker extends KindVisitorImplementation
     }
 
     /**
-     * @return ?bool
      * @override
      */
     public function visitClosure(Node $_) : ?bool
@@ -141,7 +140,6 @@ final class ReachabilityChecker extends KindVisitorImplementation
     }
 
     /**
-     * @return ?bool
      * @override
      */
     public function visitArrowFunc(Node $_) : ?bool
@@ -150,7 +148,6 @@ final class ReachabilityChecker extends KindVisitorImplementation
     }
 
     /**
-     * @return ?bool
      * @override
      */
     public function visitFuncDecl(Node $_) : ?bool
@@ -159,7 +156,6 @@ final class ReachabilityChecker extends KindVisitorImplementation
     }
 
     /**
-     * @return ?bool
      * @override
      */
     public function visitClass(Node $node) : ?bool

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -356,7 +356,6 @@ class BlockAnalysisVisitor extends AnalysisVisitor
     }
 
     /**
-     * @return void
      * @see ConditionVarUtil::getVariableFromScope()
      */
     private static function createVarForInlineComment(CodeBase $code_base, Context $context, string $var_name, UnionType $type, bool $create_variable) : void

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -164,7 +164,6 @@ class CLI
     private $output;
 
     /**
-     * @return OutputInterface
      * @suppress PhanUnreferencedPublicMethod not used yet.
      */
     public function getOutput() : OutputInterface
@@ -280,7 +279,6 @@ class CLI
      *
      * @param array<string,string|array<int,mixed>|false> $opts
      * @param array<int,string> $argv
-     * @return CLI
      * @throws ExitException
      * @throws UsageException
      * @internal - used for unit tests only
@@ -851,8 +849,6 @@ class CLI
      * (This is internal, so it was duplicated in case their API changed)
      *
      * @param mixed $output A valid CLI output stream
-     *
-     * @return bool
      * @suppress PhanUndeclaredFunction
      */
     public static function supportsColor($output) : bool
@@ -1441,7 +1437,6 @@ EOB
      * which match with a distance of <= 5
      *
      * @param string $key Misspelled key to attempt to correct
-     * @return string
      * @internal
      */
     public static function getFlagSuggestionString(
@@ -1754,7 +1749,6 @@ EOB
     }
 
     /**
-     * @return void
      * @param ?(string|FQSEN|AddressableElement) $details
      */
     public static function debugProgress(string $msg, float $p, $details) : void
@@ -1896,7 +1890,6 @@ EOB
 
     /**
      * This will assert that ast\parse_code or a polyfill can be called.
-     * @return void
      * @throws AssertionError on failure
      */
     private static function ensureASTParserExists() : void

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -354,7 +354,6 @@ class CodeBase
 
     /**
      * Returns the most recently parsed or analyzed file.
-     * @return ?string
      * @internal - For use only by the phan error handler, to help with debugging crashes
      */
     public static function getMostRecentlyParsedOrAnalyzedFile() : ?string
@@ -500,7 +499,6 @@ class CodeBase
 
     /**
      * @param string[] $internal_function_name_list
-     * @return void
      * @suppress PhanThrowTypeAbsentForCall
      */
     private function addInternalFunctionsByNames(array $internal_function_name_list) : void
@@ -694,8 +692,6 @@ class CodeBase
      * This should be called in the parse phase
      *
      * @param array<int,array<string,NamespaceMapEntry>> $namespace_map
-     *
-     * @return void
      * @internal
      */
     public function addParsedNamespaceMap(string $file, string $namespace, int $id, array $namespace_map) : void

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -1010,7 +1010,6 @@ class Config
 
     /**
      * Resets the configuration to the initial state, prior to parsing config files and CLI arguments.
-     * @return void
      * @internal - this should only be used in unit tests.
      */
     public static function reset() : void

--- a/src/Phan/Config/Initializer.php
+++ b/src/Phan/Config/Initializer.php
@@ -246,7 +246,6 @@ EOT;
      * @param array<string,mixed> $composer_settings (can be empty for --init-no-composer)
      * @param ?string $vendor_path (can be null for --init-no-composer)
      * @param array{init-analyze-file?:string,init-overwrite?:mixed,init-no-composer?:mixed,init-level?:(int|string)} $opts parsed from getopt
-     * @return InitializedSettings
      * @throws UsageException if provided settings are invalid
      * @internal
      */

--- a/src/Phan/Config/Initializer.php
+++ b/src/Phan/Config/Initializer.php
@@ -67,9 +67,6 @@ class Initializer
             }
         }
         $phan_settings = self::createPhanSettingsForComposerSettings($composer_settings, $vendor_path, $opts);
-        if (!($phan_settings instanceof InitializedSettings)) {
-            throw new UsageException("phan --init failed to generate settings", EXIT_FAILURE, UsageException::PRINT_INIT_ONLY);
-        }
 
         $phan_dir = \dirname($config_path);
         if (!\file_exists($phan_dir)) {

--- a/src/Phan/Daemon.php
+++ b/src/Phan/Daemon.php
@@ -182,7 +182,6 @@ class Daemon
     }
 
     /**
-     * @return void
      * @throws Exception if analysis throws
      */
     private static function analyzeDaemonRequestOnMainThread(CodeBase $code_base, Request $request) : void

--- a/src/Phan/Daemon/Request.php
+++ b/src/Phan/Daemon/Request.php
@@ -295,7 +295,6 @@ class Request
 
     /**
      * Respond with issues in the requested format
-     * @return void
      * @see LanguageServer::handleJSONResponseFromWorker() for one possible usage of this
      */
     public function respondWithIssues(int $issue_count) : void

--- a/src/Phan/Daemon/Transport/CapturerResponder.php
+++ b/src/Phan/Daemon/Transport/CapturerResponder.php
@@ -32,7 +32,6 @@ class CapturerResponder implements Responder
 
     /**
      * @param array<string,mixed> $data
-     * @return void
      * @throws \RuntimeException if called twice
      */
     public function sendResponseAndClose(array $data) : void

--- a/src/Phan/Daemon/Transport/StreamResponder.php
+++ b/src/Phan/Daemon/Transport/StreamResponder.php
@@ -63,7 +63,6 @@ class StreamResponder implements Responder
 
     /**
      * @param array<string,mixed> $data the response fields
-     * @return void
      * @throws \RuntimeException if called twice
      */
     public function sendResponseAndClose(array $data) : void

--- a/src/Phan/Debug.php
+++ b/src/Phan/Debug.php
@@ -36,9 +36,6 @@ class Debug
      *
      * @param string|int|float|Node|null $node
      * An AST node
-     *
-     * @return void
-     *
      * @suppress PhanUnreferencedPublicMethod
      */
     public static function printNode($node) : void
@@ -62,8 +59,6 @@ class Debug
 
     /**
      * Print $message with the given indent level
-     *
-     * @return void
      * @suppress PhanUnreferencedPublicMethod
      */
     public static function print(string $message, int $indent = 0) : void
@@ -174,9 +169,6 @@ class Debug
     /**
      * Computes a string representation of AST node flags such as
      * 'ASSIGN_DIV|TYPE_ARRAY'
-     *
-     * @return string
-     *
      * @see self::formatFlags() for a similar function also printing the integer flag value.
      */
     public static function astFlagDescription(int $flags, int $kind) : string

--- a/src/Phan/Debug/DebugUnionType.php
+++ b/src/Phan/Debug/DebugUnionType.php
@@ -18,8 +18,6 @@ class DebugUnionType extends UnionType
 
     /**
      * Add a type name to the list of types
-     *
-     * @return UnionType
      * @override
      */
     public function withType(Type $type) : UnionType

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -4263,7 +4263,6 @@ class Issue
     }
 
     /**
-     * @return int
      * @suppress PhanUnreferencedPublicMethod (no reporters use this right now)
      */
     public function getRemediationDifficulty() : int
@@ -4342,8 +4341,6 @@ class Issue
      * @param string|int|float|bool|Type|UnionType|FQSEN|TypedElement|UnaddressableTypedElement ...$template_parameters
      * Any template parameters required for the issue
      * message
-     *
-     * @return void
      * @suppress PhanUnreferencedPublicMethod
      */
     public static function emit(

--- a/src/Phan/IssueFixSuggester.php
+++ b/src/Phan/IssueFixSuggester.php
@@ -221,7 +221,6 @@ class IssueFixSuggester
     }
 
     /**
-     * @return ?FullyQualifiedClassName
      * @internal
      */
     public static function maybeGetClassInCurrentScope(Context $context) : ?FullyQualifiedClassName

--- a/src/Phan/Language/AnnotatedUnionType.php
+++ b/src/Phan/Language/AnnotatedUnionType.php
@@ -79,8 +79,6 @@ class AnnotatedUnionType extends UnionType
 
     /**
      * Add a type name to the list of types
-     *
-     * @return UnionType
      * @override
      */
     public function withType(Type $type) : UnionType
@@ -90,8 +88,6 @@ class AnnotatedUnionType extends UnionType
 
     /**
      * Add a type name to the list of types
-     *
-     * @return UnionType
      * @override
      */
     public function withoutType(Type $type) : UnionType
@@ -101,8 +97,6 @@ class AnnotatedUnionType extends UnionType
 
     /**
      * Returns a union type which add the given types to this type
-     *
-     * @return UnionType
      * @override
      */
     public function withUnionType(UnionType $union_type) : UnionType

--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -874,7 +874,6 @@ class Context extends FileRef
     }
 
     /**
-     * @return void
      * @internal
      * @suppress PhanAccessMethodInternal
      */

--- a/src/Phan/Language/Element/AddressableElement.php
+++ b/src/Phan/Language/Element/AddressableElement.php
@@ -261,8 +261,6 @@ abstract class AddressableElement extends TypedElement implements AddressableEle
     /**
      * This method must be called before analysis
      * begins.
-     *
-     * @return void
      * @override
      */
     public function hydrate(CodeBase $code_base) : void

--- a/src/Phan/Language/Element/ClassElement.php
+++ b/src/Phan/Language/Element/ClassElement.php
@@ -35,7 +35,6 @@ abstract class ClassElement extends AddressableElement
 
     /**
      * @param FullyQualifiedClassElement $fqsen
-     * @return void
      * @override
      * @suppress PhanParamSignatureMismatch deliberately more specific
      */

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -2278,8 +2278,6 @@ class Clazz extends AddressableElement
      * @param FileRef $file_ref
      * A reference to a location in which this typed structural
      * element is referenced.
-     *
-     * @return void
      * @override
      */
     public function addReference(FileRef $file_ref) : void
@@ -2840,8 +2838,6 @@ class Clazz extends AddressableElement
 
     /**
      * This method should be called after hydration
-     *
-     * @return void
      * @throws RecursionDepthException for deep class hierarchies
      */
     final public function analyze(CodeBase $code_base) : void
@@ -2936,8 +2932,6 @@ class Clazz extends AddressableElement
     /**
      * This method must be called before analysis
      * begins.
-     *
-     * @return void
      * @override
      */
     public function hydrate(CodeBase $code_base) : void

--- a/src/Phan/Language/Element/Comment/Builder.php
+++ b/src/Phan/Language/Element/Comment/Builder.php
@@ -814,9 +814,6 @@ final class Builder
 
         $entry = FileCache::getOrReadEntry(Config::projectPath($context->getFile()));
         $declaration_lineno = $context->getLineNumberStart();
-        if (!$entry) {
-            return $declaration_lineno;
-        }
         $lines_array = $entry->getLines();
         $count = \count($lines);
         $lineno_search = $declaration_lineno - ($count - $i - 1);

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -495,8 +495,6 @@ trait FunctionTrait
      * A list of parameters to set on this method
      * (When quick_mode is false, this is also called to temporarily
      * override parameter types, etc.)
-     *
-     * @return void
      * @internal
      */
     public function setParameterList(array $parameter_list) : void
@@ -622,8 +620,6 @@ trait FunctionTrait
     /**
      * @param Parameter $parameter
      * A parameter to append to the parameter list
-     *
-     * @return void
      * @internal
      * @suppress PhanUnreferencedPublicMethod Phan knows FunctionInterface's method is referenced, but can't associate that yet.
      */
@@ -846,7 +842,6 @@ trait FunctionTrait
 
     /**
      * @param array<string,UnionType> $parameter_map maps a subset of param names to the unmodified phpdoc parameter types. This may differ from real parameter types.
-     * @return void
      * @suppress PhanUnreferencedPublicMethod Phan knows FunctionInterface's method is referenced, but can't associate that yet.
      */
     public function setPHPDocParameterTypeMap(array $parameter_map) : void
@@ -857,7 +852,6 @@ trait FunctionTrait
     /**
      * Records the fact that $parameter_name is an output-only reference.
      * @param string $parameter_name
-     * @return void
      * @suppress PhanUnreferencedPublicMethod Phan knows FunctionInterface's method is referenced, but can't associate that yet.
      */
     public function recordOutputReferenceParamName(string $parameter_name) : void
@@ -1019,7 +1013,6 @@ trait FunctionTrait
      * @param Context $context
      * @param array<int,Node|int|string|float> $args
      * @param ?Node $node - the node causing the call. This may be dynamic, e.g. call_user_func_array. This will be required in Phan 3.
-     * @return void
      * @suppress PhanUnreferencedPublicMethod Phan knows FunctionInterface's method is referenced, but can't associate that yet.
      */
     public function analyzeFunctionCall(CodeBase $code_base, Context $context, array $args, Node $node = null) : void

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -1318,7 +1318,7 @@ trait FunctionTrait
                     $normalized_phpdoc_return_type = ParameterTypesAnalyzer::normalizeNarrowedParamType($phpdoc_return_type, $real_return_type);
                     if ($normalized_phpdoc_return_type) {
                         // TODO: How does this currently work when there are multiple types in the union type that are compatible?
-                        $this->setUnionType($normalized_phpdoc_return_type);
+                        $this->setUnionType($normalized_phpdoc_return_type->withRealTypeSet($real_return_type->getTypeSet()));
                     } else {
                         // This check isn't urgent to fix, and is specific to nullable casting rules,
                         // so use a different issue type.

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -558,8 +558,9 @@ class Method extends ClassElement implements FunctionInterface
             if (!$is_trait) {
                 $comment_return_union_type = $comment_return_union_type->withSelfResolvedInContext($context);
             }
+            $signature_union_type = $method->getUnionType();
 
-            $method->setUnionType($method->getUnionType()->withUnionType($comment_return_union_type));
+            $method->setUnionType($signature_union_type->withUnionType($comment_return_union_type)->withRealTypeSet($signature_union_type->getRealTypeSet()));
             $method->setPHPDocReturnType($comment_return_union_type);
         }
         $element_context->freeElementReference();

--- a/src/Phan/Language/Element/Property.php
+++ b/src/Phan/Language/Element/Property.php
@@ -316,7 +316,6 @@ class Property extends ClassElement
 
     /**
      * @param bool $from_phpdoc - True if this is a magic phpdoc property (declared via (at)property (-read,-write,) on class declaration phpdoc)
-     * @return void
      * @suppress PhanUnreferencedPublicMethod the caller now just sets all phan flags at once (including IS_READ_ONLY)
      */
     public function setIsFromPHPDoc(bool $from_phpdoc) : void

--- a/src/Phan/Language/Element/TypedElement.php
+++ b/src/Phan/Language/Element/TypedElement.php
@@ -195,8 +195,6 @@ abstract class TypedElement implements TypedElementInterface
 
     /**
      * @param int $bits combination of flags from Flags::* constants to disable
-     *
-     * @return void
      * @suppress PhanUnreferencedPublicMethod keeping this for consistency
      */
     public function disablePhanFlagBits(int $bits) : void

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -55,8 +55,6 @@ final class EmptyUnionType extends UnionType
 
     /**
      * Add a type name to the list of types
-     *
-     * @return UnionType
      * @override
      */
     public function withType(Type $type) : UnionType
@@ -70,8 +68,6 @@ final class EmptyUnionType extends UnionType
      * keeping the keys in a consecutive order.
      *
      * Each type in $this->type_set occurs exactly once.
-     *
-     * @return UnionType
      * @override
      */
     public function withoutType(Type $type) : UnionType
@@ -92,8 +88,6 @@ final class EmptyUnionType extends UnionType
 
     /**
      * Returns a union type which add the given types to this type
-     *
-     * @return UnionType
      * @override
      */
     public function withUnionType(UnionType $union_type) : UnionType

--- a/src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php
@@ -162,7 +162,6 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN
         return self::memoizeStatic(
             $key,
             /**
-             * @return FullyQualifiedGlobalStructuralElement
              * @throws FQSENException
              */
             static function () use ($fully_qualified_string) : FullyQualifiedGlobalStructuralElement {

--- a/src/Phan/Language/Type/ArrayShapeType.php
+++ b/src/Phan/Language/Type/ArrayShapeType.php
@@ -188,7 +188,6 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
     }
 
     /**
-     * @return UnionType
      * @phan-override
      */
     public function iterableKeyUnionType(CodeBase $unused_code_base) : UnionType
@@ -211,7 +210,6 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
     }
 
     /**
-     * @return UnionType
      * @override
      */
     public function iterableValueUnionType(CodeBase $unused_code_base) : UnionType

--- a/src/Phan/Language/Type/ClosureType.php
+++ b/src/Phan/Language/Type/ClosureType.php
@@ -171,7 +171,6 @@ final class ClosureType extends Type
      * Gets the function-like this type was created from.
      *
      * TODO: Uses of this may keep outdated data in language server mode.
-     * @return ?FunctionInterface
      * @deprecated use asFunctionInterfaceOrNull
      * @suppress PhanUnreferencedPublicMethod
      */

--- a/src/Phan/Language/Type/FunctionLikeDeclarationType.php
+++ b/src/Phan/Language/Type/FunctionLikeDeclarationType.php
@@ -530,7 +530,6 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
     }
 
     /**
-     * @return Parameter|null
      * @override
      */
     public function getParameterForCaller(int $i) : ?Parameter
@@ -548,7 +547,6 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
     }
 
     /**
-     * @return Parameter|null
      * @override
      */
     public function getRealParameterForCaller(int $i) : ?Parameter
@@ -628,7 +626,6 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
     }
 
     /**
-     * @return void
      * @unused
      */
     public function setComment(Comment $comment) : void

--- a/src/Phan/Language/Type/MixedType.php
+++ b/src/Phan/Language/Type/MixedType.php
@@ -26,7 +26,6 @@ final class MixedType extends NativeType
 
     /**
      * @param Type[] $target_type_set 1 or more types @phan-unused-param
-     * @return bool
      * @override
      */
     public function canCastToAnyTypeInSet(array $target_type_set) : bool

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -177,9 +177,6 @@ class UnionType implements Serializable
      * @param string $fully_qualified_string
      * A '|' delimited string representing a type in the form
      * 'int|string|null|ClassName'.
-     *
-     * @return UnionType
-     *
      * @throws InvalidArgumentException if any type name in the union type was invalid
      *
      * @see self::fromFullyQualifiedRealString() if you are absolutely sure this is the real type of the expression.
@@ -249,9 +246,6 @@ class UnionType implements Serializable
      * @param string $fully_qualified_string
      * A '|' delimited string representing a type in the form
      * 'int|string|null|ClassName'.
-     *
-     * @return UnionType
-     *
      * @throws InvalidArgumentException if any type name in the union type was invalid
      */
     public static function fromFullyQualifiedRealString(

--- a/src/Phan/LanguageServer/CompletionRequest.php
+++ b/src/Phan/LanguageServer/CompletionRequest.php
@@ -57,7 +57,6 @@ final class CompletionRequest extends NodeInfoRequest
 
     /**
      * @param ?CompletionItem|?array<int,CompletionItem>|array<string,mixed> $completions
-     * @return void
      * @suppress PhanPartialTypeMismatchArgument this accepts multiple types of arrays
      */
     public function recordCompletionList($completions) : void

--- a/src/Phan/LanguageServer/LanguageServer.php
+++ b/src/Phan/LanguageServer/LanguageServer.php
@@ -669,8 +669,6 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
 
     /**
      * @param array<string,string> $uris_to_analyze
-     * @return void
-     *
      * @throws Exception if analysis throws an exception
      *
      * @suppress PhanAccessMethodInternal
@@ -741,7 +739,6 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
     /**
      * @param array<string,string> $uris_to_analyze
      * @param array{issues:array[],definitions?:?Location|?(Location[]),completions?:?(CompletionItem[]),hover_response?:Hover} $response_data
-     * @return void
      * @see Request::respondWithIssues() for where $response_data is serialized
      */
     private function handleJSONResponseFromWorker(array $uris_to_analyze, array $response_data) : void

--- a/src/Phan/LanguageServer/Logger.php
+++ b/src/Phan/LanguageServer/Logger.php
@@ -90,7 +90,6 @@ class Logger
     /**
      * Overrides the log file to a different one
      * @param resource $new_file
-     * @return void
      * @suppress PhanUnreferencedPublicMethod this is made available for debugging issues
      */
     public static function setLogFile($new_file) : void

--- a/src/Phan/LanguageServer/Protocol/Position.php
+++ b/src/Phan/LanguageServer/Protocol/Position.php
@@ -60,7 +60,6 @@ class Position
      * Returns the offset of the position in a string
      *
      * @param string $content
-     * @return int
      * @suppress PhanUnreferencedPublicMethod
      */
     public function toOffset(string $content): int

--- a/src/Phan/LanguageServer/Protocol/Range.php
+++ b/src/Phan/LanguageServer/Protocol/Range.php
@@ -38,7 +38,6 @@ class Range
      * Checks if a position is within the range
      *
      * @param Position $position
-     * @return bool
      * @suppress PhanUnreferencedPublicMethod
      */
     public function includes(Position $position): bool

--- a/src/Phan/LanguageServer/Server/TextDocument.php
+++ b/src/Phan/LanguageServer/Server/TextDocument.php
@@ -86,7 +86,6 @@ class TextDocument
      * document's uri.
      *
      * @param TextDocumentItem $textDocument The document that was opened.
-     * @return void
      * @suppress PhanUnreferencedPublicMethod called by client via AdvancedJsonRpc
      */
     public function didOpen(TextDocumentItem $textDocument) : void
@@ -116,7 +115,6 @@ class TextDocument
      *
      * @param VersionedTextDocumentIdentifier $textDocument
      * @param string|null $text (NOTE: can't use ?T here)
-     * @return void
      * @suppress PhanUnreferencedPublicMethod called by client via AdvancedJsonRpc
      */
     public function didSave(TextDocumentIdentifier $textDocument, string $text = null) : void
@@ -138,7 +136,6 @@ class TextDocument
      *
      * @param VersionedTextDocumentIdentifier $textDocument
      * @param TextDocumentContentChangeEvent[] $contentChanges
-     * @return void
      * @suppress PhanUnreferencedPublicMethod called by client via AdvancedJsonRpc
      */
     public function didChange(VersionedTextDocumentIdentifier $textDocument, array $contentChanges) : void
@@ -161,7 +158,6 @@ class TextDocument
      * truth now exists on disk).
      *
      * @param TextDocumentIdentifier $textDocument The document that was closed
-     * @return void
      * @suppress PhanUnreferencedPublicMethod called by client via AdvancedJsonRpc
      */
     public function didClose(TextDocumentIdentifier $textDocument) : void

--- a/src/Phan/LanguageServer/Server/Workspace.php
+++ b/src/Phan/LanguageServer/Server/Workspace.php
@@ -53,7 +53,6 @@ class Workspace
      * The watched files notification is sent from the client to the server when the client detects changes to files watched by the language client.
      *
      * @param FileEvent[] $changes
-     * @return void
      * @suppress PhanUnreferencedPublicMethod called by client via AdvancedJsonRpc
      */
     public function didChangeWatchedFiles(array $changes) : void

--- a/src/Phan/LanguageServer/Utils.php
+++ b/src/Phan/LanguageServer/Utils.php
@@ -21,8 +21,6 @@ class Utils
      * Causes the sabre event loop to crash, for debugging.
      *
      * E.g. this is called if there is an unrecoverable error elsewhere.
-     *
-     * @return void
      * @suppress PhanUnreferencedPublicMethod
      */
     public static function crash(Throwable $err) : void
@@ -58,7 +56,6 @@ class Utils
      * Transforms URI into an absolute file path
      *
      * @param string $uri
-     * @return string
      * @throws InvalidArgumentException
      */
     public static function uriToPath(string $uri) : string

--- a/src/Phan/Library/StderrLogger.php
+++ b/src/Phan/Library/StderrLogger.php
@@ -16,8 +16,6 @@ class StderrLogger implements LoggerInterface
      * @param string $level
      * @param string $message
      * @param array<string,mixed> $unused_context
-     * @return void
-     *
      * @override
      */
     public function log($level, $message, array $unused_context = []) : void

--- a/src/Phan/Output/Collector/ParallelChildCollector.php
+++ b/src/Phan/Output/Collector/ParallelChildCollector.php
@@ -75,7 +75,6 @@ class ParallelChildCollector implements IssueCollectorInterface
     /**
      * Collect issue
      * @param IssueInstance $issue
-     * @return void
      * @throws AssertionError if the message failed to be sent to the parent process
      */
     public function collectIssue(IssueInstance $issue) : void
@@ -122,8 +121,6 @@ class ParallelChildCollector implements IssueCollectorInterface
      * Called from daemon mode.
      *
      * @param string[] $files @phan-unused-param - the relative paths to those files
-     * @return void
-     *
      * @override
      */
     public function removeIssuesForFiles(array $files) : void

--- a/src/Phan/Phan.php
+++ b/src/Phan/Phan.php
@@ -671,7 +671,6 @@ class Phan implements IgnoredFilesFilterInterface
 
     /**
      * Loads configured stubs for internal PHP extensions.
-     * @return void
      * @throws InvalidArgumentException if the stubs or stub config is invalid
      */
     private static function loadConfiguredPHPExtensionStubs(CodeBase $code_base) : void

--- a/src/Phan/Plugin/ClosuresForKind.php
+++ b/src/Phan/Plugin/ClosuresForKind.php
@@ -33,7 +33,6 @@ class ClosuresForKind
      *
      * @param int $kind - A valid value of a node kind
      * @param Closure $c
-     * @return void
      * @throws InvalidArgumentException if $kind is invalid
      */
     public function record(int $kind, Closure $c) : void

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -299,7 +299,6 @@ final class ConfigPluginSet extends PluginV3 implements
      *
      * @param string $file_contents
      * @param Node $node
-     * @return void
      * @override
      */
     public function beforeAnalyzeFile(
@@ -359,7 +358,6 @@ final class ConfigPluginSet extends PluginV3 implements
      *
      * @param string $file_contents
      * @param Node $node
-     * @return void
      * @override
      */
     public function afterAnalyzeFile(
@@ -384,8 +382,6 @@ final class ConfigPluginSet extends PluginV3 implements
      *
      * @param Clazz $class
      * A class being analyzed
-     *
-     * @return void
      * @override
      */
     public function analyzeClass(
@@ -411,8 +407,6 @@ final class ConfigPluginSet extends PluginV3 implements
      *
      * @param Method $method
      * A method being analyzed
-     *
-     * @return void
      * @override
      */
     public function analyzeMethod(
@@ -507,8 +501,6 @@ final class ConfigPluginSet extends PluginV3 implements
      *
      * @param Func $function
      * A function being analyzed
-     *
-     * @return void
      * @override
      */
     public function analyzeFunction(
@@ -531,8 +523,6 @@ final class ConfigPluginSet extends PluginV3 implements
      * A property being analyzed
      *
      * (Called by analyzeClass())
-     *
-     * @return void
      * @override
      */
     public function analyzeProperty(
@@ -560,8 +550,6 @@ final class ConfigPluginSet extends PluginV3 implements
     /**
      * @param CodeBase $code_base
      * The code base used for previous analysis steps
-     *
-     * @return void
      * @override
      */
     public function finalizeProcess(
@@ -656,7 +644,6 @@ final class ConfigPluginSet extends PluginV3 implements
 
     /**
      * @internal
-     * @return void
      * @see addTemporaryAnalysisPlugin
      */
     public function prepareNodeSelectionPluginForNode(Node $node) : void

--- a/src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php
@@ -121,7 +121,6 @@ final class DependentReturnTypeOverridePlugin extends PluginV3 implements
         $string_if_2_true_else_true = $make_dependent_type_method(1, $string_union_type, $true_union_type, $string_or_true_union_type);
 
         /**
-         * @return UnionType
          * @param Func $function @phan-unused-param
          * @param array<int,Node|int|float|string> $args
          */

--- a/src/Phan/Plugin/Internal/DumpPHPDocPlugin.php
+++ b/src/Phan/Plugin/Internal/DumpPHPDocPlugin.php
@@ -46,9 +46,6 @@ final class DumpPHPDocPlugin extends PluginV3 implements
      *
      * @param Clazz $class
      * A class being analyzed
-     *
-     * @return void
-     *
      * @override
      */
     public function analyzeClass(
@@ -87,9 +84,6 @@ final class DumpPHPDocPlugin extends PluginV3 implements
      *
      * @param Property $property
      * A property being analyzed
-     *
-     * @return void
-     *
      * @override
      */
     public function analyzeProperty(
@@ -124,9 +118,6 @@ final class DumpPHPDocPlugin extends PluginV3 implements
      *
      * @param Method $method
      * A method being analyzed
-     *
-     * @return void
-     *
      * @override
      */
     public function analyzeMethod(
@@ -170,9 +161,6 @@ final class DumpPHPDocPlugin extends PluginV3 implements
      *
      * @param Func $function
      * A function being analyzed
-     *
-     * @return void
-     *
      * @override
      */
     public function analyzeFunction(

--- a/src/Phan/Plugin/Internal/NodeSelectionPlugin.php
+++ b/src/Phan/Plugin/Internal/NodeSelectionPlugin.php
@@ -53,8 +53,6 @@ class NodeSelectionVisitor extends PluginAwarePostAnalysisVisitor
      * A node to check
      *
      * @param array<int,Node> $parent_node_list
-     *
-     * @return void
      * @see ConfigPluginSet::prepareNodeSelectionPlugin() for how this is called
      */
     public function visitCommonImplementation(Node $node, array $parent_node_list) : void

--- a/src/Phan/Plugin/Internal/RequireExistsPlugin.php
+++ b/src/Phan/Plugin/Internal/RequireExistsPlugin.php
@@ -35,7 +35,6 @@ class RequireExistsPlugin extends PluginV3 implements PostAnalyzeNodeCapability
 class RequireExistsVisitor extends PluginAwarePostAnalysisVisitor
 {
     /**
-     * @return void
      * @override
      */
     public function visitIncludeOrEval(Node $node) : void

--- a/src/Phan/Plugin/Internal/ThrowAnalyzerPlugin.php
+++ b/src/Phan/Plugin/Internal/ThrowAnalyzerPlugin.php
@@ -52,7 +52,6 @@ class ThrowVisitor extends PluginAwarePostAnalysisVisitor
     protected $parent_node_list;
 
     /**
-     * @return void
      * @override
      */
     public function visitThrow(Node $node) : void
@@ -216,7 +215,6 @@ class ThrowVisitor extends PluginAwarePostAnalysisVisitor
 class ThrowRecursiveVisitor extends ThrowVisitor
 {
     /**
-     * @return void
      * @override
      */
     public function visitCall(Node $node) : void
@@ -248,7 +246,6 @@ class ThrowRecursiveVisitor extends ThrowVisitor
     }
 
     /**
-     * @return void
      * @override
      */
     public function visitMethodCall(Node $node) : void
@@ -290,7 +287,6 @@ class ThrowRecursiveVisitor extends ThrowVisitor
     }
 
     /**
-     * @return void
      * @override
      */
     public function visitStaticCall(Node $node) : void

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
@@ -60,7 +60,6 @@ final class VariableTrackerVisitor extends AnalysisVisitor
 
     /**
      * This is the default implementation for node types which don't have any overrides
-     * @return VariableTrackingScope
      * @override
      */
     public function visit(Node $node) : VariableTrackingScope
@@ -122,7 +121,6 @@ final class VariableTrackerVisitor extends AnalysisVisitor
 
     /**
      * This is the default implementation for node types which don't have any overrides
-     * @return VariableTrackingScope
      * @override
      */
     public function visitStmtList(Node $node) : VariableTrackingScope
@@ -142,7 +140,6 @@ final class VariableTrackerVisitor extends AnalysisVisitor
     }
 
     /**
-     * @return VariableTrackingScope
      * @override
      */
     public function visitAssignRef(Node $node) : VariableTrackingScope
@@ -236,7 +233,6 @@ final class VariableTrackerVisitor extends AnalysisVisitor
     }
 
     /**
-     * @return VariableTrackingScope
      * @override
      */
     public function visitAssignOp(Node $node) : VariableTrackingScope
@@ -276,7 +272,6 @@ final class VariableTrackerVisitor extends AnalysisVisitor
     }
 
     /**
-     * @return VariableTrackingScope
      * @override
      */
     public function visitAssign(Node $node) : VariableTrackingScope
@@ -445,7 +440,6 @@ final class VariableTrackerVisitor extends AnalysisVisitor
 
     /**
      * Do not recurse into function declarations within a scope
-     * @return VariableTrackingScope
      * @override
      */
     public function visitFuncDecl(Node $unused_node) : VariableTrackingScope
@@ -455,7 +449,6 @@ final class VariableTrackerVisitor extends AnalysisVisitor
 
     /**
      * Do not recurse into class declarations within a scope
-     * @return VariableTrackingScope
      * @override
      */
     public function visitClass(Node $unused_node) : VariableTrackingScope
@@ -465,8 +458,6 @@ final class VariableTrackerVisitor extends AnalysisVisitor
 
     /**
      * Do not recurse into closure declarations within a scope.
-     *
-     * @return VariableTrackingScope
      * @override
      */
     public function visitClosure(Node $node) : VariableTrackingScope
@@ -495,8 +486,6 @@ final class VariableTrackerVisitor extends AnalysisVisitor
      * Do not recurse into short arrow (`fn() => ...`) closure declarations within a scope.
      *
      * TODO: This could be improved by checking if the short arrow redefines the variable and ignores the original value.
-     *
-     * @return VariableTrackingScope
      * @override
      */
     public function visitArrowFunc(Node $node) : VariableTrackingScope
@@ -519,7 +508,6 @@ final class VariableTrackerVisitor extends AnalysisVisitor
 
     /**
      * TODO: Check if the current context is a function call passing an argument by reference
-     * @return VariableTrackingScope
      * @override
      */
     public function visitVar(Node $node) : VariableTrackingScope
@@ -539,8 +527,6 @@ final class VariableTrackerVisitor extends AnalysisVisitor
 
     /**
      * Analyzes `static $var [ = default ];`
-     *
-     * @return VariableTrackingScope
      * @override
      */
     public function visitStatic(Node $node) : VariableTrackingScope
@@ -556,8 +542,6 @@ final class VariableTrackerVisitor extends AnalysisVisitor
 
     /**
      * Analyzes `global $var;` (analyzed like it was declared with the value from the global scope).
-     *
-     * @return VariableTrackingScope
      * @override
      */
     public function visitGlobal(Node $node) : VariableTrackingScope
@@ -600,7 +584,6 @@ final class VariableTrackerVisitor extends AnalysisVisitor
 
     /**
      * Analyzes `while (cond) { stmts }`
-     * @return VariableTrackingScope
      * @override
      */
     public function visitWhile(Node $node) : VariableTrackingScope
@@ -624,7 +607,6 @@ final class VariableTrackerVisitor extends AnalysisVisitor
      * TODO: Fix https://github.com/phan/phan/issues/2029
      *
      * @param Node $node a node of type AST_DO_WHILE
-     * @return VariableTrackingScope
      * @override
      */
     public function visitDoWhile(Node $node) : VariableTrackingScope
@@ -646,7 +628,6 @@ final class VariableTrackerVisitor extends AnalysisVisitor
     /**
      * Analyzes `for (init; cond; loop) { stmts }`
      * @param Node $node a node of type AST_FOR
-     * @return VariableTrackingScope
      * @override
      */
     public function visitFor(Node $node) : VariableTrackingScope
@@ -695,8 +676,6 @@ final class VariableTrackerVisitor extends AnalysisVisitor
      * Analyzes if statements.
      *
      * @param Node $node a node of kind AST_IF
-     * @return VariableTrackingScope
-     *
      * @see BlockAnalysisVisitor::visitIf()
      * @override
      */
@@ -748,8 +727,6 @@ final class VariableTrackerVisitor extends AnalysisVisitor
      * Analyzes switch statements.
      *
      * @param Node $node a node of kind AST_SWITCH
-     * @return VariableTrackingScope
-     *
      * @override
      */
     public function visitSwitchList(Node $node) : VariableTrackingScope
@@ -797,7 +774,6 @@ final class VariableTrackerVisitor extends AnalysisVisitor
 
     /**
      * Implements analysis of `cond_node ? true_node : false_node` and `cond_node ?: false_node`
-     * @return VariableTrackingScope
      * @override
      */
     public function visitConditional(Node $node) : VariableTrackingScope
@@ -829,8 +805,6 @@ final class VariableTrackerVisitor extends AnalysisVisitor
      * Analyzes try nodes and their catch statement lists and finally blocks.
      *
      * @param Node $node a node of kind AST_TRY
-     * @return VariableTrackingScope
-     *
      * @override
      */
     public function visitTry(Node $node) : VariableTrackingScope
@@ -862,8 +836,6 @@ final class VariableTrackerVisitor extends AnalysisVisitor
     /**
      * Analyzes catch statement lists.
      * @param Node $node a node of kind AST_CATCH_LIST
-     * @return VariableTrackingScope
-     *
      * @override
      */
     public function visitCatchList(Node $node) : VariableTrackingScope
@@ -891,8 +863,6 @@ final class VariableTrackerVisitor extends AnalysisVisitor
     /**
      * Analyzes catch statement lists.
      * @param Node $node a node of kind AST_CATCH
-     * @return VariableTrackingScope
-     *
      * @override
      */
     public function visitCatch(Node $node) : VariableTrackingScope

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackingBranchScope.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackingBranchScope.php
@@ -69,8 +69,6 @@ class VariableTrackingBranchScope extends VariableTrackingScope
      * @param VariableTrackingBranchScope $inner_scope @phan-unused-param
      * @param bool $exits true if this branch will exit.
      *             This would mean that the branch uses variables, but does not define them outside of that scope.
-     *
-     * @return void
      * @override
      */
     public function recordSkippedScope(VariableTrackingBranchScope $inner_scope, bool $exits) : void

--- a/src/Phan/Suggestion.php
+++ b/src/Phan/Suggestion.php
@@ -49,7 +49,6 @@ final class Suggestion
      * (Create a Suggestion with the empty string if the suggestion should not be visible in error messages)
      *
      * @param mixed $data
-     * @return void
      * @suppress PhanUnreferencedPublicMethod
      */
     public function setInternalData($data) : void

--- a/tests/Phan/AbstractPhanFileTest.php
+++ b/tests/Phan/AbstractPhanFileTest.php
@@ -140,7 +140,6 @@ abstract class AbstractPhanFileTest extends BaseTest implements CodeBaseAwareTes
      * @param string[] $test_file_list
      * @param string $expected_file_path
      * @param ?string $config_file_path
-     * @return void
      * @suppress PhanThrowTypeAbsentForCall
      * @dataProvider getTestFiles
      */

--- a/tests/Phan/BaseTest.php
+++ b/tests/Phan/BaseTest.php
@@ -12,7 +12,6 @@ use PHPUnit\Framework\TestCase;
 abstract class BaseTest extends TestCase
 {
     /**
-     * @return void
      * @suppress PhanAccessMethodInternal
      */
     public static function setUpBeforeClass() : void

--- a/tests/Phan/LanguageServer/LanguageServerIntegrationTest.php
+++ b/tests/Phan/LanguageServer/LanguageServerIntegrationTest.php
@@ -1695,7 +1695,6 @@ EOT;
     /**
      * @param resource $proc_in
      * @param resource $proc_out
-     * @return void
      * @throws InvalidArgumentException
      */
     private function writeInitializeRequestAndAwaitResponse($proc_in, $proc_out) : void
@@ -1847,7 +1846,6 @@ EOT;
     /**
      * @param resource $proc_in
      * @param resource $proc_out
-     * @return void
      * @throws InvalidArgumentException
      */
     private function writeShutdownRequestAndAwaitResponse($proc_in, $proc_out) : void
@@ -1865,7 +1863,6 @@ EOT;
 
     /**
      * @param resource $proc_in
-     * @return void
      * @throws InvalidArgumentException
      */
     private function writeInitializedNotification($proc_in) : void
@@ -1880,7 +1877,6 @@ EOT;
 
     /**
      * @param resource $proc_in
-     * @return void
      * @throws InvalidArgumentException
      */
     private function writeExitNotification($proc_in) : void
@@ -1890,7 +1886,6 @@ EOT;
 
     /**
      * @param resource $proc_in
-     * @return void
      * @throws InvalidArgumentException
      */
     private function writeDidChangeNotificationToDefaultFile($proc_in, string $new_contents) : void
@@ -1900,7 +1895,6 @@ EOT;
 
     /**
      * @param resource $proc_in
-     * @return void
      * @throws InvalidArgumentException
      */
     private function writeDidChangeNotificationToFile($proc_in, string $requested_uri, string $new_contents) : void

--- a/tests/Phan/Library/RegexKeyExtractorTest.php
+++ b/tests/Phan/Library/RegexKeyExtractorTest.php
@@ -15,7 +15,6 @@ final class RegexKeyExtractorTest extends BaseTest
      *
      * @param string $regex a regular expression for preg_match
      * @param array<int,int|string> $expected_keys
-     * @return void
      * @dataProvider getKeysProvider
      */
     public function testGetKeys(string $regex, array $expected_keys) : void

--- a/tests/Phan/PHP72Test.php
+++ b/tests/Phan/PHP72Test.php
@@ -30,8 +30,6 @@ class PHP72Test extends AbstractPhanFileTest
      * @param string[] $test_file_list
      * @param string $expected_file_path
      * @param ?string $config_file_path
-     * @return void
-     *
      * @dataProvider getTestFiles
      * @override
      */

--- a/tests/files/expected/0736_too_few.php.expected
+++ b/tests/files/expected/0736_too_few.php.expected
@@ -1,0 +1,6 @@
+%s:3 PhanParamReqAfterOpt Required argument follows optional
+%s:7 PhanParamReqAfterOpt Required argument follows optional
+%s:10 PhanParamTooFew Call with 2 arg(s) to \incorrect736() which requires 3 arg(s) defined at %s:7
+%s:11 PhanParamTooFew Call with 2 arg(s) to \C736::incorrect() which requires 3 arg(s) defined at %s:3
+%s:12 PhanParamTooMany Call with 4 arg(s) to \incorrect736() which only takes 3 arg(s) defined at %s:7
+%s:13 PhanParamTooMany Call with 4 arg(s) to \C736::incorrect() which only takes 3 arg(s) defined at %s:3

--- a/tests/files/expected/0737_redundant_detection_with_phpdoc.php.expected
+++ b/tests/files/expected/0737_redundant_detection_with_phpdoc.php.expected
@@ -1,0 +1,2 @@
+%s:20 PhanRedundantCondition Redundant attempt to cast $o of type \stdClass to \stdClass
+%s:24 PhanRedundantCondition Redundant attempt to cast $o2 of type \stdClass to \stdClass

--- a/tests/files/src/0736_too_few.php
+++ b/tests/files/src/0736_too_few.php
@@ -1,0 +1,13 @@
+<?php
+class C736 {
+    public static function incorrect($a = null, $b = null, $c) {
+        return [$a, $b, $c];
+    }
+}
+function incorrect736($a, $b = null, $c) {
+    return [$a, $b, $c];
+}
+incorrect736(1, 2);  // Expected: Emit PhanParamTooFew
+C736::incorrect(1, 2);  // Expected: Emit PhanParamTooFew
+incorrect736(1, 2, 3, 4);  // Expected: Emit PhanParamTooMany
+C736::incorrect(1, 2, 3, 4);  // Expected: Emit PhanParamTooMany

--- a/tests/files/src/0737_redundant_detection_with_phpdoc.php
+++ b/tests/files/src/0737_redundant_detection_with_phpdoc.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace NS737;
+use stdClass;
+
+/**
+ * @return stdClass
+ */
+function returns_stdClass() : stdClass {
+    return new stdClass();
+}
+class TestRedundant {
+
+    /** @return stdClass */
+    public static function main() : stdClass {
+        return new stdClass();
+    }
+    public static function other() {
+        $o = self::main();
+        if ($o instanceof stdClass) {
+            echo "Fail\n";
+        }
+        $o2 = returns_stdClass();
+        if ($o2 instanceof stdClass)  {
+            echo "Fail\n";
+        }
+    }
+}


### PR DESCRIPTION
and remove redundant `@return` annotations from Phan.