### PR TITLE
Fix bugs in analyzing property assignments and loops

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,8 @@ New features(Analysis):
 + Make inferred real/phpdoc types for results of division more accurate.
 + Improve analysis of for loops and while loops.
   Account for the possibility of the loop iteration never occurring. (unless the condition is unconditionally true)
++ Fix some edge cases that can cause PhanTypeMismatchProperty (#3067, #1867)
+  If there was a phpdoc or real type, check against that instead when emitting issues.
 
 Plugins:
 + Add `StrictComparisonPlugin`, which warns about the following issue types:

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -831,7 +831,7 @@ class AssignmentVisitor extends AnalysisVisitor
         // know what the array structure of the parameter is
         // outside of the scope of this assignment, so we add to
         // its union type rather than replace it.
-        $property_union_type = $property->getUnionType();
+        $property_union_type = $property->getPHPDocUnionType()->withStaticResolvedInContext($this->context);
         $resolved_right_type = $this->right_type->withStaticResolvedInContext($this->context);
         if ($this->dim_depth > 0) {
             if ($resolved_right_type->canCastToExpandedUnionType(

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -628,7 +628,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
 
         $context = $context->withExitLoop($node);
         if (!$always_iterates_at_least_once) {
-            $context = (new ContextMergeVisitor($context, [$original_context, $context]))->combineChildContextList();
+            $context = (new ContextMergeVisitor($context, [$context, $original_context]))->combineChildContextList();
         }
 
         // Now that we know all about our context (like what
@@ -751,7 +751,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
 
         $context = $context->withExitLoop($node);
         if (!$always_iterates_at_least_once) {
-            $context = (new ContextMergeVisitor($original_context, [$original_context, $context]))->combineChildContextList();
+            $context = (new ContextMergeVisitor($context, [$context, $original_context]))->combineChildContextList();
         }
 
         // Now that we know all about our context (like what

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -833,6 +833,7 @@ class Clazz extends AddressableElement
                 $property_fqsen,
                 UnionType::empty()
             );
+            $property->setPHPDocUnionType($union_type);
             if ($original_union_type !== $union_type) {
                 $phan_flags |= Flags::HAS_STATIC_UNION_TYPE;
             }

--- a/src/Phan/Language/Type/ArrayShapeType.php
+++ b/src/Phan/Language/Type/ArrayShapeType.php
@@ -165,11 +165,12 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
         $union_type_builder = new UnionTypeBuilder();
         foreach ($this->field_types as $key => $field_union_type) {
             foreach ($field_union_type->getTypeSet() as $type) {
-                $union_type_builder->addType(GenericArrayType::fromElementType(
-                    $type->asNonLiteralType(),
-                    $this->is_nullable,
-                    \is_string($key) ? GenericArrayType::KEY_STRING : GenericArrayType::KEY_INT
-                ));
+                $union_type_builder->addUnionType(
+                    $type->asPHPDocUnionType()
+                         ->withFlattenedArrayShapeOrLiteralTypeInstances()
+                         ->asGenericArrayTypes(\is_string($key) ? GenericArrayType::KEY_STRING : GenericArrayType::KEY_INT)
+                         ->withIsNullable($this->is_nullable)
+                );
             }
         }
         return $union_type_builder->getTypeSet();

--- a/src/Phan/LanguageServer/ProtocolStreamWriter.php
+++ b/src/Phan/LanguageServer/ProtocolStreamWriter.php
@@ -65,7 +65,7 @@ class ProtocolStreamWriter implements ProtocolWriter
             $bytesWritten = @\fwrite($this->output, $message);
 
             if ($bytesWritten > 0) {
-                $message = \substr($message, $bytesWritten);
+                $message = (string)\substr($message, $bytesWritten);
             }
 
             // Determine if this message was completely sent

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -531,6 +531,8 @@ class ParseVisitor extends ScopeVisitor
             );
             if ($variable) {
                 $property->setPHPDocUnionType($variable->getUnionType());
+            } elseif ($real_union_type) {
+                $property->setPHPDocUnionType($real_union_type);
             }
 
             $property->setPhanFlags($comment->getPhanFlagsForProperty());

--- a/tests/Phan/Language/TypeTest.php
+++ b/tests/Phan/Language/TypeTest.php
@@ -595,15 +595,15 @@ final class TypeTest extends BaseTest
                 'array{field:int[],field2:?int}'
             ],
             [
-                'array<string,array{}>',
+                'array<string,array>',
                 'array{field:array{}}'
             ],
             [
-                'array<string,array{innerField:int}>',
+                'array<string,array<string,int>>',
                 'array{field:array{innerField:int}}'
             ],
             [
-                'array<string,array{0:\'test\x2cother\',1:\'x\'}>',
+                'array<string,array<int,string>>',
                 'array{field:array{0:\'test,other\',1:\'x\'}}'
             ],
         ];

