### PR TITLE
Improve typed property support, add warnings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,17 @@ Phan NEWS
 ??? ?? 2019, Phan 2.2.9 (dev)
 -----------------------
 
+New features(Analysis):
++ Support php 7.4 typed property groups in the polyfill/fallback parser.
++ Detect redundant conditions such as `is_array($this->array_prop)` on typed properties.
+  Their values will either be a value of the correct type, or unset. (Reading from unset properties will throw an Error at runtime)
++ Emit `PhanCompatibleTypedProperty` if the target php version is less than 7.4 but typed properties are used.
++ Emit `PhanTypeMismatchPropertyReal` instead of `PhanTypeMismatchProperty` if the properties have real types that are incompatible with the inferred type of the assignment.
++ Stop warning about `(float) $int` being redundant - there are small differences in how ints and floats are treated by `serialize`, `var_export`, `is_int`, etc.
+
+Bug fixes:
++ When a typed property has an incompatible default, don't infer the union type from the default. (#3024)
+
 Jul 30 2019, Phan 2.2.8
 -----------------------
 

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -516,6 +516,14 @@ Saw a notice while parsing with the native parser: {DETAILS}
 
 e.g. [this issue](https://github.com/phan/phan/tree/master/tests/php74_files/expected/012_real_cast.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/php74_files/src/012_real_cast.php#L2).
 
+## PhanCompatibleTypedProperty
+
+```
+Cannot use typed properties before php 7.4. This property group has type {TYPE}
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/php70_files/expected/011_typed_properties.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/php70_files/src/011_typed_properties.php#L4).
+
 ## PhanCompatibleUnparenthesizedTernary
 
 ```
@@ -2960,6 +2968,14 @@ This issue is emitted from the following code
 ```php
 function f(int $p = false) {}
 ```
+
+## PhanTypeMismatchPropertyReal
+
+```
+Assigning {TYPE} to property but {PROPERTY} is {TYPE}
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/php74_files/expected/014_real_type_mismatch.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/php74_files/src/014_real_type_mismatch.php#L9).
 
 ## PhanTypeMismatchReturn
 

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -522,7 +522,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/master/tests/php74_files/exp
 Cannot use typed properties before php 7.4. This property group has type {TYPE}
 ```
 
-e.g. [this issue](https://github.com/phan/phan/tree/master/tests/php70_files/expected/011_typed_properties.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/php70_files/src/011_typed_properties.php#L4).
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/php70_files/expected/011_typed_properties.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/php70_files/src/011_typed_properties.php#L3).
 
 ## PhanCompatibleUnparenthesizedTernary
 
@@ -2975,7 +2975,7 @@ function f(int $p = false) {}
 Assigning {TYPE} to property but {PROPERTY} is {TYPE}
 ```
 
-e.g. [this issue](https://github.com/phan/phan/tree/master/tests/php74_files/expected/014_real_type_mismatch.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/php74_files/src/014_real_type_mismatch.php#L9).
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/php70_files/expected/012_typed_properties_errors.php.expected#L11) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/php70_files/src/012_typed_properties_errors.php#L20).
 
 ## PhanTypeMismatchReturn
 

--- a/src/Phan/AST/ASTReverter.php
+++ b/src/Phan/AST/ASTReverter.php
@@ -111,6 +111,15 @@ class ASTReverter
             return '(unknown)';
         };
         self::$closure_map = [
+            /**
+             * @suppress PhanAccessClassConstantInternal
+             */
+            ast\AST_TYPE => static function (Node $node) : string {
+                return PostOrderAnalysisVisitor::AST_CAST_FLAGS_LOOKUP[$node->flags];
+            },
+            ast\AST_NULLABLE_TYPE => static function (Node $node) : string {
+                return '?' . self::toShortString($node->children['type']);
+            },
             ast\AST_POST_INC => static function (Node $node) : string {
                 return self::formatIncDec('%s++', $node->children['var']);
             },
@@ -293,6 +302,13 @@ class ASTReverter
                     self::toShortString($node->children['class']),
                     self::toShortString($node->children['args'])
                 );
+            },
+            ast\AST_CONDITIONAL => static function (Node $node) : string {
+                ['cond' => $cond, 'true' => $true, 'false' => $false] = $node->children;
+                if ($true !== null) {
+                    return \sprintf('(%s ? %s : %s)', self::toShortString($cond), self::toShortString($true), self::toShortString($false));
+                }
+                return \sprintf('(%s ?: %s)', self::toShortString($cond), self::toShortString($false));
             },
         ];
     }

--- a/src/Phan/AST/Parser.php
+++ b/src/Phan/AST/Parser.php
@@ -125,7 +125,7 @@ class Parser
         $original_error_reporting = error_reporting();
         error_reporting($original_error_reporting & ~\E_COMPILE_WARNING);
         $__no_echo_phan_errors = static function (int $errno, string $errstr, string $unused_errfile, int $errline) use ($code_base, $context) : bool {
-            if ($errno == E_DEPRECATED && preg_match('/Version.*is deprecated/i', $errstr)) {
+            if ($errno == \E_DEPRECATED && \preg_match('/Version.*is deprecated/i', $errstr)) {
                 return false;
             }
             // Catch errors such as E_DEPRECATED in php 7.4 for the (real) cast.

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -2514,8 +2514,9 @@ class TolerantASTConverter
 
         $line = $prop_elems[0]->lineno ?? (self::getStartLine($n) ?: $start_line);
         $prop_decl = new ast\Node(ast\AST_PROP_DECL, 0, $prop_elems, $line);
+        $type_line = static::getEndLine($n->typeDeclaration) ?: $start_line;
         return new ast\Node(ast\AST_PROP_GROUP, $flags, [
-            'type' => null,  // TODO
+            'type' => static::phpParserTypeToAstNode($n->typeDeclaration, $type_line),
             'props' => $prop_decl,
         ], $line);
     }
@@ -3030,7 +3031,8 @@ class TolerantASTConverter
         return \sha1($details);
     }
 
-    private static function normalizeTernaryExpression(TernaryExpression $n) : TernaryExpression {
+    private static function normalizeTernaryExpression(TernaryExpression $n) : TernaryExpression
+    {
         $else = $n->elseExpression;
         if (!($else instanceof TernaryExpression)) {
             return $n;

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -628,6 +628,7 @@ class UnionTypeVisitor extends AnalysisVisitor
     public function visitNullableType(Node $node) : UnionType
     {
         // Get the type
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable other node kinds have nullable type
         $union_type = $this->__invoke($node->children['type']);
 
         // Make each nullable

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -931,6 +931,10 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         flags\TYPE_STRING => 'string',
         flags\TYPE_ARRAY => 'array',
         flags\TYPE_OBJECT => 'object',
+        // These aren't casts, but they are used in various places
+        flags\TYPE_CALLABLE => 'callable',
+        flags\TYPE_VOID => 'void',
+        flags\TYPE_ITERABLE => 'iterable',
     ];
 
     /**
@@ -2743,7 +2747,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             return;
         }
         // @phan-suppress-next-line PhanUndeclaredProperty
-        if (PHP_VERSION_ID < 70400 && !isset($cond->is_not_parenthesized)) {
+        if (\PHP_VERSION_ID < 70400 && !isset($cond->is_not_parenthesized)) {
             // This is from the native parser in php 7.3 or earlier.
             // We don't know whether or not the AST is parenthesized.
             return;

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -62,7 +62,7 @@ class CLI
     /**
      * This should be updated to x.y.z-dev after every release, and x.y.z before a release.
      */
-    const PHAN_VERSION = '2.2.8';
+    const PHAN_VERSION = '2.2.9-dev';
 
     /**
      * List of short flags passed to getopt

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -198,7 +198,8 @@ class Issue
     const TypeInvalidStaticPropertyName = 'PhanTypeInvalidStaticPropertyName';
     const TypeErrorInInternalCall = 'PhanTypeErrorInInternalCall';
     const TypeErrorInOperation = 'PhanTypeErrorInOperation';
-    const TypeInvalidPropertyDefaultReal  = 'PhanTypeInvalidPropertyDefaultReal';
+    const TypeInvalidPropertyDefaultReal    = 'PhanTypeInvalidPropertyDefaultReal';
+    const TypeMismatchPropertyReal          = 'PhanTypeMismatchPropertyReal';
     const ImpossibleCondition               = 'PhanImpossibleCondition';
     const ImpossibleConditionInLoop         = 'PhanImpossibleConditionInLoop';
     const ImpossibleConditionInGlobalScope  = 'PhanImpossibleConditionInGlobalScope';
@@ -458,6 +459,7 @@ class Issue
     const CompatibleDimAlternativeSyntax     = 'PhanCompatibleDimAlternativeSyntax';
     const CompatibleImplodeOrder             = 'PhanCompatibleImplodeOrder';
     const CompatibleUnparenthesizedTernary   = 'PhanCompatibleUnparenthesizedTernary';
+    const CompatibleTypedProperty            = 'PhanCompatibleTypedProperty';
 
     // Issue::CATEGORY_GENERIC
     const TemplateTypeConstant       = 'PhanTemplateTypeConstant';
@@ -2126,6 +2128,14 @@ class Issue
                 "Default value for {TYPE} \${PROPERTY} can't be {TYPE}",
                 self::REMEDIATION_B,
                 10108
+            ),
+            new Issue(
+                self::TypeMismatchPropertyReal,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_CRITICAL,
+                "Assigning {TYPE} to property but {PROPERTY} is {TYPE}",
+                self::REMEDIATION_B,
+                10137
             ),
             new Issue(
                 self::ImpossibleCondition,
@@ -3942,6 +3952,14 @@ class Issue
                 "Unparenthesized '{CODE}' is deprecated. Use either '{CODE}' or '{CODE}'",
                 self::REMEDIATION_B,
                 3020
+            ),
+            new Issue(
+                self::CompatibleTypedProperty,
+                self::CATEGORY_COMPATIBLE,
+                self::SEVERITY_NORMAL,
+                "Cannot use typed properties before php 7.4. This property group has type {TYPE}",
+                self::REMEDIATION_B,
+                3021
             ),
 
             // Issue::CATEGORY_GENERIC

--- a/src/Phan/Language/Element/Property.php
+++ b/src/Phan/Language/Element/Property.php
@@ -458,6 +458,11 @@ class Property extends ClassElement
         return $union_type;
     }
 
+    public function getRealUnionType() : UnionType
+    {
+        return $this->real_union_type;
+    }
+
     public function setPHPDocUnionType(UnionType $type) : void
     {
         $this->phpdoc_union_type = $type;

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -1451,4 +1451,14 @@ final class EmptyUnionType extends UnionType
     {
         return false;
     }
+
+    public function hasSubtypeOf(UnionType $type) : bool
+    {
+        return true;
+    }
+
+    public function isStrictSubtypeOf(CodeBase $code_base, UnionType $type) : bool
+    {
+        return true;
+    }
 }

--- a/src/Phan/Language/Internal/PropertyMap.php
+++ b/src/Phan/Language/Internal/PropertyMap.php
@@ -24,6 +24,7 @@ $ast_node_shape_inner = \implode(',', [
     "right?:$ordinary_ast_node",
     "stmts?:?ast\Node",
     "try?:ast\Node",
+    "type?:?ast\Node",
     "value?:$ordinary_ast_node",
     "var?:ast\Node",
 ]);

--- a/src/Phan/Language/Type/LiteralFloatType.php
+++ b/src/Phan/Language/Type/LiteralFloatType.php
@@ -171,6 +171,26 @@ final class LiteralFloatType extends FloatType implements LiteralTypeInterface
     }
 
     /**
+     * @return bool
+     * True if this Type can be cast to the given Type
+     * cleanly
+     */
+    protected function isSubtypeOfNonNullableType(Type $type) : bool
+    {
+        if ($type instanceof ScalarType) {
+            if ($type::NAME === 'float') {
+                if ($type instanceof LiteralFloatType) {
+                    return $type->getValue() === $this->getValue();
+                }
+                return true;
+            }
+            return false;
+        }
+
+        return parent::isSubtypeOfNonNullableType($type);
+    }
+
+    /**
      * @param bool $is_nullable
      * Set to true if the type should be nullable, else pass
      * false

--- a/src/Phan/Language/Type/LiteralIntType.php
+++ b/src/Phan/Language/Type/LiteralIntType.php
@@ -141,6 +141,9 @@ final class LiteralIntType extends IntType implements LiteralTypeInterface
                     }
                     break;
                 case 'float':
+                    if ($type instanceof LiteralFloatType) {
+                        return $type->getValue() == $this->getValue();
+                    }
                     return true;
                 case 'true':
                     if (!$this->value) {
@@ -159,6 +162,25 @@ final class LiteralIntType extends IntType implements LiteralTypeInterface
                     }
                     break;
             }
+        }
+
+        return parent::canCastToNonNullableType($type);
+    }
+
+    /**
+     * @return bool
+     * True if this Type is a subtype of the given type
+     */
+    protected function isSubtypeOfNonNullableType(Type $type) : bool
+    {
+        if ($type instanceof ScalarType) {
+            if ($type instanceof IntType) {
+                if ($type instanceof LiteralIntType) {
+                    return $type->getValue() === $this->getValue();
+                }
+                return true;
+            }
+            return false;
         }
 
         return parent::canCastToNonNullableType($type);

--- a/src/Phan/Language/Type/LiteralStringType.php
+++ b/src/Phan/Language/Type/LiteralStringType.php
@@ -263,6 +263,25 @@ final class LiteralStringType extends StringType implements LiteralTypeInterface
     }
 
     /**
+     * @return bool
+     * True if this Type is a subtype of the given type.
+     */
+    protected function isSubtypeOfNonNullableType(Type $type) : bool
+    {
+        if ($type instanceof ScalarType) {
+            if ($type instanceof StringType) {
+                if ($type instanceof LiteralStringType) {
+                    return $type->value === $this->value;
+                }
+                return true;
+            }
+            return false;
+        }
+
+        return parent::canCastToNonNullableType($type);
+    }
+
+    /**
      * @param bool $is_nullable
      * Set to true if the type should be nullable, else pass
      * false

--- a/src/Phan/Language/Type/MixedType.php
+++ b/src/Phan/Language/Type/MixedType.php
@@ -40,6 +40,16 @@ final class MixedType extends NativeType
         return true;
     }
 
+    public function isSubtypeOf(Type $type) : bool
+    {
+        return $type instanceof MixedType;
+    }
+
+    public function isSubtypeOfNonNullableType(Type $type) : bool
+    {
+        return $type instanceof MixedType;
+    }
+
     public function isExclusivelyNarrowedFormOrEquivalentTo(
         UnionType $union_type,
         Context $unused_context,

--- a/src/Phan/Language/Type/NativeType.php
+++ b/src/Phan/Language/Type/NativeType.php
@@ -125,6 +125,29 @@ abstract class NativeType extends Type
             ?? parent::canCastToNonNullableType($type);
     }
 
+    protected function isSubtypeOfNonNullableType(Type $type) : bool
+    {
+        // Anything is a subtype of mixed or ?mixed
+        if ($type instanceof MixedType) {
+            return true;
+        }
+
+        if (!($type instanceof NativeType)
+            || $this instanceof GenericArrayType
+            || $type instanceof GenericArrayType
+        ) {
+            return parent::canCastToNonNullableType($type);
+        }
+
+        static $matrix;
+        if ($matrix === null) {
+            $matrix = self::initializeTypeCastingMatrix();
+        }
+
+        return $matrix[$this->getName()][$type->getName()]
+            ?? parent::canCastToNonNullableType($type);
+    }
+
     /**
      * @return array<string,array<string,bool>>
      */

--- a/src/Phan/Language/Type/NullType.php
+++ b/src/Phan/Language/Type/NullType.php
@@ -52,6 +52,16 @@ final class NullType extends ScalarType
             || parent::canCastToNonNullableType($type);
     }
 
+    public function isSubtypeOf(Type $type) : bool
+    {
+        return $type->isNullable();
+    }
+
+    public function isSubtypeOfNonNullableType(Type $unused_type) : bool
+    {
+        return false;
+    }
+
     /**
      * @return bool
      * True if this Type can be cast to the given Type

--- a/src/Phan/Language/Type/ObjectType.php
+++ b/src/Phan/Language/Type/ObjectType.php
@@ -21,6 +21,11 @@ class ObjectType extends NativeType
         return parent::canCastToNonNullableType($type);
     }
 
+    protected function isSubtypeOfNonNullableType(Type $type) : bool
+    {
+        return $type instanceof ObjectType || $type instanceof MixedType;
+    }
+
     /**
      * @return bool
      * True if this type is an object (or the phpdoc `object`)

--- a/src/Phan/Language/Type/StringType.php
+++ b/src/Phan/Language/Type/StringType.php
@@ -21,6 +21,11 @@ class StringType extends ScalarType
         return parent::canCastToNonNullableType($type) || $type instanceof CallableDeclarationType;
     }
 
+    protected function isSubtypeOfNonNullableType(Type $type) : bool
+    {
+        return \get_class($type) === self::class || $type instanceof MixedType;
+    }
+
     /** @override */
     public function isPossiblyNumeric() : bool
     {

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -7,6 +7,7 @@ use ast;
 use ast\Node;
 use InvalidArgumentException;
 use Phan\Analysis\ScopeVisitor;
+use Phan\AST\ASTReverter;
 use Phan\AST\ContextNode;
 use Phan\AST\UnionTypeVisitor;
 use Phan\CodeBase;
@@ -385,6 +386,13 @@ class ParseVisitor extends ScopeVisitor
         $props_node = $node->children['props'];
         $type_node = $node->children['type'];
         if ($type_node) {
+            if (Config::get_closest_target_php_version_id() < 70400) {
+                $this->emitIssue(
+                    Issue::CompatibleTypedProperty,
+                    $type_node->lineno,
+                    ASTReverter::toShortString($type_node)
+                );
+            }
             try {
                 $real_union_type = (new UnionTypeVisitor($this->code_base, $this->context))->fromTypeInSignature($type_node);
             } catch (IssueException $e) {
@@ -394,6 +402,7 @@ class ParseVisitor extends ScopeVisitor
         } else {
             $real_union_type = UnionType::empty();
         }
+        $real_type_set = $real_union_type->getTypeSet();
 
         $class = $this->getContextClass();
         $doc_comment = '';
@@ -468,17 +477,23 @@ class ParseVisitor extends ScopeVisitor
                         $union_type = Type::nonLiteralFromObject($default_node)->asPHPDocUnionType();
                     }
                 }
-                if (!$real_union_type->isEmpty() && !$union_type->canStrictCastToUnionType($this->code_base, $real_union_type)) {
-                    $this->emitIssue(
-                        Issue::TypeInvalidPropertyDefaultReal,
-                        $context_for_property->getLineNumberStart(),
-                        $real_union_type,
-                        $property_name,
-                        $union_type
-                    );
-                }
-                if ($union_type->isType(NullType::instance(false))) {
-                    $union_type = UnionType::empty();
+                if ($real_union_type->isEmpty()) {
+                    if ($union_type->isType(NullType::instance(false))) {
+                        $union_type = UnionType::empty();
+                    }
+                } else {
+                    if (!$union_type->isStrictSubtypeOf($this->code_base, $real_union_type)) {
+                        $this->emitIssue(
+                            Issue::TypeInvalidPropertyDefaultReal,
+                            $context_for_property->getLineNumberStart(),
+                            $real_union_type,
+                            $property_name,
+                            $union_type
+                        );
+                        $union_type = $real_union_type;
+                    } else {
+                        $union_type = $union_type->withRealTypeSet($real_type_set);
+                    }
                 }
             }
 
@@ -554,7 +569,7 @@ class ParseVisitor extends ScopeVisitor
                             $union_type = $original_union_type;
                         }
                         // Replace the empty union type with the resolved union type.
-                        $property->setUnionType($union_type);
+                        $property->setUnionType($union_type->withRealTypeSet($real_type_set));
                     }
                 }
 
@@ -599,11 +614,11 @@ class ParseVisitor extends ScopeVisitor
                     return \get_class($type) !== ArrayType::class;
                 })) {
                     // Don't convert `/** @var T[] */ public $x = []` to union type `T[]|array`
-                    $property->setUnionType($variable_type);
+                    $property->setUnionType($variable_type->withRealTypeSet($real_type_set));
                 } else {
                     // Set the declared type to the doc-comment type and add
                     // |null if the default value is null
-                    $property->setUnionType($original_property_type->withUnionType($variable_type));
+                    $property->setUnionType($original_property_type->withUnionType($variable_type)->withRealTypeSet($real_type_set));
                 }
             }
 

--- a/src/Phan/Plugin/Internal/RedundantConditionCallPlugin.php
+++ b/src/Phan/Plugin/Internal/RedundantConditionCallPlugin.php
@@ -804,8 +804,12 @@ class RedundantConditionVisitor extends PluginAwarePostAnalysisVisitor
                 }
                 break;
             case \ast\flags\TYPE_DOUBLE:
+                // the int `2` and the float `2.0` are not identical
+                // in terms of json encoding, var_export, etc.
                 if ($real_expr_type->floatTypes()->isEqualTo($real_expr_type)) {
-                    $this->warnForCast($node, $real_expr_type, 'float');
+                    if (!$real_expr_type->intTypes()->isEqualTo($real_expr_type)) {
+                        $this->warnForCast($node, $real_expr_type, 'float');
+                    }
                 }
                 break;
             case \ast\flags\TYPE_STRING:

--- a/tests/Phan/AST/TolerantASTConverter/ErrorTolerantConversionTest.php
+++ b/tests/Phan/AST/TolerantASTConverter/ErrorTolerantConversionTest.php
@@ -361,10 +361,11 @@ class C{
 EOT;
  */
 
-    private static function normalizePolyfillAST(ast\Node $ast) : void {
+    private static function normalizePolyfillAST(ast\Node $ast) : void
+    {
         switch ($ast->kind) {
             case ast\AST_DIM:
-                if (PHP_VERSION_ID < 70400) {
+                if (\PHP_VERSION_ID < 70400) {
                     $ast->flags = 0;
                 }
                 break;

--- a/tests/Phan/PHP74Test.php
+++ b/tests/Phan/PHP74Test.php
@@ -14,6 +14,7 @@ final class PHP74Test extends AbstractPhanFileTest
     const OVERRIDES = [
         'allow_method_param_type_widening' => true,
         'unused_variable_detection' => true,  // for use with tests of arrow functions
+        'redundant_condition_detection' => true,  // for use with typed properties
         'target_php_version' => '7.4',
     ];
 

--- a/tests/files/expected/0620_more_noop_expressions.php.expected
+++ b/tests/files/expected/0620_more_noop_expressions.php.expected
@@ -9,7 +9,6 @@
 %s:10 PhanCompatibleUnsetCast The unset cast (in (unset)($a)) was deprecated in PHP 7.2 and will become a fatal error in PHP 8.0.
 %s:10 PhanNoopCast Unused result of a (unset)(expr) cast
 %s:11 PhanNoopCast Unused result of a (float)(expr) cast
-%s:11 PhanRedundantConditionInGlobalScope Redundant attempt to cast $a of type 2 to float in the global scope (likely a false positive)
 %s:12 PhanNoopCast Unused result of a (array)(expr) cast
 %s:13 PhanNoopCast Unused result of a (object)(expr) cast
 %s:22 PhanNoopBinaryOperator Unused result of a binary '??' operator

--- a/tests/files/expected/0689_redundant_cast.php.expected
+++ b/tests/files/expected/0689_redundant_cast.php.expected
@@ -1,6 +1,5 @@
 %s:6 PhanRedundantCondition Redundant attempt to cast $b of type bool to bool
 %s:7 PhanRedundantCondition Redundant attempt to cast $i of type int to int
-%s:9 PhanRedundantCondition Redundant attempt to cast $i of type int to float
 %s:10 PhanRedundantCondition Redundant attempt to cast $f of type float to float
 %s:11 PhanRedundantCondition Redundant attempt to cast $s of type string to string
 %s:12 PhanRedundantCondition Redundant attempt to cast $a of type array to array

--- a/tests/files/expected/0693_redundant_cast_operations.php.expected
+++ b/tests/files/expected/0693_redundant_cast_operations.php.expected
@@ -21,7 +21,6 @@
 %s:28 PhanRedundantCondition Redundant attempt to cast (array)($a) of type array to array
 %s:29 PhanRedundantCondition Redundant attempt to cast (object)($a) of type object to object
 %s:30 PhanRedundantCondition Redundant attempt to cast ($a * $b) of type float|int to float
-%s:32 PhanRedundantCondition Redundant attempt to cast ($a % $b) of type int to float
 %s:34 PhanRedundantCondition Redundant attempt to cast ($a - $b) of type float|int to float
 %s:35 PhanRedundantCondition Redundant attempt to cast ($a . $b) of type string to string
 %s:37 PhanRedundantCondition Redundant attempt to cast ($a >> $b) of type int to int

--- a/tests/php70_files/expected/011_typed_properties.php.expected
+++ b/tests/php70_files/expected/011_typed_properties.php.expected
@@ -1,3 +1,3 @@
 %s:3 PhanCompatibleTypedProperty Cannot use typed properties before php 7.4. This property group has type callable
 %s:4 PhanCompatibleTypedProperty Cannot use typed properties before php 7.4. This property group has type int
-%s:5 PhanCompatibleTypedProperty Cannot use typed properties before php 7.4. This property group has type self
+%s:5 PhanCompatibleTypedProperty Cannot use typed properties before php 7.4. This property group has type \Foo

--- a/tests/php70_files/expected/011_typed_properties.php.expected
+++ b/tests/php70_files/expected/011_typed_properties.php.expected
@@ -1,0 +1,3 @@
+%s:3 PhanCompatibleTypedProperty Cannot use typed properties before php 7.4. This property group has type callable
+%s:4 PhanCompatibleTypedProperty Cannot use typed properties before php 7.4. This property group has type int
+%s:5 PhanCompatibleTypedProperty Cannot use typed properties before php 7.4. This property group has type self

--- a/tests/php70_files/expected/012_typed_properties_errors.php.expected
+++ b/tests/php70_files/expected/012_typed_properties_errors.php.expected
@@ -1,0 +1,12 @@
+%s:8 PhanCompatibleTypedProperty Cannot use typed properties before php 7.4. This property group has type (unknown)
+%s:8 PhanParentlessClass Reference to parent of class \NS11\Bar that does not extend anything
+%s:8 PhanUnreferencedPrivateProperty Possibly zero references to private property \NS11\Bar->invalid
+%s:12 PhanCompatibleTypedProperty Cannot use typed properties before php 7.4. This property group has type \NS11\Bar
+%s:12 PhanWriteOnlyPublicProperty Possibly zero read references to public property \NS11\Foo->foo
+%s:14 PhanCompatibleTypedProperty Cannot use typed properties before php 7.4. This property group has type \NS11\stdClass
+%s:14 PhanUndeclaredTypeProperty Property \NS11\Foo->std has undeclared type \NS11\stdClass (Did you mean class \stdClass)
+%s:14 PhanWriteOnlyPublicProperty Possibly zero read references to public property \NS11\Foo->std
+%s:15 PhanCompatibleTypedProperty Cannot use typed properties before php 7.4. This property group has type \ArrayObject
+%s:15 PhanWriteOnlyPublicProperty Possibly zero read references to public property \NS11\Foo->arrayObject
+%s:20 PhanTypeMismatchPropertyReal Assigning \stdClass to property but \NS11\Foo->std is \NS11\stdClass
+%s:21 PhanTypeMismatchPropertyReal Assigning \NS11\Foo to property but \NS11\Foo->arrayObject is \ArrayObject

--- a/tests/php70_files/src/011_typed_properties.php
+++ b/tests/php70_files/src/011_typed_properties.php
@@ -1,0 +1,12 @@
+<?php
+class Foo {
+    public callable $c1, $c2;
+    public int $bar;
+    public self $foo;
+}
+$foo = new Foo();
+$foo->bar = 2;
+$foo->foo = $foo;
+$foo->c1 = 'strlen';
+$foo->c2 = function () { return 'x'; };
+var_export([$foo->bar, $foo->foo, $foo->c1, ($foo->c2)()]);

--- a/tests/php70_files/src/012_typed_properties_errors.php
+++ b/tests/php70_files/src/012_typed_properties_errors.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace NS11;
+
+use ArrayObject;
+
+class Bar {
+    private parent $invalid;
+}
+
+class Foo extends Bar {
+    public parent $foo;
+    // Wrong, this is Foo\stdClass
+    public stdClass $std;
+    public ArrayObject $arrayObject;
+}
+$f = new Foo();
+$f->foo = $f;
+$f->foo = new Bar();
+$f->std = new \stdClass();
+$f->arrayObject = $f;
+$f->arrayObject = new ArrayObject([2]);

--- a/tests/php74_files/expected/013_ambiguous_ternary.php.expected
+++ b/tests/php74_files/expected/013_ambiguous_ternary.php.expected
@@ -1,6 +1,12 @@
 %s:6 PhanCompatibleUnparenthesizedTernary Unparenthesized 'a ? b : c ? d : e' is deprecated. Use either '(a ? b : c) ? d : e' or 'a ? b : (c ? d : e)'
+%s:6 PhanImpossibleCondition Impossible attempt to cast (1 ? 0 : 1) of type 0 to truthy
+%s:6 PhanRedundantCondition Redundant attempt to cast 1 of type 1 to truthy
 %s:7 PhanCompatibleUnparenthesizedTernary Unparenthesized 'a ? b : c ? d : e' is deprecated. Use either '(a ? b : c) ? d : e' or 'a ? b : (c ? d : e)'
 %s:8 PhanCompatibleUnparenthesizedTernary Unparenthesized 'a ? b : c ?: d' is deprecated. Use either '(a ? b : c) ?: d' or 'a ? b : (c ?: d)'
+%s:8 PhanImpossibleCondition Impossible attempt to cast (1 ? 0 : 1) of type 0 to truthy
+%s:8 PhanRedundantCondition Redundant attempt to cast 1 of type 1 to truthy
 %s:9 PhanCompatibleUnparenthesizedTernary Unparenthesized 'a ? b : c ?: d' is deprecated. Use either '(a ? b : c) ?: d' or 'a ? b : (c ?: d)'
 %s:10 PhanCompatibleUnparenthesizedTernary Unparenthesized 'a ?: b ? c : d' is deprecated. Use either '(a ?: b) ? c : d' or 'a ?: (b ? c : d)'
 %s:11 PhanCompatibleUnparenthesizedTernary Unparenthesized 'a ?: b ? c : d' is deprecated. Use either '(a ?: b) ? c : d' or 'a ?: (b ? c : d)'
+%s:11 PhanRedundantCondition Redundant attempt to cast (1 ?: 0) of type 1 to truthy
+%s:11 PhanRedundantCondition Redundant attempt to cast 1 of type 1 to truthy

--- a/tests/php74_files/expected/014_real_type_mismatch.php.expected
+++ b/tests/php74_files/expected/014_real_type_mismatch.php.expected
@@ -1,0 +1,6 @@
+%s:6 PhanTypeInvalidPropertyDefaultReal Default value for string $incompatibleVal can't be int
+%s:9 PhanTypeMismatchPropertyReal Assigning 'bar' to property but \Example742->intVal is int
+%s:12 PhanTypeMismatchPropertyReal Assigning array{0:'x'} to property but \Example742->strVal is string
+%s:13 PhanTypeMismatchPropertyReal Assigning array<int,array{}> to property but \Example742->strVal is string
+%s:14 PhanTypeMismatchPropertyReal Assigning array<int,array{}> to property but \Example742->strVal is string
+%s:16 PhanTypeMismatchPropertyReal Assigning 2 to property but \Example742->incompatibleVal is string

--- a/tests/php74_files/expected/015_real_type_redundant.php.expected
+++ b/tests/php74_files/expected/015_real_type_redundant.php.expected
@@ -1,0 +1,6 @@
+%s:19 PhanRedundantCondition Redundant attempt to cast self::$my_int of type int to int
+%s:20 PhanRedundantCondition Redundant attempt to cast self::$my_int2 of type int to int
+%s:23 PhanImpossibleCondition Impossible attempt to cast self::$my_int of type int to string
+%s:26 PhanRedundantCondition Redundant attempt to cast self::$my_array of type array to array
+%s:27 PhanRedundantCondition Redundant attempt to cast self::$my_array2 of type array to array
+%s:28 PhanRedundantCondition Redundant attempt to cast self::$my_string of type string to string

--- a/tests/php74_files/src/014_real_type_mismatch.php
+++ b/tests/php74_files/src/014_real_type_mismatch.php
@@ -1,0 +1,16 @@
+<?php
+
+class Example742 {
+    public int $intVal = 2;
+    public string $strVal;
+    public string $incompatibleVal = 2;  // should warn
+}
+$foo = new Example742();
+$foo->intVal = 'bar';  // should warn
+$foo->strVal = 'bar';
+$foo->strVal[0] = 'x';
+$foo->strVal = ['x'];
+$foo->strVal[0] = [];  // should warn
+$foo->strVal[0] = [];  // should warn again
+$foo->incompatibleVal = 'bar';
+$foo->incompatibleVal = 2;  // should warn

--- a/tests/php74_files/src/015_real_type_redundant.php
+++ b/tests/php74_files/src/015_real_type_redundant.php
@@ -1,0 +1,34 @@
+<?php
+
+class TypedProperties15 {
+    public static int $my_int = 3;
+    public static int $my_int2;
+    /** @var mixed */
+    public static array $my_array;
+    /** @var array<int,string> */
+    public static array $my_array2;
+    /** @var callable-string */
+    public static string $my_string;
+
+    public static function setUp() {
+        self::$my_array = [];
+        self::$my_string = 'strlen';
+    }
+
+    public static function main() {
+        $value = (int)self::$my_int;
+        if (is_int(self::$my_int2)) {  // should warn
+            echo "Definitely an int\n";
+        }
+        if (is_string(self::$my_int)) {  // should warn
+            echo "Impossible\n";
+        }
+        assert(is_array(self::$my_array));  // should warn
+        assert(is_array(self::$my_array2));  // should warn
+        assert(is_string(self::$my_string)); // should warn - php would throw when reading if it was not a string
+        if (is_callable(self::$my_string)) {  // should not warn
+            echo "This is callable\n";
+        }
+        return $value;
+    }
+}

--- a/tests/plugin_test/expected/093_multiple_format_strings.php.expected
+++ b/tests/plugin_test/expected/093_multiple_format_strings.php.expected
@@ -1,3 +1,3 @@
-src/093_multiple_format_strings.php:10 PhanPluginPrintfVariableFormatString Code (unknown) has a dynamic format string that could not be inferred by Phan
-src/093_multiple_format_strings.php:11 PhanPluginPrintfVariableFormatString Code (unknown) has a dynamic format string that could not be inferred by Phan
+src/093_multiple_format_strings.php:10 PhanPluginPrintfVariableFormatString Code (rand(0, 2) ? 'a%s' : 'b%s') has a dynamic format string that could not be inferred by Phan
+src/093_multiple_format_strings.php:11 PhanPluginPrintfVariableFormatString Code (rand(0, 2) ? '%sa' : '%sb') has a dynamic format string that could not be inferred by Phan
 src/093_multiple_format_strings.php:11 PhanTypeMismatchArgument Argument 1 ($x) is 'xa'|'xb' but \expect_ab() takes 'ax'|'bx' defined at src/093_multiple_format_strings.php:6


### PR DESCRIPTION
Warn about real type mismatches for properties.
Enable support for typed properties in the fallback.

Fixes #3024