### PR TITLE
Make order of array shape field types match php

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@ New features(Analysis):
   These represent arrays with consecutive integer keys starting at 0 without any gaps (e.g. `function (string ...$args) {}`)
 + Allow omitting keys from array shapes for sequential array elements
   (e.g. `array{stdClass, array}` is equivalent to `array{0:stdClass, 1:array}`).
++ Add array key of array shapes in the same field order that php would for assignments such as `$x = [10]; $x[1] = 11;`. (#3359)
 
 Oct 03 2019, Phan 2.2.13
 ------------------------

--- a/src/Phan/Analysis/AssignOperatorAnalysisVisitor.php
+++ b/src/Phan/Analysis/AssignOperatorAnalysisVisitor.php
@@ -175,7 +175,7 @@ class AssignOperatorAnalysisVisitor extends FlagVisitorImplementation
                 if ($left->isEqualTo($right)) {
                     return $left;
                 }
-                return ArrayType::combineArrayTypesOverriding($left, $right);
+                return ArrayType::combineArrayTypesOverriding($left, $right, false);
             }
 
             $this->warnAboutInvalidUnionType(
@@ -220,7 +220,7 @@ class AssignOperatorAnalysisVisitor extends FlagVisitorImplementation
             if ($left_is_array || $right_is_array) {
                 if ($left_is_array && $right_is_array) {
                     // TODO: Make the right types for array offsets completely override the left types?
-                    return ArrayType::combineArrayTypesOverriding($left, $right);
+                    return ArrayType::combineArrayTypesOverriding($left, $right, false);
                 }
 
                 if ($left_is_array

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -964,14 +964,9 @@ class AssignmentVisitor extends AnalysisVisitor
                 $old_type = ArrayType::instance(false)->asPHPDocUnionType();
             }
             if ($this->dim_depth > 1 || ($old_type->hasTopLevelNonArrayShapeTypeInstances() || $right_type->hasTopLevelNonArrayShapeTypeInstances() || $right_type->isEmpty())) {
-                $new_type = $old_type->withUnionType(
-                    $right_type
-                );
+                $new_type = $old_type->withUnionType($right_type);
             } else {
-                $new_type = ArrayType::combineArrayTypesOverriding(
-                    $right_type,
-                    $old_type
-                );
+                $new_type = ArrayType::combineArrayTypesOverriding($right_type, $old_type, true);
             }
         }
         $this->context = $this->context->withThisPropertySetToTypeByName($prop_name, $new_type);
@@ -1365,7 +1360,8 @@ class AssignmentVisitor extends AnalysisVisitor
                 } else {
                     $variable->setUnionType(ArrayType::combineArrayTypesOverriding(
                         $right_type,
-                        $old_variable_union_type
+                        $old_variable_union_type,
+                        true
                     ));
                 }
             } else {

--- a/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
+++ b/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
@@ -722,12 +722,12 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
         }
 
         // If both left and right union types are arrays, then this is array
