### PR TITLE
Properly print progress bar for parallel analysis

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@ New features(CLI, Configs):
   `hide_issue_column` can be used to remove the column from issue messages.
 + Add `--absolute-path-issue-messages` to emit absolute paths instead of relative paths for the file of an issue. (#1640)
   Note that this does not affect files within the issue message.
++ Properly render the progress bar when Phan runs with multiple processes (#2928)
 
 New features(Analysis):
 + Fix failure to infer real types when an invoked function or method had a phpdoc `@return` in addition to the real type.

--- a/internal/CLI-HELP.md
+++ b/internal/CLI-HELP.md
@@ -257,6 +257,10 @@ Extended help:
  --markdown-issue-messages
   Emit issue messages with markdown formatting.
 
+ --absolute-path-issue-messages
+  Emit issues with their absolute paths instead of relative paths.
+  This does not affect files mentioned within the issue.
+
  --constant-variable-detection
   Emit issues for variables that could be replaced with literals or constants.
   (i.e. they are declared once (as a constant expression) and never modified).

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -845,7 +845,7 @@ class ConditionVisitor extends KindVisitorImplementation implements ConditionVis
                 }
                 return $this->context;
             }
-            // @phan-suppress-next-line PhanPartialTypeMismatchArgument
+            // @phan-suppress-next-line PhanPartialTypeMismatchArgument, PhanTypeMismatchArgumentNullable
             return $this->modifyComplexExpression($first_arg, $type_modification_callback, $this->context, $args);
         }
 

--- a/src/Phan/ForkPool.php
+++ b/src/Phan/ForkPool.php
@@ -5,11 +5,13 @@ namespace Phan;
 use AssertionError;
 use Closure;
 use InvalidArgumentException;
+use Phan\ForkPool\Progress;
+use Phan\ForkPool\Reader;
+use Phan\ForkPool\Writer;
 
 use function count;
-use function gettype;
 use function intval;
-use function strlen;
+use function unserialize;
 
 use const EXIT_FAILURE;
 use const EXIT_SUCCESS;
