### PR TITLE
Improve analysis of tracking properties of $this

### DIFF
--- a/.phan/plugins/PrintfCheckerPlugin.php
+++ b/.phan/plugins/PrintfCheckerPlugin.php
@@ -149,7 +149,7 @@ class PrintfCheckerPlugin extends PluginV3 implements AnalyzeFunctionCallCapabil
                 return null;
             }
             $new_specs = ConversionSpec::extractAll($str);
-            if (is_array($known_specs)) {
+            if (\is_array($known_specs)) {
                 if ($known_specs != $new_specs) {
                     // We have different specs, e.g. %s and %d, %1$s and %2$s, etc.
                     // TODO: Could allow differences in padding or alignment

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,10 @@ New features(Analysis):
 + Emit `PhanCompatibleTypedProperty` if the target php version is less than 7.4 but typed properties are used.
 + Emit `PhanTypeMismatchPropertyReal` instead of `PhanTypeMismatchProperty` if the properties have real types that are incompatible with the inferred type of the assignment.
 + Stop warning about `(float) $int` being redundant - there are small differences in how ints and floats are treated by `serialize`, `var_export`, `is_int`, etc.
++ Treat all assignments to `$this->prop` in a scope the same way (for real, dynamic, and magic properties)
+  Previously, Phan would not track the effects of some assignments to dynamic properties.
++ Make `unset($this->prop)` make Phan infer that the property is unset in the current scope (and treat it like null) (only affects `$this`). (#3025)
+  Emit `PhanPossiblyUnsetPropertyOfThis` if the property is read from without setting it.
 
 Bug fixes:
 + When a typed property has an incompatible default, don't infer the union type from the default. (#3024)

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -3245,6 +3245,14 @@ This issue will be emitted from the following code
 class F { function f() { $v = parent::f(); } }
 ```
 
+## PhanPossiblyUnsetPropertyOfThis
+
+```
+Attempting to read property {PROPERTY} which was unset in the current scope
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0742_dynamic_property_tracking.php.expected#L5) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0742_dynamic_property_tracking.php#L10).
+
 ## PhanRequiredTraitNotAdded
 
 This happens when a trait name is used in a trait adaptations clause, but that trait wasn't added to the class.

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -2029,6 +2029,8 @@ class UnionTypeVisitor extends AnalysisVisitor
      */
     private function analyzeProp(Node $node, bool $is_static) : UnionType
     {
+        // Either expr(instance) or class(static) is set
+        $expr_node = $node->children['expr'] ?? null;
         try {
             $property = (new ContextNode(
                 $this->code_base,
@@ -2046,14 +2048,13 @@ class UnionTypeVisitor extends AnalysisVisitor
                 );
             }
 
-            $expr_node = $node->children['expr'] ?? null;
             if ($expr_node instanceof Node &&
                     $expr_node->kind === ast\AST_VAR &&
                     $expr_node->children['name'] === 'this') {
                 $override_union_type = $this->context->getThisPropertyIfOverridden($property->getName());
                 if ($override_union_type) {
-                    // There was an earlier expression such as `$this->prop = 2;`
-                    // fwrite(STDERR, "Saw override '$override_union_type' for $property\n");
+                    $this->warnIfPossiblyUndefinedProperty($node, $property->getName(), $override_union_type);
+                    // There was an earlier assignment in scope such as `$this->prop = 2;`
                     return $override_union_type;
                 }
             }
@@ -2112,8 +2113,32 @@ class UnionTypeVisitor extends AnalysisVisitor
             // Swallow it. There are some constructs that we
             // just can't figure out.
         }
+        $property_name = $property_name ?? $node->children['prop'];
+        if (\is_string($property_name) && $expr_node instanceof Node &&
+                $expr_node->kind === ast\AST_VAR &&
+                $expr_node->children['name'] === 'this') {
+            $override_union_type = $this->context->getThisPropertyIfOverridden($property_name);
+            if ($override_union_type) {
+                $this->warnIfPossiblyUndefinedProperty($node, $property_name, $override_union_type);
+                // There was an earlier expression such as `$this->prop = 2;`
+                // fwrite(STDERR, "Saw override '$override_union_type' for $property\n");
+                return $override_union_type;
+            }
+        }
 
         return UnionType::empty();
+    }
+
+    private function warnIfPossiblyUndefinedProperty(Node $node, string $prop_name, UnionType $union_type) : void
+    {
+        if (!$union_type->isPossiblyUndefined()) {
+            return;
+        }
+        $this->emitIssue(
+            Issue::PossiblyUnsetPropertyOfThis,
+            $node->lineno,
+            '$this->' . $prop_name
+        );
     }
 
     /**

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -80,7 +80,8 @@ class Issue
     const EmptyFQSENInCallable      = 'PhanEmptyFQSENInCallable';
     const InvalidFQSENInCallable    = 'PhanInvalidFQSENInCallable';
     const EmptyFQSENInClasslike     = 'PhanEmptyFQSENInClasslike';
-    const InvalidFQSENInClasslike     = 'PhanInvalidFQSENInClasslike';
+    const InvalidFQSENInClasslike   = 'PhanInvalidFQSENInClasslike';
+    const PossiblyUnsetPropertyOfThis = 'PhanPossiblyUnsetPropertyOfThis';
 
     // Issue::CATEGORY_TYPE
     const NonClassMethodCall                = 'PhanNonClassMethodCall';
@@ -1179,6 +1180,14 @@ class Issue
                 "Possible attempt to access missing magic method {FUNCTIONLIKE} of '{CLASS}'",
                 self::REMEDIATION_B,
                 11045
+            ),
+            new Issue(
+                self::PossiblyUnsetPropertyOfThis,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_LOW,
+                'Attempting to read property {PROPERTY} which was unset in the current scope',
+                self::REMEDIATION_B,
+                11048
             ),
 
             // Issue::CATEGORY_ANALYSIS

--- a/src/Phan/Language/AnnotatedUnionType.php
+++ b/src/Phan/Language/AnnotatedUnionType.php
@@ -14,8 +14,10 @@ namespace Phan\Language;
  */
 class AnnotatedUnionType extends UnionType
 {
+    protected const DEFINITELY_UNDEFINED = 1;
+
     /**
-     * @var bool is this union type possibly undefined
+     * @var bool|1 is this union type possibly undefined
      * (e.g. a possibly undefined array shape offset)
      */
     protected $is_possibly_undefined = false;
@@ -31,13 +33,24 @@ class AnnotatedUnionType extends UnionType
         if (!$is_possibly_undefined) {
             return UnionType::of($this->getTypeSet(), $this->getRealTypeSet());
         }
-        if (!$this->is_possibly_undefined) {
-            return $this;
-        }
         $result = clone($this);
         $result->is_possibly_undefined = $is_possibly_undefined;
         return $result;
     }
+
+    /**
+     * @override
+     */
+    public function withIsDefinitelyUndefined() : UnionType
+    {
+        if ($this->is_possibly_undefined === self::DEFINITELY_UNDEFINED) {
+            return $this;
+        }
+        $result = clone($this);
+        $result->is_possibly_undefined = self::DEFINITELY_UNDEFINED;
+        return $result;
+    }
+
 
     public function asSingleScalarValueOrNull()
     {
@@ -65,7 +78,12 @@ class AnnotatedUnionType extends UnionType
 
     public function isPossiblyUndefined() : bool
     {
-        return $this->is_possibly_undefined;
+        return (bool) $this->is_possibly_undefined;
+    }
+
+    public function isDefinitelyUndefined() : bool
+    {
+        return $this->is_possibly_undefined === self::DEFINITELY_UNDEFINED;
     }
 
     public function __toString() : string

--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -988,16 +988,20 @@ class Context extends FileRef
             return null;
         }
 
-        $result = UnionType::empty();
+        $result = null;
         foreach ($types->getTypeSet() as $type) {
             if (!$type instanceof ArrayShapeType) {
                 return null;
             }
             $extra = $type->getFieldTypes()[$name] ?? null;
-            if (!$extra || $extra->isPossiblyUndefined()) {
+            if (!$extra || ($extra->isPossiblyUndefined() && !$extra->isDefinitelyUndefined())) {
                 return null;
             }
-            $result = $result->withUnionType($extra);
+            if ($result) {
+                $result = $result->withUnionType($extra);
+            } else {
+                $result = $extra;
+            }
         }
         return $result;
     }

--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -900,6 +900,7 @@ class Context extends FileRef
 
     /**
      * Analyzes the side effects of setting the type of $this->property to $type
+     * @suppress PhanUnreferencedPublicMethod this might be used in the future
      */
     public function withThisPropertySetToType(Property $property, UnionType $type) : Context
     {

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -1461,4 +1461,9 @@ final class EmptyUnionType extends UnionType
     {
         return true;
     }
+
+    public function isDefinitelyUndefined() : bool
+    {
+        return false;
+    }
 }

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -4140,12 +4140,35 @@ class UnionType implements Serializable
     }
 
     /**
+     * Mark this union type as being possibly definitely undefined.
+     * This is used for properties (of $this) and is planned for local variables.
+     *
+     * Base implementation. Overridden by AnnotatedUnionType.
+     */
+    public function withIsDefinitelyUndefined() : UnionType
+    {
+        $result = new AnnotatedUnionType($this->getTypeSet(), true, []);
+        $result->is_possibly_undefined = AnnotatedUnionType::DEFINITELY_UNDEFINED;
+        return $result;
+    }
+
+    /**
      * Base implementation. Overridden by AnnotatedUnionType.
      * Used for fields of array shapes.
      *
      * This is distinct from null - The array shape offset potentially doesn't exist at all, which is different from existing and being null.
      */
     public function isPossiblyUndefined() : bool
+    {
+        return false;
+    }
+
+    /**
+     * Base implementation. Overridden by AnnotatedUnionType.
+     *
+     * Used for properties(tracking unset of $this) and planned for variables.
+     */
+    public function isDefinitelyUndefined() : bool
     {
         return false;
     }

--- a/tests/Phan/Language/EmptyUnionTypeTest.php
+++ b/tests/Phan/Language/EmptyUnionTypeTest.php
@@ -42,6 +42,8 @@ final class EmptyUnionTypeTest extends BaseTest
         'withIsPossiblyUndefined',
         'isPossiblyUndefined',
         'getIsPossiblyUndefined',  // alias of isPossiblyUndefined
+        'isDefinitelyUndefined',
+        'withIsDefinitelyUndefined',
     ];
 
     public function testMethods() : void

--- a/tests/files/expected/0742_dynamic_property_tracking.php.expected
+++ b/tests/files/expected/0742_dynamic_property_tracking.php.expected
@@ -1,0 +1,13 @@
+%s:7 PhanUndeclaredProperty Reference to undeclared property \DynamicProperty742->prop
+%s:8 PhanPossiblyUnsetPropertyOfThis Attempting to read property $this->prop which was unset in the current scope
+%s:8 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is null but \intdiv() takes int
+%s:8 PhanUndeclaredProperty Reference to undeclared property \DynamicProperty742->prop
+%s:9 PhanTypeObjectUnsetDeclaredProperty Suspicious attempt to unset class \DynamicProperty742's property declared_prop declared at %s:5 (This can be done, but is more commonly done for dynamic properties and Phan does not expect this)
+%s:10 PhanPossiblyUnsetPropertyOfThis Attempting to read property $this->declared_prop which was unset in the current scope
+%s:10 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is null but \intdiv() takes int
+%s:11 PhanUndeclaredProperty Reference to undeclared property \DynamicProperty742->prop
+%s:12 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is array{} but \intdiv() takes int
+%s:12 PhanUndeclaredProperty Reference to undeclared property \DynamicProperty742->prop
+%s:13 PhanUndeclaredProperty Reference to undeclared property \DynamicProperty742->prop
+%s:14 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is \stdClass but \intdiv() takes int
+%s:14 PhanUndeclaredProperty Reference to undeclared property \DynamicProperty742->prop

--- a/tests/files/src/0742_dynamic_property_tracking.php
+++ b/tests/files/src/0742_dynamic_property_tracking.php
@@ -1,0 +1,16 @@
+<?php
+// Phan warns when a property is unset and tracks the value, for both declared and undeclared properties.
+class DynamicProperty742 {
+    /** @var string */
+    public $declared_prop = 'value';
+    public function main() {
+        unset($this->prop);
+        echo intdiv($this->prop, 2);
+        unset($this->declared_prop);
+        echo intdiv($this->declared_prop, 2);
+        $this->prop = [];
+        echo intdiv($this->prop, 2);
+        $this->prop = new stdClass();
+        echo intdiv($this->prop, 2);
+    }
+}


### PR DESCRIPTION
Include dynamic and magic properties in scope tracking for $this

Track when properties of $this are unset.

For #3025