### PR TITLE
Improve empty() detection, fix edge cases in Phan

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,10 @@ New features(Analysis):
 + Show argument names and types in issue messages for functions/methods for PhanParamTooFew and PhanParamTooMany.
 + Show more accurate columns for PhanSyntaxError for unexpected tokens in more cases.
 + Ignore scalar and null type casting config settings when checking for redundant or impossible conditions. (#3105)
++ Infer that `empty($x)` implies that the value of $x is null, an empty scalar, or the empty array.
++ Avoid false positives with `if (empty($x['first']['second']))` - Do not infer any types for the offset 'first' if there weren't any already. (#3112)
++ Avoid some bad inferences when using the value of expressions of the form `A || B`.
++ Improve redundant condition detection for empty/falsey/truthy checks.
 
 Plugins:
 + Fix false positive in InvalidVariableIssetPlugin for expressions such as `isset(self::$prop['field'])` (#3089)
@@ -23,6 +27,7 @@ Plugins:
 Bug fixes:
 + Don't scan over folders that would be excluded by `'exclude_file_regex'` while parsing. (#3088)
   That adds additional time and may cause unnecessary permissions errors.
++ Properly parse literal float union types starting with `0.`
 
 Aug 12 2019, Phan 2.2.10
 ------------------------

--- a/src/Phan/AST/ASTSimplifier.php
+++ b/src/Phan/AST/ASTSimplifier.php
@@ -180,6 +180,7 @@ class ASTSimplifier
      *
      * @param Node|string|float|int $node
      * @internal the way this behaves may change
+     * @see ScopeImpactCheckingVisitor::hasPossibleImpact() for a more general check
      */
     public static function isExpressionWithoutSideEffects($node) : bool
     {

--- a/src/Phan/AST/Parser.php
+++ b/src/Phan/AST/Parser.php
@@ -248,19 +248,19 @@ class Parser
             return 0;
         }
         $message = $native_parse_error->getMessage();
-        if (!preg_match("/ unexpected '(.+)' \((T_\w+)\)/", $message, $matches)) {
-            if (!preg_match("/ unexpected '(.+)', expecting/", $message, $matches)) {
-                if (!preg_match("/ unexpected '(.+)'$/", $message, $matches)) {
+        if (!\preg_match("/ unexpected '(.+)' \((T_\w+)\)/", $message, $matches)) {
+            if (!\preg_match("/ unexpected '(.+)', expecting/", $message, $matches)) {
+                if (!\preg_match("/ unexpected '(.+)'$/", $message, $matches)) {
                     return 0;
                 }
             }
         }
         $token_name = $matches[2] ?? null;
         if (\is_string($token_name)) {
-            if (!defined($token_name)) {
+            if (!\defined($token_name)) {
                 return 0;
             }
-            $token_kind = constant($token_name);
+            $token_kind = \constant($token_name);
         } else {
             $token_kind = null;
         }
@@ -269,7 +269,7 @@ class Parser
         $candidates = [];
         $desired_line = $native_parse_error->getLine();
         foreach ($tokens as $i => $token) {
-            if (!is_array($token)) {
+            if (!\is_array($token)) {
                 if ($token_str === $token) {
                     $candidates[] = $i;
                 }
@@ -289,7 +289,7 @@ class Parser
             }
             $candidates[] = $i;
         }
-        if (count($candidates) !== 1) {
+        if (\count($candidates) !== 1) {
             return 0;
         }
         return self::computeColumnForTokenAtIndex($tokens, $candidates[0], $desired_line);
@@ -299,25 +299,26 @@ class Parser
      * @param array<int,array{0:int,1:string,2:int}|string> $tokens
      * @return int the 1-based line number, or 0 on failure
      */
-    private static function computeColumnForTokenAtIndex(array $tokens, int $i, int $desired_line) : int {
+    private static function computeColumnForTokenAtIndex(array $tokens, int $i, int $desired_line) : int
+    {
         if ($i == 0) {
             return 1;
         }
         $column = 0;
         for ($j = $i - 1; $j >= 0; $j--) {
             $token = $tokens[$j];
-            if (!is_array($token)) {
-                $column += strlen($token);
+            if (!\is_array($token)) {
+                $column += \strlen($token);
                 continue;
             }
             $token_str = $token[1];
             if ($token[2] >= $desired_line) {
-                $column += strlen($token_str);
+                $column += \strlen($token_str);
                 continue;
             }
-            $last_newline = strrpos($token_str, "\n");
+            $last_newline = \strrpos($token_str, "\n");
             if ($last_newline !== false) {
-                $column += strlen($token_str) - $last_newline;
+                $column += \strlen($token_str) - $last_newline;
             }
             break;
         }
@@ -359,7 +360,7 @@ class Parser
             return 0;
         }
         // If the current character is whitespace, keep searching forward for the next non-whitespace character
-        $file_length = strlen($file_contents);
+        $file_length = \strlen($file_contents);
         while ($start + 1 < $file_length && \ctype_space($file_contents[$start])) {
             $start++;
         }

--- a/src/Phan/AST/PhanAnnotationAdder.php
+++ b/src/Phan/AST/PhanAnnotationAdder.php
@@ -62,7 +62,7 @@ class PhanAnnotationAdder
     ];
 
     /**
-     * @param array<mixed,Node|string|float|int|null> $children (should all be Nodes or null)
+     * @param array<mixed,?(Node|string|float|int)> $children (should all be Nodes or null)
      * @param int $bit_set
      */
     private static function markArrayElements($children, int $bit_set) : void

--- a/src/Phan/AST/ScopeImpactCheckingVisitor.php
+++ b/src/Phan/AST/ScopeImpactCheckingVisitor.php
@@ -1,0 +1,149 @@
+<?php declare(strict_types=1);
+
+namespace Phan\AST;
+
+use ast;
+use ast\Node;
+use Phan\CodeBase;
+use Phan\Exception\NodeException;
+use Phan\Language\Context;
+
+/**
+ * This checks if the expression/statement is likely to have an impact on inferences in the current scope.
+ *
+ * Based on InferPureVisitor.
+ * - InferPureVisitor allows assignments, increments, and other operations that would affect the types in the scope, unlike this
+ * - InferPureVisitor allows self-calls, unlike this
+ * - InferPureVisitor allows moving to other scopes with break/continue, unlike this
+ * - TODO: Allow function/method calls with side effects as long as they don't impact the current scope. e.g. continue to forbid extract().
+ *
+ * @phan-file-suppress PhanThrowTypeAbsent
+ */
+class ScopeImpactCheckingVisitor extends InferPureVisitor
+{
+    private const NOT_A_VALID_FQSEN_KEY = 'X';
+
+    /**
+     * Returns true if this expression has a possible impact on the inferences in this scope.
+     * (e.g. calls that assign by reference, assignments, control flow, throwing, etc.)
+     *
+     * @param Node|string|int|float|null $node
+     */
+    public static function hasPossibleImpact(
+        CodeBase $code_base,
+        Context $context,
+        $node
+    ) : bool {
+        if (!($node instanceof Node)) {
+            return false;
+        }
+
+        try {
+            (new self($code_base, $context, self::NOT_A_VALID_FQSEN_KEY))($node);
+            return false;
+        } catch (NodeException $_) {
+            return true;
+        }
+    }
+
+    // echo/print don't impact the scope.
+    public function visitEcho(Node $node) : void
+    {
+        $this->maybeInvoke($node->children['expr']);
+    }
+
+    public function visitPrint(Node $node) : void
+    {
+        $this->maybeInvoke($node->children['expr']);
+    }
+
+
+    public function visitVar(Node $node) : void
+    {
+        if (!\is_scalar($node->children['name'])) {
+            throw new NodeException($node);
+        }
+    }
+
+    /** @override */
+    public function visitContinue(Node $node) : void
+    {
+        throw new NodeException($node);
+    }
+
+    public function visitBreak(Node $node) : void
+    {
+        throw new NodeException($node);
+    }
+
+    public function visitPreInc(Node $node) : void
+    {
+        throw new NodeException($node);
+    }
+
+    public function visitPreDec(Node $node) : void
+    {
+        throw new NodeException($node);
+    }
+
+    public function visitPostInc(Node $node) : void
+    {
+        throw new NodeException($node);
+    }
+
+    public function visitPostDec(Node $node) : void
+    {
+        throw new NodeException($node);
+    }
+
+    private function checkPureIncDec(Node $node) : void
+    {
+        $var = $node->children['var'];
+        if (!$var instanceof Node) {
+            throw new NodeException($node);
+        }
+        if ($var->kind !== ast\AST_VAR) {
+            throw new NodeException($var);
+        }
+        $this->visitVar($var);
+    }
+
+    /** @override */
+    public function visitGoto(Node $node) : void
+    {
+        throw new NodeException($node);
+    }
+
+    /** @override */
+    public function visitAssignOp(Node $node) : void
+    {
+        throw new NodeException($node);
+    }
+
+    /** @override */
+    public function visitAssign(Node $node) : void
+    {
+        throw new NodeException($node);
+    }
+
+    /** @override */
+    public function visitReturn(Node $node) : void
+    {
+        throw new NodeException($node);
+    }
+
+    /** @override */
+    public function visitYield(Node $node) : void
+    {
+        $this->maybeInvoke($node->children['key']);
+        $this->maybeInvoke($node->children['value']);
+    }
+
+    /** @override */
+    public function visitYieldFrom(Node $node) : void
+    {
+        $this->maybeInvoke($node->children['expr']);
+    }
+
+    // TODO: Allow calls that accept scalars and regular data that wouldn't get modified?
+}

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1203,7 +1203,8 @@ class UnionTypeVisitor extends AnalysisVisitor
      * @param Node|string|int|float $expr
      * @suppress PhanThrowTypeAbsentForCall
      */
-    private function typeAfterCastToObject($expr) : UnionType {
+    private function typeAfterCastToObject($expr) : UnionType
+    {
         static $stdclass;
         if ($stdclass === null) {
             $stdclass = Type::fromFullyQualifiedString('\stdClass');
@@ -1223,7 +1224,7 @@ class UnionTypeVisitor extends AnalysisVisitor
         if ($has_array) {
             $expr_type = $expr_type->withType($stdclass);
             if ($expr_type->hasRealTypeSet()) {
-                return $expr_type->withRealTypeSet(array_merge($expr_type->getRealTypeSet(), [$stdclass]));
+                return $expr_type->withRealTypeSet(\array_merge($expr_type->getRealTypeSet(), [$stdclass]));
             } else {
                 return $expr_type->withRealType(ObjectType::instance(false));
             }

--- a/src/Phan/Analysis/ArgumentType.php
+++ b/src/Phan/Analysis/ArgumentType.php
@@ -497,7 +497,7 @@ final class ArgumentType
                     $argument->is_reference = true;
                 }
             }
-            if ($argument_kind === \ast\AST_UNPACK) {
+            if ($argument_kind === \ast\AST_UNPACK && $argument instanceof Node) {
                 self::analyzeRemainingParametersForVariadic($code_base, $context, $method, $i + 1, $node, $argument, $argument_type);
             }
         }
@@ -861,7 +861,7 @@ final class ArgumentType
      * Used to check if a place expecting a reference is actually getting a reference from a node.
      * Obvious types which are always references (properties, variables) must be checked for before calling this.
      *
-     * @param Node|string|int|float $node
+     * @param Node|string|int|float|null $node
      *
      * @return bool - True if this node is a call to a function that may return a reference?
      */

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -925,7 +925,8 @@ class ConditionVisitor extends KindVisitorImplementation implements ConditionVis
                 }
                 return $type;
             },
-            true
+            true,
+            false
         );
     }
 
@@ -946,7 +947,7 @@ class ConditionVisitor extends KindVisitorImplementation implements ConditionVis
         // Should always be a node for valid ASTs, tolerant-php-parser may produce invalid nodes
         if (\in_array($var_node->kind, [ast\AST_VAR, ast\AST_PROP, ast\AST_DIM], true)) {
             // Don't emit notices for if (empty($x)) {}, etc. We already do that in RedundantConditionPlugin.
-            return $this->removeTruthyFromVariable($var_node, $this->context, true);
+            return $this->removeTruthyFromVariable($var_node, $this->context, true, true);
         }
         $this->checkVariablesDefinedInIsset($var_node);
         return $this->context;

--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -489,7 +489,7 @@ class Context extends FileRef
     {
         $result = (string)$this;
         foreach ($this->getScope()->getVariableMap() as $variable) {
-            $result .= "\n$variable";
+            $result .= "\n{$variable->getDebugRepresentation()}";
         }
         return $result;
     }

--- a/src/Phan/Language/Element/Parameter.php
+++ b/src/Phan/Language/Element/Parameter.php
@@ -679,7 +679,7 @@ class Parameter extends Variable
 
         // TODO: hide template types, generic array or real array types
         $union_type_string = $union_type->__toString();
-        if ($union_type_string === 'mixed')  {
+        if ($union_type_string === 'mixed') {
             return '';
         }
         if (strlen($union_type_string) < 100) {

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -111,7 +111,7 @@ class Type
      * NOTE: The / is escaped
      */
     const noncapturing_literal_regex =
-        '\??(?:-?(?:0|[1-9][0-9]*(?:\.[0-9]+)?)|\'(?:[- ,.\/?:;"!#$%^&*_+=a-zA-Z0-9_\x80-\xff]|\\\\(?:[\'\\\\]|x[0-9a-fA-F]{2}))*\')';
+        '\??(?:-?(?:(?:0|[1-9][0-9]*)(?:\.[0-9]+)?)|\'(?:[- ,.\/?:;"!#$%^&*_+=a-zA-Z0-9_\x80-\xff]|\\\\(?:[\'\\\\]|x[0-9a-fA-F]{2}))*\')';
         // '\??(?:-?(?:0|[1-9][0-9]*)|\'(?:[a-zA-Z0-9_])*\')';
 
     /**
@@ -1657,7 +1657,7 @@ class Type
      */
     public function isAlwaysTruthy() : bool
     {
-        return true;
+        return !$this->is_nullable;
     }
 
     /**
@@ -1675,7 +1675,7 @@ class Type
      */
     public function isPossiblyFalse() : bool
     {
-        return false;
+        return $this->is_nullable;
     }
 
     /**

--- a/src/Phan/Language/Type/FunctionLikeDeclarationType.php
+++ b/src/Phan/Language/Type/FunctionLikeDeclarationType.php
@@ -929,11 +929,13 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
         return null;
     }
 
-    public function setIsPure() : void {
+    public function setIsPure() : void
+    {
         // no-op
     }
 
-    public function isPure() : bool {
+    public function isPure() : bool
+    {
         return false;
     }
 

--- a/tests/Phan/Language/TypeTest.php
+++ b/tests/Phan/Language/TypeTest.php
@@ -98,6 +98,9 @@ final class TypeTest extends BaseTest
         $this->assertParsesAsType(LiteralIntType::instanceForValue(190, false), '190');
         $this->assertParsesAsType(LiteralFloatType::instanceForValue(1111111111111111111111111111111111, false), '1111111111111111111111111111111111');
         $this->assertParsesAsType(LiteralFloatType::instanceForValue(-1.5, false), '-1.5');
+        $this->assertParsesAsType(LiteralFloatType::instanceForValue(0.0, false), '0.0');
+        $this->assertParsesAsType(LiteralFloatType::instanceForValue(0.25, false), '0.25');
+        $this->assertParsesAsType(LiteralFloatType::instanceForValue(0.25, true), '?0.25');
         $this->assertParsesAsType(LiteralIntType::instanceForValue(1, true), '?1');
         $this->assertParsesAsType(LiteralIntType::instanceForValue(-1, true), '?-1');
     }

--- a/tests/files/expected/0065_tostring.php.expected
+++ b/tests/files/expected/0065_tostring.php.expected
@@ -1,1 +1,1 @@
-%s:16 PhanTypeMismatchArgument Argument 2 ($arg) is \Stringular|string but \test() takes int defined at %s:10
+%s:16 PhanTypeMismatchArgumentReal Argument 2 ($arg) is \Stringular|string but \test() takes int defined at %s:10

--- a/tests/files/expected/0254_array_bool_comparison.php.expected
+++ b/tests/files/expected/0254_array_bool_comparison.php.expected
@@ -1,5 +1,6 @@
 %s:3 PhanRedundantCondition Redundant attempt to cast true of type true to truthy
 %s:4 PhanRedundantCondition Redundant attempt to cast true of type true to truthy
+%s:5 PhanSuspiciousWeakTypeComparison Suspicious attempt to compare $p of type array|array{} to 'string' of type 'string'
 %s:5 PhanTypeComparisonFromArray array to string comparison
 %s:6 PhanSuspiciousWeakTypeComparison Suspicious attempt to compare 'string' of type 'string' to $p2 of type array
 %s:6 PhanTypeComparisonToArray string to array comparison

--- a/tests/files/expected/0280_should_infer_nullable_from_default.php.expected
+++ b/tests/files/expected/0280_should_infer_nullable_from_default.php.expected
@@ -1,4 +1,4 @@
 %s:23 PhanParamSignatureMismatch Declaration of function foo(int $arg = 20) should be compatible with function foo(?int $arg = null) defined in %s:10
 %s:23 PhanParamSignatureRealMismatchParamType Declaration of function foo(int $arg = 20) should be compatible with function foo(?int $arg = null) (parameter #1 of type 'int' cannot replace original parameter of type '?int') defined in %s:10
 %s:27 PhanTypeMismatchDefault Default value for ?int $x can't be float
-%s:34 PhanTypeMismatchArgument Argument 1 ($arg) is null but \C280::foo() takes int defined at %s:23
+%s:34 PhanTypeMismatchArgumentReal Argument 1 ($arg) is null but \C280::foo() takes int defined at %s:23

--- a/tests/files/expected/0413_traversable.php.expected
+++ b/tests/files/expected/0413_traversable.php.expected
@@ -1,5 +1,5 @@
 %s:5 PhanTypeMismatchArgumentInternal Argument 1 ($string) is array but \strlen() takes string
-%s:9 PhanTypeMismatchReturn Returning type \Traversable but to_array() is declared to return array
+%s:9 PhanTypeMismatchReturnReal Returning type \Traversable but to_array() is declared to return array
 %s:18 PhanUndeclaredMethod Call to undeclared method \Traversable::nnnext
 %s:19 PhanTypeMismatchReturnReal Returning type \Traversable but check_iterable() is declared to return array
 %s:21 PhanTypeMismatchArgumentInternal Argument 1 ($string) is array but \strlen() takes string

--- a/tests/files/expected/0421_binary_operator.php.expected
+++ b/tests/files/expected/0421_binary_operator.php.expected
@@ -1,6 +1,7 @@
 %s:4 PhanNoopBinaryOperator Unused result of a binary '|' operator
 %s:5 PhanNoopBinaryOperator Unused result of a binary '^' operator
 %s:8 PhanNoopBinaryOperator Unused result of a binary 'xor' operator
+%s:12 PhanCoalescingNeverNull Using non-null $left of type int as the left hand side of a null coalescing (??) operation. The right hand side may be unnecessary.
 %s:13 PhanNoopBinaryOperator Unused result of a binary '.' operator
 %s:14 PhanNoopBinaryOperator Unused result of a binary '*' operator
 %s:15 PhanNoopBinaryOperator Unused result of a binary '%' operator

--- a/tests/files/expected/0477_array_negation.php.expected
+++ b/tests/files/expected/0477_array_negation.php.expected
@@ -1,2 +1,2 @@
 %s:6 PhanTypeMismatchArgumentInternal Argument 1 ($string) is null but \strlen() takes string
-%s:11 PhanTypeMismatchArgumentInternal Argument 1 ($string) is ?array{} but \strlen() takes string
+%s:11 PhanTypeMismatchArgumentInternal Argument 1 ($string) is array{}|null but \strlen() takes string

--- a/tests/files/expected/0757_empty_nested.php.expected
+++ b/tests/files/expected/0757_empty_nested.php.expected
@@ -1,0 +1,4 @@
+%s:10 PhanTypeInvalidDimOffset Invalid offset "listprice" of array type ?''|?'0'|?0|?0.0|?array{}|?false
+%s:10 PhanTypeSuspiciousStringExpression Suspicious type null of a variable or expression used to build a string. (Expected type to be able to cast to a string)
+%s:18 PhanImpossibleCondition Impossible attempt to cast $x of type ?''|?'0'|?0|?0.0|?array{}|?false to object
+%s:22 PhanImpossibleCondition Impossible attempt to cast $x of type ?''|?'0'|?0|?0.0|?false to resource

--- a/tests/files/src/0757_empty_nested.php
+++ b/tests/files/src/0757_empty_nested.php
@@ -1,0 +1,26 @@
+<?php
+function test757(array $additional) {
+    if (empty($additional['product']['comment'])) {
+        // Should not warn
+        echo $additional['product']['listprice'] . "\n";
+    }
+    if (empty($additional['product'])) {
+
+        // should warn
+        echo $additional['product']['listprice'] . "\n";
+    }
+}
+/**
+ * @param int $x
+ */
+function test757b($x) {
+    if (empty($x)) {
+        if (is_object($x)) {
+            echo "Impossible\n";
+        } elseif (is_array($x)) {
+            echo "The empty array\n";
+        } elseif (is_resource($x)) {
+            echo "Impossible\n";
+        }
+    }
+}

--- a/tests/rasmus_files/expected/0005_arg_types.php.expected
+++ b/tests/rasmus_files/expected/0005_arg_types.php.expected
@@ -1,2 +1,2 @@
-%s:7 PhanTypeMismatchArgument Argument 4 ($arg4) is 4 but \test() takes array defined at %s:2
+%s:7 PhanTypeMismatchArgumentReal Argument 4 ($arg4) is 4 but \test() takes array defined at %s:2
 %s:8 PhanTypeMismatchArgument Argument 2 ($arg2) is 2.5 but \test() takes int defined at %s:2


### PR DESCRIPTION
Properly warn about redundant conditions when parameters have default
values.

Avoid some bad inferences from passing `A || B` to a function

Fixes #3112 