### PR TITLE
Add `@phan-pure` annotation for functionlikes.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,9 @@ New features(Analysis):
 + Improve redundant condition detection for empty/falsey/truthy checks, `self`, and internal functions building or processing arrays.
 + Include strings that are suffixes of variable names, classes, methods, properties, etc. in issue suggestions for undeclared elements. (#2342)
 + Emit `PhanTypeNonVarReturnByRef` when an invalid expression is returned by a function declared to return a reference.
++ Support manually annotating that functions/methods/closures are pure with `/** @phan-pure */`.
+  This is automatically inherited by overriding methods.
+  Also see `UseReturnValuePlugin` and `'plugin_config' => ['infer_pure_methods' => true]`.
 
 Plugins:
 + In `UseReturnValuePlugin`, support inferring whether closures, functions, and methods are pure

--- a/NEWS.md
+++ b/NEWS.md
@@ -40,6 +40,10 @@ Plugins:
   Automatic inference of function purity is done recursively.
 + Fix false positive in InvalidVariableIssetPlugin for expressions such as `isset(self::$prop['field'])` (#3089)
 
+Maintenance:
++ Add example vim syntax highlighting snippet for Phan's custom phpdoc annotations to `plugins/vim/syntax/phan.vim`
+  This makes it easier to tell if annotations were correctly typed.
+
 Bug fixes:
 + Don't scan over folders that would be excluded by `'exclude_file_regex'` while parsing. (#3088)
   That adds additional time and may cause unnecessary permissions errors.

--- a/plugins/vim/syntax/php.vim
+++ b/plugins/vim/syntax/php.vim
@@ -1,0 +1,5 @@
+" Highlights Phan's phpdoc annotations in vim.
+" (in addition to what is already highlighted by vim)
+"
+" To use this, add this file to ~/.vim/syntax/php.vim (or the equivalent) 
+syntax match phpDocTags "@\(\(phan-\(forbid-undeclared-magic-\(properties\|methods\)\|closure-scope\|file-suppress\|suppress\|\|suppress-next-line\|suppress-current-line\|method\|output-reference\|ignore-reference\|override\|param\|property-read\|template\|assert\|assert-\(true\|false\)-condition\|read-only\|write-only\|property\|property-write\|return\|real-return\|unused-param\|pure\|var\|var-force\|var-debug\|transient\|\)\)\|transient\|property-read\|property-write\|template\)" containedin=phpComment

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -426,6 +426,10 @@ class ParameterTypesAnalyzer
         if ($o_method->isPrivate()) {
             return;
         }
+        // Inherit (at)phan-pure annotations by default.
+        if ($o_method->isPure()) {
+            $method->setIsPure();
+        }
 
         // Get the class that the overridden method lives on
         $o_class = $o_method->getClass($code_base);

--- a/src/Phan/Language/Element/Comment.php
+++ b/src/Phan/Language/Element/Comment.php
@@ -344,6 +344,9 @@ class Comment
             case 'extends':
                 $this->inherited_type = $value;
                 return;
+            case 'pure':
+                $this->comment_flags |= Flags::IS_PURE;
+                return;
         }
     }
 
@@ -430,6 +433,16 @@ class Comment
     public function isNSInternal() : bool
     {
         return ($this->comment_flags & Flags::IS_NS_INTERNAL) != 0;
+    }
+
+    /**
+     * @return bool
+     * Set to true if the comment contains an 'phan-pure'
+     * directive.
+     */
+    public function isPure() : bool
+    {
+        return ($this->comment_flags & Flags::IS_PURE) != 0;
     }
 
     /**

--- a/src/Phan/Language/Element/Comment/Builder.php
+++ b/src/Phan/Language/Element/Comment/Builder.php
@@ -667,6 +667,9 @@ final class Builder
             case 'phan-property-write':
                 $this->parsePhanProperty($i, $line);
                 return;
+            case 'phan-pure':
+                $this->phan_overrides['pure'] = true;
+                return;
             case 'phan-method':
                 $this->parsePhanMethod($i, $line);
                 return;
@@ -739,6 +742,7 @@ final class Builder
         '@phan-property' => '',
         '@phan-property-read' => '',
         '@phan-property-write' => '',
+        '@phan-pure' => '',
         '@phan-read-only' => '',
         '@phan-return' => '',
         '@phan-real-return' => '',

--- a/src/Phan/Language/Element/Comment/Builder.php
+++ b/src/Phan/Language/Element/Comment/Builder.php
@@ -668,6 +668,7 @@ final class Builder
                 $this->parsePhanProperty($i, $line);
                 return;
             case 'phan-pure':
+                $this->checkCompatible('@phan-pure', Comment::FUNCTION_LIKE, $i);
                 $this->phan_overrides['pure'] = true;
                 return;
             case 'phan-method':

--- a/src/Phan/Language/Element/Flags.php
+++ b/src/Phan/Language/Element/Flags.php
@@ -59,6 +59,7 @@ class Flags
     // Currently for strict visibility checking, because fake constructors have public visibility by default, and Phan
     // fails thinking that child classes are violating the visibility if they have a private or protected __construct
     const IS_FAKE_CONSTRUCTOR = (1 << 27);
+    const IS_PURE = (1 << 28);
 
     /**
      * Either enable or disable the given flag on

--- a/src/Phan/Language/Element/Func.php
+++ b/src/Phan/Language/Element/Func.php
@@ -243,9 +243,14 @@ class Func extends AddressableElement implements FunctionInterface
         // function is deprecated
         $func->setIsDeprecated($comment->isDeprecated());
 
-        // Set whether or not the element is internal to
+        // Set whether or not the function is internal to
         // the namespace.
         $func->setIsNSInternal($comment->isNSInternal());
+
+        // Set whether this function is pure.
+        if ($comment->isPure()) {
+            $func->setIsPure();
+        }
 
         $func->setSuppressIssueSet(
             $comment->getSuppressIssueSet()

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -1757,7 +1757,7 @@ trait FunctionTrait
      */
     public function setIsPure() : void
     {
-        $this->setPhanFlags($this->getPhanFlags() | Flags::IS_READ_ONLY);
+        $this->setPhanFlags($this->getPhanFlags() | Flags::IS_PURE);
     }
 
     /**
@@ -1766,6 +1766,6 @@ trait FunctionTrait
      */
     public function isPure() : bool
     {
-        return $this->getPhanFlagsHasState(Flags::IS_READ_ONLY);
+        return $this->getPhanFlagsHasState(Flags::IS_PURE);
     }
 }

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -523,9 +523,14 @@ class Method extends ClassElement implements FunctionInterface
         // method is deprecated
         $method->setIsDeprecated($comment->isDeprecated());
 
-        // Set whether or not the element is internal to
+        // Set whether or not the method is internal to
         // the namespace.
         $method->setIsNSInternal($comment->isNSInternal());
