### PR TITLE
Check if method calls in loops are free of side effects

### DIFF
--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -1061,6 +1061,8 @@ e.g. [this issue](https://github.com/phan/phan/tree/2.7.0/tests/php74_files/expe
 ## PhanSideEffectFreeDoWhileBody
 
 **Note that `PhanSideEffectFree...` issue types rely on `--unused-variable-detection`, and will not run in the global scope as a result.**
+Also note that the `plugin_config` setting `infer_pure_methods` of the plugin `UseReturnValuePlugin` should be enabled,
+for this to warn about loops containing function and method calls.
 
 ```
 Saw a do-while loop which probably has no side effects
@@ -1068,15 +1070,12 @@ Saw a do-while loop which probably has no side effects
 
 ## PhanSideEffectFreeForBody
 
-**Note that `PhanSideEffectFree...` issue types rely on `--unused-variable-detection`, and will not run in the global scope as a result.**
-
 ```
 Saw a for loop which probably has no side effects
 ```
 
 ## PhanSideEffectFreeForeachBody
 
-**Note that `PhanSideEffectFree...` issue types rely on `--unused-variable-detection`, and will not run in the global scope as a result.**
 Also, this issue will not be emitted if the expression being iterated over is possibly an object (of any class) or has an unknown real type.
 
 ```
@@ -1084,8 +1083,6 @@ Saw a foreach loop which probably has no side effects
 ```
 
 ## PhanSideEffectFreeWhileBody
-
-**Note that `PhanSideEffectFree...` issue types rely on `--unused-variable-detection`, and will not run in the global scope as a result.**
 
 ```
 Saw a while loop which probably has no side effects

--- a/src/Phan/Language/Type/FunctionLikeDeclarationType.php
+++ b/src/Phan/Language/Type/FunctionLikeDeclarationType.php
@@ -855,6 +855,7 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
             if (StringUtil::isNonZeroLengthString($signature)) {
                 $fragment = "$signature $fragment";
             }
+            $fragments[] = $fragment;
         }
         $signature = static::NAME . '(' . \implode(',', $fragments) . ')';
         if (StringUtil::isNonZeroLengthString($return_type)) {

--- a/tests/files/expected/0129_suppress_stmts.php.expected
+++ b/tests/files/expected/0129_suppress_stmts.php.expected
@@ -1,2 +1,3 @@
 %s:38 PhanSuspiciousWeakTypeComparison Suspicious attempt to compare [1,2] of type array{0:1,1:2} to 'string' of type 'string'
 %s:39 PhanSuspiciousWeakTypeComparison Suspicious attempt to compare 42 of type 42 to [1,2] of type array{0:1,1:2}
+%s:41 PhanSideEffectFreeForeachBody Saw a foreach loop which probably has no side effects

--- a/tests/files/expected/0189_2d_array.php.expected
+++ b/tests/files/expected/0189_2d_array.php.expected
@@ -1,1 +1,2 @@
+%s:7 PhanSideEffectFreeForeachBody Saw a foreach loop which probably has no side effects
 %s:8 PhanUnusedVariable Unused definition of variable $x

--- a/tests/files/expected/0246_iterable.php.expected
+++ b/tests/files/expected/0246_iterable.php.expected
@@ -1,5 +1,6 @@
 %s:3 PhanUnusedVariable Unused definition of variable $v
 %s:6 PhanEmptyForeachBody Saw a foreach statement with empty body over array of type array (iterating has no side effects)
+%s:6 PhanSideEffectFreeForeachBody Saw a foreach loop which probably has no side effects
 %s:6 PhanUnusedVariable Unused definition of variable $v
 %s:9 PhanTypeNoPropertiesForeach Class \ArrayAccess was passed to foreach, but it does not extend Traversable and doesn't have any declared properties. (This check excludes dynamic properties)
 %s:9 PhanUnusedVariable Unused definition of variable $v

--- a/tests/files/expected/0799_array_destructuring_failures.php.expected
+++ b/tests/files/expected/0799_array_destructuring_failures.php.expected
@@ -6,8 +6,10 @@
 %s:5 PhanUnusedVariable Unused definition of variable $arg
 %s:6 PhanSyntaxEmptyListArrayDestructuring Cannot use an empty list in the left hand side of an array destructuring operation
 %s:8 PhanEmptyForeachBody Saw a foreach statement with empty body over array of type array (iterating has no side effects)
+%s:8 PhanSideEffectFreeForeachBody Saw a foreach loop which probably has no side effects
 %s:8 PhanSyntaxEmptyListArrayDestructuring Cannot use an empty list in the left hand side of an array destructuring operation
 %s:10 PhanEmptyForeachBody Saw a foreach statement with empty body over array of type array (iterating has no side effects)
+%s:10 PhanSideEffectFreeForeachBody Saw a foreach loop which probably has no side effects
 %s:10 PhanSyntaxMixedKeyNoKeyArrayDestructuring Cannot mix keyed and unkeyed array entries in array destructuring assignments ([$a,'other'=>$b])
 %s:10 PhanUnusedVariable Unused definition of variable $a
 %s:10 PhanUnusedVariable Unused definition of variable $b

--- a/tests/plugin_test/expected/172_infer_pure_useless_loop.php.expected
+++ b/tests/plugin_test/expected/172_infer_pure_useless_loop.php.expected
@@ -1,0 +1,4 @@
+src/172_infer_pure_useless_loop.php:13 PhanSideEffectFreeForBody Saw a for loop which probably has no side effects
+src/172_infer_pure_useless_loop.php:19 PhanSideEffectFreeWhileBody Saw a while loop which probably has no side effects
+src/172_infer_pure_useless_loop.php:24 PhanSideEffectFreeDoWhileBody Saw a do-while loop which probably has no side effects
+src/172_infer_pure_useless_loop.php:33 PhanSideEffectFreeForeachBody Saw a foreach loop which probably has no side effects

--- a/tests/plugin_test/src/172_infer_pure_useless_loop.php
+++ b/tests/plugin_test/src/172_infer_pure_useless_loop.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace NS172;
+
+class SomeClass {
+    /** @var bool */
+    public $x = false;
+    public function getX(): bool {
+        return $this->x;
+    }
+}
+function test_loop_method(SomeClass $x) {
+  for ($i = 0; $i < 10; $i++) {
+    if ($x->getX()) { break; }
+  }
+}
+
+function test_while_method(SomeClass $x) {
+  while (true) {
+    if ($x->getX()) { break; }
+  }
+}
+function test_do_while_method(SomeClass $x) {
+  do {
+    if ($x->getX()) { break; }
+  } while (rand(0,1));
+}
+
+/**
+ * @param SomeClass[] $a
+ */
+function test_foreach_method(array $a) {
+  foreach ($a as $x) {
+    if ($x->getX()) {
+      break;
+    }
+  }
+}
+test_loop_method(new SomeClass());
+$s = new SomeClass();
+$s->x = true;
+test_while_method($s);
+test_do_while_method($s);
+test_foreach_method([$s]);


### PR DESCRIPTION
Fixes #3860
Phan will now know guess more variable types when checking if a
loop is free of side effects

Phan will also more aggressively check if foreach over arrays have no
side effects.
