### PR TITLE
Add config setting to infer additional types for `@return mixed`

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -554,7 +554,8 @@ return [
         'StrictComparisonPlugin',
         // Warn about `$var == SOME_INT_OR_STRING_CONST` due to unintuitive behavior such as `0 == 'a'`
         '.phan/plugins/StrictLiteralComparisonPlugin.php',
-        '.phan/plugins/UnknownClassElementAccessPlugin.php',
+        // 'UnknownClassElementAccessPlugin' is more useful with batch analysis than in an editor.
+        // It's used in tests/run_test __FakeSelfFallbackTest
 
         ////////////////////////////////////////////////////////////////////////
         // End plugins for Phan's self-analysis

--- a/.phan/plugins/MoreSpecificElementTypePlugin.php
+++ b/.phan/plugins/MoreSpecificElementTypePlugin.php
@@ -143,7 +143,7 @@ class MoreSpecificElementTypePlugin extends PluginV3 implements
             $function_context = $function->getContext();
             // TODO: Do a better job for Traversable<MyClass> and iterable<MyClass>
             $actual_type = UnionType::merge($type_info->types->toArray())->withStaticResolvedInContext($function_context)->eraseTemplatesRecursive()->asNormalizedTypes();
-            $declared_return_type = $function->getUnionType()->withStaticResolvedInContext($function_context)->eraseTemplatesRecursive()->asNormalizedTypes();
+            $declared_return_type = $function->getOriginalReturnType()->withStaticResolvedInContext($function_context)->eraseTemplatesRecursive()->asNormalizedTypes();
             if (!self::shouldWarnAboutMoreSpecificType($code_base, $actual_type, $declared_return_type)) {
                 continue;
             }

--- a/NEWS.md
+++ b/NEWS.md
@@ -52,6 +52,8 @@ Bug fixes:
 + Don't let less specific type signatures such as `@param object $x` override the real type signature of `MyClass $x` (#3749)
 + Support PHP 7.4's `??=` null coalescing assignment operator in the polyfill.
 + Fix crash analyzing invalid nodes such as `2 = $x` in `RedundantAssignmentPlugin`.
++ Fix false positive unreferenced method warnings for methods from traits
+  when the methods were referenced in base classes or interfaces of classes using those traits.
 
 Feb 20 2020, Phan 2.5.0
 -----------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,11 @@ New features(CLI, Configs):
 + Add a CLI option `--analyze-all-files` to analyze all files, ignoring `exclude_analysis_file_list`.
   This is potentially useful if third party dependencies are missing type information (also see `--analyze-twice`).
 + Add `--dump-analyzed-file-list` to dump all files Phan would analyze to stdout.
++ Add `allow_overriding_vague_return_types` to allow Phan to add inferred return types to functions/closures/methods declared with `@return mixed` or `@return object`.
+  This is disabled by default.
+
+  Previously, Phan would only add inferred return types if there was no return type declaration.
+  (also see `--analyze-twice`)
 
 New features(Analysis):
 + Support parsing php 8.0 union types (and the static return type) in the polyfill. (#3419, #3634)

--- a/internal/Phan-Config-Settings.md
+++ b/internal/Phan-Config-Settings.md
@@ -195,6 +195,15 @@ defined.
 
 (Default: `false`)
 
+## allow_overriding_vague_return_types
+
+Allow adding types to vague return types such as @return object, @return ?mixed in function/method/closure union types.
+Normally, Phan only adds inferred returned types when there is no `@return` type or real return type signature..
+
+Disabled by default. This is more useful with `--analyze-twice`.
+
+(Default: `false`)
+
 ## analyze_signature_compatibility
 
 If enabled, check all methods that override a

--- a/internal/update_wiki_config_types.php
+++ b/internal/update_wiki_config_types.php
@@ -58,6 +58,7 @@ class ConfigEntry
         'assume_no_external_class_overrides' => self::CATEGORY_ANALYSIS,
         'allow_method_param_type_widening' => self::CATEGORY_ANALYSIS_VERSION,
         'guess_unknown_parameter_type_using_default' => self::CATEGORY_ANALYSIS,
+        'allow_overriding_vague_return_types' => self::CATEGORY_ANALYSIS,
         'infer_default_properties_in_construct' => self::CATEGORY_ANALYSIS,
         'inherit_phpdoc_types' => self::CATEGORY_ANALYSIS,
         'minimum_severity' => self::CATEGORY_ISSUE_FILTERING,

--- a/src/Phan/Analysis/ConditionVisitorUtil.php
+++ b/src/Phan/Analysis/ConditionVisitorUtil.php
@@ -890,7 +890,6 @@ trait ConditionVisitorUtil
      * @param Node $var_node
      * @param Node|int|float|string $expr
      * @return Context - Context after inferring type from an expression such as `if ($x === 'literal')`
-     * @suppress PhanUnreferencedPublicMethod referenced in ConditionVisitorInterface
      */
     final public function updateVariableToBeIdentical(
         Node $var_node,
@@ -913,7 +912,6 @@ trait ConditionVisitorUtil
      * @param Node $var_node
      * @param Node|int|float|string $expr
      * @return Context - Context after inferring type from an expression such as `if ($x == true)`
-     * @suppress PhanUnreferencedPublicMethod referenced in ConditionVisitorInterface
      */
     final public function updateVariableToBeEqual(
         Node $var_node,
@@ -937,7 +935,6 @@ trait ConditionVisitorUtil
      * @param Node|int|float|string $expr
      * @param int $flags (e.g. \ast\flags\BINARY_IS_SMALLER)
      * @return Context - Context after inferring type from a comparison expression involving a variable such as `if ($x > 0)`
-     * @suppress PhanUnreferencedPublicMethod referenced in ConditionVisitorInterface
      */
     final public function updateVariableToBeCompared(
         Node $var_node,
@@ -1011,7 +1008,6 @@ trait ConditionVisitorUtil
      * @param Node $var_node a node of type ast\AST_VAR, ast\AST_DIM (planned), or ast\AST_PROP
      * @param Node|int|float|string $expr
      * @return Context - Context after inferring type from an expression such as `if ($x !== 'literal')`
-     * @suppress PhanUnreferencedPublicMethod referenced in ConditionVisitorInterface
      */
     final public function updateVariableToBeNotIdentical(
         Node $var_node,
@@ -1048,7 +1044,6 @@ trait ConditionVisitorUtil
      * @param Node $var_node
      * @param Node|int|float|string $expr
      * @return Context - Context after inferring type from an expression such as `if ($x != 'literal')`
-     * @suppress PhanUnreferencedPublicMethod referenced in ConditionVisitorInterface
      * @suppress PhanSuspiciousTruthyCondition, PhanSuspiciousTruthyString didn't implement special handling of `if ($x != [...])`
      */
     final public function updateVariableToBeNotEqual(
@@ -1218,7 +1213,6 @@ trait ConditionVisitorUtil
      *
      * @param Node|string|int|float $object_node
      * @param Node|string|int|float|bool $expr_node
-     * @suppress PhanUnreferencedPublicMethod referenced in ConditionVisitorInterface
      */
     public function analyzeClassAssertion($object_node, $expr_node): ?Context
     {
@@ -1462,7 +1456,6 @@ trait ConditionVisitorUtil
     /**
      * Returns this ConditionVisitorUtil's CodeBase.
      * This is needed by subclasses of BinaryCondition.
-     * @suppress PhanUnreferencedPublicMethod
      */
     public function getCodeBase(): CodeBase
     {
@@ -1472,7 +1465,6 @@ trait ConditionVisitorUtil
     /**
      * Returns this ConditionVisitorUtil's Context.
      * This is needed by subclasses of BinaryCondition.
-     * @suppress PhanUnreferencedPublicMethod phan has issues with dead code detection with traits and interfaces
      */
     public function getContext(): Context
     {

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -307,6 +307,12 @@ class Config
         // Phan will not assume it knows specific types if the default value is `false` or `null`.
         'guess_unknown_parameter_type_using_default' => false,
 
+        // Allow adding types to vague return types such as @return object, @return ?mixed in function/method/closure union types.
+        // Normally, Phan only adds inferred returned types when there is no `@return` type or real return type signature..
+        //
+        // Disabled by default. This is more useful with `--analyze-twice`.
+        'allow_overriding_vague_return_types' => false,
+
         // When enabled, infer that the types of the properties of `$this` are equal to their default values at the start of `__construct()`.
         // This will have some false positives due to Phan not checking for setters and initializing helpers.
         // This does not affect inherited properties.

--- a/src/Phan/Language/Element/Func.php
+++ b/src/Phan/Language/Element/Func.php
@@ -306,6 +306,8 @@ class Func extends AddressableElement implements FunctionInterface
         }
         $element_context->freeElementReference();
 
+        $func->setOriginalReturnType();
+
         return $func;
     }
 

--- a/src/Phan/Language/Element/FunctionInterface.php
+++ b/src/Phan/Language/Element/FunctionInterface.php
@@ -453,4 +453,11 @@ interface FunctionInterface extends AddressableElementInterface
      * Other approaches, such as analyzing loops multiple times, are possible, but not implemented.
      */
     public function getVariableTypeFallbackMap(CodeBase $code_base): array;
+
+    /**
+     * Gets the original union type of this function/method.
+     *
+     * This is populated the first time it is called.
+     */
+    public function getOriginalReturnType(): UnionType;
 }

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -629,6 +629,8 @@ class Method extends ClassElement implements FunctionInterface
             $method->setPHPDocReturnType($comment_return_union_type);
         }
         $element_context->freeElementReference();
+        // Populate the original return type.
+        $method->setOriginalReturnType();
 
         return $method;
     }

--- a/src/Phan/Language/Type/FunctionLikeDeclarationType.php
+++ b/src/Phan/Language/Type/FunctionLikeDeclarationType.php
@@ -743,6 +743,11 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
         return $this->return_type;
     }
 
+    public function getOriginalReturnType(): UnionType
+    {
+        return $this->return_type;
+    }
+
     public function getSuppressIssueList(): array
     {
         // TODO: Inherit suppress issue list from phpdoc declaring this?

--- a/tests/infer_missing_types_test/.phan/config.php
+++ b/tests/infer_missing_types_test/.phan/config.php
@@ -127,4 +127,10 @@ return [
     // Even when this is false, Phan will still infer return values and check parameters of internal functions
     // if Phan has the signatures.
     'ignore_undeclared_functions_with_known_signatures' => false,
+
+    // Allow adding types to vague return types such as @return object, @return ?mixed in function/method/closure union types.
+    // Normally, phan only adds inferred returned types when there is no `@return` type.
+    //
+    // Disabled by default. This is more useful with `--analyze-twice`.
+    'allow_overriding_vague_return_types' => true,
 ];

--- a/tests/infer_missing_types_test/expected/004_infer_return_type.php.expected
+++ b/tests/infer_missing_types_test/expected/004_infer_return_type.php.expected
@@ -1,0 +1,2 @@
+src/004_infer_return_type.php:6 PhanPluginMoreSpecificActualReturnTypeContainsFQSEN Phan inferred that \returns_object4() documented to have return type object (without an FQSEN) returns the more specific type \stdClass(real=\stdClass) (with an FQSEN)
+src/004_infer_return_type.php:9 PhanUndeclaredMethod Call to undeclared method \stdClass::missingMethod

--- a/tests/infer_missing_types_test/src/004_infer_return_type.php
+++ b/tests/infer_missing_types_test/src/004_infer_return_type.php
@@ -1,0 +1,9 @@
+<?php
+// When allow_overriding_vague_return_types is enabled, phan will add the observed return types to the function return type, for types such as object/mixed.
+/**
+ * @return object
+ */
+function returns_object4() {
+    return new stdClass();
+}
+returns_object4()->missingMethod();

--- a/tests/run_test
+++ b/tests/run_test
@@ -32,6 +32,7 @@ case "$TEST_SUITE" in
 		./phan --plugin PHPUnitNotDeadCodePlugin \
 			--plugin InvokePHPNativeSyntaxCheckPlugin \
 			--plugin AvoidableGetterPlugin \
+			--plugin UnknownClassElementAccessPlugin \
 			--dead-code-detection \
 			--assume-real-types-for-internal-functions \
 			--force-polyfill-parser \


### PR DESCRIPTION
And `@return object`.
Normally, phan would not add types inferred during analysis
if there were any phpdoc or real type declarations.

Also, fix false positive unreferenced element warnings
for methods inherited from traits.