### PR TITLE
Emit more specific PhanCoalescingNeverNull.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@ Phan NEWS
 New features(Analysis):
 + Fix edge cases in checking if some nullable types were possibly falsey
   (`?true` and literal floats (e.g. `?1.1`))
++ Emit `PhanCoalescingNeverNull` instead of `PhanCoalescingNeverNullIn*`
+  if it's impossible for the node kind to be null. (#3386)
 
 Oct 20 2019, Phan 2.3.1
 -----------------------

--- a/src/Phan/Analysis/RedundantCondition.php
+++ b/src/Phan/Analysis/RedundantCondition.php
@@ -68,8 +68,15 @@ class RedundantCondition
      * @param list<mixed> $issue_args
      * @param Closure(UnionType):bool $is_still_issue
      */
-    public static function emitInstance($node, CodeBase $code_base, Context $context, string $issue_name, array $issue_args, Closure $is_still_issue) : void
-    {
+    public static function emitInstance(
+        $node,
+        CodeBase $code_base,
+        Context $context,
+        string $issue_name,
+        array $issue_args,
+        Closure $is_still_issue,
+        bool $dont_specialize_issue = false
+    ) : void {
         if ($context->isInLoop() && $node instanceof Node) {
             $type_fetcher = self::getLoopNodeTypeFetcher($code_base, $node);
             if ($type_fetcher) {
@@ -90,10 +97,13 @@ class RedundantCondition
                 return;
             }
         }
+        if (!$dont_specialize_issue) {
+            $issue_name = RedundantCondition::chooseSpecificImpossibleOrRedundantIssueKind($node, $context, $issue_name);
+        }
         Issue::maybeEmit(
             $code_base,
             $context,
-            RedundantCondition::chooseSpecificImpossibleOrRedundantIssueKind($node, $context, $issue_name),
+            $issue_name,
             $node->lineno ?? $context->getLineNumberStart(),
             ...$issue_args
         );

--- a/tests/files/expected/0708_loop_issue_examples.php.expected
+++ b/tests/files/expected/0708_loop_issue_examples.php.expected
@@ -1,9 +1,11 @@
 %s:9 PhanCoalescingAlwaysNullInLoop Using $x of type null as the left hand side of a null coalescing (??) operation. The left hand side may be unnecessary. (in a loop body - this is likely a false positive)
+%s:12 PhanCoalescingNeverNull Using non-null (unknown) of type Closure():'never called' as the left hand side of a null coalescing (??) operation. The right hand side may be unnecessary.
 %s:15 PhanCoalescingNeverNull Using non-null $varInLoop of type 2.3 as the left hand side of a null coalescing (??) operation. The right hand side may be unnecessary.
 %s:17 PhanCoalescingNeverNullInLoop Using non-null $y of type 2|3 as the left hand side of a null coalescing (??) operation. The right hand side may be unnecessary. (in a loop body - this is likely a false positive)
 %s:18 PhanImpossibleConditionInLoop Impossible attempt to cast $x of type null to truthy in a loop body (may be a false positive)
 %s:24 PhanCoalescingNeverNullInLoop Using non-null $varInLoop of type 2.3 as the left hand side of a null coalescing (??) operation. The right hand side may be unnecessary. (in a loop body - this is likely a false positive)
 %s:28 PhanCoalescingAlwaysNullInGlobalScope Using $nullVarInGlobalScope of type null as the left hand side of a null coalescing (??) operation. The left hand side may be unnecessary. (in the global scope - this is likely a false positive)
 %s:29 PhanCoalescingAlwaysNull Using null of type null as the left hand side of a null coalescing (??) operation. The left hand side may be unnecessary.
-%s:30 PhanCoalescingNeverNullInGlobalScope Using non-null $zeroInGlobalScope of type 0 as the left hand side of a null coalescing (??) operation. The right hand side may be unnecessary. (in the global scope - this is likely a false positive)
+%s:30 PhanCoalescingNeverNull Using non-null $zeroInGlobalScope of type 0 as the left hand side of a null coalescing (??) operation. The right hand side may be unnecessary.
 %s:31 PhanImpossibleTypeComparisonInGlobalScope Impossible attempt to check if $zeroInGlobalScope of type 0 is identical to $nullVarInGlobalScope of type null in the global scope (likely a false positive)
+%s:32 PhanCoalescingNeverNull Using non-null __LINE__ of type 32 as the left hand side of a null coalescing (??) operation. The right hand side may be unnecessary.

--- a/tests/files/src/0708_loop_issue_examples.php
+++ b/tests/files/src/0708_loop_issue_examples.php
@@ -9,8 +9,8 @@ function test_in_loop() {
         $value = $x ?? $y;
         echo "Found $value\n";
         $x = null;
+        var_export(function () { return 'never called'; } ?? 'default');  // This is definitely non-null whether it's in a loop or not.
     }
-
     $varInLoop = 2.3;
     echo $varInLoop ?? 'blah';
     foreach ([2, 3] as $y) {
@@ -29,3 +29,4 @@ echo $nullVarInGlobalScope ?? "default";  // PhanCoalescingAlwaysNullInGlobalSco
 echo null ?? rand(0,2);  // PhanCoalescingAlwaysNull
 echo $zeroInGlobalScope ?? rand(0,2);  // PhanCoalescingNeverNullInGlobalScope
 var_export($zeroInGlobalScope === $nullVarInGlobalScope);  // PhanImpossibleTypeComparisonInGlobalScope
+var_export(__LINE__ ?? 'default');  // This is definitely non-null whether it's in the global scope or not.


### PR DESCRIPTION
Don't emit the weaker issue types if the node kind is never null.

Fixes #3386