### PR TITLE
Fix a crash in UseReturnValueVisitor, fix false positive

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -48,6 +48,7 @@ New features(Analysis):
 + Warn about redundant condition detection in more cases in loops.
 + Warn about PHP 4 constructors such as `Foo::Foo()` if the class has no namespace and `__construct()` does not exist. (#740)
   Infer that defining `Foo::Foo()` creates the method alias `Foo::__construct()`.
++ Don't emit `PhanTypeMismatchArgumentReal` if the only cause of the mismatch is nullability of real types (if phpdoc types were compatible) (#3231)
 
 Language Server/Daemon mode:
 + Ignore `'plugin_config' => ['infer_pure_methods' => true]` in language server and daemon mode. (#3220)

--- a/src/Phan/Plugin/Internal/UseReturnValuePlugin/UseReturnValueVisitor.php
+++ b/src/Phan/Plugin/Internal/UseReturnValuePlugin/UseReturnValueVisitor.php
@@ -207,7 +207,12 @@ class UseReturnValueVisitor extends PluginAwarePostAnalysisVisitor
     {
         $args = $node->children['args']->children;
         $bool_node = $args[1] ?? null;
-        if (!$bool_node) {
+        if (!$bool_node instanceof Node) {
+            if ($const_name === 'true') {
+                return (bool)$bool_node;
+            } elseif ($const_name === 'false') {
+                return (bool)$bool_node;
+            }
             return false;
         }
         if ($bool_node->kind !== ast\AST_CONST) {

--- a/tests/plugin_test/expected/140_use_return_value_misc.php.expected
+++ b/tests/plugin_test/expected/140_use_return_value_misc.php.expected
@@ -7,3 +7,6 @@ src/140_use_return_value_misc.php:17 PhanPluginUseReturnValueInternalKnown Expec
 src/140_use_return_value_misc.php:19 PhanPluginUseReturnValueInternalKnown Expected to use the return value of the internal function/method \call_user_func
 src/140_use_return_value_misc.php:20 PhanPluginUseReturnValueInternalKnown Expected to use the return value of the internal function/method \call_user_func_array
 src/140_use_return_value_misc.php:29 PhanPluginUseReturnValueInternalKnown Expected to use the return value of the internal function/method \preg_match_all
+src/140_use_return_value_misc.php:32 PhanTypeMismatchArgumentInternal Argument 2 ($return) is 0 but \var_export() takes bool
+src/140_use_return_value_misc.php:33 PhanPluginUseReturnValueInternalKnown Expected to use the return value of the internal function/method \var_export
+src/140_use_return_value_misc.php:33 PhanTypeMismatchArgumentInternal Argument 2 ($return) is 1 but \var_export() takes bool

--- a/tests/plugin_test/src/140_use_return_value_misc.php
+++ b/tests/plugin_test/src/140_use_return_value_misc.php
@@ -29,3 +29,5 @@ call_user_func_array('var_dump', [1, 2]);
 preg_match_all('/x/', 'executable');
 // should not warn
 preg_match_all('/x/', 'executable', $matches);
+var_export($matches, 0);
+var_export($matches, 1);


### PR DESCRIPTION
Analysis of `var_export($x, literal)` would crash on 2.2.12-dev

Fixes #3231 as well.