### PR TITLE
Type check even when emitting PhanUndeclaredFunction

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -452,10 +452,14 @@ return [
         'sysvshm'     => '.phan/internal_stubs/sysvshm.phan_php',
     ],
 
-    // Set this to false to emit PhanUndeclaredFunction issues for internal functions that Phan has signatures for,
-    // but aren't available in the codebase, or the internal functions used to run phan (may lead to false positives if an extension isn't loaded)
+    // Set this to false to emit `PhanUndeclaredFunction` issues for internal functions that Phan has signatures for,
+    // but aren't available in the codebase, or from Reflection.
+    // (may lead to false positives if an extension isn't loaded)
+    //
     // If this is true(default), then Phan will not warn.
-    // Also see 'autoload_internal_extension_signatures' for an alternative way to fix this type of issue.
+    //
+    // Even when this is false, Phan will still infer return values and check parameters of internal functions
+    // if Phan has the signatures.
     'ignore_undeclared_functions_with_known_signatures' => false,
 
     'plugin_config' => [

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,10 @@ New features(Analysis):
 + Support `@readonly` as an alias of the `@phan-read-only` annotation.
 + Also emit `PhanImpossibleTypeComparison` for `int === float` checks. (#3106)
 + Emit `PhanSuspiciousMagicConstant` when using `__METHOD__` in a function instead of a method.
++ Check return types and parameter types of global functions which Phan has signatures for,
+  when `ignore_undeclared_functions_with_known_signatures` is `false` and `PhanUndeclaredFunction` is emitted. (#3441)
+
+  Previously, Phan would emit `PhanUndeclaredFunction` without checking param or return types.
 
 Bug fixes:
 + Fix a bug where global functions, closures, and arrow functions may have inferred values from previous analysis unintentionally

--- a/internal/Phan-Config-Settings.md
+++ b/internal/Phan-Config-Settings.md
@@ -351,10 +351,13 @@ Phan will not assume it knows specific types if the default value is `false` or 
 ## ignore_undeclared_functions_with_known_signatures
 
 Set this to false to emit `PhanUndeclaredFunction` issues for internal functions that Phan has signatures for,
-but aren't available in the codebase, or the internal functions used to run Phan
+but aren't available in the codebase, or from Reflection.
 (may lead to false positives if an extension isn't loaded)
 
 If this is true(default), then Phan will not warn.
+
+Even when this is false, Phan will still infer return values and check parameters of internal functions
+if Phan has the signatures.
 
 (Default: `true`)
 

--- a/src/Phan/AST/InferPureVisitor.php
+++ b/src/Phan/AST/InferPureVisitor.php
@@ -468,7 +468,7 @@ class InferPureVisitor extends AnalysisVisitor
                 $this->code_base,
                 $this->context,
                 $expr
-            ))->getFunctionFromNode();
+            ))->getFunctionFromNode(true);
 
             foreach ($function_list_generator as $function) {
                 $this->checkCalledFunction($node, $function);

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -2373,7 +2373,7 @@ class UnionTypeVisitor extends AnalysisVisitor
             $this->code_base,
             $this->context,
             $expression
-        ))->getFunctionFromNode();
+        ))->getFunctionFromNode(true);
 
         $possible_types = null;
         foreach ($function_list_generator as $function) {

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -2000,11 +2000,13 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
     {
         $expression = $node->children['expr'];
         try {
+            // Get the function.
+            // If the function is undefined, always try to create a placeholder from Phan's type signatures for internal functions so they can still be type checked.
             $function_list_generator = (new ContextNode(
                 $this->code_base,
                 $this->context,
                 $expression
-            ))->getFunctionFromNode();
+            ))->getFunctionFromNode(true);
 
             foreach ($function_list_generator as $function) {
                 // Check the call for parameter and argument types

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -764,10 +764,13 @@ class Config
         ],
 
         // Set this to false to emit `PhanUndeclaredFunction` issues for internal functions that Phan has signatures for,
-        // but aren't available in the codebase, or the internal functions used to run Phan
+        // but aren't available in the codebase, or from Reflection.
         // (may lead to false positives if an extension isn't loaded)
         //
         // If this is true(default), then Phan will not warn.
+        //
+        // Even when this is false, Phan will still infer return values and check parameters of internal functions
+        // if Phan has the signatures.
         'ignore_undeclared_functions_with_known_signatures' => true,
 
         // If a file to be analyzed can't be parsed,

--- a/tests/real_types_test/.phan/config.php
+++ b/tests/real_types_test/.phan/config.php
@@ -136,4 +136,14 @@ return [
         'WhitespacePlugin',
         'UnknownElementTypePlugin',
     ],
+
+    // Set this to false to emit `PhanUndeclaredFunction` issues for internal functions that Phan has signatures for,
+    // but aren't available in the codebase, or from Reflection.
+    // (may lead to false positives if an extension isn't loaded)
+    //
+    // If this is true(default), then Phan will not warn.
+    //
+    // Even when this is false, Phan will still infer return values and check parameters of internal functions
+    // if Phan has the signatures.
+    'ignore_undeclared_functions_with_known_signatures' => false,
 ];

--- a/tests/real_types_test/expected/006_type_check_undeclared_function.php.expected
+++ b/tests/real_types_test/expected/006_type_check_undeclared_function.php.expected
@@ -1,0 +1,6 @@
+src/006_type_check_undeclared_function.php:6 PhanParamTooManyInternal Call with 1 arg(s) to \xdebug_get_stack_depth() which only takes 0 arg(s)
+src/006_type_check_undeclared_function.php:6 PhanTypeMismatchArgumentInternal Argument 1 ($obj) is int but \spl_object_hash() takes object
+src/006_type_check_undeclared_function.php:6 PhanUndeclaredFunction Call to undeclared function \xdebug_get_stack_depth()
+src/006_type_check_undeclared_function.php:9 PhanParamTooManyInternal Call with 1 arg(s) to \xdebug_get_stack_depth() which only takes 0 arg(s)
+src/006_type_check_undeclared_function.php:9 PhanTypeMismatchArgumentInternal Argument 1 ($obj) is int but \spl_object_hash() takes object
+src/006_type_check_undeclared_function.php:9 PhanUndeclaredFunction Call to undeclared function \xdebug_get_stack_depth()

--- a/tests/real_types_test/src/006_type_check_undeclared_function.php
+++ b/tests/real_types_test/src/006_type_check_undeclared_function.php
@@ -1,0 +1,10 @@
+<?php
+// 1. Should infer the return type
+// 2. Should warn that the parameters would be invalid
+// 3. Should warn that xdebug is undefined due to ignore_undeclared_functions_with_known_signatures being false (This test should restart itself without xdebug if that was loaded)
+namespace {
+    echo spl_object_hash(xdebug_get_stack_depth('stack'));
+}
+namespace My\Project {
+    echo spl_object_hash(xdebug_get_stack_depth('stack'));
+}


### PR DESCRIPTION
This only applies to functions that Phan has signatures for,
when ignore_undeclared_functions_with_known_signatures is false.

Fixes #3441