### PR TITLE
Add an option to automatically warn about pure functions

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -453,6 +453,9 @@ return [
 
         // If true, then never allow empty statement lists, even if there is a TODO/FIXME/"deliberately empty" comment.
         'empty_statement_list_ignore_todos' => true,
+
+        // Automatically infer which methods are pure (i.e. should have no side effects) in UseReturnValuePlugin.
+        'infer_pure_methods' => true,
     ],
 
     // A list of plugin files to execute

--- a/.phan/plugins/UseReturnValuePlugin/InferPureVisitor.php
+++ b/.phan/plugins/UseReturnValuePlugin/InferPureVisitor.php
@@ -1,0 +1,312 @@
+<?php declare(strict_types=1);
+
+use Phan\AST\AnalysisVisitor;
+use Phan\Exception\NodeException;
+use ast\Node;
+
+/**
+ * Used to check if a method is pure.
+ * Throws NodeException if it sees a node that isn't likely to be in a method that is free of side effects.
+ *
+ * This ignores many edge cases, including:
+ * - Magic properties
+ * - The possibility of emitting notices or throwing
+ * - Whether or not referenced elements exist (Phan checks that elsewhere)
+ *
+ * @phan-file-suppress PhanThrowTypeAbsent
+ */
+class InferPureVisitor extends AnalysisVisitor
+{
+    // visitAssignRef
+    // visitThrow
+    // visitEcho
+    // visitPrint
+    // visitIncludeOrExec
+    public function visit(Node $node) : void {
+        throw new NodeException($node);
+    }
+
+    public function visitVar(Node $node) : void {
+        if (!is_scalar($node->children['name'])) {
+            throw new NodeException($node);
+        }
+    }
+
+    /** @override */
+    public function visitClassName(Node $_) : void {
+    }
+
+    /** @override */
+    public function visitMagicConst(Node $_) : void {
+    }
+
+    /** @override */
+    public function visitConst(Node $_) : void {
+    }
+
+    /** @override */
+    public function visitEmpty(Node $node) : void {
+        $this->maybeInvoke($node->children['expr']);
+    }
+
+    /** @override */
+    public function visitIsset(Node $node) : void {
+        $this->maybeInvoke($node->children['var']);
+    }
+
+    /** @override */
+    public function visitContinue(Node $_) : void {
+    }
+
+    /** @override */
+    public function visitBreak(Node $_) : void {
+    }
+
+    /** @override */
+    public function visitClassConst(Node $node) : void {
+        $this->maybeInvokeAllChildNodes($node);
+    }
+
+    public function visitStatic(Node $node) : void {
+        $this->maybeInvokeAllChildNodes($node);
+    }
+
+    public function visitArray(Node $node) : void {
+        $this->maybeInvokeAllChildNodes($node);
+    }
+
+    public function visitArrayElem(Node $node) : void {
+        $this->maybeInvokeAllChildNodes($node);
+    }
+
+    public function visitEncapsList(Node $node) : void {
+        $this->maybeInvokeAllChildNodes($node);
+    }
+
+    public function visitInstanceof(Node $node) : void {
+        $this->maybeInvokeAllChildNodes($node);
+    }
+
+    public function visitPreInc(Node $node) : void {
+        $this->checkPureIncDec($node);
+    }
+
+    public function visitPreDec(Node $node) : void {
+        $this->checkPureIncDec($node);
+    }
+
+    public function visitPostInc(Node $node) : void {
+        $this->checkPureIncDec($node);
+    }
+
+    public function visitPostDec(Node $node) : void {
+        $this->checkPureIncDec($node);
+    }
+
+    private function checkPureIncDec(Node $node) : void {
+        $var = $node->children['var'];
+        if (!$var instanceof Node) {
+            throw new NodeException($node);
+        }
+        if ($var->kind !== ast\AST_VAR) {
+            throw new NodeException($var);
+        }
+        $this->visitVar($var);
+    }
+
+    /**
+     * @param Node|string|int|float|null $node
+     */
+    private function maybeInvoke($node) : void {
+        if ($node instanceof Node) {
+            $this->__invoke($node);
+        }
+    }
+
+    public function visitBinaryOp(Node $node) : void {
+        $this->maybeInvoke($node->children['left']);
+        $this->maybeInvoke($node->children['right']);
+    }
+
+    public function visitUnaryOp(Node $node) : void {
+        $this->maybeInvoke($node->children['expr']);
+    }
+
+    public function visitDim(Node $node) : void {
+        $this->maybeInvoke($node->children['expr']);
+        $this->maybeInvoke($node->children['dim']);
+    }
+
+    public function visitProp(Node $node) : void {
+        ['expr' => $expr, 'prop' => $prop] = $node->children;
+        if (!$expr instanceof Node) {
+            throw new NodeException($node);
+        }
+        $this->__invoke($expr);
+        if ($prop instanceof Node) {
+            throw new NodeException($prop);
+        }
+    }
+
+    /** @override */
+    public function visitStmtList(Node $node) : void {
+        foreach ($node->children as $stmt) {
+            if ($stmt instanceof Node) {
+                $this->__invoke($stmt);
+            }
+        }
+    }
+
+    /** @override */
+    public function visitStaticProp(Node $node) : void {
+        ['class' => $class, 'prop' => $prop] = $node->children;
+        if (!$class instanceof Node) {
+            throw new NodeException($node);
+        }
+        $this->__invoke($class);
+        if ($prop instanceof Node) {
+            throw new NodeException($prop);
+        }
+    }
+
+    private function maybeInvokeAllChildNodes(Node $node) : void
+    {
+        foreach ($node->children as $c) {
+            if ($c instanceof Node) {
+                $this->__invoke($c);
+            }
+        }
+    }
+
+    /** @override */
+    public function visitCast(Node $node) : void {
+        $this->maybeInvoke($node->children['expr']);
+    }
+
+    /** @override */
+    public function visitConditional(Node $node) : void {
+        $this->maybeInvokeAllChildNodes($node);
+    }
+
+    /** @override */
+    public function visitWhile(Node $node) : void {
+        $this->maybeInvokeAllChildNodes($node);
+    }
+
+    /** @override */
+    public function visitDoWhile(Node $node) : void {
+        $this->maybeInvokeAllChildNodes($node);
+    }
+
+    /** @override */
+    public function visitFor(Node $node) : void {
+        $this->maybeInvokeAllChildNodes($node);
+    }
+
+    /** @override */
+    public function visitForeach(Node $node) : void {
+        $this->maybeInvokeAllChildNodes($node);
+    }
+
+    /** @override */
+    public function visitIf(Node $node) : void {
+        $this->maybeInvokeAllChildNodes($node);
+    }
+
+    /** @override */
+    public function visitIfElem(Node $node) : void {
+        $this->maybeInvokeAllChildNodes($node);
+    }
+
+    /** @override */
+    public function visitSwitch(Node $node) : void {
+        $this->maybeInvokeAllChildNodes($node);
+    }
+
+    /** @override */
+    public function visitSwitchList(Node $node) : void {
+        $this->maybeInvokeAllChildNodes($node);
+    }
+
+    /** @override */
+    public function visitSwitchCase(Node $node) : void {
+        $this->maybeInvokeAllChildNodes($node);
+    }
+
+    /** @override */
+    public function visitGoto(Node $_) : void {
+    }
+
+    /** @override */
+    public function visitLabel(Node $_) : void {
+    }
+
+    /** @override */
+    public function visitAssignOp(Node $node) : void {
+        $this->visitAssign($node);
+    }
+
+    /** @override */
+    public function visitAssign(Node $node) : void {
+        ['var' => $var, 'expr' => $expr] = $node->children;
+        if (!$var instanceof Node) {
+            throw new NodeException($node);
+        }
+        if ($var->kind !== ast\AST_VAR) {
+            throw new NodeException($var);
+        }
+        $this->visitVar($var);
+        if ($expr instanceof Node) {
+            $this->__invoke($expr);
+        }
+    }
+
+    /** @override */
+    public function visitReturn(Node $node) : void {
+        $expr_node = $node->children['expr'];
+        if ($expr_node instanceof Node) {
+            $this->__invoke($expr_node);
+        }
+    }
+
+    /** @override */
+    public function visitYield(Node $node) : void {
+        $this->maybeInvoke($node->children['key']);
+        $this->maybeInvoke($node->children['value']);
+    }
+
+    /** @override */
+    public function visitYieldFrom(Node $node) : void {
+        $this->maybeInvoke($node->children['expr']);
+    }
+
+    /** @override */
+    public function visitName(Node $_) : void {
+        // do nothing
+    }
+
+    /** @override */
+    public function visitCall(Node $node) : void {
+        $expr = $node->children['expr'];
+        if (!is_string($expr)) {
+            throw new NodeException($node);
+        }
+        $key = strtolower($expr);
+        if (($key[0] ?? '') === '\\') {
+            $key = substr($key, 1);
+        }
+        if ((UseReturnValuePlugin::HARDCODED_FQSENS[$key] ?? false) !== true) {
+            throw new NodeException($node);
+        }
+        $this->visitArgList($node->children['args']);
+    }
+
+    // TODO: visitStaticCall
+    public function visitArgList(Node $node) : void {
+        foreach ($node->children as $x) {
+            if ($x instanceof Node) {
+                $this->__invoke($x);
+            }
+        }
+    }
+}

