### PR TITLE
Improve checks of assignment operators

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@ New Features(Analysis)
 + Infer that array offsets are no longer possibly undefined after conditions such as `if (!is_null($x['offset']))`
 + Improve worst-case runtime when merging union types with many types (#3587)
 + Handle being installed in a non-standard composer directory name (i.e. not `vendor`) (mentioned in #1612)
++ Improve analysis of assignment operators. (#3597)
++ Infer `$x op= expr` and `++`/`--` operators have a literal value when possible, outside of loops. (#3250, #3248)
 
 Bug fixes:
 + Fix false positive PhanTypePossiblyInvalidDimOffset seen after

--- a/src/Phan/AST/PhanAnnotationAdder.php
+++ b/src/Phan/AST/PhanAnnotationAdder.php
@@ -97,11 +97,21 @@ class PhanAnnotationAdder
     {
         /**
          * @param Node $node
-         * @return void
          */
         $binary_op_handler = static function (Node $node) : void {
             if ($node->flags === flags\BINARY_COALESCE) {
                 $inner_node = $node->children['left'];
+                if ($inner_node instanceof Node) {
+                    self::markNode($inner_node, self::FLAG_IGNORE_NULLABLE_AND_UNDEF);
+                }
+            }
+        };
+        /**
+         * @param Node $node a node of kind ast\AST_ASSIGN_OP
+         */
+        $assign_op_handler = static function (Node $node) : void {
+            if ($node->flags === flags\BINARY_COALESCE) {
+                $inner_node = $node->children['var'];
                 if ($inner_node instanceof Node) {
                     self::markNode($inner_node, self::FLAG_IGNORE_NULLABLE_AND_UNDEF);
                 }
@@ -160,6 +170,7 @@ class PhanAnnotationAdder
 
         self::$closures_for_kind = [
             ast\AST_BINARY_OP => $binary_op_handler,
+            ast\AST_ASSIGN_OP => $assign_op_handler,
             ast\AST_DIM => $dim_handler,
             ast\AST_PROP => $prop_handler,
             ast\AST_EMPTY => $ignore_nullable_and_undef_expr_handler,

--- a/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
+++ b/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
@@ -275,8 +275,11 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
         return UnionType::fromFullyQualifiedPHPDocAndRealString('int', 'int|string');
     }
 
-    // TODO: Switch to asRealUnionType when both operands are real
-    private static function computeIntOrFloatOperationResult(
+    /**
+     * TODO: Switch to asRealUnionType when both operands are real
+     * @internal
+     */
+    public static function computeIntOrFloatOperationResult(
         Node $node,
         UnionType $left,
         UnionType $right
@@ -311,17 +314,17 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
                     case ast\flags\BINARY_BITWISE_OR:
                         return $make_literal_union_type(
                             LiteralIntType::instanceForValue($left_value | $right_value, false),
-                            $real_int_or_string
+                            $real_int
                         );
                     case ast\flags\BINARY_BITWISE_AND:
                         return $make_literal_union_type(
                             LiteralIntType::instanceForValue($left_value & $right_value, false),
-                            $real_int_or_string
+                            $real_int
                         );
                     case ast\flags\BINARY_BITWISE_XOR:
                         return $make_literal_union_type(
                             LiteralIntType::instanceForValue($left_value ^ $right_value, false),
-                            $real_int_or_string
+                            $real_int
                         );
                     case ast\flags\BINARY_MUL:
                         $value = $left_value * $right_value;
@@ -340,6 +343,16 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
                             is_int($value) ? LiteralIntType::instanceForValue($value, false)
                                            : LiteralFloatType::instanceForValue($value, false),
                             $real_int_or_float
+                        );
+                    case ast\flags\BINARY_MOD:
+                        if (!$right_value) {
+                            // TODO: Emit warning about division by zero.
+                            return IntType::instance(false)->asRealUnionType();
+                        }
+                        $value = $left_value % $right_value;
+                        return $make_literal_union_type(
+                            LiteralIntType::instanceForValue($value, false),
+                            $real_int
                         );
                     case ast\flags\BINARY_SUB:
                         $value = $left_value - $right_value;

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -5589,6 +5589,7 @@ class UnionType implements Serializable
 
     /**
      * Returns the union type resulting from applying the `++`/`--` operator to an expression with union type.
+     * TODO: Compute the real type set
      */
     public function getTypeAfterIncOrDec() : UnionType
     {

--- a/tests/Phan/Language/UnionTypeTest.php
+++ b/tests/Phan/Language/UnionTypeTest.php
@@ -130,24 +130,25 @@ final class UnionTypeTest extends BaseTest
         // TODO: Optionally, convert to "prefixSuffix"
         $this->assertUnionTypeStringEqual('$x="prefixSuffix"; $x .= "Suffix"; $x', 'string');
         $this->assertUnionTypeStringEqual('$x=[2]; $x += [3,"other"]; $x', "array{0:2,1:'other'}");
-        $this->assertUnionTypeStringEqual('$x=2; $x += 3; $x', 'int');
-        $this->assertUnionTypeStringEqual('$x=2.5; $x += 3; $x', 'float');
-        $this->assertUnionTypeStringEqual('$x=2; $x += 3.5; $x', 'float');
+        $this->assertUnionTypeStringEqual('$x=2; $x += 3; $x', '5');
+        $this->assertUnionTypeStringEqual('$x=2.5; $x += 3; $x', '5.5');
+        $this->assertUnionTypeStringEqual('$x=2; $x += 3.5; $x', '5.5');
         $this->assertUnionTypeStringEqual('$x=2; $x += (rand()%2) ? 3.5 : 2; $x', 'float|int');
-        $this->assertUnionTypeStringEqual('$x=2; $x -= 3; $x', 'int');
-        $this->assertUnionTypeStringEqual('$x=2; $x -= 3.5; $x', 'float');
-        $this->assertUnionTypeStringEqual('$x=2; $x *= 3.5; $x', 'float');
-        $this->assertUnionTypeStringEqual('$x=2; $x *= 3; $x', 'int');
-        $this->assertUnionTypeStringEqual('$x=2; $x **= 3; $x', 'int');
-        $this->assertUnionTypeStringEqual('$x=2; $x **= 3.5; $x', 'float');
-        $this->assertUnionTypeStringEqual('$x=5; $x %= 3; $x', 'int');  // This casts to float
-        $this->assertUnionTypeStringEqual('$x=21.2; $x %= 3.5; $x', 'int');  // This casts to float
-        $this->assertUnionTypeStringEqual('$x=5;    $x ^= 3;    $x', 'int');
+        $this->assertUnionTypeStringEqual('$x=2; $x -= 3; $x', '-1');
+        $this->assertUnionTypeStringEqual('$x=2; $x -= 3.5; $x', '-1.5');
+        $this->assertUnionTypeStringEqual('$x=2; $x *= 3.5; $x', '7.0');
+        $this->assertUnionTypeStringEqual('$x=2; $x *= 3; $x', '6');
+        $this->assertUnionTypeStringEqual('$x=2; $x **= 3; $x', '8');
+        $this->assertUnionTypeStringEqual('$x=4; $x **= 3.5; $x', '128.0');
+        $this->assertUnionTypeStringEqual('$x=5; $x %= 3; $x', '2');  // This casts to float
+        $this->assertUnionTypeStringEqual('$x=21.2; $x %= 3.5; $x', '0');
+        $this->assertUnionTypeStringEqual('$x=23.2; $x %= 3.5; $x', '2');
+        $this->assertUnionTypeStringEqual('$x=5;    $x ^= 3;    $x', '6');
         $this->assertUnionTypeStringEqual('$x="ab"; $x ^= "ac"; $x', 'string');
-        $this->assertUnionTypeStringEqual('$x=5;    $x |= 3;    $x', 'int');
+        $this->assertUnionTypeStringEqual('$x=5;    $x |= 3;    $x', '7');
         $this->assertUnionTypeStringEqual('$x="ab"; $x |= "ac"; $x', 'string');
         // `&=` is a bitwise and, not to be confused with `=&`
-        $this->assertUnionTypeStringEqual('$x=5;    $x &= 3;    $x', 'int');
+        $this->assertUnionTypeStringEqual('$x=5;    $x &= 3;    $x', '1');
         $this->assertUnionTypeStringEqual('$x="ab"; $x &= "ac"; $x', 'string');
 
         // TODO: Implement more code to warn about invalid operands.
@@ -268,7 +269,8 @@ final class UnionTypeTest extends BaseTest
     ) : void {
         $this->assertSame(
             $type_name,
-            self::typeStringFromCode('<' . '?php ' . $code_stub . ';')
+            self::typeStringFromCode('<' . '?php ' . $code_stub . ';'),
+            "Unexpected result of $code_stub"
         );
     }
 

--- a/tests/files/expected/0299_binary_op.php.expected
+++ b/tests/files/expected/0299_binary_op.php.expected
@@ -42,9 +42,9 @@
 %s:42 PhanTypeMismatchArgument Argument 1 ($x) is int but \expect_string_298() takes string defined at %s:3
 %s:43 PhanTypeMismatchArgument Argument 1 ($x) is int but \expect_string_298() takes string defined at %s:3
 %s:44 PhanTypeMismatchArgument Argument 1 ($x) is int but \expect_string_298() takes string defined at %s:3
-%s:45 PhanTypeMismatchArgumentInternal Argument 1 ($string) is float|int but \strlen() takes string
+%s:45 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($string) is 21.5 but \strlen() takes string
 %s:45 PhanTypeMismatchArgumentReal Argument 1 ($x) is float but \expect_string_298() takes string defined at %s:3
-%s:46 PhanTypeMismatchArgumentReal Argument 1 ($x) is int (real type float) but \expect_string_298() takes string defined at %s:3
+%s:46 PhanTypeMismatchArgumentReal Argument 1 ($x) is float but \expect_string_298() takes string defined at %s:3
 %s:47 PhanTypeMismatchArgumentReal Argument 1 ($x) is float but \expect_string_298() takes string defined at %s:3
 %s:48 PhanTypeMismatchArgumentReal Argument 1 ($x) is int but \expect_string_298() takes string defined at %s:3
 %s:48 PhanUnusedVariable Unused definition of variable $intVar

--- a/tests/files/expected/0300_misc_types.php.expected
+++ b/tests/files/expected/0300_misc_types.php.expected
@@ -1,6 +1,8 @@
 %s:10 PhanTypeMismatchArgument Argument 1 ($x) is int but \expect_string_300() takes string defined at %s:3
+%s:11 PhanDebugAnnotation @phan-debug-var requested for variable $intVar - it has union type 44
 %s:11 PhanTypeMismatchArgument Argument 1 ($x) is int but \expect_string_300() takes string defined at %s:3
 %s:12 PhanTypeMismatchArgument Argument 1 ($x) is int but \expect_string_300() takes string defined at %s:3
+%s:13 PhanDebugAnnotation @phan-debug-var requested for variable $intVar - it has union type 42
 %s:13 PhanTypeMismatchArgument Argument 1 ($x) is int but \expect_string_300() takes string defined at %s:3
 %s:14 PhanTypeMismatchArgument Argument 1 ($x) is string but \expect_int_300() takes int defined at %s:4
 %s:19 PhanTypeInvalidCloneNotObject Expected an object to be passed to clone() but got 42
@@ -9,7 +11,7 @@
 %s:21 PhanUndeclaredVariableAssignOp Variable $undefIntVar was undeclared, but it is being used as the left-hand side of an assignment operation
 %s:21 PhanUndeclaredVariable Variable $undefIntVar is undeclared
 %s:21 PhanUnusedVariable Unused definition of variable $undefIntVar
-%s:22 PhanTypeMismatchArgument Argument 1 ($x) is int but \expect_string_300() takes string defined at %s:3
+%s:22 PhanTypeMismatchArgument Argument 1 ($x) is 42 but \expect_string_300() takes string defined at %s:3
 %s:22 PhanUnusedVariableReference Unused definition of variable $refIntVar as a reference
 %s:23 PhanImpossibleCondition Impossible attempt to cast false of type false to truthy
 %s:23 PhanTypeMismatchArgument Argument 1 ($x) is ?string but \expect_int_300() takes int defined at %s:4

--- a/tests/files/expected/0574_inc_dec.php.expected
+++ b/tests/files/expected/0574_inc_dec.php.expected
@@ -16,7 +16,7 @@
 %s:26 PhanTypeMismatchArgumentInternal Argument 1 ($string) is bool but \strlen() takes string
 %s:27 PhanTypeInvalidUnaryOperandIncOrDec Invalid operator: unary operand of (expr)-- is ?\stdClass (expected int or string or float)
 %s:28 PhanTypeMismatchArgumentInternal Argument 1 ($string) is \stdClass|int but \strlen() takes string
-%s:31 PhanTypeMismatchArgumentInternal Argument 1 ($string) is int but \strlen() takes string
+%s:31 PhanTypeMismatchArgumentInternal Argument 1 ($string) is 3 but \strlen() takes string
 %s:37 PhanTypeInvalidUnaryOperandIncOrDec Invalid operator: unary operand of ++(expr) is object (expected int or string or float)
 %s:37 PhanTypeMismatchArgumentInternal Argument 1 ($string) is object but \strlen() takes string
 %s:38 PhanTypeInvalidUnaryOperandIncOrDec Invalid operator: unary operand of --(expr) is array (expected int or string or float)
@@ -42,4 +42,4 @@
 %s:54 PhanTypeMismatchArgumentInternal Argument 1 ($string) is int but \strlen() takes string
 %s:56 PhanTypeMismatchArgumentInternal Argument 1 ($string) is int but \strlen() takes string
 %s:58 PhanTypeMismatchArgumentInternal Argument 1 ($string) is float but \strlen() takes string
-%s:61 PhanTypeMismatchArgumentInternal Argument 1 ($string) is float but \strlen() takes string
+%s:61 PhanTypeMismatchArgumentInternal Argument 1 ($string) is 4.25 but \strlen() takes string

--- a/tests/files/expected/0628_arithmetic_op_more_warn.php.expected
+++ b/tests/files/expected/0628_arithmetic_op_more_warn.php.expected
@@ -7,7 +7,7 @@
 %s:12 PhanTypeInvalidRightOperandOfNumericOp Invalid operator: right operand of /= is \stdClass (expected number)
 %s:14 PhanTypeInvalidRightOperandOfNumericOp Invalid operator: right operand of -= is \stdClass (expected number)
 %s:16 PhanTypeInvalidRightOperandOfIntegerOp Invalid operator: right operand of >>= is \stdClass (expected int)
-%s:19 PhanTypeMismatchArgumentInternal Argument 1 ($string) is float|int but \strlen() takes string
+%s:19 PhanTypeMismatchArgumentInternal Argument 1 ($string) is 3.666666%d but \strlen() takes string
 %s:21 PhanTypeInvalidRightOperandOfNumericOp Invalid operator: right operand of %= is \stdClass (expected number)
 %s:26 PhanTypeInvalidRightOperandOfIntegerOp Invalid operator: right operand of << is \stdClass (expected int)
 %s:27 PhanTypeInvalidLeftOperandOfIntegerOp Invalid operator: left operand of << is \stdClass (expected int)

--- a/tests/files/expected/0832_assign_op.php.expected
+++ b/tests/files/expected/0832_assign_op.php.expected
@@ -1,0 +1,1 @@
+%s:7 PhanTypeMismatchReturnReal Returning type string but test_offset() is declared to return array

--- a/tests/files/expected/0833_assign_op_prop.php.expected
+++ b/tests/files/expected/0833_assign_op_prop.php.expected
@@ -1,0 +1,1 @@
+%s:8 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($var) is 13 but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array

--- a/tests/files/expected/0834_increment_array_field.php.expected
+++ b/tests/files/expected/0834_increment_array_field.php.expected
@@ -1,0 +1,2 @@
+%s:15 PhanUnusedVariable Unused definition of variable $resultArr
+%s:26 PhanSuspiciousValueComparison Suspicious attempt to compare $resultArr['requests'] of type 1 to $resultArr['foo'] of type -1 with operator '>'

--- a/tests/files/src/0300_misc_types.php
+++ b/tests/files/src/0300_misc_types.php
@@ -8,9 +8,9 @@ function test300() {
     $strVar = 'x';
     // Every one of these statements should warn about incorrect types, unless commented otherwise
     expect_string_300(++$intVar);
-    expect_string_300($intVar++);
+    expect_string_300($intVar++); '@phan-debug-var $intVar';
     expect_string_300(--$intVar);
-    expect_string_300($intVar--);
+    expect_string_300($intVar--); '@phan-debug-var $intVar';
     expect_int_300($strVar++);  // The first time we see it, we just convert $strVar from 'x' to type string
     expect_int_300(++$strVar);  // But then ++string can be anything (string/int, also float)
     expect_int_300($strVar--);

--- a/tests/files/src/0574_inc_dec.php
+++ b/tests/files/src/0574_inc_dec.php
@@ -56,7 +56,7 @@ function testIncDec2($x, array $y, iterable $it, $r, stdClass $s = null, stdClas
     echo strlen($v++);
     $f = 2.5;
     echo strlen(++$f);
-    $f = 3.1415;
+    $f = 3.25;
     $f++;
-    echo strlen($f);  // TODO: Fix this, should be 4.1415
+    echo strlen($f);  // This is 4.25
 }

--- a/tests/files/src/0628_arithmetic_op_more_warn.php
+++ b/tests/files/src/0628_arithmetic_op_more_warn.php
@@ -16,7 +16,7 @@ call_user_func(function () {
     $k >>= $o;
     $w = 11;
     $w /= 3;
-    echo strlen($w);
+    echo strlen($w);  // $w==3.666...
     $w = 2.3;
     $w %= $o;
     $h = 'hello ';

--- a/tests/files/src/0832_assign_op.php
+++ b/tests/files/src/0832_assign_op.php
@@ -1,0 +1,8 @@
+<?php
+
+function test_offset() : array {
+    $x = ['type' => null];
+    $x['type'] .= 'first';
+    // should infer string
+    return $x['type'];
+}

--- a/tests/files/src/0833_assign_op_prop.php
+++ b/tests/files/src/0833_assign_op_prop.php
@@ -1,0 +1,10 @@
+<?php
+
+class MyClass {
+    public $prop;
+    public function __construct() {
+        $this->prop = 1;
+        $this->prop += 12;
+        echo count($this->prop);
+    }
+}

--- a/tests/files/src/0834_increment_array_field.php
+++ b/tests/files/src/0834_increment_array_field.php
@@ -1,0 +1,27 @@
+<?php
+
+function test834(array $foo) {
+    $resultArr = [
+        'requests' => 0,
+        'responsetime' => 123,
+    ];
+
+    // some foreach loop
+    foreach ($foo as $_) {
+        $resultArr['requests']++;
+    }
+
+    if ($resultArr["requests"] > 0) {  // should not emit PhanDivisionByZero
+        $resultArr["responsetime"]    = 2 / $resultArr["requests"];
+    }
+}
+
+function test834b() {
+    $resultArr = [
+        'requests' => 0,
+        'foo' => 0,
+    ];
+    $resultArr['requests']++;
+    --$resultArr['foo'];
+    return $resultArr['requests'] > $resultArr['foo'];
+}

--- a/tests/php74_files/expected/024_coalesce_assign_op.php.expected
+++ b/tests/php74_files/expected/024_coalesce_assign_op.php.expected
@@ -1,0 +1,1 @@
+%s:7 PhanTypeMismatchReturnReal Returning type array{x:2,y:string} but test() is declared to return bool

--- a/tests/php74_files/src/024_coalesce_assign_op.php
+++ b/tests/php74_files/src/024_coalesce_assign_op.php
@@ -1,0 +1,8 @@
+<?php
+
+function test(string $y) : bool {
+    $result = ['x' => null];
+    $result['x'] ??= 2;
+    $result['y'] ??= $y;
+    return $result;
+}


### PR DESCRIPTION
Support analyzing assignment operators on instance properties and field
types.

Infer the exact value outside of loops.

Don't change the outer scope of branches when analyzing `$var op= expr`

Fixes #3597
Fixes #3250
Fixes #3248