### PR TITLE
Implement support for list<T> and non-empty-list<T>

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@ Phan NEWS
 ------------------------
 
 New features(Analysis):
+
++ Add support for `list<T>` and `non-empty-list<T>` in phpdoc and in inferred values.
+  These represent arrays with consecutive integer keys starting at 0 without any gaps (e.g. `function (string ...$args) {}`)
 + Allow omitting keys from array shapes for sequential array elements
   (e.g. `array{stdClass, array}` is equivalent to `array{0:stdClass, 1:array}`).
 

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -1804,6 +1804,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 return;
             }
 
+            // TODO: Infer list<>
             $key_type_enum = GenericArrayType::getKeyTypeOfArrayNode($this->code_base, $context, $node);
             foreach (self::deduplicateUnionTypes($this->getReturnTypesOfArray($context, $node)) as $lineno => $elem_type) {
                 yield $lineno => $elem_type->asGenericArrayTypes($key_type_enum);  // TODO: Infer corresponding key types
@@ -3888,11 +3889,11 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             // For https://github.com/phan/phan/issues/1525 : Collapse array shapes into generic arrays before recursively analyzing a method.
             if ($parameter->hasEmptyNonVariadicType()) {
                 $parameter->setUnionType(
-                    $argument_type->withFlattenedArrayShapeOrLiteralTypeInstances()->asGenericArrayTypes(GenericArrayType::KEY_INT)->withRealTypeSet($parameter->getNonVariadicUnionType()->getRealTypeSet())
+                    $argument_type->withFlattenedArrayShapeOrLiteralTypeInstances()->asListTypes()->withRealTypeSet($parameter->getNonVariadicUnionType()->getRealTypeSet())
                 );
             } else {
                 $parameter->addUnionType(
-                    $argument_type->withFlattenedArrayShapeOrLiteralTypeInstances()->asGenericArrayTypes(GenericArrayType::KEY_INT)->withRealTypeSet($parameter->getNonVariadicUnionType()->getRealTypeSet())
+                    $argument_type->withFlattenedArrayShapeOrLiteralTypeInstances()->asListTypes()->withRealTypeSet($parameter->getNonVariadicUnionType()->getRealTypeSet())
                 );
             }
         } else {

--- a/src/Phan/Language/Element/VariadicParameter.php
+++ b/src/Phan/Language/Element/VariadicParameter.php
@@ -2,7 +2,6 @@
 
 namespace Phan\Language\Element;
 
-use Phan\Language\Type\GenericArrayType;
 use Phan\Language\UnionType;
 
 /**
@@ -142,8 +141,7 @@ class VariadicParameter extends Parameter
     public function getUnionType() : UnionType
     {
         if (!$this->isCloneOfVariadic()) {
-            // TODO: Figure out why asNonEmptyGenericArrayTypes() causes test failures
-            return parent::getUnionType()->asNonEmptyGenericArrayTypes(GenericArrayType::KEY_INT);
+            return parent::getUnionType()->asNonEmptyListTypes();
         }
         return $this->type;
     }

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -13,6 +13,7 @@ use Phan\Language\FQSEN\FullyQualifiedClassName;
 use Phan\Language\Type\ArrayType;
 use Phan\Language\Type\BoolType;
 use Phan\Language\Type\IterableType;
+use Phan\Language\Type\ListType;
 use Phan\Language\Type\MixedType;
 use Phan\Language\Type\ObjectType;
 use Phan\Language\Type\TemplateType;
@@ -1011,6 +1012,11 @@ final class EmptyUnionType extends UnionType
         return $this;  // empty
     }
 
+    public function asListTypes() : UnionType
+    {
+        return $this;
+    }
+
     /**
      * @return UnionType
      * Get a new type for each type in this union which is
@@ -1023,6 +1029,12 @@ final class EmptyUnionType extends UnionType
     {
         static $cache = [];
         return ($cache[$key_type] ?? ($cache[$key_type] = MixedType::instance(false)->asGenericArrayType($key_type)->asRealUnionType()));
+    }
+
+    public function asNonEmptyListTypes() : UnionType
+    {
+        static $type = null;
+        return ($type ?? ($type = ListType::fromElementType(MixedType::instance(false), false)->asRealUnionType()));
     }
 
     /**

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -376,9 +376,10 @@ class GenericArrayType extends ArrayType implements GenericArrayInterface
                 $class_union_type = $class_union_type->withUnionType($additional_union_type);
             }
 
-            $union_type = $union_type->withUnionType(
-                $class_union_type->asGenericArrayTypes($this->key_type)
-            );
+            // TODO: Use helpers for list, non-empty-array, etc.
+            foreach ($class_union_type->getTypeSet() as $type) {
+                $union_type = $union_type->withType(static::fromElementType($type, $this->is_nullable, $this->key_type));
+            }
 
             // Recurse up the tree to include all types
             $recursive_union_type_builder = new UnionTypeBuilder();
@@ -683,7 +684,7 @@ class GenericArrayType extends ArrayType implements GenericArrayInterface
         }
         $results = [];
         foreach ($type_instances as $type) {
-            $results[] = GenericArrayType::fromElementType($type, $this->is_nullable, $this->key_type);
+            $results[] = static::fromElementType($type, $this->is_nullable, $this->key_type);
         }
         return $results;
     }
@@ -811,5 +812,22 @@ class GenericArrayType extends ArrayType implements GenericArrayInterface
             false,
             $this->key_type
         );
+    }
+
+    /**
+     * Do not use this. Use ArrayType::instance or static::fromElementType
+     * @internal
+     * @deprecated
+     */
+    public static function instance(bool $unused_is_nullable) {
+        throw new \AssertionError(static::class . '::' . __FUNCTION__ . ' should not be used');
+    }
+
+    /**
+     * Overridden in subclasses for non-empty-array and non-empty-list.
+     */
+    public function isDefinitelyNonEmptyArray() : bool
+    {
+        return false;
     }
 }

