### PR TITLE
Suggest use($missingVar). Warn about $this instanceof self/static.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,8 @@ New features(Analysis):
 + Support analyzing php 7.3's `is_countable()`, and warn when the check is redundant or impossible (#3172)
 + Don't suggest `$this->prop` as an alternative to the undeclared variable `$prop` from a static method/closure. (#3174)
 + Make real return types of `Closure::bind()` and other closure helpers more accurate. (#3184)
++ Include `use($missingVar)` in suggestions for `PhanUndeclaredVariable` if it is defined outside the closure(s) scope.
++ Warn about `$this instanceof self` and `$this instanceof static` being redundant.
 
 Plugins:
 + If possible, suggest the types that Phan observed during analysis with `UnknownElementTypePlugin`. (#3146)

--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,7 @@ New features(Analysis):
 + Don't suggest `$this->prop` as an alternative to the undeclared variable `$prop` from a static method/closure. (#3174)
 + Make real return types of `Closure::bind()` and other closure helpers more accurate. (#3184)
 + Include `use($missingVar)` in suggestions for `PhanUndeclaredVariable` if it is defined outside the closure(s) scope.
+  Also, suggest *hardcoded* globals such as `$argv`.
 + Warn about `$this instanceof self` and `$this instanceof static` being redundant.
 
 Plugins:

--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -338,6 +338,7 @@ class Context extends FileRef
     /**
      * @return Context
      * A new context with the given scope
+     * @phan-pure
      */
     public function withScope(Scope $scope) : Context
     {
@@ -346,6 +347,9 @@ class Context extends FileRef
         return $context;
     }
 
+    /**
+     * @phan-pure
+     */
     public function withEnterLoop(Node $node) : Context
     {
         $context = clone($this);
@@ -432,6 +436,7 @@ class Context extends FileRef
      * @return Context
      * A new context based on this with a variable
      * as defined by the parameters in scope
+     * @phan-pure
      */
     public function withScopeVariable(
         Variable $variable

--- a/src/Phan/Language/Scope.php
+++ b/src/Phan/Language/Scope.php
@@ -250,6 +250,7 @@ abstract class Scope
      * A variable to add to the local scope
      *
      * @return Scope a clone of this scope with $variable added
+     * @phan-pure
      */
     public function withVariable(Variable $variable) : Scope
     {

--- a/tests/files/expected/0219_superglobal_type_check.php.expected
+++ b/tests/files/expected/0219_superglobal_type_check.php.expected
@@ -11,5 +11,5 @@
 %s:37 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is array<string,array<int,int>>|array<string,array<int,string>>|array<string,int>|array<string,string> but \intdiv() takes int
 %s:40 PhanTypeMismatchArgumentInternal Argument 1 ($string) is array<int,string>|null but \strlen() takes string
 %s:43 PhanUnusedVariable Unused definition of variable $http_response_headers (Did you mean $http_response_header)
-%s:49 PhanUndeclaredVariable Variable $argc is undeclared
-%s:50 PhanUndeclaredVariable Variable $argv is undeclared
+%s:49 PhanUndeclaredVariable Variable $argc is undeclared (Did you mean (global $argc))
+%s:50 PhanUndeclaredVariable Variable $argv is undeclared (Did you mean (global $argv))

--- a/tests/files/expected/0637_access_protected_of_this.php.expected
+++ b/tests/files/expected/0637_access_protected_of_this.php.expected
@@ -1,4 +1,7 @@
+%s:8 PhanImpossibleCondition Impossible attempt to cast $this of type \AccessProtectedTest\Unrelated to \AccessProtectedTest\SomeClass
 %s:14 PhanUndeclaredStaticMethod Static call to undeclared method \AccessProtectedTest\Unrelated::staticMethod
 %s:15 PhanUndeclaredStaticProperty Static property 'static_something' on \AccessProtectedTest\Unrelated is undeclared
 %s:17 PhanUndeclaredStaticMethod Static call to undeclared method \AccessProtectedTest\Unrelated::staticMethod
 %s:18 PhanUndeclaredStaticProperty Static property 'static_something' on \AccessProtectedTest\Unrelated is undeclared
+%s:39 PhanRedundantCondition Redundant attempt to cast $this of type static to \AccessProtectedTest\SomeClass
+%s:40 PhanRedundantCondition Redundant attempt to cast $this of type static to static

--- a/tests/files/expected/0765_suggest_outer_closure_var.php.expected
+++ b/tests/files/expected/0765_suggest_outer_closure_var.php.expected
@@ -1,0 +1,1 @@
+%s:5 PhanUndeclaredVariable Variable $a is undeclared (Did you mean $b or (use($a) for Closure(int $b) at line 4))

--- a/tests/files/src/0637_access_protected_of_this.php
+++ b/tests/files/src/0637_access_protected_of_this.php
@@ -5,7 +5,7 @@ namespace AccessProtectedTest;
 class Unrelated {
     public function main() {
         $closure = function () {
-            if ($this instanceof SomeClass) {
+            if ($this instanceof SomeClass) {  // NOTE: This is treated as impossible because @phan-closure-scope was not used. However, the rest of the block is analyzed like SomeClass
                 // Observed: Emits PhanAccessMethodProtected and PhanAccessPropertyProtected
                 // Expected: Should not emit, but only when the variable name is `$this`
                 $this->method();
@@ -33,6 +33,11 @@ class SomeClass {
     }
     protected static function staticMethod() {
         echo "in static method";
+    }
+
+    public function test() {
+        var_export($this instanceof self);
+        var_export($this instanceof static);
     }
 }
 (new Unrelated())->main();

--- a/tests/files/src/0765_suggest_outer_closure_var.php
+++ b/tests/files/src/0765_suggest_outer_closure_var.php
@@ -1,0 +1,8 @@
+<?php
+
+function make_adder(int $a) : Closure {
+    return function (int $b) {
+        return $a + $b;
+    };
+}
+var_export(make_adder(2)(2));

--- a/tests/plugin_test/expected/154_phan_pure_magic.php.expected
+++ b/tests/plugin_test/expected/154_phan_pure_magic.php.expected
@@ -1,0 +1,7 @@
+src/154_phan_pure_magic.php:25 PhanUnusedPublicNoOverrideMethodParameter Parameter $name is never used
+src/154_phan_pure_magic.php:25 PhanUnusedPublicNoOverrideMethodParameter Parameter $value is never used
+src/154_phan_pure_magic.php:33 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \Magic154::__get() defined at src/154_phan_pure_magic.php:28
+src/154_phan_pure_magic.php:34 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \Magic154::__call() defined at src/154_phan_pure_magic.php:15
+src/154_phan_pure_magic.php:36 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \Magic154::instance_fn() defined at src/154_phan_pure_magic.php:5
+src/154_phan_pure_magic.php:38 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \Magic154::__call() defined at src/154_phan_pure_magic.php:15
+src/154_phan_pure_magic.php:39 PhanAccessReadOnlyProperty Cannot modify read-only property \Magic154->values defined at src/154_phan_pure_magic.php:9

--- a/tests/plugin_test/src/154_phan_pure_magic.php
+++ b/tests/plugin_test/src/154_phan_pure_magic.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @method static int static_fn()
+ * @method int instance_fn()
+ * @phan-pure
+ */
+class Magic154 {
+    public $values;
+
+    public function __construct(array $values) {
+        $this->values = $values;
+    }
+
+    public function __call(string $method, array $args) {
+        return [$method, $args];
+    }
+
+    public static function __callStatic(string $method, array $args) {
+        $args[] = $method;
+        sort($args);
+        return $args;
+    }
+
+    public function __set(string $name, $value) {
+        // no-op
+    }
+    public function __get(string $name) {
+        return $this->values[$name] ?? null;
+    }
+}
+$m = new Magic154(['blah' => 'v1']);
+$m->__get('blah');  // should warn about this being unused
+$m->__call('blah', ['args']);  // should warn about this being unused
+$m->__set('blah', 'unused');
+$m->instance_fn();  // should warn about being unused
+Magic154::static_fn();  // should not warn
+$m->unknown_instance_fn();  // should warn about being unused, the class is pure
+$m->values = ['blah' => 'v2'];  // should warn


### PR DESCRIPTION
Except for in closure re-binding,
$this instanceof self/static is redundant.

Check if PhanUndeclaredVariable refers to a variable outside the current
closure(s) scope.