### PR TITLE
Fix InfiniteIterator::__construct parameter typo.

### DIFF
--- a/src/Phan/Language/Internal/FunctionSignatureMap.php
+++ b/src/Phan/Language/Internal/FunctionSignatureMap.php
@@ -6055,7 +6055,7 @@ return [
 'inclued_get_data' => ['array'],
 'inet_ntop' => ['string|false', 'in_addr'=>'string'],
 'inet_pton' => ['string|false', 'ip_address'=>'string'],
-'InfiniteIterator::__construct' => ['void', 'iterator'=>'Iteator'],
+'InfiniteIterator::__construct' => ['void', 'iterator'=>'Iterator'],
 'InfiniteIterator::current' => ['mixed'],
 'InfiniteIterator::getInnerIterator' => ['Traversable'],
 'InfiniteIterator::key' => ['bool|float|int|string'],


### PR DESCRIPTION
Fixes #3828.

I would expect the following code to not issue any Phan issues.
```
<?php
$iter = null;
assert($iter instanceof \Iterator);
$a = new InfiniteIterator($iter);
```

Instead it emits,
```
__file__:4 PhanTypeMismatchArgumentInternal Argument 1 ($iterator) is $iter of type \Iterator|\Traversable|iterable but \InfiniteIterator::__construct() takes \Iteator
```

Line 6058 of `src\Phan\Language\Internal\FunctionSignatureMap.php` seems to be the cause of the issue:

```
'InfiniteIterator::__construct' => ['void', 'iterator'=>'Iteator'],
```