### PR TITLE
Omit options that should usually be on from 'phan --init'

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@ New features(CLI, Configs):
   - `PhanSuspiciousTruthyCondition` (e.g. for `if ($x)` where `$x` is `object|int`)
   - `PhanSuspiciousTruthyString` (e.g. for `?string` - `'0'` is also falsey in PHP)
 + Limit calculation of max memory usage to the **running** worker processes with `--processes N` (#3606)
++ Omit options that should almost always be on (e.g. `analyze_signature_compatibility`) from the output of `phan --init` (#3660)
 
 New Features(Analysis):
 + Infer that merging defined variables with possibly undefined variables is also possibly undefined. (#1942)
@@ -45,6 +46,7 @@ Maintenance:
   (`<?php` on its own line, `function(): T` instead of `function() : T`, declare visibility for class constants)
 + Internal: Check if strings are non-zero length in Phan's implementation instead of checking for variable truthiness.
   (`'0'` is falsey)
++ Show `null` as lowercase instead of uppercase (the way `var_export` renders it) in more places.
 
 Dec 29 2019, Phan 2.4.6
 -----------------------

--- a/src/Phan/AST/TolerantASTConverter/NodeDumper.php
+++ b/src/Phan/AST/TolerantASTConverter/NodeDumper.php
@@ -144,8 +144,10 @@ class NodeDumper
                 $this->include_offset ? ' (@' . $ast_node->start . ')' : '',
                 \Phan\Library\StringUtil::jsonEncode(\substr($this->file_contents, $ast_node->fullStart, $ast_node->length))
             );
-        } elseif (\is_scalar($ast_node) || $ast_node === null) {
+        } elseif (\is_scalar($ast_node)) {
             return \var_export($ast_node, true);
+        } elseif ($ast_node === null) {
+            return 'null';
         } else {
             $type = is_object($ast_node) ? get_class($ast_node) : gettype($ast_node);
             throw new \InvalidArgumentException("Unexpected type of \$ast_node was seen in dumper: " . $type);

--- a/src/Phan/Config/Initializer.php
+++ b/src/Phan/Config/Initializer.php
@@ -15,6 +15,7 @@ use Phan\Config;
 use Phan\Exception\UsageException;
 use Phan\Issue;
 use Phan\Language\Context;
+use Phan\Library\StringUtil;
 use TypeError;
 
 use function count;
@@ -152,14 +153,14 @@ class Initializer
                     if (!is_int($key)) {
                         throw new TypeError("Expected setting default for $setting_name to have consecutive integer keys");
                     }
-                    $source .= '        ' . \var_export($element, true) . ",\n";
+                    $source .= '        ' . StringUtil::varExportPretty($element) . ",\n";
                 }
                 $source .= "    ],\n";
             } else {
                 $source .= "[],\n";
             }
         } else {
-            $encoded_value = \var_export($setting_value, true);
+            $encoded_value = StringUtil::varExportPretty($setting_value);
             if ($setting_name === 'minimum_severity') {
                 switch ($setting_value) {
                     case Issue::SEVERITY_LOW:
@@ -316,18 +317,14 @@ EOT;
             'strict_return_checking'   => $is_strongest_level,
             'ignore_undeclared_variables_in_global_scope' => $is_average_level,
             'ignore_undeclared_functions_with_known_signatures' => $is_strong_or_weaker_level,
-            'backward_compatibility_checks' => false,  // this is slow
+            'backward_compatibility_checks' => false,  // this is only useful for migrating from php5
             'check_docblock_signature_return_type_match' => !$is_average_level,
-            'prefer_narrowed_phpdoc_param_type' => true,
-            'prefer_narrowed_phpdoc_return_type' => true,
-            'analyze_signature_compatibility' => !$is_weak_level,
             'phpdoc_type_mapping' => [],
             'dead_code_detection' => false,  // this is slow
             'unused_variable_detection' => !$is_average_level,
             'redundant_condition_detection' => !$is_average_level,
             'assume_real_types_for_internal_functions' => !$is_average_level,
             'quick_mode' => $is_weakest_level,
-            'generic_types_enabled' => true,
             'globals_type_map' => [],
             'minimum_severity' => $minimum_severity,
             'suppress_issue_types' => [],

--- a/src/Phan/Language/Element/ClassConstant.php
+++ b/src/Phan/Language/Element/ClassConstant.php
@@ -9,6 +9,7 @@ use Phan\Language\Context;
 use Phan\Language\FQSEN;
 use Phan\Language\FQSEN\FullyQualifiedClassConstantName;
 use Phan\Language\UnionType;
+use Phan\Library\StringUtil;
 
 /**
  * ClassConstant represents the information Phan has
@@ -175,7 +176,7 @@ class ClassConstant extends ClassElement implements ConstantInterface
         if (\defined($fqsen)) {
             // TODO: Could start using $this->getNodeForValue()?
             // NOTE: This is used by tool/make_stubs, which is why it uses reflection instead of getting a node.
-            $string .= \var_export(\constant($fqsen), true) . ';';
+            $string .= StringUtil::varExportPretty(\constant($fqsen)) . ';';
         } else {
             $string .= "null;  // could not find";
         }

--- a/src/Phan/Language/Element/GlobalConstant.php
+++ b/src/Phan/Language/Element/GlobalConstant.php
@@ -11,6 +11,7 @@ use Phan\Language\Context;
 use Phan\Language\FQSEN\FullyQualifiedGlobalConstantName;
 use Phan\Language\Type;
 use Phan\Language\UnionType;
+use Phan\Library\StringUtil;
 
 /**
  * Phan's representation of a global constant
@@ -144,7 +145,7 @@ class GlobalConstant extends AddressableElement implements ConstantInterface
 
         $is_defined = \defined($fqsen);
         if ($is_defined) {
-            $repr = \var_export(\constant($fqsen), true);
+            $repr = StringUtil::varExportPretty(\constant($fqsen));
             $comment = '';
         } else {
             $repr = 'null';

--- a/src/Phan/Language/Element/Parameter.php
+++ b/src/Phan/Language/Element/Parameter.php
@@ -22,6 +22,7 @@ use Phan\Language\Type\MixedType;
 use Phan\Language\Type\NullType;
 use Phan\Language\Type\TrueType;
 use Phan\Language\UnionType;
+use Phan\Library\StringUtil;
 use Phan\Parse\ParseVisitor;
 
 use function strlen;
@@ -522,7 +523,7 @@ class Parameter extends Variable
             if ($default_value instanceof Node) {
                 $string .= ' = null';
             } else {
-                $string .= ' = ' . \var_export($default_value, true);
+                $string .= ' = ' . StringUtil::varExportPretty($default_value);
             }
         }
 
@@ -576,7 +577,7 @@ class Parameter extends Variable
                     $default_repr = 'null';
                 }
             } else {
-                $default_repr = \var_export($this->default_value, true);
+                $default_repr = StringUtil::varExportPretty($default_value);
             }
             if (\strtolower($default_repr) === 'null') {
                 $default_repr = 'null';
@@ -639,7 +640,7 @@ class Parameter extends Variable
                     $default_repr = 'null';
                 }
             } else {
-                $default_repr = \var_export($this->default_value, true);
+                $default_repr = StringUtil::varExportPretty($default_value);
                 if (strlen($default_repr) >= 50) {
                     $default_repr = 'default';
                 }

--- a/src/Phan/Library/StringUtil.php
+++ b/src/Phan/Library/StringUtil.php
@@ -24,6 +24,20 @@ class StringUtil
             // Use double quoted strings if this contains newlines, tabs, control characters, etc.
             return '"' . ASTReverter::escapeInnerString($value, '"') . '"';
         }
+        return self::varExportPretty($value);
+    }
+
+    /**
+     * Same as var_export($value, true), but converts top-level NULL to null.
+     * Other changes may be made in the future, e.g. shorter list representations.
+     *
+     * @param ?(int|bool|string|array|float) $value
+     */
+    public static function varExportPretty($value) : string
+    {
+        if ($value === null) {
+            return 'null';  // return lowercase instead of uppercase 'NULL'
+        }
         return \var_export($value, true);
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,27 +1,27 @@
 <?php
 declare(strict_types=1);
-
-const RASMUS_TEST_FILE_DIR = __DIR__ . '/rasmus_files/src';
-const RASMUS_EXPECTED_DIR = __DIR__ . '/rasmus_files/expected';
-const AST_TEST_FILE_DIR = __DIR__ . '/misc/ast/src';
-const AST_EXPECTED_DIR = __DIR__ . '/misc/ast/expected';
-const TEST_FILE_DIR = __DIR__ . '/files/src';
-const EXPECTED_DIR = __DIR__ . '/files/expected';
-const MULTI_FILE_DIR = __DIR__ . '/multi_files/src';
-const MULTI_EXPECTED_DIR = __DIR__ . '/multi_files/expected';
-const SOAP_TEST_FILE_DIR = __DIR__ . '/misc/soap_files/src';
-const SOAP_EXPECTED_DIR = __DIR__ . '/misc/soap_files/expected';
-const INTL_TEST_FILE_DIR = __DIR__ . '/misc/intl_files/src';
-const INTL_EXPECTED_DIR = __DIR__ . '/misc/intl_files/expected';
-const PHP70_TEST_FILE_DIR = __DIR__ . '/php70_files/src';
-const PHP70_EXPECTED_DIR = __DIR__ . '/php70_files/expected';
-const PHP72_TEST_FILE_DIR = __DIR__ . '/php72_files/src';
-const PHP72_EXPECTED_DIR = __DIR__ . '/php72_files/expected';
-const PHP73_TEST_FILE_DIR = __DIR__ . '/php73_files/src';
-const PHP73_EXPECTED_DIR = __DIR__ . '/php73_files/expected';
-const PHP74_TEST_FILE_DIR = __DIR__ . '/php74_files/src';
-const PHP74_EXPECTED_DIR = __DIR__ . '/php74_files/expected';
-const PHP80_TEST_FILE_DIR = __DIR__ . '/php80_files/src';
-const PHP80_EXPECTED_DIR = __DIR__ . '/php80_files/expected';
+// Test output of failures is shorter with relative paths than absolute paths
+const RASMUS_TEST_FILE_DIR = './tests/rasmus_files/src';
+const RASMUS_EXPECTED_DIR = './tests/rasmus_files/expected';
+const AST_TEST_FILE_DIR = './tests/misc/ast/src';
+const AST_EXPECTED_DIR = './tests/misc/ast/expected';
+const TEST_FILE_DIR = './tests/files/src';
+const EXPECTED_DIR = './tests/files/expected';
+const MULTI_FILE_DIR = './tests/multi_files/src';
+const MULTI_EXPECTED_DIR = './tests/multi_files/expected';
+const SOAP_TEST_FILE_DIR = './tests/misc/soap_files/src';
+const SOAP_EXPECTED_DIR = './tests/misc/soap_files/expected';
+const INTL_TEST_FILE_DIR = './tests/misc/intl_files/src';
+const INTL_EXPECTED_DIR = './tests/misc/intl_files/expected';
+const PHP70_TEST_FILE_DIR = './tests/php70_files/src';
+const PHP70_EXPECTED_DIR = './tests/php70_files/expected';
+const PHP72_TEST_FILE_DIR = './tests/php72_files/src';
+const PHP72_EXPECTED_DIR = './tests/php72_files/expected';
+const PHP73_TEST_FILE_DIR = './tests/php73_files/src';
+const PHP73_EXPECTED_DIR = './tests/php73_files/expected';
+const PHP74_TEST_FILE_DIR = './tests/php74_files/src';
+const PHP74_EXPECTED_DIR = './tests/php74_files/expected';
+const PHP80_TEST_FILE_DIR = './tests/php80_files/src';
+const PHP80_EXPECTED_DIR = './tests/php80_files/expected';
 
 require_once dirname(__DIR__) . '/src/Phan/Bootstrap.php';

--- a/tests/files/expected/0627_signature_mismatch.php.expected
+++ b/tests/files/expected/0627_signature_mismatch.php.expected
@@ -6,8 +6,8 @@
 %s:22 PhanUnextractableAnnotationPart Saw unextractable annotation for a fragment of comment '* @method isNotReference(&$x)': '&$x'
 %s:23 PhanParamSignatureMismatch Declaration of function variadic($x) : void should be compatible with function variadic(...$x) defined in %s:10
 %s:23 PhanParamSignaturePHPDocMismatchTooManyRequiredParameters Declaration of real/@method function variadic($x) should be compatible with real/@method function variadic(...$x) (the method override requires 1 parameter(s), but the overridden method requires only 0) defined in %s:10
-%s:24 PhanParamSignatureMismatch Declaration of function variadic2($x = NULL) : void should be compatible with function variadic2(...$x) defined in %s:11
-%s:24 PhanParamSignaturePHPDocMismatchParamNotVariadic Declaration of real/@method function variadic2($x = NULL) should be compatible with real/@method function variadic2(...$x) (parameter #1 is a non-variadic parameter replacing a variadic parameter) defined in %s:11
+%s:24 PhanParamSignatureMismatch Declaration of function variadic2($x = null) : void should be compatible with function variadic2(...$x) defined in %s:11
+%s:24 PhanParamSignaturePHPDocMismatchParamNotVariadic Declaration of real/@method function variadic2($x = null) should be compatible with real/@method function variadic2(...$x) (parameter #1 is a non-variadic parameter replacing a variadic parameter) defined in %s:11
 %s:25 PhanParamSignatureMismatch Declaration of function notVariadic(...$x) : void should be compatible with function notVariadic($x) defined in %s:12
 %s:25 PhanParamSignaturePHPDocMismatchParamVariadic Declaration of real/@method function notVariadic(...$x) should be compatible with real/@method function notVariadic($x) (parameter #1 is a variadic parameter replacing a non-variadic parameter) defined in %s:12
 %s:26 PhanParamSignatureMismatch Declaration of function returnsInt() : string should be compatible with function returnsInt() : int defined in %s:13


### PR DESCRIPTION
Fixes #3660

Also, show `NULL` as `null` in more places
(phan --init, parameter defaults and class constants in issue messages)