### PR TITLE
Strictly warn about invalid real args/parameters in more cases

### DIFF
--- a/.phan/plugins/HasPHPDocPlugin.php
+++ b/.phan/plugins/HasPHPDocPlugin.php
@@ -20,8 +20,8 @@ use Phan\PluginV3\PostAnalyzeNodeCapability;
 use function array_shift;
 use function count;
 use function gettype;
-use function json_encode;
 use function is_string;
+use function json_encode;
 use function ltrim;
 use function preg_match;
 use function strpos;
@@ -264,7 +264,7 @@ class BasePHPDocCheckerPlugin extends PluginAwarePostAnalysisVisitor
             );
             return null;
         }
-        return new ClassElementEntry($method, trim(preg_replace('/\s+/', ' ', $description)));
+        return new ClassElementEntry($method, \trim(\preg_replace('/\s+/', ' ', $description)));
     }
 
     /**
@@ -302,7 +302,7 @@ class BasePHPDocCheckerPlugin extends PluginAwarePostAnalysisVisitor
             );
             return null;
         }
-        return new ClassElementEntry($property, trim(preg_replace('/\s+/', ' ', $description)));
+        return new ClassElementEntry($property, \trim(\preg_replace('/\s+/', ' ', $description)));
     }
 }
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,9 @@ New features(Analysis):
 + Expose the last compilation warning seen when tokenizing or parsing with the native parser, if possible (#3263)
   New issue types: `PhanSyntaxCompileWarning`
   Additionally, expose the last compilation warning or deprecation notice seen when tokenizing in the polyfill.
++ Improve inference of when the real result of a binary operation is a float. (#3256)
++ Emit stricter warnings for more real type mismatches (#3256)
+  (e.g. emit `PhanTypeMismatchArgumentReal` for `float->int` when `strict_types=1`, `'literal string'->int`, etc.)
 
 Language Server/Daemon mode:
 + Fix logged Error when language server receives `didChangeConfiguration` events. (this is a no-op)

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -1228,7 +1228,6 @@ class ContextNode
         );
         if ($parameter->getReferenceType() === Parameter::REFERENCE_READ_WRITE ||
             ($real_parameter && !$real_parameter->getNonVariadicUnionType()->containsNullableOrIsEmpty())) {
-
             static $null_type = null;
             if ($null_type === null) {
                 $null_type = NullType::instance(false)->asPHPDocUnionType();

--- a/src/Phan/AST/Parser.php
+++ b/src/Phan/AST/Parser.php
@@ -459,7 +459,6 @@ class Parser
     {
         if (\in_array($error['type'], [\E_DEPRECATED, \E_COMPILE_WARNING], true) &&
             \basename($error['file']) === 'PhpTokenizer.php') {
-
             Issue::maybeEmit(
                 $code_base,
                 $context,
@@ -468,7 +467,7 @@ class Parser
                 $error['message']
             );
         }
-}
+    }
 
     /**
      * Remove the leading #!/path/to/interpreter/of/php from a CLI script, if any was found.

--- a/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
+++ b/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
@@ -368,6 +368,9 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
         if ($is_binary_op) {
             return UnionType::fromFullyQualifiedPHPDocAndRealString('int', 'int|string');
         }
+        if ($left->isExclusivelyRealFloatTypes() || $right->isExclusivelyRealFloatTypes()) {
+            return FloatType::instance(false)->asRealUnionType();
+        }
         if ($node->flags === ast\flags\BINARY_DIV) {
             return UnionType::fromFullyQualifiedRealString('int|float');
         }
@@ -838,23 +841,12 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
         static $float_type = null;
         static $int_or_float_union_type = null;
         if ($int_or_float_union_type === null) {
-            $float_type = FloatType::instance(false);
+            $float_type = FloatType::instance(false)->asRealUnionType();
             $int_or_float_union_type = UnionType::fromFullyQualifiedRealString('int|float');
         }
-        if ($node->flags === ast\flags\BINARY_DIV) {
-            return $int_or_float_union_type;
+        if ($left->isExclusivelyRealFloatTypes() || $right->isExclusivelyRealFloatTypes()) {
+            return $float_type;
         }
-
-        if ($left->isNonNullNumberType() && $right->isNonNullNumberType()) {
-            if (!$left->hasNonNullIntType() || !$right->hasNonNullIntType()) {
-                // Heuristic: If one or more of the sides is a float, the result is always a float.
-                return $float_type->asRealUnionType();
-            }
-            return $int_or_float_union_type;
-        }
-
-        // TODO: warn about subtracting to/from non-number
-
         return $int_or_float_union_type;
     }
 

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -633,7 +633,7 @@ class Clazz extends AddressableElement
             $visited[$fqsen->__toString()] = true;
 
             // Prevent infinite loops
-            if (array_key_exists($parent->getFQSEN()->__toString(), $visited)) {
+            if (\array_key_exists($parent->getFQSEN()->__toString(), $visited)) {
                 return $fqsen;
             }
         }
@@ -1873,7 +1873,7 @@ class Clazz extends AddressableElement
             }
             $checked[$current->getFQSEN()->__toString()] = true;
             $current = $this->getParentClass($code_base);
-            if (array_key_exists($current->getFQSEN()->__toString(), $checked)) {
+            if (\array_key_exists($current->getFQSEN()->__toString(), $checked)) {
                 // Prevent infinite recursion.
                 return false;
             }

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -1245,6 +1245,11 @@ final class EmptyUnionType extends UnionType
         return false;
     }
 
+    public function isExclusivelyRealFloatTypes() : bool
+    {
+        return false;
+    }
+
     public function isNonNullIntType() : bool
     {
         return false;

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -2029,6 +2029,18 @@ class Type
     }
 
     /**
+     * Check if this type can possibly cast to the declared type, ignoring nullability of this type
+     *
+     * Precondition: This is either non-nullable or the type NullType/VoidType
+     */
+    public function canCastToDeclaredType(CodeBase $code_base, Context $unused_context, Type $other) : bool
+    {
+        if ($other->isPossiblyObject() && $this->canPossiblyCastToClass($code_base, $other->withIsNullable(false))) {
+            return true;
+        }
+        return $this->canCastToType($other);
+    }
+    /**
      * Check if there is any way this type or a subclass could cast to $other.
      * (does not check for mixed)
      */

