### PR TITLE
Make Phan check for suppressions of PhanTypeMismatchProperty on property

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,7 @@ New features(Analysis):
   Emit `PhanPossiblyUnsetPropertyOfThis` if the property is read from without setting it.
 + Don't emit `PhanTypeArraySuspiciousNull` when array access is used with the null coalescing operator. (#3032)
 + Don't emit `PhanTypeInvalidDimOffset` when array access is used with the null coalescing operator. (#2123)
++ Make Phan check for `PhanUndeclaredTypeProperty` suppressions on the property's doc comment, not the class. (#3047)
 
 Plugins:
 + Add `StrictComparisonPlugin`, which warns about the following issue types:

--- a/src/Phan/Language/Element/Property.php
+++ b/src/Phan/Language/Element/Property.php
@@ -66,6 +66,11 @@ class Property extends ClassElement
         FullyQualifiedPropertyName $fqsen,
         UnionType $real_union_type
     ) {
+        $internal_scope = new PropertyScope(
+            $context->getScope(),
+            $fqsen
+        );
+        $context = $context->withScope($internal_scope);
         parent::__construct(
             $context,
             $name,
@@ -84,10 +89,7 @@ class Property extends ClassElement
         // Set an internal scope, so that issue suppressions can be placed on property doc comments.
         // (plugins acting on properties would then pick those up).
         // $fqsen is used to locate this property.
-        $this->setInternalScope(new PropertyScope(
-            $context->getScope(),
-            $fqsen
-        ));
+        $this->setInternalScope($internal_scope);
     }
 
     /**

--- a/tests/files/expected/0745_mismatch_return_real.php.expected
+++ b/tests/files/expected/0745_mismatch_return_real.php.expected
@@ -1,5 +1,6 @@
-%s:7 PhanTypeMismatchReturnReal Returning type string but test745SoftCast() is declared to return bool
-%s:10 PhanTypeMismatchReturnReal Returning type \stdClass but test745SoftCast() is declared to return bool
-%s:13 PhanTypeMismatchReturnReal Returning type int but test745SoftCast() is declared to return bool
-%s:16 PhanTypeMismatchReturnReal Returning type iterable but test745SoftCast() is declared to return bool
-%s:19 PhanTypeMismatchReturnReal Returning type null but test745SoftCast() is declared to return bool
+%s:6 PhanTypeMismatchReturnReal Returning type string but test745SoftCast() is declared to return bool
+%s:8 PhanTypeMismatchReturnReal Returning type int but test745SoftCast() is declared to return bool
+%s:10 PhanTypeMismatchReturnReal Returning type float but test745SoftCast() is declared to return bool
+%s:12 PhanTypeMismatchReturnReal Returning type \stdClass but test745SoftCast() is declared to return bool
+%s:14 PhanTypeMismatchReturnReal Returning type iterable but test745SoftCast() is declared to return bool
+%s:17 PhanTypeMismatchReturnReal Returning type null but test745SoftCast() is declared to return bool

--- a/tests/files/expected/0746_suppress_undeclared_type_property.php.expected
+++ b/tests/files/expected/0746_suppress_undeclared_type_property.php.expected
@@ -1,0 +1,1 @@
+%s:12 PhanUndeclaredTypeProperty Property \HasMissing746::$_missing2 has undeclared type \MissingClass

--- a/tests/files/src/0745_mismatch_return_real.php
+++ b/tests/files/src/0745_mismatch_return_real.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+function test745SoftCast(string $s, bool $b, int $i, iterable $iter, float $f) : bool {
+    if ($b) {
+        // Should emit TypeMismatchReturn instead of TypeMismatchReturnReal because it won't throw an error at runtime.
+        return $s;
+    } elseif (rand() % 2 == 1) {
+        return $i;
+    } elseif (rand() % 2 == 0) {
+        return $f;
+    } elseif (rand() % 3 == 1) {
+        return new stdClass();
+    } elseif (rand() % 3 == 2) {
+        return $iter;
+    }
+    // Should always warn
+    return null;
+}

--- a/tests/files/src/0746_suppress_undeclared_type_property.php
+++ b/tests/files/src/0746_suppress_undeclared_type_property.php
@@ -1,0 +1,13 @@
+<?php
+
+class HasMissing746 {
+    /**
+     * @suppress PhanUndeclaredTypeProperty
+     * @var MissingClass
+     */
+    protected static $_missing;
+    /**
+     * @var MissingClass
+     */
+    protected static $_missing2;
+}


### PR DESCRIPTION
And make suppressing warnings about undeclared types check the comment
of the property, not the class.

Fixes #3047

Add a missing test