--- a/internal/lib/IncompatibleSignatureDetectorBase.php
+++ b/internal/lib/IncompatibleSignatureDetectorBase.php
@@ -344,6 +344,7 @@ EOT;
 
     /**
      * @param string $msg @phan-unused-param
+     * @suppress PhanPluginUseReturnValueNoopVoid implementation is usually commented out
      */
     protected static function debug(string $msg) : void
     {

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -1506,6 +1506,7 @@ class CodeBase
 
     /**
      * @param string $file_path @phan-unused-param
+     * @suppress PhanPluginUseReturnValueNoopVoid
      */
     public function flushDependenciesForFile(string $file_path) : void
     {

--- a/src/Phan/Daemon.php
+++ b/src/Phan/Daemon.php
@@ -241,6 +241,7 @@ class Daemon
      *
      * @param string $format - printf style format string @phan-unused-param
      * @param mixed ...$args - printf args @phan-unused-param
+     * @suppress PhanPluginUseReturnValueNoopVoid
      */
     public static function debugf(string $format, ...$args) : void
     {

--- a/src/Phan/Language/Element/Func.php
+++ b/src/Phan/Language/Element/Func.php
@@ -163,7 +163,7 @@ class Func extends AddressableElement implements FunctionInterface
             $context,
             (string)$node->children['name'],
             UnionType::empty(),
-            $node->flags ?? 0,
+            $node->flags,
             $fqsen,
             null
         );

--- a/src/Phan/Language/Element/FunctionInterface.php
+++ b/src/Phan/Language/Element/FunctionInterface.php
@@ -360,6 +360,16 @@ interface FunctionInterface extends AddressableElementInterface
     public function setComment(Comment $comment) : void;
 
     /**
+     * Mark this function or method as pure (having no visible side effects)
+     */
+    public function setIsPure() : void;
+
+    /**
+     * Check if this function or method is marked as pure (having no visible side effects)
+     */
+    public function isPure() : bool;
+
+    /**
      * @return UnionType of 0 or more types from (at)throws annotations on this function-like
      */
     public function getThrowsUnionType() : UnionType;

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -1747,4 +1747,21 @@ trait FunctionTrait
             return $parameter->toStubString();
         }, $this->getRealParameterList()));
     }