--- a/tests/files/expected/0501_less_specific_default.php.expected
+++ b/tests/files/expected/0501_less_specific_default.php.expected
@@ -1,3 +1,0 @@
-%s:11 PhanTypeMismatchProperty Assigning 2 to property but \Example501->propWithStringDefault is string
-%s:12 PhanTypeMismatchProperty Assigning \stdClass to property but \Example501->propWithStringDefault is string
-%s:14 PhanTypeMismatchProperty Assigning \stdClass to property but \Example501->propWithIntDefault is int

--- a/tests/files/expected/0504_prop_assignment_fetch.php.expected
+++ b/tests/files/expected/0504_prop_assignment_fetch.php.expected
@@ -1,4 +1,4 @@
-%s:11 PhanTypeMismatchProperty Assigning 2 to property but \Test504::$prop is array{0:2}|int[]
+%s:11 PhanTypeMismatchProperty Assigning 2 to property but \Test504::$prop is int[]
 %s:12 PhanTypeConversionFromArray array to string conversion
 %s:13 PhanUndeclaredStaticProperty Static property 'propMissing' on \Test504 is undeclared
 %s:14 PhanUndeclaredStaticProperty Static property 'otherMissingProp' on \Test504 is undeclared

--- a/tests/files/expected/0556_literal_in_property.php.expected
+++ b/tests/files/expected/0556_literal_in_property.php.expected
@@ -3,4 +3,4 @@
 %s:15 PhanTypeMismatchProperty Assigning 'b' to property but \Foo->a is 'A'|'a'
 %s:17 PhanTypeMismatchProperty Assigning 'c' to property but \Foo->a is 'A'|'a'
 %s:18 PhanTypeMismatchProperty Assigning 1 to property but \Foo->maybeArray is 0|array
-%s:20 PhanTypeMismatchProperty Assigning 2 to property but \Foo->maybeArray is 0|array|array<string,int>
+%s:20 PhanTypeMismatchProperty Assigning 2 to property but \Foo->maybeArray is 0|array

--- a/tests/files/expected/0575_nullable_self.php.expected
+++ b/tests/files/expected/0575_nullable_self.php.expected
@@ -1,2 +1,2 @@
-%s:16 PhanTypeMismatchProperty Assigning 2 to property but \PhanBug\Foo->parent is ?\PhanBug\Foo|\PhanBug\Foo|null
-%s:23 PhanTypeMismatchProperty Assigning array{0:null} to property but \PhanBug\Foo->other is \PhanBug\Foo[]|array<int,\PhanBug\Foo>
+%s:16 PhanTypeMismatchProperty Assigning 2 to property but \PhanBug\Foo->parent is \PhanBug\Foo|null
+%s:23 PhanTypeMismatchProperty Assigning array{0:null} to property but \PhanBug\Foo->other is \PhanBug\Foo[]

--- a/tests/files/expected/0579_array_combine.php.expected
+++ b/tests/files/expected/0579_array_combine.php.expected
@@ -1,1 +1,1 @@
-%s:17 PhanTypeMismatchProperty Assigning array<int,'x'>|array<int,'y'> to property but \TestCombine->array is array<string,'x'>|array<string,'y'>|array<string,string>
+%s:17 PhanTypeMismatchProperty Assigning array<int,'x'>|array<int,'y'> to property but \TestCombine->array is array<string,string>

--- a/tests/files/expected/0641_array_shape_offset.php.expected
+++ b/tests/files/expected/0641_array_shape_offset.php.expected
@@ -1,6 +1,3 @@
 %s:8 PhanTypeMismatchArgumentInternal Argument 1 ($string) is array but \strlen() takes string
-%s:8 PhanTypeMismatchArgumentInternal Argument 1 ($string) is array<string,array{mode:'Foo'}>[] but \strlen() takes string
-%s:9 PhanTypeInvalidDimOffset Invalid offset "class" of array type array{mode:'Foo'}
-%s:10 PhanNonClassMethodCall Call to method __construct on non-class type null
-%s:10 PhanTypeExpectedObjectOrClassName Expected an object instance or the name of a class but saw expression with type null
+%s:8 PhanTypeMismatchArgumentInternal Argument 1 ($string) is array<string,array<string,string>>[] but \strlen() takes string
 %s:10 PhanUnusedVariable Unused definition of variable $test

