### PR TITLE
Warn in more cases about useless branches

### DIFF
--- a/src/Phan/Analysis/BlockExitStatusChecker.php
+++ b/src/Phan/Analysis/BlockExitStatusChecker.php
@@ -230,21 +230,30 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
 
     /**
      * @return int the corresponding status code
+     * @suppress PhanTypeMismatchArgumentNullable
      */
     public function visitSwitch(Node $node) : int
     {
+        return $this->visitSwitchList($node->children['stmts']);
+    }
+
+    /**
+     * @return int the corresponding status code
+     * @suppress PhanTypeMismatchArgumentNullable
+     */
+    public function visitSwitchList(Node $node) : int {
         $status = $node->flags & self::STATUS_BITMASK;
         if ($status) {
             return $status;
         }
-        $status = $this->computeStatusOfSwitch($node);
+        $status = $this->computeStatusOfSwitchList($node);
         $node->flags = $status;
         return $status;
     }
 
-    private function computeStatusOfSwitch(Node $node) : int
+    private function computeStatusOfSwitchList(Node $node) : int
     {
-        $switch_stmt_case_nodes = $node->children['stmts']->children ?? [];
+        $switch_stmt_case_nodes = $node->children ?? [];
         if (\count($switch_stmt_case_nodes) === 0) {
             return self::STATUS_PROCEED;
         }

--- a/src/Phan/Language/Type/AssociativeArrayType.php
+++ b/src/Phan/Language/Type/AssociativeArrayType.php
@@ -9,6 +9,7 @@ use Phan\Language\Type;
  * @see GenericArrayType for representations of `string[]` and `array<int,bool>`
  * @see ArrayShapeType for representations of `array{key:MyClass}`
  * @see ArrayType for the representation of `array`
+ * @phan-pure
  */
 class AssociativeArrayType extends GenericArrayType
 {

--- a/src/Phan/Language/Type/BoolType.php
+++ b/src/Phan/Language/Type/BoolType.php
@@ -12,6 +12,7 @@ use Phan\Language\Type;
  *
  * @see TrueType
  * @see FalseType
+ * @phan-pure
  */
 final class BoolType extends ScalarType
 {

--- a/src/Phan/Language/Type/CallableArrayType.php
+++ b/src/Phan/Language/Type/CallableArrayType.php
@@ -9,6 +9,7 @@ use Phan\Language\UnionType;
 
 /**
  * Phan's representation of the type for `callable-array`.
+ * @phan-pure
  */
 class CallableArrayType extends ArrayType
 {

--- a/src/Phan/Language/Type/CallableDeclarationType.php
+++ b/src/Phan/Language/Type/CallableDeclarationType.php
@@ -6,6 +6,7 @@ use Phan\Language\Type;
 
 /**
  * Phan's representation for types such as `callable(MyClass):MyOtherClass`
+ * @phan-pure
  */
 final class CallableDeclarationType extends FunctionLikeDeclarationType implements CallableInterface
 {

--- a/src/Phan/Language/Type/CallableInterface.php
+++ b/src/Phan/Language/Type/CallableInterface.php
@@ -6,6 +6,7 @@ namespace Phan\Language\Type;
  * This is generated from phpdoc such as callable-string, callable, callable(int):void, etc.
  *
  * This does not include Closure types.
+ * @phan-pure
  */
 interface CallableInterface
 {

--- a/src/Phan/Language/Type/CallableObjectType.php
+++ b/src/Phan/Language/Type/CallableObjectType.php
@@ -10,6 +10,7 @@ use Phan\Language\Type;
  * Represents the type `callable-object` (an instance of an unspecified callable class)
  *
  * This includes Closures and classes with __invoke.
+ * @phan-pure
  */
 final class CallableObjectType extends ObjectType
 {

--- a/src/Phan/Language/Type/CallableStringType.php
+++ b/src/Phan/Language/Type/CallableStringType.php
@@ -11,6 +11,7 @@ use Phan\Language\UnionType;
  * Phan's representation for `callable-string`
  *
  * @see CallableDeclarationType for Phan's representation of `callable(MyClass):MyOtherClass`
+ * @phan-pure
  */
 final class CallableStringType extends StringType implements CallableInterface
 {

--- a/src/Phan/Language/Type/CallableType.php
+++ b/src/Phan/Language/Type/CallableType.php
@@ -10,6 +10,7 @@ use Phan\Language\Type;
  * Phan's representation for `callable`
  *
  * @see CallableDeclarationType for Phan's representation of `callable(MyClass):MyOtherClass`
+ * @phan-pure
  */
 final class CallableType extends NativeType implements CallableInterface
 {

--- a/src/Phan/Language/Type/ClassStringType.php
+++ b/src/Phan/Language/Type/ClassStringType.php
@@ -12,6 +12,7 @@ use Phan\Language\UnionType;
  * A type representing a string with an unknown value that is a fully qualified class name.
  *
  * Phan's representation for `class-string` and `class-string<T>`.
+ * @phan-pure
  */
 final class ClassStringType extends StringType
 {

--- a/src/Phan/Language/Type/ClosureDeclarationParameter.php
+++ b/src/Phan/Language/Type/ClosureDeclarationParameter.php
@@ -9,6 +9,7 @@ use Phan\Language\UnionType;
 
 /**
  * Not a type, but used by ClosureDeclarationType
+ * @phan-pure
  */
 final class ClosureDeclarationParameter
 {

--- a/src/Phan/Language/Type/ClosureDeclarationType.php
+++ b/src/Phan/Language/Type/ClosureDeclarationType.php
@@ -7,6 +7,7 @@ use Phan\Language\Type;
 /**
  * Phan's representation for annotations such as `Closure(MyClass):MyOtherClass`
  * @see ClosureType for the representation of `Closure` (and closures for function-like FQSENs)
+ * @phan-pure
  */
 final class ClosureDeclarationType extends FunctionLikeDeclarationType
 {

--- a/src/Phan/Language/Type/ClosureType.php
+++ b/src/Phan/Language/Type/ClosureType.php
@@ -12,6 +12,7 @@ use Phan\Language\Type;
 /**
  * Phan's representation of `Closure` and of closures associated with a given function-like's FQSEN
  * @see ClosureDeclarationType for representations created from PHPDoc `Closure(MyClass):MyOtherClass`.
+ * @phan-pure
  */
 final class ClosureType extends Type
 {
@@ -41,6 +42,7 @@ final class ClosureType extends Type
 
     /**
      * Create an instance of Closure for the FQSEN of the passed in function/closure/method $func with FQSEN $fqsen
+     * @suppress PhanAccessReadOnlyProperty this is acting on a clone
      */
     public static function instanceWithClosureFQSEN(FQSEN $fqsen, FunctionInterface $func = null) : ClosureType
     {

--- a/src/Phan/Language/Type/FalseType.php
+++ b/src/Phan/Language/Type/FalseType.php
@@ -12,6 +12,7 @@ use Phan\Language\Type;
  * Phan's representation of PHPDoc `false`
  * @see TrueType
  * @see BoolType
+ * @phan-pure
  */
 final class FalseType extends ScalarType
 {

--- a/src/Phan/Language/Type/FloatType.php
+++ b/src/Phan/Language/Type/FloatType.php
@@ -10,6 +10,7 @@ use Phan\Language\UnionType;
 
 /**
  * Phan's representation of the type for `float`
+ * @phan-pure
  */
 class FloatType extends ScalarType
 {

--- a/src/Phan/Language/Type/FunctionLikeDeclarationType.php
+++ b/src/Phan/Language/Type/FunctionLikeDeclarationType.php
@@ -21,6 +21,7 @@ use Phan\Language\UnionType;
 /**
  * Phan's base class for representations of `callable(MyClass):MyOtherClass` and `Closure(MyClass):MyOtherClass`
  * @phan-file-suppress PhanUnusedPublicMethodParameter
+ * @phan-pure
  */
 abstract class FunctionLikeDeclarationType extends Type implements FunctionInterface
 {

--- a/src/Phan/Language/Type/GenericArrayInterface.php
+++ b/src/Phan/Language/Type/GenericArrayInterface.php
@@ -6,6 +6,7 @@ use Phan\Language\UnionType;
 
 /**
  * This is generated from phpdoc such as array<string,mixed>, array{field:int}, etc.
+ * @phan-pure
  */
 interface GenericArrayInterface
 {

--- a/src/Phan/Language/Type/GenericArrayTemplateKeyType.php
+++ b/src/Phan/Language/Type/GenericArrayTemplateKeyType.php
@@ -10,6 +10,7 @@ use Phan\Language\UnionType;
 
 /**
  * A generic array type with a template as the key
+ * @phan-pure
  */
 class GenericArrayTemplateKeyType extends GenericArrayType
 {

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -21,6 +21,7 @@ use Phan\Language\UnionTypeBuilder;
  * Phan's representation for the types `array<string,MyClass>` and `MyClass[]`
  * @see ArrayShapeType for representations of `array{key:MyClass}`
  * @see ArrayType for the representation of `array`
+ * @phan-pure
  */
 class GenericArrayType extends ArrayType implements GenericArrayInterface
 {

--- a/src/Phan/Language/Type/GenericIterableType.php
+++ b/src/Phan/Language/Type/GenericIterableType.php
@@ -12,6 +12,7 @@ use function json_encode;
 
 /**
  * Phan's representation of the type `iterable<KeyType,ValueType>`
+ * @phan-pure
  */
 final class GenericIterableType extends IterableType
 {

--- a/src/Phan/Language/Type/GenericMultiArrayType.php
+++ b/src/Phan/Language/Type/GenericMultiArrayType.php
@@ -16,6 +16,7 @@ use Phan\Language\UnionTypeBuilder;
  * Callers should split this up into multiple GenericArrayType instances.
  *
  * This is generated from phpdoc `array<int, T1|T2>` where callers expect a subclass of Type.
+ * @phan-pure
  */
 final class GenericMultiArrayType extends ArrayType implements MultiType, GenericArrayInterface
 {
@@ -231,6 +232,8 @@ final class GenericMultiArrayType extends ArrayType implements MultiType, Generi
      * @return UnionType
      * A variation of this type that is not generic.
      * i.e. '(int|string)[]' becomes 'int|string'.
+     *
+     * @suppress PhanAccessReadOnlyProperty this is lazily instantiating a property.
      */
     public function genericArrayElementUnionType() : UnionType
     {

--- a/src/Phan/Language/Type/IntType.php
+++ b/src/Phan/Language/Type/IntType.php
@@ -10,6 +10,7 @@ use Phan\Language\UnionType;
 /**
  * Phan's representation of `int`
  * @see LiteralIntType for Phan's representation of specific integers
+ * @phan-pure
  */
 class IntType extends ScalarType
 {

--- a/src/Phan/Language/Type/ListType.php
+++ b/src/Phan/Language/Type/ListType.php
@@ -9,6 +9,7 @@ use Phan\Language\Type;
  * @see GenericArrayType for representations of `string[]` and `array<int,bool>`
  * @see ArrayShapeType for representations of `array{key:MyClass}`
  * @see ArrayType for the representation of `array`
+ * @phan-pure
  */
 class ListType extends GenericArrayType
 {

--- a/src/Phan/Language/Type/LiteralFloatType.php
+++ b/src/Phan/Language/Type/LiteralFloatType.php
@@ -8,6 +8,7 @@ use RuntimeException;
 
 /**
  * Phan's representation of the type for a specific float, e.g. `-1.2`
+ * @phan-pure
  */
 final class LiteralFloatType extends FloatType implements LiteralTypeInterface
 {

--- a/src/Phan/Language/Type/LiteralIntType.php
+++ b/src/Phan/Language/Type/LiteralIntType.php
@@ -8,6 +8,7 @@ use RuntimeException;
 
 /**
  * Phan's representation of the type for a specific integer, e.g. `-1`
+ * @phan-pure
  */
 final class LiteralIntType extends IntType implements LiteralTypeInterface
 {

--- a/src/Phan/Language/Type/LiteralStringType.php
+++ b/src/Phan/Language/Type/LiteralStringType.php
@@ -17,6 +17,7 @@ use const FILTER_VALIDATE_INT;
 
 /**
  * Phan's representation of the type for a specific string, e.g. `'a string'`
+ * @phan-pure
  */
 final class LiteralStringType extends StringType implements LiteralTypeInterface
 {

--- a/src/Phan/Language/Type/LiteralTypeInterface.php
+++ b/src/Phan/Language/Type/LiteralTypeInterface.php
@@ -5,6 +5,7 @@ namespace Phan\Language\Type;
 /**
  * Empty interface used by quick checks if a Type is a specific literal int/string.
  * @method mixed getValue()
+ * @phan-pure
  */
 interface LiteralTypeInterface
 {

--- a/src/Phan/Language/Type/MixedType.php
+++ b/src/Phan/Language/Type/MixedType.php
@@ -11,6 +11,7 @@ use Phan\Language\UnionType;
  * Represents the PHPDoc `mixed` type, which can cast to/from any type
  *
  * For purposes of analysis, there's usually no difference between mixed and nullable mixed.
+ * @phan-pure
  */
 final class MixedType extends NativeType
 {

--- a/src/Phan/Language/Type/MultiType.php
+++ b/src/Phan/Language/Type/MultiType.php
@@ -6,6 +6,7 @@ use Phan\Language\Type;
 
 /**
  * Callers should split this up into multiple Type instances.
+ * @phan-pure
  */
 interface MultiType
 {

--- a/src/Phan/Language/Type/NonEmptyAssociativeArrayType.php
+++ b/src/Phan/Language/Type/NonEmptyAssociativeArrayType.php
@@ -9,6 +9,7 @@ use Phan\Language\Type;
  * @see GenericArrayType for representations of `string[]` and `array<int,bool>`
  * @see ArrayShapeType for representations of `array{key:MyClass}`
  * @see ArrayType for the representation of `array`
+ * @phan-pure
  */
 final class NonEmptyAssociativeArrayType extends AssociativeArrayType
 {

--- a/src/Phan/Language/Type/NonEmptyGenericArrayType.php
+++ b/src/Phan/Language/Type/NonEmptyGenericArrayType.php
@@ -9,6 +9,7 @@ use Phan\Language\Type;
  * @see GenericArrayType for representations of `string[]` and `array<int,bool>`
  * @see ArrayShapeType for representations of `array{key:MyClass}`
  * @see ArrayType for the representation of `array`
+ * @phan-pure
  */
 final class NonEmptyGenericArrayType extends GenericArrayType
 {

--- a/src/Phan/Language/Type/NonEmptyListType.php
+++ b/src/Phan/Language/Type/NonEmptyListType.php
@@ -9,6 +9,7 @@ use Phan\Language\Type;
  * @see GenericArrayType for representations of `string[]` and `array<int,bool>`
  * @see ArrayShapeType for representations of `array{key:MyClass}`
  * @see ArrayType for the representation of `array`
+ * @phan-pure
  */
 final class NonEmptyListType extends ListType
 {

--- a/src/Phan/Language/Type/NullType.php
+++ b/src/Phan/Language/Type/NullType.php
@@ -10,6 +10,7 @@ use Phan\Language\UnionType;
 
 /**
  * Singleton representing the type `null`
+ * @phan-pure
  */
 final class NullType extends ScalarType
 {

--- a/src/Phan/Language/Type/ObjectType.php
+++ b/src/Phan/Language/Type/ObjectType.php
@@ -8,6 +8,7 @@ use Phan\Language\Type;
 
 /**
  * Represents the type `object` (an instance of an unspecified class)
+ * @phan-pure
  */
 class ObjectType extends NativeType
 {

--- a/src/Phan/Language/Type/ResourceType.php
+++ b/src/Phan/Language/Type/ResourceType.php
@@ -8,6 +8,7 @@ use Phan\Language\Type;
 
 /**
  * Represents the type `resource`
+ * @phan-pure
  */
 final class ResourceType extends NativeType
 {

--- a/src/Phan/Language/Type/ScalarRawType.php
+++ b/src/Phan/Language/Type/ScalarRawType.php
@@ -8,6 +8,7 @@ namespace Phan\Language\Type;
  *
  * This is used in the middle of parsing PHPDoc types,
  * but is quickly converted to bool|int|float|string once parsing is finished.
+ * @phan-pure
  */
 final class ScalarRawType extends ScalarType implements MultiType
 {

--- a/src/Phan/Language/Type/ScalarType.php
+++ b/src/Phan/Language/Type/ScalarType.php
@@ -11,6 +11,7 @@ use Phan\Language\UnionType;
 /**
  * The base class for various scalar types (BoolType, StringType, ScalarRawType,
  * NullType (null is technically not a scalar, but included), etc.
+ * @phan-pure
  */
 abstract class ScalarType extends NativeType
 {

--- a/src/Phan/Language/Type/SelfType.php
+++ b/src/Phan/Language/Type/SelfType.php
@@ -11,6 +11,7 @@ use Phan\Language\UnionType;
  * Represents the PHPDoc type `self`.
  * This is converted to a real class when necessary.
  * @see self::withStaticResolvedInContext()
+ * @phan-pure
  */
 final class SelfType extends StaticOrSelfType
 {

--- a/src/Phan/Language/Type/StaticOrSelfType.php
+++ b/src/Phan/Language/Type/StaticOrSelfType.php
@@ -9,6 +9,7 @@ use Phan\Language\Type;
  * Represents the PHPDoc type `self` or `static`.
  * This is converted to a real class when necessary.
  * @see self::withStaticResolvedInContext()
+ * @phan-pure
  */
 class StaticOrSelfType extends Type
 {

--- a/src/Phan/Language/Type/StaticType.php
+++ b/src/Phan/Language/Type/StaticType.php
@@ -12,6 +12,7 @@ use Phan\Language\UnionType;
  * Represents the PHPDoc type `static`.
  * This is converted to a real class when necessary.
  * @see self::withStaticResolvedInContext()
+ * @phan-pure
  */
 final class StaticType extends StaticOrSelfType
 {

--- a/src/Phan/Language/Type/StringType.php
+++ b/src/Phan/Language/Type/StringType.php
@@ -11,6 +11,7 @@ use Phan\Language\UnionType;
 /**
  * Represents the type `string`.
  * @see LiteralStringType for the representation of types for specific string literals
+ * @phan-pure
  */
 class StringType extends ScalarType
 {

--- a/src/Phan/Language/Type/TemplateType.php
+++ b/src/Phan/Language/Type/TemplateType.php
@@ -11,6 +11,7 @@ use Phan\Language\UnionType;
 /**
  * Represents a template type that has not yet been resolved.
  * @see https://github.com/phan/phan/wiki/Generic-Types
+ * @phan-pure
  */
 final class TemplateType extends Type
 {

--- a/src/Phan/Language/Type/TrueType.php
+++ b/src/Phan/Language/Type/TrueType.php
@@ -12,6 +12,7 @@ use Phan\Language\Type;
  * Represents the type `true`
  * @see BoolType
  * @see FalseType
+ * @phan-pure
  */
 final class TrueType extends ScalarType
 {

--- a/src/Phan/Language/Type/VoidType.php
+++ b/src/Phan/Language/Type/VoidType.php
@@ -10,6 +10,7 @@ use Phan\Language\UnionType;
 
 /**
  * Represents the return type `void`
+ * @phan-pure
  */
 final class VoidType extends NativeType
 {

--- a/tests/plugin_test/expected/160_useless_return.php.expected
+++ b/tests/plugin_test/expected/160_useless_return.php.expected
@@ -8,3 +8,6 @@ src/160_useless_return.php:37 PhanUnreferencedPublicMethod Possibly zero referen
 src/160_useless_return.php:41 PhanPluginNonBoolInLogicalArith Non bool value of type  in logical arithmetic
 src/160_useless_return.php:41 PhanPluginNumericalComparison numerical values compared by the operators '===' or '!=='
 src/160_useless_return.php:45 PhanUnusedReturnBranchWithoutSideEffects Possibly useless branch in a function where the return value must be used - all branches return values equivalent to true (previous return is at line 42)
+src/160_useless_return.php:62 PhanUnusedReturnBranchWithoutSideEffects Possibly useless branch in a function where the return value must be used - all branches return values equivalent to false (previous return is at line 60)
+src/160_useless_return.php:72 PhanUnusedReturnBranchWithoutSideEffects Possibly useless branch in a function where the return value must be used - all branches return values equivalent to (3 - 1) (previous return is at line 70)
+src/160_useless_return.php:84 PhanUnusedReturnBranchWithoutSideEffects Possibly useless branch in a function where the return value must be used - all branches return values equivalent to [PHP_VERSION] (previous return is at line 82)

--- a/tests/plugin_test/src/160_useless_return.php
+++ b/tests/plugin_test/src/160_useless_return.php
@@ -51,3 +51,37 @@ class Group {
         return false;
     }
 }
+
+function test_chain(string $x) : bool {
+    if (strtolower($x) === 'true') {
+        return true;
+    }
+    if (strtolower($x) === 'false') {
+        return false;
+    }
+    return false;
+}
+var_export(test_chain('true'));
+
+function test_chain2(string $x) : int {
+    if (strtolower($x) === 'zero') {
+        return 0;
+    } elseif (strtolower($x) === '1') {
+        return 1+1;
+    } else {
+        return 3-1;
+    }
+}
+var_export(test_chain2('true'));
+
+function test_chain3(string $x) : ?array {
+    switch ($x) {
+    case 'zero':
+        return null;
+    case 'one':
+        return [PHP_VERSION];
+    default:
+        return [PHP_VERSION];
+    }
+}
+var_export(test_chain3('true'));


### PR DESCRIPTION
And add phan-pure to subclasses of Type,
to make unused branches more obvious.