--- a/src/Phan/Language/Type/ArrayType.php
+++ b/src/Phan/Language/Type/ArrayType.php
@@ -3,6 +3,7 @@
 namespace Phan\Language\Type;
 
 use Phan\CodeBase;
+use Phan\Language\Context;
 use Phan\Language\Type;
 use Phan\Language\UnionType;
 use Phan\Language\UnionTypeBuilder;
@@ -202,6 +203,17 @@ class ArrayType extends IterableType
     {
         // CallableDeclarationType is not a native type, we check separately here
         return parent::canCastToNonNullableTypeWithoutConfig($type) || $type instanceof ArrayType || $type instanceof CallableDeclarationType;
+    }
+
+    public function canCastToDeclaredType(CodeBase $unused_code_base, Context $unused_context, Type $other) : bool
+    {
+        if ($other instanceof IterableType) {
+            return true;
+        }
+        if ($this->isDefiniteNonCallableType()) {
+            return false;
+        }
+        return $other instanceof CallableDeclarationType || $other instanceof CallableType;
     }
 
     /**

--- a/src/Phan/Language/Type/BoolType.php
+++ b/src/Phan/Language/Type/BoolType.php
@@ -2,7 +2,9 @@
 
 namespace Phan\Language\Type;
 
+use Phan\CodeBase;
 use Phan\Config;
+use Phan\Language\Context;
 use Phan\Language\Type;
 
 /**
@@ -38,6 +40,11 @@ final class BoolType extends ScalarType
     public function asNonFalseType() : Type
     {
         return TrueType::instance($this->is_nullable);
+    }
+
+    public function canCastToDeclaredType(CodeBase $code_base, Context $context, Type $other) : bool
+    {
+        return $other->isInBoolFamily() || (!$context->isStrictTypes() && parent::canCastToDeclaredType($code_base, $context, $other));
     }
 
     public function isPossiblyTrue() : bool

--- a/src/Phan/Language/Type/FalseType.php
+++ b/src/Phan/Language/Type/FalseType.php
@@ -3,7 +3,9 @@
 namespace Phan\Language\Type;
 
 use AssertionError;
+use Phan\CodeBase;
 use Phan\Config;
+use Phan\Language\Context;
 use Phan\Language\Type;
 
 /**
@@ -88,6 +90,12 @@ final class FalseType extends ScalarType
     {
         return self::performComparison(false, $scalar, $flags);
     }
+
+    public function canCastToDeclaredType(CodeBase $code_base, Context $context, Type $other) : bool
+    {
+        return $other->isInBoolFamily() || (!$context->isStrictTypes() && parent::canCastToDeclaredType($code_base, $context, $other));
+    }
+
 
     // public function getTypeAfterIncOrDec() : UnionType - doesn't need to be changed
     /**

--- a/src/Phan/Language/Type/FloatType.php
+++ b/src/Phan/Language/Type/FloatType.php
@@ -2,7 +2,10 @@
 
 namespace Phan\Language\Type;
 
+use Phan\CodeBase;
 use Phan\Config;
+use Phan\Language\Context;
+use Phan\Language\Type;
 use Phan\Language\UnionType;
 
 /**
@@ -47,5 +50,14 @@ class FloatType extends ScalarType
     public function getTypeAfterIncOrDec() : UnionType
     {
         return FloatType::instance(false)->asPHPDocUnionType();
+    }
+
+    public function canCastToDeclaredType(CodeBase $code_base, Context $context, Type $other) : bool
+    {
+        // Allow casting scalars to other scalars, but not to null.
+        if ($other instanceof ScalarType) {
+            return $other instanceof FloatType || (!$context->isStrictTypes() && parent::canCastToDeclaredType($code_base, $context, $other));
+        }
+        return $other instanceof CallableType;
     }
 }

--- a/src/Phan/Language/Type/IntType.php
+++ b/src/Phan/Language/Type/IntType.php
@@ -2,6 +2,9 @@
 
 namespace Phan\Language\Type;
 
+use Phan\CodeBase;
+use Phan\Language\Context;
+use Phan\Language\Type;
 use Phan\Language\UnionType;
 
 /**
@@ -22,6 +25,21 @@ class IntType extends ScalarType
     public function getTypeAfterIncOrDec() : UnionType
     {
         return IntType::instance(false)->asPHPDocUnionType();
+    }
+
+    /**
+     * Check if this type can possibly cast to the declared type, ignoring nullability of this type
+     */
+    public function canCastToDeclaredType(CodeBase $code_base, Context $context, Type $other) : bool
+    {
+        // always allow int -> float or int -> int
+        if ($other instanceof IntType || $other instanceof FloatType) {
+            return true;
+        }
+        if ($context->isStrictTypes()) {
+            return false;
+        }
+        return parent::canCastToDeclaredType($code_base, $context, $other);
     }
 
     public function isPossiblyTruthy() : bool

--- a/src/Phan/Language/Type/IterableType.php
+++ b/src/Phan/Language/Type/IterableType.php
@@ -3,6 +3,7 @@
 namespace Phan\Language\Type;
 
 use Phan\CodeBase;
