### PR TITLE
Handle negative limit in explode

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,12 @@ Bug fixes:
 + Fix a crash analyzing assignment operations on `$GLOBALS` such as `$GLOBALS['var'] += expr;` (#3615)
 + Fix false positive `Phan[Possibly]UndeclaredGlobalVariable` after conditions such as `assert($var instanceof MyClass` when the variable was not assigned to within the file or previously analyzed files. (#3616)
 
+Plugins:
++ Make Phan use the real type set of the return value of the function being analyzed when plugins return a union type without a real type set.
+
+Maintenance:
++ Infer that `explode()` is possibly the empty list when `$limit` is possibly negative. (#3617)
+
 Dec 29 2019, Phan 2.4.6
 -----------------------
 

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -1003,7 +1003,14 @@ trait FunctionTrait
     public function getDependentReturnType(CodeBase $code_base, Context $context, array $args) : UnionType
     {
         // @phan-suppress-next-line PhanTypePossiblyInvalidCallable - Callers should check hasDependentReturnType
-        return ($this->return_type_callback)($code_base, $context, $this, $args);
+        $result = ($this->return_type_callback)($code_base, $context, $this, $args);
+        if (!$result->hasRealTypeSet()) {
+            $real_return_type = $this->getRealReturnType();
+            if (!$real_return_type->isEmpty()) {
+                return $result->withRealTypeSet($real_return_type->getTypeSet());
+            }
+        }
+        return $result;
     }
 
     public function setDependentReturnTypeClosure(Closure $closure) : void

--- a/src/Phan/Language/Internal/FunctionSignatureMap.php
+++ b/src/Phan/Language/Internal/FunctionSignatureMap.php
@@ -2979,7 +2979,7 @@ return [
 'exp' => ['float', 'number'=>'float'],
 'expect_expectl' => ['int', 'expect'=>'resource', 'cases'=>'array', 'match='=>'array'],
 'expect_popen' => ['resource', 'command'=>'string'],
-'explode' => ['non-empty-list<string>', 'separator'=>'string', 'str'=>'string', 'limit='=>'int'],
+'explode' => ['list<string>', 'separator'=>'string', 'str'=>'string', 'limit='=>'int'],
 'expm1' => ['float', 'number'=>'float'],
 'extension_loaded' => ['bool', 'extension_name'=>'string'],
 'extract' => ['int', '&rw_var_array'=>'array', 'extract_type='=>'int', 'prefix='=>'?string'],

--- a/tests/files/expected/0605_array_shape_template.php.expected
+++ b/tests/files/expected/0605_array_shape_template.php.expected
@@ -1,2 +1,2 @@
 %s:13 PhanUndeclaredMethod Call to undeclared method \stdClass::method
-%s:24 PhanTypeMismatchArgumentInternal Argument 1 ($string) is array{0:\stdClass,1:int} but \strlen() takes string
+%s:24 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($string) is array{0:\stdClass,1:int} (real type array) but \strlen() takes string

--- a/tests/files/expected/0817_real_type_of_array_dim.php.expected
+++ b/tests/files/expected/0817_real_type_of_array_dim.php.expected
@@ -1,6 +1,8 @@
-%s:3 PhanDebugAnnotation @phan-debug-var requested for variable $vals - it has union type non-empty-list<string>
+%s:3 PhanDebugAnnotation @phan-debug-var requested for variable $vals - it has union type non-empty-list<string>(real=?non-empty-list<string>)
 %s:3 PhanParamSuspiciousOrder Argument #1 of this call to \explode is typically a literal or constant but isn't, but argument #2 (which is typically a variable) is a literal or constant. The arguments may be in the wrong order.
 %s:3 PhanTypeMismatchArgumentInternal Argument 2 ($str) is 2 but \explode() takes string
-%s:5 PhanDebugAnnotation @phan-debug-var requested for variable $methodName - it has union type string
+%s:5 PhanDebugAnnotation @phan-debug-var requested for variable $methodName - it has union type string(real=?string)
 %s:5 PhanUnusedVariable Unused definition of variable $className
-%s:7 PhanDebugAnnotation @phan-debug-var requested for variable $methodName - it has union type string(real=non-empty-array<mixed,mixed>|object|string)
+%s:7 PhanDebugAnnotation @phan-debug-var requested for variable $methodName - it has union type string(real=string)
+%s:11 PhanDebugAnnotation @phan-debug-var requested for variable $nvals - it has union type list<string>(real=?list<string>)
+%s:11 PhanUnusedVariable Unused definition of variable $nvals (Did you mean $vals)

--- a/tests/files/src/0817_real_type_of_array_dim.php
+++ b/tests/files/src/0817_real_type_of_array_dim.php
@@ -8,4 +8,6 @@ function main(string $name) {
         '@phan-debug-var $methodName';
         echo "Saw $methodName\n";
     }
+    $nvals = explode('-', $name, -2);
+    '@phan-debug-var $nvals';
 }


### PR DESCRIPTION
Fixes #3617

Also, make Phan use the real return type set of the function being
analyzed when plugins return a union type without a real type set.