--- a/src/Phan/Language/Type/GenericMultiArrayType.php
+++ b/src/Phan/Language/Type/GenericMultiArrayType.php
@@ -41,6 +41,12 @@ final class GenericMultiArrayType extends ArrayType implements MultiType, Generi
     private $always_has_elements;
 
     /**
+     * @var bool
+     * True if the array will have consecutive keys starting from 0
+     */
+    private $is_list;
+
+    /**
      * @param array<int,Type> $types
      * The 2 or more possible types of every element in this array
      *
@@ -53,9 +59,12 @@ final class GenericMultiArrayType extends ArrayType implements MultiType, Generi
      * @param bool $always_has_elements
      * True if the array will have one or more elements.
      *
+     * @param bool $is_list
+     * True if the array will have consecutive keys starting from 0
+     *
      * @throws InvalidArgumentException if there are less than 2 types in $types
      */
-    protected function __construct(array $types, bool $is_nullable, int $key_type, bool $always_has_elements = false)
+    protected function __construct(array $types, bool $is_nullable, int $key_type, bool $always_has_elements = false, bool $is_list = false)
     {
         if (\count($types) < 2) {
             throw new InvalidArgumentException('Expected $types to have at least 2 array elements');
@@ -67,6 +76,7 @@ final class GenericMultiArrayType extends ArrayType implements MultiType, Generi
         $this->is_nullable = $is_nullable;
         $this->key_type = $key_type;
         $this->always_has_elements = $always_has_elements;
+        $this->is_list = $is_list;
     }
 
     /**
@@ -88,7 +98,8 @@ final class GenericMultiArrayType extends ArrayType implements MultiType, Generi
             $this->element_types,
             $is_nullable,
             $this->key_type,
-            $this->always_has_elements
+            $this->always_has_elements,
+            $this->is_list
         );
     }
 
@@ -100,8 +111,14 @@ final class GenericMultiArrayType extends ArrayType implements MultiType, Generi
     {
         return \array_map(function (Type $type) : GenericArrayType {
             if ($this->always_has_elements) {
+                if ($this->is_list) {
+                    return NonEmptyListType::fromElementType($type, $this->is_nullable);
+                }
                 return NonEmptyGenericArrayType::fromElementType($type, $this->is_nullable, $this->key_type);
             } else {
+                if ($this->is_list) {
+                    return ListType::fromElementType($type, $this->is_nullable, $this->key_type);
+                }
                 return GenericArrayType::fromElementType($type, $this->is_nullable, $this->key_type);
             }
         }, UnionType::normalizeMultiTypes($this->element_types));
@@ -114,14 +131,16 @@ final class GenericMultiArrayType extends ArrayType implements MultiType, Generi
      * @param bool $is_nullable
      * @param int $key_type
      * @param bool $always_has_elements
+     * @param bool $is_list
      */
     public static function fromElementTypes(
         array $element_types,
         bool $is_nullable,
         int $key_type,
-        bool $always_has_elements = false
+        bool $always_has_elements = false,
+        bool $is_list = false
     ) : GenericMultiArrayType {
-        return new self($element_types, $is_nullable, $key_type, $always_has_elements);
+        return new self($element_types, $is_nullable, $key_type, $always_has_elements, $is_list);
     }
 
     /**

--- a/src/Phan/Language/Type/ListType.php
+++ b/src/Phan/Language/Type/ListType.php
@@ -1,0 +1,86 @@
+<?php declare(strict_types=1);
+
+namespace Phan\Language\Type;
+
+use Phan\Language\Type;
+
+/**
+ * Phan's representation for types such as `list` and `list<MyClass>`
+ * @see GenericArrayType for representations of `string[]` and `array<int,bool>`
+ * @see ArrayShapeType for representations of `array{key:MyClass}`
+ * @see ArrayType for the representation of `array`
+ */
+class ListType extends GenericArrayType
+{
+    protected function __construct(Type $type, bool $is_nullable)
+    {
+        parent::__construct($type, $is_nullable, GenericArrayType::KEY_INT);
+    }
+
+    public static function fromElementType(
+        Type $type,
+        bool $is_nullable,
+        int $unused_key_type = GenericArrayType::KEY_INT
+    ) : GenericArrayType {
+        // Make sure we only ever create exactly one
+        // object for any unique type
+        static $map = null;
+
+        if ($map === null) {
+            $map = new \SplObjectStorage();
+        }
+
+        if (!$map->contains($type)) {
+            $map->attach(
+                $type,
+                new ListType($type, $is_nullable)
+            );
+        }
+
+        return $map->offsetGet($type);
+    }
+    /**
+     * @return bool
+     * True if this Type can be cast to the given Type
+     * cleanly
+     */
+    protected function canCastToNonNullableType(Type $type) : bool
+    {
+        if (!$type->isPossiblyTruthy()) {
+            return false;
+        }
+        if ($type instanceof ArrayShapeType) {
+            if (!$type->canCastToGenericArrayKeys($this)) {
+                return false;
+            }
+        }
+        return parent::canCastToNonNullableType($type);
+    }
+
+    protected function canCastToNonNullableTypeWithoutConfig(Type $type) : bool
+    {
+        if (!$type->isPossiblyTruthy()) {
+            return false;
+        }
+        if ($type instanceof ArrayShapeType) {
+            if (!$type->canCastToGenericArrayKeys($this)) {
+                return false;
+            }
+        }
+        return parent::canCastToNonNullableTypeWithoutConfig($type);
+    }
+
+    public function asNonFalseyType() : Type
+    {
+        return NonEmptyListType::fromElementType(
+            $this->element_type,
+            false,
+            $this->key_type
+        );
+    }
+
+    public function __toString() : string
+    {
+        return ($this->is_nullable ? '?' : '') . 'list<' . $this->element_type->__toString() . '>';
+    }
+}

--- a/src/Phan/LanguageServer/LanguageServer.php
+++ b/src/Phan/LanguageServer/LanguageServer.php
@@ -746,7 +746,7 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
         $most_recent_node_info_request = $this->most_recent_node_info_request;
         if ($most_recent_node_info_request) {
             if ($most_recent_node_info_request instanceof GoToDefinitionRequest) {
-                // @phan-suppress-next-line PhanPartialTypeMismatchArgument
+                // @phan-suppress-next-line PhanPartialTypeMismatchArgument, PhanTypeMismatchArgumentNullable
                 $most_recent_node_info_request->recordDefinitionLocationList($response_data['definitions'] ?? null);
                 $most_recent_node_info_request->setHoverResponse($response_data['hover_response'] ?? null);
             } elseif ($most_recent_node_info_request instanceof CompletionRequest) {

--- a/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
@@ -14,6 +14,7 @@ use Phan\Language\Type\ArrayShapeType;
 use Phan\Language\Type\ArrayType;
 use Phan\Language\Type\FalseType;
 use Phan\Language\Type\GenericArrayType;
+use Phan\Language\Type\ListType;
 use Phan\Language\Type\MixedType;
 use Phan\Language\Type\NullType;
 use Phan\Language\UnionType;
@@ -44,7 +45,7 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
         $array_type  = ArrayType::instance(false);
         $null_type   = NullType::instance(false);
         $nullable_array_type_set = [ArrayType::instance(true)];
-        $nullable_int_key_array_type_set = [MixedType::instance(true)->asGenericArrayType(GenericArrayType::KEY_INT)];
+        $nullable_int_key_array_type_set = [ListType::fromElementType(MixedType::instance(true), true)];
         $int_or_string_or_false = UnionType::fromFullyQualifiedRealString('int|string|false');
         $int_or_string_or_null = UnionType::fromFullyQualifiedRealString('int|string|null');
         $int_or_string = UnionType::fromFullyQualifiedRealString('int|string');
@@ -402,9 +403,9 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
             }
             $union_type = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $args[0]);
             $element_type = $union_type->genericArrayElementTypes();
-            $result = $element_type->asGenericArrayTypes(GenericArrayType::KEY_INT);
+            $result = $element_type->asListTypes();
             if ($result->isEmpty()) {
-                return UnionType::fromFullyQualifiedPHPDocAndRealString('array<int,mixed>', '?array<int,mixed>');
+                return UnionType::fromFullyQualifiedPHPDocAndRealString('list<mixed>', '?list<mixed>');
             }
             return $result->withRealTypeSet($nullable_int_key_array_type_set);
         };

