### PR TITLE
Properly render FQSENs in original cases more of the time

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,7 @@ New features(Analysis):
 Bug Fixes:
 + Work around unintentionally using `symfony/polyfill-72` for `spl_object_id` instead of Phan's polyfill.
   The version used caused issues on 32-bit php 7.1 installations, and a slight slowdown in php 7.1.
++ Fix bug causing FQSEN names or namespaces to be converted to lowercase even if they were never lowercase in the codebase being analyzed (#3583)
 
 Miscellaneous:
 + Replace `PhanTypeInvalidPropertyDefaultReal` with `TypeMismatchPropertyDefault` (emitted instead of `TypeMismatchProperty`)

--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -144,19 +144,17 @@ class Context extends FileRef
         // slash
         $name_parts = \explode('\\', $name, 2);
         if (\count($name_parts) > 1) {
-            // We're looking for a namespace if there's more than one part
-            // Namespaces are case-insensitive.
-            $namespace_map_key = \strtolower($name_parts[0]);
+            $name = $name_parts[0];
+            // In php, namespaces, functions, and classes are case-insensitive.
+            // However, constants are almost always case-insensitive.
+            // The name we're looking for is a namespace(USE_NORMAL).
+            // The suffix has type $flags
             $flags = \ast\flags\USE_NORMAL;
-        } else {
-            if ($flags !== \ast\flags\USE_CONST) {
-                $namespace_map_key = \strtolower($name);
-            } else {
-                // Constants are case-sensitive, and stored in a case-sensitive manner.
-                $namespace_map_key = $name;
-            }
         }
-        return isset($this->namespace_map[$flags][$namespace_map_key]);
+        if ($flags !== \ast\flags\USE_CONST) {
+            $name = \strtolower($name);
+        }
+        return isset($this->namespace_map[$flags][$name]);
     }
 
     /**
@@ -172,28 +170,27 @@ class Context extends FileRef
         // slash
         $name_parts = \explode('\\', $name, 2);
         if (\count($name_parts) > 1) {
-            $name = \strtolower($name_parts[0]);
+            $name = $name_parts[0];
             $suffix = $name_parts[1];
             // In php, namespaces, functions, and classes are case-insensitive.
             // However, constants are almost always case-insensitive.
-            if ($flags !== \ast\flags\USE_CONST) {
-                $suffix = \strtolower($suffix);
-            }
             // The name we're looking for is a namespace(USE_NORMAL).
             // The suffix has type $flags
             $map_flags = \ast\flags\USE_NORMAL;
         } else {
             $suffix = '';
             $map_flags = $flags;
-            if ($flags !== \ast\flags\USE_CONST) {
-                $name = \strtolower($name);
-            }
+        }
+        if ($map_flags !== \ast\flags\USE_CONST) {
+            $name_key = \strtolower($name);
+        } else {
+            $name_key = $name;
         }
 
-        $namespace_map_entry = $this->namespace_map[$map_flags][$name] ?? null;
+        $namespace_map_entry = $this->namespace_map[$map_flags][$name_key] ?? null;
 
         if (!$namespace_map_entry) {
-            throw new AssertionError('No namespace defined for name');
+            throw new AssertionError("No namespace defined for name '$name_key'");
         }
         $fqsen = $namespace_map_entry->fqsen;
         $namespace_map_entry->is_used = true;

--- a/tests/files/expected/0288_use_relative_namespace_function.php.expected
+++ b/tests/files/expected/0288_use_relative_namespace_function.php.expected
@@ -1,5 +1,5 @@
-%s:19 PhanUndeclaredFunction Call to undeclared function \A510\inner\missingthisfn()
+%s:19 PhanUndeclaredFunction Call to undeclared function \A510\Inner\missingThisFn()
 %s:21 PhanUndeclaredFunction Call to undeclared function \A510\Inner\MissingGroupUseFn()
 %s:22 PhanUndeclaredFunction Call to undeclared function \mixedCaseFn() (Did you mean \A510\Inner\mixedCaseFn())
 %s:23 PhanUndeclaredFunction Call to undeclared function \B510\A510\Inner\mixedCaseFn() (Did you mean \A510\Inner\mixedCaseFn())
-%s:25 PhanUndeclaredFunction Call to undeclared function \A510\Inner\missingfn()
+%s:25 PhanUndeclaredFunction Call to undeclared function \A510\Inner\missingFn()

--- a/tests/files/expected/0872_namespace_lookup.php.expected
+++ b/tests/files/expected/0872_namespace_lookup.php.expected
@@ -1,0 +1,2 @@
+%s:4 PhanUndeclaredTypeReturnType Return type of test() is undeclared type \Foo\B\B (Did you mean bool)
+%s:5 PhanTypeMismatchReturnReal Returning null of type null but test() is declared to return \Foo\B\B

--- a/tests/files/expected/0873_namespace_lookup_class.php.expected
+++ b/tests/files/expected/0873_namespace_lookup_class.php.expected
@@ -1,0 +1,1 @@
+%s:6 PhanUndeclaredExtendedClass Class extends undeclared class \TeST\ABC\Clause\Limit

--- a/tests/files/src/0872_namespace_lookup.php
+++ b/tests/files/src/0872_namespace_lookup.php
@@ -1,0 +1,6 @@
+<?php
+namespace Foo\A;
+use Foo\B;
+function test(): B\B {
+    return null;
+}

--- a/tests/files/src/0873_namespace_lookup_class.php
+++ b/tests/files/src/0873_namespace_lookup_class.php
@@ -1,0 +1,6 @@
+<?php
+namespace Other873;
+
+use TeST\ABC;
+
+class Offset extends ABC\Clause\Limit {}


### PR DESCRIPTION
For #3583
Phan was unnecessarily converting parts of FQSENs to lowercase
when looking up aliased uses.