### PR TITLE
Treat Foo::class as a reference to class foo.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,9 @@ New features(Analysis):
 Plugins:
 + Properly warn about redundant `@return` annotations followed by other annotation lines in `PHPDocRedundantPlugin`.
 
+Bug fixes:
++ Treat `Foo::class` as a reference to the class/interface/trait `Foo` (#2945)
+
 Jul 17 2019, Phan 2.2.6
 -----------------------
 

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -1169,11 +1169,13 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
     public function visitClassName(Node $node) : Context
     {
         try {
-            (new ContextNode(
+            foreach ((new ContextNode(
                 $this->code_base,
                 $this->context,
                 $node->children['class']
-            ))->getClassList(false, ContextNode::CLASS_LIST_ACCEPT_OBJECT_OR_CLASS_NAME);
+            ))->getClassList(false, ContextNode::CLASS_LIST_ACCEPT_OBJECT_OR_CLASS_NAME) as $class) {
+                $class->addReference($this->context);
+            }
         } catch (CodeBaseException $exception) {
             $exception_fqsen = $exception->getFQSEN();
             $this->emitIssueWithSuggestion(

--- a/tests/plugin_test/expected/134_class_reference.php.expected
+++ b/tests/plugin_test/expected/134_class_reference.php.expected
@@ -1,0 +1,1 @@
+src/134_class_reference.php:4 PhanUnreferencedClass Possibly zero references to class \X\Y\Z\Other

--- a/tests/plugin_test/src/134_class_reference.php
+++ b/tests/plugin_test/src/134_class_reference.php
@@ -1,0 +1,10 @@
+<?php
+namespace X\Y\Z;
+class Foo{}
+class Other{}
+
+namespace A\B\C;
+use X\Y\Z\Foo;
+// Unconditionally treat Foo::class (ast\AST_CLASS_NAME) as a reference to that class,
+// in the same way using a constant from that class (ast\AST_CLASS_CONST) would count as a reference.
+$something = Foo::class;


### PR DESCRIPTION
Fixes #2954