--- a/tests/files/expected/0217_variadic_call_types.php.expected
+++ b/tests/files/expected/0217_variadic_call_types.php.expected
@@ -4,7 +4,7 @@
 %s:30 PhanTypeMismatchArgumentReal Argument 2 ($params) is \DateTime|\DateTimeInterface but \test_ints() takes int defined at %s:6
 %s:31 PhanTypeMismatchArgumentReal Argument 2 ($params) is array{0:2,1:3,2:4,3:5} but \test_ints() takes int defined at %s:6
 %s:35 PhanTypeMismatchArgumentReal Argument 1 ($date_time_list) is 42 but \test_vararg_within_function() takes \DateTime defined at %s:9
-%s:38 PhanTypeMismatchArgument Argument 1 ($a) is array<int,array>|array<int,int>|array<int,mixed> but \accept_int() takes int defined at %s:17
-%s:41 PhanTypeMismatchArgument Argument 1 ($a) is array<int,array<int,string>>|array<int,array>|array<int,int>|array<int,mixed> but \accept_int() takes int defined at %s:17
-%s:42 PhanTypeMismatchArgument Argument 1 ($a) is array<int,array<int,string>>|array<int,array>|array<int,bool>|array<int,int>|array<int,mixed> but \accept_int() takes int defined at %s:17
-%s:43 PhanTypeMismatchArgument Argument 1 ($a) is array<int,array<int,string>>|array<int,array>|array<int,bool>|array<int,int>|array<int,mixed> but \accept_int() takes int defined at %s:17
+%s:38 PhanTypeMismatchArgument Argument 1 ($a) is list<array>|list<int>|list<mixed> but \accept_int() takes int defined at %s:17
+%s:41 PhanTypeMismatchArgument Argument 1 ($a) is list<array<int,string>>|list<array>|list<int>|list<mixed> but \accept_int() takes int defined at %s:17
+%s:42 PhanTypeMismatchArgument Argument 1 ($a) is list<array<int,string>>|list<array>|list<bool>|list<int>|list<mixed> but \accept_int() takes int defined at %s:17
+%s:43 PhanTypeMismatchArgument Argument 1 ($a) is list<array<int,string>>|list<array>|list<bool>|list<int>|list<mixed> but \accept_int() takes int defined at %s:17