+use Phan\Language\Context;
 use Phan\Language\Type;
 
 /**
@@ -18,6 +19,13 @@ class IterableType extends NativeType
     {
         return true;
     }
+
+    public function canCastToDeclaredType(CodeBase $unused_code_base, Context $unused_context, Type $other) : bool
+    {
+        // TODO: Check if $other is final and non-iterable
+        return $other instanceof IterableType || $other instanceof CallableDeclarationType || $other->isPossiblyObject();
+    }
+
 
     public function asIterable(CodeBase $_) : ?Type
     {

--- a/src/Phan/Language/Type/LiteralStringType.php
+++ b/src/Phan/Language/Type/LiteralStringType.php
@@ -262,6 +262,30 @@ final class LiteralStringType extends StringType implements LiteralTypeInterface
         return parent::canCastToNonNullableType($type);
     }
 
+    public function canCastToDeclaredType(CodeBase $unused_code_base, Context $context, Type $type) : bool
+    {
+        if ($type instanceof ScalarType) {
+            switch ($type::NAME) {
+                case 'string':
+                    return true;
+                case 'int':
+                    // Allow int or float strings to cast to int or floats
+                    if (filter_var($this->value, FILTER_VALIDATE_INT) === false) {
+                        return false;
+                    }
+                    break;
+                case 'float':
+                    // Allow int or float strings to cast to int or floats
+                    if (filter_var($this->value, FILTER_VALIDATE_FLOAT) === false) {
+                        return false;
+                    }
+                    break;
+            }
+            return !$context->isStrictTypes();
+        }
+        return $type instanceof CallableType;
+    }
+
     /**
      * @return bool
      * True if this Type can be cast to the given Type

--- a/src/Phan/Language/Type/MixedType.php
+++ b/src/Phan/Language/Type/MixedType.php
@@ -98,6 +98,11 @@ final class MixedType extends NativeType
         return true;  // It's possible.
     }
 
+    public function canCastToDeclaredType(CodeBase $unused_code_base, Context $unused_context, Type $unused_other) : bool
+    {
+        return true;  // It's possible.
+    }
+
     public function isDefiniteNonObjectType() : bool
     {
         return false;

--- a/src/Phan/Language/Type/NullType.php
+++ b/src/Phan/Language/Type/NullType.php
@@ -4,6 +4,7 @@ namespace Phan\Language\Type;
 
 use Phan\CodeBase;
 use Phan\Config;
+use Phan\Language\Context;
 use Phan\Language\Type;
 use Phan\Language\UnionType;
 
@@ -50,6 +51,11 @@ final class NullType extends ScalarType
         return Config::get_null_casts_as_any_type()
             || (Config::get_null_casts_as_array() && $type->isArrayLike())
             || parent::canCastToNonNullableType($type);
+    }
+
+    public function canCastToDeclaredType(CodeBase $unused_code_base, Context $unused_context, Type $other) : bool
+    {
+        return $other->isNullable();
     }
 
     public function isSubtypeOf(Type $type) : bool

--- a/src/Phan/Language/Type/ObjectType.php
+++ b/src/Phan/Language/Type/ObjectType.php
@@ -3,6 +3,7 @@
 namespace Phan\Language\Type;
 
 use Phan\CodeBase;
+use Phan\Language\Context;
 use Phan\Language\Type;
 
 /**
@@ -62,6 +63,14 @@ class ObjectType extends NativeType
     public function isPossiblyObject() : bool
     {
         return true;
+    }
+
+    /**
+     * Check if this type can possibly cast to the declared type, ignoring nullability of this type
+     */
+    public function canCastToDeclaredType(CodeBase $unused_code_base, Context $unused_context, Type $other) : bool
+    {
+        return $other->isPossiblyObject();
     }
 
     public function canUseInRealSignature() : bool

--- a/src/Phan/Language/Type/ResourceType.php
+++ b/src/Phan/Language/Type/ResourceType.php
@@ -2,6 +2,10 @@
 
 namespace Phan\Language\Type;
 
+use Phan\CodeBase;
+use Phan\Language\Context;
+use Phan\Language\Type;
+
 /**
  * Represents the type `resource`
  */
@@ -23,5 +27,11 @@ final class ResourceType extends NativeType
     public function canUseInRealSignature() : bool
     {
         return false;
+    }
+
+    public function canCastToDeclaredType(CodeBase $unused_code_base, Context $unused_context, Type $other) : bool
+    {
+        // Allow casting resources to other resources.
+        return $other instanceof ResourceType;
     }
 }

--- a/src/Phan/Language/Type/ScalarType.php
+++ b/src/Phan/Language/Type/ScalarType.php
@@ -126,6 +126,12 @@ abstract class ScalarType extends NativeType
         return true;
     }
 
