### PR TITLE
Avoid false positives for real types of array shape types

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,8 @@ New features(CLI, Configs):
 
 New features(Analysis):
 + Make inferred real types more accurate for equality/identity/instanceof checks.
++ Combine array shape types into a single union type when merging variable types from multiple branches. (#3506)
+  Do a better job of invalidating the real union type of fields of array shape types when the field is only checked/set on some code branches.
 + Make issue suggestions (and CLI suggestions) for completions of prefixes case-insensitive.
 + Support `@seal-properties` and `@seal-methods` as aliases of `@phan-forbid-undeclared-magic-properties` and `@phan-forbid-undeclared-magic-methods`
 + More aggressively infer real types of array destructuring(e.g. `[$x] = expr`) and accesses of array dimensions (e.g. `$x = expr[dim]`) (#3481)

--- a/src/Phan/Language/AnnotatedUnionType.php
+++ b/src/Phan/Language/AnnotatedUnionType.php
@@ -141,7 +141,7 @@ class AnnotatedUnionType extends UnionType
     {
         $id = parent::generateUniqueId();
         if ($this->is_possibly_undefined) {
-            return $id . '=';
+            return '(' . $id . ')=';
         }
         return $id;
     }

--- a/tests/files/expected/0253_keys_in_lists.php.expected
+++ b/tests/files/expected/0253_keys_in_lists.php.expected
@@ -7,6 +7,6 @@
 %s:30 PhanTypeMismatchArgument Argument 1 ($p1) is 1 but \f253_1() takes bool defined at %s:2
 %s:31 PhanTypeMismatchArgument Argument 1 ($p1) is 2 but \f253_1() takes bool defined at %s:2
 %s:39 PhanTypeMismatchArgument Argument 1 ($p1) is 'string' but \f253_1() takes bool defined at %s:2
-%s:42 PhanTypeInvalidDimOffsetArrayDestructuring Invalid offset 1 of array type array{k1:1,k2:'string'}|array{k1:2,k2:'string'} in an array destructuring assignment
+%s:42 PhanTypeInvalidDimOffsetArrayDestructuring Invalid offset 1 of array type array{k1:1|2,k2:'string'} in an array destructuring assignment
 %s:42 PhanTypeMismatchArrayDestructuringKey Attempting an array destructing assignment with a key of type int but the only key types of the right-hand side are of type string
-%s:46 PhanTypeInvalidDimOffsetArrayDestructuring Invalid offset "kMissing" of array type array{k1:1,k2:'string'}|array{k1:2,k2:'string'} in an array destructuring assignment
+%s:46 PhanTypeInvalidDimOffsetArrayDestructuring Invalid offset "kMissing" of array type array{k1:1|2,k2:'string'} in an array destructuring assignment

--- a/tests/files/expected/0440_no_warn_set_check.php.expected
+++ b/tests/files/expected/0440_no_warn_set_check.php.expected
@@ -1,1 +1,1 @@
-%s:7 PhanTypeMismatchReturnReal Returning type array{} (real type ?array{}) but test() is declared to return string
+%s:7 PhanTypeMismatchReturn Returning type array{} but test() is declared to return string

--- a/tests/files/expected/0652_array_narrow.php.expected
+++ b/tests/files/expected/0652_array_narrow.php.expected
@@ -3,4 +3,4 @@
 %s:35 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($numerator) is string but \intdiv() takes int
 %s:37 PhanDebugAnnotation @phan-debug-var requested for variable $options - it has union type array{hooks:array}(real=non-empty-array<mixed,mixed>)
 %s:37 PhanTypeMismatchArgumentInternal Argument 1 ($string) is array but \strlen() takes string
-%s:40 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($string) is array{hooks:array}|array{hooks:string} (real type non-empty-array<mixed,mixed>) but \strlen() takes string
+%s:40 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($string) is array{hooks:array|string} (real type non-empty-array<mixed,mixed>) but \strlen() takes string

--- a/tests/files/expected/0821_false_positives_array_shapes.php.expected
+++ b/tests/files/expected/0821_false_positives_array_shapes.php.expected
@@ -1,0 +1,2 @@
+%s:12 PhanDebugAnnotation @phan-debug-var requested for variable $value - it has union type array{a:,b?:'y'}(real=array{a:,b?:'y'})
+%s:36 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type array|array{field:array}|non-empty-array<mixed,mixed>

--- a/tests/files/src/0440_no_warn_set_check.php
+++ b/tests/files/src/0440_no_warn_set_check.php
@@ -4,6 +4,6 @@ function test(array $data = []) : string {
     if (!isset($data['key'])) {
         $data['key'] = [];
     }
-    return $data['key'];  // TODO: The inferred real type could be improved (e.g. unknown?)
+    return $data['key'];  // The real type is unknown, but the phpdoc type is array, so emit PhanTypeMismatchReturn
 }
 test();

--- a/tests/files/src/0821_false_positives_array_shapes.php
+++ b/tests/files/src/0821_false_positives_array_shapes.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace NS821;
+
+class Example {
+    const A = 'a';
+    const B = 'b';
+
+    public function test_redundant(bool $cond, $other) {
+        $value = [];
+        $value['a'] = $other;
+        if ($cond) {
+            $value['b'] = 'y';
+        }
+        '@phan-debug-var $value';
+        if (isset($value['a']) || isset($value['b'])) {
+            echo "At least one was non-null\n";
+        }
+    }
+}
+
+function test_not_empty_foreach(array $x) {
+    foreach ($x as $elem) {
+        if (!isset($elem['offset'])) {
+            $elem['offset'] = [];
+        }
+        // Should not emit PhanEmptyForeach.
+        foreach ($elem['offset'] as $x) {
+            echo "$x\n";
+        }
+    }
+}
+
+/** @param array $x */
+function test_unknown_field_type($x) {
+    if (is_array($x['field']) && count($x['field']) == 2) {
+        return true;
+    }
+    // src/mixed.php:4 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type array|array{field:array}|array{field:null}|non-empty-array<mixed,mixed>
+    // Inferring mixed for the non-array case instead of null is one way to fix that.
+    '@phan-debug-var $x';
+    if (is_string($x['field'])) {
+        return false;
+    }
+    return null;
+}


### PR DESCRIPTION
Fix some false positives for redundant or impossible conditions when
fields are only set/checked on some branches.

And add new tests.

Fixes #3506