### PR TITLE
Add a `--native-syntax-check=/path/to/php` option.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,13 @@ Phan NEWS
 ??? ?? 2020, Phan 2.7.2 (dev)
 -----------------------
 
+New features(CLI, Config):
++ Add a `--native-syntax-check=/path/to/php` option to enable `InvokePHPNativeSyntaxCheckPlugin`
+  and add that php binary to the `php_native_syntax_check_binaries` array of `plugin_config`
+  (treated here as initially being the empty array if not configured).
+
+  This CLI flag can be repeated to run PHP's native syntax checks with multiple php binaries.
+
 New features(Analysis):
 + Emit `PhanTypeInvalidThrowStatementNonThrowable` when throwing expressions that can't cast to `\Throwable`. (#3853)
 + Include the relevant expression in more issue messages for type errors. (#3844)

--- a/internal/CLI-HELP.md
+++ b/internal/CLI-HELP.md
@@ -391,6 +391,14 @@ Extended help:
   This can be increased to work around race conditions in clients processing Phan issues (e.g. if your editor/IDE shows outdated diagnostics)
   Defaults to 0. (no delay)
 
+ --native-syntax-check </path/to/php_binary>
+  If php_binary (e.g. `php72`, `/usr/bin/php`) can be found in `$PATH`, enables `InvokePHPNativeSyntaxCheckPlugin`
+  and adds `php_binary` (resolved using `$PATH`) to the `php_native_syntax_check_binaries` array of `plugin_config`
+  (treated here as initially being the empty array)
+  Phan exits if any php binary could not be found.
+
+  This can be repeated to run native syntax checks with multiple php versions.
+
  --require-config-exists
   Exit immediately with an error code if `.phan/config.php` does not exist.
 


### PR DESCRIPTION
This makes it easier to run Phan with to run syntax checks
with locally configured php binaries.
(e.g. for regular analysis, or with the daemon/language server)