+    public function canCastToDeclaredType(CodeBase $unused_code_base, Context $unused_context, Type $other) : bool
+    {
+        // Allow casting scalars to other scalars, but not to null.
+        return $other instanceof ScalarType && !($other instanceof NullType);
+    }
+
     /**
      * Returns true if this contains a type that is definitely nullable or a non-object.
      * e.g. returns true false, array, int

--- a/src/Phan/Language/Type/StringType.php
+++ b/src/Phan/Language/Type/StringType.php
@@ -2,7 +2,9 @@
 
 namespace Phan\Language\Type;
 
+use Phan\CodeBase;
 use Phan\Config;
+use Phan\Language\Context;
 use Phan\Language\Type;
 use Phan\Language\UnionType;
 
@@ -36,6 +38,15 @@ class StringType extends ScalarType
     public function isPossiblyNumeric() : bool
     {
         return true;
+    }
+
+    public function canCastToDeclaredType(CodeBase $code_base, Context $context, Type $other) : bool
+    {
+        // Allow casting scalars to other scalars, but not to null.
+        if ($other instanceof ScalarType) {
+            return $other instanceof StringType || (!$context->isStrictTypes() && parent::canCastToDeclaredType($code_base, $context, $other));
+        }
+        return $other instanceof CallableType;
     }
 
     /**

--- a/src/Phan/Language/Type/TemplateType.php
+++ b/src/Phan/Language/Type/TemplateType.php
@@ -179,4 +179,10 @@ final class TemplateType extends Type
     {
         return false;
     }
+
+    public function canCastToDeclaredType(CodeBase $unused_code_base, Context $unused_context, Type $unused_other) : bool
+    {
+        // Always possible until we support inferring `@template T as ConcreteType`
+        return true;
+    }
 }

--- a/src/Phan/Language/Type/TrueType.php
+++ b/src/Phan/Language/Type/TrueType.php
@@ -3,7 +3,9 @@
 namespace Phan\Language\Type;
 
 use AssertionError;
+use Phan\CodeBase;
 use Phan\Config;
+use Phan\Language\Context;
 use Phan\Language\Type;
 
 /**
@@ -77,6 +79,11 @@ final class TrueType extends ScalarType
     public function canSatisfyComparison($scalar, int $flags) : bool
     {
         return self::performComparison(true, $scalar, $flags);
+    }
+
+    public function canCastToDeclaredType(CodeBase $code_base, Context $context, Type $other) : bool
+    {
+        return $other->isInBoolFamily() || (!$context->isStrictTypes() && parent::canCastToDeclaredType($code_base, $context, $other));
     }
 
     // public function getTypeAfterIncOrDec() : UnionType - doesn't need to be changed

--- a/src/Phan/Language/Type/VoidType.php
+++ b/src/Phan/Language/Type/VoidType.php
@@ -4,6 +4,7 @@ namespace Phan\Language\Type;
 
 use Phan\CodeBase;
 use Phan\Config;
+use Phan\Language\Context;
 use Phan\Language\Type;
 use Phan\Language\UnionType;
 
@@ -42,6 +43,11 @@ final class VoidType extends NativeType
             [],
             true
         );
+    }
+
+    public function canCastToDeclaredType(CodeBase $unused_code_base, Context $unused_context, Type $other) : bool
+    {
+        return $other->isNullable();
     }
 
     public function isSubtypeOf(Type $type) : bool

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -1401,6 +1401,19 @@ class UnionType implements Serializable
     }
 
     /**
+     * Returns true if this type's real type set is exclusively non-null float types and is non-empty
+     */
+    public function isExclusivelyRealFloatTypes() : bool
+    {
+        foreach ($this->real_type_set as $type) {
+            if (!($type instanceof FloatType) || $type->isNullable()) {
+                return false;
+            }
+        }
+        return \count($this->real_type_set) > 0;
+    }
+
+    /**
      * Returns true if this is exclusively non-null IntType or LiteralIntType
      */
     public function isNonNullIntType() : bool
@@ -2433,6 +2446,7 @@ class UnionType implements Serializable
         if ($this->isNull()) {
             return $other->containsNullable();
         }
+        // TODO forbid float or literal float->int with strict_types=1
         if ($this->hasAnyTypeOverlap($code_base, $other)) {
             return true;
         }

--- a/tests/files/expected/0044_closure_types.php.expected
+++ b/tests/files/expected/0044_closure_types.php.expected
@@ -1,2 +1,2 @@
-%s:6 PhanTypeMismatchArgument Argument 1 ($i) is 'string' but Closure(int $i) : int takes int defined at %s:3
+%s:6 PhanTypeMismatchArgumentReal Argument 1 ($i) is 'string' but Closure(int $i) : int takes int defined at %s:3
 %s:7 PhanTypeMismatchArgument Argument 1 ($s) is 42 but Closure(string $s) : string takes string defined at %s:4

--- a/tests/files/expected/0050_parameter_dim_assignment.php.expected
+++ b/tests/files/expected/0050_parameter_dim_assignment.php.expected
@@ -1,1 +1,1 @@
-%s:21 PhanTypeMismatchReturn Returning type 'literalstring' but h() is declared to return int
+%s:21 PhanTypeMismatchReturnReal Returning type 'literalstring' but h() is declared to return int

--- a/tests/files/expected/0084_branch_scope.php.expected
+++ b/tests/files/expected/0084_branch_scope.php.expected
@@ -1,2 +1,2 @@
 %s:6 PhanRedundantCondition Redundant attempt to cast true of type true to truthy
-%s:17 PhanTypeMismatchArgument Argument 1 ($v) is 'str' but \f() takes int defined at %s:16
+%s:17 PhanTypeMismatchArgumentReal Argument 1 ($v) is 'str' but \f() takes int defined at %s:16

--- a/tests/files/expected/0099_type_error.php.expected
+++ b/tests/files/expected/0099_type_error.php.expected
@@ -5,5 +5,5 @@
 %s:16 PhanTypeInstantiateInterface Instantiation of interface \E
 %s:19 PhanCompatiblePHP8PHP4Constructor PHP4 constructors will be removed in php 8, and should not be used. __construct() should be added/used instead to avoid accidentally calling \F::f()
 %s:19 PhanTypeNonVarPassByRef Only variables can be passed by reference at argument 1 of \F::f()
-%s:22 PhanTypeMismatchReturn Returning type 'string' but f() is declared to return int
+%s:22 PhanTypeMismatchReturnReal Returning type 'string' but f() is declared to return int
 %s:25 PhanTypeMissingReturn Method \H::f is declared to return int but has no return value

