### PR TITLE
Fix regression in json_decode typing

### DIFF
--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1835,7 +1835,14 @@ class UnionTypeVisitor extends AnalysisVisitor
                 } elseif ($type->isArrayLike() || $type->isObject() || $type instanceof MixedType) {
                     if ($type instanceof ListType && (!\is_numeric($dim_value) || $dim_value < 0)) {
                         continue;
+                    } elseif ($type instanceof ListType) {
+                        if ($resulting_element_type === null) {
+                            $resulting_element_type = $type->genericArrayElementType()->asPHPDocUnionType();
+                        } else {
+                            $resulting_element_type = $resulting_element_type->withType($type->genericArrayElementType());
+                        }
                     }
+
                     // TODO: Could be more precise about check for ArrayAccess
                     $has_non_array_shape_type = true;
                     continue;

--- a/src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php
@@ -117,7 +117,7 @@ final class DependentReturnTypeOverridePlugin extends PluginV3 implements
         };
 
         $json_decode_array_types = UnionType::fromFullyQualifiedPHPDocString('array|string|float|int|bool|null');
-        $json_decode_object_types = UnionType::fromFullyQualifiedPHPDocString('\stdClass|list<int,mixed>|string|float|int|bool|null');
+        $json_decode_object_types = UnionType::fromFullyQualifiedPHPDocString('\stdClass|list<mixed>|string|float|int|bool|null');
         $json_decode_array_or_object_types = UnionType::fromFullyQualifiedPHPDocString('\stdClass|array|string|float|int|bool|null');
 
         $string_if_2_true           = $make_dependent_type_method(1, $string_union_type, $void_union_type, $nullable_string_union_type);


### PR DESCRIPTION
Running phan on this code:
```php
<?php
$content = json_decode($_GET['whatever']);
$content_type = is_object($content) ? $content->content_type : $content[0]->content_type;
```

Phan outputs: 
```
test.php:3 PhanTypeExpectedObjectPropAccess Expected an object instance when accessing an instance property, but saw an expression with type string
```

But this should be valid code -- phan should not be complaining.

I believe this regression was introduced here: https://github.com/phan/phan/commit/cf68e649e8113c0b8042f1cd3b637bb465b85592#diff-0ca96f332776cf1c3a313799a7aa95eeR120