### PR TITLE
Warn about the last compilation warning when parsing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,9 @@ New features(Analysis):
 + Import more specific phpdoc/real array return types for internal global functions from opcache.
 + Emit `PhanUndeclaredVariable` and other warnings about arguments when there are too many parameters for methods. (#3245)
 + Infer real types of array/iterable keys and values in more cases.
++ Expose the last compilation warning seen when tokenizing or parsing with the native parser, if possible (#3263)
+  New issue types: `PhanSyntaxCompileWarning`
+  Additionally, expose the last compilation warning or deprecation notice seen when tokenizing in the polyfill.
 
 Language Server/Daemon mode:
 + Fix logged Error when language server receives `didChangeConfiguration` events. (this is a no-op)

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -527,7 +527,7 @@ This is used for notices that are emitted while Phan is parsing with the native 
 Currently, this only catches the notice about the `(real)` cast from the native parser in php 7.4.
 
 ```
-Saw a notice while parsing with the native parser: {DETAILS}
+Saw a parse notice: {DETAILS}
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/2.2.9/tests/php74_files/expected/012_real_cast.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/2.2.9/tests/php74_files/src/012_real_cast.php#L2).
@@ -4016,6 +4016,8 @@ e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/files/expected/0
 @phan-debug-var requested for variable ${VARIABLE} - it has union type {TYPE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0760_iterable_false_positive.php.expected#L4) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0760_iterable_false_positive.php#L19).
+
 ## PhanInvalidCommentForDeclarationType
 
 ```
@@ -4180,6 +4182,14 @@ Cannot use temporary expression (of type {TYPE}) in write context
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/files/expected/0518_crash_assignment.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/2.0.0/tests/files/src/0518_crash_assignment.php#L4).
+
+## PhanSyntaxCompileWarning
+
+```
+Saw a warning while parsing: {DETAILS}
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/plugin_test/expected/157_polyfill_compilation_warning.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/plugin_test/src/157_polyfill_compilation_warning.php#L77).
 
 ## PhanSyntaxError
 

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -32,6 +32,7 @@ class Issue
     const ContinueTargetingSwitch        = 'PhanContinueTargetingSwitch';
     const ContinueOrBreakNotInLoop       = 'PhanContinueOrBreakNotInLoop';
     const ContinueOrBreakTooManyLevels   = 'PhanContinueOrBreakTooManyLevels';
+    const SyntaxCompileWarning           = 'PhanSyntaxCompileWarning';
 
     // Issue::CATEGORY_UNDEFINED
     const AmbiguousTraitAliasSource = 'PhanAmbiguousTraitAliasSource';
@@ -813,6 +814,14 @@ class Issue
                 "Cannot use constant {CONST} as {CONST} because the name is already in use",
                 self::REMEDIATION_B,
                 17010
+            ),
+            new Issue(
+                self::SyntaxCompileWarning,
+                self::CATEGORY_SYNTAX,
+                self::SEVERITY_NORMAL,
+                'Saw a warning while parsing: {DETAILS}',
+                self::REMEDIATION_A,
+                17011
             ),
 
             // Issue::CATEGORY_UNDEFINED
@@ -4090,7 +4099,7 @@ class Issue
                 self::CompatibleSyntaxNotice,
                 self::CATEGORY_COMPATIBLE,
                 self::SEVERITY_NORMAL,
-                "Saw a notice while parsing with the native parser: {DETAILS}",
+                "Saw a parse notice: {DETAILS}",
                 self::REMEDIATION_B,
                 3017
             ),

--- a/tests/files/expected/0771_unterminated_comment.php.expected
+++ b/tests/files/expected/0771_unterminated_comment.php.expected
@@ -1,0 +1,1 @@
+%s:3 PhanSyntaxCompileWarning Saw a warning while parsing: Unterminated comment starting line 3

--- a/tests/files/src/0771_unterminated_comment.php
+++ b/tests/files/src/0771_unterminated_comment.php
@@ -1,0 +1,7 @@
+<?php
+
+/**
+ * This is a function
+ *
+function test() {
+}

--- a/tests/php74_files/expected/012_real_cast.php.expected
+++ b/tests/php74_files/expected/012_real_cast.php.expected
@@ -1,1 +1,1 @@
-%s:2 PhanCompatibleSyntaxNotice Saw a notice while parsing with the native parser: The (real) cast is deprecated, use (float) instead
+%s:2 PhanCompatibleSyntaxNotice Saw a parse notice: The (real) cast is deprecated, use (float) instead


### PR DESCRIPTION
Fixes #3260

The PHP API limits us to knowing about the last compile warning,
since E_COMPILE_WARNING can't be handled by user error handlers.