+
+    /**
+     * Mark this function or method as read-only
+     */
+    public function setIsPure() : void {
+        $this->setPhanFlags(
+            $this->getPhanFlags() | Flags::IS_READ_ONLY
+        );
+    }
+
+    /**
+     * Check if this function or method is marked as pure (having no visible side effects)
+     * @suppress PhanUnreferencedPublicMethod phan has issues with dead code detection with traits and interfaces.
+     */
+    public function isPure() : bool {
+        return $this->getPhanFlagsHasState(Flags::IS_READ_ONLY);
+    }
 }

--- a/src/Phan/Language/Type/FunctionLikeDeclarationType.php
+++ b/src/Phan/Language/Type/FunctionLikeDeclarationType.php
@@ -722,10 +722,6 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
     public function checkHasSuppressIssueAndIncrementCount(string $issue_type) : bool
     {
         // helpers are no-ops right now
-        if ($this->hasSuppressIssue($issue_type)) {
-            $this->incrementSuppressIssueCount($issue_type);
-            return true;
-        }
         return false;
     }
 
@@ -931,6 +927,14 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
     public function getCommentParamAssertionClosure(CodeBase $code_base) : ?Closure
     {
         return null;
+    }
+
+    public function setIsPure() : void {
+        // no-op
+    }
+
+    public function isPure() : bool {
+        return false;
     }
 
     ////////////////////////////////////////////////////////////////////////////////

