### PR TITLE
Don't scan over folders excluded by exclude_file_regex

### DIFF
--- a/.phan/plugins/InvalidVariableIssetPlugin.php
+++ b/.phan/plugins/InvalidVariableIssetPlugin.php
@@ -85,7 +85,7 @@ class InvalidVariableIssetVisitor extends PluginAwarePostAnalysisVisitor
         // emit issue if name is not declared
         // Check for edge cases such as isset($$var)
         if (is_string($name)) {
-            if ($variable->kind !== ast\AST_VAR)  {
+            if ($variable->kind !== ast\AST_VAR) {
                 // e.g. ast\AST_NAME of an ast\AST_CONST
                 return $this->context;
             }

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,10 @@ Phan NEWS
 Plugins:
 + Fix false positive in InvalidVariableIssetPlugin for expressions such as `isset(self::$prop['field'])` (#3089)
 
+Bug fixes:
++ Don't scan over folders that would be excluded by `'exclude_file_regex'` while parsing. (#3088)
+  That adds additional time and may cause unnecessary permissions errors.
+
 Aug 12 2019, Phan 2.2.10
 ------------------------
 
@@ -17,7 +21,7 @@ New features(Analysis):
 Plugins:
 + In EmptyStatementListPlugin, warn about switch statements where all cases are no-ops. (#3030)
 
-Bug fixes
+Bug fixes:
 + Fix infinite recursion seen when passing `void` to something expecting a non-null type. (#3085)
   This only occurs with some settings, e.g. when `null_casts_as_any_type` is true. (introduced in 2.2.9)
 


### PR DESCRIPTION
Fixes #3088

This avoids wasting time and potential permissions issues for
files/folders that wouldn't get parsed.