### PR TITLE
Part II: Emit a different issue type for undeclared variables in the global scope

### DIFF
--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -1081,14 +1081,8 @@ class ContextNode
                 );
             }
 
-            if ($variable_name === 'this') {
-                $issue_type = Issue::UndeclaredThis;
-            } else {
-                $issue_type = $this->context->isInGlobalScope() ? Issue::UndeclaredGlobalVariable : Issue::UndeclaredVariable;
-            }
-
             throw new IssueException(
-                Issue::fromType($issue_type)(
+                Issue::fromType(Variable::chooseIssueForUndeclaredVariable($this->context, $variable_name))(
                     $this->context->getFile(),
                     $node->lineno,
                     [ $variable_name ],
@@ -1145,14 +1139,8 @@ class ContextNode
                     );
                 }
 
-                if ($variable_name === 'this') {
-                    $issue_type = Issue::UndeclaredThis;
-                } else {
-                    $issue_type = $this->context->isInGlobalScope() ? Issue::UndeclaredGlobalVariable : Issue::UndeclaredVariable;
-                }
-
                 throw new IssueException(
-                    Issue::fromType($issue_type)(
+                    Issue::fromType(Variable::chooseIssueForUndeclaredVariable($this->context, $variable_name))(
                         $this->context->getFile(),
                         $node->lineno,
                         [ $variable_name ],

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1805,14 +1805,8 @@ class UnionTypeVisitor extends AnalysisVisitor
             }
 
             if (!($this->context->isInGlobalScope() && Config::getValue('ignore_undeclared_variables_in_global_scope'))) {
-                if ($variable_name === 'this') {
-                    $issue_type = Issue::UndeclaredThis;
-                } else {
-                    $issue_type = $this->context->isInGlobalScope() ? Issue::UndeclaredGlobalVariable : Issue::UndeclaredVariable;
-                }
-
                 throw new IssueException(
-                    Issue::fromType($issue_type)(
+                    Issue::fromType(Variable::chooseIssueForUndeclaredVariable($this->context, $variable_name))(
                         $this->context->getFile(),
                         $node->lineno,
                         [$variable_name],

--- a/src/Phan/Analysis/ConditionVisitorUtil.php
+++ b/src/Phan/Analysis/ConditionVisitorUtil.php
@@ -984,31 +984,25 @@ trait ConditionVisitorUtil
             return null;
         }
 
-        $var_name = (string)$var_name_node;
+        $variable_name = (string)$var_name_node;
 
-        if (!$context->getScope()->hasVariableWithName($var_name)) {
-            if (Variable::isHardcodedVariableInScopeWithName($var_name, $context->isInGlobalScope())) {
+        if (!$context->getScope()->hasVariableWithName($variable_name)) {
+            if (Variable::isHardcodedVariableInScopeWithName($variable_name, $context->isInGlobalScope())) {
                 return null;
             }
             if (!($context->isInGlobalScope() && Config::getValue('ignore_undeclared_variables_in_global_scope'))) {
-                if ($var_name === 'this') {
-                    $issue_type = Issue::UndeclaredThis;
-                } else {
-                    $issue_type = $context->isInGlobalScope() ? Issue::UndeclaredGlobalVariable : Issue::UndeclaredVariable;
-                }
-
                 throw new IssueException(
-                    Issue::fromType($issue_type)(
+                    Issue::fromType(Variable::chooseIssueForUndeclaredVariable($context, $variable_name))(
                         $context->getFile(),
                         $var_node->lineno ?? 0,
-                        [$var_name],
-                        IssueFixSuggester::suggestVariableTypoFix($this->code_base, $context, $var_name)
+                        [$variable_name],
+                        IssueFixSuggester::suggestVariableTypoFix($this->code_base, $context, $variable_name)
                     )
                 );
             }
             $variable = new Variable(
                 $context,
-                $var_name,
+                $variable_name,
                 UnionType::empty(),
                 0
             );
@@ -1016,7 +1010,7 @@ trait ConditionVisitorUtil
             return $variable;
         }
         return $context->getScope()->getVariableByName(
-            $var_name
+            $variable_name
         );
     }
 

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -492,14 +492,8 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         if (!$this->context->getScope()->hasVariableWithName($variable_name)
             && !Variable::isHardcodedVariableInScopeWithName($variable_name, $this->context->isInGlobalScope())
         ) {
-            if ($variable_name === 'this') {
-                $issue_type = Issue::UndeclaredThis;
-            } else {
-                $issue_type = $this->context->isInGlobalScope() ? Issue::UndeclaredGlobalVariable : Issue::UndeclaredVariable;
-            }
-
             $this->emitIssueWithSuggestion(
-                $issue_type,
+                Variable::chooseIssueForUndeclaredVariable($this->context, $variable_name),
                 $node->lineno,
                 [$variable_name],
                 IssueFixSuggester::suggestVariableTypoFix($this->code_base, $this->context, $variable_name)

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -358,26 +358,26 @@ class BlockAnalysisVisitor extends AnalysisVisitor
     /**
      * @see ConditionVarUtil::getVariableFromScope()
      */
-    private static function createVarForInlineComment(CodeBase $code_base, Context $context, string $var_name, UnionType $type, bool $create_variable) : void
+    private static function createVarForInlineComment(CodeBase $code_base, Context $context, string $variable_name, UnionType $type, bool $create_variable) : void
     {
-        if (!$context->getScope()->hasVariableWithName($var_name)) {
-            if (Variable::isHardcodedVariableInScopeWithName($var_name, $context->isInGlobalScope())) {
+        if (!$context->getScope()->hasVariableWithName($variable_name)) {
+            if (Variable::isHardcodedVariableInScopeWithName($variable_name, $context->isInGlobalScope())) {
                 return;
             }
             if (!$create_variable && !($context->isInGlobalScope() && Config::getValue('ignore_undeclared_variables_in_global_scope'))) {
                 Issue::maybeEmitWithParameters(
                     $code_base,
                     $context,
-                    $context->isInGlobalScope() ? Issue::UndeclaredGlobalVariable : Issue::UndeclaredVariable,
+                    Variable::chooseIssueForUndeclaredVariable($context, $variable_name),
                     $context->getLineNumberStart(),
-                    [$var_name],
-                    IssueFixSuggester::suggestVariableTypoFix($code_base, $context, $var_name)
+                    [$variable_name],
+                    IssueFixSuggester::suggestVariableTypoFix($code_base, $context, $variable_name)
                 );
                 return;
             }
             $variable = new Variable(
                 $context,
-                $var_name,
+                $variable_name,
                 $type,
                 0
             );
@@ -385,7 +385,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
             return;
         }
         $variable = clone($context->getScope()->getVariableByName(
-            $var_name
+            $variable_name
         ));
         $variable->setUnionType($type);
         $context->addScopeVariable($variable);

--- a/src/Phan/Language/Element/Variable.php
+++ b/src/Phan/Language/Element/Variable.php
@@ -8,6 +8,7 @@ use Phan\AST\UnionTypeVisitor;
 use Phan\CodeBase;
 use Phan\Config;
 use Phan\Exception\IssueException;
+use Phan\Issue;
 use Phan\Language\Context;
 use Phan\Language\Type;
 use Phan\Language\UnionType;
@@ -258,5 +259,20 @@ class Variable extends UnaddressableTypedElement implements TypedElementInterfac
         }
 
         return "$string\${$this->getName()}";
+    }
+
+    /**
+     * Determine which issue type should be used when Phan finds an undefined var
+     *
+     * @param Context $context
+     * @param string $variable_name
+     */
+    public static function chooseIssueForUndeclaredVariable(Context $context, string $variable_name): string
+    {
+        if ($variable_name === 'this') {
+            return Issue::UndeclaredThis;
+        }
+
+        return $context->isInGlobalScope() ? Issue::UndeclaredGlobalVariable : Issue::UndeclaredVariable;
     }
 }

--- a/src/Phan/Plugin/Internal/CompactPlugin.php
+++ b/src/Phan/Plugin/Internal/CompactPlugin.php
@@ -11,6 +11,7 @@ use Phan\IssueFixSuggester;
 use Phan\Language\Context;
 use Phan\Language\Element\Func;
 use Phan\Language\Element\FunctionInterface;
+use Phan\Language\Element\Variable;
 use Phan\Plugin\Internal\VariableTracker\VariableTrackerVisitor;
 use Phan\PluginV3;
 use Phan\PluginV3\AnalyzeFunctionCallCapability;
@@ -57,7 +58,7 @@ final class CompactPlugin extends PluginV3 implements
                     Issue::maybeEmitWithParameters(
                         $code_base,
                         $context,
-                        $context->isInGlobalScope() ? Issue::UndeclaredGlobalVariable : Issue::UndeclaredVariable,
+                        Variable::chooseIssueForUndeclaredVariable($context, $variable_name),
                         $arg->lineno ?? $context->getLineNumberStart(),
                         [$variable_name],
                         IssueFixSuggester::suggestVariableTypoFix($code_base, $context, $variable_name)


### PR DESCRIPTION
Related to PR #3008 (Issue #1652)

@TysonAndre you were quick to merge it, here's the updated version with a method to fetch the issue type based on var name & context. Feel free to discard if you're ok with the way it's in the `master` now.