### PR TITLE
If all format strings have the same specs, use the first.

### DIFF
--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -776,7 +776,7 @@ class UnionTypeVisitor extends AnalysisVisitor
                 return UnionTypeVisitor::unionTypeFromNode(
                     $this->code_base,
                     $this->context,
-                    $node->children['false'] ?? ''
+                    $node->children['false']
                 );
             }
         }
@@ -820,7 +820,7 @@ class UnionTypeVisitor extends AnalysisVisitor
                 $false_type = UnionTypeVisitor::unionTypeFromNode(
                     $this->code_base,
                     $false_context,
-                    $node->children['false'] ?? ''
+                    $node->children['false']
                 );
                 $true_type_is_empty = $true_type->isEmpty();
                 if (!$false_type->isEmpty()) {
@@ -862,7 +862,7 @@ class UnionTypeVisitor extends AnalysisVisitor
         $false_type = UnionTypeVisitor::unionTypeFromNode(
             $this->code_base,
             $false_context,
-            $node->children['false'] ?? ''
+            $node->children['false']
         );
 
         // Add the type for the 'true' side to the 'false' side

--- a/tests/plugin_test/expected/093_multiple_format_strings.php.expected
+++ b/tests/plugin_test/expected/093_multiple_format_strings.php.expected
@@ -1,3 +1,2 @@
-src/093_multiple_format_strings.php:10 PhanPluginPrintfVariableFormatString Code (rand(0, 2) ? 'a%s' : 'b%s') has a dynamic format string that could not be inferred by Phan
-src/093_multiple_format_strings.php:11 PhanPluginPrintfVariableFormatString Code (rand(0, 2) ? '%sa' : '%sb') has a dynamic format string that could not be inferred by Phan
 src/093_multiple_format_strings.php:11 PhanTypeMismatchArgument Argument 1 ($x) is 'xa'|'xb' but \expect_ab() takes 'ax'|'bx' defined at src/093_multiple_format_strings.php:6
+src/093_multiple_format_strings.php:15 PhanPluginPrintfUnusedArgument Format string "The argument is %s" does not use provided argument #2

--- a/tests/plugin_test/src/093_multiple_format_strings.php
+++ b/tests/plugin_test/src/093_multiple_format_strings.php
@@ -9,3 +9,7 @@ function expect_ab($x) {
 
 expect_ab(sprintf(rand(0, 2) ? 'a%s' : 'b%s', 'x'));
 expect_ab(sprintf(rand(0, 2) ? '%sa' : '%sb', 'x'));
+
+// Phan will be able to check for too many arguments if the conversion specifiers of the format string are identical.
+// It currently does not check if format strings are compatible.
+printf(rand(0, 2) ? 'The argument is %s' : 'The arguments are %s', 'first', 'extra');


### PR DESCRIPTION
(In PrintfCheckerPlugin)