### PR TITLE
Improve analysis of assignment to/pass-by-reference of properties

### DIFF
--- a/.phan/plugins/UseReturnValuePlugin.php
+++ b/.phan/plugins/UseReturnValuePlugin.php
@@ -834,7 +834,7 @@ class UseReturnValuePlugin extends PluginV3 implements PostAnalyzeNodeCapability
         'rename' => false,  // some code is optimistic
         'reset' => false,  // move array cursor
         'session_id' => false,  // Triggers regeneration
-        'strtok' => self::SPECIAL_CASE,  // advances a cursor if called with 1 argument
+        'strtok' => false,  // advances a cursor if called with 1 argument - Any argument position can be ignored.
         'trait_exists' => self::SPECIAL_CASE,  // triggers class autoloader to load the trait
         'var_export' => self::SPECIAL_CASE,  // returns a string if second arg is true
     ];
@@ -1072,9 +1072,6 @@ class UseReturnValueVisitor extends PluginAwarePostAnalysisVisitor
             case 'trait_exists':
                 // Triggers autoloader unless second argument is false
                 return !self::isSecondArgumentEqualToConst($node, 'false');
-            case 'strtok':
-                // advances a cursor if called with 1 argument
-                return count($node->children['args']->children) <= 1;
             case 'preg_match':
             case 'preg_match_all':
                 return count($node->children['args']->children) >= 3;

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@ New features(Analysis):
 + Emit the stricter issue type `PhanTypeMismatchArgumentReal` instead of `PhanTypeMismatchArgument`
   when Phan infers that the real type of the argument is likely to cause a TypeError at runtime (#403)
 + Support php 7.4 typed property groups in the polyfill/fallback parser.
++ Warn about passing properties with incompatible types to reference parameters (#3060)
+  New issue types: `PhanTypeMismatchArgumentPropertyReference`, `PhanTypeMismatchArgumentPropertyReferenceReal`
 + Detect redundant conditions such as `is_array($this->array_prop)` on typed properties.
   Their values will either be a value of the correct type, or unset. (Reading from unset properties will throw an Error at runtime)
 + Emit `PhanCompatibleTypedProperty` if the target php version is less than 7.4 but typed properties are used.

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -218,9 +218,9 @@ class TolerantASTConverter
     }
 
     /**
-     * @param null|Diagnostic[] &$errors @phan-output-reference (TODO: param-out)
+     * @param Diagnostic[] &$errors @phan-output-reference (TODO: param-out)
      */
-    public static function phpParserParse(string $file_contents, array &$errors = null) : PhpParser\Node
+    public static function phpParserParse(string $file_contents, array &$errors = []) : PhpParser\Node
     {
         $parser = new Parser();  // TODO: In php 7.3, we might need to provide a version, due to small changes in lexing?
         $result = $parser->parseSourceFile($file_contents);

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -227,6 +227,8 @@ class Issue
     const CoalescingAlwaysNull              = 'PhanCoalescingAlwaysNull';
     const CoalescingAlwaysNullInLoop        = 'PhanCoalescingAlwaysNullInLoop';
     const CoalescingAlwaysNullInGlobalScope = 'PhanCoalescingAlwaysNullInGlobalScope';
+    const TypeMismatchArgumentPropertyReference = 'PhanTypeMismatchArgumentPropertyReference';
+    const TypeMismatchArgumentPropertyReferenceReal = 'PhanTypeMismatchArgumentPropertyReferenceReal';
 
     // Issue::CATEGORY_ANALYSIS
     const Unanalyzable              = 'PhanUnanalyzable';
@@ -1331,6 +1333,22 @@ class Issue
                 'Argument {INDEX} (${PARAMETER}) is {TYPE} but {FUNCTIONLIKE} takes {TYPE} (expected type to be non-nullable)',
                 self::REMEDIATION_B,
                 10106
+            ),
+            new Issue(
+                self::TypeMismatchArgumentPropertyReference,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                'Argument {INDEX} is property {PROPERTY} with type {TYPE} but {FUNCTIONLIKE} takes a reference of type {TYPE}',
+                self::REMEDIATION_B,
+                10141
+            ),
+            new Issue(
+                self::TypeMismatchArgumentPropertyReferenceReal,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                'Argument {INDEX} is property {PROPERTY} with type {TYPE}{DETAILS} but {FUNCTIONLIKE} takes a reference of type {TYPE}{DETAILS}',
+                self::REMEDIATION_B,
+                10142
             ),
             new Issue(
                 self::TypeMismatchGeneratorYieldValue,

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -304,6 +304,9 @@ class Clazz extends AddressableElement
                 $property_fqsen,
                 UnionType::empty()
             );
+            // Record that Phan has known union types for this internal property,
+            // so that analysis of assignments to the property can account for it.
+            $property->setPHPDocUnionType($property_type);
 
             $clazz->addProperty($code_base, $property, new None());
         }

