### PR TITLE
Improve detection of pure functions and methods

### DIFF
--- a/.phan/plugins/UseReturnValuePlugin/InferPureVisitor.php
+++ b/.phan/plugins/UseReturnValuePlugin/InferPureVisitor.php
@@ -376,12 +376,23 @@ class InferPureVisitor extends AnalysisVisitor
         $this->visitArgList($node->children['args']);
     }
 
+    /**
+     * @param Node $node the node of the call, with 'args'
+     */
     private function checkCalledFunctionLikeKey(Node $node, string $key) : void
     {
-        if ((UseReturnValuePlugin::HARDCODED_FQSENS[$key] ?? false) !== true) {
-            if ($key !== $this->function_fqsen_key) {
+        $value = (UseReturnValuePlugin::HARDCODED_FQSENS[$key] ?? false);
+        if ($value === true) {
+            return;
+        } elseif ($value === UseReturnValuePlugin::SPECIAL_CASE) {
+            if (UseReturnValueVisitor::doesSpecialCaseHaveSideEffects($key, $node)) {
+                // infer that var_export($x, true) is pure but not var_export($x)
                 throw new NodeException($node, $key);
             }
+            return;
+        }
+        if ($key !== $this->function_fqsen_key) {
+            throw new NodeException($node, $key);
         }
     }
 

--- a/tests/plugin_test/expected/000_plugins.php.expected
+++ b/tests/plugin_test/expected/000_plugins.php.expected
@@ -24,6 +24,7 @@ src/000_plugins.php:64 PhanUnusedGlobalFunctionParameter Parameter $className is
 src/000_plugins.php:66 PhanUnreferencedClass Possibly zero references to class \__autoload
 src/000_plugins.php:67 PhanUnreferencedConstant Possibly zero references to global constant \__autoload
 src/000_plugins.php:69 PhanPluginAlwaysReturnFunction Function \missingReturnType has a return type of int, but may fail to return a value
+src/000_plugins.php:74 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \missingReturnType
 src/000_plugins.php:77 PhanPluginAlwaysReturnMethod Method \ReturnChecks::missingReturnTypeSwitch has a return type of int, but may fail to return a value
 src/000_plugins.php:80 PhanThrowTypeAbsent \ReturnChecks::missingReturnTypeSwitch() can throw \RuntimeException here, but has no '@throws' declarations for that class
 src/000_plugins.php:93 PhanThrowTypeAbsent \ReturnChecks::missingReturnTypeSwitchGood() can throw \RuntimeException here, but has no '@throws' declarations for that class

--- a/tests/plugin_test/expected/005_always_return.php.expected
+++ b/tests/plugin_test/expected/005_always_return.php.expected
@@ -1,4 +1,10 @@
 src/005_always_return.php:3 PhanPluginAlwaysReturnFunction Function \test5 has a return type of ?string, but may fail to return a value
 src/005_always_return.php:23 PhanPluginAlwaysReturnFunction Function \soft_non_nullable_test5 has a return type of string, but may fail to return a value
+src/005_always_return.php:30 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \test5
+src/005_always_return.php:31 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \soft_nullable_test5
+src/005_always_return.php:32 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \soft_non_nullable_test5
 src/005_always_return.php:39 PhanPluginAlwaysReturnMethod Method \C5::test has a return type of ?string, but may fail to return a value
 src/005_always_return.php:59 PhanPluginAlwaysReturnMethod Method \C5::soft_non_nullable_test5 has a return type of string, but may fail to return a value
+src/005_always_return.php:66 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \C5::test
+src/005_always_return.php:68 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \C5::soft_nullable_test5
+src/005_always_return.php:69 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \C5::soft_non_nullable_test5

--- a/tests/plugin_test/expected/016_dead_code_fromCallable.php.expected
+++ b/tests/plugin_test/expected/016_dead_code_fromCallable.php.expected
@@ -1,1 +1,2 @@
 src/016_dead_code_fromCallable.php:4 PhanUnreferencedFunction Possibly zero references to function \callable16bUnused()
+src/016_dead_code_fromCallable.php:8 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \main16b

--- a/tests/plugin_test/expected/039_loop_return.php.expected
+++ b/tests/plugin_test/expected/039_loop_return.php.expected
@@ -1,1 +1,2 @@
 src/039_loop_return.php:11 PhanUnusedVariable Unused definition of variable $myUnusedVariable
+src/039_loop_return.php:15 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \test_loop_var_return

--- a/tests/plugin_test/expected/145_fibonacci_use_return_value.php.expected
+++ b/tests/plugin_test/expected/145_fibonacci_use_return_value.php.expected
@@ -1,0 +1,4 @@
+src/145_fibonacci_use_return_value.php:10 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \fibonacci145
+src/145_fibonacci_use_return_value.php:27 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \X145::f
+src/145_fibonacci_use_return_value.php:28 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \X145::f
+src/145_fibonacci_use_return_value.php:29 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \X145::g

--- a/tests/plugin_test/expected/146_dependent_args_pure.php.expected
+++ b/tests/plugin_test/expected/146_dependent_args_pure.php.expected
@@ -1,0 +1,1 @@
+src/146_dependent_args_pure.php:14 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \f146c

--- a/tests/plugin_test/src/145_fibonacci_use_return_value.php
+++ b/tests/plugin_test/src/145_fibonacci_use_return_value.php
@@ -1,0 +1,29 @@
+<?php
+// Phan is able to infer if a function is pure when the only calls are self-references.
+function fibonacci145(int $i) {
+    if ($i <= 1) {
+        return 1;
+    }
+    return 'fibonacci145'($i - 1) + fibonacci145($i - 2);
+}
+// Should infer that the value should be used.
+fibonacci145(5);
+class X145 {
+    public static function f(int $i) {
+        if ($i <= 1) {
+            return 1;
+        }
+        return self::f($i - 1) + X145::f($i - 2);
+    }
+
+    public function g(int $i) {
+        if ($i <= 1) {
+            return 1;
+        }
+        return $this->g($i - 1) + $this->g($i - 2);
+    }
+}
+// Should also warn for static and instance methods that call themselves
+X145::f(4);
+X145::f(-1);
+(new X145())->g(3);

--- a/tests/plugin_test/src/146_dependent_args_pure.php
+++ b/tests/plugin_test/src/146_dependent_args_pure.php
@@ -1,0 +1,14 @@
+<?php
+
+function f146($x) {
+    return var_export($x);
+}
+function f146b($x) {
+    return var_export($x, false);
+}
+function f146c($x) {
+    return var_export($x, true);
+}
+f146('x');
+f146b('x');
+f146c('x');


### PR DESCRIPTION
For self-references, don't warn.

Also, fix a bug where calls to global functions were never treated as
pure when checking if methods were pure.