### PR TITLE
Split out `PhanUndeclaredConstantOfClass`.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 Phan NEWS
 
+??? ?? 2020, Phan 2.4.10 (dev)
+------------------------
+
+New Features(Analysis):
++ Emit `PhanUndeclaredConstantOfClass` (severity critical) for undeclared class constants instead of `PhanUndeclaredConstant` (severity normal)
+  This should not be confused with `PhanUndeclaredClassConstant`, which already exists and refers to accessing class constants of classes that don't exist.
+
 Feb 13 2020, Phan 2.4.9
 -----------------------
 

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -1914,7 +1914,7 @@ class ContextNode
         if ($class_fqsen) {
             $class_constant_fqsen = FullyQualifiedClassConstantName::make($class_fqsen, $constant_name);
             throw new IssueException(
-                Issue::fromType(Issue::UndeclaredConstant)(
+                Issue::fromType(Issue::UndeclaredConstantOfClass)(
                     $this->context->getFile(),
                     $node->lineno,
                     [ "$class_fqsen::$constant_name" ],

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -69,7 +69,7 @@ class CLI
     /**
      * This should be updated to x.y.z-dev after every release, and x.y.z before a release.
      */
-    public const PHAN_VERSION = '2.4.9';
+    public const PHAN_VERSION = '2.4.10-dev';
 
     /**
      * List of short flags passed to getopt

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -62,6 +62,8 @@ class Issue
     public const UndeclaredClassStaticProperty = 'PhanUndeclaredClassStaticProperty';
     public const UndeclaredClosureScope    = 'PhanUndeclaredClosureScope';
     public const UndeclaredConstant        = 'PhanUndeclaredConstant';
+    // Sadly, PhanUndeclaredClassConstant already exists and means the class is undeclared
+    public const UndeclaredConstantOfClass = 'PhanUndeclaredConstantOfClass';
     public const UndeclaredMagicConstant   = 'PhanUndeclaredMagicConstant';
     public const UndeclaredExtendedClass   = 'PhanUndeclaredExtendedClass';
     public const UndeclaredFunction        = 'PhanUndeclaredFunction';
@@ -1014,6 +1016,14 @@ class Issue
                 "Reference to undeclared constant {CONST}",
                 self::REMEDIATION_B,
                 11011
+            ),
+            new Issue(
+                self::UndeclaredConstantOfClass,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_CRITICAL,
+                "Reference to undeclared class constant {CONST}",
+                self::REMEDIATION_B,
+                11053
             ),
             new Issue(
                 self::UndeclaredFunction,

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -1507,7 +1507,7 @@ class Clazz extends AddressableElement
 
         if (!$code_base->hasClassConstantWithFQSEN($constant_fqsen)) {
             throw new IssueException(
-                Issue::fromType(Issue::UndeclaredConstant)(
+                Issue::fromType(Issue::UndeclaredConstantOfClass)(
                     $context->getFile(),
                     $context->getLineNumberStart(),
                     [

--- a/tests/files/expected/0040_parent_const_and_properties.php.expected
+++ b/tests/files/expected/0040_parent_const_and_properties.php.expected
@@ -1,2 +1,2 @@
 %s:18 PhanUndeclaredProperty Reference to undeclared property \B->x
-%s:19 PhanUndeclaredConstant Reference to undeclared constant \A::y
+%s:19 PhanUndeclaredConstantOfClass Reference to undeclared class constant \A::y

--- a/tests/files/expected/0101_one_of_each.php.expected
+++ b/tests/files/expected/0101_one_of_each.php.expected
@@ -52,7 +52,7 @@
 %s:161 PhanParentlessClass Reference to parent of class \C12 that does not extend anything
 %s:164 PhanTraitParentReference Reference to parent from trait \T1
 %s:172 PhanUndeclaredClassCatch Catching undeclared class \Undef
-%s:176 PhanUndeclaredConstant Reference to undeclared constant \C16::C
+%s:176 PhanUndeclaredConstantOfClass Reference to undeclared class constant \C16::C
 %s:180 PhanImpossibleConditionInGlobalScope Impossible attempt to cast $v5 of type null to \Undef in the global scope (may be a false positive)
 %s:180 PhanUndeclaredClassInstanceof Checking instanceof against undeclared class \Undef
 %s:183 PhanUndeclaredClassMethod Call to method f5 from undeclared class \Undef

--- a/tests/files/expected/0113_uncaught_undef_class_const_exception.php.expected
+++ b/tests/files/expected/0113_uncaught_undef_class_const_exception.php.expected
@@ -1,1 +1,1 @@
-%s:5 PhanUndeclaredConstant Reference to undeclared constant \UndefClassConst::MY_CONST
+%s:5 PhanUndeclaredConstantOfClass Reference to undeclared class constant \UndefClassConst::MY_CONST

--- a/tests/files/expected/0236_array_key_undefined_class_const.php.expected
+++ b/tests/files/expected/0236_array_key_undefined_class_const.php.expected
@@ -1,4 +1,4 @@
-%s:11 PhanUndeclaredConstant Reference to undeclared constant \Bar::B
-%s:12 PhanUndeclaredConstant Reference to undeclared constant \Bar::C
-%s:14 PhanUndeclaredConstant Reference to undeclared constant \FooParent::Y
-%s:16 PhanUndeclaredConstant Reference to undeclared constant \Foo::UNDECLARED_PAST_FIRST_5
+%s:11 PhanUndeclaredConstantOfClass Reference to undeclared class constant \Bar::B
+%s:12 PhanUndeclaredConstantOfClass Reference to undeclared class constant \Bar::C
+%s:14 PhanUndeclaredConstantOfClass Reference to undeclared class constant \FooParent::Y
+%s:16 PhanUndeclaredConstantOfClass Reference to undeclared class constant \Foo::UNDECLARED_PAST_FIRST_5

--- a/tests/files/expected/0398_future_array_key_in_prop.php.expected
+++ b/tests/files/expected/0398_future_array_key_in_prop.php.expected
@@ -1,1 +1,1 @@
-%s:11 PhanUndeclaredConstant Reference to undeclared constant \B398::UNDEFINED_KEY
+%s:11 PhanUndeclaredConstantOfClass Reference to undeclared class constant \B398::UNDEFINED_KEY

--- a/tests/files/expected/0405_array_union_type_bug.php.expected
+++ b/tests/files/expected/0405_array_union_type_bug.php.expected
@@ -1,1 +1,1 @@
-%s:12 PhanUndeclaredConstant Reference to undeclared constant \CC::TYPE_MISSING
+%s:12 PhanUndeclaredConstantOfClass Reference to undeclared class constant \CC::TYPE_MISSING

--- a/tests/files/expected/0410_hydration_bug.php.expected
+++ b/tests/files/expected/0410_hydration_bug.php.expected
@@ -1,2 +1,2 @@
-%s:5 PhanUndeclaredConstant Reference to undeclared constant \HydrateExample::INVALID
-%s:12 PhanUndeclaredConstant Reference to undeclared constant \HydrateExampleStep::INVALID
+%s:5 PhanUndeclaredConstantOfClass Reference to undeclared class constant \HydrateExample::INVALID
+%s:12 PhanUndeclaredConstantOfClass Reference to undeclared class constant \HydrateExampleStep::INVALID

--- a/tests/files/expected/0415_class_property_hydration_fail.php.expected
+++ b/tests/files/expected/0415_class_property_hydration_fail.php.expected
@@ -1,1 +1,1 @@
-%s:18 PhanUndeclaredConstant Reference to undeclared constant \D415::MISSING_CONSTNAME
+%s:18 PhanUndeclaredConstantOfClass Reference to undeclared class constant \D415::MISSING_CONSTNAME

--- a/tests/files/expected/0416_method_hydration_test.php.expected
+++ b/tests/files/expected/0416_method_hydration_test.php.expected
@@ -1,1 +1,1 @@
-%s:30 PhanUndeclaredConstant Reference to undeclared constant \D416::MISSING_CONSTNAME
+%s:30 PhanUndeclaredConstantOfClass Reference to undeclared class constant \D416::MISSING_CONSTNAME

--- a/tests/files/expected/0485_suggest_constants.php.expected
+++ b/tests/files/expected/0485_suggest_constants.php.expected
@@ -1,9 +1,9 @@
-%s:16 PhanUndeclaredConstant Reference to undeclared constant \SubClass485::base_const (Did you mean \SubClass485::base__const)
-%s:17 PhanUndeclaredConstant Reference to undeclared constant \SubClass485::casesensitive (Did you mean \SubClass485::CASESENSITIVE or \SubClass485::CaseSensitive)
-%s:18 PhanUndeclaredConstant Reference to undeclared constant \SubClass485::_casesensitive (Did you mean \SubClass485::CASESENSITIVE or \SubClass485::CaseSensitive)
-%s:20 PhanUndeclaredConstant Reference to undeclared constant \SubClass485::private_const_in_same_class (Did you mean \SubClass485::PrivateConstInSameClass)
-%s:21 PhanUndeclaredConstant Reference to undeclared constant \SubClass485::privateConstInSameClass (Did you mean \SubClass485::PrivateConstInSameClass)
-%s:22 PhanUndeclaredConstant Reference to undeclared constant \SubClass485::otherconst (Did you mean \SubClass485::other_const)
-%s:25 PhanUndeclaredConstant Reference to undeclared constant \SubClass485::base_const
-%s:28 PhanUndeclaredConstant Reference to undeclared constant \SubClass485::base_const
-%s:29 PhanUndeclaredConstant Reference to undeclared constant \SubClass485::casesensitive (Did you mean \SubClass485::CASESENSITIVE or \SubClass485::CaseSensitive)
+%s:16 PhanUndeclaredConstantOfClass Reference to undeclared class constant \SubClass485::base_const (Did you mean \SubClass485::base__const)
+%s:17 PhanUndeclaredConstantOfClass Reference to undeclared class constant \SubClass485::casesensitive (Did you mean \SubClass485::CASESENSITIVE or \SubClass485::CaseSensitive)
+%s:18 PhanUndeclaredConstantOfClass Reference to undeclared class constant \SubClass485::_casesensitive (Did you mean \SubClass485::CASESENSITIVE or \SubClass485::CaseSensitive)
+%s:20 PhanUndeclaredConstantOfClass Reference to undeclared class constant \SubClass485::private_const_in_same_class (Did you mean \SubClass485::PrivateConstInSameClass)
+%s:21 PhanUndeclaredConstantOfClass Reference to undeclared class constant \SubClass485::privateConstInSameClass (Did you mean \SubClass485::PrivateConstInSameClass)
+%s:22 PhanUndeclaredConstantOfClass Reference to undeclared class constant \SubClass485::otherconst (Did you mean \SubClass485::other_const)
+%s:25 PhanUndeclaredConstantOfClass Reference to undeclared class constant \SubClass485::base_const
+%s:28 PhanUndeclaredConstantOfClass Reference to undeclared class constant \SubClass485::base_const
+%s:29 PhanUndeclaredConstantOfClass Reference to undeclared class constant \SubClass485::casesensitive (Did you mean \SubClass485::CASESENSITIVE or \SubClass485::CaseSensitive)

--- a/tests/files/expected/0498_lookup_class_var.php.expected
+++ b/tests/files/expected/0498_lookup_class_var.php.expected
@@ -1,2 +1,2 @@
 %s:11 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($string) is \X\Example (real type object) but \strlen() takes string
-%s:13 PhanUndeclaredConstant Reference to undeclared constant \X\Example::BAD (Did you mean \X\Example::BAR)
+%s:13 PhanUndeclaredConstantOfClass Reference to undeclared class constant \X\Example::BAD (Did you mean \X\Example::BAR)

--- a/tests/files/expected/0804_suggestions.php.expected
+++ b/tests/files/expected/0804_suggestions.php.expected
@@ -1,2 +1,2 @@
-%s:11 PhanUndeclaredConstant Reference to undeclared constant \Shop804::LIST_OF_CHEESES (Did you mean \Shop804::$LIST_OF_CHEESES)
-%s:12 PhanUndeclaredConstant Reference to undeclared constant \Shop804::buyCheese (Did you mean \Shop804::buyCheese())
+%s:11 PhanUndeclaredConstantOfClass Reference to undeclared class constant \Shop804::LIST_OF_CHEESES (Did you mean \Shop804::$LIST_OF_CHEESES)
+%s:12 PhanUndeclaredConstantOfClass Reference to undeclared class constant \Shop804::buyCheese (Did you mean \Shop804::buyCheese())

--- a/tests/misc/fallback_test/expected/015_class_const_declaration9.php.expected
+++ b/tests/misc/fallback_test/expected/015_class_const_declaration9.php.expected
@@ -2,4 +2,4 @@ src/015_class_const_declaration9.php:3 PhanInvalidConstantExpression Constant ex
 src/015_class_const_declaration9.php:3 PhanSyntaxError syntax error, unexpected '=', expecting ',' or ';'
 src/015_class_const_declaration9.php:3 PhanUnanalyzable Expression is unanalyzable or feature is unimplemented. Please create an issue at https://github.com/phan/phan/issues/new.
 src/015_class_const_declaration9.php:3 PhanUndeclaredConstant Reference to undeclared constant \b
-src/015_class_const_declaration9.php:6 PhanUndeclaredConstant Reference to undeclared constant \A15::b
+src/015_class_const_declaration9.php:6 PhanUndeclaredConstantOfClass Reference to undeclared class constant \A15::b

--- a/tests/multi_files/expected/1898.php.expected
+++ b/tests/multi_files/expected/1898.php.expected
@@ -1,1 +1,1 @@
-%s:7 PhanUndeclaredConstant Reference to undeclared constant \B1898::MISSING
+%s:7 PhanUndeclaredConstantOfClass Reference to undeclared class constant \B1898::MISSING

--- a/tests/plugin_test/expected/013_duplicate_array_key_uncaught.php.expected
+++ b/tests/plugin_test/expected/013_duplicate_array_key_uncaught.php.expected
@@ -1,2 +1,2 @@
-src/013_duplicate_array_key_uncaught.php:7 PhanUndeclaredConstant Reference to undeclared constant \Bar13::B
-src/013_duplicate_array_key_uncaught.php:17 PhanUndeclaredConstant Reference to undeclared constant \Bar13::a
+src/013_duplicate_array_key_uncaught.php:7 PhanUndeclaredConstantOfClass Reference to undeclared class constant \Bar13::B
+src/013_duplicate_array_key_uncaught.php:17 PhanUndeclaredConstantOfClass Reference to undeclared class constant \Bar13::a


### PR DESCRIPTION
Often, global constants can be missing because of different extension
versions, etc, and PHP 7 will only emit a warning if a global constant is
undefined. (PHP 8 will throw)