### PR TITLE
Infer some functions cause possibly empty arrays

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,7 @@ New features(Analysis):
 + Convert to `list` or `associative-array` in `sort`/`asort` in more edge cases.
 + Infer that `sort`/`asort` on an array (and other internal functions using references) returns a real `list` or `associative-array`.
   Infer that `sort`/`asort` on a non-empty array (and other internal functions using references) returns a real `non-empty-list` or `non-empty-associative-array`.
++ Infer that some array operations (`array_reduce`, `array_filter`, etc.) result in `array` instead of `non-empty-array` (etc.)
 
 Bug fixes:
 + Fix a bug where global functions, closures, and arrow functions may have inferred values from previous analysis unintentionally

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -377,6 +377,9 @@ class Method extends ClassElement implements FunctionInterface
             ast\flags\MODIFIER_PRIVATE |
             ast\flags\MODIFIER_STATIC
         ));  // clear MODIFIER_ABSTRACT and other flags
+        $method->setPhanFlags(
+            ($method->getPhanFlags() | Flags::IS_FROM_PHPDOC) & ~(Flags::IS_OVERRIDDEN_BY_ANOTHER | Flags::IS_OVERRIDE)
+        );
 
         // TODO: Handle template. Possibly support @mixin Foo<stdClass, bool> and resolve methods.
         // $method->setPhanFlags(Flags::IS_FROM_PHPDOC);

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -1181,6 +1181,12 @@ final class EmptyUnionType extends UnionType
     }
 
     /** @override */
