### PR TITLE
Speed up language server/daemon mode

### DIFF
--- a/.phan/plugins/MoreSpecificElementTypePlugin.php
+++ b/.phan/plugins/MoreSpecificElementTypePlugin.php
@@ -9,8 +9,8 @@ use Phan\Language\Element\FunctionInterface;
 use Phan\Language\Element\Method;
 use Phan\Language\FQSEN;
 use Phan\Language\UnionType;
-use Phan\Library\Set;
 use Phan\Library\Map;
+use Phan\Library\Set;
 use Phan\PluginV3;
 use Phan\PluginV3\FinalizeProcessCapability;
 use Phan\PluginV3\PluginAwarePostAnalysisVisitor;
@@ -176,7 +176,8 @@ class MoreSpecificElementTypePlugin extends PluginV3 implements
  * Represents the actual return types seen during analysis
  * (including recursive analysis)
  */
-class ElementTypeInfo {
+class ElementTypeInfo
+{
     /** @var FunctionInterface the function with the return values*/
     public $function;
     /** @var Set<UnionType> the set of observed return types */
@@ -184,7 +185,8 @@ class ElementTypeInfo {
     /**
      * @param list<UnionType> $return_types
      */
-    public function __construct(FunctionInterface $function, array $return_types) {
+    public function __construct(FunctionInterface $function, array $return_types)
+    {
         $this->function = $function;
         $this->types = new Set($return_types);
     }

--- a/NEWS.md
+++ b/NEWS.md
@@ -60,7 +60,7 @@ Bug fixes:
   when the methods were referenced in base classes or interfaces of classes using those traits.
 
 Language Server/Daemon mode:
-+ Minor performance improvements for the language server/daemon when the use of pcntl is unavailable or disabled. (#3758)
++ Various performance improvements for the language server/daemon with or without pcntl (#3758, #3769, #3771)
 
 Feb 20 2020, Phan 2.5.0
 -----------------------

--- a/src/Phan/AST/TolerantASTConverter/CachingTolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/CachingTolerantASTConverter.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phan\AST\TolerantASTConverter;
+
+use Microsoft\PhpParser\Diagnostic;
+use Microsoft\PhpParser\Node\SourceFileNode;
+
+/**
+ * This is a plain ast\Node generator that adds caching of the PhpParser\Nodes.
+ */
+final class CachingTolerantASTConverter extends TolerantASTConverter
+{
+    const MAX_CACHE_SIZE = 10;
+
+    /**
+     * @var array<string,PhpParserNodeEntry> - an LRU cache of nodes used to generate php-ast nodes.
+     * The same PhpParser\Node can be used to create ast\Node instances in multiple ways (e.g. should_add_placeholders changes what gets generated)
+     */
+    private static $php_parser_node_cache = [];
+
+    /**
+     * @param Diagnostic[] &$errors @phan-output-reference (TODO: param-out)
+     * @override
+     */
+    public static function phpParserParse(string $file_contents, array &$errors = []): SourceFileNode
+    {
+        $entry = self::$php_parser_node_cache[$file_contents] ?? null;
+        if ($entry) {
+            // This was recently used, move the entry to the end of the associative array.
+            unset(self::$php_parser_node_cache[$file_contents]);
+            self::$php_parser_node_cache[$file_contents] = $entry;
+            $errors = $entry->errors;
+            // \fwrite(\STDERR, "Found a cached entry for " . \md5($file_contents) . ' #errors=' . \count($errors) . "\n");
+            return $entry->node;
+        }
+        $new_errors = [];
+        $node = parent::phpParserParse($file_contents, $new_errors);
+        if (\count(self::$php_parser_node_cache) >= self::MAX_CACHE_SIZE) {
+            // The cache is full, evict the element at the beginning of the associative array.
+            \reset(self::$php_parser_node_cache);
+            unset(self::$php_parser_node_cache[\key(self::$php_parser_node_cache)]);
+        }
+        $entry = new PhpParserNodeEntry($node, $new_errors);
+        self::$php_parser_node_cache[$file_contents] = $entry;
+
+        $errors = $new_errors;
+        // \fwrite(\STDERR, "Creating entry for " . \md5($file_contents) . ' #errors=' . \count($errors) . "\n");
+        return $node;
+    }
+}

--- a/src/Phan/AST/TolerantASTConverter/PhpParserNodeEntry.php
+++ b/src/Phan/AST/TolerantASTConverter/PhpParserNodeEntry.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phan\AST\TolerantASTConverter;
+
+use Microsoft\PhpParser;
+use Microsoft\PhpParser\Diagnostic;
+
+/**
+ * The Microsoft\PhpParser instance produced for a given file contents for the currently running php version's tokenizer.
+ *
+ * These are kept in memory when the language server is running.
+ *
+ * @phan-read-only
+ */
+class PhpParserNodeEntry
+{
+    /** @var PhpParser\Node the node generated for the given file contents */
+    public $node;
+    /** @var Diagnostic[] the list of diagnostics generated for the given file contents */
+    public $errors;
+
+    /**
+     * @param Diagnostic[] $errors
+     */
+    public function __construct(PhpParser\Node $node, array $errors)
+    {
+        $this->node = $node;
+        $this->errors = $errors;
+    }
+}

--- a/src/Phan/Daemon/ParseRequest.php
+++ b/src/Phan/Daemon/ParseRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phan\Daemon;
+
+/**
+ * This is used to signal to Phan\AST\Parser that Phan is running in daemon mode,
+ * and that the AST generated during the parse phase should be reused during the analysis phase
+ * or when generating column numbers for php's error messages
+ */
+class ParseRequest extends Request
+{
+    public function __construct()
+    {
+        // Deliberately do not call parent::__construct
+    }
+}

--- a/src/Phan/Daemon/Request.php
+++ b/src/Phan/Daemon/Request.php
@@ -683,7 +683,7 @@ class Request
             Daemon::debugf("Parsing %s yet again", $file_path);
             try {
                 // Parse the file
-                Analysis::parseFile($code_base, $file_path, false, $file_contents_override);
+                Analysis::parseFile($code_base, $file_path, false, $file_contents_override, false, new ParseRequest());
             } catch (\Throwable $throwable) {
                 \error_log(\sprintf("Analysis::parseFile threw %s for %s: %s\n%s", get_class($throwable), $file_path, $throwable->getMessage(), $throwable->getTraceAsString()));
             }


### PR DESCRIPTION
(only when in language server or in daemon mode)

Cache the ASTs generated by tolerant-php-parser.

Preload classes and expensive data structures from Phan itself
before forking when pcntl is used

Fixes #3771
Fixes #3769