--- a/tests/files/expected/0101_one_of_each.php.expected
+++ b/tests/files/expected/0101_one_of_each.php.expected
@@ -34,7 +34,7 @@
 %s:110 PhanTypeComparisonToArray int to array comparison
 %s:116 PhanTypeInstantiateAbstract Instantiation of abstract class \C6
 %s:119 PhanTypeInstantiateInterface Instantiation of interface \C7
-%s:129 PhanTypeMismatchArgument Argument 1 ($i) is 'string' but \f8() takes int defined at %s:128
+%s:129 PhanTypeMismatchArgumentReal Argument 1 ($i) is 'string' but \f8() takes int defined at %s:128
 %s:132 PhanTypeMismatchArgumentInternal Argument 1 ($string) is 42 but \strlen() takes string
 %s:138 PhanTypeMismatchForeach null passed to foreach instead of array
 %s:139 PhanTypeMismatchForeach resource passed to foreach instead of array

--- a/tests/files/expected/0277_literal_conditional.php.expected
+++ b/tests/files/expected/0277_literal_conditional.php.expected
@@ -14,7 +14,7 @@
 %s:17 PhanRedundantCondition Redundant attempt to cast TRUE of type true to truthy
 %s:17 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is true but \intdiv() takes int
 %s:18 PhanRedundantCondition Redundant attempt to cast 'key' of type 'key' to truthy
-%s:18 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is 'key' but \intdiv() takes int
+%s:18 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($numerator) is 'key' but \intdiv() takes int
 %s:19 PhanRedundantCondition Redundant attempt to cast '1' of type '1' to truthy
 %s:19 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is '1' but \intdiv() takes int
 %s:20 PhanImpossibleCondition Impossible attempt to cast '' of type '' to truthy

--- a/tests/files/expected/0294_trait_as_and_insteadof.php.expected
+++ b/tests/files/expected/0294_trait_as_and_insteadof.php.expected
@@ -1,4 +1,4 @@
 %s:32 PhanTypeMismatchArgument Argument 1 ($x) is 42 but \ClassUsingTrait294::foO() takes string defined at %s:14
 %s:34 PhanUndeclaredMethod Call to undeclared method \ClassUsingTrait294::foo3 (Did you mean expr->foO() or expr->foo2())
-%s:36 PhanTypeMismatchArgument Argument 1 ($x) is '?' but \ClassUsingTrait294::foo2() takes int defined at %s:5
+%s:36 PhanTypeMismatchArgumentReal Argument 1 ($x) is '?' but \ClassUsingTrait294::foo2() takes int defined at %s:5
 %s:37 PhanTypeMismatchArgumentReal Argument 1 ($x) is 4.2 but \ClassUsingTrait294::bAr() takes array defined at %s:17

--- a/tests/files/expected/0310_self_construct.php.expected
+++ b/tests/files/expected/0310_self_construct.php.expected
@@ -1,8 +1,8 @@
 %s:8 PhanUndeclaredStaticMethod Static call to undeclared method \Baz310::__construct
 %s:19 PhanAccessOwnConstructor Accessing own constructor directly via self::__construct
-%s:19 PhanTypeMismatchArgument Argument 1 ($arg) is 'y' but \Foo310::__construct() takes int defined at %s:14
+%s:19 PhanTypeMismatchArgumentReal Argument 1 ($arg) is 'y' but \Foo310::__construct() takes int defined at %s:14
 %s:20 PhanAccessOwnConstructor Accessing own constructor directly via static::__construct
-%s:20 PhanTypeMismatchArgument Argument 1 ($arg) is 'z' but \Foo310::__construct() takes int defined at %s:14
+%s:20 PhanTypeMismatchArgumentReal Argument 1 ($arg) is 'z' but \Foo310::__construct() takes int defined at %s:14
 %s:21 PhanParamTooMany Call with 1 arg(s) to \Bar310::__construct() which only takes 0 arg(s) defined at %s:7
-%s:25 PhanTypeMismatchArgument Argument 1 ($arg) is 'x' but \Foo310::__construct() takes int defined at %s:14
+%s:25 PhanTypeMismatchArgumentReal Argument 1 ($arg) is 'x' but \Foo310::__construct() takes int defined at %s:14
 %s:27 PhanParamTooMany Call with 1 arg(s) to \Baz310::__construct() which only takes 0 arg(s) defined at %s:3

--- a/tests/files/expected/0333_closure_return_types.php.expected
+++ b/tests/files/expected/0333_closure_return_types.php.expected
@@ -1,4 +1,4 @@
 %s:4 PhanTypeMismatchReturnReal Returning type \stdClass but f333() is declared to return int
-%s:6 PhanTypeMismatchArgument Argument 1 ($arg) is 'notanint' but Closure(int $arg) : \stdClass takes int defined at %s:4
+%s:6 PhanTypeMismatchArgumentReal Argument 1 ($arg) is 'notanint' but Closure(int $arg) : \stdClass takes int defined at %s:4
 %s:14 PhanParamTooFew Call with 0 arg(s) to Closure(int $arg) : \stdClass which requires 1 arg(s) defined at %s:11
 %s:15 PhanTypeMismatchReturnReal Returning type \stdClass but g333() is declared to return int

