### PR TITLE
InvalidVariableIssetPlugin should respect the "ignore_undeclared_variables_in_global_scope" option

### DIFF
--- a/.phan/plugins/InvalidVariableIssetPlugin.php
+++ b/.phan/plugins/InvalidVariableIssetPlugin.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 
 use ast\Node;
+use Phan\Config;
 use Phan\Language\Context;
 use Phan\Language\Element\Variable;
 use Phan\PluginV3;
@@ -89,8 +90,12 @@ class InvalidVariableIssetVisitor extends PluginAwarePostAnalysisVisitor
                 // e.g. ast\AST_NAME of an ast\AST_CONST
                 return $this->context;
             }
-            if (!Variable::isHardcodedVariableInScopeWithName($name, $this->context->isInGlobalScope()) &&
-                    !$this->context->getScope()->hasVariableWithName($name)) {
+            if (!Variable::isHardcodedVariableInScopeWithName($name, $this->context->isInGlobalScope())
+                && !$this->context->getScope()->hasVariableWithName($name)
+                && !(
+                    $this->context->isInGlobalScope() && Config::getValue('ignore_undeclared_variables_in_global_scope')
+                )
+            ) {
                 $this->emit(
                     'PhanPluginUndeclaredVariableIsset',
                     'undeclared variable ${VARIABLE} in isset()',

--- a/tests/plugin_test/.phan/config.php
+++ b/tests/plugin_test/.phan/config.php
@@ -57,7 +57,7 @@ return [
     // scope will be ignored. This is useful for projects
     // with complicated cross-file globals that you have no
     // hope of fixing.
-    'ignore_undeclared_variables_in_global_scope' => false,
+    'ignore_undeclared_variables_in_global_scope' => true,
 
     // Backwards Compatibility Checking
     // Check for $$var[] and $foo->$bar['baz'] and Foo::$bar['baz']() and $this->$bar['baz']

--- a/tests/plugin_test/src/143_invalid_variable_isset_nonvar.php
+++ b/tests/plugin_test/src/143_invalid_variable_isset_nonvar.php
@@ -17,3 +17,5 @@ class X143{
     }
 }
 var_export((new X143())->query('foo', 'bar'));
+
+$a = isset($this->a); // should not throw as the config is set to ignore vars in global scope


### PR DESCRIPTION
Fixes #1403

Note that I've changed the config file for `__FakePluginTest` in order to have this tested. No other tests relied on the option, so I chose this way instead of creating a whole new test with separate config and then test just 1 single case.