--- a/tests/files/expected/0305_is_a_tests.php.expected
+++ b/tests/files/expected/0305_is_a_tests.php.expected
@@ -1,3 +1,4 @@
+%s:4 PhanTypeMismatchArgumentInternal Argument 1 ($object_or_string) is int but \is_a() takes object|string
 %s:5 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is \stdClass but \intdiv() takes int
 %s:7 PhanTypeMismatchArgumentInternal Argument 1 ($object_or_string) is int but \is_a() takes object|string
 %s:8 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is \stdClass but \intdiv() takes int

--- a/tests/files/expected/0383_output_reference.php.expected
+++ b/tests/files/expected/0383_output_reference.php.expected
@@ -1,1 +1,1 @@
-%s:17 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is string but \intdiv() takes int
+%s:17 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is 'value' but \intdiv() takes int

--- a/tests/files/expected/0635_array_push_side_effects.php.expected
+++ b/tests/files/expected/0635_array_push_side_effects.php.expected
@@ -2,4 +2,3 @@
 %s:19 PhanTypeMismatchArgumentInternal Argument 1 ($stack) is 'x' but \array_unshift() takes array
 %s:19 PhanTypeMismatchUnpackValue Attempting to unpack a value of type \stdClass which does not contain any subtypes of iterable (such as array or Traversable)
 %s:19 PhanTypeNonVarPassByRef Only variables can be passed by reference at argument 1 of \array_unshift()
-%s:31 PhanTypeSuspiciousEcho Suspicious argument \ast\Node|\stdClass for an echo/print statement

--- a/tests/files/expected/0641_array_shape_offset.php.expected
+++ b/tests/files/expected/0641_array_shape_offset.php.expected
@@ -1,5 +1,5 @@
 %s:8 PhanTypeMismatchArgumentInternal Argument 1 ($string) is array but \strlen() takes string
-%s:8 PhanTypeMismatchArgumentInternal Argument 1 ($string) is array<string,array{mode:'Foo'}>[]|array{} but \strlen() takes string
+%s:8 PhanTypeMismatchArgumentInternal Argument 1 ($string) is array<string,array{mode:'Foo'}>[] but \strlen() takes string
 %s:9 PhanTypeInvalidDimOffset Invalid offset "class" of array type array{mode:'Foo'}
 %s:10 PhanNonClassMethodCall Call to method __construct on non-class type null
 %s:10 PhanTypeExpectedObjectOrClassName Expected an object instance or the name of a class but saw expression with type null

--- a/tests/files/expected/0741_crash_dynamic_property.php.expected
+++ b/tests/files/expected/0741_crash_dynamic_property.php.expected
@@ -1,1 +1,1 @@
-%s:5 PhanTypeMismatchArgumentInternal Argument 1 ($string) is array{0:string} but \strlen() takes string
+%s:5 PhanTypeMismatchArgumentInternal Argument 1 ($string) is array<int,string> but \strlen() takes string

--- a/tests/files/expected/0748_property_incompatible_reference.php.expected
+++ b/tests/files/expected/0748_property_incompatible_reference.php.expected
@@ -1,0 +1,8 @@
+%s:25 PhanTypeMismatchArgumentPropertyReference Argument 2 is property \MyClass->x with type string but \fn16b() takes a reference of type array
+%s:25 PhanTypeMismatchArgument Argument 3 ($x) is 'default' but \fn16b() takes array defined at %s:13
+%s:31 PhanTypeMismatchArgumentPropertyReference Argument 2 is property \MyClass->x with type string but \fn16() takes a reference of type array
+%s:32 PhanTypeMismatchArgumentPropertyReference Argument 2 is property \MyClass::$phpdocString with type string but \fn16() takes a reference of type array
+%s:34 PhanTypeMismatchArgumentPropertyReference Argument 2 is property \MyClass->x with type string but \fn16b() takes a reference of type array
+%s:34 PhanTypeMismatchArgument Argument 3 ($x) is string but \fn16b() takes array defined at %s:13
+%s:35 PhanTypeMismatchArgumentPropertyReference Argument 2 is property \MyClass::$phpdocString with type string but \fn16b() takes a reference of type array
+%s:35 PhanTypeMismatchArgument Argument 3 ($x) is string but \fn16b() takes array defined at %s:13

--- a/tests/files/src/0635_array_push_side_effects.php
+++ b/tests/files/src/0635_array_push_side_effects.php
@@ -28,4 +28,4 @@ $test->add('katze');
 echo $test->x[0];
 $test2 = new TestArrayUnshift();
 $test2->add(new stdClass(), new ast\Node());
-echo $test2->x[0];
+echo $test2->x[0];  // Sadly not able to associate candidate types with individual instances - just takes the union of all known types

--- a/tests/files/src/0748_property_incompatible_reference.php
+++ b/tests/files/src/0748_property_incompatible_reference.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @param array $x @phan-output-reference
+ */
+function fn16(string $a, string $b, &$x) : void {
+    $x = [$a, $b];
+}
+
+/**
+ * @param array &$x
+ */
+function fn16b(string $a, string $b, &$x) : void {
+    $x = [$a, $b];
+}
+
+class MyClass {
+    /** @var string */
+    public $x = 'someValue';
+    /** @var string */
+    public static $phpdocString = 'someValue';
+
+    public function modifyX() {
+        $this->x = 'default';
+        fn16b('first', 'second', $this->x);
+    }
+}
+
+$m = new MyClass();
+
+fn16('/ab/', $argv[0], $m->x);
+fn16('/ab/', $argv[0], MyClass::$phpdocString);
+$m->x = 'default';  // ignored
+fn16b('/ab/', $argv[0], $m->x);
+fn16b('/ab/', $argv[0], MyClass::$phpdocString);

--- a/tests/php74_files/expected/016_typed_property_by_reference.php.expected
+++ b/tests/php74_files/expected/016_typed_property_by_reference.php.expected
@@ -1,0 +1,11 @@
+%s:25 PhanTypeMismatchArgumentPropertyReferenceReal Argument 2 is property \MyClass->x with type string but \fn16b() takes a reference of type array (no real type)
+%s:25 PhanTypeMismatchArgument Argument 3 ($x) is 'default' but \fn16b() takes array defined at %s:13
+%s:31 PhanTypeMismatchArgumentPropertyReferenceReal Argument 2 is property \MyClass->x with type string but \fn16() takes a reference of type array (no real type)
+%s:32 PhanTypeMismatchArgumentPropertyReferenceReal Argument 2 is property \MyClass::$typedX with type string but \fn16() takes a reference of type array (no real type)
+%s:33 PhanTypeMismatchArgumentPropertyReference Argument 2 is property \MyClass::$phpdocString with type string but \fn16() takes a reference of type array
+%s:35 PhanTypeMismatchArgumentPropertyReferenceReal Argument 2 is property \MyClass->x with type string but \fn16b() takes a reference of type array (no real type)
+%s:35 PhanTypeMismatchArgument Argument 3 ($x) is string but \fn16b() takes array defined at %s:13
+%s:36 PhanTypeMismatchArgumentPropertyReferenceReal Argument 2 is property \MyClass::$typedX with type string but \fn16b() takes a reference of type array (no real type)
+%s:36 PhanTypeMismatchArgument Argument 3 ($x) is string but \fn16b() takes array defined at %s:13
+%s:37 PhanTypeMismatchArgumentPropertyReference Argument 2 is property \MyClass::$phpdocString with type string but \fn16b() takes a reference of type array
+%s:37 PhanTypeMismatchArgument Argument 3 ($x) is string but \fn16b() takes array defined at %s:13