-        // concatenation.
+        // concatenation. (`$left + $right`)
         if ($left->isGenericArray() && $right->isGenericArray()) {
             if ($left->isEqualTo($right)) {
                 return $left;
             }
-            return ArrayType::combineArrayTypesOverriding($left, $right);
+            return ArrayType::combineArrayTypesOverriding($left, $right, false);
         }
 
         $this->warnAboutInvalidUnionType(
@@ -761,11 +761,7 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
 
         if ($left_is_array || $right_is_array) {
             if ($left_is_array && $right_is_array) {
-                // TODO: Make the right types for array offsets completely override the left types?
-                return UnionType::of(
-                    ArrayType::combineArrayTypesOverriding($left, $right)->getTypeSet(),
-                    $probably_unknown_type->getRealTypeSet()
-                );
+                return ArrayType::combineArrayTypesOverriding($left, $right, false);
             }
 
             if ($left_is_array

--- a/src/Phan/Language/Type/ArrayShapeType.php
+++ b/src/Phan/Language/Type/ArrayShapeType.php
@@ -689,10 +689,21 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
      * Computes the union of two array shape types.
      *
      * E.g. array{0: string} + array{0:stdClass,1:int} === array{0:string,1:int}
+     *
+     * @param bool $is_assignment - If true, this is computing the effect of assigning each field in $left to an array with previous type $right, keeping array key order.
      */
-    public static function combineWithPrecedence(ArrayShapeType $left, ArrayShapeType $right) : ArrayShapeType
+    public static function combineWithPrecedence(ArrayShapeType $left, ArrayShapeType $right, bool $is_assignment = false) : ArrayShapeType
     {
-        return self::fromFieldTypes($left->field_types + $right->field_types, false);
+        if ($is_assignment) {
+            // Not using $left->field_types + $right->field_types because that would put the array keys from $added before the array keys from $existing when iterating/displaying types.
+            $combination = $right->field_types;
+            foreach ($left->field_types as $i => $type) {
+                $combination[$i] = $type;
+            }
+        } else {
+            $combination = $left->field_types + $right->field_types;
+        }
+        return self::fromFieldTypes($combination, false);
     }
 
     /**

--- a/tests/files/expected/0439_multi.php.expected
+++ b/tests/files/expected/0439_multi.php.expected
@@ -1,2 +1,2 @@
-%s:4 PhanTypeInvalidDimOffset Invalid offset "otherOffset" of array type array{offset:'value',first:2}
+%s:4 PhanTypeInvalidDimOffset Invalid offset "otherOffset" of array type array{first:2,offset:'value'}
 %s:4 PhanTypeSuspiciousEcho Suspicious argument null for an echo/print statement

--- a/tests/files/expected/0622_foreach_complex.php.expected
+++ b/tests/files/expected/0622_foreach_complex.php.expected
@@ -1,2 +1,2 @@
-%s:15 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($string) is array{field2:'value',field:string} but \strlen() takes string
+%s:15 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($string) is array{field:string,field2:'value'} but \strlen() takes string
 %s:16 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($string) is \stdClass but \strlen() takes string

--- a/tests/files/expected/0652_array_narrow.php.expected
+++ b/tests/files/expected/0652_array_narrow.php.expected
@@ -1,5 +1,6 @@
 %s:12 PhanTypeMismatchArgumentInternal Argument 1 ($string) is array but \strlen() takes string
 %s:25 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is array{0:string} but \intdiv() takes int
 %s:35 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is string but \intdiv() takes int
+%s:37 PhanDebugAnnotation @phan-debug-var requested for variable $options - it has union type array{hooks:array}(real=array)
 %s:37 PhanTypeMismatchArgumentInternal Argument 1 ($string) is array but \strlen() takes string
-%s:39 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($string) is array{hooks:array}|array{hooks:string} (real type array) but \strlen() takes string
+%s:40 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($string) is array{hooks:array}|array{hooks:string} (real type array) but \strlen() takes string

--- a/tests/files/expected/0793_array_field_combination_order.php.expected
+++ b/tests/files/expected/0793_array_field_combination_order.php.expected
@@ -1,0 +1,4 @@
+%s:5 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($obj) is array{0:1,1:2} but \spl_object_id() takes object
+%s:7 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($obj) is array{0:1,1:2,-1:3} but \spl_object_id() takes object
+%s:12 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($obj) is array{0:1,1:'x'} but \spl_object_hash() takes object
+%s:15 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($obj) is array{0:1,1:'x',2:'a'} but \spl_object_hash() takes object

--- a/tests/files/src/0652_array_narrow.php
+++ b/tests/files/src/0652_array_narrow.php
@@ -35,6 +35,7 @@ function foo3(array $options)
         echo intdiv($options['hooks'], 2);  // should infer string and warn
     } else {
         echo strlen($options['hooks']);  // should infer array and warn
+        '@phan-debug-var $options';
     }
     echo strlen($options);  // should still infer array{hooks:string|array}
 }

--- a/tests/files/src/0793_array_field_combination_order.php
+++ b/tests/files/src/0793_array_field_combination_order.php
@@ -1,0 +1,17 @@
+<?php
+function test_combination_field_order() {
+    $x = [1];
+    $x[1] = 2;
+    echo spl_object_id($x);  // Should infer array{0:1,1:2} in that order
+    $x[-1] = 3;
+    echo spl_object_id($x);  // Should infer array{0:1,1:2,-1:3} in that order
+    var_export($x);
+    $a = [1];
+    $a += [1 => 'x'];
+    var_export($a);
+    echo spl_object_hash($a);  // Should infer array{0:1,1:'x'}
+    $a += [1 => 'y', 0 => 'z', 2 => 'a'];
+    var_export($a);
+    echo spl_object_hash($a);  // Should infer  array{0:1,1:'x',2:'a'}
+}
+test_combination_field_order();


### PR DESCRIPTION
(For assignment operations, etc.)

Fixes #3359