--- a/tests/files/expected/0263_alias_outside_phpdoc.php.expected
+++ b/tests/files/expected/0263_alias_outside_phpdoc.php.expected
@@ -2,7 +2,7 @@
 %s:4 PhanUndeclaredTypeParameter Parameter $b has undeclared type \integer
 %s:4 PhanUndeclaredTypeParameter Parameter $c has undeclared type \callback
 %s:4 PhanUndeclaredTypeParameter Parameter $d has undeclared type \double
-%s:4 PhanUndeclaredTypeParameter Parameter $e has undeclared type array<int,\double>
+%s:4 PhanUndeclaredTypeParameter Parameter $e has undeclared type list<\double>
 %s:4 PhanUndeclaredTypeReturnType Return type of foo263() is undeclared type \boolean
 %s:5 PhanTypeMismatchReturnReal Returning type false but foo263() is declared to return \boolean
 %s:7 PhanTypeMismatchArgumentReal Argument 1 ($a) is false but \foo263() takes \boolean defined at %s:4

--- a/tests/files/expected/0314_param_type_match.php.expected
+++ b/tests/files/expected/0314_param_type_match.php.expected
@@ -5,7 +5,7 @@
 %s:22 PhanTypeMismatchDeclaredParam Doc-block of $arg2 in f6 contains phpdoc param type string which is incompatible with the param type array declared in the signature
 %s:32 PhanTypeMismatchDeclaredParam Doc-block of $arg1 in f9 contains phpdoc param type string which is incompatible with the param type iterable declared in the signature
 %s:36 PhanTypeMismatchDeclaredParam Doc-block of $arg1 in a10 contains phpdoc param type ?int which is incompatible with the param type int declared in the signature
