### PR TITLE
Add PHP53CompatibilityPlugin as a demo plugin

### DIFF
--- a/.phan/plugins/PHP53CompatibilityPlugin.php
+++ b/.phan/plugins/PHP53CompatibilityPlugin.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+use ast\Node;
+use Phan\AST\ASTReverter;
+use Phan\PluginV3;
+use Phan\PluginV3\PluginAwarePostAnalysisVisitor;
+use Phan\PluginV3\PostAnalyzeNodeCapability;
+
+/**
+ * This plugin contains examples of checks for code that would be incompatible with php 5.3.
+ * This goes beyond what `backward_compatibility_checks` checks for.
+ *
+ * This file demonstrates plugins for Phan. Plugins hook into various events.
+ * PHP53CompatibilityPlugin hooks into one event:
+ *
+ * - getPostAnalyzeNodeVisitorClassName
+ *   This method returns a visitor that is called on every AST node from every
+ *   file being analyzed
+ *
+ * A plugin file must
+ *
+ * - Contain a class that inherits from \Phan\PluginV3
+ *
+ * - End by returning an instance of that class.
+ *
+ * It is assumed without being checked that plugins aren't
+ * mangling state within the passed code base or context.
+ *
+ * Note: When adding new plugins,
+ * add them to the corresponding section of README.md
+ */
+class PHP53CompatibilityPlugin extends PluginV3 implements PostAnalyzeNodeCapability
+{
+
+    /**
+     * @return string - name of PluginAwarePostAnalysisVisitor subclass
+     */
+    public static function getPostAnalyzeNodeVisitorClassName(): string
+    {
+        return PHP53CompatibilityVisitor::class;
+    }
+}
+
+/**
+ * When __invoke on this class is called with a node, a method
+ * will be dispatched based on the `kind` of the given node.
+ *
+ * Visitors such as this are useful for defining lots of different
+ * checks on a node based on its kind.
+ */
+class PHP53CompatibilityVisitor extends PluginAwarePostAnalysisVisitor
+{
+
+    // A plugin's visitors should not override visit() unless they need to.
+
+    /**
+     * @param Node $node
+     * A node to analyze of kind ast\AST_ARRAY
+     * @override
+     */
+    public function visitArray(Node $node): void
+    {
+        if ($node->flags === ast\flags\ARRAY_SYNTAX_SHORT) {
+            $this->emitPluginIssue(
+                $this->code_base,
+                $this->context,
+                'PhanPluginCompatibilityShortArray',
+                "Short arrays ({CODE}) require support for php 5.4+",
+                [ASTReverter::toShortString($node)]
+            );
+        }
+    }
+
+    /**
+     * @param Node $node
+     * A node to analyze of kind ast\AST_ARG_LIST
+     * @override
+     */
+    public function visitArgList(Node $node): void
+    {
+        $lastArg = end($node->children);
+        if ($lastArg instanceof Node && $lastArg->kind === ast\AST_UNPACK) {
+            $this->emitPluginIssue(
+                $this->code_base,
+                $this->context,
+                'PhanPluginCompatibilityArgumentUnpacking',
+                "Argument unpacking ({CODE}) requires support for php 5.6+",
+                [ASTReverter::toShortString($lastArg)]
+            );
+        }
+    }
+
+    /**
+     * @param Node $node
+     * A node to analyze of kind ast\AST_PARAM
+     * @override
+     */
+    public function visitParam(Node $node): void
+    {
+        if ($node->flags & ast\flags\PARAM_VARIADIC) {
+            $this->emitPluginIssue(
+                $this->code_base,
+                $this->context,
+                'PhanPluginCompatibilityVariadicParam',
+                "Variadic functions ({CODE}) require support for php 5.6+",
+                [ASTReverter::toShortString($node)]
+            );
+        }
+    }
+}
+
+// Every plugin needs to return an instance of itself at the
+// end of the file in which it's defined.
+return new PHP53CompatibilityPlugin();

--- a/.phan/plugins/README.md
+++ b/.phan/plugins/README.md
@@ -499,6 +499,21 @@ Checks for complex variable access expressions `$$x`, which may be hard to read,
 
 - **PhanPluginDollarDollar**: Warns about the use of $$x, ${(expr)}, etc.
 
