### PR TITLE
Make Phan better at inferring what method was called

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -554,6 +554,7 @@ return [
         'StrictComparisonPlugin',
         // Warn about `$var == SOME_INT_OR_STRING_CONST` due to unintuitive behavior such as `0 == 'a'`
         '.phan/plugins/StrictLiteralComparisonPlugin.php',
+        '.phan/plugins/UnknownClassElementAccessPlugin.php',
 
         ////////////////////////////////////////////////////////////////////////
         // End plugins for Phan's self-analysis

--- a/.phan/plugins/PHPDocToRealTypesPlugin/Fixers.php
+++ b/.phan/plugins/PHPDocToRealTypesPlugin/Fixers.php
@@ -9,6 +9,7 @@ use Microsoft\PhpParser\FunctionLike;
 use Microsoft\PhpParser\Node\Expression\AnonymousFunctionCreationExpression;
 use Microsoft\PhpParser\Node\MethodDeclaration;
 use Microsoft\PhpParser\Node\Statement\FunctionDeclaration;
+use Microsoft\PhpParser\Token;
 use Phan\AST\TolerantASTConverter\NodeUtils;
 use Phan\CodeBase;
 use Phan\IssueInstance;
@@ -68,10 +69,11 @@ class Fixers
         }
         // @phan-suppress-next-line PhanUndeclaredProperty
         $close_bracket = $declaration->anonymousFunctionUseClause->closeParen ?? $declaration->closeParen;
-        if (!$close_bracket) {
+        if (!$close_bracket instanceof Token) {
             return null;
         }
         // get the byte where the `)` of the argument list ends
+        // @phan-suppress-next-line PhanPluginUnknownObjectMethodCall TODO fix https://github.com/phan/phan/issues/3723
         $last_byte_index = $close_bracket->getEndPosition();
         $file_edit = new FileEdit($last_byte_index, $last_byte_index, " : $return_type");
         return new FileEditSet([$file_edit]);

--- a/.phan/plugins/PreferNamespaceUsePlugin/Fixers.php
+++ b/.phan/plugins/PreferNamespaceUsePlugin/Fixers.php
@@ -61,16 +61,20 @@ class Fixers
         return self::computeEditsForParamTypeDeclaration($contents, $declaration, $param_name, $shorter_return_type);
     }
 
