### PR TITLE
Fix real types inferred for array dim access

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,10 @@ New features(CLI, Configs):
 New features(Analysis):
 + Make issue suggestions (and CLI suggestions) for completions of prefixes case-insensitive.
 + Support `@seal-properties` and `@seal-methods` as aliases of `@phan-forbid-undeclared-magic-properties` and `@phan-forbid-undeclared-magic-methods`
++ More aggressively infer real types of array destructuring(e.g. `[$x] = expr`) and accesses of array dimensions (e.g. `$x = expr[dim]`) (#3481)
+
+  This will result in a few more false positives about potentially real redundant/impossible conditions and real type mismatches.
++ Fix false positives caused by assuming that the default values of properties are the real types of properties.
 
 Plugins:
 + Also start checking if closures (and arrow functions) can be static in `PossiblyStaticMethodPlugin`

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -347,8 +347,11 @@ class AssignmentVisitor extends AnalysisVisitor
     {
         // Figure out the type of elements in the list
         $fallback_element_type = null;
+        /** @suppress PhanAccessMethodInternal */
         $get_fallback_element_type = function () use (&$fallback_element_type) : UnionType {
-            return $fallback_element_type ?? ($fallback_element_type = $this->right_type->genericArrayElementTypes());
+            return $fallback_element_type ?? ($fallback_element_type = (
+                $this->right_type->genericArrayElementTypes()
+                                 ->withRealTypeSet(UnionType::computeRealElementTypesForDestructuringAccess($this->right_type->getRealTypeSet()))));
         };
 
         $expect_string_keys_lineno = false;
@@ -646,7 +649,9 @@ class AssignmentVisitor extends AnalysisVisitor
                 );
             }
             $element_type =
-                $array_access_types->genericArrayElementTypes();
+                $array_access_types->genericArrayElementTypes()
+                                   ->withRealTypeSet(UnionType::computeRealElementTypesForDestructuringAccess($right_type->getRealTypeSet()));
+            // @phan-suppress-previous-line PhanAccessMethodInternal
         }
 
         $expect_string_keys_lineno = false;

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -334,6 +334,7 @@ class ConditionVisitor extends KindVisitorImplementation implements ConditionVis
     public const ACCESS_ARRAY_KEY_EXISTS = 2;
     public const ACCESS_IS_SET = 3;
     public const ACCESS_DIM_SET = 4;