--- a/tests/files/expected/0338_magic_const_types.php.expected
+++ b/tests/files/expected/0338_magic_const_types.php.expected
@@ -1,9 +1,9 @@
-%s:9 PhanTypeMismatchArgument Argument 1 ($x) is 'Trait338' but \expect_int338() takes int defined at %s:3
-%s:10 PhanTypeMismatchArgument Argument 1 ($x) is 'Trait338' but \expect_int338() takes int defined at %s:3
-%s:16 PhanTypeMismatchArgument Argument 1 ($x) is '%s0338_magic_const_types.php' but \expect_int338() takes int defined at %s:3
+%s:9 PhanTypeMismatchArgumentReal Argument 1 ($x) is 'Trait338' but \expect_int338() takes int defined at %s:3
+%s:10 PhanTypeMismatchArgumentReal Argument 1 ($x) is 'Trait338' but \expect_int338() takes int defined at %s:3
+%s:16 PhanTypeMismatchArgumentReal Argument 1 ($x) is '%ssrc/0338_magic_const_types.php' but \expect_int338() takes int defined at %s:3
 %s:17 PhanTypeMismatchArgument Argument 1 ($x) is 17 but \expect_string338() takes string defined at %s:4
-%s:18 PhanTypeMismatchArgument Argument 1 ($x) is 'Test338' but \expect_int338() takes int defined at %s:3
-%s:19 PhanTypeMismatchArgument Argument 1 ($x) is '%ssrc' but \expect_int338() takes int defined at %s:3
-%s:20 PhanTypeMismatchArgument Argument 1 ($x) is 'test' but \expect_int338() takes int defined at %s:3
-%s:21 PhanTypeMismatchArgument Argument 1 ($x) is 'Test338::test' but \expect_int338() takes int defined at %s:3
-%s:22 PhanTypeMismatchArgument Argument 1 ($x) is '' but \expect_int338() takes int defined at %s:3
+%s:18 PhanTypeMismatchArgumentReal Argument 1 ($x) is 'Test338' but \expect_int338() takes int defined at %s:3
+%s:19 PhanTypeMismatchArgumentReal Argument 1 ($x) is '%ssrc' but \expect_int338() takes int defined at %s:3
+%s:20 PhanTypeMismatchArgumentReal Argument 1 ($x) is 'test' but \expect_int338() takes int defined at %s:3
+%s:21 PhanTypeMismatchArgumentReal Argument 1 ($x) is 'Test338::test' but \expect_int338() takes int defined at %s:3
+%s:22 PhanTypeMismatchArgumentReal Argument 1 ($x) is '' but \expect_int338() takes int defined at %s:3

--- a/tests/files/expected/0344_negate_unconditional_return.php.expected
+++ b/tests/files/expected/0344_negate_unconditional_return.php.expected
@@ -1,7 +1,7 @@
 %s:5 PhanUnusedVariable Unused definition of variable $b
 %s:6 PhanTypeMismatchReturn Returning type null but f344() is declared to return int
 %s:10 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is string but \intdiv() takes int
-%s:11 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is 'x' but \intdiv() takes int
+%s:11 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($numerator) is 'x' but \intdiv() takes int
 %s:27 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($numerator) is array but \intdiv() takes int
-%s:43 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is 'alternative'|array but \intdiv() takes int
+%s:43 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($numerator) is 'alternative'|array but \intdiv() takes int
 %s:44 PhanImpossibleCondition Impossible attempt to cast $x of type 'alternative'|array to int

--- a/tests/files/expected/0445_unserialize_allowed_classes.php.expected
+++ b/tests/files/expected/0445_unserialize_allowed_classes.php.expected
@@ -1,1 +1,1 @@
-%s:5 PhanTypeMismatchArgumentInternalProbablyReal Argument 2 ($allowed_classes) is array{allowed_classes:array{0:array{0:'stdClass'}}} but \unserialize() takes array{allowed_classes?:bool|string[]}
+%s:5 PhanTypeMismatchArgumentInternal Argument 2 ($allowed_classes) is array{allowed_classes:array{0:array{0:'stdClass'}}} but \unserialize() takes array{allowed_classes?:bool|string[]}

--- a/tests/files/expected/0446_new_node.php.expected
+++ b/tests/files/expected/0446_new_node.php.expected
@@ -1,2 +1,2 @@
-%s:4 PhanTypeMismatchArgumentInternal Argument 1 ($kind) is 'key' but \ast\Node::__construct() takes int
-%s:6 PhanTypeMismatchArgumentInternalProbablyReal Argument 3 ($children) is array{0:\stdClass} but \ast\Node::__construct() takes \ast\Node[]|\ast\Node\Decl[]|bool[]|float[]|int[]|null[]|string[]
+%s:4 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($kind) is 'key' but \ast\Node::__construct() takes int
+%s:6 PhanTypeMismatchArgumentInternal Argument 3 ($children) is array{0:\stdClass} but \ast\Node::__construct() takes \ast\Node[]|\ast\Node\Decl[]|bool[]|float[]|int[]|null[]|string[]

--- a/tests/files/expected/0516_literal_type_narrowing.php.expected
+++ b/tests/files/expected/0516_literal_type_narrowing.php.expected
@@ -2,4 +2,4 @@
 %s:5 PhanRedundantCondition Redundant attempt to cast $x of type 2 to numeric
 %s:6 PhanTypeMismatchArgumentInternal Argument 1 ($string) is 2 but \strlen() takes string
 %s:9 PhanRedundantCondition Redundant attempt to cast $y of type 'a string' to string
-%s:10 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is 'a string' but \intdiv() takes int
+%s:10 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($numerator) is 'a string' but \intdiv() takes int

--- a/tests/files/expected/0594_magic_constant.php.expected
+++ b/tests/files/expected/0594_magic_constant.php.expected
@@ -1,14 +1,14 @@
-%s:2 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is '' but \intdiv() takes int
+%s:2 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($numerator) is '' but \intdiv() takes int
 %s:2 PhanUndeclaredMagicConstant Reference to magic constant __FUNCTION__ that is undeclared in the current scope
