### PR TITLE
More accurately infer return type of bcdiv()

### DIFF
--- a/src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php
@@ -94,6 +94,10 @@ final class DependentReturnTypeOverridePlugin extends PluginV3 implements
             };
         };
 
+        /**
+         * @param Func $function @phan-unused-param
+         * @param list<Node|int|float|string> $args
+         */
         $bcdiv_callback = static function (
             CodeBase $code_base,
             Context $context,


### PR DESCRIPTION
If second argument to bcdiv() is non-zero, the return type is string, otherwise ?string

Adresses issue #3577