### PR TITLE
Limit warning about weak type comparisons to equality

### DIFF
--- a/tests/files/expected/0850_weak_type_comparison.php.expected
+++ b/tests/files/expected/0850_weak_type_comparison.php.expected
@@ -1,0 +1,6 @@
+%s:5 PhanSuspiciousWeakTypeComparison Suspicious attempt to compare $s of type non-empty-string to '0' of type '0'
+%s:6 PhanSuspiciousWeakTypeComparison Suspicious attempt to compare $s of type non-empty-string to 0 of type 0
+%s:14 PhanSuspiciousWeakTypeComparison Suspicious attempt to compare $i of type non-zero-int to 0 of type 0
+%s:15 PhanImpossibleTypeComparison Impossible attempt to check if $i of type non-zero-int is identical to 0 of type 0
+%s:16 PhanSuspiciousWeakTypeComparison Suspicious attempt to compare $i of type non-zero-int to 0 of type 0
+%s:17 PhanImpossibleTypeComparison Impossible attempt to check if $i of type non-zero-int is identical to 0 of type 0

--- a/tests/files/src/0850_weak_type_comparison.php
+++ b/tests/files/src/0850_weak_type_comparison.php
@@ -1,0 +1,19 @@
+<?php
+function test_weak_nes(string $s) {
+    if ($s) {
+        var_export($s > '0');
+        var_export($s == '0');
+        var_export($s == 0);  // TODO: This can be true for `0 == 'foo'`, but it is still suspicious
+    }
+}
+function test_weak_nzi(int $i) {
+    if ($i) {
+        var_export($i > 0);
+        var_export($i <=> 0);  // should not warn
+
+        var_export($i == 0);
+        var_export($i !== 0);
+        var_export($i != 0);
+        var_export($i === 0);
+    }
+}


### PR DESCRIPTION
Fixes #3646 for literals (e.g. 0 <= non-zero-int)