@@ -17,6 +19,8 @@ use const EXIT_SUCCESS;
 /**
  * Fork off to n-processes and divide up tasks between
  * each process.
+ *
+ * @internal
  */
 class ForkPool
 {
@@ -27,25 +31,75 @@ class ForkPool
     /** @var array<int,resource> a list of read strings for $this->child_pid_list */
     private $read_streams = [];
 
+    /** @var array<int,Reader> a list of Readers for $this->child_pid_list */
+    private $readers = [];
+
+    /** @var array<int,Progress> a map from workers to their progress */
+    private $progress = [];
+
+    /** @var array<int,IssueInstance> the combination of issues emitted by all workers */
+    private $issues = [];
+
     /** @var bool did any of the child processes fail (e.g. crash or send data that couldn't be unserialized) */
     private $did_have_error = false;
+
+    private function updateProgress(int $i, Progress $progress) : void
+    {
+        // fwrite(STDERR, "Received progress from $i " . json_encode($progress) . "\n");
+        $this->progress[$i] = $progress;
+
+        static $previous_update_time = 0.0;
+        $time = \microtime(true);
+
+        // If not enough time has elapsed, then don't update the progress bar.
+        // Making the update frequency based on time (instead of the number of files)
+        // prevents the terminal from rapidly flickering while processing small files.
+        $interval = Config::getValue('progress_bar_sample_interval');
+        if ($time - $previous_update_time < $interval) {
+            // Make sure to output 100%, to avoid confusion.
+            // https://github.com/phan/phan/issues/2694
+            if ($progress->progress < 1.0) {
+                return;
+            }
+        }
+        if ($previous_update_time) {
+            $previous_update_time += $interval;
+        } else {
+            $previous_update_time = $time;
+        }
+        $this->renderAggregateProgress();
+    }
+
+    private function renderAggregateProgress() : void
+    {
+        $total_progress = 0.0;
+        $total_cur_mem = 0.0;
+        $total_max_mem = 0.0;
+        foreach ($this->progress as $progress) {
+            $total_progress += $progress->progress;
+            $total_cur_mem += $progress->cur_mem / 1024 / 1024;
+            $total_max_mem += $progress->max_mem / 1024 / 1024;
+        }
+        CLI::outputProgressLine('analysis', $total_progress / count($this->progress), $total_cur_mem, $total_max_mem);
+    }
 
     /**
      * @param array<int,array> $process_task_data_iterator
      * An array of task data items to be divided up among the
      * workers. The size of this is the number of forked processes.
      *
-     * @param Closure $startup_closure
+     * @param Closure():void $startup_closure
      * A closure to execute upon starting a child
      *
-     * @param Closure $task_closure
+     * @param Closure(int,mixed,int) $task_closure
      * A method to execute on each task data.
      * This closure must return an array (to be gathered).
      *
-     * @param Closure $shutdown_closure
+     * @param Closure():array $shutdown_closure
      * A closure to execute upon shutting down a child
      * @throws InvalidArgumentException if count($process_task_data_iterator) < 2
      * @throws AssertionError if pcntl is disabled before using this
+     * @suppress PhanAccessMethodInternal
      */
     public function __construct(
         array $process_task_data_iterator,
@@ -68,6 +122,8 @@ class ForkPool
         // so that we can tell who will be doing the waiting
         $is_parent = false;
 
+        $progress = new Progress(0.0);
+
         // Fork as many times as requested to get the given
         // pool size
         for ($proc_id = 0; $proc_id < $pool_size; $proc_id++) {
@@ -89,7 +145,24 @@ class ForkPool
             if ($pid > 0) {
                 $is_parent = true;
                 $this->child_pid_list[] = $pid;
-                $this->read_streams[] = self::streamForParent($sockets);
+                $read_stream = self::streamForParent($sockets);
+                $i = \count($this->progress);
+                $this->progress[] = $progress;
+                $this->read_streams[] = $read_stream;
+                $this->readers[intval($read_stream)] = new Reader($read_stream, function (string $notification_type, string $payload) use ($i) : void {
+                    switch ($notification_type) {
+                        case Writer::TYPE_PROGRESS:
+                            $progress = unserialize($payload);
+                            $this->updateProgress($i, $progress);
+                            break;
+                        case Writer::TYPE_ISSUE_LIST:
+                            $issues = unserialize($payload);
+                            if ($issues) {
+                                \array_push($this->issues, ...$issues);
+                            }
+                            break;
+                    }
+                });
                 continue;
             }
 
@@ -107,6 +180,7 @@ class ForkPool
 
         // Get the write stream for the child.
         $write_stream = self::streamForChild($sockets);
+        Writer::initialize($write_stream);
 
         // Execute anything the children wanted to execute upon
         // starting up
@@ -114,8 +188,9 @@ class ForkPool
 
         // Get the work for this process
         $task_data_iterator = \array_values($process_task_data_iterator)[$proc_id];
+        $task_count = \count($task_data_iterator);
         foreach ($task_data_iterator as $i => $task_data) {
-            $task_closure($i, $task_data);
+            $task_closure($i, $task_data, $task_count);
         }
 
         // Execute each child's shutdown closure before
@@ -123,7 +198,7 @@ class ForkPool
         $results = $shutdown_closure();
 
         // Serialize this child's produced results and send them to the parent.
-        \fwrite($write_stream, \serialize($results ?: []));
+        Writer::emitIssues($results ?: []);
 
         \fclose($write_stream);
 
@@ -178,7 +253,8 @@ class ForkPool
      * The results are returned in an array, one for each worker. The order of the results
      * is not maintained.
      *
-     * @return array[]
+     * @return array<int,IssueInstance>
+     * @suppress PhanAccessMethodInternal
      */
     private function readResultsFromChildren() : array
     {
@@ -188,10 +264,6 @@ class ForkPool
         foreach ($this->read_streams as $stream) {
             $streams[intval($stream)] = $stream;
         }
-
-        // Create an array for the content received on each stream,
-        // indexed by resource id.
-        $content = \array_fill_keys(\array_keys($streams), '');
 
         // Read the data off of all the stream.
         while (count($streams) > 0) {
@@ -207,42 +279,45 @@ class ForkPool
             }
 
             // For each stream that was ready, read the content.
+            foreach ($this->readers as $reader) {
+                $reader->readMessages();
+            }
             foreach ($needs_read as $file) {
-                $buffer = \fread($file, 1024);
-                if ($buffer === false) {
-                    \error_log("unable to read from stream of worker process");
-                    exit(EXIT_FAILURE);
-                }
-                if (strlen($buffer) > 0) {
-                    $content[intval($file)] .= $buffer;
-                }
-
-                // If the stream has closed, stop trying to select on it.
                 if (\feof($file)) {
                     \fclose($file);
-                    unset($streams[intval($file)]);
+                    $idx = intval($file);
+                    unset($streams[$idx]);
                 }
             }
         }
+        $this->assertAnalysisWorkersExitedNormally();
 
-        // Unmarshal the content into its original form.
-        /**
-         * @param string $data
-         * @return mixed[]
-         */
-        return \array_values(\array_map(function (string $data) : array {
-            $result = \unserialize($data);
-            if (!\is_array($result)) {
-                \error_log("Child terminated without returning a serialized array (threw or crashed - not enough memory?): response type=" . gettype($result));
-                $this->did_have_error = true;
+        return $this->issues;
+    }
+
+    /**
+     * Exit with a non-zero exit code if any of the workers exited without sending a valid response.
+     * @suppress PhanAccessMethodInternal
+     */
+    private function assertAnalysisWorkersExitedNormally() : void
+    {
+        // Verify that the readers worked.
+        $saw_errors = false;
+        foreach ($this->readers as $reader) {
+            $errors = $reader->computeErrorsAfterRead();
+            if ($errors) {
+                \fwrite(\STDERR, "Saw errors for an analysis worker:\n" . $errors);
+                $saw_errors = true;
             }
-            return $result;
-        }, $content));
+        }
+        if ($saw_errors) {
+            exit(EXIT_FAILURE);
+        }
     }
 
     /**
      * Wait for all child processes to complete
-     * @return array[]
+     * @return array<int,IssueInstance>
      */
     public function wait() : array
     {

--- a/src/Phan/ForkPool/Progress.php
+++ b/src/Phan/ForkPool/Progress.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Phan\ForkPool;
+
+/**
+ * Represents the current progress of a forked analysis worker.
+ */
+class Progress
+{
+    /** @var float the fraction of progress made by this worker (0..1) */
+    public $progress;
+
+    /** @var int the current memory usage of this worker, in bytes. The total gets overestimated because summing doesn't account for memory sharing. */
+    public $cur_mem;
+
+    /** @var int the maximum memory usage of this worker, in bytes. The total gets overestimated because summing doesn't account for memory sharing. */
+    public $max_mem;
+
+    public function __construct(float $progress)
+    {
+        $this->progress = $progress;
+        $this->cur_mem = \memory_get_usage();
+        $this->max_mem = \memory_get_peak_usage();
+    }
+}

--- a/src/Phan/ForkPool/Reader.php
+++ b/src/Phan/ForkPool/Reader.php
@@ -1,0 +1,125 @@
+<?php declare(strict_types=1);
+
+namespace Phan\ForkPool;
+
+use Closure;
+use TypeError;
+
+/**
+ * This reads messages from a forked worker.
+ * This reuses code from ProtocolStreamReader.
+ *
+ * This is designed to accept notifications in a similar format to JSON-RPC (arbitrarily).
+ * @internal
+ */
+class Reader
+{
+    const PARSE_HEADERS = 1;
+    const PARSE_BODY = 2;
+
+    /** @var resource */
+    private $input;
+
+    /** @var string the bytes read from the worker */
+    private $buffer = '';
+
+    /** @var 1|2 either PARSE_HEADERS or PARSE_BODY */
+    private $parsing_mode = self::PARSE_HEADERS;
+
+    /** @var int the length of the body of the next notification. */
+    private $content_length;
+
+    /** @var string the type of the next notification. */
+    private $notification_type;
+
+    /** @var array<string,string> the JSON-RPC headers. Currently just Content-Length. */
+    private $headers;
+
+    /** @var Closure(string,string):void $notification_handler */
+    private $notification_handler;
+
+    /** @var array<string,int> $read_messages the count of read messages of each type */
+    private $read_messages = [];
+
+    /** @var bool was the end of the input stream reached */
+    private $eof = false;
+
+    /**
+     * @param resource $input
+     * @param Closure(string,string):void $notification_handler
+     */
+    public function __construct($input, Closure $notification_handler)
+    {
+        if (!\is_resource($input)) {
+            throw new TypeError('Expected resource for $input, got ' . \gettype($input));
+        }
+        $this->input = $input;
+        $this->notification_handler = $notification_handler;
+    }
+
+    /**
+     * Read serialized messages from the analysis workers
+     */
+    public function readMessages() : void
+    {
+        if ($this->eof) {
+            return;
+        }
+        while (($c = \fgetc($this->input)) !== false && $c !== '') {
+            $this->buffer .= $c;
+            switch ($this->parsing_mode) {
+                case self::PARSE_HEADERS:
+                    if ($this->buffer === "\r\n") {
+                        $this->parsing_mode = self::PARSE_BODY;
+                        $this->content_length = (int)$this->headers['Content-Length'];
+                        $this->notification_type = $this->headers['Notification-Type'] ?? 'unknown';
+                        $this->buffer = '';
+                    } elseif (\substr($this->buffer, -2) === "\r\n") {
+                        $parts = \explode(':', $this->buffer);
+                        $this->headers[$parts[0]] = \trim($parts[1]);
+                        $this->buffer = '';
+                    }
+                    break;
+                case self::PARSE_BODY:
+                    if (\strlen($this->buffer) < $this->content_length) {
+                        // We know the number of remaining bytes to read - try to read them all at once.
+                        $buf = \fread($this->input, $this->content_length - \strlen($this->buffer));
+                        if (\is_string($buf) && \strlen($buf) > 0) {
+                            $this->buffer .= $buf;
+                        }
+                    }
+                    if (\strlen($this->buffer) === $this->content_length) {
+                        $this->read_messages[$this->notification_type] = ($this->read_messages[$this->notification_type] ?? 0) + 1;
+                        ($this->notification_handler)($this->notification_type, $this->buffer);
+                        $this->parsing_mode = self::PARSE_HEADERS;
+                        $this->headers = [];
+                        $this->buffer = '';
+                    }
+                    break;
+            }
+        }
+        $this->eof = \feof($this->input);
+    }
+
+    /**
+     * Returns an error message for errors caused by an analysis worker exiting abnormally or sending invalid data.
+     * During normal operation, should return null.
+     */
+    public function computeErrorsAfterRead() : ?string
+    {
+        $error = "";
+        if ($this->buffer) {
+            $error .= \sprintf("Saw non-empty buffer of length %d\n", \strlen($this->buffer));
+        }
+        if ($this->parsing_mode !== self::PARSE_HEADERS) {
+            $error .= "Expected to be finished parsing the last message body\n";
+        }
+        if (!$this->eof) {
+            $error .= "Expected to reach eof\n";
+        }
+        if (!isset($this->read_messages[Writer::TYPE_ISSUE_LIST])) {
+            $error .= "Expected to have received a list of 0 or more issues (as the last notification)\n";
+        }
+        return $error ?: null;
+    }
+}

--- a/src/Phan/ForkPool/Writer.php
+++ b/src/Phan/ForkPool/Writer.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types=1);
+
+namespace Phan\ForkPool;
+
+use Error;
+use Phan\IssueInstance;
+use TypeError;
+
+/**
+ * This writes messages from a forked worker.
+ * This reuses code from ProtocolStreamReader.
+ *
+ * This is designed to accept notifications in the same format as JSON-RPC (arbitrarily).
+ */
+class Writer
+{
+    const TYPE_ISSUE_LIST = 'issue-list';
+    const TYPE_PROGRESS   = 'progress';
+
+    /** @var resource */
+    private static $output;
+
+
+    /**
+     * Initializes the stream writer for the forked analysis worker
+     * @param resource $output
+     */
+    public static function initialize($output) : void
+    {
+        if (!\is_resource($output)) {
+            throw new TypeError('Expected resource for $output, got ' . \gettype($output));
+        }
+        self::$output = $output;
+    }
+
+    /**
+     * Returns true if this is the forked analysis worker
+     */
+    public static function isForkPoolWorker() : bool
+    {
+        return \is_resource(self::$output);
+    }
+
+    /**
+     * Report the filtered issues seen by this analysis worker.
+     * @param array<int,IssueInstance> $issues
+     */
+    public static function emitIssues(array $issues) : void
+    {
+        self::writeNotification(self::TYPE_ISSUE_LIST, \serialize($issues));
+    }
+
+    /**
+     * Report the analysis progress
+     * @param float $percent
+     */
+    public static function recordProgress(float $percent) : void
+    {
+        self::writeNotification(self::TYPE_PROGRESS, \serialize(new Progress($percent)));
+    }
+
+    /**
+     * @suppress PhanThrowTypeAbsent
+     */
+    private static function writeNotification(string $type, string $payload) : void
+    {
+        if (!\is_resource(self::$output)) {
+            throw new Error('Attempted to writeNotification before calling Writer::initialize');
+        }
+
+        \fwrite(self::$output, \sprintf("Content-Length: %d\r\nNotification-Type: %s\r\n\r\n%s", \strlen($payload), $type, $payload));
+    }
+}

--- a/src/Phan/LanguageServer/ProtocolStreamReader.php
+++ b/src/Phan/LanguageServer/ProtocolStreamReader.php
@@ -85,6 +85,13 @@ class ProtocolStreamReader extends Emitter implements ProtocolReader
                     }
                     break;
                 case self::PARSE_BODY:
+                    if (\strlen($this->buffer) < $this->content_length) {
+                        // We know the number of remaining bytes to read - try to read them all at once.
+                        $buf = \fread($this->input, $this->content_length - \strlen($this->buffer));
+                        if (\is_string($buf) && \strlen($buf) > 0) {
+                            $this->buffer .= $buf;
+                        }
+                    }
                     if (\strlen($this->buffer) === $this->content_length) {
                         if (!$this->is_accepting_new_requests) {
                             // If we fork, don't read any bytes in the input buffer from the worker process.

--- a/src/Phan/Phan.php
+++ b/src/Phan/Phan.php
@@ -89,19 +89,13 @@ class Phan implements IgnoredFilesFilterInterface
      * Take an array of serialized issues, unserialize them and then add
      * them to the issue collector.
      *
-     * @param IssueInstance[][] $results
+     * @param array<int,IssueInstance> $issues
      */
-    private static function collectSerializedResults(array $results) : void
+    private static function collectSerializedResults(array $issues) : void
     {
         $collector = self::getIssueCollector();
-        foreach ($results as $issues) {
-            if (!$issues) {
-                continue;
-            }
-
-            foreach ($issues as $issue) {
-                $collector->collectIssue($issue);
-            }
+        foreach ($issues as $issue) {
+            $collector->collectIssue($issue);
         }
     }
 
@@ -404,7 +398,7 @@ class Phan implements IgnoredFilesFilterInterface
             /**
              * This worker takes a file and analyzes it
              */
-            $analysis_worker = static function (int $i, string $file_path) use ($file_count, $code_base, $temporary_file_mapping, $request) : void {
+            $analysis_worker = static function (int $i, string $file_path, int $file_count) use ($code_base, $temporary_file_mapping, $request) : void {
                 CLI::progress('analyze', ($i + 1) / $file_count, $file_path);
                 Analysis::analyzeFile($code_base, $file_path, $request, $temporary_file_mapping[$file_path] ?? null);
             };
@@ -459,7 +453,7 @@ class Phan implements IgnoredFilesFilterInterface
                 // If we're not running as multiple processes, just iterate
                 // over the file list and analyze them
                 foreach ($analyze_file_path_list as $i => $file_path) {
-                    $analysis_worker($i, $file_path);
+                    $analysis_worker($i, $file_path, $file_count);
                 }
 
                 // Scan through all globally accessible elements


### PR DESCRIPTION
Make the original process read the progress updates from the workers
and print summaries to stderr.

Previously, the workers just printed conflicting progress updates to
STDERR.

Fixes #2928

Update NEWS.