### PR TITLE
Add MoreSpecificElementTypePlugin to suggest more specific function r…

### DIFF
--- a/.phan/plugins/DuplicateExpressionPlugin.php
+++ b/.phan/plugins/DuplicateExpressionPlugin.php
@@ -216,7 +216,9 @@ class RedundantNodePostAnalysisVisitor extends PluginAwarePostAnalysisVisitor
     }
 
     /**
-     * @return int|string|float|bool|null|Node the resolved value of $node, or $node if it could not be resolved
+     * @return bool|null|Node the resolved value of $node, or $node if it could not be resolved
+     * This could be more permissive about what constants are allowed (e.g. user-defined constants, real constants like PI, etc.),
+     * but that may cause more false positives.
      */
     private static function resolveLiteralValue(Node $node)
     {

--- a/.phan/plugins/MoreSpecificElementTypePlugin.php
+++ b/.phan/plugins/MoreSpecificElementTypePlugin.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+use ast\Node;
+use Phan\AST\UnionTypeVisitor;
+use Phan\CodeBase;
+use Phan\Language\Element\FunctionInterface;
+use Phan\Language\Element\Method;
+use Phan\Language\FQSEN;
+use Phan\Language\UnionType;
+use Phan\Library\Set;
+use Phan\Library\Map;
+use Phan\PluginV3;
+use Phan\PluginV3\FinalizeProcessCapability;
+use Phan\PluginV3\PluginAwarePostAnalysisVisitor;
+use Phan\PluginV3\PostAnalyzeNodeCapability;
+
+/**
+ * This plugin checks for return types that can be made more specific.
+ *
+ * - E.g. `/** (at)return object (*)/ function () { return new ArrayObject(); }`
+ *   could be documented as returning an ArrayObject instead.
+ *
+ * This file demonstrates plugins for Phan. Plugins hook into various events.
+ * MoreSpecificElementTypePlugin hooks into two events:
+ *
+ * - getPostAnalyzeNodeVisitorClassName
+ *   This method returns a visitor that is called on every AST node from every
+ *   file being analyzed in post-order
+ * - finalizeProcess
+ *   This is called after the other forms of analysis are finished running.
+ *
+ * A plugin file must
+ *
+ * - Contain a class that inherits from \Phan\PluginV3
+ *
+ * - End by returning an instance of that class.
+ *
+ * It is assumed without being checked that plugins aren't
+ * mangling state within the passed code base or context.
+ *
+ * Note: When adding new plugins,
+ * add them to the corresponding section of README.md
+ *
+ * TODO: Account for methods in traits being possibly overrides
+ */
+class MoreSpecificElementTypePlugin extends PluginV3 implements
+    PostAnalyzeNodeCapability,
+    FinalizeProcessCapability
+{
+    /** @var Map<FQSEN,ElementTypeInfo> maps function/method/closure FQSEN to function info and the set of union types they return */
+    public static $method_return_types;
+
+    /** @var Set<FQSEN> the set of function/method/closure FQSENs that don't need to be more specific. */
+    public static $method_blacklist;
+
+    /**
+     * @return class-string - name of PluginAwarePostAnalysisVisitor subclass
+     */
+    public static function getPostAnalyzeNodeVisitorClassName(): string
+    {
+        return MoreSpecificElementTypeVisitor::class;
+    }
+
+    /**
+     * Record that $function contains a return statement which returns an expression of type $return_type.
+     *
+     * This may be called multiple times for the same return statement (Phan recursively analyzes functions with underspecified param types by default)
+     */
+    public static function recordType(FunctionInterface $function, UnionType $return_type): void
+    {
+        $fqsen = $function->getFQSEN();
+        if (self::$method_blacklist->offsetExists($fqsen)) {
+            return;
+        }
+        if ($return_type->isEmpty()) {
+            self::$method_blacklist->attach($fqsen);
+            self::$method_return_types->offsetUnset($fqsen);
+            return;
+        }
+        if (self::$method_return_types->offsetExists($fqsen)) {
+            self::$method_return_types->offsetGet($fqsen)->types->attach($return_type);
+        } else {
+            self::$method_return_types->offsetSet($fqsen, new ElementTypeInfo($function, [$return_type]));
+        }
+    }
+
+    private static function shouldWarnAboutMoreSpecificType(CodeBase $code_base, UnionType $actual_type, UnionType $declared_return_type): bool
+    {
+        if ($declared_return_type->isEmpty()) {
+            return true;
+        }
+        if ($declared_return_type->containsNullable() && !$actual_type->containsNullable()) {
+            // Warn about `Subclass1|Subclass2` being the real return type of `?BaseClass`
+            // because the actual returned type is non-null
+            return true;
+        }
+        if ($declared_return_type->typeCount() === 1) {
+            if ($declared_return_type->getTypeSet()[0]->isObjectWithKnownFQSEN()) {
+                if ($actual_type->typeCount() >= 2) {
+                    // Don't warn about Subclass1|Subclass2 being more specific than BaseClass
+                    return false;
+                }
+            }
+        }
+        if ($declared_return_type->isStrictSubtypeOf($code_base, $actual_type)) {
+            return false;
+        }
+        if ($declared_return_type->hasTopLevelArrayShapeTypeInstances()) {
+            return false;
+        }
+        $real_actual_type = $actual_type->asRealUnionType();
+        if (!$real_actual_type->isEmpty() && $declared_return_type->isStrictSubtypeOf($code_base, $actual_type)) {
+            // TODO: Provide a way to disable this heuristic.
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * After all return statements are gathered, suggest a more specific type for the various functions.
+     */
+    public function finalizeProcess(CodeBase $code_base): void
+    {
+        foreach (self::$method_return_types as $type_info) {
+            $function = $type_info->function;
+            $function_context = $function->getContext();
+            // TODO: Do a better job for Traversable<MyClass> and iterable<MyClass>
+            $actual_type = UnionType::merge($type_info->types->toArray())->withStaticResolvedInContext($function_context)->eraseTemplatesRecursive()->asNormalizedTypes();
+            $declared_return_type = $function->getUnionType()->withStaticResolvedInContext($function_context)->eraseTemplatesRecursive()->asNormalizedTypes();
+            if (!self::shouldWarnAboutMoreSpecificType($code_base, $actual_type, $declared_return_type)) {
+                continue;
+            }
+
+            $this->emitIssue(
+                $code_base,
+                $function->getContext(),
+                'PhanPluginMoreSpecificActualReturnType',
+                'Phan inferred that {FUNCTION} documented to have return type {TYPE} returns the more specific type {TYPE}',
+                [
+                    $function->getRepresentationForIssue(),
+                    $declared_return_type,
+                    $actual_type->getDebugRepresentation()
+                ]
+            );
+        }
+    }
+}
+
+/**
+ * Represents the actual return types seen during analysis
+ * (including recursive analysis)
+ */
+class ElementTypeInfo {
+    /** @var FunctionInterface the function with the return values*/
+    public $function;
+    /** @var Set<UnionType> the set of observed return types */
+    public $types;
+    /**
+     * @param list<UnionType> $return_types
+     */
+    public function __construct(FunctionInterface $function, array $return_types) {
+        $this->function = $function;
+        $this->types = new Set($return_types);
+    }
+}
+MoreSpecificElementTypePlugin::$method_blacklist = new Set();
+MoreSpecificElementTypePlugin::$method_return_types = new Map();
+
+/**
+ * This visitor analyzes node kinds that can be the root of expressions
+ * containing duplicate expressions, and is called on nodes in post-order.
+ */
+class MoreSpecificElementTypeVisitor extends PluginAwarePostAnalysisVisitor
+{
+    /**
+     * @param Node $node a node of kind ast\AST_RETURN, representing a return statement.
+     */
+    public function visitReturn(Node $node): void
+    {
+        if (!$this->context->isInFunctionLikeScope()) {
+            return;
+        }
+        try {
+            $function = $this->context->getFunctionLikeInScope($this->code_base);
+        } catch (Exception $_) {
+            return;
+        }
+        if ($function->hasYield()) {
+            // TODO: Support analyzing yield key/value types of generators?
+            return;
+        }
+        if ($function instanceof Method) {
+            // Skip functions that are overrides or are overridden.
+            // They may be documenting a less specific return type to deal with the inheritance hierarchy.
+            if ($function->isOverride() || $function->isOverriddenByAnother()) {
+                return;
+            }
+        }
+        try {
+            // Fetch the list of valid classes, and warn about any undefined classes.
+            // (We have more specific issue types such as PhanNonClassMethodCall below, don't emit PhanTypeExpected*)
+            $union_type = UnionTypeVisitor::unionTypeFromNode($this->code_base, $this->context, $node->children['expr']);
+        } catch (Exception $_) {
+            // Phan should already throw for this
+            return;
+        }
+        MoreSpecificElementTypePlugin::recordType($function, $union_type->withFlattenedArrayShapeOrLiteralTypeInstances());
+    }
+}
+
+// Every plugin needs to return an instance of itself at the
+// end of the file in which it's defined.
+return new MoreSpecificElementTypePlugin();

--- a/.phan/plugins/MoreSpecificElementTypePlugin.php
+++ b/.phan/plugins/MoreSpecificElementTypePlugin.php
@@ -110,8 +110,8 @@ class MoreSpecificElementTypePlugin extends PluginV3 implements
         if ($declared_return_type->hasTopLevelArrayShapeTypeInstances()) {
             return false;
         }
-        $real_actual_type = $actual_type->asRealUnionType();
-        if (!$real_actual_type->isEmpty() && $declared_return_type->isStrictSubtypeOf($code_base, $actual_type)) {
+        $real_actual_type = $actual_type->getRealUnionType();
+        if (!$real_actual_type->isEmpty() && $declared_return_type->isStrictSubtypeOf($code_base, $real_actual_type)) {
             // TODO: Provide a way to disable this heuristic.
             return false;
         }

--- a/.phan/plugins/PHPDocRedundantPlugin/Fixers.php
+++ b/.phan/plugins/PHPDocRedundantPlugin/Fixers.php
@@ -65,7 +65,7 @@ class Fixers
         return self::computeEditSetToDeleteComment($file_contents, $comment_token);
     }
 
-    private static function computeEditSetToDeleteComment(string $file_contents, Token $comment_token): ?FileEditSet
+    private static function computeEditSetToDeleteComment(string $file_contents, Token $comment_token): FileEditSet
     {
         // get the byte where the `)` of the argument list ends
         $last_byte_index = $comment_token->getEndPosition();

--- a/.phan/plugins/README.md
+++ b/.phan/plugins/README.md
@@ -232,6 +232,28 @@ To reduce false positives, this will suppress warnings if at least one recursive
 
 - **PhanPluginUnknownObjectMethodCall**: `Phan could not infer any class/interface types for the object of the method call {CODE} - inferred a type of {TYPE}`
 
+This works best when there is only one analysis process (the default, i.e. `--processes 1`).
+`--analyze-twice` will reduce the number of issues this emits.
+
+### MoreSpecificElementTypePlugin.php
+
+This plugin checks for return types that can be made more specific.
+**This has a large number of false positives - it can be used manually to point out comments that should be made more specific, but is not recommended as part of a build.**
+This plugin checks for accesses to unknown class elements that can't be type checked (which may hide potential runtime errors such as having too few parameters).
+To reduce false positives, this will suppress warnings if at least one recursive analysis could infer class/interface types for the object.
+
+- **PhanPluginUnknownObjectMethodCall**: `Phan could not infer any class/interface types for the object of the method call {CODE} - inferred a type of {TYPE}`
+
+It's strongly recommended to use this with a single analysis process (the default, i.e. `--processes 1`).
+
+This uses the following heuristics to reduce the number of false positives.
+
+- Avoids warning about methods that are overrides or are overridden.
+- Avoids checking generators.
+- Flattens array shapes and literals before comparing types
+- Avoids warning when the actual return type contains multiple types and the declared return type is a single FQSEN
+  (e.g. don't warn about `Subclass1|Subclass2` being more specific than `BaseClass`)
+
 ### 3. Plugins Specific to Code Styles
 
 These plugins may be useful to enforce certain code styles,

--- a/.phan/plugins/UnknownClassElementAccessPlugin.php
+++ b/.phan/plugins/UnknownClassElementAccessPlugin.php
@@ -21,11 +21,13 @@ use Phan\PluginV3\PostAnalyzeNodeCapability;
  * - E.g. `$unknown->someMethod(null)`
  *
  * This file demonstrates plugins for Phan. Plugins hook into various events.
- * UnknownClassElementAccessPlugin hooks into one event:
+ * UnknownClassElementAccessPlugin hooks into two events:
  *
  * - getPostAnalyzeNodeVisitorClassName
  *   This method returns a visitor that is called on every AST node from every
  *   file being analyzed in post-order
+ * - finalizeProcess
+ *   This is called after the other forms of analysis are finished running.
  *
  * A plugin file must
  *

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,10 @@ New features(Analysis):
 
 Plugins:
 + Add `UnknownClassElementAccessPlugin` to warn about cases where Phan can't infer which class an instance method is being called on.
+  (To work correctly, this plugin requires that Phan use a single analysis process)
++ Add `MoreSpecificElementTypePlugin` to warn about functions/methods where the phpdoc/actual return type is vaguer than the types that are actually returned by a method.
+  This is a work in progress, and has a lot of false positives.
+  (To work correctly, this plugin requires that Phan use a single analysis process)
 
 Bug fixes:
 + Fix bug causing phan to fail to properly recursively analyze parameters of inherited methods (#3740)

--- a/internal/CLI-HELP.md
+++ b/internal/CLI-HELP.md
@@ -259,6 +259,9 @@ Extended help:
   This is useful to verify that options such as exclude_file_regex are
   properly set up, or to run other checks on the files Phan would parse.
 
+ --dump-analyzed-file-list
+  Emit a newline-separated list of files Phan would analyze to stdout.
+
  --dump-signatures-file <filename>
   Emit JSON serialized signatures to the given file.
   This uses a method signature format similar to FunctionSignatureMap.php.

--- a/src/Phan/AST/ASTSimplifier.php
+++ b/src/Phan/AST/ASTSimplifier.php
@@ -734,8 +734,7 @@ class ASTSimplifier
     {
         $list = $catches->children;
         $new_list = array_map(
-            /** @return mixed */
-            static function (Node $node) {
+            static function (Node $node): Node {
                 return self::applyToStmts($node);
             },
             // @phan-suppress-next-line PhanPartialTypeMismatchArgument should be impossible to be float

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -987,11 +987,10 @@ class TolerantASTConverter
                 return $result;
             },
             /**
-             * @return ?ast\Node
              * @throws InvalidNodeException if the variable would be unanalyzable
              * TODO: Consider ${''} as a placeholder instead?
              */
-            'Microsoft\PhpParser\Node\Expression\Variable' => static function (PhpParser\Node\Expression\Variable $n, int $start_line): ?\ast\Node {
+            'Microsoft\PhpParser\Node\Expression\Variable' => static function (PhpParser\Node\Expression\Variable $n, int $start_line): \ast\Node {
                 $name_node = $n->name;
                 // Note: there are 2 different ways to handle an Error. 1. Add a placeholder. 2. remove all of the statements in that tree.
                 if ($name_node instanceof PhpParser\Node) {
@@ -1143,7 +1142,7 @@ class TolerantASTConverter
                 }
                 return $inner_node;
             },
-            /** @return mixed - Can return a node or a scalar, depending on the settings */
+            /** @return list<ast\Node|float|int|string> - Can return a node or a scalar, depending on the settings */
             'Microsoft\PhpParser\Node\Statement\CompoundStatementNode' => static function (PhpParser\Node\Statement\CompoundStatementNode $n, int $_) {
                 $children = [];
                 foreach ($n->statements as $parser_node) {
@@ -2824,12 +2823,11 @@ class TolerantASTConverter
     }
 
     /**
-     * @return ?ast\Node
      * @throws InvalidNodeException if the member name could not be converted
      *
      * (and various other exceptions)
      */
-    private static function phpParserMemberAccessExpressionToAstProp(PhpParser\Node\Expression\MemberAccessExpression $n, int $start_line): ?\ast\Node
+    private static function phpParserMemberAccessExpressionToAstProp(PhpParser\Node\Expression\MemberAccessExpression $n, int $start_line): \ast\Node
     {
         // TODO: Check for incomplete tokens?
         $member_name = $n->memberName;

--- a/src/Phan/Language/Element/FunctionInterface.php
+++ b/src/Phan/Language/Element/FunctionInterface.php
@@ -149,6 +149,12 @@ interface FunctionInterface extends AddressableElementInterface
     public function setHasYield(bool $has_yield): void;
 
     /**
+     * @return bool
+     * True if this method yields any value(i.e. it is a \Generator)
+     */
+    public function hasYield(): bool;
+
+    /**
      * @return list<Parameter>
      * A list of parameters on the method
      */

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -188,6 +188,12 @@ final class EmptyUnionType extends UnionType
         return $this;
     }
 
+    /** @override */
+    public function eraseTemplatesRecursive(): UnionType
+    {
+        return $this;
+    }
+
     /**
      * @return bool
      * True if this union type has any types that have generic

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -3942,6 +3942,19 @@ class Type
     }
 
     /**
+     * Convert `\MyClass<T>` and `\MyClass<\OtherClass>` to just `\MyClass`.
+     *
+     * TODO: Override in subclasses such as generic arrays, generic iterables, and array shapes.
+     */
+    public function eraseTemplatesRecursive(): Type
+    {
+        if (!$this->template_parameter_type_list) {
+            return $this;
+        }
+        return static::fromType($this, []);
+    }
+
+    /**
      * @param array<string,UnionType> $template_parameter_type_map
      * A map from template type identifiers to concrete types
      *

--- a/src/Phan/Language/Type/FunctionLikeDeclarationType.php
+++ b/src/Phan/Language/Type/FunctionLikeDeclarationType.php
@@ -221,7 +221,7 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
             return false;
         }
         // TODO: Allow nullable/null to cast to void?
-        if (!$this->return_type->canCastToUnionTypeHandlingTemplates($type->return_type, $code_base)) {
+        if (!$this->return_type->asExpandedTypes($code_base)->canCastToUnionTypeHandlingTemplates($type->return_type, $code_base)) {
             return false;
         }
         foreach ($this->params as $i => $param) {
@@ -666,6 +666,11 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
     }
 
     public function setHasYield(bool $_): void
+    {
+        throw new \AssertionError('unexpected call to ' . __METHOD__);
+    }
+
+    public function hasYield(): bool
     {
         throw new \AssertionError('unexpected call to ' . __METHOD__);
     }

--- a/src/Phan/Language/Type/ScalarType.php
+++ b/src/Phan/Language/Type/ScalarType.php
@@ -165,6 +165,12 @@ abstract class ScalarType extends NativeType
     {
         return false;
     }
+
+    /** @override */
+    public function eraseTemplatesRecursive(): Type
+    {
+        return $this;
+    }
 }
 \class_exists(IntType::class);
 \class_exists(StringType::class);

--- a/tests/infer_missing_types_test/.phan/config.php
+++ b/tests/infer_missing_types_test/.phan/config.php
@@ -1,0 +1,131 @@
+<?php
+
+use \Phan\Issue;
+
+/**
+ * This configuration will be read and overlaid on top of the
+ * default configuration. Command line arguments will be applied
+ * after this file is read.
+ *
+ * @see src/Phan/Config.php
+ * See Config for all configurable options.
+ *
+ * This is a config file which tests Phan's ability to infer and report missing types.
+ */
+return [
+    'target_php_version' => '7.3',
+
+    // If enabled, Phan will act as though it's certain of real return types of a subset of internal functions,
+    // even if those return types aren't available in reflection (real types were taken from php 8.0-dev).
+    //
+    // Note that in php 7 and earlier, php would return null or false if the argument types or counts were incorrect.
+    // As a result, enabling this setting may result in false positives for `--redundant-condition-detection`.
+    'assume_real_types_for_internal_functions' => true,
+
+    // Set to true in order to attempt to detect redundant and impossible conditions.
+    //
+    // This has some false positives involving loops,
+    // variables set in branches of loops, and global variables.
+    'redundant_condition_detection' => true,
+
+    // If true, missing properties will be created when
+    // they are first seen. If false, we'll report an
+    // error message.
+    'allow_missing_properties' => true,
+
+    // Allow null to be cast as any type and for any
+    // type to be cast to null.
+    'null_casts_as_any_type' => false,
+
+    // If enabled, scalars (int, float, bool, string, null)
+    // are treated as if they can cast to each other.
+    'scalar_implicit_cast' => false,
+
+    // If enabled, Phan will warn if **any** type in the method's object
+    // is definitely not an object.
+    // Setting this to true will introduce numerous false positives
+    // (and reveal some bugs).
+    'strict_method_checking' => true,
+
+    // If enabled, Phan will warn if **any** type in the argument's type
+    // cannot be cast to a type in the parameter's expected type.
+    // Setting this to true will introduce a large number of false positives (and some bugs).
+    // (For self-analysis, Phan has a large number of suppressions and file-level suppressions, due to \ast\Node being difficult to type check)
+    'strict_param_checking' => true,
+
+    // If enabled, Phan will warn if **any** type in a property assignment's type
+    // cannot be cast to a type in the property's expected type.
+    // Setting this to true will introduce a large number of false positives (and some bugs).
+    // (For self-analysis, Phan has a large number of suppressions and file-level suppressions, due to \ast\Node being difficult to type check)
+    'strict_property_checking' => true,
+
+    // If enabled, Phan will warn if **any** type in the return statement's type
+    // cannot be cast to a type in the method's declared return type.
+    // Setting this to true will introduce a large number of false positives (and some bugs).
+    // (For self-analysis, Phan has a large number of suppressions and file-level suppressions, due to \ast\Node being difficult to type check)
+    'strict_return_checking' => true,
+
+    // Test dead code detection
+    'dead_code_detection' => true,
+
+    'unused_variable_detection' => true,
+
+    'redundant_condition_detection' => true,
+
+    'guess_unknown_parameter_type_using_default' => true,
+
+    // If enabled, warn about throw statement where the exception types
+    // are not documented in the PHPDoc of functions, methods, and closures.
+    'warn_about_undocumented_throw_statements' => true,
+
+    // If enabled (and warn_about_undocumented_throw_statements is enabled),
+    // warn about function/closure/method calls that have (at)throws
+    // without the invoking method documenting that exception.
+    'warn_about_undocumented_exceptions_thrown_by_invoked_functions' => true,
+
+    'minimum_severity' => Issue::SEVERITY_LOW,
+
+    'directory_list' => ['src'],
+
+    'analyzed_file_extensions' => ['php'],
+
+    // Set this to true to enable the plugins that Phan uses to infer more accurate literal return types of `implode`, `implode`, and many other functions.
+    //
+    // Phan is slightly faster when these are disabled.
+    'enable_extended_internal_return_type_plugins' => true,
+
+    // This is a unit test of Phan itself, so don't cache it because the polyfill implementation may change before the next release.
+    'cache_polyfill_asts' => false,
+
+    // A list of plugin files to execute
+    // (Execute all of them.)
+    // FooName is shorthand for /path/to/phan/.phan/plugins/FooName.php.
+    'plugins' => [
+        'AlwaysReturnPlugin',
+        'DollarDollarPlugin',
+        'DuplicateArrayKeyPlugin',
+        'InvokePHPNativeSyntaxCheckPlugin',
+        'NumericalComparisonPlugin',
+        'PregRegexCheckerPlugin',
+        'PrintfCheckerPlugin',
+        'UnreachableCodePlugin',
+        'UnusedSuppressionPlugin',
+        'UseReturnValuePlugin',
+        'DuplicateExpressionPlugin',
+        'WhitespacePlugin',
+        'UnknownElementTypePlugin',
+        'AvoidableGetterPlugin',
+        //
+        'UnknownClassElementAccessPlugin',
+    ],
+
+    // Set this to false to emit `PhanUndeclaredFunction` issues for internal functions that Phan has signatures for,
+    // but aren't available in the codebase, or from Reflection.
+    // (may lead to false positives if an extension isn't loaded)
+    //
+    // If this is true(default), then Phan will not warn.
+    //
+    // Even when this is false, Phan will still infer return values and check parameters of internal functions
+    // if Phan has the signatures.
+    'ignore_undeclared_functions_with_known_signatures' => false,
+];

--- a/tests/infer_missing_types_test/expected/001_vaguer_comment_return.php.expected
+++ b/tests/infer_missing_types_test/expected/001_vaguer_comment_return.php.expected
@@ -1,0 +1,4 @@
+src/001_vaguer_comment_return.php:3 PhanPluginMoreSpecificActualReturnType Phan inferred that \test1() documented to have return type mixed returns the more specific type \ArrayObject(real=\ArrayObject)
+src/001_vaguer_comment_return.php:3 PhanUnreferencedFunction Possibly zero references to function \test1()
+src/001_vaguer_comment_return.php:6 PhanPluginMoreSpecificActualReturnType Phan inferred that \test2() documented to have return type object returns the more specific type \ArrayObject(real=\ArrayObject)
+src/001_vaguer_comment_return.php:6 PhanUnreferencedFunction Possibly zero references to function \test2()

--- a/tests/infer_missing_types_test/expected/002_analyze_twice.php.expected
+++ b/tests/infer_missing_types_test/expected/002_analyze_twice.php.expected
@@ -1,0 +1,12 @@
+src/002_analyze_twice.php:3 PhanUnreferencedClass Possibly zero references to class \A2
+src/002_analyze_twice.php:4 PhanPluginUnknownPropertyType Property \A2->x has an initial type that cannot be inferred
+src/002_analyze_twice.php:6 PhanPluginUnknownMethodParamType Method \A2::setX has no declared or inferred parameter type for $obj
+src/002_analyze_twice.php:6 PhanPluginUnknownMethodReturnType Method \A2::setX() has no declared or inferred return type
+src/002_analyze_twice.php:6 PhanUnreferencedPublicMethod Possibly zero references to public method \A2::setX()
+src/002_analyze_twice.php:10 PhanPluginUnknownMethodReturnType Method \A2::test() has no declared or inferred return type
+src/002_analyze_twice.php:10 PhanUnreferencedPublicMethod Possibly zero references to public method \A2::test()
+src/002_analyze_twice.php:15 PhanPluginUnknownObjectMethodCall Phan could not infer any class/interface types for the object of the method call $this->x->missingMethod() - inferred a type of (empty union type)
+src/002_analyze_twice.php:18 PhanPluginUnknownMethodReturnType Method \A2::register() has no declared or inferred return type
+src/002_analyze_twice.php:18 PhanUndeclaredTypeParameter Parameter $a has undeclared type \A (Did you mean class \A2 or array)
+src/002_analyze_twice.php:18 PhanUnreferencedPublicMethod Possibly zero references to public method \A2::register()
+src/002_analyze_twice.php:19 PhanUndeclaredClassMethod Call to method setX from undeclared class \A (Did you mean class \A2)

--- a/tests/infer_missing_types_test/src/001_vaguer_comment_return.php
+++ b/tests/infer_missing_types_test/src/001_vaguer_comment_return.php
@@ -1,0 +1,12 @@
+<?php
+/** @return mixed */
+function test1() { return new ArrayObject(); }
+
+/** @return object */
+function test2() {
+  static $instance;
+  if ($instance === null) {
+    $instance = new ArrayObject();
+  }
+  return $instance;
+}

--- a/tests/infer_missing_types_test/src/002_analyze_twice.php
+++ b/tests/infer_missing_types_test/src/002_analyze_twice.php
@@ -1,0 +1,21 @@
+<?php
+
+class A2 {
+    public $x;
+
+    public function setX($obj) {
+        $this->x = $obj;
+    }
+
+    public function test() {
+        // Because Phan analyzes this file twice in --analyze-twice,
+        // it is able to infer that $this->x is of type ArrayType,
+        // despite the indirection, A2->x being set in the function analyzed after test() is analyzed,
+        // and the lack of a documented property type.
+        $this->x->missingMethod();
+    }
+
+    public function register(A $a) {
+        $a->setX(new ArrayObject());
+    }
+}

--- a/tests/infer_missing_types_test/test.sh
+++ b/tests/infer_missing_types_test/test.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+EXPECTED_PATH=expected/all_output.expected
+ACTUAL_PATH=all_output.actual
+if [ ! -d expected  ]; then
+	echo "Error: must run this script from tests/infer_real_types_test folder" 1>&2
+	exit 1
+fi
+echo "Generating test cases"
+for path in $(echo expected/*.php.expected | LC_ALL=C sort); do cat $path; done > $EXPECTED_PATH
+if [[ $? != 0 ]]; then
+	echo "Failed to concatenate test cases" 1>&2
+	exit 1
+fi
+echo "Running phan in '$PWD' ..."
+rm $ACTUAL_PATH -f || exit 1
+
+# We use the polyfill parser because it behaves consistently in all php versions.
+../../phan --force-polyfill-parser --memory-limit 1G --analyze-twice --plugin MoreSpecificElementTypePlugin | tee $ACTUAL_PATH
+
+# diff returns a non-zero exit code if files differ or are missing
+# This outputs the difference between actual and expected output.
+echo
+echo "Comparing the output:"
+
+# Normalize PHP_VERSION_ID
+# and remove php 8.0 warnings
+sed -i \
+    -e 's/\(to cast array_key_exists.* of type \)bool /\1?bool /' \
+    $ACTUAL_PATH
+
+if type colordiff >/dev/null; then
+    DIFF=colordiff
+else
+    DIFF=diff
+fi
+
+$DIFF $EXPECTED_PATH $ACTUAL_PATH
+EXIT_CODE=$?
+if [ "$EXIT_CODE" == 0 ]; then
+	echo "Files $EXPECTED_PATH and output $ACTUAL_PATH are identical"
+    rm $ACTUAL_PATH
+fi
+exit $EXIT_CODE

--- a/tests/run_all_tests
+++ b/tests/run_all_tests
@@ -34,6 +34,7 @@ TEST_SUITES+=" __FakeFallbackTest"
 TEST_SUITES+=" __FakeToolTest"
 TEST_SUITES+=" __FakeConfigOverrideTest"
 TEST_SUITES+=" __FakeFixerTest"
+TEST_SUITES+=" __FakeInferMissingTypesTest"
 TEST_SUITES+=" __FakeEmptyMethodsPluginTest"
 
 FAILURES=""

--- a/tests/run_test
+++ b/tests/run_test
@@ -93,6 +93,11 @@ case "$TEST_SUITE" in
 		./test.sh
 		exit $?
 		;;
+	__FakeInferMissingTypesTest)
+		cd tests/infer_missing_types_test
+		./test.sh
+		exit $?
+		;;
 	__*)
 		echo "Unknown test '$TEST_SUITE' (Tests beginning with __ are not phpunit tests)" 1>&2
 		echo 1>&2


### PR DESCRIPTION
…eturn types

This is a work in progress, and has many unimplemented features,
but does point out many return types that could be more specific than
the current phpdoc.

Fix some of the less specific return types detected in Phan's own
codebase.