--- a/tests/files/expected/0642_additional_class_failure.php.expected
+++ b/tests/files/expected/0642_additional_class_failure.php.expected
@@ -1,4 +1,1 @@
-%s:8 PhanTypeInvalidDimOffset Invalid offset "class" of array type array{mode:'Foo'}|string
-%s:9 PhanNonClassMethodCall Call to method __construct on non-class type null
-%s:9 PhanTypeExpectedObjectOrClassName Expected an object instance or the name of a class but saw expression with type null
 %s:9 PhanUnusedVariable Unused definition of variable $test

--- a/tests/files/expected/0699_redundant_real.php.expected
+++ b/tests/files/expected/0699_redundant_real.php.expected
@@ -1,1 +1,0 @@
-%s:10 PhanTypeMismatchProperty Assigning 'other' to property but \Example699->p1 is null

--- a/tests/files/src/0699_redundant_real.php
+++ b/tests/files/src/0699_redundant_real.php
@@ -7,7 +7,7 @@ class Example699 {
 
     public function modify() {
         if (!isset($this->p1)) {
-            $this->p1 = 'other';  // TODO: Don't emit PhanTypeMismatchProperty
+            $this->p1 = 'other';  // Doesn't warn because type was undeclared.
         }
     }
 }

--- a/tests/php74_files/expected/014_real_type_mismatch.php.expected
+++ b/tests/php74_files/expected/014_real_type_mismatch.php.expected
@@ -1,6 +1,6 @@
 %s:6 PhanTypeInvalidPropertyDefaultReal Default value for string $incompatibleVal can't be int
 %s:9 PhanTypeMismatchPropertyReal Assigning 'bar' to property but \Example742->intVal is int
 %s:12 PhanTypeMismatchPropertyReal Assigning array{0:'x'} to property but \Example742->strVal is string
-%s:13 PhanTypeMismatchPropertyReal Assigning array<int,array{}> to property but \Example742->strVal is string
-%s:14 PhanTypeMismatchPropertyReal Assigning array<int,array{}> to property but \Example742->strVal is string
+%s:13 PhanTypeMismatchPropertyReal Assigning array<int,array> to property but \Example742->strVal is string
+%s:14 PhanTypeMismatchPropertyReal Assigning array<int,array> to property but \Example742->strVal is string
 %s:16 PhanTypeMismatchPropertyReal Assigning 2 to property but \Example742->incompatibleVal is string

--- a/tests/plugin_test/expected/023_write_only_property.php.expected
+++ b/tests/plugin_test/expected/023_write_only_property.php.expected
@@ -2,6 +2,5 @@ src/023_write_only_property.php:4 PhanWriteOnlyPublicProperty Possibly zero read
 src/023_write_only_property.php:5 PhanWriteOnlyProtectedProperty Possibly zero read references to protected property \MyClass23->b
 src/023_write_only_property.php:6 PhanWriteOnlyPrivateProperty Possibly zero read references to private property \MyClass23->c
 src/023_write_only_property.php:15 PhanUnreferencedPublicProperty Possibly zero references to public property \MyClass23->g
-src/023_write_only_property.php:23 PhanTypeMismatchProperty Assigning array<string,int> to property but \MyClass23->b is array<int,int>
 src/023_write_only_property.php:34 PhanWriteOnlyPublicProperty Possibly zero read references to public property \OtherClass->subclassProp
 src/023_write_only_property.php:35 PhanUnreferencedPublicProperty Possibly zero references to public property \OtherClass->subclassPropUnused

--- a/tests/rasmus_files/expected/0036_properties.php.expected
+++ b/tests/rasmus_files/expected/0036_properties.php.expected
@@ -1,6 +1,6 @@
 %s:8 PhanTypeMismatchProperty Assigning int to property but \A->text is string
 %s:8 PhanTypeMismatchProperty Assigning string to property but \A->num is int
 %s:11 PhanUndeclaredProperty Reference to undeclared property \A->str
-%s:12 PhanTypeMismatchProperty Assigning array{} to property but \A->text is int|string
+%s:12 PhanTypeMismatchProperty Assigning array{} to property but \A->text is string
 %s:18 PhanAccessPropertyProtected Cannot access protected property \A->foo defined at %s:8
 %s:19 PhanUndeclaredProperty Reference to undeclared property \A->bar


### PR DESCRIPTION
This resulted in PhanRedundantConditionInLoop outside of a loop.