+    public function withPossiblyEmptyArrays() : UnionType
+    {
+        return $this;
+    }
+
+    /** @override */
     public function withFlattenedTopLevelArrayShapeTypeInstances() : UnionType
     {
         return $this;

--- a/src/Phan/Language/Internal/FunctionSignatureMapReal.php
+++ b/src/Phan/Language/Internal/FunctionSignatureMapReal.php
@@ -205,7 +205,7 @@ return [
 'exif_tagname' => '?false|?string',
 'exif_thumbnail' => '?false|?string',
 'exp' => 'float',
-'explode' => 'list<string>|false',
+'explode' => 'non-empty-list<string>|false',
 'expm1' => 'float',
 'ezmlm_hash' => 'int',
 'fclose' => 'bool',

--- a/src/Phan/Language/Internal/FunctionSignatureMapReal_php73.php
+++ b/src/Phan/Language/Internal/FunctionSignatureMapReal_php73.php
@@ -229,7 +229,7 @@ return [
 'exif_tagname' => '?false|?string',
 'exif_thumbnail' => '?false|?string',
 'exp' => '?float',
-'explode' => '?list<string>|?false',
+'explode' => '?non-empty-list<string>|?false',
 'expm1' => '?float',
 'extract' => '?int',
 'ezmlm_hash' => '?int',

--- a/src/Phan/Language/Type/NonEmptyArrayInterface.php
+++ b/src/Phan/Language/Type/NonEmptyArrayInterface.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Phan\Language\Type;
+
+/**
+ * Common functionality for types such as `non-empty-list` and `non-empty-array`
+ * @phan-pure
+ */
+interface NonEmptyArrayInterface
+{
+    /**
+     * Convert this to the related type that's allowed to be empty
+     */
+    public function asPossiblyEmptyArrayType() : ArrayType;
+}

--- a/src/Phan/Language/Type/NonEmptyAssociativeArrayType.php
+++ b/src/Phan/Language/Type/NonEmptyAssociativeArrayType.php
@@ -12,6 +12,7 @@ use Phan\Language\Type;
  * @phan-pure
  */
 final class NonEmptyAssociativeArrayType extends AssociativeArrayType
+    implements NonEmptyArrayInterface
 {
     /**
      * @override
@@ -101,5 +102,18 @@ final class NonEmptyAssociativeArrayType extends AssociativeArrayType
             );
         }
         return $this;
+    }
+
+    /**
+     * @return ListType
+     * @phan-real-return AssociativeArrayType
+     */
+    public function asPossiblyEmptyArrayType() : ArrayType
+    {
+        return AssociativeArrayType::fromElementType(
+            $this->element_type,
+            $this->is_nullable,
+            $this->key_type
+        );
     }
 }

--- a/src/Phan/Language/Type/NonEmptyGenericArrayType.php
+++ b/src/Phan/Language/Type/NonEmptyGenericArrayType.php
@@ -12,6 +12,7 @@ use Phan\Language\Type;
  * @phan-pure
  */
 final class NonEmptyGenericArrayType extends GenericArrayType
+    implements NonEmptyArrayInterface
 {
     /**
      * @override
@@ -102,6 +103,19 @@ final class NonEmptyGenericArrayType extends GenericArrayType
             );
         }
         return NonEmptyAssociativeArrayType::fromElementType(
+            $this->element_type,
+            $this->is_nullable,
+            $this->key_type
+        );
+    }
+
+    /**
+     * @return GenericArrayType
+     * @phan-real-return GenericArrayType
+     */
+    public function asPossiblyEmptyArrayType() : ArrayType
+    {
+        return GenericArrayType::fromElementType(
             $this->element_type,
             $this->is_nullable,
             $this->key_type

--- a/src/Phan/Language/Type/NonEmptyListType.php
+++ b/src/Phan/Language/Type/NonEmptyListType.php
@@ -12,6 +12,7 @@ use Phan\Language\Type;
  * @phan-pure
  */
 final class NonEmptyListType extends ListType
+    implements NonEmptyArrayInterface
 {
     /**
      * @override
@@ -95,6 +96,19 @@ final class NonEmptyListType extends ListType
             );
         }
         return NonEmptyAssociativeArrayType::fromElementType(
+            $this->element_type,
+            $this->is_nullable,
+            $this->key_type
+        );
+    }
+
+    /**
+     * @return ListType
+     * @phan-real-return ListType
+     */
+    public function asPossiblyEmptyArrayType() : ArrayType
+    {
+        return ListType::fromElementType(
             $this->element_type,
             $this->is_nullable,
             $this->key_type

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -39,6 +39,7 @@ use Phan\Language\Type\LiteralTypeInterface;
 use Phan\Language\Type\MixedType;
 use Phan\Language\Type\MultiType;
 use Phan\Language\Type\NullType;
+use Phan\Language\Type\NonEmptyArrayInterface;
 use Phan\Language\Type\ObjectType;
 use Phan\Language\Type\ScalarType;
 use Phan\Language\Type\SelfType;
@@ -1316,7 +1317,6 @@ class UnionType implements Serializable
     /**
      * @return bool - True if type set is not empty and at least one type is NullType or nullable or FalseType or BoolType.
      * (I.e. the type is always falsey, or both sometimes falsey with a non-falsey type it can be narrowed down to)
-     * This does not include values such as `IntType`, since there is currently no `NonZeroIntType`.
      */
     public function containsFalsey() : bool
     {
@@ -4454,6 +4454,22 @@ class UnionType implements Serializable
             self::withFlattenedTopLevelArrayShapeTypeInstancesForSet($this->type_set),
             self::withFlattenedTopLevelArrayShapeTypeInstancesForSet($this->real_type_set)
         );
+    }
+
+    /**
+     * Convert non-empty-array, etc. to array.
+     *
+     * This reflects a change that removes elements from an array.
+     * @see withFlattenedTopLevelArrayShapeTypeInstances
+     */
+    public function withPossiblyEmptyArrays() : UnionType
+    {
+         return $this->asMappedUnionType(static function (Type $type) : Type {
+             if ($type instanceof NonEmptyArrayInterface) {
+                 return $type->asPossiblyEmptyArrayType();
+             }
+             return $type;
+         });
     }
 
     /**

--- a/src/Phan/Plugin/Internal/UseReturnValuePlugin/RedundantReturnVisitor.php
+++ b/src/Phan/Plugin/Internal/UseReturnValuePlugin/RedundantReturnVisitor.php
@@ -205,7 +205,7 @@ class RedundantReturnVisitor
             Issue::fromType(Issue::UnusedReturnBranchWithoutSideEffects)(
                 $this->context->getFile(),
                 $last_return->lineno,
-                [ASTReverter::toShortString($last_expr), \reset($remaining_returns)->lineno]
+                [ASTReverter::toShortString($last_expr), \reset($remaining_returns)->lineno ?? 0]
             )
         );
     }

--- a/tests/files/expected/0810_non_empty_list.php.expected
+++ b/tests/files/expected/0810_non_empty_list.php.expected
@@ -1,0 +1,1 @@
+%s:10 PhanRedundantCondition Redundant attempt to cast $a of type non-empty-array<mixed,mixed>|non-empty-list<'other'> to truthy

--- a/tests/files/src/0810_non_empty_list.php
+++ b/tests/files/src/0810_non_empty_list.php
@@ -1,0 +1,14 @@
+<?php
+
+function test(array $a) {
+    if ($a) {
+        array_pop($a);
+        if ($a) {
+            echo "a still has elements\n";
+        }
+        array_push($a, 'other');
+        if ($a) {
+            echo "a now has elements\n";
+        }
+    }
+}


### PR DESCRIPTION
- array_pop, etc. cause the reference to become a possibly empty array
  when it was previously non-empty.
- array_diff, array_filter, etc. cause possibly empty arrays
  when the arguments are non-empty.

Fix a false positive introduced with mixin support.