-%s:58 PhanTypeMismatchReturn Returning type array<int,int> but a13() is declared to return int
+%s:58 PhanTypeMismatchReturn Returning type list<int> but a13() is declared to return int
 %s:74 PhanTypeMismatchDeclaredParam Doc-block of $arg1 in g2 contains phpdoc param type \C314_1 which is incompatible with the param type \C314_2 declared in the signature
 %s:78 PhanTypeMismatchDeclaredParam Doc-block of $arg1 in g3 contains phpdoc param type \C314_1 which is incompatible with the param type \C314_2 declared in the signature
 %s:84 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($string) is int[] (real type array) but \strlen() takes string

--- a/tests/files/expected/0655_negate_instanceof.php.expected
+++ b/tests/files/expected/0655_negate_instanceof.php.expected
@@ -1,2 +1,2 @@
-%s:14 PhanTypeMismatchArgumentInternal Argument 1 ($string) is ?array<int,\NS655\TestClass>|array<int,\NS655\TestClass> but \strlen() takes string
+%s:14 PhanTypeMismatchArgumentInternal Argument 1 ($string) is ?array<int,\NS655\TestClass> but \strlen() takes string
 %s:17 PhanTypeMismatchArgumentInternal Argument 1 ($string) is \NS655\TestClass but \strlen() takes string

