### PR TITLE
Add `--analyze-twice` CLI flag

### DIFF
--- a/.phan/plugins/RedundantAssignmentPlugin.php
+++ b/.phan/plugins/RedundantAssignmentPlugin.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use ast\Node;
 use Phan\AST\UnionTypeVisitor;
+use Phan\Config;
 use Phan\Language\Context;
 use Phan\Language\Element\PassByReferenceVariable;
 use Phan\Parse\ParseVisitor;
@@ -103,6 +104,10 @@ class RedundantAssignmentPreAnalysisVisitor extends PluginAwarePreAnalysisVisito
         }
         if ($this->context->isInGlobalScope()) {
             if ($variable->getFileRef()->getFile() !== $this->context->getFile()) {
+                // Don't warn if this variable was set by a different file
+                return;
+            }
+            if (Config::getValue('__analyze_twice') && $variable->getFileRef()->getLineNumberStart() === $this->context->getLineNumberStart()) {
                 // Don't warn if this variable was set by a different file
                 return;
             }

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,8 +3,13 @@ Phan NEWS
 ??? ?? 2020, Phan 2.5.1 (dev)
 -----------------------
 
-New features(Analysis):
+New features(CLI, Configs):
 + Show empty union types as `(empty union type)` in issue messages instead of as an empty string.
++ Add a new CLI option `--analyze-twice` to run the analysis phase twice (#3743)
+
+  Phan infers additional type information for properties, return types, etc. while analyzing,
+  and this will help it detect more potential errors.
+  (on the first run, it would analyze files before some of those types were inferred)
 
 New features(Analysis):
 + Support parsing php 8.0 union types (and the static return type) in the polyfill. (#3419, #3634)

--- a/internal/CLI-HELP.md
+++ b/internal/CLI-HELP.md
@@ -234,6 +234,12 @@ Usage: ./phan [options] [files...]
   (For best results, the baseline should be generated with the same/similar
   environment and settings as those used to run Phan)
 
+ --analyze-twice
+  Runs the analyze phase twice. Because Phan gathers additional type information for properties, return types, etc. during analysis,
+  this may emit a more complete list of issues.
+
+  This cannot be used with --processes <int>.
+
  -v, --version
   Print Phan's version number
 

--- a/plugins/bash/phan
+++ b/plugins/bash/phan
@@ -95,6 +95,7 @@ _phan() {
 --save-baseline
 -B
 --load-baseline
+--analyze-twice
 -h
 --help
 -v

--- a/plugins/zsh/_phan
+++ b/plugins/zsh/_phan
@@ -35,8 +35,9 @@ _arguments \
 	'(1)*--init-analyze-file=[a relative path to a file to analyze]:file:_files' \
 	'(--save-baseline)--save-baseline=[a path to save a baseline with pre-existing issues to]:file:_files' \
 	'(--load-baseline -B)'{--load-baseline=,-B+}'[a path to a baseline with pre-existing issues to read from]:file:_files' \
-	'(--init-no-composer)--init-no-composer[don'\''t require a composer installation when initializing]:file:_files' \
-	'(--init-overwrite)--init-overwrite[allow phan --init to override the existing .phan/config.php file]:file:_files' \
+	'(--analyze-twice)'{--analyze-twice}'[run the analysis phase twice]' \
+	'(--init-no-composer)--init-no-composer[don'\''t require a composer installation when initializing]' \
+	'(--init-overwrite)--init-overwrite[allow phan --init to override the existing .phan/config.php file]' \
 	'(--color --no-color -C)'{--color,-C}'[add colors to phan'\''s output]' \
 	'(--color --no-color -C)--no-color[disable colors in phan'\''s output]' \
 	'(--color-scheme)--color-scheme[set the color scheme]:color_scheme:(default code eclipse-dark light vim)' \

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -142,6 +142,7 @@ class CLI
         'language-server-tcp-server:',
         'language-server-verbose',
         'load-baseline:',
+        'analyze-twice',
         'long-progress-bar',
         'markdown-issue-messages',
         'memory-limit:',
@@ -827,6 +828,9 @@ class CLI
                         throw new UsageException("--load-baseline passed file '$value' which could not be read", 1);
                     }
                     Config::setValue('baseline_path', $value);
+                    break;
+                case 'analyze-twice':
+                    Config::setValue('__analyze_twice', true);
                     break;
                 default:
                     // All of phan's long options are currently at least 2 characters long.
@@ -1521,6 +1525,12 @@ $init_help
 
   (For best results, the baseline should be generated with the same/similar
   environment and settings as those used to run Phan)
+
+ --analyze-twice
+  Runs the analyze phase twice. Because phan gathers additional type information for properties, return types, etc. during analysis,
+  this may emit a more complete list of issues.
+
+  This cannot be used with --processes <int>.
 
  -v, --version
   Print Phan's version number

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -1531,7 +1531,7 @@ $init_help
   environment and settings as those used to run Phan)
 
  --analyze-twice
-  Runs the analyze phase twice. Because phan gathers additional type information for properties, return types, etc. during analysis,
+  Runs the analyze phase twice. Because Phan gathers additional type information for properties, return types, etc. during analysis,
   this may emit a more complete list of issues.
 
   This cannot be used with --processes <int>.

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -1138,6 +1138,10 @@ class CLI
             \fprintf(STDERR, "Notice: Running with processes=1 instead of processes=%s - the daemon/language server assumes it will run as a single process" . PHP_EOL, (string)\json_encode($processes));
             Config::setValue('processes', 1);
         }
+        if (Config::getValue('__analyze_twice')) {
+            \fwrite(STDERR, "Notice: Running analysis phase once instead of --analyze-twice - the daemon/language server assumes it will run as a single process" . PHP_EOL);
+            Config::setValue('__analyze_twice', false);
+        }
     }
 
     /**

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -1261,6 +1261,7 @@ class Config
      *
      * @suppress PhanUnreferencedPublicMethod
      * @see FileRef::getProjectRelativePathForPath() for converting to relative paths
+     * NOTE: This deliberately does not support phar:// URLs, because those evaluate php code when the phar is first loaded.
      */
     public static function projectPath(string $relative_path): string
     {

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -913,6 +913,9 @@ class Config
         // E.g. this is used by `InvokePHPNativeSyntaxCheckPlugin`
         'plugin_config' => [
         ],
+
+        // This should only be set with `--analyze-twice`.
+        '__analyze_twice' => false,
     ];
 
     public const COMPLETION_VSCODE = 'vscode';

--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -780,6 +780,7 @@ class Context extends FileRef
     /**
      * @param int $node_id \spl_object_id($node)
      * @param bool $should_catch_issue_exception the value passed to UnionTypeVisitor
+     * @suppress PhanPartialTypeMismatchReturn seen with --analyze-twice because $this->cache is reused
      */
     public function getUnionTypeOfNodeIfCached(int $node_id, bool $should_catch_issue_exception): ?UnionType
     {

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -808,6 +808,10 @@ final class ConfigPluginSet extends PluginV3 implements
         if (\preg_match('@^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$@', $plugin_file_name) > 0) {
             $plugin_file_name = self::getBuiltinPluginDirectory() . '/' . $plugin_file_name . '.php';
         }
+        if (\preg_match('@^phar://@', $plugin_file_name)) {
+            // This is a plugin, probably from phan.phar
+            return $plugin_file_name;
+        }
         return Config::projectPath($plugin_file_name);
     }
 


### PR DESCRIPTION
Fixes #3743

Phan infers property types and return types while it analyzes the
function and method definitions.

Methods that were analyzed earlier may be missing the corresponding real
type information.

- Analyzing all of the files twice works around that issue.