### PR TITLE
Warn about infinite recursion with the same parameters

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -50,6 +50,8 @@ New features(Analysis):
 + Make stronger assumptions about real types of global constants.
 + Properly infer that parameter defaults and global constants will resolve to `null` in some edge cases.
 + Emit `PhanCompatibleDefaultEqualsNull` when using a different constant that resolves to null as the default of a non-nullable parameter. (#3307)
++ Emit `PhanPossiblyInfiniteRecursionSameParams` when a function or method calls itself with the same parameter values it was declared with (in a branch). (#2893)
+  (This requires unused variable detection to be enabled, when there are 1 or more parameters)
 
 Language Server/Daemon mode:
 + Fix logged Error when language server receives `didChangeConfiguration` events. (this is a no-op)

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -2240,6 +2240,16 @@ Returning type {TYPE} but {FUNCTIONLIKE} is declared to return {TYPE} ({TYPE} is
 
 e.g. [this issue](https://github.com/phan/phan/tree/2.0.0/tests/plugin_test/expected/026_strict_return_checks.php.expected#L3) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/2.0.0/tests/plugin_test/src/026_strict_return_checks.php#L31).
 
+## PhanPossiblyInfiniteRecursionSameParams
+
+Note that when there are 1 or more parameters, this is only emitted when unused variable detection is enabled (needed to check for reassignments)
+
+```
+{FUNCTIONLIKE} is calling itself with the same parameters it was called with. This may cause infinite recursion (Phan does not check for changes to global or shared state).
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0783_possibly_infinite_recursion.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0783_possibly_infinite_recursion.php#L9).
+
 ## PhanPossiblyNonClassMethodCall
 
 ```

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -203,6 +203,7 @@ class Issue
     const TypeInvalidTraitReturn          = 'PhanTypeInvalidTraitReturn';
     const TypeInvalidTraitParam           = 'PhanTypeInvalidTraitParam';
     const InfiniteRecursion               = 'PhanInfiniteRecursion';
+    const PossibleInfiniteRecursionSameParams = 'PhanPossiblyInfiniteRecursionSameParams';
     const TypeComparisonToInvalidClass    = 'PhanTypeComparisonToInvalidClass';
     const TypeComparisonToInvalidClassType = 'PhanTypeComparisonToInvalidClassType';
     const TypeInvalidPropertyName = 'PhanTypeInvalidPropertyName';
@@ -2163,6 +2164,14 @@ class Issue
                 "{FUNCTIONLIKE} is calling itself in a way that may cause infinite recursion.",
                 self::REMEDIATION_B,
                 10093
+            ),
+            new Issue(
+                self::PossibleInfiniteRecursionSameParams,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                "{FUNCTIONLIKE} is calling itself with the same parameters it was called with. This may cause infinite recursion (Phan does not check for changes to global or shared state).",
+                self::REMEDIATION_B,
+                10149
             ),
             new Issue(
                 self::PossiblyNonClassMethodCall,

--- a/src/Phan/Language/Element/ClassConstant.php
+++ b/src/Phan/Language/Element/ClassConstant.php
@@ -64,7 +64,7 @@ class ClassConstant extends ClassElement implements ConstantInterface
     public function getUnionType() : UnionType
     {
         if (null !== ($union_type = $this->getFutureUnionType())) {
-            $this->setUnionType($this->getUnionType()->withUnionType($union_type));
+            $this->setUnionType(parent::getUnionType()->withUnionType($union_type));
         }
 
         return parent::getUnionType();

--- a/src/Phan/Library/RegexKeyExtractor.php
+++ b/src/Phan/Library/RegexKeyExtractor.php
@@ -67,6 +67,7 @@ class RegexKeyExtractor
 
     /**
      * @throws InvalidArgumentException if an invalid pattern was seen
+     * @suppress PhanPossiblyInfiniteRecursionSameParams this issue type does not attempt to check for changes to properties or global state.
      */
     private function extractGroup() : void
     {

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableGraph.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableGraph.php
@@ -21,7 +21,7 @@ final class VariableGraph
     /**
      * @var array<string,array<int,int>>
      *
-     * Maps variable id to line number of the node for a definition ids
+     * Maps variable id to line number of the node for a definition id
      */
     public $def_lines = [];
 

--- a/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
+++ b/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
@@ -91,7 +91,7 @@ final class VariableTrackerElementVisitor extends PluginAwarePostAnalysisVisitor
 
         try {
             VariableTrackerVisitor::$variable_graph = $variable_graph;
-            $variable_tracker_visitor = new VariableTrackerVisitor($scope);
+            $variable_tracker_visitor = new VariableTrackerVisitor($this->code_base, $this->context, $scope);
             // TODO: Add params and use variables.
             $variable_tracker_visitor->__invoke($stmts_node);
         } finally {

--- a/tests/files/expected/0455_closure_type_cast.php.expected
+++ b/tests/files/expected/0455_closure_type_cast.php.expected
@@ -17,6 +17,7 @@
 %s:57 PhanUnusedVariable Unused definition of variable $result
 %s:58 PhanTypeMismatchArgument Argument 1 ($fn) is Closure():void but \expects_int_param() takes Closure(int):void defined at %s:6
 %s:59 PhanTypeMismatchArgument Argument 1 ($fn) is Closure():void but \expects_int_return() takes Closure():int defined at %s:40
+%s:61 PhanPossiblyInfiniteRecursionSameParams expects_void() is calling itself with the same parameters it was called with. This may cause infinite recursion (Phan does not check for changes to global or shared state).
 %s:67 PhanTypeMismatchArgument Argument 1 ($fn) is Closure(mixed):void but \expects_void() takes Closure():void defined at %s:56
 %s:68 PhanTypeMismatchArgument Argument 1 ($fn) is Closure():int but \expects_void() takes Closure():void defined at %s:56
 %s:69 PhanTypeMismatchArgument Argument 1 ($fn) is Closure(int):void but \expects_void() takes Closure():void defined at %s:56

--- a/tests/files/expected/0457_callable_type_cast.php.expected
+++ b/tests/files/expected/0457_callable_type_cast.php.expected
@@ -17,6 +17,7 @@
 %s:55 PhanUnusedVariable Unused definition of variable $result
 %s:56 PhanTypeMismatchArgument Argument 1 ($fn) is callable():void but \expects_cb_int_param() takes callable(int):void defined at %s:6
 %s:57 PhanTypeMismatchArgument Argument 1 ($fn) is callable():void but \expects_cb_int_return() takes callable():int defined at %s:40
+%s:59 PhanPossiblyInfiniteRecursionSameParams expects_cb_void() is calling itself with the same parameters it was called with. This may cause infinite recursion (Phan does not check for changes to global or shared state).
 %s:65 PhanTypeMismatchArgument Argument 1 ($fn) is Closure(mixed):void but \expects_cb_void() takes callable():void defined at %s:54
 %s:66 PhanTypeMismatchArgument Argument 1 ($fn) is Closure():int but \expects_cb_void() takes callable():void defined at %s:54
 %s:67 PhanTypeMismatchArgument Argument 1 ($fn) is Closure(int):void but \expects_cb_void() takes callable():void defined at %s:54

--- a/tests/files/expected/0621_infinite_recursion_conditional.php.expected
+++ b/tests/files/expected/0621_infinite_recursion_conditional.php.expected
@@ -1,2 +1,7 @@
 %s:5 PhanInfiniteRecursion main() is calling itself in a way that may cause infinite recursion.
+%s:9 PhanPossiblyInfiniteRecursionSameParams notInfinite() is calling itself with the same parameters it was called with. This may cause infinite recursion (Phan does not check for changes to global or shared state).
+%s:13 PhanPossiblyInfiniteRecursionSameParams notInfinite2() is calling itself with the same parameters it was called with. This may cause infinite recursion (Phan does not check for changes to global or shared state).
+%s:17 PhanPossiblyInfiniteRecursionSameParams infiniteRecursion() is calling itself with the same parameters it was called with. This may cause infinite recursion (Phan does not check for changes to global or shared state).
 %s:19 PhanInfiniteRecursion infiniteRecursion() is calling itself in a way that may cause infinite recursion.
+%s:22 PhanPossiblyInfiniteRecursionSameParams infiniteRecursion2() is calling itself with the same parameters it was called with. This may cause infinite recursion (Phan does not check for changes to global or shared state).
+%s:24 PhanInfiniteRecursion infiniteRecursion2() is calling itself in a way that may cause infinite recursion.

--- a/tests/files/expected/0782_nullable_compat.php.expected
+++ b/tests/files/expected/0782_nullable_compat.php.expected
@@ -1,0 +1,3 @@
+%s:4 PhanCompatibleDefaultEqualsNull In PHP 8.0, using a default (EQUALS_NULL) that resolves to null will no longer cause the parameter (int $x) to be nullable
+%s:8 PhanTypeMismatchArgumentReal Argument 1 ($x) is null but \test_nullable782() takes int defined at %s:4
+%s:9 PhanTypeMismatchArgument Argument 1 ($x) is false but \test_nullable782() takes int defined at %s:4

--- a/tests/files/expected/0783_possibly_infinite_recursion.php.expected
+++ b/tests/files/expected/0783_possibly_infinite_recursion.php.expected
@@ -1,0 +1,4 @@
+%s:3 PhanInfiniteRecursion test_infinite() is calling itself in a way that may cause infinite recursion.
+%s:9 PhanPossiblyInfiniteRecursionSameParams test_infinite2() is calling itself with the same parameters it was called with. This may cause infinite recursion (Phan does not check for changes to global or shared state).
+%s:17 PhanPossiblyInfiniteRecursionSameParams test_infinite3() is calling itself with the same parameters it was called with. This may cause infinite recursion (Phan does not check for changes to global or shared state).
+%s:30 PhanPossiblyInfiniteRecursionSameParams test_infinite5() is calling itself with the same parameters it was called with. This may cause infinite recursion (Phan does not check for changes to global or shared state).

--- a/tests/files/src/0621_infinite_recursion_conditional.php
+++ b/tests/files/src/0621_infinite_recursion_conditional.php
@@ -4,7 +4,7 @@ class Example {
     public static function main() : bool {
         return self::main() ? false : (rand(0,1) > 0);
     }
-
+    // this emits PhanPossiblyInfiniteRecursionSameParams it calls itself in a branch.
     public static function notInfinite() : bool {
         return rand(0,1) > 0 ? self::notInfinite() : (rand(0,2) > 0);
     }
@@ -17,5 +17,10 @@ class Example {
         $x = rand(0,1) > 0 ? (rand(0,2) > 0) : self::infiniteRecursion();
         var_export($x);
         return self::infiniteRecursion();
+    }
+    public function infiniteRecursion2($arg) : bool {
+        $x = rand(0,1) > 0 ? (rand(0,2) > 0) : $this->infiniteRecursion2($arg);
+        var_export($x);
+        return $this->infiniteRecursion2($arg);
     }
 }

--- a/tests/files/src/0782_nullable_compat.php
+++ b/tests/files/src/0782_nullable_compat.php
@@ -1,0 +1,9 @@
+<?php
+
+const EQUALS_NULL = null;
+function test_nullable782(int $x = EQUALS_NULL)  {
+    var_export($x);
+}
+test_nullable782(2);
+test_nullable782(null);
+test_nullable782(false);

--- a/tests/files/src/0783_possibly_infinite_recursion.php
+++ b/tests/files/src/0783_possibly_infinite_recursion.php
@@ -1,0 +1,34 @@
+<?php
+function test_infinite($x) {
+    test_infinite($x+1);
+}
+function test_infinite2($x) : string {
+    if ($x > 0) {
+        return $x;
+    }
+    return test_infinite2($x);
+}
+function test_infinite3() : int {
+    global $argc;
+    if ($argc > 3) {
+        return $argc;
+    }
+    // should warn, not able to check global state.
+    return test_infinite3();
+}
+// Should not warn
+function test_infinite4(int $x) : int {
+    $x += 3;
+    if ($x >= 10) {
+        return $x;
+    }
+    return test_infinite4($x);
+}
+// Should warn (modification isn't done in this branch)
+function test_infinite5(int $x) : int {
+    if ($x >= 10) {
+        return test_infinite5($x);
+    }
+    $x += 3;
+    return $x;
+}


### PR DESCRIPTION
Emit `PhanPossiblyInfiniteRecursionSameParams` when a function or method
calls itself with the same parameter values it was declared with (in a branch). (#2893)
(This requires unused variable detection to be enabled,
when there are 1 or more parameters)