+    public const ACCESS_STRING_DIM_SET = 5;
 
     /** @internal */
     public const DEFAULTS_FOR_ACCESS_TYPE = [
@@ -341,6 +342,7 @@ class ConditionVisitor extends KindVisitorImplementation implements ConditionVis
         self::ACCESS_ARRAY_KEY_EXISTS => 'non-empty-array|object',
         self::ACCESS_IS_SET => 'int|string|float|bool|non-empty-array|object|resource',
         self::ACCESS_DIM_SET => 'string|non-empty-array|object',
+        self::ACCESS_STRING_DIM_SET => 'non-empty-array|object',
     ];
 
     /**
@@ -468,7 +470,7 @@ class ConditionVisitor extends KindVisitorImplementation implements ConditionVis
                 // Allow `isset($x[0])` to imply $x can be a string, but not `isset($x['field'])`
                 $dim = $node->children['dim'] ?? null;
                 if (\is_string($dim) && \filter_var($dim, \FILTER_VALIDATE_INT) === false) {
-                    $access_kind = self::ACCESS_ARRAY_KEY_EXISTS;
+                    $access_kind = self::ACCESS_STRING_DIM_SET;
                 } else {
                     $access_kind = self::ACCESS_DIM_SET;
                 }

--- a/src/Phan/Analysis/ConditionVisitorUtil.php
+++ b/src/Phan/Analysis/ConditionVisitorUtil.php
@@ -286,7 +286,7 @@ trait ConditionVisitorUtil
             }
             if ($type instanceof ScalarType) {
                 if ($type instanceof StringType) {
-                    if ($access_type !== ConditionVisitor::ACCESS_IS_SET) {
+                    if (\in_array($access_type, [ConditionVisitor::ACCESS_IS_OBJECT, ConditionVisitor::ACCESS_ARRAY_KEY_EXISTS, ConditionVisitor::ACCESS_STRING_DIM_SET], true)) {
                         return [];
                     }
                     if ($type instanceof LiteralStringType && $type->getValue() === '') {

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -2141,6 +2141,9 @@ class BlockAnalysisVisitor extends AnalysisVisitor
         }
         $left = $left->getRealUnionType();
         if (!$left->containsNullableOrUndefined()) {
+            if (RedundantCondition::shouldNotWarnAboutIssetCheckForNonNullExpression($this->code_base, $context, $left_node)) {
+                return;
+            }
             RedundantCondition::emitInstance(
                 $left_node,
                 $this->code_base,

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -934,7 +934,8 @@ class CLI
         }
     }
 
-    private static function hasNoColorEnv() : bool {
+    private static function hasNoColorEnv() : bool
+    {
         return getenv('PHAN_DISABLE_COLOR_OUTPUT') || getenv('NO_COLOR');
     }
 

--- a/src/Phan/Daemon/Request.php
+++ b/src/Phan/Daemon/Request.php
@@ -524,6 +524,7 @@ class Request
                 $files = $request[self::PARAM_FILES] ?? null;
                 $request[self::PARAM_FORMAT] = $request[self::PARAM_FORMAT] ?? 'json';
                 $error_message = null;
+                // @phan-suppress-next-line PhanRedundantCondition failed to infer other types for PARAM_FILES were possible
                 if (\is_array($files) && count($files)) {
                     foreach ($files as $file) {
                         if (!\is_string($file)) {

--- a/src/Phan/Debug.php
+++ b/src/Phan/Debug.php
@@ -453,4 +453,14 @@ class Debug
 
         return [$exclusive, $combinable];
     }
+
+    /**
+     * Print a message with the file and line.
+     * @suppress PhanUnreferencedPublicMethod added for debugging
+     */
+    public static function debugLog(string $message) : void
+    {
+        $frame = \debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS)[0];
+        \fprintf(\STDERR, "%s:%d %s\n", $frame['file'] ?? 'unknown', $frame['line'] ?? 0, $message);
+    }
 }

--- a/src/Phan/Language/AnnotatedUnionType.php
+++ b/src/Phan/Language/AnnotatedUnionType.php
@@ -145,4 +145,24 @@ class AnnotatedUnionType extends UnionType
         }
         return $id;
     }
+
+    /**
+     * Returns a union type with an empty real type set (including in elements of generic arrays, etc.)
+     */
+    public function eraseRealTypeSetRecursively() : UnionType
+    {
+        $type_set = $this->getTypeSet();
+        $new_type_set = [];
+        foreach ($type_set as $type) {
+            $new_type_set[] = $type->withErasedUnionTypes();
+        }
+        $real_type_set = $this->getRealTypeSet();
+        if (!$real_type_set && $new_type_set === $type_set) {
+            return $this;
+        }
+        $result = new AnnotatedUnionType($new_type_set, false, $real_type_set);
+        // @phan-suppress-next-line PhanAccessReadOnlyProperty
+        $result->is_possibly_undefined = $this->is_possibly_undefined;
+        return $result;
+    }
 }

--- a/src/Phan/Language/Element/Property.php
+++ b/src/Phan/Language/Element/Property.php
@@ -475,9 +475,11 @@ class Property extends ClassElement
         // given that its the default.
         if ($union_type->isType(NullType::instance(false))) {
             $union_type = UnionType::empty();
+        } else {
+            $union_type = $union_type->eraseRealTypeSetRecursively();
         }
 
-        return $union_type;
+        return $union_type->withRealTypeSet($this->real_union_type->getTypeSet());
     }
 
     public function getRealUnionType() : UnionType

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -960,7 +960,7 @@ final class EmptyUnionType extends UnionType
      * @return UnionType
      * The subset of types in this
      */
-    public function genericArrayElementTypes() : UnionType
+    public function genericArrayElementTypes(bool $add_real_types = false) : UnionType
     {
         return $this; // empty
     }
@@ -1447,6 +1447,11 @@ final class EmptyUnionType extends UnionType
     }
 
     public function eraseRealTypeSet() : UnionType
