### PR TITLE
Analyze assignments to fields of properties of $this

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,8 @@ New features(Analysis):
   Account for the possibility of the loop iteration never occurring. (unless the condition is unconditionally true)
 + Fix some edge cases that can cause PhanTypeMismatchProperty (#3067, #1867)
   If there was a phpdoc or real type, check against that instead when emitting issues.
++ Analyze assignments to fields of properties of `$this` (e.g. `$this->prop[] = 'value';`)
+  for correctness and for the new type combination. (#3059)
 
 Plugins:
 + Add `StrictComparisonPlugin`, which warns about the following issue types:

--- a/tests/files/expected/0748_property_incompatible_reference.php.expected
+++ b/tests/files/expected/0748_property_incompatible_reference.php.expected
@@ -1,4 +1,4 @@
-%s:25 PhanTypeMismatchArgumentPropertyReference Argument 2 is property \MyClass->x with type string but \fn16b() takes a reference of type array
+%s:25 PhanTypeMismatchArgumentPropertyReferenceReal Argument 2 is property \MyClass->x with type 'default' but \fn16b() takes a reference of type array (no real type)
 %s:25 PhanTypeMismatchArgument Argument 3 ($x) is 'default' but \fn16b() takes array defined at %s:13
 %s:31 PhanTypeMismatchArgumentPropertyReference Argument 2 is property \MyClass->x with type string but \fn16() takes a reference of type array
 %s:32 PhanTypeMismatchArgumentPropertyReference Argument 2 is property \MyClass::$phpdocString with type string but \fn16() takes a reference of type array

--- a/tests/files/expected/0752_local_property_reference.php.expected
+++ b/tests/files/expected/0752_local_property_reference.php.expected
@@ -1,0 +1,2 @@
+%s:13 PhanTypeMismatchArgumentInternal Argument 1 ($array_arg) is string but \reset() takes array|object
+%s:13 PhanTypeMismatchArgumentPropertyReference Argument 0 is property \C752->prop with type string but \reset() takes a reference of type array|object

--- a/tests/files/src/0751_adding_to_property_of_this.php
+++ b/tests/files/src/0751_adding_to_property_of_this.php
@@ -1,0 +1,16 @@
+<?php
+
+class MyArrayBuilder {
+    public $prop;
+    public function create(array $values) {
+        $this->prop = [];
+        foreach ($values as $k => $_) {
+            $this->prop[] = $k;
+        }
+        // should not emit false positive PhanRedundantCondition Redundant attempt to cast $this->prop of type array{} to empty
+        if (empty($this->prop)) {
+            echo "Had empty input\n";
+        }
+        return $this->prop;
+    }
+}

--- a/tests/files/src/0752_local_property_reference.php
+++ b/tests/files/src/0752_local_property_reference.php
@@ -1,0 +1,16 @@
+<?php
+
+class C752 {
+    /** @var array|string */
+    public $prop;
+
+    public function check() {
+        if (is_array($this->prop)) {
+            // should not warn
+            return reset($this->prop);
+        } elseif (is_string($this->prop)) {
+            // should warn
+            return reset($this->prop);
+        }
+    }
+}

--- a/tests/php74_files/expected/016_typed_property_by_reference.php.expected
+++ b/tests/php74_files/expected/016_typed_property_by_reference.php.expected
@@ -1,4 +1,4 @@
-%s:25 PhanTypeMismatchArgumentPropertyReferenceReal Argument 2 is property \MyClass->x with type string but \fn16b() takes a reference of type array (no real type)
+%s:25 PhanTypeMismatchArgumentPropertyReferenceReal Argument 2 is property \MyClass->x with type 'default' but \fn16b() takes a reference of type array (no real type)
 %s:25 PhanTypeMismatchArgument Argument 3 ($x) is 'default' but \fn16b() takes array defined at %s:13
 %s:31 PhanTypeMismatchArgumentPropertyReferenceReal Argument 2 is property \MyClass->x with type string but \fn16() takes a reference of type array (no real type)
 %s:32 PhanTypeMismatchArgumentPropertyReferenceReal Argument 2 is property \MyClass::$typedX with type string but \fn16() takes a reference of type array (no real type)

--- a/tests/rasmus_files/expected/0038_properties3.php.expected
+++ b/tests/rasmus_files/expected/0038_properties3.php.expected
@@ -1,2 +1,3 @@
 %s:9 PhanTypeMismatchProperty Assigning array<int,string> to property but \A->prop is int[]
 %s:10 PhanTypeMismatchProperty Assigning 1 to property but \A->prop is int[]
+%s:11 PhanTypeArraySuspicious Suspicious array access to 1

--- a/tests/rasmus_files/src/0038_properties3.php
+++ b/tests/rasmus_files/src/0038_properties3.php
@@ -8,7 +8,9 @@ class A {
 	function test() {
 		$this->prop[] = "abc";
 		$this->prop = 1;
-		$this->prop[] = 2;
+		$this->prop[] = 2;  // Phan warns because it's set to 1 in this scope.
+		$this->prop = [];
+		$this->prop[] = 2;  // Phan does not warn
 	}
 }
 


### PR DESCRIPTION
Analyze assignments to fields of properties of `$this`
(e.g. `$this->prop[] = 'value';`)
for correctness and for the new type combination.

Fixes #3059

Fixes #3066 