+    /**
+     * @suppress PhanThrowTypeAbsentForCall
+     */
     private static function computeEditsForReturnTypeDeclaration(
         FunctionLike $declaration,
         string $shorter_return_type
     ): ?FileEditSet {
         // @phan-suppress-next-line PhanUndeclaredProperty
         $return_type_node = $declaration->returnType;
-        if (!$return_type_node) {
+        if (!$return_type_node instanceof PhpParser\Node) {
             return null;
         }
         // Generate an edit to replace the long return type with the shorter return type
+        // Long return types are always Nodes instead of Tokens.
         $file_edit = new FileEdit(
             $return_type_node->getStart(),
             $return_type_node->getEndPosition(),

--- a/.phan/plugins/README.md
+++ b/.phan/plugins/README.md
@@ -225,6 +225,12 @@ has the given value.
 - **PhanPluginRedundantAssignmentInLoop** `Assigning {TYPE} to variable ${VARIABLE} which already has that value`
 - **PhanPluginRedundantAssignmentInGlobalScope** `Assigning {TYPE} to variable ${VARIABLE} which already has that value`
 
+### UnknownClassElementAccessPlugin.php
+
+This plugin checks for accesses to unknown class elements that can't be type checked.
+
+- **PhanPluginUnknownObjectMethodCall**: `Phan could not infer any class/interface types for the object of the method call {CODE} - inferred a type of {TYPE}`
+
 ### 3. Plugins Specific to Code Styles
 
 These plugins may be useful to enforce certain code styles,

--- a/.phan/plugins/UnknownClassElementAccessPlugin.php
+++ b/.phan/plugins/UnknownClassElementAccessPlugin.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+use ast\Node;
+use Phan\AST\ASTReverter;
+use Phan\AST\UnionTypeVisitor;
+use Phan\PluginV3;
+use Phan\PluginV3\PluginAwarePostAnalysisVisitor;
+use Phan\PluginV3\PostAnalyzeNodeCapability;
+
+/**
+ * This plugin checks for accesses to unknown class elements that can't be type checked.
+ *
+ * - E.g. `$unknown->someMethod(null)`
+ *
+ * This file demonstrates plugins for Phan. Plugins hook into various events.
+ * UnknownClassElementAccessPlugin hooks into one event:
+ *
+ * - getPostAnalyzeNodeVisitorClassName
+ *   This method returns a visitor that is called on every AST node from every
+ *   file being analyzed in post-order
+ *
+ * A plugin file must
+ *
+ * - Contain a class that inherits from \Phan\PluginV3
+ *
+ * - End by returning an instance of that class.
+ *
+ * It is assumed without being checked that plugins aren't
+ * mangling state within the passed code base or context.
+ *
+ * Note: When adding new plugins,
+ * add them to the corresponding section of README.md
+ */
+class UnknownClassElementAccessPlugin extends PluginV3 implements
+    PostAnalyzeNodeCapability
+{
+
+    /**
+     * @return class-string - name of PluginAwarePostAnalysisVisitor subclass
+     */
+    public static function getPostAnalyzeNodeVisitorClassName(): string
+    {
+        return UnknownClassElementAccessVisitor::class;
+    }
+}
+
+/**
+ * This visitor analyzes node kinds that can be the root of expressions
+ * containing duplicate expressions, and is called on nodes in post-order.
+ */
+class UnknownClassElementAccessVisitor extends PluginAwarePostAnalysisVisitor
+{
+    /**
+     * @param Node $node a node of kind ast\AST_METHOD_CALL, representing a call to an instance method
+     */
+    public function visitMethodCall(Node $node): void
+    {
+        try {
+            // Fetch the list of valid classes, and warn about any undefined classes.
+            // (We have more specific issue types such as PhanNonClassMethodCall below, don't emit PhanTypeExpected*)
+            $union_type = UnionTypeVisitor::unionTypeFromNode($this->code_base, $this->context, $node->children['expr']);
+        } catch (Exception $_) {
+            // Phan should already throw for this
+            return;
+        }
+        foreach ($union_type->getTypeSet() as $type) {
+            if ($type->isObjectWithKnownFQSEN()) {
+                return;
+            }
+        }
+        $this->emitPluginIssue(
+            $this->code_base,
+            $this->context,
+            'PhanPluginUnknownObjectMethodCall',
+            'Phan could not infer any class/interface types for the object of the method call {CODE} - inferred a type of {TYPE}',
+            [
+                ASTReverter::toShortString($node),
+                $union_type->isEmpty() ? '(no types)' : $union_type
+            ]
+        );
+    }
+}
+
+// Every plugin needs to return an instance of itself at the
+// end of the file in which it's defined.
+return new UnknownClassElementAccessPlugin();

--- a/.phan/plugins/UnknownElementTypePlugin.php
+++ b/.phan/plugins/UnknownElementTypePlugin.php
@@ -124,7 +124,7 @@ class UnknownElementTypePlugin extends PluginV3 implements
                             return;
                         }
                         $combined_type = $inferred_types[$i] ?? null;
-                        if ($combined_type) {
+                        if ($combined_type instanceof UnionType) {
                             $combined_type = $combined_type->withUnionType($parameter_type);
                         } else {
                             $combined_type = $parameter_type;
@@ -342,7 +342,7 @@ class UnknownElementTypePlugin extends PluginV3 implements
                             return;
                         }
                         $combined_type = $inferred_types[$i] ?? null;
-                        if ($combined_type) {
+                        if ($combined_type instanceof UnionType) {
                             $combined_type = $combined_type->withUnionType($parameter_type);
                         } else {
                             $combined_type = $parameter_type;

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,11 +7,14 @@ New features(Analysis):
 + Support parsing php 8.0 union types (and the static return type) in the polyfill. (#3419, #3634)
 + Emit `PhanCompatibleUnionType` and `PhanCompatibleStaticType` when the target php version is less than 8.0 and union types or static return types are seen. (#3419, #3634)
 + Be more consistent about warning about issues in values of class constants, global constants, and property defaults.
++ Infer key and element types from `iterator_to_array()`
 
 Bug fixes:
 + Fix ambiguity in the way `Closure():T[]` and `callable():T[]` are rendered in error messages. (#3731)
   Either render it as `(Closure():T)[]` or `Closure():(T[])`
 + Don't include both `.` and `vendor/x/y/` when initializing Phan configs with settings such as `--init --init-analyze-dir=.` (#3699)
++ Be more consistent about resolving `static` in generators and template types.
++ Infer the iterable value type for `Generator<V>`. It was previously only inferred when there were 2 or more template args in phpdoc.
 
 Feb 20 2020, Phan 2.5.0
 -----------------------

--- a/internal/lib/IncompatibleXMLSignatureDetector.php
+++ b/internal/lib/IncompatibleXMLSignatureDetector.php
@@ -61,6 +61,7 @@ class IncompatibleXMLSignatureDetector extends IncompatibleSignatureDetectorBase
             return [];
         }
         $result = [];
+        // @phan-suppress-next-line PhanPluginUnknownObjectMethodCall TODO fix https://github.com/phan/phan/issues/3723
         foreach ($xml->children()[2]->table->tgroup->tbody->children() as $row) {
             $entry = $row->entry;
             $alias = (string)$entry[0];
@@ -625,6 +626,7 @@ class IncompatibleXMLSignatureDetector extends IncompatibleSignatureDetectorBase
                 $param_name = 'arg' . $i;
             }
 
+            // @phan-suppress-next-line PhanPluginUnknownObjectMethodCall TODO fix https://github.com/phan/phan/issues/3723
             if (((string)($part->attributes()['choice'] ?? '')) === 'opt') {
                 $param_name .= '=';
             }
@@ -955,6 +957,7 @@ class IncompatibleXMLSignatureDetector extends IncompatibleSignatureDetectorBase
             // var_export($entry);
             // echo "The extracted names are:\n";
             // var_export($name);
+            // @phan-suppress-next-line PhanPluginUnknownObjectMethodCall TODO fix https://github.com/phan/phan/issues/3723
             if ($name->count() !== 1) {
                 fwrite(STDERR, "Failed to parse $entry\n");
                 continue;

--- a/internal/package.php
+++ b/internal/package.php
@@ -43,6 +43,7 @@ foreach (glob('LICENSE*') as $license) {
     $phar->addFile($license);
 }
 foreach ($phar as $file) {
+    // @phan-suppress-next-line PhanPluginUnknownObjectMethodCall TODO fix https://github.com/phan/phan/issues/3723
     echo $file->getFileName() . "\n";
 }
 

--- a/src/Phan/AST/FallbackUnionTypeVisitor.php
+++ b/src/Phan/AST/FallbackUnionTypeVisitor.php
@@ -642,7 +642,7 @@ class FallbackUnionTypeVisitor extends KindVisitorImplementation
                 // NOTE: Deliberately do not use the closure for $function->hasDependentReturnType().
                 // Most plugins expect the context to have variables, which this won't provide.
                 $function_types = $function->getUnionType();
-                if ($possible_types) {
+                if ($possible_types instanceof UnionType) {
                     $possible_types = $possible_types->withUnionType($function_types);
                 } else {
                     $possible_types = $function_types;
@@ -681,7 +681,7 @@ class FallbackUnionTypeVisitor extends KindVisitorImplementation
                 }
                 $method = $class->getMethodByName($this->code_base, $method_name);
                 $method_types = $method->getUnionType();
-                if ($possible_types) {
+                if ($possible_types instanceof UnionType) {
                     $possible_types = $possible_types->withUnionType($method_types);
                 } else {
                     $possible_types = $method_types;

--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -553,6 +553,7 @@ class Analysis
         ConfigPluginSet::instance()->beforeAnalyzeFile($code_base, $context, $file_contents, $node);
 
         $context = (new BlockAnalysisVisitor($code_base, $context))($node);
+        // @phan-suppress-next-line PhanAccessMethodInternal
         $context->warnAboutUnusedUseElements($code_base);
 
         ConfigPluginSet::instance()->afterAnalyzeFile($code_base, $context, $file_contents, $node);

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -1178,6 +1178,7 @@ class AssignmentVisitor extends AnalysisVisitor
      * Modifies $this->context (if needed) to track the assignment to a property of $this within a function-like.
      * This handles conditional branches.
      * @param string $prop_name
+     * TODO: If $this->right_type is the empty union type and the property is declared, assume the phpdoc/real types instead of the empty union type.
      */
     private function handleThisPropertyAssignmentInLocalScopeByName(Node $node, string $prop_name): void
     {

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -830,6 +830,7 @@ class ConditionVisitor extends KindVisitorImplementation implements ConditionVis
             $method = new ReflectionMethod(UnionType::class, $extract_types);
             /**
              * @param list<Node|mixed> $args
+             * @suppress PhanPluginUnknownObjectMethodCall can't analye ReflectionMethod
              */
             return static function (CodeBase $code_base, Context $context, Variable $variable, array $args) use ($method, $default_if_empty, $allow_undefined): void {
                 // Change the type to match the is_a relationship

--- a/src/Phan/Analysis/ConditionVisitorInterface.php
+++ b/src/Phan/Analysis/ConditionVisitorInterface.php
@@ -14,6 +14,7 @@ use Phan\Language\Element\Variable;
  * This implements common functionality to update variables based on checks within a conditional (of an if/elseif/else/while/for/assert(), etc.)
  *
  * Classes using ConditionVisitorUtil must implement this trait.
+ * @method Context __invoke(Node $node)
  */
 interface ConditionVisitorInterface
 {

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -955,6 +955,10 @@ class ParameterTypesAnalyzer
         Method $method,
         Method $o_method
     ): void {
+        // The method was already from phpdoc.
+        if ($method->isFromPHPDoc()) {
+            return;
+        }
         // Get the parameters for that method
         $phpdoc_parameter_list = $method->getParameterList();
         $o_phpdoc_parameter_list = $o_method->getParameterList();

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -1696,7 +1696,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         }
         $expected_value_type = $template_type_list[\min(1, $type_list_count - 1)];
         try {
-            if (!$yield_value_type->withStaticResolvedInContext($context)->asExpandedTypes($code_base)->canCastToUnionType($expected_value_type)) {
+            if (!$yield_value_type->withStaticResolvedInContext($context)->asExpandedTypes($code_base)->canCastToUnionType($expected_value_type->withStaticResolvedInContext($context))) {
                 $this->emitIssue(
                     Issue::TypeMismatchGeneratorYieldValue,
                     $node->lineno,
@@ -1718,7 +1718,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             }
             // TODO: finalize syntax to indicate the absence of a key or value (e.g. use void instead?)
             $expected_key_type = $template_type_list[0];
-            if (!$yield_key_type->withStaticResolvedInContext($context)->asExpandedTypes($code_base)->canCastToUnionType($expected_key_type)) {
+            if (!$yield_key_type->withStaticResolvedInContext($context)->asExpandedTypes($code_base)->canCastToUnionType($expected_key_type->withStaticResolvedInContext($context))) {
                 $this->emitIssue(
                     Issue::TypeMismatchGeneratorYieldKey,
                     $node->lineno,

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -59,6 +59,7 @@ use function rtrim;
  * @see self::visit()
  *
  * @phan-file-suppress PhanPartialTypeMismatchArgument
+ * @method Context __invoke(Node $node)
  */
 class BlockAnalysisVisitor extends AnalysisVisitor
 {
@@ -1394,7 +1395,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
             // Step into each child node and get an
             // updated context for the node
 
-            if ($previous_child_context) {
+            if ($previous_child_context instanceof Context) {
                 // The previous case statement fell through some of the time or all of the time.
                 $child_context = (new ContextMergeVisitor(
                     $previous_child_context,
@@ -1425,6 +1426,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
                             // Add the variable type from the above case statements, if it was possible for it to fall through
                             // TODO: Also support switch(get_class($variable))
                             $child_context = $switch_variable_condition($child_context, $case_cond_node);
+                            '@phan-var Context $child_context';
                             if ($previous_child_context !== null) {
                                 $variable = $child_context->getScope()->getVariableByNameOrNull($var_name);
                                 if ($variable) {

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -787,6 +787,7 @@ class CodeBase
         if ($this->undo_tracker) {
             // TODO: Track a count of aliases instead? This doesn't work in daemon mode if multiple files add the same alias to the same class.
             // TODO: Allow .phan/config.php to specify aliases or precedences for aliases?
+            /** @suppress PhanPluginUnknownObjectMethodCall TODO: Infer types from ArrayAccess->offsetGet in UnionTypeVisitor->visitDim() */
             $this->undo_tracker->recordUndo(static function (CodeBase $inner) use ($original, $alias_record): void {
                 $fqsen_alias_map = $inner->fqsen_alias_map[$original] ?? null;
                 if ($fqsen_alias_map) {

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -972,6 +972,8 @@ class Config
     /**
      * @return array<string,mixed>
      * A map of configuration keys and their values
+     *
+     * @suppress PhanUnreferencedPublicMethod useful for plugins, testing, etc.
      */
     public static function toArray(): array
     {

--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -1020,6 +1020,7 @@ class Context extends FileRef
                 return null;
             }
             if ($result) {
+                '@phan-var UnionType $result';
                 $result = $result->withUnionType($extra);
             } else {
                 $result = $extra;

--- a/src/Phan/Language/Element/Comment.php
+++ b/src/Phan/Language/Element/Comment.php
@@ -311,8 +311,9 @@ class Comment
         switch ($key) {
             case 'param':
                 foreach ($value as $parameter) {
+                    '@phan-var CommentParameter $parameter';
                     $name = $parameter->getName();
-                    if ($name) {
+                    if ($name !== '') {
                         // Add it to the named map
                         // TODO: could check that @phan-param is compatible with the original @param
                         $this->parameter_map[$name] = $parameter;
@@ -331,8 +332,9 @@ class Comment
                 return;
             case 'property':
                 foreach ($value as $property) {
+                    '@phan-var CommentProperty $property';
                     $name = $property->getName();
-                    if ($name) {
+                    if ($name !== '') {
                         // Override or add the entry in the named map
                         $this->magic_property_map[$name] = $property;
                     }
@@ -340,9 +342,10 @@ class Comment
                 return;
             case 'method':
                 foreach ($value as $method) {
+                    '@phan-var CommentMethod $method';
                     $name = $method->getName();
-                    if ($name) {
-                        // Override or add the entry in the named map
+                    if ($name !== '') {
+                        // Override or add the entry in the named map (probably always has a name)
                         $this->magic_method_map[$name] = $method;
                     }
                 }

--- a/src/Phan/Language/Element/Func.php
+++ b/src/Phan/Language/Element/Func.php
@@ -318,6 +318,7 @@ class Func extends AddressableElement implements FunctionInterface
      * @return \Generator
      * @phan-return \Generator<Func>
      * The set of all alternates to this function
+     * @suppress PhanParamSignatureMismatch
      */
     public function alternateGenerator(CodeBase $code_base): \Generator
     {

--- a/src/Phan/Language/Element/FunctionFactory.php
+++ b/src/Phan/Language/Element/FunctionFactory.php
@@ -219,7 +219,7 @@ class FunctionFactory
 
             // Set the return type if one is defined
             $return_type = $map['return_type'] ?? null;
-            if ($return_type) {
+            if ($return_type instanceof UnionType) {
                 $real_return_type = $function->getRealReturnType();
                 if (!$real_return_type->isEmpty()) {
                     $return_type = UnionType::of($return_type->getTypeSet(), $real_return_type->getTypeSet());

--- a/src/Phan/Language/Element/FunctionInterface.php
+++ b/src/Phan/Language/Element/FunctionInterface.php
@@ -201,7 +201,7 @@ interface FunctionInterface extends AddressableElementInterface
     public function getOutputReferenceParamNames(): array;
 
     /**
-     * @return \Generator
+     * @return \Generator<static>
      * The set of all alternates to this function
      */
     public function alternateGenerator(CodeBase $code_base): \Generator;

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -210,12 +210,12 @@ trait FunctionTrait
     private $real_return_type;
 
     /**
-     * @var Closure|null (CodeBase, Context, Func|Method $func, Node[]|string[]|int[] $arg_list) => UnionType
+     * @var ?Closure(CodeBase, Context, FunctionInterface, list<Node|int|string|float>):UnionType
      */
     private $return_type_callback = null;
 
     /**
-     * @var Closure|null (CodeBase, Context, Func|Method $func, Node[]|string[]|int[] $arg_list) => void
+     * @var ?Closure(CodeBase, Context, FunctionInterface, list<Node|int|string|float>, ?Node):void
      */
     private $function_call_analyzer_callback = null;
 
@@ -1009,7 +1009,7 @@ trait FunctionTrait
      */
     public function getDependentReturnType(CodeBase $code_base, Context $context, array $args): UnionType
     {
-        // @phan-suppress-next-line PhanTypePossiblyInvalidCallable - Callers should check hasDependentReturnType
+        // @phan-suppress-next-line PhanTypeMismatchArgument, PhanTypePossiblyInvalidCallable - Callers should check hasDependentReturnType
         $result = ($this->return_type_callback)($code_base, $context, $this, $args);
         if (!$result->hasRealTypeSet()) {
             $real_return_type = $this->getRealReturnType();
@@ -1045,7 +1045,7 @@ trait FunctionTrait
      */
     public function analyzeFunctionCall(CodeBase $code_base, Context $context, array $args, Node $node = null): void
     {
-        // @phan-suppress-next-line PhanTypePossiblyInvalidCallable - Callers should check hasFunctionCallAnalyzer
+        // @phan-suppress-next-line PhanTypePossiblyInvalidCallable, PhanTypeMismatchArgument - Callers should check hasFunctionCallAnalyzer
         ($this->function_call_analyzer_callback)($code_base, $context, $this, $args, $node);
     }
 

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -739,6 +739,7 @@ class Method extends ClassElement implements FunctionInterface
      * @return \Generator
      * @phan-return \Generator<Method>
      * The set of all alternates to this method
+     * @suppress PhanParamSignatureMismatch
      */
     public function alternateGenerator(CodeBase $code_base): \Generator
     {

--- a/src/Phan/Language/Element/PassByReferenceVariable.php
+++ b/src/Phan/Language/Element/PassByReferenceVariable.php
@@ -160,6 +160,7 @@ class PassByReferenceVariable extends Variable
     /**
      * Is the variable/property this is referring to part of a PHP module?
      * (only possible for properties)
+     * @suppress PhanUnreferencedPublicMethod this may be called by plugins or Phan in the future
      */
     public function isPHPInternal(): bool
     {

--- a/src/Phan/Language/Element/TypedElement.php
+++ b/src/Phan/Language/Element/TypedElement.php
@@ -323,6 +323,7 @@ abstract class TypedElement implements TypedElementInterface
     /**
      * This method must be called before analysis
      * begins.
+     * @suppress PhanUnreferencedPublicMethod not called directly, a future version may remove this.
      */
     public function hydrate(CodeBase $unused_code_base): void
     {

--- a/src/Phan/Language/Element/Variable.php
+++ b/src/Phan/Language/Element/Variable.php
@@ -85,6 +85,7 @@ class Variable extends UnaddressableTypedElement implements TypedElementInterfac
      * @return bool
      * This will always return false in so far as variables
      * cannot be passed by reference.
+     * @suppress PhanUnreferencedPublicMethod this is added for convenience for plugins
      */
     public function isPassByReference(): bool
     {

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -2604,6 +2604,8 @@ class Type
         $template_type_list = $this->template_parameter_type_list;
         if (count($template_type_list) >= 2 && count($template_type_list) <= 4) {
             return $template_type_list[1];
+        } elseif (count($template_type_list) === 1) {
+            return $template_type_list[0];
         }
         return null;
     }
@@ -3358,9 +3360,25 @@ class Type
      * Either this or 'static' resolved in the given context.
      */
     public function withStaticResolvedInContext(
-        Context $_
+        Context $context
     ): Type {
+        if ($this->template_parameter_type_list) {
+            return $this->withStaticResolvedInContextTemplate($context);
+        }
         return $this;
+    }
+
+    private function withStaticResolvedInContextTemplate(
+        Context $context
+    ): Type {
+        $new_template_parameter_type_list = [];
+        foreach ($this->template_parameter_type_list as $t) {
+            $new_template_parameter_type_list[] = $t->withStaticResolvedInContext($context);
+        }
+        if ($new_template_parameter_type_list === $this->template_parameter_type_list) {
+            return $this;
+        }
+        return self::fromType($this, $new_template_parameter_type_list);
     }
 
     /**

--- a/src/Phan/Language/Type/ArrayShapeType.php
+++ b/src/Phan/Language/Type/ArrayShapeType.php
@@ -261,6 +261,7 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
                     continue;
                 }
                 if ($element_union_types) {
+                    '@phan-var UnionType $element_union_types';
                     $element_union_types = $element_union_types->withType($target_type->genericArrayElementType());
                 } else {
                     $element_union_types = $target_type->genericArrayElementUnionType();

--- a/src/Phan/Language/Type/FunctionLikeDeclarationType.php
+++ b/src/Phan/Language/Type/FunctionLikeDeclarationType.php
@@ -83,6 +83,7 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
     /**
      * @param list<ClosureDeclarationParameter> $params
      * @param UnionType $return_type
+     * @suppress PhanPluginUnknownObjectMethodCall TODO: Figure out how the type is getting overridden in PostOrderAnalysisVisitor->analyzeCallToFunctionLike
      */
     public function __construct(FileRef $file_ref, array $params, UnionType $return_type, bool $returns_reference, bool $is_nullable)
     {
@@ -366,7 +367,7 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
     }
 
     /**
-     * @phan-return \Generator<FunctionLikeDeclarationType>
+     * @phan-return \Generator<static>
      * @override
      */
     public function alternateGenerator(CodeBase $_): Generator

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -1005,7 +1005,7 @@ class UnionType implements Serializable
             }
         }
 
-        return $has_template ? UnionType::of($concrete_type_list, []) : $this;
+        return $has_template ? UnionType::of($concrete_type_list, $this->real_type_set) : $this;
     }
 
     /**

--- a/src/Phan/Language/UnionTypeBuilder.php
+++ b/src/Phan/Language/UnionTypeBuilder.php
@@ -86,6 +86,7 @@ final class UnionTypeBuilder
     /**
      * Build and return the UnionType for the unique type set that this was building.
      * @deprecated use self::getPHPDocUnionType()
+     * @suppress PhanUnreferencedPublicMethod
      */
     public function getUnionType(): UnionType
     {

--- a/src/Phan/Library/Map.php
+++ b/src/Phan/Library/Map.php
@@ -14,6 +14,13 @@ use SplObjectStorage;
  * @template K
  * @template V
  * @suppress PhanTemplateTypeNotDeclaredInFunctionParams
+ * @phan-file-suppress PhanParamSignaturePHPDocMismatchHasParamType, PhanParamSignatureMismatchInternal
+ * @method void attach(K $object,V $data = null)
+ * @method void detach(K $object)
+ * @method bool offsetExists(K $object)
+ * @method V offsetGet(K $object )
+ * @method void offsetSet(K $object,V $data = null)
+ * @method void offsetUnset(K $object)
  */
 class Map extends SplObjectStorage
 {

--- a/src/Phan/Library/Set.php
+++ b/src/Phan/Library/Set.php
@@ -17,12 +17,13 @@ use TypeError;
  *
  * - Afterwards, remove this boilerplate overriding methods of SplObjectStorage<T,T>
  *
- * @method attach(T $object,mixed $data = null):void
- * @method detach(T $object):void
- * @method offsetExists(T $object):bool
- * @method offsetGet(T $object ):bool
- * @method offsetSet(T $object,mixed $data = null):void
- * @method offsetUnset(T $object):void
+ * @method void attach(T $object,mixed $data = null)
+ * @method void detach(T $object)
+ * @method bool offsetExists(T $object)
+ * @method bool offsetGet(T $object )
+ * @method void offsetSet(T $object,mixed $data = null)
+ * @method void offsetUnset(T $object)
+ * @method T current()
  *
  * @phan-file-suppress PhanParamSignatureMismatchInternal, PhanParamSignaturePHPDocMismatchHasParamType for these comment method overrides
  * TODO: Make suppressions in the class doc comment work for magic methods.

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -58,6 +58,8 @@ use Phan\Library\None;
  * @phan-file-suppress PhanUnusedPublicMethodParameter implementing faster no-op methods for common visit*
  * @phan-file-suppress PhanPartialTypeMismatchArgument
  * @phan-file-suppress PhanPartialTypeMismatchArgumentInternal
+ *
+ * @method Context __invoke(Node $node)
  */
 class ParseVisitor extends ScopeVisitor
 {

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -595,9 +595,9 @@ final class ConfigPluginSet extends PluginV3 implements
     }
 
     /**
-     * @param Closure(CodeBase, Context, FunctionInterface, list<Node|mixed>, ?Node):void $a
-     * @param ?Closure(CodeBase, Context, FunctionInterface, list<Node|mixed>, ?Node):void $b
-     * @return Closure(CodeBase, Context, FunctionInterface, list<Node|mixed>, ?Node):void $b
+     * @param Closure(CodeBase, Context, FunctionInterface, list<Node|int|string|float>, ?Node):void $a
+     * @param ?Closure(CodeBase, Context, FunctionInterface, list<Node|int|string|float>, ?Node):void $b
+     * @return Closure(CodeBase, Context, FunctionInterface, list<Node|int|string|float>, ?Node):void $b
      */
     public static function mergeAnalyzeFunctionCallClosures(Closure $a, Closure $b = null): Closure
     {

--- a/src/Phan/Plugin/Internal/RedundantConditionCallPlugin.php
+++ b/src/Phan/Plugin/Internal/RedundantConditionCallPlugin.php
@@ -136,6 +136,7 @@ final class RedundantConditionCallPlugin extends PluginV3 implements
 
         $make_simple_first_arg_checker = static function (string $extract_types_method, string $expected_type) use ($make_first_arg_checker): Closure {
             $method = new ReflectionMethod(UnionType::class, $extract_types_method);
+            /** @suppress PhanPluginUnknownObjectMethodCall ReflectionMethod cannot be analyzed */
             return $make_first_arg_checker(static function (UnionType $type) use ($method): int {
                 $new_real_type = $method->invoke($type)->nonNullableClone();
                 if ($new_real_type->isEmpty()) {

--- a/tests/Phan/AST/TolerantASTConverter/ConversionTest.php
+++ b/tests/Phan/AST/TolerantASTConverter/ConversionTest.php
@@ -31,6 +31,7 @@ final class ConversionTest extends BaseTest
 {
     /**
      * @return list<string>
+     * @suppress PhanPluginUnknownObjectMethodCall
      */
     protected function scanSourceDirForPHP(string $source_dir): array
     {

--- a/tests/files/expected/0591_template_types.php.expected
+++ b/tests/files/expected/0591_template_types.php.expected
@@ -3,6 +3,6 @@
 %s:66 PhanTypeSuspiciousEcho Suspicious argument \ArrayObject for an echo/print statement
 %s:69 PhanTypeMismatchArgument Argument 1 ($v) is \ArrayAccess|\ArrayObject|\Countable|\IteratorAggregate|\Serializable|\Traversable|iterable but \SingletonList::hasValue() takes \stdClass defined at %s:37
 %s:71 PhanTypeMismatchArgument Argument 1 ($p1) is \ArrayAccess|\ArrayObject|\Countable|\IteratorAggregate|\Serializable|\Traversable|iterable but \SingletonList::hasValueMagic() takes \stdClass defined at %s:7
-%s:73 PhanTypeMismatchArgumentInternal Argument 1 ($string) is array<int,\stdClass> but \strlen() takes string
-%s:74 PhanTypeMismatchArgumentInternal Argument 1 ($string) is array<int,\ArrayAccess>|array<int,\ArrayObject>|array<int,\Countable>|array<int,\IteratorAggregate>|array<int,\Serializable>|array<int,\Traversable>|array<int,iterable> but \strlen() takes string
+%s:73 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($string) is array<int,\stdClass> (real type array) but \strlen() takes string
+%s:74 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($string) is array<int,\ArrayAccess>|array<int,\ArrayObject>|array<int,\Countable>|array<int,\IteratorAggregate>|array<int,\Serializable>|array<int,\Traversable>|array<int,iterable> (real type array) but \strlen() takes string
 %s:77 PhanTypeMismatchArgument Argument 1 ($v) is \stdClass but \NodeSingletonList::hasValue() takes \ast\Node defined at %s:37

--- a/tests/files/expected/0861_foreach.php.expected
+++ b/tests/files/expected/0861_foreach.php.expected
@@ -1,0 +1,1 @@
+%s:15 PhanTypeMismatchReturn Returning type \ArrayObject but test() is declared to return string

--- a/tests/files/src/0861_foreach.php
+++ b/tests/files/src/0861_foreach.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @template T
+ * @method T current()
+ */
+class Set extends \SplObjectStorage
+{
+}
+/**
+ * @param Set<ArrayObject> $arrays
+ * @return string
+ */
+function test(Set $arrays) {
+    foreach ($arrays as $elem) {
+        return $elem;
+    }
+    return 'default';
+}


### PR DESCRIPTION
Add plugin `UnknownClassElementAccessPlugin` to warn about calling unknown methods.

Fix bugs that prevented Phan from resolving some methods in its own
codebase, support iterator_to_array.