### PR TITLE
Add CLI option `--absolute-path-issue-messages`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@ Phan NEWS
 ??? ?? 2019, Phan 2.2.7 (dev)
 -----------------------
 
+New features(CLI, Configs):
++ Add `--absolute-path-issue-messages` to emit absolute paths instead of relative paths for the file of an issue. (#1640)
+  Note that this does not affect files within the issue message.
+
 New features(Analysis):
 + Fix failure to infer real types when an invoked function or method had a phpdoc `@return` in addition to the real type.
 + Infer union type from all classes that an instance method could possibly be, not just the first type seen in the expression's union type. (#2988)

--- a/plugins/bash/phan
+++ b/plugins/bash/phan
@@ -93,6 +93,7 @@ _phan() {
 --find-signature
 --print-memory-usage-summary
 --markdown-issue-messages
+--absolute-path-issue-messages
 --constant-variable-detection
 --require-config-exists
 --help-annotaitons

--- a/plugins/zsh/_phan
+++ b/plugins/zsh/_phan
@@ -70,6 +70,7 @@ _arguments \
 	'(--find-signature)--find-signature=[find a signature (see tool/_phoogle)]:expr:()' \
 	'(--print-memory-usage-summary)--print-memory-usage-summary[print a summary of memory usage and maximum memory usage]' \
 	'(--markdown-issue-messages)--markdown-issue-messages[emit issues with markdown formatting]' \
+	'(--absolute-path-issue-messages)--absolute-path-issue-messages[emit issues with absolute paths]' \
 	'(--constant-variable-detection)--constant-variable-detection[warn about variables that could be constants]' \
 	'(--require-config-exists)--require-config-exists[exit immediately if .phan/config.php did not exist]' \
 	'(--help-annotations)--help-annotations[print annotations supported by Phan]'

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -75,6 +75,7 @@ class CLI
      * @internal
      */
     const GETOPT_LONG_OPTIONS = [
+        'absolute-path-issue-messages',
         'allow-polyfill-parser',
         'assume-real-types-for-internal-functions',
         'automatic-fix',
@@ -739,6 +740,9 @@ class CLI
                 case 'markdown-issue-messages':
                     Config::setValue('markdown_issue_messages', true);
                     break;
+                case 'absolute-path-issue-messages':
+                    Config::setValue('absolute_path_issue_messages', true);
+                    break;
                 case 'color-scheme':
                 case 'C':
                 case 'color':
@@ -1300,6 +1304,10 @@ Extended help:
 
  --markdown-issue-messages
   Emit issue messages with markdown formatting.
+
+ --absolute-path-issue-messages
+  Emit issues with their absolute paths instead of relative paths.
+  This does not affect files mentioned within the issue.
 
  --constant-variable-detection
   Emit issues for variables that could be replaced with literals or constants.

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -657,6 +657,9 @@ class Config
         // Enable this to emit issue messages with markdown formatting.
         'markdown_issue_messages' => false,
 
+        // Enable this with `--absolute-path-issue-messages` to use absolute paths in issue messages
+        'absolute_path_issue_messages' => false,
+
         // Enable this to automatically use colorized phan output for the 'text' output format if the terminal supports it.
         // Alternately, set PHAN_ENABLE_COLOR_OUTPUT=1.
         // This config setting can be overridden with PHAN_DISABLE_COLOR_OUTPUT=1.

--- a/src/Phan/IssueInstance.php
+++ b/src/Phan/IssueInstance.php
@@ -162,6 +162,14 @@ class IssueInstance
         return $this->file;
     }
 
+    public function getDisplayedFile() : string
+    {
+        if (Config::getValue('absolute_path_issue_messages')) {
+            return Config::projectPath($this->file);
+        }
+        return $this->file;
+    }
+
     public function getLine() : int
     {
         return $this->line;

--- a/src/Phan/Output/Printer/CSVPrinter.php
+++ b/src/Phan/Output/Printer/CSVPrinter.php
@@ -23,7 +23,7 @@ final class CSVPrinter implements BufferedPrinterInterface
     public function print(IssueInstance $instance) : void
     {
         \fputcsv($this->stream, [
-            $instance->getFile(),
+            $instance->getDisplayedFile(),
             $instance->getLine(),
             $instance->getIssue()->getSeverity(),
             $instance->getIssue()->getSeverityName(),

--- a/src/Phan/Output/Printer/CheckstylePrinter.php
+++ b/src/Phan/Output/Printer/CheckstylePrinter.php
@@ -21,12 +21,13 @@ final class CheckstylePrinter implements BufferedPrinterInterface
 
     public function print(IssueInstance $instance) : void
     {
-        if (!isset($this->files[$instance->getFile()])) {
-            $this->files[$instance->getFile()] = [];
+        $file = $instance->getDisplayedFile();
+        if (!isset($this->files[$file])) {
+            $this->files[$file] = [];
         }
 
         // Group issues by file
-        $this->files[$instance->getFile()][] = [
+        $this->files[$file][] = [
             'line' => $instance->getLine(),
             'source' => $instance->getIssue()->getType(),
             'message' => $instance->getMessageAndMaybeSuggestion(),

--- a/src/Phan/Output/Printer/CodeClimatePrinter.php
+++ b/src/Phan/Output/Printer/CodeClimatePrinter.php
@@ -33,6 +33,7 @@ final class CodeClimatePrinter implements BufferedPrinterInterface
             'categories' => ['Bug Risk'],
             'severity' => self::mapSeverity($instance->getIssue()->getSeverity()),
             'location' => [
+                // XXX this puts the docker volume in /code/ when running on codeclimate.
                 'path' => \preg_replace('/^\/code\//', '', $instance->getFile()),
                 'lines' => [
                     'begin' => $instance->getLine(),

--- a/src/Phan/Output/Printer/FilteringPrinter.php
+++ b/src/Phan/Output/Printer/FilteringPrinter.php
@@ -48,7 +48,7 @@ final class FilteringPrinter implements BufferedPrinterInterface
      */
     public function print(IssueInstance $instance) : void
     {
-        $file = $instance->getFile();
+        $file = $instance->getDisplayedFile();
         if (!isset($this->file_set[self::normalize($file)])) {
             return;
         }

--- a/src/Phan/Output/Printer/JSONPrinter.php
+++ b/src/Phan/Output/Printer/JSONPrinter.php
@@ -34,7 +34,7 @@ final class JSONPrinter implements BufferedPrinterInterface
                 $instance->getMessage(),  // suggestion included separately
             'severity' => $issue->getSeverity(),
             'location' => [
-                'path' => \preg_replace('/^\/code\//', '', $instance->getFile()),
+                'path' => $instance->getDisplayedFile(),
                 'lines' => [
                     'begin' => $instance->getLine(),
                     'end' => $instance->getLine(),

--- a/src/Phan/Output/Printer/PlainTextPrinter.php
+++ b/src/Phan/Output/Printer/PlainTextPrinter.php
@@ -22,7 +22,7 @@ final class PlainTextPrinter implements IssuePrinterInterface
 
     public function print(IssueInstance $instance) : void
     {
-        $file    = $instance->getFile();
+        $file    = $instance->getDisplayedFile();
         $line    = $instance->getLine();
         $issue   = $instance->getIssue();
         $type    = $issue->getType();

--- a/src/Phan/Output/Printer/PylintPrinter.php
+++ b/src/Phan/Output/Printer/PylintPrinter.php
@@ -24,7 +24,7 @@ final class PylintPrinter implements IssuePrinterInterface
         );
         $line = \sprintf(
             "%s:%d: [%s] %s",
-            $instance->getFile(),
+            $instance->getDisplayedFile(),
             $instance->getLine(),
             self::getSeverityCode($instance),
             $message


### PR DESCRIPTION
This is useful when the tooling used with Phan expects absolute paths in
its input.

Fixes #1640