### PR TITLE
Improve type inferences for inherited properties

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,13 @@ New features(Analysis):
 + Emit `PhanCompatibleUnionType` and `PhanCompatibleStaticType` when the target php version is less than 8.0 and union types or static return types are seen. (#3419, #3634)
 + Be more consistent about warning about issues in values of class constants, global constants, and property defaults.
 + Infer key and element types from `iterator_to_array()`
++ Infer that modification of or reading from static properties all use the same property declaration. (#3760)
+  Previously, Phan would track the static property's type separately for each subclass.
+  (static properties from traits become different instances, in each class using the trait)
++ Make assignments to properties of the declaring class affect type inference for those properties when accessed on subclasses (#3760)
+
+  Note that Phan is only guaranteed to analyze files once, so if type information is missing,
+  the only way to ensure it's available is to add it to phpdoc (`UnknownElementTypePlugin` can help) or use `--analyze-twice`.
 
 Plugins:
 + Add `UnknownClassElementAccessPlugin` to warn about cases where Phan can't infer which class an instance method is being called on.

--- a/composer.lock
+++ b/composer.lock
@@ -231,9 +231,9 @@
             "authors": [
                 {
                     "name": "Christian Weiske",
-                    "role": "Developer",
                     "email": "cweiske@cweiske.de",
-                    "homepage": "http://github.com/cweiske/jsonmapper/"
+                    "homepage": "http://github.com/cweiske/jsonmapper/",
+                    "role": "Developer"
                 }
             ],
             "description": "Map nested JSON structures onto PHP classes",
@@ -548,16 +548,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v4.4.4",
+            "version": "v4.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "f512001679f37e6a042b51897ed24a2f05eba656"
+                "reference": "4fa15ae7be74e53f6ec8c83ed403b97e23b665e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/f512001679f37e6a042b51897ed24a2f05eba656",
-                "reference": "f512001679f37e6a042b51897ed24a2f05eba656",
+                "url": "https://api.github.com/repos/symfony/console/zipball/4fa15ae7be74e53f6ec8c83ed403b97e23b665e9",
+                "reference": "4fa15ae7be74e53f6ec8c83ed403b97e23b665e9",
                 "shasum": ""
             },
             "require": {
@@ -620,7 +620,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2020-01-25T12:44:29+00:00"
+            "time": "2020-02-24T13:10:00+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -938,9 +938,9 @@
             "authors": [
                 {
                     "name": "Brian",
-                    "role": "Lead",
                     "email": "scaturrob@gmail.com",
-                    "homepage": "http://brianscaturro.com"
+                    "homepage": "http://brianscaturro.com",
+                    "role": "Lead"
                 }
             ],
             "description": "A dependable php environment",
@@ -1329,8 +1329,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
             "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
@@ -2183,16 +2183,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v4.4.4",
+            "version": "v4.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "f5697ab4cb14a5deed7473819e63141bf5352c36"
+                "reference": "bf9166bac906c9e69fb7a11d94875e7ced97bcd7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/f5697ab4cb14a5deed7473819e63141bf5352c36",
-                "reference": "f5697ab4cb14a5deed7473819e63141bf5352c36",
+                "url": "https://api.github.com/repos/symfony/process/zipball/bf9166bac906c9e69fb7a11d94875e7ced97bcd7",
+                "reference": "bf9166bac906c9e69fb7a11d94875e7ced97bcd7",
                 "shasum": ""
             },
             "require": {
@@ -2228,7 +2228,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2020-01-09T09:50:08+00:00"
+            "time": "2020-02-07T20:06:44+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -733,7 +733,7 @@ class Clazz extends AddressableElement
             // Private properties of traits are accessible from the class that used that trait
             // (as well as from within the trait itself).
             // Also, for inheritance purposes, treat protected properties the same way.
-            if ($from_trait && !$property->isPublic()) {
+            if ($from_trait) {
                 $property->setDefiningFQSEN($property_fqsen);
             }
 
@@ -1012,6 +1012,15 @@ class Clazz extends AddressableElement
                 $code_base,
                 $context->getClassFQSENOrNull()
             );
+        }
+        if ($is_static && $property) {
+            // If the property is from a trait, the (different) defining FQSEN is the FQSEN of the class using the FQSEN, not the trait.
+            $defining_fqsen = $property->getDefiningFQSEN();
+            if ($defining_fqsen !== $property_fqsen) {
+                if ($code_base->hasPropertyWithFQSEN($defining_fqsen)) {
+                    $property = $code_base->getPropertyByFQSEN($defining_fqsen);
+                }
+            }
         }
 
         // If the property exists and is accessible, return it

--- a/src/Phan/Language/Element/Property.php
+++ b/src/Phan/Language/Element/Property.php
@@ -19,6 +19,8 @@ use TypeError;
  * Phan's representation of a class/trait/interface's property (including magic and dynamic properties)
  * @phan-file-suppress PhanPluginDescriptionlessCommentOnPublicMethod
  * @phan-file-suppress PhanPluginNoCommentOnPublicMethod TODO: Add comments
+ * @phan-suppress-next-line PhanParamSignaturePHPDocMismatchReturnType TODO fix https://github.com/phan/phan/issues/3761
+ * @method FullyQualifiedPropertyName getDefiningFQSEN()
  */
 class Property extends ClassElement
 {

--- a/tests/files/expected/0864_static_properties_inferences.php.expected
+++ b/tests/files/expected/0864_static_properties_inferences.php.expected
@@ -1,0 +1,3 @@
+%s:20 PhanUndeclaredMethod Call to undeclared method \ArrayObject::missingMethod
+%s:22 PhanUndeclaredMethod Call to undeclared method \SplObjectStorage::missingMethod
+%s:24 PhanUndeclaredMethod Call to undeclared method \DefiningStaticProperties\A::missingMethod

--- a/tests/files/src/0864_static_properties_inferences.php
+++ b/tests/files/src/0864_static_properties_inferences.php
@@ -1,0 +1,24 @@
+<?php
+namespace DefiningStaticProperties;
+
+trait T {
+    public static $traitInstance;
+}
+
+class A {
+    public static $instance;
+}
+class B1 extends A {
+    use T;
+}
+class B2 extends A {
+    use T;
+}
+
+B1::$traitInstance = new \ArrayObject();
+B2::$traitInstance->missingMethod();  // Phan should not yet infer a value for B2::$traitInstance because it's not the same property
+B1::$traitInstance->missingMethod();  // should warn
+B2::$traitInstance = new \SplObjectStorage();
+B2::$traitInstance->missingMethod();  // should warn
+B1::$instance = new A();
+B2::$instance->missingMethod();  // should warn

--- a/tests/infer_missing_types_test/.phan/config.php
+++ b/tests/infer_missing_types_test/.phan/config.php
@@ -115,7 +115,6 @@ return [
         'WhitespacePlugin',
         'UnknownElementTypePlugin',
         'AvoidableGetterPlugin',
-        //
         'UnknownClassElementAccessPlugin',
     ],
 

--- a/tests/infer_missing_types_test/README.md
+++ b/tests/infer_missing_types_test/README.md
@@ -1,0 +1,12 @@
+
+This folder contains tests of Phan's ability to infer missing union types.
+This is useful when a codebase has gaps in type information for properties, return types, etc.,
+but still needs to be checked for potential bugs.
+
+Features that this tests:
+
+- `--analyze-twice` - Run the analysis phase on all files, twice.
+  Phan gathers additional type information during the analysis phase (for return types and param types),
+  and this may help detect missing methods, potential type errors, etc.
+- `UnknownClassElementAccessPlugin` - Useful to know what parts of the code have unanalyzable types, even if the code gets analyzed twice.
+- `UnknownElementTypePlugin` - Useful to assist with adding types to the codebase so that Phan doesn't need to infer potentially incomplete types.

--- a/tests/infer_missing_types_test/expected/003_inherit_property.php.expected
+++ b/tests/infer_missing_types_test/expected/003_inherit_property.php.expected
@@ -1,0 +1,5 @@
+src/003_inherit_property.php:10 PhanUnreferencedClass Possibly zero references to class \NS3\Z
+src/003_inherit_property.php:11 PhanPluginUnknownMethodReturnType Method \NS3\Z::test() has no declared or inferred return type
+src/003_inherit_property.php:11 PhanUnreferencedPublicMethod Possibly zero references to public method \NS3\Z::test()
+src/003_inherit_property.php:14 PhanUndeclaredMethod Call to undeclared method \ArrayObject::missingMethod
+src/003_inherit_property.php:18 PhanPluginUnknownPropertyType Property \NS3\X->val has an initial type that cannot be inferred (Types inferred after analysis: \ArrayObject)

--- a/tests/infer_missing_types_test/src/003_inherit_property.php
+++ b/tests/infer_missing_types_test/src/003_inherit_property.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace NS3;
+
+use ArrayObject;
+
+class Y extends X {
+
+}
+class Z extends Y {
+    public function test() {
+        // Phan should infer that $this->val is of type ArrayObject when --analyze-twice is used,
+        // despite the assignment occurring later in analysis.
+        $this->val->missingMethod();
+    }
+}
+class X {
+    protected $val;
+    public function __construct(ArrayObject $val) {
+        $this->val = $val;
+    }
+}


### PR DESCRIPTION
Inherit property union types in subclasses
from the declaration when reading their types.
(This is useful for inferring the effects of constructors,
when the property has no phpdoc or real type declaration)

Properly infer which inherited static properties are aliases of each
other.

Fixes #3760