### PR TITLE
Fix false positives that are emitted when --no-progress-bar is used

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 Phan NEWS
 
+Jan 25 2020, Phan 2.4.8
+-----------------------
+
+Bug fixes:
++ Fix bug introduced in 2.4.7 where there were more false positives when `--no-progress-bar` was used. (#3677)
+
 Jan 22 2020, Phan 2.4.7
 -----------------------
 

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -550,8 +550,7 @@ class ContextNode
             $result = [$union_type, $class_list];
             $context->setCachedClassListOfNode($node_id, $result);
             return $result;
-        }
-        catch (CodeBaseException $e) {
+        } catch (CodeBaseException $e) {
             if ($ignore_missing_classes) {
                 // swallow it
                 // TODO: Is it appropriate to return class_list

--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -308,9 +308,7 @@ class Analysis
         // Analyze user-defined method declarations.
         // Plugins may also analyze user-defined methods here.
         $i = 0;
-        if ($show_progress) {
-            CLI::progress('function', 0.0, null);
-        }
+        CLI::progress('function', 0.0, null);
         $function_map = $code_base->getFunctionMap();
         foreach ($function_map as $function) {  // iterate, ignoring $fqsen
             if ($show_progress) {
@@ -323,9 +321,7 @@ class Analysis
         // Plugins may also analyze user-defined methods here.
         $i = 0;
         $method_set = $code_base->getMethodSet();
-        if ($show_progress) {
-            CLI::progress('method', 0.0, null);
-        }
+        CLI::progress('method', 0.0, null);
         foreach ($method_set as $method) {
             if ($show_progress) {
                 // I suspect that method analysis is hydrating some of the classes,

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -1815,7 +1815,7 @@ class AssignmentVisitor extends AnalysisVisitor
                         return StringType::instance(false)->asPHPDocUnionType();
                     }
                 }
-            } elseif (!$assign_type->hasTypeMatchingCallback(static function (Type $type) use ($simple_xml_element_type) : bool {
+            } elseif (!$assign_type->hasTypeMatchingCallback(static function (Type $type) use ($simple_xml_element_type): bool {
                 return !$type->isNullable() && ($type instanceof MixedType || $type === $simple_xml_element_type);
             })) {
                 // Imitate the check in UnionTypeVisitor, don't warn for mixed, etc.

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -69,7 +69,7 @@ class CLI
     /**
      * This should be updated to x.y.z-dev after every release, and x.y.z before a release.
      */
-    public const PHAN_VERSION = '2.4.7';
+    public const PHAN_VERSION = '2.4.8';
 
     /**
      * List of short flags passed to getopt

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -1183,7 +1183,7 @@ class Config
      * @return array<string,list<string>>
      * @suppress PhanPluginCanUseParamType
      */
-    private static function normalizeScalarImplicitPartial($value) : array
+    private static function normalizeScalarImplicitPartial($value): array
     {
         if (!is_array($value)) {
             return [];
@@ -1192,7 +1192,7 @@ class Config
             if (isset($value[$scalar]) && !isset($value[$non_falsey_scalar])) {
                 $value[$non_falsey_scalar] = \array_values(\array_filter(
                     $value[$scalar],
-                    static function (string $type) : bool {
+                    static function (string $type): bool {
                         return !in_array($type, ['null', 'false'], true);
                     }
                 ));

--- a/src/Phan/Library/StringUtil.php
+++ b/src/Phan/Library/StringUtil.php
@@ -33,7 +33,7 @@ class StringUtil
      *
      * @param ?(int|bool|string|array|float) $value
      */
-    public static function varExportPretty($value) : string
+    public static function varExportPretty($value): string
     {
         if ($value === null) {
             return 'null';  // return lowercase instead of uppercase 'NULL'

--- a/src/Phan/Plugin/Internal/RedundantConditionCallPlugin.php
+++ b/src/Phan/Plugin/Internal/RedundantConditionCallPlugin.php
@@ -443,8 +443,7 @@ class RedundantConditionVisitor extends PluginAwarePostAnalysisVisitor
         if ($this->checkUselessScalarComparison($node, $left->getRealUnionType(), $right->getRealUnionType())) {
             return;
         }
-        if (
-            !$left->hasAnyTypeOverlap($code_base, $right) &&
+        if (!$left->hasAnyTypeOverlap($code_base, $right) &&
             ($strict || (
                 // Warn about 0 == non-zero-int, but not non-zero-int <= 0
                 \in_array($node->flags, self::EQUALITY_CHECKS, true)

--- a/tests/Phan/ConfigTest.php
+++ b/tests/Phan/ConfigTest.php
@@ -59,7 +59,8 @@ final class ConfigTest extends BaseTest
         ];
     }
 
-    public function testScalarImplicitPartial(): void {
+    public function testScalarImplicitPartial(): void
+    {
         Config::setValue('scalar_implicit_partial', ['null' => ['int', 'string', 'false'], 'int' => ['string', 'null']]);
         $this->assertSame([
             'null' => ['int', 'string', 'false'],
@@ -67,5 +68,6 @@ final class ConfigTest extends BaseTest
             'non-zero-int' => ['string', 'non-empty-string'],
         ], Config::getValue('scalar_implicit_partial'), 'should add implied allowed casts');
         Config::setValue('scalar_implicit_partial', []);
-        $this->assertSame([], Config::getValue('scalar_implicit_partial')); }
+        $this->assertSame([], Config::getValue('scalar_implicit_partial'));
+    }
 }


### PR DESCRIPTION
The memoized methods of Union Types got cleared when Phan started a
different analysis phase, to deal with false positives when
inheritance wasn't analyzed yet.
However, CLI::progress would not get called for some phases when there
was no progress bar, so this didn't work all of the time.

Fixes #3677