### PR TITLE
Emit a warning on all duplicate classes/functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@ New Features(Analysis):
   and that `method_exists` implies the first argument is a class-string or an object. (#2804, #3058)
 
   Note that Phan still does not infer that the class or method actually exists.
++ Emit `PhanRedefineClass` on **all** occurrences of a duplicate class, not just the ones after the first occurrence of the class. (#511)
++ Emit `PhanRedefineFunction` on **all** occurrences of a duplicate function/method, not just the ones after the first.
 
 Bug fixes:
 + Fix false positive PhanParamSuspiciousOrder for `preg_replace_callback` (#3680)
@@ -1670,7 +1672,7 @@ New features(Analysis):
 
   To enable these checks, set `enable_include_path_checks` to `true` in your Phan config.
 
-  New issue types: `PhanRelativePathUsed`, `PhanTypeInvalidEval`, `PhanTypeInvalidRequire`, `PhanInvalidRequireFile`, `PhanMissingRequiredFile`
+  New issue types: `PhanRelativePathUsed`, `PhanTypeInvalidEval`, `PhanTypeInvalidRequire`, `PhanInvalidRequireFile`, `PhanMissingRequireFile`
 
   New config settings: `enable_include_path_checks`, `include_paths`, `warn_about_relative_include_statement`
 + Warn when attempting to unset a property that was declared (i.e. not a dynamic or magic property) (#569)

--- a/src/Phan/Analysis/DuplicateClassAnalyzer.php
+++ b/src/Phan/Analysis/DuplicateClassAnalyzer.php
@@ -55,7 +55,6 @@ class DuplicateClassAnalyzer
                     (string)$original_class
                 );
             }
-
         // Otherwise, print the coordinates of the original
         // definition
         } else {
@@ -72,6 +71,25 @@ class DuplicateClassAnalyzer
                     $original_class->getFileRef()->getFile(),
                     $original_class->getFileRef()->getLineNumberStart()
                 );
+            }
+            // If there are 3 classes with the same namespace and name,
+            // warn *once* about the first (user-defined) class being a duplicate.
+            // NOTE: This won't work very well in language server mode.
+            if ($clazz->getFQSEN()->getAlternateId() === 1) {
+                if (!$original_class->checkHasSuppressIssueAndIncrementCount(Issue::RedefineClass)) {
+                    Issue::maybeEmit(
+                        $code_base,
+                        $original_class->getContext(),
+                        Issue::RedefineClass,
+                        $original_class->getFileRef()->getLineNumberStart(),
+                        (string)$original_class,
+                        $original_class->getFileRef()->getFile(),
+                        $original_class->getFileRef()->getLineNumberStart(),
+                        (string)$clazz,
+                        $clazz->getFileRef()->getFile(),
+                        $clazz->getFileRef()->getLineNumberStart()
+                    );
+                }
             }
         }
 

--- a/src/Phan/Analysis/DuplicateFunctionAnalyzer.php
+++ b/src/Phan/Analysis/DuplicateFunctionAnalyzer.php
@@ -72,6 +72,22 @@ class DuplicateFunctionAnalyzer
                 $original_method->getFileRef()->getFile(),
                 $original_method->getFileRef()->getLineNumberStart()
             );
+            // If there are 3 functions with the same namespace and name,
+            // warn *once* about the first functions being a duplicate.
+            // NOTE: This won't work very well in language server mode.
+            if ($fqsen->getAlternateId() === 1) {
+                Issue::maybeEmit(
+                    $code_base,
+                    $original_method->getContext(),
+                    Issue::RedefineFunction,
+                    $original_method->getFileRef()->getLineNumberStart(),
+                    $original_method->getName(),
+                    $original_method->getFileRef()->getFile(),
+                    $original_method->getFileRef()->getLineNumberStart(),
+                    $method->getFileRef()->getFile(),
+                    $method->getFileRef()->getLineNumberStart()
+                );
+            }
         }
     }
 }

--- a/tests/files/expected/0002_duplicate_class.php.expected
+++ b/tests/files/expected/0002_duplicate_class.php.expected
@@ -1,1 +1,2 @@
+%s:3 PhanRedefineClass Class \DuplicateClass defined at %s:3 was previously defined as Class \DuplicateClass at %s:9
 %s:9 PhanRedefineClass Class \DuplicateClass defined at %s:9 was previously defined as Class \DuplicateClass at %s:3

