### PR TITLE
Do a better job of guessing unseen types in loops

### DIFF
--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
@@ -791,6 +791,8 @@ final class VariableTrackerVisitor extends AnalysisVisitor
             // Skip over empty case statements (incomplete heuristic), TODO: test
             if (\count($stmts_node->children ?? []) !== 0 || $i === \count($node->children) - 1) {
                 if ($inner_scope) {
+                    // $this->analyze() returns a VariableTrackingLoopScope when a VariableTrackingLoopScope is passed in.
+                    '@phan-var VariableTrackingLoopScope $inner_scope';
                     $inner_scope = clone($inner_scope);
                     $inner_scope->inheritDefsFromOuterScope($outer_scope);
                 } else {

--- a/tests/files/expected/0840_method_calls.php.expected
+++ b/tests/files/expected/0840_method_calls.php.expected
@@ -1,0 +1,4 @@
+%s:14 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($obj) is string but \spl_object_hash() takes object
+%s:20 PhanTypeMismatchReturnReal Returning type string but main() is declared to return ?array
+%s:28 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($obj) is string but \spl_object_hash() takes object
+%s:34 PhanTypeMismatchReturnReal Returning type string but main2() is declared to return ?array

--- a/tests/files/src/0840_method_calls.php
+++ b/tests/files/src/0840_method_calls.php
@@ -1,0 +1,36 @@
+<?php
+
+class Test840 {
+    /** @return string */
+    public static function returns_string() : string {
+        return 'prefix';
+    }
+
+    public function main() : ?array {
+        $result = null;
+        foreach (['e1', 'e2'] as $value) {
+            if (isset($result)) {
+                // Should infer that $result must be a string and warn.
+                echo spl_object_hash($result);
+                $result .= $value;
+                continue;
+            }
+            $result = self::returns_string();
+        }
+        return $result;
+    }
+
+    public function main2() : ?array {
+        $result = null;
+        foreach (['e1', 'e2'] as $value) {
+            if (isset($result)) {
+                // Should infer that $result must be a string and warn.
+                echo spl_object_hash($result);
+                $result .= $value;
+                continue;
+            }
+            $result = $this->returns_string();
+        }
+        return $result;
+    }
+}


### PR DESCRIPTION
Add support for using static methods and methods of $this
as fallbacks when no types seen yet are matched by a condition.