-%s:3 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is '' but \intdiv() takes int
+%s:3 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($numerator) is '' but \intdiv() takes int
 %s:3 PhanUndeclaredMagicConstant Reference to magic constant __METHOD__ that is undeclared in the current scope
-%s:4 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is '' but \intdiv() takes int
+%s:4 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($numerator) is '' but \intdiv() takes int
 %s:4 PhanUndeclaredMagicConstant Reference to magic constant __TRAIT__ that is undeclared in the current scope
-%s:5 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is '' but \intdiv() takes int
+%s:5 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($numerator) is '' but \intdiv() takes int
 %s:5 PhanUndeclaredMagicConstant Reference to magic constant __CLASS__ that is undeclared in the current scope
-%s:7 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is '\x7bclosure\x7d' but \intdiv() takes int
-%s:8 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is '\x7bclosure\x7d' but \intdiv() takes int
-%s:9 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is '' but \intdiv() takes int
+%s:7 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($numerator) is '\x7bclosure\x7d' but \intdiv() takes int
+%s:8 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($numerator) is '\x7bclosure\x7d' but \intdiv() takes int
+%s:9 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($numerator) is '' but \intdiv() takes int
 %s:9 PhanUndeclaredMagicConstant Reference to magic constant __TRAIT__ that is undeclared in the current scope
-%s:10 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is '' but \intdiv() takes int
+%s:10 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($numerator) is '' but \intdiv() takes int
 %s:10 PhanUndeclaredMagicConstant Reference to magic constant __CLASS__ that is undeclared in the current scope

--- a/tests/files/expected/0595_crash_variadic.php.expected
+++ b/tests/files/expected/0595_crash_variadic.php.expected
@@ -1,3 +1,3 @@
 %s:6 PhanTypeMismatchArgument Argument 2 ($args) is 0 but \b595() takes string defined at %s:5
+%s:8 PhanTypeMismatchArgumentReal Argument 4 ($args) is '' but \c595() takes int defined at %s:7
 %s:8 PhanTypeMismatchArgument Argument 3 ($args) is '0' but \c595() takes int defined at %s:7
-%s:8 PhanTypeMismatchArgument Argument 4 ($args) is '' but \c595() takes int defined at %s:7

--- a/tests/files/expected/0685_this_callable.php.expected
+++ b/tests/files/expected/0685_this_callable.php.expected
@@ -1,6 +1,6 @@
 %s:16 PhanParamTooFew Call with 0 arg(s) to \Invokable685::__construct(array $values) which requires 1 arg(s) defined at %s:4
-%s:17 PhanTypeMismatchArgument Argument 1 ($arg) is 'invalid' but \Invokable685::__invoke() takes int defined at %s:7
-%s:19 PhanTypeMismatchArgument Argument 1 ($arg) is 'invalid' but \Invokable685::__invoke() takes int defined at %s:7
+%s:17 PhanTypeMismatchArgumentReal Argument 1 ($arg) is 'invalid' but \Invokable685::__invoke() takes int defined at %s:7
+%s:19 PhanTypeMismatchArgumentReal Argument 1 ($arg) is 'invalid' but \Invokable685::__invoke() takes int defined at %s:7
 %s:23 PhanParamTooFewCallable Call with 0 arg(s) to \Invokable685::dynamic(\stdClass $o) (as a provided callable) which requires 1 arg(s) defined at %s:11
 %s:24 PhanUndeclaredMethodInCallable Call to undeclared method missing in callable. Possible object type(s) for that method are static
 %s:25 PhanParamTooFewCallable Call with 0 arg(s) to \Invokable685::dynamic(\stdClass $o) (as a provided callable) which requires 1 arg(s) defined at %s:11

--- a/tests/files/expected/0772_real_float_types.php.expected
+++ b/tests/files/expected/0772_real_float_types.php.expected
@@ -1,0 +1,2 @@
+%s:3 PhanDebugAnnotation @phan-debug-var requested for variable $g - it has union type array{0:float,1:float,2:int,3:float,4:float,5:float}(real=array{0:float,1:float,2:int,3:float,4:float,5:float})
+%s:3 PhanUnusedVariable Unused definition of variable $g

--- a/tests/files/expected/0801_trait_analyze_method_body.php.expected
+++ b/tests/files/expected/0801_trait_analyze_method_body.php.expected
@@ -1,2 +1,2 @@
-%s:4 PhanTypeMismatchReturn Returning type 'a' but f2() is declared to return int
+%s:4 PhanTypeMismatchReturnReal Returning type 'a' but f2() is declared to return int
 %s:10 PhanTypeMismatchReturnReal Returning type array{} but f() is declared to return \U301|self (real type self)

--- a/tests/files/src/0445_unserialize_allowed_classes.php
+++ b/tests/files/src/0445_unserialize_allowed_classes.php
@@ -2,5 +2,5 @@
 
 $serialized = serialize(new stdClass());
 unserialize($serialized, []);
-unserialize($serialized, ['allowed_classes' => [['stdClass']]]);
+unserialize($serialized, ['allowed_classes' => [['stdClass']]]);  // TODO: Decide on specifics of when TypeMismatchArgumentInternal vs InternalReal will be emitted
 unserialize($serialized, ['allowed_classes' => ['stdClass']]);