--- a/tests/files/expected/0011_duplicate_function.php.expected
+++ b/tests/files/expected/0011_duplicate_function.php.expected
@@ -1,1 +1,2 @@
+%s:3 PhanRedefineFunction Function alpha defined at %s:3 was previously defined at %s:6
 %s:6 PhanRedefineFunction Function alpha defined at %s:6 was previously defined at %s:3

--- a/tests/files/expected/0101_one_of_each.php.expected
+++ b/tests/files/expected/0101_one_of_each.php.expected
@@ -22,8 +22,10 @@
 %s:64 PhanParamTooFew Call with 0 arg(s) to \f6($i) which requires 1 arg(s) defined at %s:63
 %s:71 PhanParamTooMany Call with 2 arg(s) to \f7($i) which only takes 1 arg(s) defined at %s:70
 %s:74 PhanParamTooManyInternal Call with 2 arg(s) to \strlen(string $string) which only takes 1 arg(s)
+%s:79 PhanRedefineClass Class \C15 defined at %s:79 was previously defined as Class \C15 at %s:80
 %s:80 PhanRedefineClass Class \C15 defined at %s:80 was previously defined as Class \C15 at %s:79
 %s:83 PhanRedefineClassInternal Class \DateTime defined at %s:83 was previously defined as Class \DateTime internally
+%s:86 PhanRedefineFunction Function f9 defined at %s:86 was previously defined at %s:87
 %s:87 PhanRedefineFunction Function f9 defined at %s:87 was previously defined at %s:86
 %s:90 PhanRedefineFunctionInternal Function strlen defined at %s:90 was previously defined internally
 %s:94 PhanStaticCallToNonStatic Static call to non-static method \C19::f() defined at %s:93

--- a/tests/files/expected/0242_void_71.php.expected
+++ b/tests/files/expected/0242_void_71.php.expected
@@ -1,4 +1,5 @@
 %s:3 PhanSyntaxReturnValueInVoid Syntax error: void function f2() must not return a value (did you mean "return;" instead of "return rand(0, 2);"?)
+%s:4 PhanRedefineFunction Function f3 defined at %s:4 was previously defined at %s:5
 %s:4 PhanTypeMissingReturn Method \f3 is declared to return int but has no return value
 %s:5 PhanRedefineFunction Function f3 defined at %s:5 was previously defined at %s:4
 %s:5 PhanTypeMissingReturn Method \f3 is declared to return int but has no return value

--- a/tests/files/expected/0298_call_magic_method_accesses_inaccessible.php.expected
+++ b/tests/files/expected/0298_call_magic_method_accesses_inaccessible.php.expected
@@ -1,3 +1,4 @@
+%s:19 PhanRedefineFunction Function hidden defined at %s:19 was previously defined at %s:26
 %s:74 PhanAccessMethodPrivateWithCallMagicMethod Cannot access private method \A298::hidden defined at %s:5 (if this call should be handled by __call, consider adding a @method tag to the class)
 %s:80 PhanAccessMethodProtectedWithCallMagicMethod Cannot access protected method \C298::hidden defined at %s:41 (if this call should be handled by __call, consider adding a @method tag to the class)
 %s:83 PhanAccessMethodProtectedWithCallMagicMethod Cannot access protected method \D298::hidden defined at %s:41 (if this call should be handled by __call, consider adding a @method tag to the class)

--- a/tests/files/expected/0373_crash.php.expected
+++ b/tests/files/expected/0373_crash.php.expected
@@ -1,1 +1,2 @@
+%s:6 PhanRedefineFunction Function foo defined at %s:6 was previously defined at %s:9
 %s:9 PhanRedefineFunction Function foo defined at %s:9 was previously defined at %s:6

--- a/tests/files/expected/0493_inherit_redefined.php.expected
+++ b/tests/files/expected/0493_inherit_redefined.php.expected
@@ -1,5 +1,8 @@
+%s:3 PhanRedefineClass Class \Base493 defined at %s:3 was previously defined as Class \Base493 at %s:4
 %s:4 PhanRedefineClass Class \Base493 defined at %s:4 was previously defined as Class \Base493 at %s:3
+%s:6 PhanRedefineClass Interface \I493 defined at %s:6 was previously defined as Interface \I493 at %s:7
 %s:7 PhanRedefineClass Interface \I493 defined at %s:7 was previously defined as Interface \I493 at %s:6
