### PR TITLE
Add support for @immutable classes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 Phan NEWS
 
-Aug 18 2019, Phan 2.2.12 (dev)
+??? ?? 2019, Phan 2.2.12 (dev)
 ------------------------
 
 New features(CLI):
@@ -8,6 +8,13 @@ New features(CLI):
   Previously, Phan would fail with a confusing error message.
 
 New features(Analysis):
++ Support `@immutable` annotation on class doc comments, to indicate that all instance properties are read-only.
+
+  - Phan does not check if object fields of those immutable properties will change. (e.g. `$this->foo->prop = 'x';` is allowed)
+  - This annotation does not imply that methods have no side effects (e.g. I/O, modifying global state)
+  - This annotation does not imply that methods have deterministic return values or that methods' results should be used.
+
+  `@immutable` is an alias of `@phan-read-only`. `@phan-read-only` was previously supported on properties.
 + Fix false positives for checking for redundant conditions with `iterable` and `is_iterable`.
 + Properly infer real types for `is_resource` checks and other cases where UnionType::fromFullyQualifiedRealString() was used.
 + Avoid false positives for the config setting `'assume_real_types_for_internal_functions'`.

--- a/src/Phan/AST/AnalysisVisitor.php
+++ b/src/Phan/AST/AnalysisVisitor.php
@@ -22,13 +22,14 @@ abstract class AnalysisVisitor extends KindVisitorImplementation
     /**
      * @var CodeBase
      * The code base within which we're operating
+     * @phan-read-only
      */
     protected $code_base;
 
     /**
      * @var Context
      * The context in which the node we're going to be looking
-     * at exits.
+     * at exists.
      */
     protected $context;
 

--- a/src/Phan/AST/TolerantASTConverter/ParseResult.php
+++ b/src/Phan/AST/TolerantASTConverter/ParseResult.php
@@ -9,6 +9,7 @@ use Microsoft\PhpParser\Diagnostic;
  * All details about the results of parsing.
  *
  * This can be serialized and used in a cache.