+#### PHP53CompatibilityPlugin.php
+
+Catches common incompatibilities from PHP 5.3 to 5.6.
+**This plugin does not aim to be comprehensive - read the guides on https://www.php.net/manual/en/appendices.php if you need to migrate from php versions older than 5.6**
+
+`InvokePHPNativeSyntaxCheckPlugin` with `'php_native_syntax_check_binaries' => [PHP_BINARY, '/path/to/php53']` in the `'plugin_config'` is a better but slower way to check that syntax used does not cause errors in PHP 5.3.
+
+`backward_compatibility_checks` should also be enabled if migrating a project from php 5 to php 7.
+
+Emitted issue types:
+
+- **PhanPluginCompatibilityShortArray**: `Short arrays ({CODE}) require support for php 5.4+`
+- **PhanPluginCompatibilityArgumentUnpacking**: `Argument unpacking ({CODE}) requires support for php 5.6+`
+- **PhanPluginCompatibilityVariadicParam**: `Variadic functions ({CODE}) require support for php 5.6+`
+
 #### AvoidableGetterPlugin.php
 
 This plugin checks for uses of getters on `$this` that can be avoided inside of a class.

--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,8 @@ New features(Analysis):
 
 Plugins
 + Emit `PhanPluginDuplicateCatchStatementBody` when a catch statement has the same body and variable name as an adjacent catch statement.
++ Add `PHP53CompatibilityPlugin` as a demo plugin to catch common incompatibilities with PHP 5.3. (#915)
+  New issue types: `PhanPluginCompatibilityArgumentUnpacking`, `PhanPluginCompatibilityArgumentUnpacking`, `PhanPluginCompatibilityArgumentUnpacking`
 
 Bug Fixes:
 + Fix bug causing FQSEN names or namespaces to be converted to lowercase even if they were never lowercase in the codebase being analyzed (#3583)

--- a/src/Phan/AST/ASTReverter.php
+++ b/src/Phan/AST/ASTReverter.php
@@ -159,6 +159,25 @@ class ASTReverter
             ast\AST_ARG_LIST => static function (Node $node): string {
                 return '(' . implode(', ', \array_map('self::toShortString', $node->children)) . ')';
             },
+            ast\AST_PARAM_LIST => static function (Node $node): string {
+                return '(' . implode(', ', \array_map('self::toShortString', $node->children)) . ')';
+            },
+            ast\AST_PARAM => static function (Node $node): string {
+                $str = '$' . $node->children['name'];
+                if ($node->flags & ast\flags\PARAM_VARIADIC) {
+                    $str = "...$str";
+                }
+                if ($node->flags & ast\flags\PARAM_REF) {
+                    $str = "&$str";
+                }
+                if (isset($node->children['type'])) {
+                    $str = ASTReverter::toShortString($node->children['type']) . ' ' . $str;
+                }
+                if (isset($node->children['default'])) {
+                    $str .= ' = ' . ASTReverter::toShortString($node->children['default']);
+                }
+                return $str;
+            },
             ast\AST_EXPR_LIST => static function (Node $node): string {
                 return implode(', ', \array_map('self::toShortString', $node->children));
             },

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -236,6 +236,11 @@ class Config
         // [php7cc (no longer maintained)](https://github.com/sstalle/php7cc)
         // and [php7mar](https://github.com/Alexia/php7mar),
         // which have different backwards compatibility checks.
+        //
+        // If you are still using versions of php older than 5.6,
+        // `PHP53CompatibilityPlugin` may be worth looking into if you are not running
+        // syntax checks for php 5.3 through another method such as
+        // `InvokePHPNativeSyntaxCheckPlugin` (see .phan/plugins/README.md).
         'backward_compatibility_checks' => true,
 
         // A set of fully qualified class-names for which


### PR DESCRIPTION
This warns about common mistakes, and doesn't aim to be comprehensive.

E.g. it doesn't check for
https://www.php.net/manual/en/migration56.new-features.php#migration56.new-features.exponentiation

Closes #915