### PR TITLE
Handle nullable in param defaults, improve real type inference

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -47,6 +47,9 @@ New features(Analysis):
 + Suggest obvious getters and setters for instance properties in `PhanAccessPropertyProtected` and `PhanAccessPropertyPrivate` (#2540)
 + When `strict_method_checking` is enabled,
   warn if some of the **object** types in the union type don't contain that method. (#3262)
++ Make stronger assumptions about real types of global constants.
++ Properly infer that parameter defaults and global constants will resolve to `null` in some edge cases.
++ Emit `PhanCompatibleDefaultEqualsNull` when using a different constant that resolves to null as the default of a non-nullable parameter. (#3307)
 
 Language Server/Daemon mode:
 + Fix logged Error when language server receives `didChangeConfiguration` events. (this is a no-op)

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -413,6 +413,14 @@ Declaring an autoloader with function __autoload() was deprecated in PHP 7.2 and
 
 e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/plugin_test/expected/000_plugins.php.expected#L20) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/2.0.0/tests/plugin_test/src/000_plugins.php#L64).
 
+## PhanCompatibleDefaultEqualsNull
+
+```
+In PHP 8.0, using a default ({CODE}) that resolves to null will no longer cause the parameter ({PARAMETER}) to be nullable
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0782_nullable_compat.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0782_nullable_compat.php#L4).
+
 ## PhanCompatibleDimAlternativeSyntax
 
 This is emitted deliberately when using the polyfill and/or using php 7.4+.
@@ -761,6 +769,14 @@ Empty protected method {METHOD}
 ```
 Empty public method {METHOD}
 ```
+
+## PhanEmptyYieldFrom
+
+```
+Saw a yield from statement with empty iterable type {TYPE}
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0774_empty_foreach.php.expected#L6) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0774_empty_foreach.php#L16).
 
 ## PhanNoopArray
 
@@ -3414,6 +3430,18 @@ This issue will be emitted from the following code
 
 ```php
 class F { function f() { $v = parent::f(); } }
+```
+
+## PhanPossiblyUndeclaredMethod
+
+```
+Call to possibly undeclared method {METHOD} on type {TYPE} ({TYPE} does not declare the method)
+```
+
+## PhanPossiblyUndeclaredProperty
+
+```
+Reference to possibly undeclared property {PROPERTY} of expression of type {TYPE} ({TYPE} does not declare that property)
 ```
 
 ## PhanPossiblyUnsetPropertyOfThis

--- a/src/Phan/Config/Initializer.php
+++ b/src/Phan/Config/Initializer.php
@@ -474,7 +474,7 @@ EOT;
                     echo "Warning: could not find '$composer_lib_relative_path'\n";
                     continue;
                 }
-                $composer_lib_relative_path = \trim(str_replace(DIRECTORY_SEPARATOR, '/', $composer_lib_relative_path), '/');
+                $composer_lib_relative_path = \trim(\str_replace(\DIRECTORY_SEPARATOR, '/', $composer_lib_relative_path), '/');
 
                 $composer_lib_relative_path = \preg_replace('@(/+\.)+$@', '', $composer_lib_relative_path);
                 if (\is_dir($composer_lib_absolute_path)) {

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -484,6 +484,7 @@ class Issue
     const CompatibleImplodeOrder             = 'PhanCompatibleImplodeOrder';
     const CompatibleUnparenthesizedTernary   = 'PhanCompatibleUnparenthesizedTernary';
     const CompatibleTypedProperty            = 'PhanCompatibleTypedProperty';
+    const CompatibleDefaultEqualsNull        = 'PhanCompatibleDefaultEqualsNull';
     const CompatiblePHP8PHP4Constructor      = 'PhanCompatiblePHP8PHP4Constructor';
 
     // Issue::CATEGORY_GENERIC
@@ -4178,6 +4179,14 @@ class Issue
                 "PHP4 constructors will be removed in php 8, and should not be used. __construct() should be added/used instead to avoid accidentally calling {METHOD}",
                 self::REMEDIATION_B,
                 3022
+            ),
+            new Issue(
+                self::CompatibleDefaultEqualsNull,
+                self::CATEGORY_COMPATIBLE,
+                self::SEVERITY_NORMAL,
+                "In PHP 8.0, using a default ({CODE}) that resolves to null will no longer cause the parameter ({PARAMETER}) to be nullable",
+                self::REMEDIATION_B,
+                3023
             ),
 
             // Issue::CATEGORY_GENERIC

--- a/src/Phan/Language/Element/ElementFutureUnionType.php
+++ b/src/Phan/Language/Element/ElementFutureUnionType.php
@@ -4,7 +4,6 @@ namespace Phan\Language\Element;
 
 use Phan\Exception\IssueException;
 use Phan\Language\FutureUnionType;
-use Phan\Language\Type\NullType;
 use Phan\Language\UnionType;
 
 /**
@@ -74,17 +73,9 @@ trait ElementFutureUnionType
         $this->future_union_type = null;
 
         try {
-            $union_type = $future_union_type->get();
+            return $future_union_type->get();
         } catch (IssueException $_) {
-            $union_type = UnionType::empty();
+            return null;
         }
-
-        // Don't set 'null' as the type if that's the default
-        // given that its the default.
-        if ($union_type->isType(NullType::instance(false))) {
-            $union_type = UnionType::empty();
-        }
-
-        return $union_type;
     }
 }

--- a/src/Phan/Language/Element/GlobalConstant.php
+++ b/src/Phan/Language/Element/GlobalConstant.php
@@ -24,10 +24,19 @@ class GlobalConstant extends AddressableElement implements ConstantInterface
     public function getUnionType() : UnionType
     {
         if (null !== ($union_type = $this->getFutureUnionType())) {
-            $this->setUnionType(parent::getUnionType()->withUnionType($union_type));
+            $this->setUnionType($union_type);
         }
 
         return parent::getUnionType();
+    }
+
+    // TODO: Make callers check for object types. Those are impossible.
+    public function setUnionType(UnionType $type) : void
+    {
+        if (!$type->hasRealTypeSet()) {
+            $type = $type->withRealTypeSet(UnionType::typeSetFromString('array|bool|float|int|string|resource|null'));
+        }
+        parent::setUnionType($type);
     }
 
     /**

--- a/src/Phan/Language/Element/Parameter.php
+++ b/src/Phan/Language/Element/Parameter.php
@@ -52,8 +52,8 @@ class Parameter extends Variable
     private $default_value_future_type = null;
 
     /**
-     * @var mixed
-     * The value of the default, if one is set
+     * @var Node|string|int|float|null
+     * The value of the node of the default, if one is set
      */
     private $default_value = null;
 
@@ -299,7 +299,7 @@ class Parameter extends Variable
                     $code_base,
                     $context,
                     Issue::InvalidConstantExpression,
-                    $default_node->lineno ?? 0
+                    $default_node->lineno ?? $node->lineno
                 );
                 $has_error = true;
             }

