### PR TITLE
Add a warning for PHP 4 constructors Foo::Foo(), but only if Foo::__construct() does not exist

### DIFF
--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -4107,7 +4107,8 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
      */
     private function checkForPHP4StyleConstructor(Clazz $class, Method $method) : void
     {
-        if ($class->getElementNamespace() !== ""
+        if ($class->isClass()
+            && ($class->getElementNamespace() ?: "\\") === "\\"
             && \strcasecmp($class->getName(), $method->getName()) === 0
             && $class->hasMethodWithName($this->code_base, "__construct")
         ) {

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -173,7 +173,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
         $comment = $method->getComment();
 
         $context = $this->context->withScope(
-            clone $method->getInternalScope()
+            clone($method->getInternalScope())
         );
 
         // For any @var references in the method declaration,

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -144,7 +144,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
         $code_base = $this->code_base;
         $context = $this->context;
 
-        if (!($context->isInClassScope())) {
+        if (!$context->isInClassScope()) {
             throw new AssertionError("Must be in class context to see a method");
         }
 
@@ -173,7 +173,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
         $comment = $method->getComment();
 
         $context = $this->context->withScope(
-            clone($method->getInternalScope())
+            clone $method->getInternalScope()
         );
 
         // For any @var references in the method declaration,
@@ -188,7 +188,7 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
 
         // Add $this to the scope of non-static methods
         if (!($node->flags & ast\flags\MODIFIER_STATIC)) {
-            if (!($clazz->getInternalScope()->hasVariableWithName('this'))) {
+            if (!$clazz->getInternalScope()->hasVariableWithName('this')) {
                 throw new AssertionError("Classes must have a \$this variable.");
             }
 

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -473,6 +473,7 @@ class Issue
     const CompatibleImplodeOrder             = 'PhanCompatibleImplodeOrder';
     const CompatibleUnparenthesizedTernary   = 'PhanCompatibleUnparenthesizedTernary';
     const CompatibleTypedProperty            = 'PhanCompatibleTypedProperty';
+    const CompatiblePHP8PHP4Constructor      = 'PhanCompatiblePHP8PHP4Constructor';
 
     // Issue::CATEGORY_GENERIC
     const TemplateTypeConstant       = 'PhanTemplateTypeConstant';
@@ -4078,6 +4079,14 @@ class Issue
                 "Cannot use typed properties before php 7.4. This property group has type {TYPE}",
                 self::REMEDIATION_B,
                 3021
+            ),
+            new Issue(
+                self::CompatiblePHP8PHP4Constructor,
+                self::CATEGORY_COMPATIBLE,
+                self::SEVERITY_NORMAL,
+                "PHP4 constructors will be removed in php 8, and should not be used. __construct() should be added/used instead to avoid accidentally calling {CLASS}::{METHOD}()",
+                self::REMEDIATION_B,
+                3022
             ),
 
             // Issue::CATEGORY_GENERIC

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -4084,7 +4084,7 @@ class Issue
                 self::CompatiblePHP8PHP4Constructor,
                 self::CATEGORY_COMPATIBLE,
                 self::SEVERITY_NORMAL,
-                "PHP4 constructors will be removed in php 8, and should not be used. __construct() should be added/used instead to avoid accidentally calling {CLASS}::{METHOD}()",
+                "PHP4 constructors will be removed in php 8, and should not be used. __construct() should be added/used instead to avoid accidentally calling {METHOD}",
                 self::REMEDIATION_B,
                 3022
             ),

--- a/tests/files/expected/0099_type_error.php.expected
+++ b/tests/files/expected/0099_type_error.php.expected
@@ -3,6 +3,7 @@
 %s:10 PhanTypeMismatchProperty Assigning 'str' to property but \C->p is int
 %s:13 PhanTypeInstantiateAbstract Instantiation of abstract class \D
 %s:16 PhanTypeInstantiateInterface Instantiation of interface \E
+%s:19 PhanCompatiblePHP8PHP4Constructor PHP4 constructors will be removed in php 8, and should not be used. __construct() should be added/used instead to avoid accidentally calling \F::f()
 %s:19 PhanTypeNonVarPassByRef Only variables can be passed by reference at argument 1 of \F::f()
 %s:22 PhanTypeMismatchReturn Returning type 'string' but f() is declared to return int
 %s:25 PhanTypeMissingReturn Method \H::f is declared to return int but has no return value

--- a/tests/files/expected/0198_list_property.php.expected
+++ b/tests/files/expected/0198_list_property.php.expected
@@ -1,2 +1,3 @@
+%s:7 PhanCompatiblePHP8PHP4Constructor PHP4 constructors will be removed in php 8, and should not be used. __construct() should be added/used instead to avoid accidentally calling \Test::test()
 %s:8 PhanUnusedVariable Unused definition of variable $x
 %s:8 PhanUnusedVariable Unused definition of variable $y

--- a/tests/files/expected/0325_php4_construct.php.expected
+++ b/tests/files/expected/0325_php4_construct.php.expected
@@ -3,7 +3,7 @@
 %s:7 PhanUndeclaredStaticMethod Static call to undeclared method self::__construct()
 %s:15 PhanTypeMismatchArgumentReal Argument 1 ($arg) is int but \Bar325::Bar325() takes array defined at %s:6
 %s:19 PhanTypeMismatchArgumentReal Argument 1 ($arg) is 11 but \Bar325::__construct() takes array defined at %s:6
-%s:26 PhanCompatiblePHP8PHP4Constructor PHP4 constructors will be removed in php 8, and should not be used. __construct() should be added/used instead to avoid accidentally calling \NS325\X325::X325()
-%s:34 PhanParamTooMany Call with 1 arg(s) to \NS325\X325::__construct() which only takes 0 arg(s) defined at %s:24
+%s:34 PhanUndeclaredStaticMethod Static call to undeclared method \NS325\X325::__construct
 %s:35 PhanTypeMismatchArgumentReal Argument 1 ($arg) is int but \NS325\X325::X325() takes array defined at %s:26
 %s:39 PhanParamTooMany Call with 1 arg(s) to \NS325\X325::__construct() which only takes 0 arg(s) defined at %s:24
+%s:68 PhanCompatiblePHP8PHP4Constructor PHP4 constructors will be removed in php 8, and should not be used. __construct() should be added/used instead to avoid accidentally calling \Abstract325::AbStRaCt325()

--- a/tests/files/expected/0325_php4_construct.php.expected
+++ b/tests/files/expected/0325_php4_construct.php.expected
@@ -7,4 +7,3 @@
 %s:34 PhanParamTooMany Call with 1 arg(s) to \NS325\X325::__construct() which only takes 0 arg(s) defined at %s:24
 %s:35 PhanTypeMismatchArgumentReal Argument 1 ($arg) is int but \NS325\X325::X325() takes array defined at %s:26
 %s:39 PhanParamTooMany Call with 1 arg(s) to \NS325\X325::__construct() which only takes 0 arg(s) defined at %s:24
-

--- a/tests/files/expected/0325_php4_construct.php.expected
+++ b/tests/files/expected/0325_php4_construct.php.expected
@@ -1,7 +1,10 @@
+%s:6 PhanCompatiblePHP8PHP4Constructor PHP4 constructors will be removed in php 8, and should not be used. __construct() should be added/used instead to avoid accidentally calling \Bar325::Bar325()
 %s:7 PhanUndeclaredStaticMethod Static call to undeclared method \Bar325::__construct
 %s:7 PhanUndeclaredStaticMethod Static call to undeclared method self::__construct()
 %s:15 PhanTypeMismatchArgumentReal Argument 1 ($arg) is int but \Bar325::Bar325() takes array defined at %s:6
 %s:19 PhanTypeMismatchArgumentReal Argument 1 ($arg) is 11 but \Bar325::__construct() takes array defined at %s:6
-%s:34 PhanUndeclaredStaticMethod Static call to undeclared method \NS325\X325::__construct
+%s:26 PhanCompatiblePHP8PHP4Constructor PHP4 constructors will be removed in php 8, and should not be used. __construct() should be added/used instead to avoid accidentally calling \NS325\X325::X325()
+%s:34 PhanParamTooMany Call with 1 arg(s) to \NS325\X325::__construct() which only takes 0 arg(s) defined at %s:24
 %s:35 PhanTypeMismatchArgumentReal Argument 1 ($arg) is int but \NS325\X325::X325() takes array defined at %s:26
 %s:39 PhanParamTooMany Call with 1 arg(s) to \NS325\X325::__construct() which only takes 0 arg(s) defined at %s:24
+

--- a/tests/files/src/0325_php4_construct.php
+++ b/tests/files/src/0325_php4_construct.php
@@ -43,8 +43,30 @@ $f325 = new Y325(11);
 // this should not emit PhanCompatiblePHP8PHP4Constructor because the class is in a non-global namespace
 namespace NotPHP4Class325 {
     class NoWarning {
-        function NotPHP4Class325() {
+        function NoWarning() {
             return 42;
+        }
+    }
+}
+
+namespace {
+    // no PhanCompatiblePHP8PHP4Constructor warning for interfaces
+    interface Interface325 {
+        public function Interface325() : int;
+    }
+
+    // no PhanCompatiblePHP8PHP4Constructor warning for traits
+    trait Trait325 {
+        public function Trait325(): int
+        {
+            return 42;
+        }
+    }
+
+    // PhanCompatiblePHP8PHP4Constructor warning test for different capitalization of class/method names
+    abstract class Abstract325 {
+        function AbStRaCt325() { // throws a warning
+            echo 42;
         }
     }
 }

--- a/tests/files/src/0325_php4_construct.php
+++ b/tests/files/src/0325_php4_construct.php
@@ -39,3 +39,12 @@ class Y325 extends X325 {
 $f325 = new X325(11);  // PhanParamTooMany
 $f325 = new Y325(11);
 }  // end of NS325
+
+// this should not emit PhanCompatiblePHP8PHP4Constructor because the class is in a non-global namespace
+namespace NotPHP4Class325 {
+    class NoWarning {
+        function NotPHP4Class325() {
+            return 42;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #740