### PR TITLE
Infer that unset causes arrays to be possibly empty.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,8 +3,10 @@ Phan NEWS
 ??? ?? 2019, Phan 2.2.14 (dev)
 ------------------------
 
-New features(Analysis):
+New features(CLI, Configs):
++ Limit --debug-emitted-issues to the files that weren't excluded from analysis.
 
+New features(Analysis):
 + Add support for `list<T>` and `non-empty-list<T>` in phpdoc and in inferred values.
   These represent arrays with consecutive integer keys starting at 0 without any gaps (e.g. `function (string ...$args) {}`)
 + Add support for `associative-array<T>` and `non-empty-associative-array<T>` in phpdoc and in inferred values. (#3357)
@@ -18,6 +20,8 @@ New features(Analysis):
   (e.g. `array{stdClass, array}` is equivalent to `array{0:stdClass, 1:array}`).
 + Add array key of array shapes in the same field order that php would for assignments such as `$x = [10]; $x[1] = 11;`. (#3359)
 + Infer that arrays are non-empty after analyzing code such as `$x[expr] = expr` or `$x[] = expr`.
++ Infer that arrays are possibly empty after analyzing code such as `unset($x[expr]);`.
++ Fix false positives in redundant condition detection when the source union type contains the `mixed` type.
 
 Oct 03 2019, Phan 2.2.13
 ------------------------

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1763,10 +1763,11 @@ class UnionTypeVisitor extends AnalysisVisitor
      *
      * @throws IssueException
      * if the unpack is on an invalid expression
+     * @suppress PhanUndeclaredProperty
      */
     public function visitUnpack(Node $node) : UnionType
     {
-        return $this->analyzeUnpack($node, false);
+        return $this->analyzeUnpack($node, isset($node->is_in_array));
     }
 
     /**

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -483,7 +483,7 @@ class CLI
                     if (!is_string($value)) {
                         $value = Issue::TRACE_BASIC;
                     }
-                    Issue::setTraceIssues($value);
+                    BufferingCollector::setTraceIssues($value);
                     break;
                 case 'a':
                 case 'dump-ast':

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -4739,35 +4739,12 @@ class Issue
     const TRACE_VERBOSE = 'verbose';
 
     /**
-     * @var ?string - This is null unless debugging.
-     */
-    private static $trace_issues = null;
-
-    /**
-     * Ensure that backtraces with the cause of the emitted issue are printed to stderr.
-     * If null, stop emitting backtraces.
-     */
-    public static function setTraceIssues(?string $level) : void
-    {
-        self::$trace_issues = $level ? \strtolower($level) : null;
-    }
-
-    /**
      * @param IssueInstance $issue_instance
      * An issue instance to emit
      */
     public static function emitInstance(
         IssueInstance $issue_instance
     ) : void {
-        if (self::$trace_issues) {
-            if (self::$trace_issues === self::TRACE_VERBOSE) {
-                \phan_print_backtrace();
-            } else {
-                \ob_start();
-                \debug_print_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS);
-                \fwrite(\STDERR, (\ob_get_clean() ?: "failed to dump backtrace") . \PHP_EOL);
-            }
-        }
         Phan::getIssueCollector()->collectIssue($issue_instance);
     }
 

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -1043,6 +1043,11 @@ final class EmptyUnionType extends UnionType
         return $this;
     }
 
+    public function withIntegerKeyArraysAsLists() : UnionType
+    {
+        return $this;
+    }
+
     public function asNonEmptyListTypes() : UnionType
     {
         static $type = null;

--- a/src/Phan/Language/Internal/FunctionSignatureMap.php
+++ b/src/Phan/Language/Internal/FunctionSignatureMap.php
@@ -3278,7 +3278,7 @@ return [
 'ffmpeg_movie::hasAudio' => ['bool'],
 'ffmpeg_movie::hasVideo' => ['bool'],
 'fgetc' => ['string|false', 'fp'=>'resource'],
-'fgetcsv' => ['?list<?string>|?false', 'fp'=>'resource', 'length='=>'int', 'delimiter='=>'string', 'enclosure='=>'string', 'escape='=>'string'],
+'fgetcsv' => ['list<?string>|false', 'fp'=>'resource', 'length='=>'int', 'delimiter='=>'string', 'enclosure='=>'string', 'escape='=>'string'],
 'fgets' => ['string|false', 'fp'=>'resource', 'length='=>'int'],
 'fgetss' => ['string|false', 'fp'=>'resource', 'length='=>'int', 'allowable_tags='=>'string'],
 'file' => ['list<string>|false', 'filename'=>'string', 'flags='=>'int', 'context='=>'resource'],

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -3493,6 +3493,7 @@ class Type
         if ($N !== count($results)) {
             return \array_values($results);
         }
+        // @phan-suppress-next-line PhanPartialTypeMismatchReturn this is already a list (ensured by above check).
         return $results;
     }
 

--- a/src/Phan/Language/Type/ArrayType.php
+++ b/src/Phan/Language/Type/ArrayType.php
@@ -281,6 +281,16 @@ class ArrayType extends IterableType
             GenericArrayType::KEY_MIXED
         );
     }
+
+    /**
+     * Convert ArrayTypes with integer-only keys to ListType.
+     * Calling withFlattenedArrayShapeTypeInstances first is recommended.
+     */
+    public function convertIntegerKeyArrayToList() : ArrayType
+    {
+        // The base type has unknown keys. Do nothing.
+        return $this;
+    }
 }
 // Trigger the autoloader for GenericArrayType so that it won't be called
 // before ArrayType.

--- a/src/Phan/Language/Type/FloatType.php
+++ b/src/Phan/Language/Type/FloatType.php
@@ -58,6 +58,6 @@ class FloatType extends ScalarType
         if ($other instanceof ScalarType) {
             return $other instanceof FloatType || (!$context->isStrictTypes() && parent::canCastToDeclaredType($code_base, $context, $other));
         }
-        return $other instanceof CallableType;
+        return $other instanceof CallableType || $other instanceof MixedType;
     }
 }

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -842,4 +842,18 @@ class GenericArrayType extends ArrayType implements GenericArrayInterface
             $this->key_type
         );
     }
+
+    /**
+     * Convert ArrayTypes with integer-only keys to ListType.
+     */
+    public function convertIntegerKeyArrayToList() : ArrayType
+    {
+        if ($this->key_type !== GenericArrayType::KEY_INT) {
+            return $this;
+        }
+        if ($this->isDefinitelyNonEmptyArray()) {
+            return NonEmptyListType::fromElementType($this->element_type, $this->is_nullable, $this->key_type);
+        }
+        return ListType::fromElementType($this->element_type, $this->is_nullable, $this->key_type);
+    }
 }

--- a/src/Phan/Language/Type/ListType.php
+++ b/src/Phan/Language/Type/ListType.php
@@ -90,4 +90,10 @@ class ListType extends GenericArrayType
     {
         return ($this->is_nullable ? '?' : '') . 'list<' . $this->element_type->__toString() . '>';
     }
+
+    // This is already a list.
+    public function convertIntegerKeyArrayToList() : ArrayType
+    {
+        return $this;
+    }
 }

--- a/src/Phan/Language/Type/MixedType.php
+++ b/src/Phan/Language/Type/MixedType.php
@@ -98,6 +98,11 @@ final class MixedType extends NativeType
         return true;  // It's possible.
     }
 
+    public function isPossiblyNumeric() : bool
+    {
+        return true;  // It's possible.
+    }
+
     public function canCastToDeclaredType(CodeBase $unused_code_base, Context $unused_context, Type $unused_other) : bool
     {
         return true;  // It's possible.

--- a/src/Phan/Language/Type/StringType.php
+++ b/src/Phan/Language/Type/StringType.php
@@ -46,7 +46,7 @@ class StringType extends ScalarType
         if ($other instanceof ScalarType) {
             return $other instanceof StringType || (!$context->isStrictTypes() && parent::canCastToDeclaredType($code_base, $context, $other));
         }
-        return $other instanceof CallableType;
+        return $other instanceof CallableType || $other instanceof MixedType;
     }
 
     /**

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -3495,7 +3495,6 @@ class UnionType implements Serializable
         // If array is in there, then it can be any type
         if (\in_array($array_type_nonnull, $type_set, true)) {
             $builder->addType($mixed_type);
-            $builder->addType($null_type);
         } elseif (\in_array($mixed_type, $type_set, true)
             || \in_array($array_type_nullable, $type_set, true)
         ) {
@@ -4510,6 +4509,33 @@ class UnionType implements Serializable
                 continue;
             }
             $type_set[$i] = $type->asAssociativeArrayType($can_reduce_size);
+        }
+        return $type_set;
+    }
+
+    /**
+     * Returns this union type after an operation that converts arrays with integer keys to lists is applied.
+     * (e.g. array_unshift, array_merge)
+     */
+    public function withIntegerKeyArraysAsLists() : UnionType
+    {
+        return UnionType::of(
+            self::withIntegerKeyArraysAsListsForSet($this->type_set),
+            self::withIntegerKeyArraysAsListsForSet($this->real_type_set)
+        );
+    }
+
+    /**
+     * @param list<Type> $type_set
+     * @return list<Type> with all array types as lists, or as arrays with mixed or string keys
+     */
+    private static function withIntegerKeyArraysAsListsForSet(array $type_set) : array
+    {
+        foreach ($type_set as $i => $type) {
+            if (!$type instanceof ArrayType) {
+                continue;
+            }
+            $type_set[$i] = $type->convertIntegerKeyArrayToList();
         }
         return $type_set;
     }

--- a/src/Phan/Output/Collector/BufferingCollector.php
+++ b/src/Phan/Output/Collector/BufferingCollector.php
@@ -2,6 +2,7 @@
 
 namespace Phan\Output\Collector;
 
+use Phan\Issue;
 use Phan\IssueInstance;
 use Phan\Output\Filter\AnyFilter;
 use Phan\Output\IssueCollectorInterface;
@@ -29,6 +30,21 @@ final class BufferingCollector implements IssueCollectorInterface
     }
 
     /**
+     * @var ?string - This is null unless debugging.
+     */
+    private static $trace_issues = null;
+
+    /**
+     * Ensure that backtraces with the cause of the emitted issue are printed to stderr.
+     * If null, stop emitting backtraces.
+     */
+    public static function setTraceIssues(?string $level) : void
+    {
+        self::$trace_issues = $level ? \strtolower($level) : null;
+    }
+
+
+    /**
      * Collect issue
      * @param IssueInstance $issue
      */
@@ -36,6 +52,15 @@ final class BufferingCollector implements IssueCollectorInterface
     {
         if (!$this->filter->supports($issue)) {
             return;
+        }
+        if (self::$trace_issues) {
+            if (self::$trace_issues === Issue::TRACE_VERBOSE) {
+                \phan_print_backtrace();
+            } else {
+                \ob_start();
+                \debug_print_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS);
+                \fwrite(\STDERR, (\ob_get_clean() ?: "failed to dump backtrace") . \PHP_EOL);
+            }
         }
 
         $this->issues[$this->formatSortableKey($issue)] = $issue;

--- a/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
@@ -287,7 +287,8 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
                 $passed_array_type = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $arg);
                 $types = $types->withUnionType($passed_array_type->genericArrayTypes());
             }
-            $types = $types->withFlattenedArrayShapeOrLiteralTypeInstances();
+            $types = $types->withFlattenedArrayShapeOrLiteralTypeInstances()
+                           ->withIntegerKeyArraysAsLists();
             if ($types->isEmpty()) {
                 $types = $types->withType($array_type);
             }