+    {
+        return $this;
+    }
+
+    public function eraseRealTypeSetRecursively() : UnionType
     {
         return $this;
     }

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -4005,4 +4005,14 @@ class Type
     {
         return $this->isPossiblyFalsey() && $other->isPossiblyFalsey();
     }
+
+    /**
+     * Returns a type where all referenced union types (e.g. in generic arrays) have real type sets removed.
+     * Overridden in subclasses
+     * @phan-pure
+     */
+    public function withErasedUnionTypes() : Type
+    {
+        return $this;
+    }
 }

--- a/src/Phan/Language/Type/ArrayShapeType.php
+++ b/src/Phan/Language/Type/ArrayShapeType.php
@@ -1074,6 +1074,23 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
         return self::fromFieldTypes($new_field_types, $this->is_nullable);
     }
 
+    /**
+     * Returns a type where all referenced union types (e.g. in generic arrays) have real type sets removed.
+     */
+    public function withErasedUnionTypes() : Type
+    {
+        return $this->memoize(__METHOD__, function () : ArrayShapeType {
+            $new_field_types = $this->field_types;
+            foreach ($this->field_types as $offset => $union_type) {
+                $new_field_types[$offset] = $union_type->eraseRealTypeSetRecursively();
+            }
+            if ($new_field_types === $this->field_types) {
+                return $this;
+            }
+            return self::fromFieldTypes($new_field_types, $this->is_nullable);
+        });
+    }
+
     public function asCallableType() : ?Type
     {
         if ($this->isDefiniteNonCallableType()) {

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -798,6 +798,25 @@ class GenericArrayType extends ArrayType implements GenericArrayInterface
         );
     }
 
+    /**
+     * Returns a type where all referenced union types (e.g. in generic arrays) have real type sets removed.
+     * @phan-real-return static
+     */
+    public function withErasedUnionTypes() : Type
+    {
+        return $this->memoize(__METHOD__, function () : GenericArrayType {
+            $erased_element_type = $this->element_type->withErasedUnionTypes();
+            if ($erased_element_type === $this->element_type) {
+                return $this;
+            }
+            return static::fromElementType(
+                $erased_element_type,
+                $this->is_nullable,
+                $this->key_type
+            );
+        });
+    }
+
     public function asCallableType() : ?Type
     {
         if ($this->key_type === self::KEY_INT) {

--- a/src/Phan/Language/Type/GenericIterableType.php
+++ b/src/Phan/Language/Type/GenericIterableType.php
@@ -225,6 +225,21 @@ final class GenericIterableType extends IterableType
         }
         return GenericArrayType::fromElementType($element_type, false, $key_type);
     }
+
+    /**
+     * Returns a type where all referenced union types (e.g. in generic arrays) have real type sets removed.
+     */
+    public function withErasedUnionTypes() : Type
+    {
+        return $this->memoize(__METHOD__, function () : Type {
+            $erased_element_union_type = $this->element_union_type->eraseRealTypeSetRecursively();
+            $erased_key_union_type = $this->key_union_type->eraseRealTypeSetRecursively();
+            if ($erased_key_union_type === $this->key_union_type && $erased_element_union_type === $this->element_union_type) {
+                return $this;
+            }
+            return self::fromKeyAndValueTypes($this->key_union_type, $erased_element_union_type, $this->is_nullable);
+        });
+    }
 }
 // Trigger autoloader for subclass before make() can get called.
 \class_exists(ArrayType::class);

