### PR TITLE
Improve analysis of negated conditions in switches

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@ New features(Analysis):
   3. The code is in a functionlike scope.
 
   New issue types: `PhanSideEffectFreeForeachBody`, `PhanSideEffectFreeForBody`, `PhanSideEffectFreeWhileBody`, `PhanSideEffectFreeDoWhileBody`
++ Infer that previous conditions are negated when analyzing the cases of a switch statement (#3866)
 
 Bug Fixes:
 + Work around unintentionally using `symfony/polyfill-72` for `spl_object_id` instead of Phan's polyfill.

--- a/src/Phan/Analysis/ConditionVisitorUtil.php
+++ b/src/Phan/Analysis/ConditionVisitorUtil.php
@@ -1287,7 +1287,7 @@ trait ConditionVisitorUtil
      * @param Node|int|float|string $right
      * @return Context - Context after inferring type from an expression such as `if ($x == 'literal')`
      */
-    protected function analyzeAndUpdateToBeNotEqual($left, $right): Context
+    public function analyzeAndUpdateToBeNotEqual($left, $right): Context
     {
         return $this->analyzeBinaryConditionPattern(
             $left,

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -1432,7 +1432,6 @@ class BlockAnalysisVisitor extends AnalysisVisitor
         $context->setLineNumberStart($node->lineno);
         $context = $this->preOrderAnalyze(clone($context), $node);
 
-        $scope = $context->getScope();
         $child_context_list = [];
 
         // TODO: Improve inferences in switch statements?
@@ -1440,10 +1439,10 @@ class BlockAnalysisVisitor extends AnalysisVisitor
         $has_default = false;
         // parent_node_list should always end in AST_SWITCH
         // @phan-suppress-next-next-line PhanPossiblyUndeclaredProperty
-        [$switch_variable_node, $switch_variable_condition] = $this->createSwitchConditionAnalyzer(
+        [$switch_variable_node, $switch_variable_condition, $switch_variable_negated_condition] = $this->createSwitchConditionAnalyzer(
             end($this->parent_node_list)->children['cond']
         );
-        if ($switch_variable_condition && $switch_variable_node instanceof Node) {
+        if (($switch_variable_condition || $switch_variable_negated_condition) && $switch_variable_node instanceof Node) {
             $switch_variable_cond_variable_set = RedundantCondition::getVariableSet($switch_variable_node);
         } else {
             $switch_variable_cond_variable_set = [];
@@ -1455,6 +1454,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
                 end($this->parent_node_list)->lineno ?? $node->lineno
             );
         }
+        $fallthrough_context = $context;
 
         $previous_child_context = null;
         foreach ($node->children as $i => $child_node) {
@@ -1469,18 +1469,18 @@ class BlockAnalysisVisitor extends AnalysisVisitor
                 // The previous case statement fell through some of the time or all of the time.
                 $child_context = (new ContextMergeVisitor(
                     $previous_child_context,
-                    [$previous_child_context, $context]
-                ))->combineScopeList([$previous_child_context->getScope(), $scope]);
+                    [$previous_child_context, $fallthrough_context]
+                ))->combineScopeList([$previous_child_context->getScope(), $fallthrough_context->getScope()]);
             } else {
                 // The previous case statement did not fall through, or does not exist.
-                $child_context = $context->withScope(new BranchScope($scope));
+                $child_context = $fallthrough_context->withScope(clone($fallthrough_context->getScope()));
             }
             $child_context->withLineNumberStart($child_node->lineno);
             try {
                 $this->parent_node_list[] = $node;
                 ConfigPluginSet::instance()->preAnalyzeNode(
                     $this->code_base,
-                    $context,
+                    $fallthrough_context,
                     $child_node
                 );
                 if ($case_cond_node !== null) {
@@ -1496,7 +1496,6 @@ class BlockAnalysisVisitor extends AnalysisVisitor
                             // Add the variable type from the above case statements, if it was possible for it to fall through
                             // TODO: Also support switch(get_class($variable))
                             $child_context = $switch_variable_condition($child_context, $case_cond_node);
-                            '@phan-var Context $child_context';
                             if ($previous_child_context !== null) {
                                 $variable = $child_context->getScope()->getVariableByNameOrNull($var_name);
                                 if ($variable) {
@@ -1511,6 +1510,36 @@ class BlockAnalysisVisitor extends AnalysisVisitor
                             }
                         }
                     }
+                    if ($switch_variable_negated_condition) {
+                        // e.g. make sure to handle $x from `switch (true) { case $x instanceof stdClass: }` or `switch ($x)`
+                        // Note that this won't properly combine types from `case $x = expr: case $x = expr2:` (latter would override former),
+                        // but I don't expect to see that in reasonable code.
+                        $variables_to_check = $switch_variable_cond_variable_set + RedundantCondition::getVariableSet($case_cond_node);
+                        foreach ($variables_to_check as $var_name) {
+                            // Add the variable type that were ruled out by the above case statements, if it was possible for it to fall through
+                            // TODO: Also support switch(get_class($variable))
+                            $fallthrough_context = $switch_variable_negated_condition($fallthrough_context, $case_cond_node);
+                        }
+                    }
+                } else {
+                    foreach ($switch_variable_cond_variable_set as $var_name) {
+                        // Add the variable types from the default to the
+                        // TODO: Handle the default not being the last case statement
+                        // TODO: Improve handling of possibly undefined variables
+                        $variable = $child_context->getScope()->getVariableByNameOrNull($var_name);
+                        if (!$variable) {
+                            continue;
+                        }
+                        if ($previous_child_context) {
+                            $old_variable = $previous_child_context->getScope()->getVariableByNameOrNull($var_name);
+
+                            if ($old_variable) {
+                                $variable = clone($variable);
+                                $variable->setUnionType($variable->getUnionType()->withUnionType($old_variable->getUnionType()));
+                                $child_context->addScopeVariable($variable);
+                            }
+                        }
+                    }
                 }
 
                 if ($case_stmts_node instanceof Node) {
@@ -1518,7 +1547,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
                 }
                 ConfigPluginSet::instance()->postAnalyzeNode(
                     $this->code_base,
-                    $context,
+                    $fallthrough_context,
                     $child_node
                 );
             } finally {
@@ -1551,7 +1580,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
 
         if (count($child_context_list) > 0) {
             if (!$has_default) {
-                $child_context_list[] = $context;
+                $child_context_list[] = $fallthrough_context;
             }
             if (count($child_context_list) >= 2) {
                 // For case statements, we need to merge the contexts
@@ -1569,9 +1598,10 @@ class BlockAnalysisVisitor extends AnalysisVisitor
         return $this->postOrderAnalyze($context, $node);
     }
 
+    private const NOOP_SWITCH_COND_ANALYZER = [null, null, null];
     /**
      * @param Node|int|string|float $switch_case_node
-     * @return array{0:?Node,1:?Closure}
+     * @return array{0:?Node, 1:?Closure(Context, mixed): Context, 2:?Closure(Context, mixed): Context}
      */
     private function createSwitchConditionAnalyzer($switch_case_node): array
     {
@@ -1580,7 +1610,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
             if ($switch_kind === ast\AST_VAR) {
                 $switch_variable = (new ConditionVisitor($this->code_base, $this->context))->getVariableFromScope($switch_case_node, $this->context);
                 if (!$switch_variable) {
-                    return [null, null];
+                    return self::NOOP_SWITCH_COND_ANALYZER;
                 }
                 return [
                     $switch_case_node,
@@ -1591,6 +1621,13 @@ class BlockAnalysisVisitor extends AnalysisVisitor
                         $visitor = new ConditionVisitor($this->code_base, $child_context);
                         return $visitor->updateVariableToBeEqual($switch_case_node, $cond_node, $child_context);
                     },
+                    /**
+                     * @param Node|string|int|float $cond_node
+                     */
+                    function (Context $child_context, $cond_node) use ($switch_case_node): Context {
+                        $visitor = new ConditionVisitor($this->code_base, $child_context);
+                        return $visitor->updateVariableToBeNotEqual($switch_case_node, $cond_node, $child_context);
+                    },
                 ];
             } elseif ($switch_kind === ast\AST_CALL) {
                 $name = $switch_case_node->children['expr']->children['name'] ?? null;
@@ -1599,14 +1636,14 @@ class BlockAnalysisVisitor extends AnalysisVisitor
                     if ($name === 'get_class') {
                         $switch_variable_node = $switch_case_node->children['args']->children[0] ?? null;
                         if (!$switch_variable_node instanceof Node) {
-                            return [null, null];
+                            return self::NOOP_SWITCH_COND_ANALYZER;
                         }
                         if ($switch_variable_node->kind !== ast\AST_VAR) {
-                            return [null, null];
+                            return self::NOOP_SWITCH_COND_ANALYZER;
                         }
                         $switch_variable = (new ConditionVisitor($this->code_base, $this->context))->getVariableFromScope($switch_variable_node, $this->context);
                         if (!$switch_variable) {
-                            return [null, null];
+                            return self::NOOP_SWITCH_COND_ANALYZER;
                         }
                         return [
                             $switch_variable_node,
@@ -1620,6 +1657,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
                                     $cond_node
                                 ) ?? $child_context;
                             },
+                            null,
                         ];
                     }
                 }
@@ -1634,12 +1672,19 @@ class BlockAnalysisVisitor extends AnalysisVisitor
                         $visitor = new ConditionVisitor($this->code_base, $child_context);
                         return $visitor->analyzeAndUpdateToBeEqual($switch_case_node, $cond_node);
                     },
