### PR TITLE
Fix false positives for password_hash()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,10 @@ Bug fixes:
 + Fix bug in native parsing of `AST_TYPE_UNION` (union type) nodes for PHP 8.0.0-dev.
 + Don't print duplicate entries for functions with alternate signatures in `tool/make_stubs`
 + Fix Error parsing internal template types such as `non-empty-list<string>` when using `Type::fromFullyQualifiedString()`.
++ Fix warnings about `password_hash()` algorithm constants with php 7.4 (#3560)
+  `PASSWORD_DEFAULT` became null in php 7.4, and other constants became strings.
+
+  Note that you will need to run Phan with both php 7.4 and a `target_php_version` of 7.4 to fix the errors.
 
 Nov 24 2019, Phan 2.4.4
 -----------------------

--- a/src/Phan/Language/Internal/FunctionSignatureMap_php74_delta.php
+++ b/src/Phan/Language/Internal/FunctionSignatureMap_php74_delta.php
@@ -37,7 +37,7 @@ return [
 'imagecreatefromtga' => ['resource|false', 'filename'=>'string'],
 'openssl_x509_verify' => ['resource|false', 'cert'=>'string|resource', 'key'=>'string|resource'],
 'password_algos' => ['list<string>'],
-'password_hash' => ['string|false|null', 'password'=>'string', 'algo'=>'string', 'options='=>'array'],
+'password_hash' => ['string|false|null', 'password'=>'string', 'algo'=>'?string|?int', 'options='=>'array'],
 'pcntl_unshare' => ['bool', 'flags'=>'int'],
 'proc_open' => ['resource|false', 'command'=>'string|string[]', 'descriptorspec'=>'array', '&w_pipes'=>'resource[]', 'cwd='=>'?string', 'env='=>'?array', 'other_options='=>'array'],
 'ReflectionReference::fromArrayElement' => ['?ReflectionReference', 'array'=>'array', 'key'=>'int|string'],


### PR DESCRIPTION
Fixes #3560

Note that php 7.4 also accepts the original `int` values - change Phan deltas to account for that.

```
php > echo password_hash('test', 1);
$2y$10$T11itiOZoUaXnd.SZTw.7eDbExk36KgL4xsBTooNyRNRuNx6Ugvy.
php > echo PASSWORD_BCRYPT;
2y
php > echo password_hash('test', PASSWORD_BCRYPT);
$2y$10$3AP12P6Nk.75EmKL.X2jN.gvLm7dXxSBKFBuvJ.p1NkinXFekMx9O
```