--- a/tests/php74_files/src/016_typed_property_by_reference.php
+++ b/tests/php74_files/src/016_typed_property_by_reference.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @param array $x @phan-output-reference
+ */
+function fn16(string $a, string $b, &$x) : void {
+    $x = [$a, $b];
+}
+
+/**
+ * @param array &$x
+ */
+function fn16b(string $a, string $b, &$x) : void {
+    $x = [$a, $b];
+}
+
+class MyClass {
+    public string $x = 'someValue';
+    public static string $typedX = 'someValue';
+    /** @var string */
+    public static $phpdocString = 'someValue';
+
+    public function modifyX() {
+        $this->x = 'default';
+        fn16b('first', 'second', $this->x);
+    }
+}
+
+$m = new MyClass();
+
+fn16('/ab/', $argv[0], $m->x);
+fn16('/ab/', $argv[0], MyClass::$typedX);
+fn16('/ab/', $argv[0], MyClass::$phpdocString);
+$m->x = 'default';
+fn16b('/ab/', $argv[0], $m->x);
+fn16b('/ab/', $argv[0], MyClass::$typedX);
+fn16b('/ab/', $argv[0], MyClass::$phpdocString);

--- a/tests/plugin_test/expected/023_write_only_property.php.expected
+++ b/tests/plugin_test/expected/023_write_only_property.php.expected
@@ -2,5 +2,6 @@ src/023_write_only_property.php:4 PhanWriteOnlyPublicProperty Possibly zero read
 src/023_write_only_property.php:5 PhanWriteOnlyProtectedProperty Possibly zero read references to protected property \MyClass23->b
 src/023_write_only_property.php:6 PhanWriteOnlyPrivateProperty Possibly zero read references to private property \MyClass23->c
 src/023_write_only_property.php:15 PhanUnreferencedPublicProperty Possibly zero references to public property \MyClass23->g
+src/023_write_only_property.php:23 PhanTypeMismatchProperty Assigning array<string,int> to property but \MyClass23->b is array<int,int>
 src/023_write_only_property.php:34 PhanWriteOnlyPublicProperty Possibly zero read references to public property \OtherClass->subclassProp
 src/023_write_only_property.php:35 PhanUnreferencedPublicProperty Possibly zero references to public property \OtherClass->subclassPropUnused

--- a/tests/rasmus_files/expected/0039_static_property_ref.php.expected
+++ b/tests/rasmus_files/expected/0039_static_property_ref.php.expected
@@ -1,1 +1,1 @@
-%s:10 PhanTypeMismatchArgument Argument 1 ($arg) is 'abc' but \test3() takes array defined at %s:7
+%s:10 PhanTypeMismatchArgument Argument 1 ($arg) is int|string but \test3() takes array defined at %s:7

--- a/tests/rasmus_files/src/0039_static_property_ref.php
+++ b/tests/rasmus_files/src/0039_static_property_ref.php
@@ -8,3 +8,5 @@ function test3(array $arg) { }
 test(A::$var);
 test2(A::$var);
 test3(A::$var);
+// Phan takes the union type of all types for static properties with no type declarations.
+// It currently does not attempt to track assignments in individual scopes, but may do that in the future.


### PR DESCRIPTION
Fixes #3060

Instead of replacing property types, add to the existing union type
when analyzing instance/static property assignments.

Warn if passing a property by reference to a function which would set
the parameter to an incompatible type.