--- a/src/Phan/LanguageServer/Server/Workspace.php
+++ b/src/Phan/LanguageServer/Server/Workspace.php
@@ -81,6 +81,7 @@ class Workspace
      * no-op for now. Stop the JSON RPC2 framework from warning about this method being undefined.
      * TODO: Define this so that Phan can respond to changes in client configuration.
      * @suppress PhanUnreferencedPublicMethod called by client via AdvancedJsonRpc
+     * @suppress PhanPluginUseReturnValueNoopVoid deliberate no-op
      *
      * @param array $settings @phan-unused-param
      * @phan-param array<string,mixed> $settings @phan-unused-param NOTE: reflection-docblock does not support generic arrays

--- a/tests/plugin_test/.phan/config.php
+++ b/tests/plugin_test/.phan/config.php
@@ -110,6 +110,7 @@ return [
         'php_native_syntax_check_max_processes' => 4,
         'unused_suppression_ignore_list' => ['Unused-Issue-In-Config'],
         'possibly_static_method_ignore_regex' => '/^(?!PSM)/',
+        'infer_pure_methods' => true,
     ],
 
     // A list of plugin files to execute

--- a/tests/plugin_test/expected/000_plugins.php.expected
+++ b/tests/plugin_test/expected/000_plugins.php.expected
@@ -16,8 +16,10 @@ src/000_plugins.php:49 PhanPluginBothLiteralsBinaryOp Suspicious usage of a bina
 src/000_plugins.php:49 PhanPluginNumericalComparison numerical values compared by the operators '===' or '!=='
 src/000_plugins.php:50 PhanPluginBothLiteralsBinaryOp Suspicious usage of a binary operator where both operands are literals. Expression: 2.0 != 2 (result is false)
 src/000_plugins.php:55 UnusedSuppression Element \testUnusedSuppressionPlugin suppresses issue PhanParamTooFew but does not use it
+src/000_plugins.php:61 PhanPluginUseReturnValueNoopVoid The internal function/method \testUnreferencedFunction is declared to return void and it has no side effects
 src/000_plugins.php:61 PhanUnreferencedFunction Possibly zero references to function \testUnreferencedFunction()
 src/000_plugins.php:64 PhanCompatibleAutoload Declaring an autoloader with function __autoload() was deprecated in PHP 7.2 and will become a fatal error in PHP 8.0. Use spl_autoload_register() instead (supported since PHP 5.1).
+src/000_plugins.php:64 PhanPluginUseReturnValueNoopVoid The internal function/method \__autoload is declared to return void and it has no side effects
 src/000_plugins.php:64 PhanUnusedGlobalFunctionParameter Parameter $className is never used
 src/000_plugins.php:66 PhanUnreferencedClass Possibly zero references to class \__autoload
 src/000_plugins.php:67 PhanUnreferencedConstant Possibly zero references to global constant \__autoload

--- a/tests/plugin_test/expected/001_dead_code.php.expected
+++ b/tests/plugin_test/expected/001_dead_code.php.expected
@@ -15,4 +15,6 @@ src/001_dead_code.php:44 PhanUnreferencedPublicProperty Possibly zero references
 src/001_dead_code.php:47 PhanUnreferencedPublicProperty Possibly zero references to public property \DuplicateClass001,1->instance_prop2
 src/001_dead_code.php:50 PhanUnreferencedPublicMethod Possibly zero references to public method \DuplicateClass001,1::f2()
 src/001_dead_code.php:51 PhanUnreferencedPublicMethod Possibly zero references to public method \DuplicateClass001,1::f4()
+src/001_dead_code.php:56 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \duplicateFnA
 src/001_dead_code.php:59 PhanTypeSuspiciousStringExpression Suspicious type true of a variable or expression used to build a string. (Expected type to be able to cast to a string)
+src/001_dead_code.php:60 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \DuplicateClass001::f1

