### PR TITLE
Fix slow line number calculation of diagnostics for polyfill parser

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,7 @@ New features(Analysis):
 
   This requires that `UseReturnValuePlugin` be enabled and works best when `'plugin_config' => ['infer_pure_methods' => true]` is set.
 + Allow `list<X>` to cast to `array{0:X, 1?:X}` (#3390)
++ Speed up computing line numbers of diagnostics in the polyfill/fallback parser when there are multiple diagnostics.
 
 Oct 13 2019, Phan 2.3.0
 -----------------------

--- a/src/Phan/Library/StringUtil.php
+++ b/src/Phan/Library/StringUtil.php
@@ -61,6 +61,10 @@ class StringUtil
      */
     public static function asSingleLineUtf8(string $str) : string
     {
+        if (!\preg_match("@[\\n\\r\x80-\xff]@", $str)) {
+            // Around 5x faster for the common case of being ASCII without newlines.
+            return $str;
+        }
         return \str_replace(["\n", "\r"], "�", self::asUtf8($str));
     }
 }


### PR DESCRIPTION
And don't bother tokenizing third party files to check for suppressions if Issue::maybeEmit would have excluded them.