--- a/src/Phan/Plugin/Internal/MethodSearcherPlugin.php
+++ b/src/Phan/Plugin/Internal/MethodSearcherPlugin.php
@@ -329,8 +329,8 @@ final class MethodSearcherPlugin extends PluginV3 implements
 
     /**
      * Check if param_types contains unique types that can cast to search_param_types
-     * @param list<UnionType> $search_param_types
-     * @param list<UnionType> $signature_param_types
+     * @param array<int, UnionType> $search_param_types (array keys are removed from both params when this recursively calls itself)
+     * @param array<int, UnionType> $signature_param_types
      */
     public static function matchesParamTypes(CodeBase $code_base, array $search_param_types, array $signature_param_types) : float
     {

--- a/src/Phan/Plugin/Internal/RedundantConditionCallPlugin.php
+++ b/src/Phan/Plugin/Internal/RedundantConditionCallPlugin.php
@@ -71,7 +71,11 @@ final class RedundantConditionCallPlugin extends PluginV3 implements
                 if (!$union_type->hasRealTypeSet()) {
                     return;
                 }
-                $result = $checker($union_type->getRealUnionType()->withStaticResolvedInContext($context));
+                $real_union_type = $union_type->getRealUnionType()->withStaticResolvedInContext($context);
+                if ($real_union_type->hasMixedType()) {
+                    return;
+                }
+                $result = $checker($real_union_type);
                 if ($result === null) {
                     return;
                 }

--- a/tests/files/expected/0364_extended_array_analyze.php.expected
+++ b/tests/files/expected/0364_extended_array_analyze.php.expected
@@ -19,11 +19,11 @@
 %s:27 PhanTypeMismatchArgumentReal Argument 1 ($x) is associative-array<int,float> (real type ?associative-array<mixed,mixed>) but \p364() takes \stdClass defined at %s:45
 %s:28 PhanTypeMismatchArgumentReal Argument 1 ($x) is associative-array<int,float> (real type ?associative-array<mixed,mixed>) but \p364() takes \stdClass defined at %s:45
 %s:29 PhanTypeMismatchArgumentReal Argument 1 ($x) is associative-array<int,float> (real type ?associative-array<mixed,mixed>) but \p364() takes \stdClass defined at %s:45
-%s:30 PhanTypeMismatchArgument Argument 1 ($x) is array<int,int>|array<int,string> but \p364() takes \stdClass defined at %s:45
-%s:31 PhanTypeMismatchArgument Argument 1 ($x) is array<int,int>|array<int,string> but \p364() takes \stdClass defined at %s:45
+%s:30 PhanTypeMismatchArgument Argument 1 ($x) is list<int>|list<string> but \p364() takes \stdClass defined at %s:45
+%s:31 PhanTypeMismatchArgument Argument 1 ($x) is list<int>|list<string> but \p364() takes \stdClass defined at %s:45
 %s:32 PhanTypeMismatchArgumentReal Argument 1 ($x) is array<int,'val'>|array{0:2,1:4} (real type ?array) but \p364() takes \stdClass defined at %s:45
-%s:33 PhanTypeMismatchArgument Argument 1 ($x) is array<int,int>|array<int,string> but \p364() takes \stdClass defined at %s:45
-%s:34 PhanTypeMismatchArgument Argument 1 ($x) is array<int,int>|array<int,string> but \p364() takes \stdClass defined at %s:45
+%s:33 PhanTypeMismatchArgument Argument 1 ($x) is list<int>|list<string> but \p364() takes \stdClass defined at %s:45
+%s:34 PhanTypeMismatchArgument Argument 1 ($x) is list<int>|list<string> but \p364() takes \stdClass defined at %s:45
 %s:35 PhanTypeMismatchArgumentReal Argument 1 ($x) is array<int,\stdClass> (real type ?array) but \p364() takes \stdClass defined at %s:45
 %s:36 PhanTypeMismatchArgumentReal Argument 1 ($x) is associative-array<int,\stdClass> (real type ?associative-array<mixed,mixed>) but \p364() takes \stdClass defined at %s:45
 %s:37 PhanTypeMismatchArgumentReal Argument 1 ($x) is associative-array<int,\stdClass> (real type ?associative-array<mixed,mixed>) but \p364() takes \stdClass defined at %s:45

--- a/tests/files/expected/0478_array_reference_functions.php.expected
+++ b/tests/files/expected/0478_array_reference_functions.php.expected
@@ -1,5 +1,5 @@
 %s:9 PhanTypeMismatchArgumentInternal Argument 1 ($string) is non-empty-array<int,2>|non-empty-array<int,\stdClass>|non-empty-array<string,string> but \strlen() takes string
-%s:19 PhanTypeMismatchArgumentInternal Argument 1 ($string) is non-empty-array<int,2>|non-empty-array<int,\stdClass>|non-empty-array<string,string> but \strlen() takes string
+%s:19 PhanTypeMismatchArgumentInternal Argument 1 ($string) is non-empty-array<string,string>|non-empty-list<2>|non-empty-list<\stdClass> but \strlen() takes string
 %s:26 PhanTypeMismatchArgumentInternal Argument 1 ($string) is array<int,int> but \strlen() takes string
 %s:32 PhanTypeMismatchArgumentInternal Argument 1 ($string) is array<int,int> but \strlen() takes string
 %s:39 PhanTypeMismatchArgumentInternal Argument 1 ($string) is array<int,\stdClass>|array<int,int>|array<string,string> but \strlen() takes string

--- a/tests/files/expected/0796_possibly_empty_associative_array.php.expected
+++ b/tests/files/expected/0796_possibly_empty_associative_array.php.expected
@@ -1,0 +1,2 @@
+%s:8 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type associative-array<int,\stdClass>(real=associative-array<int,\stdClass>)
+%s:11 PhanTypeMismatchReturn Returning type non-empty-associative-array<int,\stdClass> but test_associative_array_possibly_empty() is declared to return ?list<\stdClass>

--- a/tests/files/src/0795_array_iteration.php
+++ b/tests/files/src/0795_array_iteration.php
@@ -1,0 +1,8 @@
+<?php
+namespace NS795\SubNS;
+/** @param array $points */
+function test($points) {
+    foreach ($points as $point) {
+        echo $point[1];
+    }
+}

--- a/tests/files/src/0796_possibly_empty_associative_array.php
+++ b/tests/files/src/0796_possibly_empty_associative_array.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * @return ?list<stdClass>
+ */
+function test_associative_array_possibly_empty(int $i, int $j) : ?array {
+    $x = [];
+    $x[$i] = new stdClass();
+    unset($x[$j]);
+    '@phan-debug-var $x';  // should not infer non-empty as a result of the unset statement.
+    if ($x) {
+        return $x;  // warns about returning associative-array instead of list
+    }
+    return null;
+}

--- a/tests/php74_files/expected/009_unpack_warnings.php.expected
+++ b/tests/php74_files/expected/009_unpack_warnings.php.expected
@@ -10,4 +10,3 @@
 %s:19 PhanTypeMismatchReturn Returning type array<int,array<string,object>> but expects_stringmap() is declared to return array<int,false>
 %s:20 PhanTypeMismatchReturn Returning type array<int,object> but expects_stringmap() is declared to return array<int,false>
 %s:20 PhanTypeMismatchUnpackKeyArraySpread When unpacking a value of type array<string,object>, the value's keys were of type string, but the keys should be integers
-%s:20 PhanTypeMismatchUnpackKey When unpacking a value of type array<string,object>, the value's keys were of type string, but the keys should be consecutive integers starting from 0

--- a/tests/php74_files/expected/021_associative_array_casting_rules.php.expected
+++ b/tests/php74_files/expected/021_associative_array_casting_rules.php.expected
@@ -1,0 +1,1 @@
+%s:11 PhanTypeMismatchUnpackKeyArraySpread When unpacking a value of type array<string,string>, the value's keys were of type string, but the keys should be integers

--- a/tests/php74_files/src/021_associative_array_casting_rules.php
+++ b/tests/php74_files/src/021_associative_array_casting_rules.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @param associative-array<int,string> $a
+ * @param associative-array<string,string> $b
+ */
+function test_cannot_pass_associative_to_list($a, $b) {
+    if (rand() % 2 === 0) {
+        // For php 7.4, this should not warn, this renumbers the keys
+        return [...$a];
+    }
+    return [...$b];
+}

--- a/tests/plugin_test/expected/159_array_unshift_convert_to_list.php.expected
+++ b/tests/plugin_test/expected/159_array_unshift_convert_to_list.php.expected
@@ -1,0 +1,2 @@
+src/159_array_unshift_convert_to_list.php:9 PhanTypeMismatchReturn Returning type non-empty-list<string> but test_unshift_converts_assoc_int_to_list() is declared to return associative-array<int,string>
+src/159_array_unshift_convert_to_list.php:18 PhanPartialTypeMismatchReturn Returning type non-empty-array<string,string>|non-empty-list<string> but test_unshift_doesnt_convert_assoc_string() is declared to return list<string> (non-empty-array<string,string> is incompatible)

--- a/tests/plugin_test/src/159_array_unshift_convert_to_list.php
+++ b/tests/plugin_test/src/159_array_unshift_convert_to_list.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @return associative-array<int,string>
+ */
+function test_unshift_converts_assoc_int_to_list(int $i) : array {
+    $values = [$i => "value $i"];
+    array_unshift($values, "before $i");
+    return $values;  // should warn, this is a list.
+}
+
+/**
+ * @return list<string>
+ */
+function test_unshift_doesnt_convert_assoc_string(int $i) : array {
+    $values = ["key $i" => "value $i"];
+    array_unshift($values, "before $i");
+    return $values;  // should warn, this is also an array with string keys
+}
+test_unshift_doesnt_convert_assoc_string(2);
+test_unshift_converts_assoc_int_to_list(3);


### PR DESCRIPTION
And fix false positives in redundant condition detection for `mixed`