--- a/tests/files/expected/0773_variadic_real_array.php.expected
+++ b/tests/files/expected/0773_variadic_real_array.php.expected
@@ -1,8 +1,8 @@
-%s:2 PhanDebugAnnotation @phan-debug-var requested for variable $v - it has union type array<int,mixed>(real=array<int,mixed>)
+%s:2 PhanDebugAnnotation @phan-debug-var requested for variable $v - it has union type list<mixed>(real=list<mixed>)
 %s:7 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($obj) is int but \spl_object_id() takes object
-%s:9 PhanRedundantCondition Redundant attempt to cast $v of type array<int,mixed> to array
-%s:13 PhanDebugAnnotation @phan-debug-var requested for variable $v - it has union type array<int,int>(real=array<int,int>)
+%s:9 PhanRedundantCondition Redundant attempt to cast $v of type list<mixed> to array
+%s:13 PhanDebugAnnotation @phan-debug-var requested for variable $v - it has union type list<int>(real=list<int>)
 %s:18 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($obj) is int but \spl_object_id() takes object
 %s:19 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($obj) is int but \spl_object_id() takes object
-%s:21 PhanRedundantCondition Redundant attempt to cast $v of type array<int,int> to array
-%s:26 PhanDebugAnnotation @phan-debug-var requested for variable $v - it has union type array<int,int>(real=array<int,mixed>)
+%s:21 PhanRedundantCondition Redundant attempt to cast $v of type list<int> to array
+%s:26 PhanDebugAnnotation @phan-debug-var requested for variable $v - it has union type list<int>(real=list<mixed>)

--- a/tests/files/expected/0791_short_array_shape.php.expected
+++ b/tests/files/expected/0791_short_array_shape.php.expected
@@ -1,0 +1,7 @@
+%s:10 PhanCommentDuplicateParam Comment declares @param $c multiple times
+%s:10 PhanUndeclaredTypeParameter Parameter $b has undeclared type array<int,\NS781\stdClass> (Did you mean class \stdClass)
+%s:11 PhanUnusedVariable Unused definition of variable $val
+%s:12 PhanTypeMismatchArgumentInternal Argument 1 ($obj) is int but \spl_object_hash() takes object
+%s:13 PhanTypeMismatchArgumentInternal Argument 1 ($obj) is void but \spl_object_hash() takes object
+%s:14 PhanTypeMismatchArgumentInternal Argument 1 ($obj) is array{0:\NS781\stdClass} but \spl_object_hash() takes object
+%s:15 PhanTypeMismatchArgumentInternal Argument 1 ($obj) is array{0:'',1:array<int,string>,2:'1'} but \spl_object_hash() takes object

--- a/tests/files/expected/0792_list_type.php.expected
+++ b/tests/files/expected/0792_list_type.php.expected
@@ -1,0 +1,10 @@
+%s:9 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($obj) is list<\stdClass> (real type array) but \spl_object_id() takes object
+%s:10 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($obj) is non-empty-list<\stdClass>|non-empty-list<bool> (real type array) but \spl_object_id() takes object
+%s:12 PhanTypeArraySuspicious Suspicious array access to \stdClass
+%s:14 PhanTypeInvalidDimOffset Invalid offset -1 of array type non-empty-list<\stdClass>|non-empty-list<bool>
+%s:14 PhanTypeSuspiciousEcho Suspicious argument null for an echo/print statement
+%s:17 PhanTypeMismatchArgument Argument 2 ($y) is array{} but \test692() takes non-empty-list<\stdClass>|non-empty-list<bool> defined at %s:8
+%s:19 PhanTypeMismatchArgument Argument 1 ($x) is array{0:false} but \test692() takes list<\stdClass> defined at %s:8
+%s:19 PhanTypeMismatchArgument Argument 2 ($y) is array{0:0} but \test692() takes non-empty-list<\stdClass>|non-empty-list<bool> defined at %s:8
+%s:24 PhanDebugAnnotation @phan-debug-var requested for variable $args - it has union type list<\stdClass>(real=list<\stdClass>)
+%s:26 PhanTypeMismatchReturn Returning type list<\stdClass> but test_cast() is declared to return array{1:\stdClass}

