### PR TITLE
Warn about `null['offset']`, handle empty array property

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@ New features(Analysis):
 + Infer union type from all classes that an instance method could possibly be, not just the first type seen in the expression's union type. (#2988)
 + Preserve remaining real union types after negation of `instanceof` checks (e.g. to check for redundant conditions).
 + Warn about throwing from `__toString()` in php versions prior to php 7.4. (#2805)
++ Emit `PhanTypeArraySuspiciousNull` for code such as `null['foo']` (#2965)
++ If a property with no phpdoc type has a default of an empty array, assume that it's type can be any array (when reading it) until the first assignment is seen.
 
 Plugins:
 + Properly warn about redundant `@return` annotations followed by other annotation lines in `PHPDocRedundantPlugin`.

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -519,6 +519,22 @@ Return type '{TYPE}' means the absence of a return value starting in PHP 7.1. In
 
 e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/php70_files/expected/004_void.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/2.0.0/tests/php70_files/src/004_void.php#L4).
 
+## PhanThrowCommentInToString
+
+```
+{FUNCTIONLIKE} documents that it throws {TYPE}, but throwing in __toString() is a fatal error prior to PHP 7.4
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/plugin_test/expected/133_throw_in_to_string.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/plugin_test/src/133_throw_in_to_string.php#L6).
+
+## PhanThrowStatementInToString
+
+```
+{FUNCTIONLIKE} throws {TYPE} here, but throwing in __toString() is a fatal error prior to PHP 7.4
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/plugin_test/expected/133_throw_in_to_string.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/plugin_test/src/133_throw_in_to_string.php#L7).
+
 # Context
 
 This category of issue is for when you're doing stuff out of the context in which you're allowed to do it, e.g. referencing `self` or `parent` when not in a class, interface or trait.
@@ -2231,6 +2247,14 @@ This issue will be emitted for the following code
 ```php
 $a = false; if($a[1]) {}
 ```
+
+## PhanTypeArraySuspiciousNull
+
+```
+Suspicious array access to null
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0739_access_null.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0739_access_null.php#L5).
 
 ## PhanTypeArraySuspiciousNullable
 

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -82,16 +82,17 @@ class Issue
     const InvalidFQSENInClasslike     = 'PhanInvalidFQSENInClasslike';
 
     // Issue::CATEGORY_TYPE
-    const NonClassMethodCall        = 'PhanNonClassMethodCall';
-    const PossiblyNonClassMethodCall = 'PhanPossiblyNonClassMethodCall';
-    const TypeArrayOperator         = 'PhanTypeArrayOperator';
-    const TypeInvalidBitwiseBinaryOperator = 'PhanTypeInvalidBitwiseBinaryOperator';
+    const NonClassMethodCall                = 'PhanNonClassMethodCall';
+    const PossiblyNonClassMethodCall        = 'PhanPossiblyNonClassMethodCall';
+    const TypeArrayOperator                 = 'PhanTypeArrayOperator';
+    const TypeInvalidBitwiseBinaryOperator  = 'PhanTypeInvalidBitwiseBinaryOperator';
     const TypeMismatchBitwiseBinaryOperands = 'PhanTypeMismatchBitwiseBinaryOperands';
-    const TypeArraySuspicious       = 'PhanTypeArraySuspicious';
-    const TypeArrayUnsetSuspicious  = 'PhanTypeArrayUnsetSuspicious';
-    const TypeArraySuspiciousNullable = 'PhanTypeArraySuspiciousNullable';
-    const TypeSuspiciousIndirectVariable = 'PhanTypeSuspiciousIndirectVariable';
-    const TypeObjectUnsetDeclaredProperty  = 'PhanTypeObjectUnsetDeclaredProperty';
+    const TypeArraySuspicious               = 'PhanTypeArraySuspicious';
+    const TypeArrayUnsetSuspicious          = 'PhanTypeArrayUnsetSuspicious';
+    const TypeArraySuspiciousNullable       = 'PhanTypeArraySuspiciousNullable';
+    const TypeArraySuspiciousNull           = 'PhanTypeArraySuspiciousNull';
+    const TypeSuspiciousIndirectVariable    = 'PhanTypeSuspiciousIndirectVariable';
+    const TypeObjectUnsetDeclaredProperty   = 'PhanTypeObjectUnsetDeclaredProperty';
     const TypeComparisonFromArray   = 'PhanTypeComparisonFromArray';
     const TypeComparisonToArray     = 'PhanTypeComparisonToArray';
     const TypeConversionFromArray   = 'PhanTypeConversionFromArray';
@@ -1813,6 +1814,14 @@ class Issue
                 "Suspicious array access to nullable {TYPE}",
                 self::REMEDIATION_B,
                 10045
+            ),
+            new Issue(
+                self::TypeArraySuspiciousNull,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                "Suspicious array access to null",
+                self::REMEDIATION_B,
+                10136
             ),
             new Issue(
                 self::TypeInvalidDimOffset,

--- a/src/Phan/Language/Element/Property.php
+++ b/src/Phan/Language/Element/Property.php
@@ -37,6 +37,11 @@ class Property extends ClassElement
     private $real_union_type;
 
     /**
+     * @var ?UnionType the phpdoc union type
+     */
+    private $phpdoc_union_type;
+
+    /**
      * @param Context $context
      * The context in which the structural element lives
      *
@@ -451,5 +456,15 @@ class Property extends ClassElement
         }
 
         return $union_type;
+    }
+
+    public function setPHPDocUnionType(UnionType $type) : void
+    {
+        $this->phpdoc_union_type = $type;
+    }
+
+    public function getPHPDocUnionType() : UnionType
+    {
+        return $this->phpdoc_union_type ?? UnionType::empty();
     }
 }

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -1446,4 +1446,9 @@ final class EmptyUnionType extends UnionType
     {
         return true;
     }
+
+    public function isEmptyArrayShape() : bool
+    {
+        return false;
+    }
 }

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -4584,6 +4584,19 @@ class UnionType implements Serializable
         }
         return \count($this->type_set) === 0;
     }
+
+    /**
+     * Returns true if this is the empty array shape (or the nullable version of it)
+     */
+    public function isEmptyArrayShape() : bool
+    {
+        foreach ($this->type_set as $type) {
+            if (!($type instanceof ArrayShapeType) || $type->isNotEmptyArrayShape()) {
+                return false;
+            }
+        }
+        return \count($this->type_set) !== 0;
+    }
 }
 
 UnionType::init();

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -515,6 +515,9 @@ class ParseVisitor extends ScopeVisitor
                 $property_fqsen,
                 $real_union_type
             );
+            if ($variable) {
+                $property->setPHPDocUnionType($variable->getUnionType());
+            }
 
             $property->setPhanFlags($comment->getPhanFlagsForProperty());
             $property->setDocComment($doc_comment);

--- a/tests/files/expected/0146_array_concat.php.expected
+++ b/tests/files/expected/0146_array_concat.php.expected
@@ -1,4 +1,4 @@
 %s:5 PhanTypeMismatchArgument Argument 1 ($p) is array{0:1,1:2} but \f() takes int defined at %s:3
 %s:6 PhanTypeMismatchArgument Argument 1 ($p) is array{0:1,1:2} but \f() takes int defined at %s:3
-%s:16 PhanTypeMismatchArgument Argument 1 ($p) is array{} but \f() takes int defined at %s:3
+%s:16 PhanTypeMismatchArgument Argument 1 ($p) is array but \f() takes int defined at %s:3
 %s:17 PhanTypeMismatchArgument Argument 1 ($p) is array but \f() takes int defined at %s:3

--- a/tests/files/expected/0641_array_shape_offset.php.expected
+++ b/tests/files/expected/0641_array_shape_offset.php.expected
@@ -1,7 +1,6 @@
+%s:8 PhanTypeMismatchArgumentInternal Argument 1 ($string) is array but \strlen() takes string
 %s:8 PhanTypeMismatchArgumentInternal Argument 1 ($string) is array<string,array{mode:'Foo'}>[]|array{} but \strlen() takes string
-%s:8 PhanTypeMismatchArgumentInternal Argument 1 ($string) is array{} but \strlen() takes string
 %s:9 PhanTypeInvalidDimOffset Invalid offset "class" of array type array{mode:'Foo'}
-%s:9 PhanTypeInvalidDimOffset Invalid offset 0 of array type array{}
 %s:10 PhanNonClassMethodCall Call to method __construct on non-class type null
 %s:10 PhanTypeExpectedObjectOrClassName Expected an object instance or the name of a class but saw expression with type null
 %s:10 PhanUnusedVariable Unused definition of variable $test

--- a/tests/files/expected/0642_additional_class_failure.php.expected
+++ b/tests/files/expected/0642_additional_class_failure.php.expected
@@ -1,5 +1,4 @@
 %s:8 PhanTypeInvalidDimOffset Invalid offset "class" of array type array{mode:'Foo'}|string
-%s:8 PhanTypeInvalidDimOffset Invalid offset 0 of array type array{}
 %s:9 PhanNonClassMethodCall Call to method __construct on non-class type null
 %s:9 PhanTypeExpectedObjectOrClassName Expected an object instance or the name of a class but saw expression with type null
 %s:9 PhanUnusedVariable Unused definition of variable $test

--- a/tests/files/expected/0739_access_null.php.expected
+++ b/tests/files/expected/0739_access_null.php.expected
@@ -1,0 +1,5 @@
+%s:3 PhanTypeArraySuspiciousNullable Suspicious array access to nullable ?array
+%s:5 PhanTypeArraySuspiciousNull Suspicious array access to null
+%s:5 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is null but \intdiv() takes int
+%s:6 PhanTypeArraySuspiciousNull Suspicious array access to null
+%s:8 PhanTypeArraySuspicious Suspicious array access to null

--- a/tests/files/src/0642_additional_class_failure.php
+++ b/tests/files/src/0642_additional_class_failure.php
@@ -5,7 +5,7 @@ abstract class PhanUndeclaredClassFailureString
     private $fields = array();
     public function set($data, $value = null)
     {
-        $class = $this->fields[0]['opt']['class'];
+        $class = $this->fields[0]['opt']['class'];  // infers that $this->fields (empty array with no phpdoc) can be any array until an assignment is analyzed.
         $test = new $class();
     }
 

--- a/tests/files/src/0739_access_null.php
+++ b/tests/files/src/0739_access_null.php
@@ -1,0 +1,9 @@
+<?php
+function test739(?array $a)  {
+    var_export($a['field']);
+    $nil = null;
+    echo intdiv(null['field'], 2);
+    var_export($nil['field']);
+    $nil = null;
+    $nil['field'] = 2;
+}


### PR DESCRIPTION
Also, if a property has no phpdoc type and its default is the empty array,
then assume that it can have any type until the first assignment is seen.

Fixes #2965