+
+        // Set whether this method is pure.
+        if ($comment->isPure()) {
+            $method->setIsPure();
+        }
 
         // Set whether or not the comment indicates that the method is intended
         // to override another method.

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -1507,6 +1507,7 @@ class Type
      *
      * @deprecated use self::asPHPDocUnionType()
      * @suppress PhanUnreferencedPublicMethod
+     * @phan-pure
      */
     public function asUnionType() : UnionType
     {
@@ -1517,6 +1518,7 @@ class Type
      * @return UnionType
      * A UnionType representing this and only this type (from phpdoc or real types)
      * @see asRealUnionType() if you are certain this is the real type of the expression.
+     * @phan-pure
      */
     public function asPHPDocUnionType() : UnionType
     {
@@ -1528,6 +1530,7 @@ class Type
     /**
      * @return UnionType
      * A UnionType representing this and only this type
+     * @phan-pure
      */
     public function asRealUnionType() : UnionType
     {
@@ -1548,6 +1551,7 @@ class Type
      * from this type
      *
      * @see FullyQualifiedClassName::fromType() for a method that always returns FullyQualifiedClassName
+     * @phan-pure
      */
     public function asFQSEN() : FQSEN
     {
@@ -1558,6 +1562,7 @@ class Type
     /**
      * @return string
      * The name associated with this type
+     * @phan-pure
      */
     public function getName() : string
     {
@@ -1567,6 +1572,7 @@ class Type
     /**
      * @return string
      * The namespace associated with this type
+     * @phan-pure
      */
     public function getNamespace() : string
     {
@@ -1577,6 +1583,7 @@ class Type
      * Is this nullable?
      *
      * E.g. returns true for `?array`, `null`, etc.
+     * @phan-pure
      */
     public function isNullable() : bool
     {
@@ -1595,6 +1602,7 @@ class Type
 
     /**
      * Returns true if this has some possibly falsey values
+     * @phan-pure
      */
     public function isPossiblyFalsey() : bool
     {
@@ -1605,6 +1613,7 @@ class Type
      * Returns true if this has some possibly falsey values
      * @deprecated
      * @suppress PhanUnreferencedPublicMethod
+     * @phan-pure
      */
     final public function getIsPossiblyFalsey() : bool
     {
@@ -1613,6 +1622,7 @@ class Type
 
     /**
      * Returns true if this is guaranteed to be falsey
+     * @phan-pure
      */
     public function isAlwaysFalsey() : bool
     {
@@ -1631,6 +1641,7 @@ class Type
 
     /**
      * Returns true if this is possibly truthy.
+     * @phan-pure
      */
     public function isPossiblyTruthy() : bool
     {
@@ -1654,6 +1665,7 @@ class Type
      *
      * This base class (Type) is type of an object with a known FQSEN,
      * which is always truthy.
+     * @phan-pure
      */
     public function isAlwaysTruthy() : bool
     {
@@ -1672,6 +1684,7 @@ class Type
 
     /**
      * Returns true for types such as `mixed`, `bool`, `false`
+     * @phan-pure
      */
     public function isPossiblyFalse() : bool
     {
@@ -1682,6 +1695,7 @@ class Type
      * Returns true for types such as `mixed`, `bool`, `false`
      * @deprecated use isPossiblyFalse
      * @suppress PhanUnreferencedPublicMethod
+     * @phan-pure
      */
     final public function getIsPossiblyFalse() : bool
     {
@@ -1709,6 +1723,7 @@ class Type
     /**
      * Returns true if this could include the type `true`
      * (e.g. for `mixed`, `bool`, etc.)
+     * @phan-pure
      */
     public function isPossiblyTrue() : bool
     {
@@ -1719,6 +1734,7 @@ class Type
      * Returns true if this could include the type `true`
      * @deprecated use isPossiblyTrue
      * @suppress PhanUnreferencedPublicMethod
+     * @phan-pure
      */
     final public function getIsPossiblyTrue() : bool
     {
@@ -1727,6 +1743,7 @@ class Type
 
     /**
      * Returns true for non-nullable `TrueType`
+     * @phan-pure
      */
     public function isAlwaysTrue() : bool
     {
@@ -1745,6 +1762,7 @@ class Type
 
     /**
      * Returns true for FalseType, TrueType, and BoolType
+     * @phan-pure
      */
     public function isInBoolFamily() : bool
     {
@@ -1763,6 +1781,7 @@ class Type
 
     /**
      * Returns true if this type may satisfy `is_numeric()`
+     * @phan-pure
      */
     public function isPossiblyNumeric() : bool
     {
@@ -1787,6 +1806,7 @@ class Type
      * @return Type
      * A new type that is a copy of this type but with the
      * given nullability value.
+     * @phan-pure
      */
     public function withIsNullable(bool $is_nullable) : Type
     {
@@ -1807,6 +1827,7 @@ class Type
      *
      * Overridden by BoolType, etc.
      * @see self::isAlwaysFalsey()
+     * @phan-pure
      */
     public function asNonFalseyType() : Type
     {
@@ -1819,6 +1840,7 @@ class Type
      *
      * Overridden by BoolType, etc.
      * @see self::isAlwaysTruthy()
+     * @phan-pure
      */
     public function asNonTruthyType() : Type
     {
@@ -1831,6 +1853,7 @@ class Type
      *
      * Overridden by BoolType, etc.
      * @see self::isAlwaysFalse()
+     * @phan-pure
      */
     public function asNonFalseType() : Type
     {
@@ -1842,6 +1865,7 @@ class Type
      *
      * Overridden by BoolType, etc.
      * @see self::isAlwaysTrue()
+     * @phan-pure
      */
     public function asNonTrueType() : Type
     {
@@ -1851,7 +1875,7 @@ class Type
     /**
      * @return bool
      * True if this is a native type (like int, string, etc.)
-     *
+     * @phan-pure
      */
     public function isNativeType() : bool
     {
@@ -1884,6 +1908,7 @@ class Type
      * True if this type is a type referencing the
      * class context in which it exists such as 'static'
      * or 'self'.
+     * @phan-pure
      */
     public function isSelfType() : bool
     {
@@ -1896,6 +1921,7 @@ class Type
      * True if this type is a type referencing the
      * class context 'static'.
      * Overridden in the subclass StaticType
+     * @phan-pure
      */
     public function isStaticType() : bool
     {
@@ -1905,6 +1931,7 @@ class Type
     /**
      * Returns true if this has any instance of `static` or `self`.
      * This is overridden in subclasses such as `SelfType`.
+     * @phan-pure
      */
     public function hasStaticOrSelfTypesRecursive(CodeBase $code_base) : bool
     {
@@ -1927,6 +1954,7 @@ class Type
      * @return bool
      * True if the given type references the class context
      * in which it exists such as 'self' or 'parent'
+     * @phan-pure
      */
     public static function isSelfTypeString(
         string $type_string
@@ -1943,6 +1971,7 @@ class Type
      * @return bool
      * True if the given type references the class context
      * in which it exists is '$this' or 'static'
+     * @phan-pure
      */
     public static function isStaticTypeString(
         string $type_string
@@ -1955,6 +1984,7 @@ class Type
     /**
      * @return bool
      * True if this type is scalar.
+     * @phan-pure
      */
     public function isScalar() : bool
     {
@@ -1965,6 +1995,7 @@ class Type
      * @return bool
      * True if this type is a printable scalar.
      * @internal
+     * @phan-pure
      */
     public function isPrintableScalar() : bool
     {
@@ -1975,6 +2006,7 @@ class Type
      * @return bool
      * True if this type is a valid operand for a bitwise operator ('|', '&', or '^').
      * @internal
+     * @phan-pure
      */
     public function isValidBitwiseOperand() : bool
     {
@@ -1984,6 +2016,7 @@ class Type
     /**
      * @return bool
      * True if this type is a callable or a Closure.
+     * @phan-pure
      */
     public function isCallable() : bool
     {
@@ -1993,6 +2026,7 @@ class Type
     /**
      * @return bool
      * True if this type is an object (or the phpdoc `object`)
+     * @phan-pure
      */
     public function isObject() : bool
     {
@@ -2002,6 +2036,7 @@ class Type
     /**
      * Returns this type (or a subtype) converted to a type of an expression satisfying is_object(expr)
      * Returns null if Phan cannot cast this type to an object type.
+     * @phan-pure
      */
     public function asObjectType() : ?Type
     {
@@ -2012,6 +2047,7 @@ class Type
     /**
      * @return bool
      * True if this type is an object (and not the phpdoc `object` or a template)
+     * @phan-pure
      */
     public function isObjectWithKnownFQSEN() : bool
     {
@@ -2022,6 +2058,7 @@ class Type
      * @return bool
      * True if this type is possibly an object (or the phpdoc `object`)
      * This is the same as isObject(), except that it returns true for the exact class of IterableType.
+     * @phan-pure
      */
     public function isPossiblyObject() : bool
     {
@@ -2031,6 +2068,7 @@ class Type
     /**
      * Check if there is any way this type or a subclass could cast to $other.
      * (does not check for mixed)
+     * @phan-pure
      */
     public function canPossiblyCastToClass(CodeBase $code_base, Type $other) : bool
     {
@@ -2077,6 +2115,7 @@ class Type
     /**
      * @return bool
      * True if this type is iterable.
+     * @phan-pure
      */
     public function isIterable() : bool
     {
@@ -2087,6 +2126,7 @@ class Type
      * @return bool
      * True if this type is array-like (is of type array, is
      * a generic array, or implements ArrayAccess).
+     * @phan-pure
      */
     public function isArrayLike() : bool
     {
@@ -2100,6 +2140,7 @@ class Type
      * True if this is a generic type such as 'int[]' or 'string[]'.
      * Currently, this is the same as `$type instanceof GenericArrayInterface`
      * @suppress PhanUnreferencedPublicMethod
+     * @phan-pure
      */
     public function isGenericArray() : bool
     {
@@ -2118,6 +2159,7 @@ class Type
     /**
      * Is this an array or ArrayAccess, or a subtype of those?
      * E.g. returns true for `\ArrayObject`, `array<int,string>`, etc.
+     * @phan-pure
      */
     public function isArrayOrArrayAccessSubType(CodeBase $code_base) : bool
     {
@@ -2126,6 +2168,7 @@ class Type
 
     /**
      * @return bool - Returns true if this is \Traversable (nullable or not)
+     * @phan-pure
      */
     public function isTraversable() : bool
     {
@@ -2136,6 +2179,7 @@ class Type
     /**
      * @return bool - Returns true if this is \Generator (nullable or not)
      * @suppress PhanUnreferencedPublicMethod
+     * @phan-pure
      */
     public function isGenerator() : bool
     {
@@ -2150,6 +2194,7 @@ class Type
      * @return bool
      * True if this is a generic type such as 'int[]' or
      * 'string[]'.
+     * @phan-pure
      */
     private static function isGenericArrayString(string $type_name) : bool
     {
@@ -2161,6 +2206,7 @@ class Type
 
     /**
      * @return ?UnionType returns the iterable key's union type, if this is a subtype of iterable. null otherwise.
+     * @phan-pure
      */
     public function iterableKeyUnionType(CodeBase $unused_code_base) : ?UnionType
     {
@@ -2189,6 +2235,7 @@ class Type
      * @return ?UnionType returns the iterable value's union type if this is a subtype of iterable, null otherwise.
      *
      * This is overridden by the array subclasses
+     * @phan-pure
      */
     public function iterableValueUnionType(CodeBase $unused_code_base) : ?UnionType
     {
@@ -2256,6 +2303,7 @@ class Type
      * As a special case to reduce false positives, 'array' (with no known types) will produce 'array'
      *
      * Overridden in subclasses
+     * @phan-pure
      */
     public function asGenericArrayType(int $key_type) : Type
     {
@@ -2267,6 +2315,7 @@ class Type
      * True if this type has any template parameter types
      * @suppress PhanUnreferencedPublicMethod potentially used in the future
      *           TODO: Would need to override this in ArrayShapeType, GenericArrayType
+     * @phan-pure
      */
     public function hasTemplateParameterTypes() : bool
     {
@@ -2277,6 +2326,7 @@ class Type
      * @return array<int,UnionType>
      * The set of types filling in template parameter types defined
      * on the class specified by this type.
+     * @phan-pure
      */
     public function getTemplateParameterTypeList() : array
     {
@@ -2289,6 +2339,7 @@ class Type
      *
      * @return array<string,UnionType>
      * A map from template type identifier to a concrete type
+     * @phan-pure
      */
     public function getTemplateParameterTypeMap(CodeBase $code_base) : array
     {
@@ -2330,6 +2381,7 @@ class Type
      * a superset of this type.
      *
      * TODO: Add equivalent to preserve the real type
+     * @phan-pure
      */
     public function asExpandedTypes(
         CodeBase $code_base,
@@ -2411,6 +2463,7 @@ class Type
      * @return UnionType
      * Expands class types to all inherited classes returning
      * a superset of this type.
+     * @phan-pure
      */
     public function asExpandedTypesPreservingTemplate(
         CodeBase $code_base,
@@ -2498,6 +2551,7 @@ class Type
      * @return bool
      * True if this Type can be cast to the given Type cleanly.
      * This is overridden by ArrayShapeType to allow array{a:string,b:stdClass} to cast to string[]|stdClass[]
+     * @phan-pure
      */
     public function canCastToAnyTypeInSet(array $target_type_set) : bool
     {
@@ -2514,6 +2568,7 @@ class Type
      * @return bool
      * True if this Type can be cast to the given Type cleanly, ignoring permissive config settings.
      * This is overridden by ArrayShapeType to allow array{a:string,b:stdClass} to cast to string[]|stdClass[]
+     * @phan-pure
      */
     public function canCastToAnyTypeInSetWithoutConfig(array $target_type_set) : bool
     {
@@ -2530,6 +2585,7 @@ class Type
      * @return bool
      * True if this Type can be cast to the given Type cleanly.
      * This is overridden by ArrayShapeType to allow array{a:string,b:stdClass} to cast to string[]|stdClass[]
+     * @phan-pure
      */
     public function isSubtypeOfAnyTypeInSet(array $target_type_set) : bool
     {
@@ -2546,6 +2602,7 @@ class Type
      * @return bool
      * True if this Type can be cast to the given Type cleanly.
      * This is overridden by ArrayShapeType to allow array{a:string,b:stdClass} to cast to string[]|stdClass[]
+     * @phan-pure
      */
     public function canCastToAnyTypeInSetHandlingTemplates(array $target_type_set, CodeBase $code_base) : bool
     {
@@ -2561,6 +2618,7 @@ class Type
      * @return bool
      * True if this Type can be cast to the given Type
      * cleanly
+     * @phan-pure
      */
     public function canCastToType(Type $type) : bool
     {
@@ -2607,6 +2665,7 @@ class Type
      * @return bool
      * True if this Type can be cast to the given Type
      * cleanly (accounting for templates)
+     * @phan-pure
      */
     public function canCastToTypeHandlingTemplates(Type $type, CodeBase $code_base) : bool
     {
@@ -2653,6 +2712,7 @@ class Type
      * @return bool
      * True if this Type can be cast to the given Type
      * cleanly without config settings.
+     * @phan-pure
      */
     public function canCastToTypeWithoutConfig(Type $type) : bool
     {
@@ -2696,6 +2756,7 @@ class Type
      * @return bool
      * True if this Type can be cast to the given Type
      * cleanly
+     * @phan-pure
      */
     protected function canCastToNonNullableType(Type $type) : bool
     {
@@ -2736,6 +2797,7 @@ class Type
      * @return bool
      * True if this Type can be cast to the given Type
      * cleanly, ignoring permissive config casting rules
+     * @phan-pure
      */
     protected function canCastToNonNullableTypeWithoutConfig(Type $type) : bool
     {
@@ -2776,6 +2838,7 @@ class Type
      * @return bool
      * True if this Type can be cast to the given Type
      * cleanly
+     * @phan-pure
      */
     protected function canCastToNonNullableTypeHandlingTemplates(Type $type, CodeBase $code_base) : bool
     {
@@ -2793,6 +2856,7 @@ class Type
     /**
      * @return bool
      * True if this Type is a subtype of the other type.
+     * @phan-pure
      */
     public function isSubtypeOf(Type $type) : bool
     {
@@ -2833,6 +2897,7 @@ class Type
      * (All types are sub-types of mixed, but mixed isn't a subtype of those types)
      *
      * TODO: Override everywhere else
+     * @phan-pure
      */
     protected function isSubtypeOfNonNullableType(Type $type) : bool
     {
@@ -2924,6 +2989,7 @@ class Type
      * TODO: Refactor.
      *
      * @see UnionType::isExclusivelyNarrowedFormOrEquivalentTo() for a check on union types as a whole.
+     * @phan-pure
      */
     public function isExclusivelyNarrowedFormOrEquivalentTo(
         UnionType $union_type,
@@ -2960,6 +3026,7 @@ class Type
     /**
      * @return Type
      * Either this or 'static' resolved in the given context.
+     * @phan-pure
      */
     public function withStaticResolvedInContext(
         Context $_
@@ -2970,6 +3037,7 @@ class Type
     /**
      * @return string
      * A string representation of this type in FQSEN form.
+     * @phan-pure
      */
     public function asFQSENString() : string
     {
@@ -2989,6 +3057,7 @@ class Type
      * @return string
      * A human readable representation of this type
      * (This is frequently called, so prefer efficient operations)
+     * @phan-pure
      */
     public function __toString()
     {
@@ -3010,6 +3079,7 @@ class Type
     /**
      * Gets the part of the Type string for the template parameters.
      * Precondition: $this->template_parameter_string is not null.
+     * @phan-pure
      */
     final protected function templateParameterTypeListAsString() : string
     {
@@ -3019,25 +3089,26 @@ class Type
             }, $this->template_parameter_type_list)) . '>';
     }
 
+    private const CANONICAL_NAME_MAP = [
+        'boolean'  => 'bool',
+        'callback' => 'callable',
+        'closure'  => 'Closure',
+        'double'   => 'float',
+        'integer'  => 'int',
+    ];
+
     /**
      * @param string $name
      * Any type name
      *
      * @return string
      * A canonical name for the given type name
+     * @phan-pure
      */
     public static function canonicalNameFromName(
         string $name
     ) : string {
-        static $map = [
-            'boolean'  => 'bool',
-            'callback' => 'callable',
-            'closure'  => 'Closure',
-            'double'   => 'float',
-            'integer'  => 'int',
-        ];
-
-        return $map[strtolower($name)] ?? $name;
+        return self::CANONICAL_NAME_MAP[strtolower($name)] ?? $name;
     }
 
     /**
@@ -3303,6 +3374,7 @@ class Type
     /**
      * Helper function for internal use by UnionType.
      * Overridden by subclasses.
+     * @phan-pure
      */
     public function getNormalizationFlags() : int
     {
@@ -3313,6 +3385,7 @@ class Type
      * Returns true if this contains any array shape type instances
      * or literal type instances that could be normalized to
      * regular generic array types or scalar types.
+     * @phan-pure
      */
     public function hasArrayShapeOrLiteralTypeInstances() : bool
     {
@@ -3322,6 +3395,7 @@ class Type
     /**
      * Returns true if this contains any array shape type instances
      * that could be normalized to regular generic array types.
+     * @phan-pure
      */
     public function hasArrayShapeTypeInstances() : bool
     {
@@ -3332,6 +3406,7 @@ class Type
      * Used to check if this type can be replaced by more specific types, for non-quick mode
      *
      * @internal
+     * @phan-pure
      */
     public function shouldBeReplacedBySpecificTypes() : bool
     {
@@ -3347,6 +3422,7 @@ class Type
      * This is overridden by subclasses.
      *
      * @return Type[]
+     * @phan-pure
      */
     public function withFlattenedArrayShapeOrLiteralTypeInstances() : array
     {
@@ -3355,6 +3431,7 @@ class Type
 
     /**
      * Overridden in subclasses such as LiteralIntType
+     * @phan-pure
      */
     public function asNonLiteralType() : Type
     {
@@ -3364,6 +3441,7 @@ class Type
     /**
      * Returns true if this is a potentially valid operand for a numeric operator.
      * Callers should also check if this is nullable.
+     * @phan-pure
      */
     public function isValidNumericOperand() : bool
     {
@@ -3374,6 +3452,7 @@ class Type
      * Returns true if this contains a type that is definitely nullable or a non-object.
      * e.g. returns true for false, array, int
      *      returns false for callable, object, iterable, T, etc.
+     *      @phan-pure
      */
     public function isDefiniteNonObjectType() : bool
     {
@@ -3384,6 +3463,7 @@ class Type
      * Returns true if this contains a type that is definitely non-callable
      * e.g. returns true for false, array, int
      *      returns false for callable, array, object, iterable, T, etc.
+     *      @phan-pure
      */
     public function isDefiniteNonCallableType() : bool
     {
@@ -3398,6 +3478,7 @@ class Type
      * @param int $flags (e.g. \ast\flags\BINARY_IS_SMALLER)
      * @internal
      * @suppress PhanUnusedPublicMethodParameter
+     * @phan-pure
      */
     public function canSatisfyComparison($scalar, int $flags) : bool
     {
@@ -3410,6 +3491,7 @@ class Type
      * @param int|string|float|bool|null $b
      * @param int $flags
      * @internal
+     * @phan-pure
      */
     public static function performComparison($a, $b, int $flags) : bool
     {
@@ -3428,6 +3510,7 @@ class Type
 
     /**
      * Returns the type after an expression such as `++$x`
+     * @phan-pure
      */
     public function getTypeAfterIncOrDec() : UnionType
     {
@@ -3443,6 +3526,7 @@ class Type
      * Returns the Type for \Traversable
      *
      * @suppress PhanThrowTypeAbsentForCall
+     * @phan-pure
      */
     public static function traversableInstance() : Type
     {
@@ -3454,6 +3538,7 @@ class Type
      * Returns the Type for \Throwable
      *
      * @suppress PhanThrowTypeAbsentForCall
+     * @phan-pure
      */
     public static function throwableInstance() : Type
     {
@@ -3463,6 +3548,7 @@ class Type
 
     /**
      * Returns true if this is `MyNs\MyClass<T..>` when $type is `MyNs\MyClass`
+     * @phan-pure
      */
     public function isTemplateSubtypeOf(Type $type) : bool
     {
@@ -3476,6 +3562,7 @@ class Type
      * Returns true for `T` and `T[]` and `\MyClass<T>`, but not `\MyClass<\OtherClass>`
      *
      * Overridden in subclasses.
+     * @phan-pure
      */
     public function hasTemplateTypeRecursive() : bool
     {
@@ -3496,6 +3583,7 @@ class Type
      * mapped to concrete types defined in the given map.
      *
      * Overridden in subclasses
+     * @phan-pure
      */
     public function withTemplateParameterTypeMap(
         array $template_parameter_type_map
@@ -3515,6 +3603,7 @@ class Type
 
     /**
      * Precondition: Callers should check isObjectWithKnownFQSEN
+     * @phan-pure
      */
     public function hasSameNamespaceAndName(Type $type) : bool
     {
@@ -3527,6 +3616,7 @@ class Type
      *
      * @return ?Closure(UnionType, Context):UnionType a closure to determine the union type(s) that are in the same position(s) as the template type.
      * This is overridden in subclasses.
+     * @phan-pure
      */
     public function getTemplateTypeExtractorClosure(CodeBase $code_base, TemplateType $template_type) : ?Closure
     {
@@ -3599,6 +3689,7 @@ class Type
      * @return Generator<mixed,Type>
      *
      * TODO: Also support template types
+     * @phan-pure
      */
     public function getReferencedClasses() : Generator
     {
@@ -3608,6 +3699,7 @@ class Type
     /**
      * Returns true if this type or a parent type can be used in a signature.
      * Returns false for template types, resources, object, etc.
+     * @phan-pure
      */
     public function canUseInRealSignature() : bool
     {
@@ -3616,6 +3708,7 @@ class Type
 
     /**
      * Returns the corresponding type that would be used in a signature
+     * @phan-pure
      */
     public function asSignatureType() : Type
     {
@@ -3627,6 +3720,7 @@ class Type
 
     /**
      * Convert this to a subtype that satisfies is_callable(), or return null
+     * @phan-pure
      */
     public function asCallableType() : ?Type
     {
@@ -3639,6 +3733,7 @@ class Type
     /**
      * Convert this to a subtype that satisfies is_array(), or returns null
      * @see UnionType::arrayTypesStrictCast
+     * @phan-pure
      */
     public function asArrayType() : ?Type
     {
@@ -3647,6 +3742,7 @@ class Type
 
     /**
      * Convert this to a subtype that satisfies is_scalar(), or returns null
+     * @phan-pure
      */
     public function asScalarType() : ?Type
     {
@@ -3657,6 +3753,7 @@ class Type
      * callers should use UnionType->hasAnyTypeOverlap() and UnionType->hasAnyWeakTypeOverlap() instead.
      * Overridden in subclasses
      * @internal
+     * @phan-pure
      */
     public function weaklyOverlaps(Type $other) : bool
     {

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -110,6 +110,7 @@ class UnionType implements Serializable
      * @param bool $is_unique - Whether or not this is already unique. Only set to true within UnionType code.
      * @param array<int,Type> $real_type_set
      * @see UnionType::of() for a more memory efficient equivalent.
+     * @phan-pure
      */
     public function __construct(array $type_list, bool $is_unique = false, array $real_type_set = [])
     {
@@ -120,6 +121,7 @@ class UnionType implements Serializable
     /**
      * @param Type[] $type_list
      * @param array<int,Type> $real_type_set
+     * @phan-pure
      */
     public static function of(array $type_list, array $real_type_set = []) : UnionType
     {
@@ -173,6 +175,7 @@ class UnionType implements Serializable
 
     /**
      * @deprecated use self::fromFullyQualifiedPHPDocString() instead.
+     * @phan-pure
      */
     public static function fromFullyQualifiedString(
         string $fully_qualified_string
@@ -187,6 +190,7 @@ class UnionType implements Serializable
      * @throws InvalidArgumentException if any type name in the union type was invalid
      *
      * @see self::fromFullyQualifiedRealString() if you are absolutely sure this is the real type of the expression.
+     * @phan-pure
      */
     public static function fromFullyQualifiedPHPDocString(
         string $fully_qualified_string
@@ -228,6 +232,7 @@ class UnionType implements Serializable
      * Use this if they are both non-empty but different.
      * The caller should pass in phpdoc types that are subtypes of the real types
      * (e.g. phpdoc='int|float' real='int')
+     * @phan-pure
      */
     public static function fromFullyQualifiedPHPDocAndRealString(
         string $fully_qualified_phpdoc_string,
@@ -254,6 +259,7 @@ class UnionType implements Serializable
      * A '|' delimited string representing a type in the form
      * 'int|string|null|ClassName'.
      * @throws InvalidArgumentException if any type name in the union type was invalid
+     * @phan-pure
      */
     public static function fromFullyQualifiedRealString(
         string $fully_qualified_string
@@ -294,6 +300,7 @@ class UnionType implements Serializable
     /**
      * @param array<int,Type> $type_list
      * @return array<int,Type>
+     * @phan-pure
      */
     public static function getUniqueTypes(array $type_list) : array
     {
@@ -321,6 +328,7 @@ class UnionType implements Serializable
      * May be provided to resolve 'parent' in the context
      * (e.g. if parsing complex phpdoc).
      * Unnecessary in most use cases.
+     * @phan-pure
      */
     public static function fromStringInContext(
         string $type_string,
@@ -635,6 +643,7 @@ class UnionType implements Serializable
 
     /**
      * Add a type name to the list of types
+     * @phan-pure
      */
     public function withType(Type $type) : UnionType
     {
@@ -657,6 +666,7 @@ class UnionType implements Serializable
      * keeping the keys in a consecutive order.
      *
      * Each type in $this->type_set occurs exactly once.
+     * @phan-pure
      */
     public function withoutType(Type $type) : UnionType
     {
@@ -686,6 +696,7 @@ class UnionType implements Serializable
 
     /**
      * Returns a union type with an empty union type set
+     * @phan-pure
      */
     public function eraseRealTypeSet() : UnionType
     {
@@ -701,6 +712,7 @@ class UnionType implements Serializable
 
     /**
      * Returns a union type which add the given types to this type
+     * @phan-pure
      */
     public function withUnionType(UnionType $union_type) : UnionType
     {

--- a/src/Phan/Plugin/Internal/UseReturnValuePlugin/UseReturnValueVisitor.php
+++ b/src/Phan/Plugin/Internal/UseReturnValuePlugin/UseReturnValueVisitor.php
@@ -301,7 +301,7 @@ class UseReturnValueVisitor extends PluginAwarePostAnalysisVisitor
             (clone($this->context))->withLineNumberStart($node->lineno),
             UseReturnValuePlugin::UseReturnValueKnown,
             'Expected to use the return value of the user-defined function/method {FUNCTION}',
-            [$fqsen]
+            [$method->getRepresentationForIssue()]
         );
     }
 }

--- a/tests/php74_files/expected/017_arrow_func_use_retval.php.expected
+++ b/tests/php74_files/expected/017_arrow_func_use_retval.php.expected
@@ -1,5 +1,5 @@
 %s:4 PhanUnusedVariable Unused definition of variable $initial
-%s:6 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \closure_fcbe0e9f1162
+%s:6 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method Closure(int $v)
 %s:9 PhanTypeNonVarPassByRef Only variables can be passed by reference at argument 1 of Closure(int &$v)
 %s:13 PhanTypeNonVarReturnByRef Only variables can be returned by reference in Closure&(int &$v)
 %s:17 PhanTypeNonVarReturnByRef Only variables can be returned by reference in Closure&(int &$v)

--- a/tests/php74_files/expected/018_arrow_func_call_use_retval.php.expected
+++ b/tests/php74_files/expected/018_arrow_func_call_use_retval.php.expected
@@ -1,1 +1,1 @@
-%s:5 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \double18
+%s:5 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \double18()

--- a/tests/plugin_test/expected/000_plugins.php.expected
+++ b/tests/plugin_test/expected/000_plugins.php.expected
@@ -24,7 +24,7 @@ src/000_plugins.php:64 PhanUnusedGlobalFunctionParameter Parameter $className is
 src/000_plugins.php:66 PhanUnreferencedClass Possibly zero references to class \__autoload
 src/000_plugins.php:67 PhanUnreferencedConstant Possibly zero references to global constant \__autoload
 src/000_plugins.php:69 PhanPluginAlwaysReturnFunction Function \missingReturnType has a return type of int, but may fail to return a value
-src/000_plugins.php:74 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \missingReturnType
+src/000_plugins.php:74 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \missingReturnType()
 src/000_plugins.php:77 PhanPluginAlwaysReturnMethod Method \ReturnChecks::missingReturnTypeSwitch has a return type of int, but may fail to return a value
 src/000_plugins.php:80 PhanThrowTypeAbsent \ReturnChecks::missingReturnTypeSwitch() can throw \RuntimeException here, but has no '@throws' declarations for that class
 src/000_plugins.php:93 PhanThrowTypeAbsent \ReturnChecks::missingReturnTypeSwitchGood() can throw \RuntimeException here, but has no '@throws' declarations for that class

--- a/tests/plugin_test/expected/001_dead_code.php.expected
+++ b/tests/plugin_test/expected/001_dead_code.php.expected
@@ -15,5 +15,5 @@ src/001_dead_code.php:44 PhanUnreferencedPublicProperty Possibly zero references
 src/001_dead_code.php:47 PhanUnreferencedPublicProperty Possibly zero references to public property \DuplicateClass001,1->instance_prop2
 src/001_dead_code.php:50 PhanUnreferencedPublicMethod Possibly zero references to public method \DuplicateClass001,1::f2()
 src/001_dead_code.php:51 PhanUnreferencedPublicMethod Possibly zero references to public method \DuplicateClass001,1::f4()
-src/001_dead_code.php:56 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \duplicateFnA
+src/001_dead_code.php:56 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \duplicateFnA()
 src/001_dead_code.php:59 PhanTypeSuspiciousStringExpression Suspicious type true of a variable or expression used to build a string. (Expected type to be able to cast to a string)

--- a/tests/plugin_test/expected/005_always_return.php.expected
+++ b/tests/plugin_test/expected/005_always_return.php.expected
@@ -1,10 +1,10 @@
 src/005_always_return.php:3 PhanPluginAlwaysReturnFunction Function \test5 has a return type of ?string, but may fail to return a value
 src/005_always_return.php:23 PhanPluginAlwaysReturnFunction Function \soft_non_nullable_test5 has a return type of string, but may fail to return a value
-src/005_always_return.php:30 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \test5
-src/005_always_return.php:31 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \soft_nullable_test5
-src/005_always_return.php:32 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \soft_non_nullable_test5
+src/005_always_return.php:30 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \test5()
+src/005_always_return.php:31 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \soft_nullable_test5()
+src/005_always_return.php:32 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \soft_non_nullable_test5()
 src/005_always_return.php:39 PhanPluginAlwaysReturnMethod Method \C5::test has a return type of ?string, but may fail to return a value
 src/005_always_return.php:59 PhanPluginAlwaysReturnMethod Method \C5::soft_non_nullable_test5 has a return type of string, but may fail to return a value
-src/005_always_return.php:66 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \C5::test
-src/005_always_return.php:68 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \C5::soft_nullable_test5
-src/005_always_return.php:69 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \C5::soft_non_nullable_test5
+src/005_always_return.php:66 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \C5::test()
+src/005_always_return.php:68 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \C5::soft_nullable_test5()
+src/005_always_return.php:69 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \C5::soft_non_nullable_test5()

--- a/tests/plugin_test/expected/016_dead_code_fromCallable.php.expected
+++ b/tests/plugin_test/expected/016_dead_code_fromCallable.php.expected
@@ -1,2 +1,2 @@
 src/016_dead_code_fromCallable.php:4 PhanUnreferencedFunction Possibly zero references to function \callable16bUnused()
-src/016_dead_code_fromCallable.php:8 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \main16b
+src/016_dead_code_fromCallable.php:8 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \main16b()

--- a/tests/plugin_test/expected/026_strict_return_checks.php.expected
+++ b/tests/plugin_test/expected/026_strict_return_checks.php.expected
@@ -4,4 +4,4 @@ src/026_strict_return_checks.php:23 PhanPartialTypeMismatchReturn Returning type
 src/026_strict_return_checks.php:31 PhanPossiblyFalseTypeReturn Returning type false|int but notFalse() is declared to return int (false is incompatible)
 src/026_strict_return_checks.php:39 PhanPartialTypeMismatchReturn Returning type false|int but expectFalse() is declared to return false (int is incompatible)
 src/026_strict_return_checks.php:53 PhanPartialTypeMismatchReturn Returning type \StrictReturnChecks|\ast\Node but partiallyValid() is declared to return \ast\Node (\StrictInterface|\StrictReturnChecks is incompatible)
-src/026_strict_return_checks.php:56 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \StrictReturnChecks::partiallyValid
+src/026_strict_return_checks.php:56 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \StrictReturnChecks::partiallyValid()

--- a/tests/plugin_test/expected/039_loop_return.php.expected
+++ b/tests/plugin_test/expected/039_loop_return.php.expected
@@ -1,2 +1,2 @@
 src/039_loop_return.php:11 PhanUnusedVariable Unused definition of variable $myUnusedVariable
-src/039_loop_return.php:15 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \test_loop_var_return
+src/039_loop_return.php:15 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \test_loop_var_return()

--- a/tests/plugin_test/expected/051_loop_unused_defs.php.expected
+++ b/tests/plugin_test/expected/051_loop_unused_defs.php.expected
@@ -1,3 +1,3 @@
 src/051_loop_unused_defs.php:33 PhanUnusedVariable Unused definition of variable $b
-src/051_loop_unused_defs.php:56 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \foo51
-src/051_loop_unused_defs.php:57 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \foo51b
+src/051_loop_unused_defs.php:56 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \foo51()
+src/051_loop_unused_defs.php:57 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \foo51b()

--- a/tests/plugin_test/expected/074_unused_function_suppression.php.expected
+++ b/tests/plugin_test/expected/074_unused_function_suppression.php.expected
@@ -1,2 +1,2 @@
 src/074_unused_function_suppression.php:8 PhanPluginWhitespaceTab The first occurrence of a tab was seen here. Running "expand" can fix that.
-src/074_unused_function_suppression.php:13 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \function_suppression_test_fn
+src/074_unused_function_suppression.php:13 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \function_suppression_test_fn()

--- a/tests/plugin_test/expected/076_array_map_multiple.php.expected
+++ b/tests/plugin_test/expected/076_array_map_multiple.php.expected
@@ -1,4 +1,4 @@
 src/076_array_map_multiple.php:10 PhanTypeMismatchReturn Returning type array<int,array> but array_map_multiple_test() is declared to return array<string,int>
 src/076_array_map_multiple.php:12 PhanTypeMismatchArgument Argument 1 ($x) is string but Closure(\stdClass $x, string $y) : array takes \stdClass defined at src/076_array_map_multiple.php:10
 src/076_array_map_multiple.php:12 PhanTypeMismatchArgument Argument 2 ($y) is \stdClass but Closure(\stdClass $x, string $y) : array takes string defined at src/076_array_map_multiple.php:10
-src/076_array_map_multiple.php:14 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \array_map_multiple_test
+src/076_array_map_multiple.php:14 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \array_map_multiple_test()

--- a/tests/plugin_test/expected/084_read_only_property.php.expected
+++ b/tests/plugin_test/expected/084_read_only_property.php.expected
@@ -1,3 +1,3 @@
 src/084_read_only_property.php:4 PhanReadOnlyPrivateProperty Possibly zero write references to private property \X84->arr
 src/084_read_only_property.php:5 PhanReadOnlyProtectedProperty Possibly zero write references to protected property \X84->count
-src/084_read_only_property.php:10 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \X84::main
+src/084_read_only_property.php:10 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \X84::main()

--- a/tests/plugin_test/expected/145_fibonacci_use_return_value.php.expected
+++ b/tests/plugin_test/expected/145_fibonacci_use_return_value.php.expected
@@ -1,4 +1,4 @@
-src/145_fibonacci_use_return_value.php:10 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \fibonacci145
-src/145_fibonacci_use_return_value.php:27 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \X145::f
-src/145_fibonacci_use_return_value.php:28 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \X145::f
-src/145_fibonacci_use_return_value.php:29 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \X145::g
+src/145_fibonacci_use_return_value.php:10 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \fibonacci145()
+src/145_fibonacci_use_return_value.php:27 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \X145::f()
+src/145_fibonacci_use_return_value.php:28 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \X145::f()
+src/145_fibonacci_use_return_value.php:29 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \X145::g()

--- a/tests/plugin_test/expected/146_dependent_args_pure.php.expected
+++ b/tests/plugin_test/expected/146_dependent_args_pure.php.expected
@@ -1,1 +1,1 @@
-src/146_dependent_args_pure.php:14 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \f146c
+src/146_dependent_args_pure.php:14 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \f146c()

--- a/tests/plugin_test/expected/147_use_return_value.php.expected
+++ b/tests/plugin_test/expected/147_use_return_value.php.expected
@@ -1,1 +1,1 @@
-src/147_use_return_value.php:12 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \closure_%s
+src/147_use_return_value.php:12 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method Closure(int $v)

--- a/tests/plugin_test/expected/148_use_return_value_recursive.php.expected
+++ b/tests/plugin_test/expected/148_use_return_value_recursive.php.expected
@@ -1,3 +1,3 @@
-src/148_use_return_value_recursive.php:14 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \f148
-src/148_use_return_value_recursive.php:15 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \g148
-src/148_use_return_value_recursive.php:16 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \square148
+src/148_use_return_value_recursive.php:14 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \f148()
+src/148_use_return_value_recursive.php:15 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \g148()
+src/148_use_return_value_recursive.php:16 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \square148()

--- a/tests/plugin_test/expected/149_use_return_value_functional.php.expected
+++ b/tests/plugin_test/expected/149_use_return_value_functional.php.expected
@@ -1,1 +1,1 @@
-src/149_use_return_value_functional.php:12 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \odds149
+src/149_use_return_value_functional.php:12 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \odds149()

--- a/tests/plugin_test/expected/150_use_constructor.php.expected
+++ b/tests/plugin_test/expected/150_use_constructor.php.expected
@@ -1,3 +1,3 @@
-src/150_use_constructor.php:17 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \MyClass150::makeInstance
-src/150_use_constructor.php:18 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \make_myclass
+src/150_use_constructor.php:17 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \MyClass150::makeInstance()
+src/150_use_constructor.php:18 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \make_myclass()
 src/150_use_constructor.php:21 PhanPluginUseReturnValueNoopVoid The internal function/method \my_void150() is declared to return void and it has no side effects

--- a/tests/plugin_test/expected/152_phan_pure_annotation.php.expected
+++ b/tests/plugin_test/expected/152_phan_pure_annotation.php.expected
@@ -1,0 +1,8 @@
+src/152_phan_pure_annotation.php:30 PhanPartialTypeMismatchReturn Returning type float|int but triple1() is declared to return int (float is incompatible)
+src/152_phan_pure_annotation.php:37 PhanPartialTypeMismatchReturn Returning type float|int but triple2() is declared to return int (float is incompatible)
+src/152_phan_pure_annotation.php:45 PhanPluginNonBoolBranch Non bool value of type false|string evaluated in if clause
+src/152_phan_pure_annotation.php:52 PhanPluginNonBoolBranch Non bool value of type false|string evaluated in if clause
+src/152_phan_pure_annotation.php:58 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \NS152\debug_trace()
+src/152_phan_pure_annotation.php:62 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \NS152\Debug::double1()
+src/152_phan_pure_annotation.php:64 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \NS152\Debug::triple1()
+src/152_phan_pure_annotation.php:77 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method Closure($o)

--- a/tests/plugin_test/expected/153_phan_pure_inherit.php.expected
+++ b/tests/plugin_test/expected/153_phan_pure_inherit.php.expected
@@ -1,0 +1,2 @@
+src/153_phan_pure_inherit.php:31 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \NS153\X::mul1()
+src/153_phan_pure_inherit.php:34 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \NS153\Tripler::mul1()

--- a/tests/plugin_test/expected/153_phan_pure_inherit.php.expected
+++ b/tests/plugin_test/expected/153_phan_pure_inherit.php.expected
@@ -1,2 +1,3 @@
 src/153_phan_pure_inherit.php:31 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \NS153\X::mul1()
 src/153_phan_pure_inherit.php:34 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \NS153\Tripler::mul1()
+src/153_phan_pure_inherit.php:38 PhanInvalidCommentForDeclarationType The phpdoc comment for @phan-pure cannot occur on a class

--- a/tests/plugin_test/src/152_phan_pure_annotation.php
+++ b/tests/plugin_test/src/152_phan_pure_annotation.php
@@ -1,0 +1,77 @@
+<?php
+// The @phan-pure annotation is used to indicate that the function does not have any side effects
+// that matter to the end user of the application/library.
+// It may be manually added when Phan can't automatically infer the function is pure,
+// or when the side effects are unimportant (e.g. debug logging, performance logging)
+namespace NS152;
+class Debug {
+    /**
+     * @phan-pure
+     * @return int
+     */
+    public function double1(int $x) {
+        var_dump($x);
+        return $x * 2;
+    }
+
+    /*
+     * @return int
+     */
+    public function double2(int $x) {
+        var_dump($x);
+        return $x * 2;
+    }
+
+    /**
+     * @phan-pure
+     * @return int
+     */
+    public static function triple1(int $x) {
+        return debug_trace_nonpure((string)$x) * 3;
+    }
+
+    /**
+     * @return int
+     */
+    public static function triple2(int $x) {
+        return debug_trace_nonpure((string)$x) * 3;
+    }
+}
+
+/**
+ * @phan-pure
+ */
+function debug_trace(string $value) {
+    if (getenv('DEBUG')) {
+        echo "Processing '''$value'''\n";
+    }
+    return $value;
+}
+
+function debug_trace_nonpure(string $value) {
+    if (getenv('DEBUG')) {
+        echo "Processing '''$value'''\n";
+    }
+    return $value;
+}
+// Should warn
+debug_trace($argv[0]);  // should warn about unused
+// Should not warn
+debug_trace_nonpure($argv[0]);
+$d = new Debug();
+$d->double1(21);  // should warn about unused
+$d->double2(2);
+Debug::triple1(14);  // should warn about unused
+Debug::triple2(14);
+
+$trace1 = function ($o) {
+    fwrite(STDERR, "Saw $o\n");
+    return $o;
+};
+/** @phan-pure */
+$trace2 = function ($o) {
+    fwrite(STDERR, "Saw $o\n");
+    return $o;
+};
+$trace1(sprintf("Hello, %s", "world"));
+$trace2(sprintf("Hello, %s", "world"));

--- a/tests/plugin_test/src/153_phan_pure_inherit.php
+++ b/tests/plugin_test/src/153_phan_pure_inherit.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace NS153;
+
+class X {
+    /** @phan-pure */
+    public function mul1(int $x) {
+        echo "Checking $x\n";
+        return $x * 2;
+    }
+
+    public function mul2(int $x) {
+        echo "Checking $x\n";
+        return $x * 2;
+    }
+}
+
+class Tripler extends X {
+    public function mul1(int $x) {
+        echo "DEBUG: Tripling $x\n";
+        return $x * 3;
+    }
+
+    public function mul2(int $x) {
+        echo "DEBUG: Tripling $x\n";
+        return $x * 3;
+    }
+}
+
+$t = new X();
+$t->mul1(3);  // should warn about being unused
+$t->mul2(4);  // should not warn
+$t = new Tripler();
+$t->mul1(3);  // should warn about being unused
+$t->mul2(4);  // should not warn

--- a/tests/plugin_test/src/153_phan_pure_inherit.php
+++ b/tests/plugin_test/src/153_phan_pure_inherit.php
@@ -33,3 +33,9 @@ $t->mul2(4);  // should not warn
 $t = new Tripler();
 $t->mul1(3);  // should warn about being unused
 $t->mul2(4);  // should not warn
+
+/**
+ * @phan-pure haven't decided what checks that would imply and haven't implemented anything for non-functions, so this warns.
+ */
+class PureNotSupported {}
+var_export(new PureNotSupported());


### PR DESCRIPTION
This will automatically be inherited by overriding methods.

Also, add vim syntax highlighting snippet for Phan's phpdoc annotations.