### PR TITLE
Check for suspicious comparisons of groups of literals.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -58,6 +58,9 @@ New features(Analysis):
 + Add a `non-empty-array` type, for arrays that have 1 or more elements.
   This gets inferred for checks such as `if ($array)`, `if (!empty($array))` (checks on `count()` are not supported yet)
   (`non-empty-array<ValueT>` and `non-empty-array<KeyT, ValueT>` can also be used in phpdoc)
++ Support checking if comparisons of types with more than one possible literal scalar are redundant/impossible.
+  Previously, Phan would only warn if both sides had exactly one possible scalar value.
+  (e.g. warn about `'string literal' >= $nullableBool`)
 
 Language Server/Daemon mode:
 + Fix logged Error when language server receives `didChangeConfiguration` events. (this is a no-op)

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -1335,7 +1335,7 @@ final class EmptyUnionType extends UnionType
         return [];
     }
 
-    public function asScalarValues() : array
+    public function asScalarValues(bool $strict = false) : ?array
     {
         return [];
     }

--- a/tests/files/expected/0787_impossible_range_check.php.expected
+++ b/tests/files/expected/0787_impossible_range_check.php.expected
@@ -1,0 +1,3 @@
+%s:4 PhanSuspiciousValueComparison Suspicious attempt to compare $value of type 3|4 to 4 of type 4 with operator '>'
+%s:5 PhanSuspiciousValueComparison Suspicious attempt to compare 'foo' of type 'foo' to $b of type bool with operator '>='
+%s:7 PhanSuspiciousValueComparison Suspicious attempt to compare $s of type 'FOO'|'bar' to $nullable of type ?bool with operator '>='

--- a/tests/files/src/0787_impossible_range_check.php
+++ b/tests/files/src/0787_impossible_range_check.php
@@ -1,0 +1,9 @@
+<?php
+function test787(string $str, bool $b, ?bool $nullable) {
+    $value = rand() % 2 ? 3 : 4;
+    var_export($value > 4);
+    var_export('foo' >= $b);
+    $s = rand(0,1) ? 'FOO' : 'bar';
+    var_export($s >= $nullable);
+}
+test787('test', (bool)rand(0,1), null);

--- a/tests/real_types_test/expected/005_preg_match_impossible.php.expected
+++ b/tests/real_types_test/expected/005_preg_match_impossible.php.expected
@@ -1,0 +1,1 @@
+src/005_preg_match_impossible.php:3 PhanSuspiciousValueComparison Suspicious attempt to compare preg_match('/si/', $str) of type ?0|?1|?false to 1 of type 1 with operator '>'

--- a/tests/real_types_test/src/005_preg_match_impossible.php
+++ b/tests/real_types_test/src/005_preg_match_impossible.php
@@ -1,0 +1,16 @@
+<?php
+function has_si(string $str) {
+    if (preg_match('/si/', $str) > 1) {
+        echo "Impossible\n";
+    }
+    if (preg_match('/si/', $str) > 0) {
+        echo "Possible\n";
+    }
+    for ($i = 0; $i < 10; $i++) {
+        $str .= rand(0,4);
+        if (preg_match('/23/', $str) > 0) {
+            echo "Possible\n";
+        }
+    }
+}
+has_si('mississippi');


### PR DESCRIPTION
Previously, Phan would only warn if both sides had a single known
literal value.
Support multiple scalar values,
as long as the number of comparisons to perform is at most 100.