### PR TITLE
Fix false positives related to class hydration

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,11 +15,11 @@ environment:
   matrix:
     # This major release of Phan (2.0) requires php-ast 1.0.1+
     - PHP_EXT_VERSION: '7.4'
-      PHP_VERSION: '7.4.1'
+      PHP_VERSION: '7.4.3'
       VC_VERSION: 15
       PHP_AST_VERSION: 1.0.5
     - PHP_EXT_VERSION: '7.3'
-      PHP_VERSION: '7.3.12'
+      PHP_VERSION: '7.3.14'
       VC_VERSION: 15
       PHP_AST_VERSION: 1.0.1
     - PHP_EXT_VERSION: '7.1'
@@ -28,7 +28,7 @@ environment:
       PHP_AST_VERSION: 1.0.1
       PHAN_RUN_INTEGRATION_TEST: 1
     - PHP_EXT_VERSION: '7.2'
-      PHP_VERSION: '7.2.25'
+      PHP_VERSION: '7.2.27'
       VC_VERSION: 15
       PHP_AST_VERSION: 1.0.4
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,9 @@ New Features(Analysis):
 + Emit `PhanRedefineFunction` on **all** occurrences of a duplicate function/method, not just the ones after the first.
 
 Bug fixes:
-+ Fix false positive PhanParamSuspiciousOrder for `preg_replace_callback` (#3680)
++ Fix false positive `PhanParamSuspiciousOrder` for `preg_replace_callback` (#3680)
++ Fix false positive `PhanUnanalyzableInheritance` for renamed methods from traits. (#3695)
++ Fix false positive `PhanUndeclaredConstant` previously seen for inherited class constants in some parse orders. (#3706)
 
 Jan 25 2020, Phan 2.4.8
 -----------------------

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "ext-tokenizer": "Needed for non-AST support and file/line-based suppressions."
     },
     "require-dev": {
-        "brianium/paratest": "^3.1.2",
+        "brianium/paratest": "^4.0.0",
         "phpunit/phpunit": "^7.5.0"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e61f560e9b13079a02d47ceffeb20828",
+    "content-hash": "e40d079d39c7b7d08612184450acaba3",
     "packages": [
         {
             "name": "composer/semver",
@@ -113,22 +113,22 @@
         },
         {
             "name": "felixfbecker/advanced-json-rpc",
-            "version": "v3.0.4",
+            "version": "v3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/felixfbecker/php-advanced-json-rpc.git",
-                "reference": "23366dd0cab0a0f3fd3016bf3c0b36dec74348e7"
+                "reference": "a407a6cb0325cd489c6dff57afcba6baeccc0483"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/felixfbecker/php-advanced-json-rpc/zipball/23366dd0cab0a0f3fd3016bf3c0b36dec74348e7",
-                "reference": "23366dd0cab0a0f3fd3016bf3c0b36dec74348e7",
+                "url": "https://api.github.com/repos/felixfbecker/php-advanced-json-rpc/zipball/a407a6cb0325cd489c6dff57afcba6baeccc0483",
+                "reference": "a407a6cb0325cd489c6dff57afcba6baeccc0483",
                 "shasum": ""
             },
             "require": {
                 "netresearch/jsonmapper": "^1.0",
                 "php": ">=7.0",
-                "phpdocumentor/reflection-docblock": "^4.0.0"
+                "phpdocumentor/reflection-docblock": "^4.0.0 || ^5.0.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^6.0.0"
@@ -150,7 +150,7 @@
                 }
             ],
             "description": "A more advanced JSONRPC implementation",
-            "time": "2019-09-12T22:41:08+00:00"
+            "time": "2020-02-11T20:48:40+00:00"
         },
         {
             "name": "microsoft/tolerant-php-parser",
@@ -488,24 +488,24 @@
         },
         {
             "name": "sabre/event",
-            "version": "5.0.3",
+            "version": "5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sabre-io/event.git",
-                "reference": "f5cf802d240df1257866d8813282b98aee3bc548"
+                "reference": "d00a17507af0e7544cfe17096372f5d733e3b276"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sabre-io/event/zipball/f5cf802d240df1257866d8813282b98aee3bc548",
-                "reference": "f5cf802d240df1257866d8813282b98aee3bc548",
+                "url": "https://api.github.com/repos/sabre-io/event/zipball/d00a17507af0e7544cfe17096372f5d733e3b276",
+                "reference": "d00a17507af0e7544cfe17096372f5d733e3b276",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": ">=6",
-                "sabre/cs": "~1.0.0"
+                "friendsofphp/php-cs-fixer": "~2.16.1",
+                "phpunit/phpunit": "^7 || ^8"
             },
             "type": "library",
             "autoload": {
@@ -544,20 +544,20 @@
                 "reactor",
                 "signal"
             ],
-            "time": "2018-03-05T13:55:47+00:00"
+            "time": "2020-01-31T18:52:29+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v4.4.2",
+            "version": "v4.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "82437719dab1e6bdd28726af14cb345c2ec816d0"
+                "reference": "f512001679f37e6a042b51897ed24a2f05eba656"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/82437719dab1e6bdd28726af14cb345c2ec816d0",
-                "reference": "82437719dab1e6bdd28726af14cb345c2ec816d0",
+                "url": "https://api.github.com/repos/symfony/console/zipball/f512001679f37e6a042b51897ed24a2f05eba656",
+                "reference": "f512001679f37e6a042b51897ed24a2f05eba656",
                 "shasum": ""
             },
             "require": {
@@ -620,7 +620,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2019-12-17T10:32:23+00:00"
+            "time": "2020-01-25T12:44:29+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -948,16 +948,16 @@
         },
         {
             "name": "brianium/paratest",
-            "version": "3.1.2",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paratestphp/paratest.git",
-                "reference": "be62103b00485442ed2909b69854d6c7ec4614ed"
+                "reference": "2a06a82742fa303b59179fb8d6037dfb9897b9b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paratestphp/paratest/zipball/be62103b00485442ed2909b69854d6c7ec4614ed",
-                "reference": "be62103b00485442ed2909b69854d6c7ec4614ed",
+                "url": "https://api.github.com/repos/paratestphp/paratest/zipball/2a06a82742fa303b59179fb8d6037dfb9897b9b2",
+                "reference": "2a06a82742fa303b59179fb8d6037dfb9897b9b2",
                 "shasum": ""
             },
             "require": {
@@ -967,9 +967,9 @@
                 "ext-reflection": "*",
                 "ext-simplexml": "*",
                 "php": "^7.1",
-                "phpunit/php-code-coverage": "^6.1.4|^7.0.2",
-                "phpunit/php-timer": "^2.0",
-                "phpunit/phpunit": "^7.5.8|^8.0",
+                "phpunit/php-code-coverage": "^6.1.4|^7.0.2|^8.0",
+                "phpunit/php-timer": "^2.0|^3.0",
+                "phpunit/phpunit": "^7.5.8|^8.0|^9.0",
                 "symfony/console": "^3.4||^4.0||^5.0",
                 "symfony/process": "^3.4||^4.0||^5.0"
             },
@@ -1008,7 +1008,7 @@
                 "phpunit",
                 "testing"
             ],
-            "time": "2019-12-27T20:54:56+00:00"
+            "time": "2020-02-07T22:07:07+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -1218,24 +1218,24 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.10.1",
+            "version": "v1.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "cbe1df668b3fe136bcc909126a0f529a78d4cbbc"
+                "reference": "b4400efc9d206e83138e2bb97ed7f5b14b831cd9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/cbe1df668b3fe136bcc909126a0f529a78d4cbbc",
-                "reference": "cbe1df668b3fe136bcc909126a0f529a78d4cbbc",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/b4400efc9d206e83138e2bb97ed7f5b14b831cd9",
+                "reference": "b4400efc9d206e83138e2bb97ed7f5b14b831cd9",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
                 "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
-                "sebastian/comparator": "^1.2.3|^2.0|^3.0",
-                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
+                "sebastian/comparator": "^1.2.3|^2.0|^3.0|^4.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0|^4.0"
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5 || ^3.2",
@@ -1277,7 +1277,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2019-12-22T21:05:45+00:00"
+            "time": "2020-01-20T15:57:02+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2183,16 +2183,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v4.4.2",
+            "version": "v4.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "b84501ad50adb72a94fb460a5b5c91f693e99c9b"
+                "reference": "f5697ab4cb14a5deed7473819e63141bf5352c36"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/b84501ad50adb72a94fb460a5b5c91f693e99c9b",
-                "reference": "b84501ad50adb72a94fb460a5b5c91f693e99c9b",
+                "url": "https://api.github.com/repos/symfony/process/zipball/f5697ab4cb14a5deed7473819e63141bf5352c36",
+                "reference": "f5697ab4cb14a5deed7473819e63141bf5352c36",
                 "shasum": ""
             },
             "require": {
@@ -2228,7 +2228,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2019-12-06T10:06:46+00:00"
+            "time": "2020-01-09T09:50:08+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/internal/Phan-Config-Settings.md
+++ b/internal/Phan-Config-Settings.md
@@ -308,6 +308,7 @@ Phan is slightly faster when these are disabled.
 ## enable_include_path_checks
 
 Enable this to enable checks of require/include statements referring to valid paths.
+The settings [`include_paths`](#include_paths) and [`warn_about_relative_include_statement`](#warn_about_relative_include_statement) affect the checks.
 
 (Default: `false`)
 

--- a/src/Phan/Bootstrap.php
+++ b/src/Phan/Bootstrap.php
@@ -270,7 +270,7 @@ function phan_error_handler(int $errno, string $errstr, string $errfile, int $er
         // Don't execute the PHP internal error handler
         return true;
     }
-    if ($errno === E_USER_DEPRECATED && preg_match('/^Passing a command as string when creating a /', $errstr)) {
+    if ($errno === E_USER_DEPRECATED && preg_match('/(^Passing a command as string when creating a |method is deprecated since Symfony 4\.4)/', $errstr)) {
         // Suppress deprecation notices running `vendor/bin/paratest`.
         // Don't execute the PHP internal error handler.
         return true;

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -289,6 +289,14 @@ class CodeBase
     }
 
     /**
+     * Returns true if hydration of elements is enabled.
+     * This is called after the parse phase is finished.
+     */
+    public function shouldHydrateRequestedElements(): bool {
+        return $this->should_hydrate_requested_elements;
+    }
+
+    /**
      * @return list<string> - The list of files which are successfully parsed.
      * This changes whenever the file list is reloaded from disk.
      * This also includes files which don't declare classes or functions or globals,

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -179,6 +179,7 @@ class Config
         'exclude_file_list' => [],
 
         // Enable this to enable checks of require/include statements referring to valid paths.
+        // The settings `include_paths` and `warn_about_relative_include_statement` affect the checks.
         'enable_include_path_checks' => false,
 
         // A list of [include paths](https://secure.php.net/manual/en/ini.core.php#ini.include-path) to check when checking if `require_once`, `include`, etc. are pointing to valid files.

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -421,7 +421,7 @@ class Method extends ClassElement implements FunctionInterface
             $method_fqsen,
             $this->getParameterList()
         );
-        $method->setPhanFlags($this->getPhanFlags());
+        $method->setPhanFlags($this->getPhanFlags() & ~(Flags::IS_OVERRIDE | Flags::IS_OVERRIDDEN_BY_ANOTHER));
         switch ($new_visibility_flags) {
             case ast\flags\MODIFIER_PUBLIC:
             case ast\flags\MODIFIER_PROTECTED:

--- a/tests/Phan/Config/InitializerTest.php
+++ b/tests/Phan/Config/InitializerTest.php
@@ -2,10 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Phan\Tests;
+namespace Phan\Tests\Config;
 
 use Phan\Config;
 use Phan\Config\Initializer;
+use Phan\Tests\BaseTest;
 
 /**
  * Unit tests of Phan's analysis creating the expected element representations on snippets of code.

--- a/tests/Phan/MultiFileTest.php
+++ b/tests/Phan/MultiFileTest.php
@@ -107,6 +107,15 @@ class MultiFileTest extends AbstractPhanFileTest
                 MULTI_EXPECTED_DIR . DIRECTORY_SEPARATOR . '3085.php' . AbstractPhanFileTest::EXPECTED_SUFFIX,
                 MULTI_FILE_DIR . DIRECTORY_SEPARATOR . '3085_config.php',
             ],
+            // #3706
+            [
+                [
+                    MULTI_FILE_DIR . DIRECTORY_SEPARATOR . '3706_BagOStuff.php',
+                    MULTI_FILE_DIR . DIRECTORY_SEPARATOR . '3706_MediumBagOStuff.php',
+                    MULTI_FILE_DIR . DIRECTORY_SEPARATOR . '3706_StorageAwareness.php',
+                ],
+                MULTI_EXPECTED_DIR . DIRECTORY_SEPARATOR . '3706.php' . AbstractPhanFileTest::EXPECTED_SUFFIX,
+            ],
             // Manually add additional file sets and expected
             // output here.
 

--- a/tests/files/expected/0855_trait_repeated.php.expected
+++ b/tests/files/expected/0855_trait_repeated.php.expected
@@ -1,0 +1,5 @@
+%s:9 PhanUndeclaredAliasedMethodOfTrait Alias \UsesTrait::alias was defined for a method \HasMethod::magicMethod which does not exist in trait HasMethod
+%s:10 PhanUndeclaredAliasedMethodOfTrait Alias \UsesTrait::alias2 was defined for a method \HasMethod::missingMethod which does not exist in trait HasMethod
+%s:12 PhanUndeclaredStaticMethod Static call to undeclared method \UsesTrait::alias
+%s:13 PhanUndeclaredStaticMethod Static call to undeclared method \UsesTrait::alias2
+%s:14 PhanParamTooMany Call with 1 arg(s) to \UsesTrait::actualMethod() which only takes 0 arg(s) defined at %s:4

--- a/tests/files/src/0854_trait_alias_override.php
+++ b/tests/files/src/0854_trait_alias_override.php
@@ -1,0 +1,21 @@
+<?php
+
+trait TraitA {
+	abstract protected function setup();
+}
+
+trait TraitB {
+	use TraitA;
+
+	protected function setup() {}
+}
+
+class TestCase {
+	use TraitB {
+		setup as parentSetup;
+	}
+
+	protected function setup() {
+		$this->parentSetup();
+	}
+}

--- a/tests/files/src/0855_trait_repeated.php
+++ b/tests/files/src/0855_trait_repeated.php
@@ -1,0 +1,15 @@
+<?php
+/** @method static string magicMethod() */
+trait HasMethod {
+    public static function actualMethod();
+}
+class UsesTrait {
+    // Both 'use' aliases should warn.
+    // Note that php allows 'use TraitName' to be repeated.
+    use HasMethod { magicMethod as alias; }
+    use HasMethod { missingMethod as alias2; }
+}
+UsesTrait::alias();
+UsesTrait::alias2();
+UsesTrait::actualMethod('extra');
+

--- a/tests/multi_files/expected/3706.php.expected
+++ b/tests/multi_files/expected/3706.php.expected
@@ -1,0 +1,1 @@
+%s:8 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($var) is 0 but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array

--- a/tests/multi_files/src/3706_BagOStuff.php
+++ b/tests/multi_files/src/3706_BagOStuff.php
@@ -1,0 +1,6 @@
+<?php
+
+use Wikimedia\LightweightObjectStore\StorageAwareness;
+
+abstract class BagOStuff implements StorageAwareness {
+}

--- a/tests/multi_files/src/3706_MediumBagOStuff.php
+++ b/tests/multi_files/src/3706_MediumBagOStuff.php
@@ -1,0 +1,8 @@
+<?php
+
+abstract class MediumSpecificBagOStuff extends BagOStuff {
+	/** @var int ERR_* class constant */
+	protected $lastError = self::ERR_NONE;
+}
+// Should have inferred the value to be an int
+echo count(MediumSpecificBagOStuff::ERR_NONE);

--- a/tests/multi_files/src/3706_StorageAwareness.php
+++ b/tests/multi_files/src/3706_StorageAwareness.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Wikimedia\LightweightObjectStore;
+
+interface StorageAwareness {
+	/** @var int No error */
+	public const ERR_NONE = 0;
+}


### PR DESCRIPTION
Fix false positive `PhanUnanalyzableInheritance` for renamed methods from traits.
Fixes #3695

Fix false positive `PhanUndeclaredConstant` for inherited class constants
(could previously be emitted while trying to evaluate property defaults early
while parsing)

Fixes #3706