### PR TITLE
Double-escape output in tocheckstyle messages (closes #3331)

### DIFF
--- a/tocheckstyle
+++ b/tocheckstyle
@@ -1,6 +1,13 @@
 #!/usr/bin/env php
 <?php
 
+$options = getopt('', ['output-format:']);
+
+$escape_html = false;
+if (array_key_exists('output-format', $options) && $options['output-format'] === 'checkstyle-escapedhtml') {
+    $escape_html = true;
+}
+
 $files = [];
 while($line = trim(fgets(STDIN))) {
     $elements = explode(' ', $line, 3);
@@ -41,8 +48,9 @@ foreach ($files as $file_name => $error_list) {
         // Write each element of the error as an attribute
         // of the error
         foreach ($error_map as $key => $value) {
+            $string_value = $escape_html ? htmlspecialchars((string)$value) : (string)$value;
             $error->appendChild(
-                new \DOMAttr($key, (string)$value)
+                new \DOMAttr($key, $string_value)
             );
         }
     }

--- a/tocheckstyle
+++ b/tocheckstyle
@@ -1,7 +1,19 @@
 #!/usr/bin/env php
 <?php
 
-$options = getopt('', ['output-format:']);
+$options = getopt('h', ['help', 'output-format:']);
+
+if (isset($options['h']) || isset($options['help'])) {
+    fwrite(STDERR, <<<EOT
+Usage: {$argv[0]} [--output-format=checkstyle-escapedhtml]
+
+Reads Phan's regular output format on stdin and outputs a checkstyle file on stdout.
+By default, errors in the XML are the plaintext of the issue, but those can be html escaped again by passing --output-format=checkstyle-escapedhtml.
+
+EOT
+    );
+    exit(0);
+}
 
 $escape_html = false;
 if (array_key_exists('output-format', $options) && $options['output-format'] === 'checkstyle-escapedhtml') {
@@ -48,7 +60,7 @@ foreach ($files as $file_name => $error_list) {
         // Write each element of the error as an attribute
         // of the error
         foreach ($error_map as $key => $value) {
-            $string_value = $escape_html ? htmlspecialchars((string)$value) : (string)$value;
+            $string_value = $escape_html ? htmlspecialchars((string)$value, ENT_NOQUOTES, 'UTF-8') : (string)$value;
             $error->appendChild(
                 new \DOMAttr($key, $string_value)
             );


### PR DESCRIPTION
The Jenkins Checkstyle Result plugin interprets the `message` attribute of `<error>` elements as HTML, which before this commit resulted in missing information when `<` and `>` characters appear in messages.

For example, `tocheckstyle` will convert this line:

```
file.php:58 PhanTypeMismatchArgumentInternal Argument 2 ($parameters) is array<string,mixed> but \call_user_func_array() takes array<int,mixed>
```

into this xml (other lines of xml omitted):

```xml
<error line="58" source="PhanTypeMismatchArgumentInternal" message="Argument 2 ($parameters) is array&lt;string,mixed&gt; but \call_user_func_array() takes array&lt;int,mixed&gt;" severity="error"/>
```

which will appear in the Jenkins interface as:

```
Argument 2 ($parameters) is array but \call_user_func_array() takes array
```

because it gets converted to the following HTML:

```html
<p><b>Argument 2 ($parameters) is array<string,mixed> but \call_user_func_array() takes array<int,mixed></b></p>
```

This commit escapes HTML characters in the error message before adding it as a `DOMAttr`, thus resulting in the following XML output:

```xml
<error line="58" source="PhanTypeMismatchArgumentInternal" message="Argument 2 ($parameters) is array&amp;lt;string,mixed&amp;gt; but \call_user_func_array() takes array&amp;lt;int,mixed&amp;gt;" severity="error"/>
```

which generates the following (correct) HTML:

```html
<p><b>Argument 2 ($parameters) is array&lt;string,mixed&gt; but \call_user_func_array() takes array&lt;int,mixed&gt;</b></p>
```