+%s:9 PhanRedefineClass Trait \T493 defined at %s:9 was previously defined as Trait \T493 at %s:10
 %s:10 PhanRedefineClass Trait \T493 defined at %s:10 was previously defined as Trait \T493 at %s:9
 %s:12 PhanClassContainsAbstractMethod non-abstract class \X493 contains abstract method \I493::abstract1() declared at %s:6
 %s:12 PhanRedefinedExtendedClass \X493 extends Class \Base493 declared at %s:3 which is also declared at %s:4. This may lead to confusing errors.

--- a/tests/files/expected/0853_duplicate_method.php.expected
+++ b/tests/files/expected/0853_duplicate_method.php.expected
@@ -1,0 +1,2 @@
+%s:3 PhanRedefineFunction Function isB defined at %s:3 was previously defined at %s:4
+%s:4 PhanRedefineFunction Function isB defined at %s:4 was previously defined at %s:3

--- a/tests/files/src/0853_duplicate_method.php
+++ b/tests/files/src/0853_duplicate_method.php
@@ -1,0 +1,5 @@
+<?php
+class C853 {
+    public function isB() {}
+    public function isB() {}
+}

--- a/tests/misc/fallback_test/expected/007_class_base_clause_2.php.expected
+++ b/tests/misc/fallback_test/expected/007_class_base_clause_2.php.expected
@@ -1,1 +1,2 @@
+src/007_class_base_clause_2.php:3 PhanRedefineClass Class \A defined at src/007_class_base_clause_2.php:3 was previously defined as Class \A at src/015_class_const_declaration9.php:2
 src/007_class_base_clause_2.php:3 PhanSyntaxError syntax error, unexpected '{', expecting identifier (T_STRING) or namespace (T_NAMESPACE) or \\ (T_NS_SEPARATOR) (at column 17)

--- a/tests/multi_files/expected/245.php.expected
+++ b/tests/multi_files/expected/245.php.expected
@@ -1,1 +1,2 @@
-%s:2 PhanRedefineClass Class \C defined at %s:2 was previously defined as Class \C at %s:2
+%s_a.php:2 PhanRedefineClass Class \C defined at %s_a.php:2 was previously defined as Class \C at %s_b.php:2
+%s_b.php:2 PhanRedefineClass Class \C defined at %s_b.php:2 was previously defined as Class \C at %s_a.php:2

--- a/tests/plugin_test/expected/001_dead_code.php.expected
+++ b/tests/plugin_test/expected/001_dead_code.php.expected
@@ -1,5 +1,8 @@
+src/001_dead_code.php:4 PhanRedefineFunction Function duplicateFnA defined at src/001_dead_code.php:4 was previously defined at src/001_dead_code.php:29
+src/001_dead_code.php:8 PhanRedefineFunction Function duplicateFnB defined at src/001_dead_code.php:8 was previously defined at src/001_dead_code.php:33
 src/001_dead_code.php:8 PhanUnreferencedFunction Possibly zero references to function \duplicateFnB()
 src/001_dead_code.php:13 PhanUnreferencedConstant Possibly zero references to global constant \Const1B
+src/001_dead_code.php:15 PhanRedefineClass Class \DuplicateClass001 defined at src/001_dead_code.php:15 was previously defined as Class \DuplicateClass001 at src/001_dead_code.php:39
 src/001_dead_code.php:18 PhanReadOnlyPublicProperty Possibly zero write references to public property \DuplicateClass001::$static_prop1
 src/001_dead_code.php:19 PhanUnreferencedPublicProperty Possibly zero references to public property \DuplicateClass001::$static_prop2
 src/001_dead_code.php:21 PhanReadOnlyPublicProperty Possibly zero write references to public property \DuplicateClass001->instance_prop1

--- a/tests/rasmus_files/expected/0012_redef_interface_class.php.expected
+++ b/tests/rasmus_files/expected/0012_redef_interface_class.php.expected
@@ -1,2 +1,3 @@
+%s:2 PhanRedefineClass Interface \Test defined at %s:2 was previously defined as Trait \Test at %s:7
 %s:7 PhanRedefineClass Trait \Test defined at %s:7 was previously defined as Interface \Test at %s:2
 %s:12 PhanRedefineClass Class \Test defined at %s:12 was previously defined as Interface \Test at %s:2


### PR DESCRIPTION
Not just the ones seen after the first declaration.

Do this because the second declaration may be in a directory that is
excluded from analysis, or the file parsing order may be random.

Warn about both duplicate functions and methods

Fixes #511