--- a/tests/plugin_test/expected/002_unreachable_code.php.expected
+++ b/tests/plugin_test/expected/002_unreachable_code.php.expected
@@ -4,3 +4,4 @@ src/002_unreachable_code.php:23 PhanPluginUnreachableCode Unreachable statement 
 src/002_unreachable_code.php:25 PhanPluginUnreachableCode Unreachable statement detected
 src/002_unreachable_code.php:40 PhanPluginUnreachableCode Unreachable statement detected
 src/002_unreachable_code.php:64 PhanPluginUnreachableCode Unreachable statement detected
+src/002_unreachable_code.php:66 PhanPluginUseReturnValueNoopVoid The internal function/method \reachableFunction is declared to return void and it has no side effects

--- a/tests/plugin_test/expected/026_strict_return_checks.php.expected
+++ b/tests/plugin_test/expected/026_strict_return_checks.php.expected
@@ -1,5 +1,7 @@
 src/026_strict_return_checks.php:16 PhanPossiblyNullTypeReturn Returning type int|null but notNull() is declared to return int (null is incompatible)
+src/026_strict_return_checks.php:22 PhanPluginUseReturnValueNoopVoid The internal function/method \StrictReturnChecks::expectNull is declared to return null and it has no side effects
 src/026_strict_return_checks.php:23 PhanPartialTypeMismatchReturn Returning type int|null but expectNull() is declared to return null (int is incompatible)
 src/026_strict_return_checks.php:31 PhanPossiblyFalseTypeReturn Returning type false|int but notFalse() is declared to return int (false is incompatible)
 src/026_strict_return_checks.php:39 PhanPartialTypeMismatchReturn Returning type false|int but expectFalse() is declared to return false (int is incompatible)
 src/026_strict_return_checks.php:53 PhanPartialTypeMismatchReturn Returning type \StrictReturnChecks|\ast\Node but partiallyValid() is declared to return \ast\Node (\StrictInterface|\StrictReturnChecks is incompatible)
+src/026_strict_return_checks.php:56 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \StrictReturnChecks::partiallyValid

--- a/tests/plugin_test/expected/051_loop_unused_defs.php.expected
+++ b/tests/plugin_test/expected/051_loop_unused_defs.php.expected
@@ -1,1 +1,3 @@
 src/051_loop_unused_defs.php:33 PhanUnusedVariable Unused definition of variable $b
+src/051_loop_unused_defs.php:56 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \foo51
+src/051_loop_unused_defs.php:57 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \foo51b

--- a/tests/plugin_test/expected/074_unused_function_suppression.php.expected
+++ b/tests/plugin_test/expected/074_unused_function_suppression.php.expected
@@ -1,1 +1,2 @@
 src/074_unused_function_suppression.php:8 PhanPluginWhitespaceTab The first occurrence of a tab was seen here. Running "expand" can fix that.
+src/074_unused_function_suppression.php:13 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \function_suppression_test_fn

--- a/tests/plugin_test/expected/083_unreferenced_class_element.php.expected
+++ b/tests/plugin_test/expected/083_unreferenced_class_element.php.expected
@@ -1,4 +1,5 @@
 src/083_unreferenced_class_element.php:4 PhanUnreferencedPrivateClassConstant Possibly zero references to private class constant \CUnref::X
 src/083_unreferenced_class_element.php:5 PhanUnreferencedProtectedClassConstant Possibly zero references to protected class constant \CUnref::Y
 src/083_unreferenced_class_element.php:6 PhanUnreferencedProtectedProperty Possibly zero references to protected property \CUnref::$protectedProp
+src/083_unreferenced_class_element.php:7 PhanPluginUseReturnValueNoopVoid The internal function/method \CUnref::privateMethod is declared to return void and it has no side effects
 src/083_unreferenced_class_element.php:7 PhanUnreferencedPrivateMethod Possibly zero references to private method \CUnref::privateMethod()

--- a/tests/plugin_test/expected/084_read_only_property.php.expected
+++ b/tests/plugin_test/expected/084_read_only_property.php.expected
@@ -1,2 +1,3 @@
 src/084_read_only_property.php:4 PhanReadOnlyPrivateProperty Possibly zero write references to private property \X84->arr
 src/084_read_only_property.php:5 PhanReadOnlyProtectedProperty Possibly zero write references to protected property \X84->count
+src/084_read_only_property.php:10 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \X84::main


### PR DESCRIPTION
Add it to UseReturnValuePlugin.
Leave it off by default.

A future PR will add support for manually annotating function/method
doc comments, and handle more edge cases.