### PR TITLE
Warn about improperly assigning to function results

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@ Phan NEWS
 ??? ?? 2019, Phan 2.4.2 (dev)
 -----------------------
 
+New features(Analysis):
++ Emit `PhanTypeInvalidCallExpressionAssignment` when improperly assigning to a function/method's result (or a dimension of that result) (#3455)
+
 Nov 03 2019, Phan 2.4.1
 -----------------------
 

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -3380,8 +3380,8 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 if ($variable_union_type->hasRealTypeSet()) {
                     // TODO: Do a better job handling the large number of edge cases
                     // - e.g. infer that stream_select will convert non-empty arrays to possibly empty arrays, while the result continues to have a real type of array.
-                    if ($method->getContext()->isPHPInternal() && in_array($parameter->getReferenceType(), [Parameter::REFERENCE_IGNORED, Parameter::REFERENCE_READ_WRITE], true)) {
-                        if (preg_match('/shuffle|sort|array_(unshift|shift|push|pop|splice)/i', $method->getName())) {
+                    if ($method->getContext()->isPHPInternal() && \in_array($parameter->getReferenceType(), [Parameter::REFERENCE_IGNORED, Parameter::REFERENCE_READ_WRITE], true)) {
+                        if (\preg_match('/shuffle|sort|array_(unshift|shift|push|pop|splice)/i', $method->getName())) {
                             // This use case is probably handled by MiscParamPlugin
                             return;
                         }

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -126,6 +126,7 @@ class Issue
     const TypeInvalidInstanceof     = 'PhanTypeInvalidInstanceof';
     const TypeInvalidDimOffset      = 'PhanTypeInvalidDimOffset';
     const TypeInvalidDimOffsetArrayDestructuring = 'PhanTypeInvalidDimOffsetArrayDestructuring';
+    const TypeInvalidCallExpressionAssignment    = 'PhanTypeInvalidCallExpressionAssignment';
     const TypeInvalidExpressionArrayDestructuring = 'PhanTypeInvalidExpressionArrayDestructuring';
     const TypeInvalidThrowsNonObject             = 'PhanTypeInvalidThrowsNonObject';
     const TypeInvalidThrowsNonThrowable          = 'PhanTypeInvalidThrowsNonThrowable';
@@ -1998,6 +1999,14 @@ class Issue
                 "Invalid offset {SCALAR} of array type {TYPE} in an array destructuring assignment",
                 self::REMEDIATION_B,
                 10047
+            ),
+            new Issue(
+                self::TypeInvalidCallExpressionAssignment,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                "Probably unused assignment to function result {CODE} for function returning {TYPE}",
+                self::REMEDIATION_B,
+                10153
             ),
             new Issue(
                 self::TypeInvalidExpressionArrayDestructuring,

--- a/src/Phan/Language/Type/GenericIterableType.php
+++ b/src/Phan/Language/Type/GenericIterableType.php
@@ -51,7 +51,7 @@ final class GenericIterableType extends IterableType
      */
     public function getKeyType() : int
     {
-        return $this->memoize(__METHOD__, function () : int{
+        return $this->memoize(__METHOD__, function () : int {
             return GenericArrayType::keyTypeFromUnionTypeValues($this->key_union_type);
         });
     }

--- a/src/Phan/Language/Type/NonEmptyAssociativeArrayType.php
+++ b/src/Phan/Language/Type/NonEmptyAssociativeArrayType.php
@@ -11,8 +11,7 @@ use Phan\Language\Type;
  * @see ArrayType for the representation of `array`
  * @phan-pure
  */
-final class NonEmptyAssociativeArrayType extends AssociativeArrayType
-    implements NonEmptyArrayInterface
+final class NonEmptyAssociativeArrayType extends AssociativeArrayType implements NonEmptyArrayInterface
 {
     /**
      * @override

--- a/src/Phan/Language/Type/NonEmptyGenericArrayType.php
+++ b/src/Phan/Language/Type/NonEmptyGenericArrayType.php
@@ -11,8 +11,7 @@ use Phan\Language\Type;
  * @see ArrayType for the representation of `array`
  * @phan-pure
  */
-final class NonEmptyGenericArrayType extends GenericArrayType
-    implements NonEmptyArrayInterface
+final class NonEmptyGenericArrayType extends GenericArrayType implements NonEmptyArrayInterface
 {
     /**
      * @override

--- a/src/Phan/Language/Type/NonEmptyListType.php
+++ b/src/Phan/Language/Type/NonEmptyListType.php
@@ -11,8 +11,7 @@ use Phan\Language\Type;
  * @see ArrayType for the representation of `array`
  * @phan-pure
  */
-final class NonEmptyListType extends ListType
-    implements NonEmptyArrayInterface
+final class NonEmptyListType extends ListType implements NonEmptyArrayInterface
 {
     /**
      * @override

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -38,8 +38,8 @@ use Phan\Language\Type\LiteralStringType;
 use Phan\Language\Type\LiteralTypeInterface;
 use Phan\Language\Type\MixedType;
 use Phan\Language\Type\MultiType;
-use Phan\Language\Type\NullType;
 use Phan\Language\Type\NonEmptyArrayInterface;
+use Phan\Language\Type\NullType;
 use Phan\Language\Type\ObjectType;
 use Phan\Language\Type\ScalarType;
 use Phan\Language\Type\SelfType;
@@ -4465,9 +4465,9 @@ class UnionType implements Serializable
     public function withPossiblyEmptyArrays() : UnionType
     {
          return $this->asMappedUnionType(static function (Type $type) : Type {
-             if ($type instanceof NonEmptyArrayInterface) {
-                 return $type->asPossiblyEmptyArrayType();
-             }
+            if ($type instanceof NonEmptyArrayInterface) {
+                return $type->asPossiblyEmptyArrayType();
+            }
              return $type;
          });
     }

--- a/src/Phan/Plugin/Internal/MiscParamPlugin.php
+++ b/src/Phan/Plugin/Internal/MiscParamPlugin.php
@@ -230,7 +230,8 @@ final class MiscParamPlugin extends PluginV3 implements
      * @param non-empty-list<Node|string|float> $args
      * @suppress PhanAccessMethodInternal
      */
-    private static function emitIssueForInArray(CodeBase $code_base, Context $context, array $args, ?Node $node) : void {
+    private static function emitIssueForInArray(CodeBase $code_base, Context $context, array $args, ?Node $node) : void
+    {
         [$needle_node, $haystack_node] = $args;
         $needle = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $needle_node);
         $haystack = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $haystack_node);
@@ -285,7 +286,8 @@ final class MiscParamPlugin extends PluginV3 implements
      * @param non-empty-list<Node|string|float> $args
      * @suppress PhanAccessMethodInternal
      */
-    private static function emitIssueForArrayKeyExists(CodeBase $code_base, Context $context, array $args, ?Node $node) : void {
+    private static function emitIssueForArrayKeyExists(CodeBase $code_base, Context $context, array $args, ?Node $node) : void
+    {
         [$key_node, $array_node] = $args;
         $key_type = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $key_node);
         $array_type = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $array_node);

--- a/tests/files/expected/0232_assignment_to_call.php.expected
+++ b/tests/files/expected/0232_assignment_to_call.php.expected
@@ -1,3 +1,5 @@
 %s:5 PhanTypeSuspiciousStringExpression Suspicious type bool of a variable or expression used to build a string. (Expected type to be able to cast to a string)
+%s:7 PhanTypeInvalidCallExpressionAssignment Probably unused assignment to function result f()[0] for function returning array{0:42}
 %s:7 PhanTypeMismatchArgument Argument 1 ($p) is 'call' but \g() takes bool defined at %s:4
+%s:8 PhanTypeInvalidCallExpressionAssignment Probably unused assignment to function result new C()->f()[0] for function returning array{0:42}
 %s:8 PhanTypeMismatchArgument Argument 1 ($p) is 'method' but \g() takes bool defined at %s:4

--- a/tests/files/expected/0811_array_values_assign.php.expected
+++ b/tests/files/expected/0811_array_values_assign.php.expected
@@ -1,0 +1,8 @@
+%s:9 PhanCompatibleNullableTypePHP71 Type 'object' refers to any object starting in PHP 7.2. In PHP 7.1 and earlier, it refers to a class/interface with the name 'object'
+%s:18 PhanTypeInvalidCallExpressionAssignment Probably unused assignment to function result array_values($a)[0] for function returning list<mixed>
+%s:19 PhanTypeInvalidCallExpressionAssignment Probably unused assignment to function result array_values($a) for function returning list<mixed>
+%s:20 PhanTypeInvalidCallExpressionAssignment Probably unused assignment to function result $e->returnsArray()[] for function returning array
+%s:21 PhanTypeInvalidCallExpressionAssignment Probably unused assignment to function result $e->returnsArray() for function returning array
+%s:22 PhanTypeInvalidCallExpressionAssignment Probably unused assignment to function result $e->returnsArray()[$i] for function returning array
+%s:25 PhanTypeInvalidCallExpressionAssignment Probably unused assignment to function result Test::returnsArray()[0] for function returning array
+%s:27 PhanTypeInvalidCallExpressionAssignment Probably unused assignment to function result $e->returnsObject() for function returning object

--- a/tests/files/src/0811_array_values_assign.php
+++ b/tests/files/src/0811_array_values_assign.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace NS811;
+
+interface Examples {
+    public function returnsIterable() : iterable;
+    public function returnsArray() : array;
+    public function &returnsArrayRef() : array;
+    public function returnsObject() : object;
+}
+class Test {
+    public static function returnsArray() : array {
+        return [0];
+    }
+}
+
+function test_assign(array $a, Examples $e, int $i) {
+    array_values($a)[0] = 3;
+    array_values($a) = 3;
+    $e->returnsArray()[] = 3;  // should warn
+    $e->returnsArray() = null;  // should warn
+    $e->returnsArray()[$i] = 3;  // should warn
+    $e->returnsArray()[$i][0] = 3;  // should not warn
+    $e->returnsArrayRef()[$i] = 3;  // should not warn
+    Test::returnsArray()[0] = 42;
+    $e->returnsObject()[$i] = 3;  // should not warn
+    $e->returnsObject() = 3;  // should not warn
+}


### PR DESCRIPTION
Fixes #3455
Introduce `PhanTypeInvalidCallExpressionAssignment`