--- a/tests/files/src/0745_mismatch_return_real.php
+++ b/tests/files/src/0745_mismatch_return_real.php
@@ -2,7 +2,7 @@
 
 function test745SoftCast(string $s, bool $b, int $i, iterable $iter, float $f) : bool {
     if ($b) {
-        // Should emit TypeMismatchReturn instead of TypeMismatchReturnReal because it won't throw an error at runtime.
+        // Should emit TypeMismatchReturnReal instead of TypeMismatchReturn because it will throw an error at runtime.
         return $s;
     } elseif (rand() % 2 == 1) {
         return $i;

--- a/tests/files/src/0772_real_float_types.php
+++ b/tests/files/src/0772_real_float_types.php
@@ -1,0 +1,5 @@
+<?php
+function test772(float $f, int $i) {
+    $g = [$f * 2, $f / $i, $f % $i, $f ** $i, $f + $i, $f - $i];
+    '@phan-debug-var $g';
+}

--- a/tests/misc/fallback_test/expected/046_invalid_extract.php.expected
+++ b/tests/misc/fallback_test/expected/046_invalid_extract.php.expected
@@ -1,3 +1,3 @@
-src/046_invalid_extract.php:6 PhanTypeMismatchArgumentInternal Argument 2 ($extract_type) is 'E' but \extract() takes int
+src/046_invalid_extract.php:6 PhanTypeMismatchArgumentInternalProbablyReal Argument 2 ($extract_type) is 'E' but \extract() takes int
 src/046_invalid_extract.php:7 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($string) is array{} but \strlen() takes string
 src/046_invalid_extract.php:8 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($string) is array{} but \strlen() takes string

--- a/tests/plugin_test/expected/006_preg_regex.php.expected
+++ b/tests/plugin_test/expected/006_preg_regex.php.expected
@@ -10,10 +10,10 @@ src/006_preg_regex.php:16 PhanPluginInvalidPregRegex Call to \preg_split was pas
 src/006_preg_regex.php:17 PhanPluginInvalidPregRegex Call to \preg_match_all was passed an invalid regex '/\\w/i/': Unknown modifier '/'
 src/006_preg_regex.php:18 PhanPluginInvalidPregRegex Call to \preg_grep was passed an invalid regex '/\\w/i/': Unknown modifier '/'
 src/006_preg_regex.php:21 PhanPluginInvalidPregRegex Call to \preg_replace_callback_array was passed an invalid regex '0': Delimiter must not be alphanumeric or backslash
-src/006_preg_regex.php:21 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($pattern) is array{0:Closure(mixed):'i'} but \preg_replace_callback_array() takes array<string,callable(array):string>
+src/006_preg_regex.php:21 PhanTypeMismatchArgumentInternal Argument 1 ($pattern) is array{0:Closure(mixed):'i'} but \preg_replace_callback_array() takes array<string,callable(array):string>
 src/006_preg_regex.php:21 PhanUnusedClosureParameter Parameter $x is never used
 src/006_preg_regex.php:22 PhanPluginInvalidPregRegex Call to \preg_replace_callback_array was passed an invalid regex '0': Delimiter must not be alphanumeric or backslash
-src/006_preg_regex.php:22 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($pattern) is array{0:Closure(mixed):'i'} but \preg_replace_callback_array() takes array<string,callable(array):string>
+src/006_preg_regex.php:22 PhanTypeMismatchArgumentInternal Argument 1 ($pattern) is array{0:Closure(mixed):'i'} but \preg_replace_callback_array() takes array<string,callable(array):string>
 src/006_preg_regex.php:22 PhanUnusedClosureParameter Parameter $x is never used
 src/006_preg_regex.php:26 PhanPluginInvalidPregRegex Call to \preg_match was passed an invalid regex '/^(a/': Compilation failed: missing ) at offset 3
 src/006_preg_regex.php:29 PhanPluginInvalidPregRegex Call to \preg_match was passed an invalid regex '/^(a/': Compilation failed: missing ) at offset 3

--- a/tests/plugin_test/expected/047_crash.php.expected
+++ b/tests/plugin_test/expected/047_crash.php.expected
@@ -1,3 +1,3 @@
 src/047_crash.php:6 PhanUnusedPublicNoOverrideMethodParameter Parameter $arg is never used
 src/047_crash.php:11 PhanUnreferencedFunction Possibly zero references to function \example()
-src/047_crash.php:12 PhanTypeMismatchArgument Argument 1 ($arg) is 'my arg' but \X47::myMethod() takes int defined at src/047_crash.php:6
+src/047_crash.php:12 PhanTypeMismatchArgumentReal Argument 1 ($arg) is 'my arg' but \X47::myMethod() takes int defined at src/047_crash.php:6

--- a/tests/plugin_test/expected/157_polyfill_compilation_warning.php.expected
+++ b/tests/plugin_test/expected/157_polyfill_compilation_warning.php.expected
@@ -1,0 +1,1 @@
+src/157_polyfill_compilation_warning.php:77 PhanSyntaxCompileWarning Saw a warning while parsing: Unterminated comment starting line 3

--- a/tests/plugin_test/src/157_polyfill_compilation_warning.php
+++ b/tests/plugin_test/src/157_polyfill_compilation_warning.php
@@ -1,0 +1,4 @@
+<?php
+
+/**
+ * This is an unterminated comment

--- a/tests/rasmus_files/expected/0028_construct.php.expected
+++ b/tests/rasmus_files/expected/0028_construct.php.expected
@@ -1,1 +1,1 @@
-%s:7 PhanTypeMismatchArgument Argument 1 ($arg) is 'wrong' but \A::__construct() takes int defined at %s:3
+%s:7 PhanTypeMismatchArgumentReal Argument 1 ($arg) is 'wrong' but \A::__construct() takes int defined at %s:3


### PR DESCRIPTION
And warn about real return values.

E.g. warn when casting a non-numeric string literal to a real
integer/float/bool.

Fixes #3256
