### PR TITLE
  Fix for infinite loop checking if void casts to non-null

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,14 @@
 Phan NEWS
 
-??? ?? 2019, Phan 2.2.10 (dev)
+Aug 12 2019, Phan 2.2.10
 ------------------------
 
 Plugins:
 + In EmptyStatementListPlugin, warn about switch statements where all cases are no-ops. (#3030)
+
+Bug fixes
++ Fix infinite recursion seen when passing `void` to something expecting a non-null type. (#3085)
+  This only occurs with some settings, e.g. when `null_casts_as_any_type` is true. (introduced in 2.2.9)
 
 Aug 11 2019, Phan 2.2.9
 -----------------------

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -62,7 +62,7 @@ class CLI
     /**
      * This should be updated to x.y.z-dev after every release, and x.y.z before a release.
      */
-    const PHAN_VERSION = '2.2.10-dev';
+    const PHAN_VERSION = '2.2.10';
 
     /**
      * List of short flags passed to getopt

--- a/tests/Phan/MultiFileTest.php
+++ b/tests/Phan/MultiFileTest.php
@@ -97,6 +97,14 @@ class MultiFileTest extends AbstractPhanFileTest
                 ],
                 MULTI_EXPECTED_DIR . DIRECTORY_SEPARATOR . '1898.php' . AbstractPhanFileTest::EXPECTED_SUFFIX,
             ],
+            // #3085
+            [
+                [
+                    MULTI_FILE_DIR . DIRECTORY_SEPARATOR . '3085.php',
+                ],
+                MULTI_EXPECTED_DIR . DIRECTORY_SEPARATOR . '3085.php' . AbstractPhanFileTest::EXPECTED_SUFFIX,
+                MULTI_FILE_DIR . DIRECTORY_SEPARATOR . '3085_config.php',
+            ],
             // Manually add additional file sets and expected
             // output here.
 

--- a/tests/multi_files/expected/3085.php.expected
+++ b/tests/multi_files/expected/3085.php.expected
@@ -1,0 +1,1 @@
+%s:13 PhanTypeMismatchArgumentReal Argument 1 ($x) is void but \expects_array_not_void() takes array defined at %s:6

--- a/tests/multi_files/src/3085.php
+++ b/tests/multi_files/src/3085.php
@@ -1,0 +1,14 @@
+<?php
+
+function test_void_real() : void {
+}
+
+function expects_array_not_void(array $x) {
+    var_export($x);
+}
+
+function test_void_phpdoc() : void {
+    // Should not cause infinite loop with null_casts_as_any_type
+    echo strlen(test_void_real());
+    echo expects_array_not_void(test_void_real());
+}

--- a/tests/multi_files/src/3085_config.php
+++ b/tests/multi_files/src/3085_config.php
@@ -1,0 +1,4 @@
+<?php
+return [
+    'null_casts_as_any_type' => true,
+];


### PR DESCRIPTION
This affected installations using null_casts_as_any_type.

Copy methods from NullType into VoidType and reorder them to be in the
same order.

For #3085