--- a/src/Phan/Plugin/Internal/RedundantConditionCallPlugin.php
+++ b/src/Phan/Plugin/Internal/RedundantConditionCallPlugin.php
@@ -685,6 +685,9 @@ class RedundantConditionVisitor extends PluginAwarePostAnalysisVisitor
         }
         $real_type = $type->getRealUnionType();
         if (!$real_type->containsNullableOrUndefined()) {
+            if (RedundantCondition::shouldNotWarnAboutIssetCheckForNonNullExpression($this->code_base, $this->context, $var_node)) {
+                return;
+            }
             RedundantCondition::emitInstance(
                 $var_node,
                 $this->code_base,

--- a/tests/files/expected/0327_references_sort_preserves_type.php.expected
+++ b/tests/files/expected/0327_references_sort_preserves_type.php.expected
@@ -1,1 +1,1 @@
-%s:6 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is \stdClass but \intdiv() takes int
+%s:6 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($numerator) is \stdClass (real type ?\stdClass) but \intdiv() takes int

--- a/tests/files/expected/0354_string_index.php.expected
+++ b/tests/files/expected/0354_string_index.php.expected
@@ -17,4 +17,4 @@
 %s:40 PhanTypeMismatchArgumentInternal Argument 1 ($string) is 2 but \strlen() takes string
 %s:41 PhanTypeInvalidDimOffset Invalid offset 2 of array type array{0:1,1:2,3:'x'}
 %s:41 PhanTypeMismatchArgumentInternal Argument 1 ($string) is null but \strlen() takes string
-%s:43 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is 'x' but \intdiv() takes int
+%s:43 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($numerator) is 'x' but \intdiv() takes int

--- a/tests/files/expected/0433_infer_array_type.php.expected
+++ b/tests/files/expected/0433_infer_array_type.php.expected
@@ -1,2 +1,2 @@
-%s:6 PhanTypeMismatchArgumentInternal Argument 1 ($var) is 'value' but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array
-%s:7 PhanTypeMismatchArgumentInternal Argument 1 ($string) is array{} but \strlen() takes string
+%s:6 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($var) is 'value' but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array
+%s:7 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($string) is array{} but \strlen() takes string

--- a/tests/files/expected/0435_false_positive_shape_offset.php.expected
+++ b/tests/files/expected/0435_false_positive_shape_offset.php.expected
@@ -1,2 +1,2 @@
-%s:5 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is 'value' but \intdiv() takes int
+%s:5 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($numerator) is 'value' (real type ?'value') but \intdiv() takes int
 %s:8 PhanUndeclaredVariableDim Variable $global435 was undeclared, but array fields are being added to it.

--- a/tests/files/expected/0440_no_warn_set_check.php.expected
+++ b/tests/files/expected/0440_no_warn_set_check.php.expected
@@ -1,1 +1,1 @@
-%s:7 PhanTypeMismatchReturn Returning type array{} but test() is declared to return string
+%s:7 PhanTypeMismatchReturnReal Returning type array{} (real type ?array{}) but test() is declared to return string

--- a/tests/files/expected/0448_each.php.expected
+++ b/tests/files/expected/0448_each.php.expected
@@ -1,3 +1,3 @@
 %s:6 PhanTypeMismatchArgumentInternal Argument 1 ($var) is string but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array
 %s:7 PhanTypeMismatchArgumentInternal Argument 1 ($string) is \stdClass but \strlen() takes string
-%s:13 PhanTypeMismatchArgumentInternal Argument 1 ($var) is int|string but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array
+%s:13 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($var) is int|string but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array

--- a/tests/files/expected/0458_isset_array.php.expected
+++ b/tests/files/expected/0458_isset_array.php.expected
@@ -1,6 +1,8 @@
 %s:9 PhanTypeMismatchArgumentInternal Argument 1 ($string) is array{otherKey:mixed,key:string} but \strlen() takes string
 %s:11 PhanTypeMismatchArgumentInternal Argument 1 ($string) is array{key:string} but \strlen() takes string
-%s:15 PhanDebugAnnotation @phan-debug-var requested for variable $str - it has union type non-empty-array<mixed,mixed>|object|string(real=non-empty-array<mixed,mixed>|object|string)
+%s:15 PhanDebugAnnotation @phan-debug-var requested for variable $str - it has union type string(real=non-empty-array<mixed,mixed>|object|string)
+%s:15 PhanTypeMismatchArgumentInternal Argument 1 ($var) is string but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array
+%s:17 PhanTypeMismatchDimFetch When fetching an array index from a value of type string, found an array index of type 'field', but expected the index to be of type int
 %s:18 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($string) is non-empty-array<mixed,mixed>|object but \strlen() takes string
 %s:21 PhanTypeMismatchArgument Argument 1 ($data) is array{} but Closure($data, $str) takes array{key:string} defined at %s:7
 %s:24 PhanParamTooFewCallable Call with 0 arg(s) to Closure($data, $str) (as a provided callable) which requires 2 arg(s) defined at %s:28

--- a/tests/files/expected/0644_unset_false_positive.php.expected
+++ b/tests/files/expected/0644_unset_false_positive.php.expected
@@ -1,0 +1,1 @@
+%s:5 PhanImpossibleTypeComparison Impossible attempt to check if $arr['x'] of type true is identical to null of type null

--- a/tests/files/expected/0652_array_narrow.php.expected
+++ b/tests/files/expected/0652_array_narrow.php.expected
@@ -1,6 +1,6 @@
-%s:12 PhanTypeMismatchArgumentInternal Argument 1 ($string) is array but \strlen() takes string
-%s:25 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is array{0:string} but \intdiv() takes int
-%s:35 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is string but \intdiv() takes int
+%s:12 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($string) is array (real type ?array) but \strlen() takes string
+%s:25 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($numerator) is array{0:string} (real type ?array{0:string}) but \intdiv() takes int
+%s:35 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($numerator) is string but \intdiv() takes int
 %s:37 PhanDebugAnnotation @phan-debug-var requested for variable $options - it has union type array{hooks:array}(real=non-empty-array<mixed,mixed>)
 %s:37 PhanTypeMismatchArgumentInternal Argument 1 ($string) is array but \strlen() takes string
 %s:40 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($string) is array{hooks:array}|array{hooks:string} (real type non-empty-array<mixed,mixed>) but \strlen() takes string

--- a/tests/files/expected/0776_this_nested_isset.php.expected
+++ b/tests/files/expected/0776_this_nested_isset.php.expected
@@ -1,1 +1,2 @@
+%s:20 PhanRedundantCondition Redundant attempt to cast $this->some_acl['acl']['set'] of type array{foo:20} to isset
 %s:26 PhanTypeMismatchArgumentInternal Argument 1 ($var) is string but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array

--- a/tests/files/expected/0788_nullable_mixed_suspicious.php.expected
+++ b/tests/files/expected/0788_nullable_mixed_suspicious.php.expected
@@ -1,2 +1,2 @@
-%s:6 PhanTypeMismatchArgumentInternal Argument 1 ($string) is string[] but \strlen() takes string
+%s:6 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($string) is string[] (real type ?array) but \strlen() takes string
 %s:9 PhanTypeArraySuspiciousNullable Suspicious array access to nullable ?mixed

--- a/tests/files/expected/0817_real_type_of_array_dim.php.expected
+++ b/tests/files/expected/0817_real_type_of_array_dim.php.expected
@@ -1,0 +1,6 @@
+%s:3 PhanDebugAnnotation @phan-debug-var requested for variable $vals - it has union type non-empty-list<string>
+%s:3 PhanParamSuspiciousOrder Argument #1 of this call to \explode is typically a literal or constant but isn't, but argument #2 (which is typically a variable) is a literal or constant. The arguments may be in the wrong order.
+%s:3 PhanTypeMismatchArgumentInternal Argument 2 ($str) is 2 but \explode() takes string
+%s:5 PhanDebugAnnotation @phan-debug-var requested for variable $methodName - it has union type string
+%s:5 PhanUnusedVariable Unused definition of variable $className
+%s:7 PhanDebugAnnotation @phan-debug-var requested for variable $methodName - it has union type string(real=non-empty-array<mixed,mixed>|object|string)

--- a/tests/files/expected/0818_property_no_real_type.php.expected
+++ b/tests/files/expected/0818_property_no_real_type.php.expected
@@ -1,0 +1,3 @@
+%s:7 PhanDebugAnnotation @phan-debug-var requested for variable $opt - it has union type array{files:array{}}
+%s:9 PhanDebugAnnotation @phan-debug-var requested for variable $files - it has union type array{}
+%s:9 PhanUnusedVariable Unused definition of variable $files

--- a/tests/files/src/0440_no_warn_set_check.php
+++ b/tests/files/src/0440_no_warn_set_check.php
@@ -4,6 +4,6 @@ function test(array $data = []) : string {
     if (!isset($data['key'])) {
         $data['key'] = [];
     }
-    return $data['key'];
+    return $data['key'];  // TODO: The inferred real type could be improved (e.g. unknown?)
 }
 test();

--- a/tests/files/src/0458_isset_array.php
+++ b/tests/files/src/0458_isset_array.php
@@ -10,12 +10,12 @@ call_user_func(
         } else {
             echo strlen($data);
         }
-        // It's possible that the phpdoc types were wrong. Don't warn (this isn't strict mode).
+        // It's possible that the phpdoc types were wrong. Emit a less severe warning.
         if (isset($str[5])) {
             echo count($str);  '@phan-debug-var $str';
         }
         if (isset($str['field'])) {
-            echo strlen($str);  // $str is definitely not a string
+            echo strlen($str);  // $str is definitely not a string TODO: Make this warn again
         }
     },
     [],

--- a/tests/files/src/0817_real_type_of_array_dim.php
+++ b/tests/files/src/0817_real_type_of_array_dim.php
@@ -1,0 +1,11 @@
+<?php
+function main(string $name) {
+    $vals = explode($name, 2);
+    '@phan-debug-var $vals';
+    [$className, $methodName] = $vals;
+    '@phan-debug-var $methodName';
+    if (isset($methodName[0])) {
+        '@phan-debug-var $methodName';
+        echo "Saw $methodName\n";
+    }
+}

--- a/tests/files/src/0818_property_no_real_type.php
+++ b/tests/files/src/0818_property_no_real_type.php
@@ -1,0 +1,15 @@
+<?php
+class Example817 {
+    public $options = [
+        'files' => [],
+    ];
+    public function processFiles() {
+        $opt = $this->options;
+        '@phan-debug-var $opt';
+        $files = $opt['files'];
+        '@phan-debug-var $files';
+        if ($this->options['files']) {  // should not emit PhanEmptyForeach
+            echo "This has files\n";
+        }
+    }
+}

--- a/tests/php74_files/expected/015_real_type_redundant.php.expected
+++ b/tests/php74_files/expected/015_real_type_redundant.php.expected
@@ -1,6 +1,7 @@
-%s:19 PhanRedundantCondition Redundant attempt to cast self::$my_int of type int to int
-%s:20 PhanRedundantCondition Redundant attempt to cast self::$my_int2 of type int to int
-%s:23 PhanImpossibleCondition Impossible attempt to cast self::$my_int of type int to string
-%s:26 PhanRedundantCondition Redundant attempt to cast self::$my_array of type array to array
-%s:27 PhanRedundantCondition Redundant attempt to cast self::$my_array2 of type array to array
-%s:28 PhanRedundantCondition Redundant attempt to cast self::$my_string of type string to string
+%s:20 PhanRedundantCondition Redundant attempt to cast self::$my_int of type int to int
+%s:21 PhanRedundantCondition Redundant attempt to cast self::$my_int2 of type int to int
+%s:24 PhanImpossibleCondition Impossible attempt to cast self::$my_int of type int to string
+%s:27 PhanRedundantCondition Redundant attempt to cast self::$my_array of type array to array
+%s:28 PhanRedundantCondition Redundant attempt to cast self::$my_array2 of type array to array
+%s:29 PhanRedundantCondition Redundant attempt to cast self::$my_array3 of type array to array
+%s:30 PhanRedundantCondition Redundant attempt to cast self::$my_string of type string to string

--- a/tests/php74_files/src/015_real_type_redundant.php
+++ b/tests/php74_files/src/015_real_type_redundant.php
@@ -7,6 +7,7 @@ class TypedProperties15 {
     public static array $my_array;
     /** @var array<int,string> */
     public static array $my_array2;
+    public static array $my_array3 = ['key' => 'value'];
     /** @var callable-string */
     public static string $my_string;
 
@@ -25,6 +26,7 @@ class TypedProperties15 {
         }
         assert(is_array(self::$my_array));  // should warn
         assert(is_array(self::$my_array2));  // should warn
+        assert(is_array(self::$my_array3));  // should warn
         assert(is_string(self::$my_string)); // should warn - php would throw when reading if it was not a string
         if (is_callable(self::$my_string)) {  // should not warn
             echo "This is callable\n";


### PR DESCRIPTION
And for array destructuring.

Add more specific inferred union types

Fixes #3481

Don't infer real types from property defaults in arrays.

Fix php74 test failures