### PR TITLE
Use sets instead of arrays in UnionTypeBuilder for ~10% phan run spee…

### DIFF
--- a/src/Phan/Language/UnionTypeBuilder.php
+++ b/src/Phan/Language/UnionTypeBuilder.php
@@ -2,6 +2,8 @@
 
 namespace Phan\Language;
 
+use Phan\Library\Set;
+
 /**
  * Utilities to build a union type.
  * Mostly used internally when the number of types in the resulting union type may be large.
@@ -13,45 +15,36 @@ namespace Phan\Language;
  */
 final class UnionTypeBuilder
 {
-    /** @var list<Type> the list of unique types in this builder instance. */
+    /** @var Set the list of unique types in this builder instance. */
     private $type_set;
 
     /** @param list<Type> $type_set (must be unique) */
     public function __construct(array $type_set = [])
     {
-        $this->type_set = $type_set;
+        $this->type_set = new Set($type_set);
     }
 
     public function addType(Type $type) : void
     {
-        if (\in_array($type, $this->type_set, true)) {
+        if ($this->type_set->contains($type)) {
             return;
         }
-        $this->type_set[] = $type;
+        $this->type_set->attach($type);
     }
 
     public function addUnionType(UnionType $union_type) : void
     {
         $old_type_set = $this->type_set;
         foreach ($union_type->getTypeSet() as $type) {
-            if (!\in_array($type, $old_type_set, true)) {
-                $this->type_set[] = $type;
+            if (!$old_type_set->contains($type)) {
+                $this->type_set->attach($type);
             }
         }
     }
 
     public function removeType(Type $type) : void
     {
-        $i = \array_search($type, $this->type_set, true);
-        if ($i !== false) {
-            // equivalent to unset($new_type_set[$i]) but fills in the gap in array keys.
-            // TODO: How do other ways of unsetting the type affect performance on large projects?
-            $replacement_type = \array_pop($this->type_set);
-            if ($replacement_type !== $type) {
-                // @phan-suppress-next-line PhanPartialTypeMismatchProperty $replacement_type is guaranteed to not be false
-                $this->type_set[$i] = $replacement_type;
-            }
-        }
+        $this->type_set->detach($type);
     }
 
     /**
@@ -67,12 +60,12 @@ final class UnionTypeBuilder
      */
     public function getTypeSet() : array
     {
-        return $this->type_set;
+        return $this->type_set->toArray();
     }
 
     public function clearTypeSet() : void
     {
-        $this->type_set = [];
+        $this->type_set = new Set();
     }
 
     /**
@@ -80,7 +73,7 @@ final class UnionTypeBuilder
      */
     public function getPHPDocUnionType() : UnionType
     {
-        return UnionType::of($this->type_set, []);
+        return UnionType::of($this->type_set->toArray(), []);
     }
 
     /**


### PR DESCRIPTION
…dup on large codebase

I used [phpspy](https://github.com/adsr/phpspy/) to profile this code.

phpspy output of a run on http://etsy.com codebase before this optimization: https://raw.githubusercontent.com/dasl-/dasl-.github.io/cd50b458897fdc96581c7e051ff7350ff880f45d/phan_before_set.svg

phpspy output of a run on http://etsy.com codebase after this optimization: https://raw.githubusercontent.com/dasl-/dasl-.github.io/cd50b458897fdc96581c7e051ff7350ff880f45d/phan_after_set.svg

Note: these SVGs should be viewed in chrome unfortunately because firefox has an SSL error due to my github user name having a hyphen.

The "before" phpspy run showed there was a lot of `in_array` activity in `UnionTypeBuilder`. I optimized by using a Set.

Timing data shows a 10% wall time improvement:
before:
```
./vendor/bin/phan -p -j 1 -f filelist.txt  284.97s user 4.34s system 99% cpu 4:49.33 total
```
after:
```
./vendor/bin/phan -p -j 1 -f filelist.txt  256.72s user 4.19s system 99% cpu 4:20.93 total
```