### PR TITLE
Fix an edge case checking if method is overridden

### DIFF
--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -1420,7 +1420,7 @@ class Clazz extends AddressableElement
                 $code_base->getMethodByFQSEN($method_fqsen);
             $existing_method_defining_fqsen = $existing_method->getDefiningFQSEN();
             // Note: For private/protected methods, the defining FQSEN is set to the FQSEN of the inheriting class.
-            // So, when multiple traits are inherited, they may identical defining FQSENs, but some may be abstract, and others may be implemented.
+            // So, when multiple traits are inherited, they may have identical defining FQSENs, but some may be abstract, and others may be implemented.
             if ($method->getDefiningFQSEN() === $existing_method_defining_fqsen) {
                 if ($method->isAbstract() === $existing_method->isAbstract()) {
                     return;
@@ -1429,14 +1429,19 @@ class Clazz extends AddressableElement
                 self::markMethodAsOverridden($code_base, $existing_method_defining_fqsen);
             }
 
-            if ($method->isAbstract() || !$existing_method->isAbstract() || $existing_method->isNewConstructor()) {
+            if ($existing_method->getRealDefiningFQSEN() === $method_fqsen || $method->isAbstract() || !$existing_method->isAbstract() || $existing_method->isNewConstructor()) {
                 // TODO: What if both of these are abstract, and those get combined into an abstract class?
                 //       Should phan check compatibility of the abstract methods it inherits?
                 $existing_method->setIsOverride(true);
+                // TODO: What happens for protected methods and traits with getDefiningFQSEN
                 self::markMethodAsOverridden($code_base, $method->getDefiningFQSEN());
 
-                // Don't add the method
+                // Don't add the method since it was already added
                 return;
+            } elseif ($method->getRealDefiningFQSEN() === $method_fqsen) {
+                $method->setIsOverride(true);
+                // TODO: What happens for traits with getDefiningFQSEN
+                self::markMethodAsOverridden($code_base, $existing_method->getDefiningFQSEN());
             }
         }
 


### PR DESCRIPTION
Not sure how to reproduce this.
This was seen when addMethod for the inherited method was called
before addMethod for the class's non-abstract method.