### PR TITLE
Support mixin and phan-mixin phpdoc annotations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,10 @@ New features(CLI, Configs):
 
 New features(Analysis):
 + Suggest similarly named static methods and static properties for `PhanUndeclaredConstant` issues on class constants. (#3393)
++ Support `@mixin` (and an alias `@phan-mixin`) as a way to load public methods and public instance properties
+  as magic methods and magic properties from another classlike. (#3237)
+
+  Attempts to parse or analyze mixins can be disabled by setting `read_mixin_annotations` to `false` in your Phan config.
 + Support `@readonly` as an alias of the `@phan-read-only` annotation.
 
 Bug fixes:

--- a/internal/Phan-Config-Settings.md
+++ b/internal/Phan-Config-Settings.md
@@ -561,6 +561,15 @@ Note: [`read_type_annotations`](#read_type_annotations) must also be enabled.
 
 (Default: `true`)
 
+## read_mixin_annotations
+
+If disabled, Phan will not read docblock type
+annotation comments for `@mixin`.
+
+Note: [`read_type_annotations`](#read_type_annotations) must also be enabled.
+
+(Default: `true`)
+
 ## read_type_annotations
 
 If disabled, Phan will not read docblock type

--- a/internal/update_wiki_config_types.php
+++ b/internal/update_wiki_config_types.php
@@ -90,6 +90,7 @@ class ConfigEntry
         'enable_class_alias_support' => self::CATEGORY_ANALYSIS,
         'read_magic_property_annotations' => self::CATEGORY_ANALYSIS,
         'read_magic_method_annotations' => self::CATEGORY_ANALYSIS,
+        'read_mixin_annotations' => self::CATEGORY_ANALYSIS,
         'read_type_annotations' => self::CATEGORY_ANALYSIS,
         'warn_about_undocumented_throw_statements' => self::CATEGORY_ANALYSIS,
         'warn_about_undocumented_exceptions_thrown_by_invoked_functions' => self::CATEGORY_ANALYSIS,

--- a/src/Phan/Analysis/Analyzable.php
+++ b/src/Phan/Analysis/Analyzable.php
@@ -69,6 +69,15 @@ trait Analyzable
     }
 
     /**
+     * Clears the node so that it won't be used for analysis.
+     * @suppress PhanTypeMismatchProperty
+     */
+    protected function clearNode() : void
+    {
+        $this->node = null;
+    }
+
+    /**
      * Ensure that annotations about what flags a function declaration has have been added
      * @suppress PhanUndeclaredProperty deliberately using dynamic properties
      */

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -537,6 +537,12 @@ class Config
         'read_magic_method_annotations' => true,
 
         // If disabled, Phan will not read docblock type
+        // annotation comments for `@mixin`.
+        //
+        // Note: `read_type_annotations` must also be enabled.
+        'read_mixin_annotations' => true,
+
+        // If disabled, Phan will not read docblock type
         // annotation comments (such as for `@return`, `@param`,
         // `@var`, `@suppress`, `@deprecated`) and only rely on
         // types expressed in code.

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -244,6 +244,7 @@ class Issue
     const DivisionByZero = 'PhanDivisionByZero';
     const ModuloByZero = 'PhanModuloByZero';
     const PowerOfZero = 'PhanPowerOfZero';
+    const InvalidMixin = 'PhanInvalidMixin';
 
     // Issue::CATEGORY_ANALYSIS
     const Unanalyzable              = 'PhanUnanalyzable';
@@ -2517,6 +2518,14 @@ class Issue
                 'Attempting to exponentiate a value to a power of {CODE} of type {TYPE} (the result will always be 1)',
                 self::REMEDIATION_B,
                 10147
+            ),
+            new Issue(
+                self::InvalidMixin,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_LOW,
+                'Attempting to use a mixin of invalid or missing type {TYPE}',
+                self::REMEDIATION_B,
+                10152
             ),
             // Issue::CATEGORY_VARIABLE
             new Issue(

--- a/src/Phan/Language/Element/Comment.php
+++ b/src/Phan/Language/Element/Comment.php
@@ -154,6 +154,12 @@ class Comment
     protected $param_assertion_map = [];
 
     /**
+     * @var list<Type>
+     * A list of mixins used by this class
+     */
+    protected $mixin_types = [];
+
+    /**
      * A private constructor meant to ingest a parsed comment
      * docblock.
      *
@@ -345,6 +351,9 @@ class Comment
             case 'inherits':
             case 'extends':
                 $this->inherited_type = $value;
+                return;
+            case 'mixin':
+                $this->mixin_types = $value;
                 return;
         }
     }
@@ -587,6 +596,15 @@ class Comment
     public function getInheritedTypeOption() : Option
     {
         return $this->inherited_type;
+    }
+
+    /**
+     * @return list<Type>
+     * An optional type declaring the mixins used by a class.
+     */
+    public function getMixinTypes() : array
+    {
+        return $this->mixin_types;
     }
 
     /**

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -363,6 +363,30 @@ class Method extends ClassElement implements FunctionInterface
     }
 
     /**
+     * Convert this method to a method from phpdoc.
+     * Used when importing methods with mixins.
+     *
+     * Precondition: This is not a magic method
+     */
+    public function asPHPDocMethod(Clazz $class) : Method
+    {
+        $method = clone($this);
+        $method->setFlags($method->getFlags() & (
+            ast\flags\MODIFIER_PUBLIC |
+            ast\flags\MODIFIER_PROTECTED |
+            ast\flags\MODIFIER_PRIVATE |
+            ast\flags\MODIFIER_STATIC
+        ));  // clear MODIFIER_ABSTRACT and other flags
+
+        // TODO: Handle template. Possibly support @mixin Foo<stdClass, bool> and resolve methods.
+        // $method->setPhanFlags(Flags::IS_FROM_PHPDOC);
+        $method->clearNode();
+        // Set the new FQSEN but keep the defining FQSEN
+        $method->setFQSEN(FullyQualifiedMethodName::make($class->getFQSEN(), $method->getName()));
+        return $method;
+    }
+
+    /**
      * @param Clazz $clazz - The class to treat as the defining class of the alias. (i.e. the inheriting class)
      * @param string $alias_method_name - The alias method name.
      * @param int $new_visibility_flags (0 if unchanged)

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -549,6 +549,7 @@ class Type
      * @param list<UnionType> $template_parameter_type_list
      * A map from a template type identifier to a
      * concrete union type
+     * @phan-side-effect-free
      */
     public static function fromType(
         Type $type,
@@ -567,6 +568,7 @@ class Type
      * @param mixed $object
      * @return Type
      * Get a type for the given object. Equivalent to Type::fromObject($object)->asNonLiteralType()
+     * @phan-side-effect-free
      */
     public static function nonLiteralFromObject($object) : Type
     {
@@ -591,6 +593,7 @@ class Type
      * Get a type for the given object
      * @param mixed $object
      * @throws AssertionError if the type was unexpected
+     * @phan-side-effect-free
      */
     public static function fromObject($object) : Type
     {
@@ -624,6 +627,7 @@ class Type
      * If $object is an array, return an ArrayShapeType (with nested fields) instead of an ArrayType
      * @param mixed $object
      * @throws AssertionError if the type was unexpected
+     * @phan-side-effect-free
      */
     public static function fromObjectExtended($object) : Type
     {
@@ -637,6 +641,7 @@ class Type
      * Get a type for the given array as an array shape, recursively.
      * @param array<mixed,mixed> $array
      * @throws AssertionError if the type was unexpected
+     * @phan-side-effect-free
      */
     public static function fromArray(array $array) : ArrayShapeType
     {
@@ -669,6 +674,7 @@ class Type
      * Get a type for the given type name
      *
      * @throws AssertionError if the type was unexpected
+     * @phan-side-effect-free
      */
     public static function fromInternalTypeName(
         string $type_name,
@@ -776,6 +782,7 @@ class Type
      * @param bool $is_nullable
      * True if this type can be null, false if it cannot
      * be null.
+     * @phan-side-effect-free
      */
     public static function fromNamespaceAndName(
         string $namespace,
@@ -787,6 +794,7 @@ class Type
 
     /**
      * Converts the reflection type to a string that Phan can understand
+     * @phan-side-effect-free
      */
     public static function stringFromReflectionType(
         ?\ReflectionType $reflection_type
@@ -807,6 +815,7 @@ class Type
 
     /**
      * Creates a type for the ReflectionType of a parameter, return value, etc.
+     * @phan-side-effect-free
      */
     public static function fromReflectionType(
         \ReflectionType $reflection_type
@@ -830,6 +839,7 @@ class Type
      * @throws InvalidArgumentException if type name was invalid
      *
      * @throws FQSENException
+     * @phan-side-effect-free
      */
     public static function fromFullyQualifiedString(
         string $fully_qualified_string
@@ -1191,6 +1201,7 @@ class Type
      * Parse a type from the given string
      *
      * @suppress PhanPossiblyFalseTypeArgument, PhanPossiblyFalseTypeArgumentInternal
+     * @phan-side-effect-free
      */
     public static function fromStringInContext(
         string $string,
@@ -2055,6 +2066,8 @@ class Type
      * @return bool
      * True if the given type references the class context
      * in which it exists such as 'self' or 'parent'
+     *
+     * @phan-side-effect-free
      */
     public static function isSelfTypeString(
         string $type_string
@@ -2071,6 +2084,8 @@ class Type
      * @return bool
      * True if the given type references the class context
      * in which it exists is '$this' or 'static'
+     *
+     * @phan-side-effect-free
      */
     public static function isStaticTypeString(
         string $type_string
@@ -3331,6 +3346,8 @@ class Type
      *
      * @return string
      * A canonical name for the given type name
+     *
+     * @phan-side-effect-free
      */
     public static function canonicalNameFromName(
         string $name
@@ -3728,6 +3745,7 @@ class Type
      * @param int|string|float|bool|null $b
      * @param int $flags
      * @internal
+     * @phan-side-effect-free
      */
     public static function performComparison($a, $b, int $flags) : bool
     {
@@ -3761,6 +3779,7 @@ class Type
      * Returns the Type for \Traversable
      *
      * @suppress PhanThrowTypeAbsentForCall
+     * @phan-side-effect-free
      */
     public static function traversableInstance() : Type
     {
@@ -3772,6 +3791,7 @@ class Type
      * Returns the Type for \Throwable
      *
      * @suppress PhanThrowTypeAbsentForCall
+     * @phan-side-effect-free
      */
     public static function throwableInstance() : Type
     {
@@ -3783,6 +3803,7 @@ class Type
      * Returns the Type for \Countable
      *
      * @suppress PhanThrowTypeAbsentForCall
+     * @phan-side-effect-free
      */
     public static function countableInstance() : Type
     {

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -232,6 +232,7 @@ class ParseVisitor extends ScopeVisitor
             if ($inherited_type_option->isDefined()) {
                 $class->setParentType($inherited_type_option->get());
             }
+            $class->setMixinTypes($comment->getMixinTypes());
 
             // Add any implemented interfaces
             foreach ($node->children['implements']->children ?? [] as $name_node) {

--- a/tests/files/expected/0301_comment_checks.php.expected
+++ b/tests/files/expected/0301_comment_checks.php.expected
@@ -11,7 +11,6 @@
 %s:26 PhanInvalidCommentForDeclarationType The phpdoc comment for @phan-forbid-undeclared-magic-properties cannot occur on a method
 %s:27 PhanInvalidCommentForDeclarationType The phpdoc comment for @property cannot occur on a method
 %s:28 PhanInvalidCommentForDeclarationType The phpdoc comment for @method cannot occur on a method
-%s:28 PhanUnextractableAnnotation Saw unextractable annotation for comment '* @method int $wrongPlaceForMethod'
 %s:35 PhanUnextractableAnnotation Saw unextractable annotation for comment '* @param'
 %s:36 PhanUnextractableAnnotation Saw unextractable annotation for comment '* @param <>$x $x (not parsable)'
 %s:42 PhanUnextractableAnnotation Saw unextractable annotation for comment '* @param <'

--- a/tests/files/expected/0806_mixin.php.expected
+++ b/tests/files/expected/0806_mixin.php.expected
@@ -1,0 +1,14 @@
+%s:17 PhanTypeMismatchReturn Returning type string but getPrivate() is declared to return int
+%s:39 PhanInvalidMixin Attempting to use a mixin of invalid or missing type \Missing
+%s:39 PhanInvalidMixin Attempting to use a mixin of invalid or missing type \NSMixin\Missing2
+%s:43 PhanUndeclaredMethod Call to undeclared method \NSMixin\MyClass::getMissing
+%s:44 PhanUndeclaredMethod Call to undeclared method \NSMixin\MyClass::getPrivate
+%s:46 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($obj) is int but \spl_object_hash() takes object
+%s:46 PhanTypeMismatchArgumentReal Argument 1 ($path) is null but \NSMixin\MyClass::getAttr() takes string defined at %s:8
+%s:48 PhanParamTooMany Call with 1 arg(s) to \NSMixin\MyClass::setAbc() which only takes 0 arg(s) defined at %s:11
+%s:49 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is string but \intdiv() takes int
+%s:51 PhanUndeclaredProperty Reference to undeclared property \NSMixin\MyClass->privateInstanceProp
+%s:53 PhanUndeclaredStaticProperty Static property 'staticProp' on \NSMixin\MyClass is undeclared
+%s:54 PhanUndeclaredInvokeInCallable Possible attempt to access missing magic method __invoke of '\NSMixin\MyClass'
+%s:55 PhanParamTooFew Call with 0 arg(s) to \NSMixin\MyClass::static_method(int $i) which requires 1 arg(s) defined at %s:19
+%s:56 PhanUndeclaredStaticMethod Static call to undeclared method \NSMixin\MyClass::static_mathod (Did you mean expr::static_method())

--- a/tests/files/src/0806_mixin.php
+++ b/tests/files/src/0806_mixin.php
@@ -1,0 +1,56 @@
+<?php
+namespace NSMixin;
+
+/**
+ * @phan-pure
+ */
+interface Test {
+    public function getAttr(string $path) : int;
+}
+class Other {
+    public function setAbc() : void {
+        echo "In abc\n";
+    }
+
+    // Private methods are not exposed by Phan's implementation of mixin.
+    private function getPrivate(string $fields) : int {
+        return "private $fields";
+    }
+    public static function static_method(int $i) : void {}
+    public function __invoke(string $method, array $args) {
+        return [$method, $args];
+    }
+    /** @var string */
+    public $instanceProp = 'in';
+    /** @var string */
+    private $privateInstanceProp = 'xyz';
+    /** @var bool */
+    public static $staticProp = false;
+}
+
+/**
+ * @mixin Test
+ * @mixin \Missing should warn
+ * @mixin Missing2 should warn
+ * @phan-mixin Other this is an alias of (at)mixin
+ * @phan-forbid-undeclared-magic-methods
+ * @phan-forbid-undeclared-magic-properties
+ */
+class MyClass {
+    // Assume this defines __call and __callStatic and __get
+}
+$m = new MyClass();
+$m->getMissing('xyz');
+$m->getPrivate('xyz');
+// Phan assumes the param/return types are exactly what the implementation that was referred to uses.
+echo spl_object_hash($m->getAttr(null));
+$m->getAttr('xyz');
+$m->setAbc('xyz');
+echo intdiv($m->instanceProp, 2);
+// Should not take private or protected properties
+echo intdiv($m->privateInstanceProp, 2);
+// Should warn about the property not existing
+echo intdiv(MyClass::$staticProp, 2);
+$m();
+MyClass::static_method();
+MyClass::static_mathod();  // Should suggest typo fixes


### PR DESCRIPTION
Support `@mixin` (and an alias `@phan-mixin`) as a way to load public methods
and public instance properties as magic methods and magic properties
from another classlike.

Attempts to parse or analyze mixins can be disabled by setting
`read_mixin_annotations` to `false` in your Phan config.

Fixes #3237