### PR TITLE
Don't assume real types for constants from define()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -48,6 +48,8 @@ New features(Analysis):
 + When `strict_method_checking` is enabled,
   warn if some of the **object** types in the union type don't contain that method. (#3262)
 + Make stronger assumptions about real types of global constants.
+  Assume that constants defined with `define(...)` can have any non-object as its real type,
+  to avoid false positives in redundant condition detection.
 + Properly infer that parameter defaults and global constants will resolve to `null` in some edge cases.
 + Emit `PhanCompatibleDefaultEqualsNull` when using a different constant that resolves to null as the default of a non-nullable parameter. (#3307)
 + Emit `PhanPossiblyInfiniteRecursionSameParams` when a function or method calls itself with the same parameter values it was declared with (in a branch). (#2893)

--- a/src/Phan/Language/Element/Flags.php
+++ b/src/Phan/Language/Element/Flags.php
@@ -44,6 +44,8 @@ class Flags
     const WAS_PROPERTY_WRITTEN = (1 << 19);
 
     const IS_DYNAMIC_PROPERTY = (1 << 20);
+    // Is this a dynamic global constant?
+    const IS_DYNAMIC_CONSTANT = (1 << 20);
     // A property can be read-only, write-only, or neither, but not both.
     // This is independent of being a magic property.
     // IS_READ_ONLY can also be set on classes as @phan-immutable

--- a/src/Phan/Language/Element/GlobalConstant.php
+++ b/src/Phan/Language/Element/GlobalConstant.php
@@ -18,6 +18,29 @@ class GlobalConstant extends AddressableElement implements ConstantInterface
     use ConstantTrait;
 
     /**
+     * Sets whether this is a global constant that should be treated as if the real type is unknown.
+     */
+    public function setIsDynamicConstant(bool $dynamic_constant) : void
+    {
+        $this->setPhanFlags(
+            Flags::bitVectorWithState(
+                $this->getPhanFlags(),
+                Flags::IS_DYNAMIC_CONSTANT,
+                $dynamic_constant
+            )
+        );
+    }
+
+    /**
+     * @return bool
+     * True if this is a global constant that should be treated as if the real type is unknown.
+     */
+    public function isDynamicConstant() : bool
+    {
+        return $this->getPhanFlagsHasState(Flags::IS_DYNAMIC_CONSTANT);
+    }
+
+    /**
      * Override the default getter to fill in a future
      * union type if available.
      */
@@ -33,7 +56,7 @@ class GlobalConstant extends AddressableElement implements ConstantInterface
     // TODO: Make callers check for object types. Those are impossible.
     public function setUnionType(UnionType $type) : void
     {
-        if (!$type->hasRealTypeSet()) {
+        if ($this->isDynamicConstant() || !$type->hasRealTypeSet()) {
             $type = $type->withRealTypeSet(UnionType::typeSetFromString('array|bool|float|int|string|resource|null'));
         }
         parent::setUnionType($type);

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -1408,6 +1408,10 @@ class ParseVisitor extends ScopeVisitor
             $flags,
             $fqsen
         );
+        // $is_fully_qualified is true for define('name', $value)
+        // define() is typically used to conditionally set constants or to set them to variable values.
+        // TODO: Could add 'configuration_constant_set' to add additional constants to treat as dynamic such as PHP_OS, PHP_VERSION_ID, etc. (convert literals to non-literal types?)
+        $constant->setIsDynamicConstant($is_fully_qualified);
 
         if ($code_base->hasGlobalConstantWithFQSEN($fqsen)) {
             $other_constant = $code_base->getGlobalConstantByFQSEN($fqsen);

--- a/src/Phan/Plugin/Internal/DependencyGraphPlugin.php
+++ b/src/Phan/Plugin/Internal/DependencyGraphPlugin.php
@@ -371,7 +371,7 @@ class DependencyGraphPlugin extends PluginV3 implements
         if (($flags & \PDEP_IGNORE_STATIC) && $cached_graph) {
             foreach ($graph as $node => $els) {
                 foreach ($els as $el => $val) {
-                    if (substr((string)$val, 0, 2) == 'v:' || substr((string)$val, 0, 2) == 's:') {
+                    if (\substr((string)$val, 0, 2) == 'v:' || \substr((string)$val, 0, 2) == 's:') {
                         unset($graph[$node][$el]);
                     }
                 }

--- a/tests/files/expected/0277_literal_conditional.php.expected
+++ b/tests/files/expected/0277_literal_conditional.php.expected
@@ -24,5 +24,3 @@
 %s:24 PhanImpossibleCondition Impossible attempt to cast 0.0 of type 0.0 to truthy
 %s:25 PhanRedundantCondition Redundant attempt to cast FEATURE_FLAG of type true to truthy
 %s:26 PhanRedundantCondition Redundant attempt to cast FEATURE_FLAG of type true to truthy
-%s:27 PhanRedundantCondition Redundant attempt to cast FEATURE_FLAG2 of type true to truthy
-%s:28 PhanRedundantCondition Redundant attempt to cast FEATURE_FLAG2 of type true to truthy

--- a/tests/files/expected/0567_invalid_constants.php.expected
+++ b/tests/files/expected/0567_invalid_constants.php.expected
@@ -4,6 +4,6 @@
 %s:18 PhanParamTooFewInternal Call with 1 arg(s) to \define(string $constant_name, $value, bool $case_insensitive = default) which requires 2 arg(s)
 %s:18 PhanUndeclaredVariable Variable $undefVar is undeclared
 %s:20 PhanInvalidConstantFQSEN '' is an invalid FQSEN for a constant
-%s:25 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($numerator) is 'a' but \intdiv() takes int
-%s:33 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($numerator) is 'a' but \intdiv() takes int
-%s:38 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($string) is int but \strlen() takes string
+%s:25 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is 'a' but \intdiv() takes int
+%s:33 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is 'a' but \intdiv() takes int
+%s:38 PhanTypeMismatchArgumentInternal Argument 1 ($string) is int but \strlen() takes string

--- a/tests/files/src/0277_literal_conditional.php
+++ b/tests/files/src/0277_literal_conditional.php
@@ -24,6 +24,6 @@ function check_literal_conditional() {
     intdiv(0.0 ?: $x, 2);  // should not warn about passing float (still not great code)
     intdiv(FEATURE_FLAG ? 'value' : $x, 2);  // In the **general** case, we're not sure about internal or external constants, so we assume both types are possible.
     intdiv(FEATURE_FLAG ? $x : 'value', 2);  // also test the other way around.
-    intdiv(FEATURE_FLAG2 ? 'value' : $x, 2);  // In the **general** case, we're not sure about internal or external constants, so we assume both types are possible.
-    intdiv(FEATURE_FLAG2 ? $x : 'value', 2);  // also test the other way around.
+    intdiv(FEATURE_FLAG2 ? 'value' : $x, 2);  // Same uncertainty in the general case. Also, PhanRedundantCondition isn't emitted because the real type of define() is less guaranteed.
+    intdiv(FEATURE_FLAG2 ? $x : 'value', 2);
 }

--- a/tests/files/src/0567_invalid_constants.php
+++ b/tests/files/src/0567_invalid_constants.php
@@ -21,7 +21,7 @@ function exampleConstantDefs() {
 }
 
 exampleConstantDefs();
-
+// Note that the warning about cons2128 is a PhanTypeMismatchArgumentInternal instead of PhanTypeMismatchArgumentInternalReal because define() was used.
 echo intdiv(cons2128, 2);  // should warn - cons2128 should have type 'string'
 var_dump(strpos(cons2128, 'b'));  // should not warn
 


### PR DESCRIPTION
This led to a lot of false positives in redundant condition detection