+                    /**
+                     * @param Node|string|int|float $cond_node
+                     */
+                    function (Context $child_context, $cond_node) use ($switch_case_node): Context {
+                        $visitor = new ConditionVisitor($this->code_base, $child_context);
+                        return $visitor->analyzeAndUpdateToBeNotEqual($switch_case_node, $cond_node);
+                    },
                 ];
             }
         } catch (IssueException $_) {
             // do nothing, we warn elsewhere
         }
-        return [null, null];
+        return self::NOOP_SWITCH_COND_ANALYZER;
     }
 
     /**

--- a/tests/Phan/Language/EmptyUnionTypeTest.php
+++ b/tests/Phan/Language/EmptyUnionTypeTest.php
@@ -159,6 +159,7 @@ final class EmptyUnionTypeTest extends BaseTest
     {
         $type = $param->getType();
         $type_name = Type::stringFromReflectionType($type);
+        // @phan-suppress-next-line PhanSuspiciousTruthyString emitted because of comparison to ''
         switch ($type_name) {
             case 'bool':
                 return [false, true];

--- a/tests/files/expected/0784_switch_constant.php.expected
+++ b/tests/files/expected/0784_switch_constant.php.expected
@@ -2,6 +2,7 @@
 %s:30 PhanUndeclaredMethod Call to undeclared method \NSConstantSwitch\T2::f1 (Did you mean expr->f2())
 %s:34 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($numerator) is $arg of type \Traversable|\stdClass|iterable but \intdiv() takes int
 %s:46 PhanTypeMismatchArgumentInternal Argument 1 ($string) is $arg of type true but \strlen() takes string
+%s:48 PhanImpossibleCondition Impossible attempt to cast $arg of type false to truthy
 %s:49 PhanTypeMismatchArgumentInternal Argument 1 ($string) is $arg of type false but \strlen() takes string
 %s:57 PhanRedundantCondition Redundant attempt to cast $x of type non-empty-string to string
 %s:58 PhanRedundantCondition Redundant attempt to cast $x of type non-empty-string to truthy

--- a/tests/files/expected/0875_switch_fallthrough.php.expected
+++ b/tests/files/expected/0875_switch_fallthrough.php.expected
@@ -1,0 +1,4 @@
+%s:7 PhanDebugAnnotation @phan-debug-var requested for variable $action - it has union type false
+%s:10 PhanDebugAnnotation @phan-debug-var requested for variable $action - it has union type non-empty-string|true(real=non-empty-mixed)
+%s:21 PhanDebugAnnotation @phan-debug-var requested for variable $action - it has union type false
+%s:24 PhanDebugAnnotation @phan-debug-var requested for variable $action - it has union type non-empty-string|true(real=non-empty-mixed)

--- a/tests/files/src/0875_switch_fallthrough.php
+++ b/tests/files/src/0875_switch_fallthrough.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @param string|bool $action
+ */
+function buggedFunc( $db = null, $action = false ) {
+	switch ( $action ) {
+		case false:
+			'@phan-debug-var $action';
+			break;
+		default:
+			'@phan-debug-var $action';
+			return "Foo $action"; // Here: PhanTypeSuspiciousStringExpression
+	}
+}
+
+/**
+ * @param string|bool $action
+ */
+function buggedFunc2( $db = null, $action = false ) {
+	switch ( false ) {
+		case $action:
+			'@phan-debug-var $action';
+			break;
+		default:
+			'@phan-debug-var $action';
+			return "Foo $action"; // Here: PhanTypeSuspiciousStringExpression
+	}
+}


### PR DESCRIPTION
This assumes that the default is at the bottom for now.
This could be improved by checking all statements, then checking the
statements for the default again.

Fixes #3866