--- a/src/Phan/Language/FutureUnionType.php
+++ b/src/Phan/Language/FutureUnionType.php
@@ -52,6 +52,7 @@ class FutureUnionType
      */
     public function get() : UnionType
     {
+        $this->context->clearCachedUnionTypes();
         return UnionTypeVisitor::unionTypeFromNode(
             $this->code_base,
             $this->context,

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -1404,7 +1404,7 @@ class ParseVisitor extends ScopeVisitor
         $constant = new GlobalConstant(
             $context->withLineNumberStart($lineno),
             $name,
-            UnionType::empty(),
+            UnionType::fromFullyQualifiedRealString('array|bool|float|int|string|resource|null'),
             $flags,
             $fqsen
         );
@@ -1442,7 +1442,7 @@ class ParseVisitor extends ScopeVisitor
                     )
                 );
             } else {
-                $constant->setUnionType(Type::fromObject($value)->asPHPDocUnionType());
+                $constant->setUnionType(Type::fromObject($value)->asRealUnionType());
             }
         } else {
             $constant->setUnionType(UnionTypeVisitor::unionTypeFromNode($code_base, $context, $value));

--- a/tests/files/expected/0277_literal_conditional.php.expected
+++ b/tests/files/expected/0277_literal_conditional.php.expected
@@ -1,24 +1,28 @@
-%s:8 PhanImpossibleCondition Impossible attempt to cast 0 of type 0 to truthy
 %s:9 PhanImpossibleCondition Impossible attempt to cast 0 of type 0 to truthy
 %s:10 PhanImpossibleCondition Impossible attempt to cast 0 of type 0 to truthy
-%s:10 PhanTypeArraySuspicious Suspicious array access to 3
-%s:11 PhanRedundantCondition Redundant attempt to cast 1 of type 1 to truthy
+%s:11 PhanImpossibleCondition Impossible attempt to cast 0 of type 0 to truthy
 %s:11 PhanTypeArraySuspicious Suspicious array access to 3
-%s:12 PhanRedundantCondition Redundant attempt to cast true of type true to truthy
-%s:12 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is true but \intdiv() takes int
-%s:13 PhanRedundantCondition Redundant attempt to cast \true of type true to truthy
+%s:12 PhanRedundantCondition Redundant attempt to cast 1 of type 1 to truthy
+%s:12 PhanTypeArraySuspicious Suspicious array access to 3
+%s:13 PhanRedundantCondition Redundant attempt to cast true of type true to truthy
 %s:13 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is true but \intdiv() takes int
-%s:14 PhanImpossibleCondition Impossible attempt to cast false of type false to truthy
-%s:15 PhanImpossibleCondition Impossible attempt to cast \false of type false to truthy
-%s:16 PhanImpossibleCondition Impossible attempt to cast false of type false to truthy
-%s:17 PhanRedundantCondition Redundant attempt to cast TRUE of type true to truthy
-%s:17 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is true but \intdiv() takes int
-%s:18 PhanRedundantCondition Redundant attempt to cast 'key' of type 'key' to truthy
-%s:18 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($numerator) is 'key' but \intdiv() takes int
-%s:19 PhanRedundantCondition Redundant attempt to cast '1' of type '1' to truthy
-%s:19 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is '1' but \intdiv() takes int
-%s:20 PhanImpossibleCondition Impossible attempt to cast '' of type '' to truthy
-%s:21 PhanImpossibleCondition Impossible attempt to cast '0' of type '0' to truthy
-%s:22 PhanRedundantCondition Redundant attempt to cast 4.2 of type 4.2 to truthy
-%s:22 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is 4.2 but \intdiv() takes int
-%s:23 PhanImpossibleCondition Impossible attempt to cast 0.0 of type 0.0 to truthy
+%s:14 PhanRedundantCondition Redundant attempt to cast \true of type true to truthy
+%s:14 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is true but \intdiv() takes int
+%s:15 PhanImpossibleCondition Impossible attempt to cast false of type false to truthy
+%s:16 PhanImpossibleCondition Impossible attempt to cast \false of type false to truthy
+%s:17 PhanImpossibleCondition Impossible attempt to cast false of type false to truthy
+%s:18 PhanRedundantCondition Redundant attempt to cast TRUE of type true to truthy
+%s:18 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is true but \intdiv() takes int
+%s:19 PhanRedundantCondition Redundant attempt to cast 'key' of type 'key' to truthy
+%s:19 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($numerator) is 'key' but \intdiv() takes int
+%s:20 PhanRedundantCondition Redundant attempt to cast '1' of type '1' to truthy
+%s:20 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is '1' but \intdiv() takes int
+%s:21 PhanImpossibleCondition Impossible attempt to cast '' of type '' to truthy
+%s:22 PhanImpossibleCondition Impossible attempt to cast '0' of type '0' to truthy
+%s:23 PhanRedundantCondition Redundant attempt to cast 4.2 of type 4.2 to truthy
+%s:23 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is 4.2 but \intdiv() takes int
+%s:24 PhanImpossibleCondition Impossible attempt to cast 0.0 of type 0.0 to truthy
+%s:25 PhanRedundantCondition Redundant attempt to cast FEATURE_FLAG of type true to truthy
+%s:26 PhanRedundantCondition Redundant attempt to cast FEATURE_FLAG of type true to truthy
+%s:27 PhanRedundantCondition Redundant attempt to cast FEATURE_FLAG2 of type true to truthy
+%s:28 PhanRedundantCondition Redundant attempt to cast FEATURE_FLAG2 of type true to truthy

--- a/tests/files/expected/0280_should_infer_nullable_from_default.php.expected
+++ b/tests/files/expected/0280_should_infer_nullable_from_default.php.expected
@@ -1,3 +1,4 @@
+%s:9 PhanCompatibleDefaultEqualsNull In PHP 8.0, using a default (self::NULLCONST) that resolves to null will no longer cause the parameter (int $arg) to be nullable
 %s:23 PhanParamSignatureMismatch Declaration of function foo(int $arg = 20) should be compatible with function foo(?int $arg = null) defined in %s:10
 %s:23 PhanParamSignatureRealMismatchParamType Declaration of function foo(int $arg = 20) should be compatible with function foo(?int $arg = null) (parameter #1 of type 'int' cannot replace original parameter of type '?int') defined in %s:10
 %s:27 PhanTypeMismatchDefault Default value for ?int $x can't be float

--- a/tests/files/src/0277_literal_conditional.php
+++ b/tests/files/src/0277_literal_conditional.php
@@ -1,6 +1,7 @@
 <?php
 
 const FEATURE_FLAG = true;
+define('FEATURE_FLAG2', true);
 
 // A literal (instead of AST node) used in a conditional should not cause crashes.
 function check_literal_conditional() {
@@ -23,4 +24,6 @@ function check_literal_conditional() {
     intdiv(0.0 ?: $x, 2);  // should not warn about passing float (still not great code)
     intdiv(FEATURE_FLAG ? 'value' : $x, 2);  // In the **general** case, we're not sure about internal or external constants, so we assume both types are possible.
     intdiv(FEATURE_FLAG ? $x : 'value', 2);  // also test the other way around.
+    intdiv(FEATURE_FLAG2 ? 'value' : $x, 2);  // In the **general** case, we're not sure about internal or external constants, so we assume both types are possible.
+    intdiv(FEATURE_FLAG2 ? $x : 'value', 2);  // also test the other way around.
 }


### PR DESCRIPTION
Fixes #3307

Allow lazily inferring that a property, parameter, or global constant is
an expression that resolves to null.
(Previously forbidden to avoid edge cases)

Emit `PhanCompatibleDefaultEqualsNull` when using a parameter default
(not `null`) that resolves to null with a non-nullable type.