+ * @immutable
  */
 class ParseResult
 {

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -46,6 +46,7 @@ class AssignmentVisitor extends AnalysisVisitor
     /**
      * @var Node
      * The AST node containing the assignment
+     * @phan-read-only
      */
     private $assignment_node;
 
@@ -62,6 +63,7 @@ class AssignmentVisitor extends AnalysisVisitor
      * We need to know this in order to decide
      * if we're replacing the union type
      * or if we're adding a type to the union type.
+     * @phan-read-only
      */
     private $dim_depth;
 
@@ -73,6 +75,7 @@ class AssignmentVisitor extends AnalysisVisitor
      * type to the union type.
      *
      * Null for `$foo[] = 42` or when dim_depth is 0
+     * @phan-read-only
      */
     private $dim_type;
 

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -44,7 +44,7 @@ class ConditionVisitor extends KindVisitorImplementation implements ConditionVis
     /**
      * @var Context
      * The context in which the node we're going to be looking
-     * at exits.
+     * at exists.
      */
     protected $context;
 

--- a/src/Phan/Analysis/ConditionVisitorUtil.php
+++ b/src/Phan/Analysis/ConditionVisitorUtil.php
@@ -55,7 +55,7 @@ trait ConditionVisitorUtil
     /**
      * @var Context
      * The context in which the node we're going to be looking
-     * at exits.
+     * at exists.
      */
     protected $context;
 

--- a/src/Phan/Analysis/ContextMergeVisitor.php
+++ b/src/Phan/Analysis/ContextMergeVisitor.php
@@ -19,7 +19,7 @@ class ContextMergeVisitor extends KindVisitorImplementation
     /**
      * @var Context
      * The context in which the node we're going to be looking
-     * at exits.
+     * at exists.
      */
     private $context;
 

--- a/src/Phan/Analysis/NegatedConditionVisitor.php
+++ b/src/Phan/Analysis/NegatedConditionVisitor.php
@@ -40,7 +40,7 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
     /**
      * @var Context
      * The context in which the node we're going to be looking
-     * at exits.
+     * at exists.
      */
     protected $context;
 

--- a/src/Phan/Config/InitializedSettings.php
+++ b/src/Phan/Config/InitializedSettings.php
@@ -3,8 +3,9 @@
 namespace Phan\Config;
 
 /**
- * This class is used by 'phan --init'
+ * This class is used by `phan --init`
  * as a representation of the data to use to create a phan config for a composer project.
+ * @immutable
  */
 class InitializedSettings
 {

--- a/src/Phan/Exception/UsageException.php
+++ b/src/Phan/Exception/UsageException.php
@@ -6,10 +6,11 @@ use Phan\Daemon\ExitException;
 
 /**
  * Thrown to indicate that retrieving the element for an FQSEN from the CodeBase failed.
+ * @immutable
  */
 class UsageException extends ExitException
 {
-    /** @var int  the type of usage to print */
+    /** @var int the type of usage to print */
     public $print_type;
 
     /** @var bool whether to forbid colorizing the exception message */

--- a/src/Phan/ForkPool/Progress.php
+++ b/src/Phan/ForkPool/Progress.php
@@ -4,6 +4,7 @@ namespace Phan\ForkPool;
 
 /**
  * Represents the current progress of a forked analysis worker.
+ * @immutable
  */
 class Progress
 {

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -4710,7 +4710,7 @@ class Issue
      *
      * @param Context $context
      * The context in which the node we're going to be looking
-     * at exits.
+     * at exists.
      *
      * @param string $issue_type
      * The type of issue to emit such as Issue::ParentlessClass
@@ -4744,7 +4744,7 @@ class Issue
      *
      * @param Context $context
      * The context in which the node we're going to be looking
-     * at exits.
+     * at exists.
      *
      * @param string $issue_type
      * The type of issue to emit such as Issue::ParentlessClass

--- a/src/Phan/Language/Element/ClassAliasRecord.php
+++ b/src/Phan/Language/Element/ClassAliasRecord.php
@@ -10,6 +10,7 @@ use Phan\Language\FQSEN\FullyQualifiedClassName;
  * to class_alias() within the codebase (FQSEN and location of alias creation)
  *
  * The original class is mapped to a set of ClassAliasRecord
+ * @immutable
  */
 class ClassAliasRecord
 {

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -1797,6 +1797,7 @@ class Clazz extends AddressableElement
      * Set whether undeclared magic properties are forbidden
      * (properties accessed through __get or __set, with no (at)property annotation on parent class)
      * @param bool $forbid_undeclared_dynamic_properties - set to true to forbid.
+     * @suppress PhanUnreferencedPublicMethod
      */
     public function setForbidUndeclaredMagicProperties(
         bool $forbid_undeclared_dynamic_properties
@@ -1828,6 +1829,7 @@ class Clazz extends AddressableElement
      * Set whether undeclared magic methods are forbidden
      * (methods accessed through __call or __callStatic, with no (at)method annotation on class)
      * @param bool $forbid_undeclared_magic_methods - set to true to forbid.
+     * @suppress PhanUnreferencedPublicMethod
      */
     public function setForbidUndeclaredMagicMethods(
         bool $forbid_undeclared_magic_methods
@@ -1837,6 +1839,17 @@ class Clazz extends AddressableElement
             Flags::CLASS_FORBID_UNDECLARED_MAGIC_METHODS,
             $forbid_undeclared_magic_methods
         ));
+    }
+
+    /**
+     * Returns whether this class is `(at)immutable`
+     *
+     * This will warn if instance properties of instances of the class will not change after the object is constructed.
+     * - Methods of (at)immutable classes may change external state (e.g. perform I/O, modify other objects)
+     */
+    public function isImmutable() : bool
+    {
+        return $this->getPhanFlagsHasState(Flags::IS_READ_ONLY);
     }
 
     /**

--- a/src/Phan/Language/Element/Comment.php
+++ b/src/Phan/Language/Element/Comment.php
@@ -445,10 +445,7 @@ class Comment
         return ($this->comment_flags & Flags::IS_PURE) != 0;
     }
 
-    /**
-     * @internal
-     */
-    const FLAGS_FOR_PROPERTY = Flags::IS_NS_INTERNAL | Flags::IS_DEPRECATED | Flags::IS_READ_ONLY | Flags::IS_WRITE_ONLY;
+    private const FLAGS_FOR_PROPERTY = Flags::IS_NS_INTERNAL | Flags::IS_DEPRECATED | Flags::IS_READ_ONLY | Flags::IS_WRITE_ONLY;
 
     /**
      * Gets the subset of the bitmask that applies to properties.
@@ -458,10 +455,26 @@ class Comment
         return $this->comment_flags & self::FLAGS_FOR_PROPERTY;
     }
 
+    private const FLAGS_FOR_CLASS =
+        Flags::IS_NS_INTERNAL |
+        Flags::IS_DEPRECATED |
+        Flags::IS_READ_ONLY |
+        Flags::CLASS_FORBID_UNDECLARED_MAGIC_METHODS |
+        Flags::CLASS_FORBID_UNDECLARED_MAGIC_PROPERTIES;
+
+    /**
+     * Gets the subset of the bitmask that applies to classes.
+     */
+    public function getPhanFlagsForClass() : int
+    {
+        return $this->comment_flags & self::FLAGS_FOR_CLASS;
+    }
+
     /**
      * @return bool
      * Set to true if the comment contains a 'phan-forbid-undeclared-magic-properties'
      * directive.
+     * @suppress PhanUnreferencedPublicMethod
      */
     public function getForbidUndeclaredMagicProperties() : bool
     {
@@ -472,6 +485,7 @@ class Comment
      * @return bool
      * Set to true if the comment contains a 'phan-forbid-undeclared-magic-methods'
      * directive.
+     * @suppress PhanUnreferencedPublicMethod
      */
     public function getForbidUndeclaredMagicMethods() : bool
     {

--- a/src/Phan/Language/Element/Comment/Assertion.php
+++ b/src/Phan/Language/Element/Comment/Assertion.php
@@ -9,6 +9,7 @@ use Phan\Language\UnionType;
  * Represents an assertion on a parameter type.
  *
  * @internal
+ * @immutable
  */
 class Assertion
 {

--- a/src/Phan/Language/Element/Flags.php
+++ b/src/Phan/Language/Element/Flags.php
@@ -46,6 +46,7 @@ class Flags
     const IS_DYNAMIC_PROPERTY = (1 << 20);
     // A property can be read-only, write-only, or neither, but not both.
     // This is independent of being a magic property.
+    // IS_READ_ONLY can also be set on classes as @immutable
     const IS_READ_ONLY = (1 << 21);
     const IS_WRITE_ONLY = (1 << 22);
     const HAS_STATIC_UNION_TYPE = (1 << 23);

--- a/src/Phan/Language/Element/Property.php
+++ b/src/Phan/Language/Element/Property.php
@@ -31,13 +31,13 @@ class Property extends ClassElement
     private $real_defining_fqsen;
 
     /**
-     * @var UnionType The real union type (typed properties were added in PHP 7.4)
+     * @var UnionType The real union type of this property (typed properties were added in PHP 7.4)
      * This does not change.
      */
     private $real_union_type;
 
     /**
-     * @var ?UnionType the phpdoc union type
+     * @var ?UnionType the phpdoc union type of this property
      */
     private $phpdoc_union_type;
 
@@ -369,7 +369,7 @@ class Property extends ClassElement
     }
 
     /**
-     * Is this parameter declared in a way hinting that it should only be written to?
+     * Is this property declared in a way hinting that it should only be written to?
      * (E.g. magic properties declared as (at)property-read, regular properties with (at)phan-read-only)
      */
     public function isReadOnly() : bool
@@ -378,7 +378,22 @@ class Property extends ClassElement
     }
 
     /**
-     * Is this parameter declared in a way hinting that it should only be written to?
+     * Record whether this property is read-only.
+     * TODO: Warn about combining IS_READ_ONLY and IS_WRITE_ONLY
+     */
+    public function setIsReadOnly(bool $is_read_only) : void
+    {
+        $this->setPhanFlags(
+            Flags::bitVectorWithState(
+                $this->getPhanFlags(),
+                Flags::IS_READ_ONLY,
+                $is_read_only
+            )
+        );
+    }
+
+    /**
+     * Is this property declared in a way hinting that it should only be written to?
      * (E.g. magic properties declared as (at)property-write, regular properties with (at)phan-write-only)
      */
     public function isWriteOnly() : bool

--- a/src/Phan/Language/NamespaceMapEntry.php
+++ b/src/Phan/Language/NamespaceMapEntry.php
@@ -11,17 +11,20 @@ use RuntimeException;
 class NamespaceMapEntry implements \Serializable
 {
     /**
-     * @var FullyQualifiedGlobalStructuralElement the FQSEN of the
+     * @var FullyQualifiedGlobalStructuralElement the FQSEN of the namespace map entry
+     * @phan-read-only
      */
     public $fqsen;
 
     /**
      * @var string the original case-sensitive name of the use statement
+     * @phan-read-only
      */
     public $original_name;
 
     /**
      * @var int the line number of the use statement
+     * @phan-read-only
      */
     public $lineno;
 
@@ -53,6 +56,7 @@ class NamespaceMapEntry implements \Serializable
 
     /**
      * @param string $representation
+     * @suppress PhanAccessReadOnlyProperty TODO fix #3179
      */
     public function unserialize($representation) : void
     {

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -75,10 +75,10 @@ use function trim;
  * A plain Type represents a class instance.
  * Separate subclasses exist for NativeType, ArrayType, ScalarType, TemplateType, etc.
  *
- * Types are immutable.
  *
  * @phan-file-suppress PhanPartialTypeMismatchArgumentInternal
  * phpcs:disable Generic.NamingConventions.UpperCaseConstantName
+ * @immutable union types are immutable.
  */
 class Type
 {
@@ -1506,7 +1506,7 @@ class Type
      * A UnionType representing this and only this type (from phpdoc or real types)
      *
      * @deprecated use self::asPHPDocUnionType()
-     * @suppress PhanUnreferencedPublicMethod
+     * @suppress PhanUnreferencedPublicMethod, PhanAccessReadOnlyProperty
      * @phan-pure
      */
     public function asUnionType() : UnionType
@@ -1519,6 +1519,7 @@ class Type
      * A UnionType representing this and only this type (from phpdoc or real types)
      * @see asRealUnionType() if you are certain this is the real type of the expression.
      * @phan-pure
+     * @suppress PhanAccessReadOnlyProperty
      */
     public function asPHPDocUnionType() : UnionType
     {
@@ -1531,6 +1532,7 @@ class Type
      * @return UnionType
      * A UnionType representing this and only this type
      * @phan-pure
+     * @suppress PhanAccessReadOnlyProperty
      */
     public function asRealUnionType() : UnionType
     {

--- a/src/Phan/Language/Type/ClosureType.php
+++ b/src/Phan/Language/Type/ClosureType.php
@@ -57,6 +57,9 @@ final class ClosureType extends Type
         return $instance;
     }
 
+    /**
+     * @suppress PhanAccessReadOnlyProperty
+     */
     public function __clone()
     {
         if ($this->fqsen !== null) {

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -70,6 +70,7 @@ if (!\function_exists('spl_object_id')) {
  * > and many other types
  *
  * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod TODO: Document the public methods
+ * @immutable union types are immutable.
  */
 class UnionType implements Serializable
 {
@@ -3768,6 +3769,7 @@ class UnionType implements Serializable
      * A serialized UnionType
      *
      * @see \Serializable
+     * @suppress PhanAccessReadOnlyProperty this unserializes
      */
     public function unserialize($serialized) : void
     {
@@ -4920,6 +4922,7 @@ class UnionType implements Serializable
 
     /**
      * Shorter version of `UnionType::of($this->getTypeSet(), [$type])`
+     * @suppress PhanAccessReadOnlyProperty
      */
     public function withRealType(Type $type) : UnionType
     {
@@ -4938,6 +4941,7 @@ class UnionType implements Serializable
     /**
      * Shorter version of `UnionType::of($this->getTypeSet(), $real_type_set)`
      * @param ?array<int,Type> $real_type_set
+     * @suppress PhanAccessReadOnlyProperty
      */
     public function withRealTypeSet(?array $real_type_set) : UnionType
     {

--- a/src/Phan/LanguageServer/ClientHandler.php
+++ b/src/Phan/LanguageServer/ClientHandler.php
@@ -11,6 +11,7 @@ use Sabre\Event\Promise;
  *
  * Source: https://github.com/felixfbecker/php-language-server/tree/master/src/ClientHandler.php
  * See ../../../LICENSE.LANGUAGE_SERVER
+ * @immutable (NOTE: Phan's definition of immutable does not check if properties that are objects get modified)
  */
 class ClientHandler
 {

--- a/src/Phan/LanguageServer/LanguageClient.php
+++ b/src/Phan/LanguageServer/LanguageClient.php
@@ -6,6 +6,7 @@ namespace Phan\LanguageServer;
 /**
  * Source: https://github.com/felixfbecker/php-language-server/tree/master/src/LanguageClient.php
  * See ../../../LICENSE.LANGUAGE_SERVER
+ * @immutable
  */
 class LanguageClient
 {

--- a/src/Phan/LanguageServer/Protocol/CompletionList.php
+++ b/src/Phan/LanguageServer/Protocol/CompletionList.php
@@ -7,6 +7,7 @@ namespace Phan\LanguageServer\Protocol;
  * Represents a collection of completion items to be presented in
  * the editor.
  * @phan-file-suppress PhanWriteOnlyPublicProperty these are sent to the language client
+ * @immutable
  */
 class CompletionList
 {

--- a/src/Phan/LanguageServer/Protocol/Diagnostic.php
+++ b/src/Phan/LanguageServer/Protocol/Diagnostic.php
@@ -9,6 +9,7 @@ namespace Phan\LanguageServer\Protocol;
  *
  * Source: https://github.com/felixfbecker/php-language-server/tree/master/src/Protocol/Diagnostic.php
  * See ../../../../LICENSE.LANGUAGE_SERVER
+ * @immutable
  */
 class Diagnostic
 {

--- a/src/Phan/LanguageServer/Protocol/FileEvent.php
+++ b/src/Phan/LanguageServer/Protocol/FileEvent.php
@@ -8,6 +8,7 @@ namespace Phan\LanguageServer\Protocol;
  *
  * Source: https://github.com/felixfbecker/php-language-server/tree/master/src/Protocol/FileEvent.php
  * See ../../../../LICENSE.LANGUAGE_SERVER
+ * @immutable
  */
 class FileEvent
 {

--- a/src/Phan/LanguageServer/Protocol/Hover.php
+++ b/src/Phan/LanguageServer/Protocol/Hover.php
@@ -6,6 +6,7 @@ namespace Phan\LanguageServer\Protocol;
 /**
  * The result of a hover request.
  * @phan-file-suppress PhanWriteOnlyPublicProperty
+ * @immutable
  */
 class Hover
 {

--- a/src/Phan/LanguageServer/Protocol/Location.php
+++ b/src/Phan/LanguageServer/Protocol/Location.php
@@ -12,6 +12,7 @@ use Phan\LanguageServer\Utils;
  *
  * Source: https://github.com/felixfbecker/php-language-server/tree/master/src/Protocol/Location.php
  * See ../../../../LICENSE.LANGUAGE_SERVER
+ * @immutable
  */
 class Location
 {

--- a/src/Phan/LanguageServer/Protocol/MarkupContent.php
+++ b/src/Phan/LanguageServer/Protocol/MarkupContent.php
@@ -27,6 +27,7 @@ namespace Phan\LanguageServer\Protocol;
  * *Please Note* that clients might sanitize the return markdown. A client could decide to
  * remove HTML from the markdown to avoid script execution.
  * @phan-file-suppress PhanUnreferencedPublicClassConstant, PhanWriteOnlyPublicProperty
+ * @immutable
  */
 class MarkupContent
 {

--- a/src/Phan/LanguageServer/Protocol/Range.php
+++ b/src/Phan/LanguageServer/Protocol/Range.php
@@ -10,6 +10,7 @@ use Phan\Language\FileRef;
  *
  * Source: https://github.com/felixfbecker/php-language-server/tree/master/src/Protocol/Range.php
  * See ../../../../LICENSE.LANGUAGE_SERVER
+ * @immutable
  */
 class Range
 {

--- a/src/Phan/LanguageServer/Protocol/SaveOptions.php
+++ b/src/Phan/LanguageServer/Protocol/SaveOptions.php
@@ -13,7 +13,7 @@ class SaveOptions
     /**
      * @var bool|null
      * The client is supposed to include the content on save.
-     * @suppress PhanWriteOnlyPublicProperty (used by AdvancedJsonRpc)
+     * @suppress PhanWriteOnlyPublicProperty (sent to client via AdvancedJsonRpc)
      */
     public $includeText;
 }

--- a/src/Phan/LanguageServer/Protocol/TextDocumentContentChangeEvent.php
+++ b/src/Phan/LanguageServer/Protocol/TextDocumentContentChangeEvent.php
@@ -9,6 +9,7 @@ namespace Phan\LanguageServer\Protocol;
  *
  * Source: https://github.com/felixfbecker/php-language-server/tree/master/src/Protocol/TextDocumentContentChangeEvent.php
  * See ../../../../LICENSE.LANGUAGE_SERVER
+ * @immutable
  */
 class TextDocumentContentChangeEvent
 {

--- a/src/Phan/LanguageServer/Protocol/TextDocumentIdentifier.php
+++ b/src/Phan/LanguageServer/Protocol/TextDocumentIdentifier.php
@@ -6,6 +6,7 @@ namespace Phan\LanguageServer\Protocol;
 /**
  * Source: https://github.com/felixfbecker/php-language-server/tree/master/src/Protocol/TextDocumentIdentifier.php
  * See ../../../../LICENSE.LANGUAGE_SERVER
+ * @immutable
  */
 class TextDocumentIdentifier
 {

--- a/src/Phan/LanguageServer/Protocol/TextDocumentItem.php
+++ b/src/Phan/LanguageServer/Protocol/TextDocumentItem.php
@@ -8,6 +8,7 @@ namespace Phan\LanguageServer\Protocol;
  *
  * Source: https://github.com/felixfbecker/php-language-server/tree/master/src/Protocol/TextDocumentItem.php
  * See ../../../../LICENSE.LANGUAGE_SERVER
+ * @immutable
  */
 class TextDocumentItem
 {
@@ -15,7 +16,6 @@ class TextDocumentItem
      * The text document's URI.
      *
      * @var string
-     * @suppress PhanReadOnlyPublicProperty
      */
     public $uri;
 
@@ -40,7 +40,6 @@ class TextDocumentItem
      * The content of the opened text document.
      *
      * @var string
-     * @suppress PhanReadOnlyPublicProperty
      */
     public $text;
 }

--- a/src/Phan/LanguageServer/Protocol/VersionedTextDocumentIdentifier.php
+++ b/src/Phan/LanguageServer/Protocol/VersionedTextDocumentIdentifier.php
@@ -6,6 +6,7 @@ namespace Phan\LanguageServer\Protocol;
 /**
  * Source: https://github.com/felixfbecker/php-language-server/tree/master/src/Protocol/VersionedTextDocumentIdentifier.php
  * See ../../../../LICENSE.LANGUAGE_SERVER
+ * @immutable
  */
 class VersionedTextDocumentIdentifier extends TextDocumentIdentifier
 {
@@ -13,7 +14,6 @@ class VersionedTextDocumentIdentifier extends TextDocumentIdentifier
      * The version number of this document.
      *
      * @var int
-     * @suppress PhanReadOnlyPublicProperty
      */
     public $version;
 }

--- a/src/Phan/LanguageServer/Server/Workspace.php
+++ b/src/Phan/LanguageServer/Server/Workspace.php
@@ -15,6 +15,7 @@ use Phan\LanguageServer\Utils;
  *
  * Source: https://github.com/felixfbecker/php-language-server/tree/master/src/Server/Workspace.php
  * See ../../../../LICENSE.LANGUAGE_SERVER
+ * @immutable
  */
 class Workspace
 {

--- a/src/Phan/Library/ConversionSpec.php
+++ b/src/Phan/Library/ConversionSpec.php
@@ -4,6 +4,7 @@ namespace Phan\Library;
 
 /**
  * An object representing a conversion specifier of a format string, such as "%1$d".
+ * @immutable
  */
 class ConversionSpec
 {
@@ -83,6 +84,7 @@ class ConversionSpec
             }
             $directive = new self($match);
             if (!isset($directive->position)) {
+                // @phan-suppress-next-line PhanAccessReadOnlyProperty
                 $directive->position = ++$unnamed_count;
             }
             $directives[$directive->position][] = $directive;

--- a/src/Phan/Library/None.php
+++ b/src/Phan/Library/None.php
@@ -8,6 +8,7 @@ use Exception;
  * This represents the absence of a value in an Option.
  *
  * @inherits Option<null>
+ * @immutable
  */
 class None extends Option
 {

--- a/src/Phan/Library/Option.php
+++ b/src/Phan/Library/Option.php
@@ -12,6 +12,7 @@ namespace Phan\Library;
  *
  * @template T
  * The type of the element
+ * @immutable
  */
 abstract class Option
 {

--- a/src/Phan/Library/Some.php
+++ b/src/Phan/Library/Some.php
@@ -11,6 +11,7 @@ namespace Phan\Library;
  *
  * @inherits Option<T>
  * phpcs:disable PSR2.Classes.PropertyDeclaration.Underscore
+ * @immutable
  */
 class Some extends Option
 {

--- a/src/Phan/Plugin/Internal/IssueFixingPlugin/FileEdit.php
+++ b/src/Phan/Plugin/Internal/IssueFixingPlugin/FileEdit.php
@@ -7,6 +7,7 @@ use InvalidArgumentException;
 /**
  * Represents a change to be made to file contents.
  * The structure of this will change.
+ * @immutable
  */
 class FileEdit
 {
@@ -14,9 +15,8 @@ class FileEdit
     public $replace_start;
     /** @var int the byte offset where the replacement will end. this is >= $replace_start */
     public $replace_end;
-    // TODO: Implement insertion
     /** @var string the contents to replace the range with. Make this empty to delete. */
-    public $new_text = '';
+    public $new_text;
 
     /**
      * Create a new file edit (currently just supports deleting lines)

--- a/src/Phan/Plugin/Internal/IssueFixingPlugin/FileEditSet.php
+++ b/src/Phan/Plugin/Internal/IssueFixingPlugin/FileEditSet.php
@@ -5,6 +5,7 @@ namespace Phan\Plugin\Internal\IssueFixingPlugin;
 /**
  * Represents a set of changes to be made to file contents.
  * The structure of this will change.
+ * @immutable
  */
 class FileEditSet
 {

--- a/src/Phan/Plugin/Internal/UseReturnValuePlugin/StatsForFQSEN.php
+++ b/src/Phan/Plugin/Internal/UseReturnValuePlugin/StatsForFQSEN.php
@@ -6,8 +6,8 @@ use Phan\Language\Context;
 use Phan\Language\Element\FunctionInterface;
 
 /**
-* Information about the function and the locations where the function was called for one FQSEN
-*/
+ * Information about the function and the locations where the function was called for one FQSEN
+ */
 class StatsForFQSEN
 {
     /** @var array<string,Context> the locations where the return value was unused */

--- a/tests/files/expected/0763_immutable_class.php.expected
+++ b/tests/files/expected/0763_immutable_class.php.expected
@@ -1,0 +1,3 @@
+%s:20 PhanAccessReadOnlyProperty Cannot modify read-only property \TestImmutable->y defined at %s:8
+%s:24 PhanAccessReadOnlyProperty Cannot modify read-only property \TestImmutable->x defined at %s:7
+%s:27 PhanAccessReadOnlyProperty Cannot modify read-only property \TestImmutable::$static2 defined at %s:12

--- a/tests/files/src/0763_immutable_class.php
+++ b/tests/files/src/0763_immutable_class.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @immutable (phan-read-only is a supported alias)
+ */
+class TestImmutable {
+    public $x;
+    private $y;
+    public $z;
+    public static $static1 = 'value1';
+    /** @immutable (phan-read-only is a supported alias) */
+    public static $static2 = 'value2';
+    public function __construct(int $x) {
+        $this->x = $x;
+        $this->y = $x * 2;
+        $this->z = new stdClass();
+    }
+
+    public function setY() {
+        $this->y = 0;  // should warn
+    }
+}
+$n = new TestImmutable(11);
+$n->x = 33;  // should warn
+$n->z->field = 'allowed';  // Phan is currently designed not to warn.
+TestImmutable::$static1 = 'good';
+TestImmutable::$static2 = 'bad';  // should warn


### PR DESCRIPTION
Support `@immutable` annotation on class doc comments,
to indicate that all instance properties are read-only.

- Phan does not check if object fields of those immutable properties
  will change. (e.g. `$this->foo->prop = 'x';` is allowed)
- This annotation does not imply that methods have no side effects
  (e.g. I/O, modifying global state)
- This annotation does not imply that methods have deterministic return values
  or that methods' results should be used.

`@immutable` is an alias of `@phan-read-only`.
`@phan-read-only` was previously supported on properties.