### PR TITLE
Consistently infer vars can be possibly undefined

### DIFF
--- a/.phan/plugins/DuplicateExpressionPlugin.php
+++ b/.phan/plugins/DuplicateExpressionPlugin.php
@@ -408,7 +408,7 @@ class RedundantNodePreAnalysisVisitor extends PluginAwarePreAnalysisVisitor
                 $condition_set[$cond_hash] = true;
             }
         }
-        if ($cond === null) {
+        if (!isset($cond)) {
             $stmts = $children[$N - 1]->children['stmts'];
             if (($stmts->children ?? null) && ASTHasher::hash($stmts) === ASTHasher::hash($children[$N - 2]->children['stmts'])) {
                 $this->emitPluginIssue(

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@ New Features(Analysis)
 + Infer `$x op= expr` and `++`/`--` operators have a literal value when possible, outside of loops. (#3250, #3248)
 + Move `PhanUndeclaredInterface` and `PhanUndeclaredTrait` warnings to the line number of the `use`/`implements`. (#2159)
 + Don't emit `PhanUndeclaredGlobalVariable` for the left side of `??`/`??=` in the global scope (#3601)
++ More consistently infer that variables are possibly undefined if they are not defined in all branches.
++ Add new issue types for possibly undeclared variables: `PhanPossiblyUndeclaredVariable` and `PhanPossiblyUndeclaredGlobalVariable`.
 
 Plugins:
 + Add `StrictLiteralComparisonPlugin` to warn about loose equality comparisons of constant string/int to other values. (#2310)

--- a/composer.lock
+++ b/composer.lock
@@ -294,16 +294,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "4.3.2",
+            "version": "4.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "b83ff7cfcfee7827e1e78b637a5904fe6a96698e"
+                "reference": "2ecaa9fef01634c83bfa8dc1fe35fb5cef223a62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/b83ff7cfcfee7827e1e78b637a5904fe6a96698e",
-                "reference": "b83ff7cfcfee7827e1e78b637a5904fe6a96698e",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/2ecaa9fef01634c83bfa8dc1fe35fb5cef223a62",
+                "reference": "2ecaa9fef01634c83bfa8dc1fe35fb5cef223a62",
                 "shasum": ""
             },
             "require": {
@@ -341,7 +341,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2019-09-12T14:27:41+00:00"
+            "time": "2019-12-20T13:40:23+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -1217,16 +1217,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.10.0",
+            "version": "1.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "d638ebbb58daba25a6a0dc7969e1358a0e3c6682"
+                "reference": "cbe1df668b3fe136bcc909126a0f529a78d4cbbc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/d638ebbb58daba25a6a0dc7969e1358a0e3c6682",
-                "reference": "d638ebbb58daba25a6a0dc7969e1358a0e3c6682",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/cbe1df668b3fe136bcc909126a0f529a78d4cbbc",
+                "reference": "cbe1df668b3fe136bcc909126a0f529a78d4cbbc",
                 "shasum": ""
             },
             "require": {
@@ -1276,7 +1276,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2019-12-17T16:54:23+00:00"
+            "time": "2019-12-22T21:05:45+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/phan_client
+++ b/phan_client
@@ -86,6 +86,7 @@ class PhanPHPLinter
                     continue;
                 }
                 $exit_code = 0;
+                $output = '';
                 if (!$opts->use_fallback_parser) {
                     ob_start();
                     try {
@@ -105,6 +106,7 @@ class PhanPHPLinter
                 // TODO: add option to capture output, suppress "No syntax error"?
                 // --no-php-ini is a faster way to parse since php doesn't need to load multiple extensions. Assumes none of the extensions change the way php is parsed.
                 $exit_code = 0;
+                $output = '';
                 if (!$opts->use_fallback_parser) {
                     ob_start();
                     try {

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -1251,9 +1251,14 @@ class ContextNode
     {
         // Return the original variable if it existed
         try {
-            return $this->getVariable();
+            $variable = $this->getVariable();
+            $union_type = $variable->getUnionType();
+            if ($union_type->isPossiblyUndefined()) {
+                $variable->setUnionType($union_type->convertUndefinedToNullable());
+            }
+            return $variable;
         } catch (IssueException $_) {
-            // Swallow it
+            // Swallow exceptions fetching the variable
         }
         // Create a new variable, and set its union type to null if that wouldn't create false positives.
 

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -118,7 +118,7 @@ class AssignmentVisitor extends AnalysisVisitor
     ) {
         parent::__construct($code_base, $context);
 
-        $this->right_type = $right_type->withSelfResolvedInContext($context);
+        $this->right_type = $right_type->withSelfResolvedInContext($context)->convertUndefinedToNullable();
         $this->dim_depth = $dim_depth;
         $this->dim_type = $dim_type;  // null for `$x[] =` or when dim_depth is 0.
         $this->assignment_node = $assignment_node;
@@ -541,6 +541,9 @@ class AssignmentVisitor extends AnalysisVisitor
         UnionType $element_type,
         $node
     ) : void {
+        // Let the caller warn about possibly undefined offsets, e.g. ['field' => $value] = ...
+        // TODO: Convert real types to nullable?
+        $element_type = $element_type->withIsPossiblyUndefined(false);
         $element->setUnionType($element_type);
         if ($element instanceof PassByReferenceVariable) {
             self::analyzeSetUnionTypePassByRef($this->code_base, $this->context, $element, $element_type, $node);

--- a/src/Phan/Analysis/ContextMergeVisitor.php
+++ b/src/Phan/Analysis/ContextMergeVisitor.php
@@ -381,24 +381,15 @@ class ContextMergeVisitor extends KindVisitorImplementation
             $name = (string)$name;
             // Skip variables that are only partially defined
             if (!$is_defined_on_all_branches($name)) {
-                if ($this->context->isStrictTypes()) {
-                    continue;
-                } else {
-                    // Limit the type of the variable to the subset
-                    // of types that are common to all branches
-                    // Record that it can be null, as the best available equivalent for undefined.
-                    $variable = clone($variable);
-
-                    $variable->setUnionType(
-                        $union_type($name)->withType(
-                            NullType::instance(false)
-                        )
-                    );
-
-                    // Add the variable to the outgoing scope
-                    $scope->addVariable($variable);
+                if ($name === Context::VAR_NAME_THIS_PROPERTIES) {
+                    // there are no overrides for $this on at least one branch.
+                    // TODO: Could try to combine local overrides with the defaults.
                     continue;
                 }
+                $variable = clone($variable);
+                $variable->setUnionType($union_type($name)->nullableClone()->withIsPossiblyUndefined(true));
+                $scope->addVariable($variable);
+                continue;
             }
 
             // Limit the type of the variable to the subset

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -145,7 +145,8 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
 
         // Handle the assignment based on the type of the
         // right side of the equation and the kind of item
-        // on the left
+        // on the left.
+        // (AssignmentVisitor converts possibly undefined types to nullable)
         $context = (new AssignmentVisitor(
             $this->code_base,
             $this->context,

--- a/src/Phan/ForkPool.php
+++ b/src/Phan/ForkPool.php
@@ -187,6 +187,9 @@ class ForkPool
         }
 
         // Get the write stream for the child.
+        if (!isset($sockets)) {
+            throw new AssertionError('$sockets must be set if this is the child process');
+        }
         $write_stream = self::streamForChild($sockets);
         Writer::initialize($write_stream);
 

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -76,7 +76,9 @@ class Issue
     const UndeclaredTypeProperty    = 'PhanUndeclaredTypeProperty';
     const UndeclaredTypeThrowsType  = 'PhanUndeclaredTypeThrowsType';
     const UndeclaredVariable        = 'PhanUndeclaredVariable';
+    const PossiblyUndeclaredVariable = 'PhanPossiblyUndeclaredVariable';
     const UndeclaredGlobalVariable  = 'PhanUndeclaredGlobalVariable';
+    const PossiblyUndeclaredGlobalVariable  = 'PhanPossiblyUndeclaredGlobalVariable';
     const UndeclaredThis            = 'PhanUndeclaredThis';
     const UndeclaredVariableDim     = 'PhanUndeclaredVariableDim';
     const UndeclaredVariableAssignOp = 'PhanUndeclaredVariableAssignOp';
@@ -1081,6 +1083,14 @@ class Issue
                 11018
             ),
             new Issue(
+                self::PossiblyUndeclaredVariable,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_NORMAL,
+                "Variable \${VARIABLE} is possibly undeclared",
+                self::REMEDIATION_B,
+                11051
+            ),
+            new Issue(
                 self::UndeclaredThis,
                 self::CATEGORY_UNDEFINED,
                 self::SEVERITY_CRITICAL,
@@ -1095,6 +1105,14 @@ class Issue
                 "Global variable \${VARIABLE} is undeclared",
                 self::REMEDIATION_B,
                 11047
+            ),
+            new Issue(
+                self::PossiblyUndeclaredGlobalVariable,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_NORMAL,
+                "Global variable \${VARIABLE} is possibly undeclared",
+                self::REMEDIATION_B,
+                11052
             ),
             new Issue(
                 self::UndeclaredTypeParameter,

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -319,6 +319,7 @@ class Type
      * @param string $namespace
      * The (optional) namespace of the type such as '\'
      * or '\Phan\Language'.
+     * This should not be the empty string.
      *
      * @param string $name
      * The name of the type such as 'int' or 'MyClass'
@@ -1182,7 +1183,7 @@ class Type
         $template_count = count($template_parameter_type_list);
         if ($template_count === 1) {
             return new ClassStringType(
-                '',
+                '\\',
                 'class-string',
                 $template_parameter_type_list,
                 $is_nullable

--- a/src/Phan/Language/Type/GenericIterableType.php
+++ b/src/Phan/Language/Type/GenericIterableType.php
@@ -31,7 +31,7 @@ final class GenericIterableType extends IterableType
 
     protected function __construct(UnionType $key_union_type, UnionType $element_union_type, bool $is_nullable)
     {
-        parent::__construct('', self::NAME, [], $is_nullable);
+        parent::__construct('\\', self::NAME, [], $is_nullable);
         $this->key_union_type = $key_union_type;
         $this->element_union_type = $element_union_type;
     }

--- a/src/Phan/Language/Type/IterableType.php
+++ b/src/Phan/Language/Type/IterableType.php
@@ -28,7 +28,6 @@ class IterableType extends NativeType
         return $other instanceof IterableType || $other instanceof CallableDeclarationType || $other->isPossiblyObject();
     }
 
-
     public function asIterable(CodeBase $_) : ?Type
     {
         return $this->withIsNullable(false);

--- a/src/Phan/Language/Type/NativeType.php
+++ b/src/Phan/Language/Type/NativeType.php
@@ -386,5 +386,6 @@ abstract class NativeType extends Type
         return false;
     }
 }
+\class_exists(IterableType::class);
 \class_exists(ArrayType::class);
 \class_exists(ScalarType::class);

--- a/tests/files/expected/0158_conditional_assignment.php.expected
+++ b/tests/files/expected/0158_conditional_assignment.php.expected
@@ -1,2 +1,3 @@
-%s:7 PhanUndeclaredGlobalVariable Global variable $important_variable is undeclared
-
+%s:3 PhanDebugAnnotation @phan-debug-var requested for variable $important_variable - it has union type ?true=(real=?true=)
+%s:7 PhanPossiblyUndeclaredGlobalVariable Global variable $important_variable is possibly undeclared
+%s:8 PhanTypeMismatchArgumentInternal Argument 1 ($var) is ?true but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array

--- a/tests/files/expected/0348_global_isset.php.expected
+++ b/tests/files/expected/0348_global_isset.php.expected
@@ -1,2 +1,2 @@
-%s:6 PhanUndeclaredGlobalVariable Global variable $global348 is undeclared
+%s:6 PhanPossiblyUndeclaredGlobalVariable Global variable $global348 is possibly undeclared
 %s:12 PhanUndeclaredGlobalVariable Global variable $globalC348 is undeclared

--- a/tests/files/expected/0489_crash.php.expected
+++ b/tests/files/expected/0489_crash.php.expected
@@ -1,1 +1,2 @@
-%s:7 PhanTypeMismatchArgumentInternal Argument 1 ($var) is 24|null but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array
+%s:7 PhanPossiblyUndeclaredVariable Variable $42 is possibly undeclared
+%s:7 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($var) is ?24 but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array

--- a/tests/files/expected/0675_unused_loop_variable_2.php.expected
+++ b/tests/files/expected/0675_unused_loop_variable_2.php.expected
@@ -1,1 +1,4 @@
 %s:10 PhanUnusedVariable Unused definition of variable $c
+%s:19 PhanPossiblyUndeclaredVariable Variable $c is possibly undeclared
+%s:20 PhanPossiblyUndeclaredVariable Variable $c is possibly undeclared
+%s:28 PhanPossiblyUndeclaredVariable Variable $c is possibly undeclared

--- a/tests/files/expected/0836_possibly_undefined_property.php.expected
+++ b/tests/files/expected/0836_possibly_undefined_property.php.expected
@@ -1,0 +1,8 @@
+%s:7 PhanDebugAnnotation @phan-debug-var requested for variable $v - it has union type 
+%s:7 PhanUnusedVariable Unused definition of variable $v
+%s:10 PhanDebugAnnotation @phan-debug-var requested for variable $v - it has union type 
+%s:10 PhanUnusedVariable Unused definition of variable $v
+%s:14 PhanDebugAnnotation @phan-debug-var requested for variable $v - it has union type array{}(real=array{})
+%s:14 PhanUnusedVariable Unused definition of variable $v
+%s:17 PhanDebugAnnotation @phan-debug-var requested for variable $v - it has union type array
+%s:17 PhanUnusedVariable Unused definition of variable $v

--- a/tests/files/src/0158_conditional_assignment.php
+++ b/tests/files/src/0158_conditional_assignment.php
@@ -3,5 +3,6 @@
 if ( !empty($_SERVER['HOST_NAME']) && $_SERVER['HOST_NAME'] == "www.some.domain" ) {
     $important_variable = true;
 }
-
+'@phan-debug-var $important_variable';
 $use_variable = $important_variable;
+echo count($use_variable);

--- a/tests/files/src/0675_unused_loop_variable_2.php
+++ b/tests/files/src/0675_unused_loop_variable_2.php
@@ -17,7 +17,7 @@ call_user_func (function () {
         } else {
         }
         var_dump($c);
-        $c = $c + 1;  // should emit PhanUnusedVariable
+        $c = $c + 1;  // should not emit PhanUnusedVariable
     }
 });
 call_user_func (function () {

--- a/tests/files/src/0836_possibly_undefined_property.php
+++ b/tests/files/src/0836_possibly_undefined_property.php
@@ -1,0 +1,22 @@
+<?php
+
+class TestBranch {
+    private $arr;
+
+    private function arr() {
+        $v = $this->arr;
+        '@phan-debug-var $v';
+        if (isset($this->arr)) {
+            $v = $this->arr;
+            '@phan-debug-var $v';
+        } else {
+            $this->arr = [];
+            $v = $this->arr;
+            '@phan-debug-var $v';
+        }
+        $v = $this->arr;
+        '@phan-debug-var $v';
+
+        return $this->arr;
+    }
+}

--- a/tests/php74_files/expected/000_null_assign.php.expected
+++ b/tests/php74_files/expected/000_null_assign.php.expected
@@ -4,3 +4,4 @@
 %s:8 PhanUndeclaredVariable Variable $missing is undeclared
 %s:9 PhanTypeMismatchArgumentInternal Argument 1 ($string) is array{0:2} but \strlen() takes string
 %s:12 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($string) is array{0:int,1:2} but \strlen() takes string
+%s:16 PhanPossiblyUndeclaredVariable Variable $otherMissing is possibly undeclared

--- a/tests/php74_files/src/000_null_assign.php
+++ b/tests/php74_files/src/000_null_assign.php
@@ -13,7 +13,7 @@ function null_handler(?int $a, ?int $b, string $default, array $values) {
     foreach ($values as $v) {
         $otherMissing ??= $v;
     }
-    echo "Saw $otherMissing\n";
+    echo "Saw $otherMissing\n";  // this is possibly undefined - $values may be the empty array.
 }
 // Should not warn
 $missing000 ??= 'default';

--- a/tests/plugin_test/expected/035_break_unused.php.expected
+++ b/tests/plugin_test/expected/035_break_unused.php.expected
@@ -2,3 +2,4 @@ src/035_break_unused.php:3 PhanPluginPossiblyStaticClosure Closure() can be stat
 src/035_break_unused.php:7 PhanUnusedVariable Unused definition of variable $myUnusedVar
 src/035_break_unused.php:8 PhanUnusedVariable Unused definition of variable $myUnusedVar3
 src/035_break_unused.php:12 PhanUnusedVariable Unused definition of variable $myUnusedVar3
+src/035_break_unused.php:14 PhanPossiblyUndeclaredVariable Variable $myVar is possibly undeclared

--- a/tests/plugin_test/expected/037_unused_return.php.expected
+++ b/tests/plugin_test/expected/037_unused_return.php.expected
@@ -7,3 +7,4 @@ src/037_unused_return.php:21 PhanUnusedVariable Unused definition of variable $m
 src/037_unused_return.php:23 PhanUnusedVariable Unused definition of variable $myVar
 src/037_unused_return.php:24 PhanUnusedVariable Unused definition of variable $myUnusedVar
 src/037_unused_return.php:25 PhanThrowTypeAbsent \unused_return() can throw \RuntimeException here, but has no '@throws' declarations for that class
+src/037_unused_return.php:29 PhanPossiblyUndeclaredVariable Variable $myVar is possibly undeclared

--- a/tests/plugin_test/expected/075_variable_suggestions.php.expected
+++ b/tests/plugin_test/expected/075_variable_suggestions.php.expected
@@ -1,3 +1,4 @@
 src/075_variable_suggestions.php:4 PhanUnusedVariable Unused definition of variable $unrelatedValuename (Did you mean $unrelatedValueName)
 src/075_variable_suggestions.php:8 PhanUnusedVariable Unused definition of variable $value2 (Did you mean $value1 or $value3)
+src/075_variable_suggestions.php:10 PhanPossiblyUndeclaredVariable Variable $value1 is possibly undeclared
 src/075_variable_suggestions.php:12 PhanUndeclaredVariable Variable $unrelatedValueName is undeclared (Did you mean $unrelatedValuename)

--- a/tests/plugin_test/src/035_break_unused.php
+++ b/tests/plugin_test/src/035_break_unused.php
@@ -11,6 +11,6 @@ $x = function() {
         $myVar = $i;
         $myUnusedVar3 = $i;
     }
-    echo $myVar;
+    echo $myVar;  // TODO: Infer the loop will run at least once and that myVar will be defined..
 };
 call_user_func($x);

--- a/tests/plugin_test/src/037_unused_return.php
+++ b/tests/plugin_test/src/037_unused_return.php
@@ -26,6 +26,6 @@ function unused_return(int $v) {
         }
         $myVar = 22;
     }
-    echo $myVar;
+    echo $myVar;  // TODO: Infer the loop will run at least once and all branches set $myVar.
 }
 unused_return(rand() % 20 - 10);

--- a/tests/plugin_test/src/075_variable_suggestions.php
+++ b/tests/plugin_test/src/075_variable_suggestions.php
@@ -7,7 +7,7 @@ function test_variable_suggestions() {
     } else {
         $value2 = 2;
     }
-    echo $value1;
+    echo $value1;  // possibly undefined
     echo $value3;
     echo $unrelatedValueName;
 }


### PR DESCRIPTION
Stop making the inference depend on the strict_types setting.
That code predated the possibly defined union types.