### PR TITLE
Correctly check for the number of CPU's/cores on MacOS

### DIFF
--- a/tests/run_test
+++ b/tests/run_test
@@ -64,7 +64,12 @@ case "$TEST_SUITE" in
 		exit $?
 		;;
 	__FakeAllPHPUnitTests)
-		PROCESSORS=$(nproc || echo 2)
+		if [[ "$OSTYPE" == "darwin"* ]]; then
+			PROCESSORS=$(sysctl -n hw.ncpu)
+		else
+			PROCESSORS=$(nproc || echo 2)
+		fi
+
 		if [[ "$PROCESSORS" > 1 ]]; then
 			vendor/bin/paratest --processes "$PROCESSORS" --runner WrapperRunner
 		else


### PR DESCRIPTION
Not a big deal but after some time it pokes my eyes seeing `tests/run_test: line 67: nproc: command not found` every time the tests run.

After this, it's correctly figuring out how many processes to use:

```
| => tests/run_test __FakeAllPHPUnitTests

Running phpunit in 4 processes with /Users/oliver/www/phan/vendor/phpunit/phpunit/phpunit
