### PR TITLE
Disable inferring defaults of properties in __construct

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -160,6 +160,11 @@ return [
     // Phan will not assume it knows specific types if the default value is false or null.
     'guess_unknown_parameter_type_using_default' => false,
 
+    // When enabled, infer that the types of the properties of `$this` are equal to their default values at the start of `__construct()`.
+    // This will have some false positives due to Phan not checking for setters and initializing helpers.
+    // This does not affect inherited properties.
+    'infer_default_properties_in_construct' => true,
+
     // Set this to true to enable the plugins that Phan uses to infer more accurate return types of `implode`, `json_decode`, and many other functions.
     //
     // Phan is slightly faster when these are disabled.

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,13 +3,17 @@ Phan NEWS
 ??? ?? 2019, Phan 2.2.13 (dev)
 ------------------------
 
-New features(CLI):
+New features(CLI, Configs):
 + Always print 100% in `--progress-bar` after completing any phase of analysis.
   This is convenient for tools such as `tool/phoogle` that exit before starting the next phase.
 + Add GraphML output support to `DependencyGraphPlugin`.
   This allows `tool/pdep` output to be imported by Neo4j, Gephi and yEd
 + Add json output and import to `tool/pdep`
   For caching large graphs in order to generate multiple sub-graphs without re-scanning
++ Add setting `infer_default_properties_in_construct`.
+  When this is enabled, infer that properties of `$this` are initialized to their default values at the start of `__construct()`. (#3213)
+  (this is limited to instance properties which are declared in the current class (i.e. not inherited)).
+  Off by default.
 
 New features(Analysis):
 + Disable `simplify_ast` by default.
@@ -27,9 +31,6 @@ New features(Analysis):
 + Improve types inferred when the config setting `enable_extended_internal_return_type_plugins` is enabled.
 + Speed up sorting the list of parsed files, and avoid unnecessary work in `--dump-parsed-file-list`.
 + Emit `PhanEmptyForeach` and `PhanEmptyYieldFrom` when iterating over empty arrays.
-+ Infer that properties of `$this` are initialized to their default values at the start of `__construct()`. (#3213)
-  (this is limited to instance properties which are declared in the current class (i.e. not inherited)).
-  To disable this, set `infer_default_properties_in_construct` to false.
 
 Language Server/Daemon mode:
 + Fix logged Error when language server receives `didChangeConfiguration` events. (this is a no-op)

--- a/internal/Phan-Config-Settings.md
+++ b/internal/Phan-Config-Settings.md
@@ -369,13 +369,13 @@ This is ignored if [`enable_include_path_checks`](#enable_include_path_checks) i
 
 ## infer_default_properties_in_construct
 
-Infer that the types of the properties of `$this` are equal to their default values at the start of `__construct()`.
+When enabled, infer that the types of the properties of `$this` are equal to their default values at the start of `__construct()`.
 This will have some false positives due to Phan not checking for setters and initializing helpers.
 This does not affect inherited properties.
 
-Set to false to disable.
+Set to true to enable.
 
-(Default: `true`)
+(Default: `false`)
 
 ## inherit_phpdoc_types
 

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -290,12 +290,12 @@ class Config
         // Phan will not assume it knows specific types if the default value is `false` or `null`.
         'guess_unknown_parameter_type_using_default' => false,
 
-        // Infer that the types of the properties of `$this` are equal to their default values at the start of `__construct()`.
+        // When enabled, infer that the types of the properties of `$this` are equal to their default values at the start of `__construct()`.
         // This will have some false positives due to Phan not checking for setters and initializing helpers.
         // This does not affect inherited properties.
         //
-        // Set to false to disable.
-        'infer_default_properties_in_construct' => true,
+        // Set to true to enable.
+        'infer_default_properties_in_construct' => false,
 
         // If enabled, inherit any missing phpdoc for types from
         // the parent method if none is provided.

--- a/tests/.phan_for_test/config.php
+++ b/tests/.phan_for_test/config.php
@@ -65,6 +65,11 @@ return [
 
     'redundant_condition_detection' => true,
 
+    // When enabled, infer that the types of the properties of `$this` are equal to their default values at the start of `__construct()`.
+    // This will have some false positives due to Phan not checking for setters and initializing helpers.
+    // This does not affect inherited properties.
+    'infer_default_properties_in_construct' => true,
+
     // If true, Phan will read `class_alias` calls in the global scope,
     // then (1) create aliases from the *parsed* files if no class definition was found,
     // and (2) emit issues in the global scope if the source or target class is invalid.


### PR DESCRIPTION
This can be enabled by a config setting.
Leave this disabled until #3292 is implemented