--- a/tests/files/src/0791_short_array_shape.php
+++ b/tests/files/src/0791_short_array_shape.php
@@ -1,0 +1,17 @@
+<?php
+namespace NS781;
+use Closure;
+/**
+ * @param array{Closure():void, int, Closure:Closure():int} $a
+ * @param array{stdClass} $b
+ * @param array{0} $c
+ * @param array{'',array<int,string>,'1'} $c
+ */
+function test_short_array_shape($a, $b, $c, $d) {
+    [$cb, $val] = $a;
+    echo spl_object_hash($a['Closure']());
+    echo spl_object_hash($cb());
+    echo spl_object_hash($b);
+    echo spl_object_hash($c);
+    echo spl_object_hash($d);
+}

--- a/tests/files/src/0792_list_type.php
+++ b/tests/files/src/0792_list_type.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @param list<stdClass> $x
+ * @param non-empty-list<stdClass|bool> $y
+ * @return list<stdClass>
+ */
+function test692(array $x, array $y) {
+    echo spl_object_id($x);
+    echo spl_object_id($y);
+    foreach ($x as $value) {
+        echo $value[0];
+    }
+    echo $y[-1];
+    return $x;
+}
+test692([], []);
+test692([new stdClass()], [new stdClass(), false]);
+test692([false], [0]);
+
+/**
+ * @return array{1:stdClass}
+ */
+function test_cast(stdClass ...$args) {
+    '@phan-debug-var $args';
+    return $args;
+}

--- a/tests/php74_files/expected/003_arrow_func.php.expected
+++ b/tests/php74_files/expected/003_arrow_func.php.expected
@@ -6,7 +6,7 @@
 %s:19 PhanTypeMismatchArgumentInternal Argument 1 ($string) is int but \strlen() takes string
 %s:20 PhanTypeMismatchArgumentInternal Argument 1 ($string) is \Generator|\Iterator|\Traversable|iterable but \strlen() takes string
 %s:23 PhanTypeNonVarPassByRef Only variables can be passed by reference at argument 1 of Closure(&$x)
-%s:26 PhanTypeMismatchArgumentInternal Argument 1 ($string) is array<int,mixed> but \strlen() takes string
+%s:26 PhanTypeMismatchArgumentInternal Argument 1 ($string) is list<mixed> but \strlen() takes string
 %s:28 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is bool but \intdiv() takes int
 %s:30 PhanNoopClosure Unused closure
 %s:32 PhanUndeclaredVariable Variable $undef is undeclared

--- a/tests/real_types_test/expected/002_unknown_return_type.php.expected
+++ b/tests/real_types_test/expected/002_unknown_return_type.php.expected
@@ -1,2 +1,2 @@
-src/002_unknown_return_type.php:3 PhanPluginUnknownFunctionReturnType Function \test2() has no declared or inferred return type (Types inferred after analysis: array<int,\stdClass>)
-src/002_unknown_return_type.php:8 PhanPluginUnknownMethodReturnType Method \MyClass2::test() has no declared or inferred return type (Types inferred after analysis: array<int,array>)
+src/002_unknown_return_type.php:3 PhanPluginUnknownFunctionReturnType Function \test2() has no declared or inferred return type (Types inferred after analysis: list<\stdClass>)
+src/002_unknown_return_type.php:8 PhanPluginUnknownMethodReturnType Method \MyClass2::test() has no declared or inferred return type (Types inferred after analysis: list<array>)


### PR DESCRIPTION
Infer it for a few obvious lists as well as from phpdoc.
Warn when trying to pass an incompatible array shape
even if the shape has integer keys.
(currently limited to detecting this when all array keys are known)