### PR TITLE
Add DuplicateConstantPlugin to warn about obvious redefinition

### DIFF
--- a/.phan/plugins/DuplicateConstantPlugin.php
+++ b/.phan/plugins/DuplicateConstantPlugin.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+use ast\Node;
+use Phan\PluginV3;
+use Phan\PluginV3\PluginAwarePostAnalysisVisitor;
+use Phan\PluginV3\PostAnalyzeNodeCapability;
+
+/**
+ * This plugin checks for duplicate constant declarations within a statement list.
+ *
+ * This file demonstrates plugins for Phan. Plugins hook into various events.
+ * DuplicateConstantPlugin hooks into one event:
+ *
+ * - getPostAnalyzeNodeVisitorClassName
+ *   This method returns a visitor that is called on every AST node from every
+ *   file being analyzed
+ *
+ * A plugin file must
+ *
+ * - Contain a class that inherits from \Phan\PluginV3
+ *
+ * - End by returning an instance of that class.
+ *
+ * It is assumed without being checked that plugins aren't
+ * mangling state within the passed code base or context.
+ *
+ * Note: When adding new plugins,
+ * add them to the corresponding section of README.md
+ */
+class DuplicateConstantPlugin extends PluginV3 implements PostAnalyzeNodeCapability
+{
+
+    /**
+     * @return string - name of PluginAwarePostAnalysisVisitor subclass
+     */
+    public static function getPostAnalyzeNodeVisitorClassName(): string
+    {
+        return DuplicateConstantVisitor::class;
+    }
+}
+
+/**
+ * When __invoke on this class is called with a node, a method
+ * will be dispatched based on the `kind` of the given node.
+ *
+ * Visitors such as this are useful for defining lots of different
+ * checks on a node based on its kind.
+ */
+class DuplicateConstantVisitor extends PluginAwarePostAnalysisVisitor
+{
+
+    // A plugin's visitors should not override visit() unless they need to.
+
+    /**
+     * @param Node $node
+     * A node to analyze of kind ast\AST_STMT_LIST
+     * @override
+     */
+    public function visitStmtList(Node $node): void
+    {
+        if (count($node->children) <= 1) {
+            return;
+        }
+        $declarations = [];
+
+        foreach ($node->children as $child) {
+            if (!$child instanceof Node) {
+                continue;
+            }
+            if ($child->kind === ast\AST_CONST_DECL) {
+                foreach ($child->children as $const) {
+                    if (!$const instanceof Node) {
+                        continue;
+                    }
+                    $name = (string) $const->children['name'];
+                    if (isset($declarations[$name])) {
+                        $this->warnDuplicateConstant($name, $declarations[$name], $const);
+                    } else {
+                        $declarations[$name] = $const;
+                    }
+                }
+            } elseif ($child->kind === ast\AST_CALL) {
+                $expr = $child->children['expr'];
+                if ($expr instanceof Node && $expr->kind === ast\AST_NAME && strcasecmp((string) $expr->children['name'], 'define') === 0) {
+                    $name = $child->children['args']->children[0] ?? null;
+                    if (is_string($name)) {
+                        if (isset($declarations[$name])) {
+                            $this->warnDuplicateConstant($name, $declarations[$name], $expr);
+                        } else {
+                            $declarations[$name] = $expr;
+                        }
+                    }
+
+                }
+            }
+        }
+    }
+
+    private function warnDuplicateConstant(string $name, Node $original_def, Node $new_def): void
+    {
+        $this->emitPluginIssue(
+            $this->code_base,
+            (clone $this->context)->withLineNumberStart($new_def->lineno),
+            'PhanPluginDuplicateConstant',
+            'Constant {CONST} was previously declared at line {LINE} - the previous declaration will be used instead',
+            [$name, $original_def->lineno]
+        );
+    }
+}
+
+// Every plugin needs to return an instance of itself at the
+// end of the file in which it's defined.
+return new DuplicateConstantPlugin();

--- a/.phan/plugins/README.md
+++ b/.phan/plugins/README.md
@@ -514,6 +514,12 @@ Emitted issue types:
 - **PhanPluginCompatibilityArgumentUnpacking**: `Argument unpacking ({CODE}) requires support for php 5.6+`
 - **PhanPluginCompatibilityVariadicParam**: `Variadic functions ({CODE}) require support for php 5.6+`
 
+#### DuplicateConstantPlugin.php
+
+Checks for duplicate constant names for calls to `define()` or `const X =` within the same statement list.
+
+- **PhanPluginDuplicateConstant**: `Constant {CONST} was previously declared at line {LINE} - the previous declaration will be used instead`
+
 #### AvoidableGetterPlugin.php
 
 This plugin checks for uses of getters on `$this` that can be avoided inside of a class.

--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,7 @@ Plugins
 + Emit `PhanPluginDuplicateCatchStatementBody` when a catch statement has the same body and variable name as an adjacent catch statement.
 + Add `PHP53CompatibilityPlugin` as a demo plugin to catch common incompatibilities with PHP 5.3. (#915)
   New issue types: `PhanPluginCompatibilityArgumentUnpacking`, `PhanPluginCompatibilityArgumentUnpacking`, `PhanPluginCompatibilityArgumentUnpacking`
++ Add `DuplicateConstantPlugin` to warn about duplicate constant names (`define('X', value)` or `const X = value`) in the same statement list.
 
 Bug Fixes:
 + Fix bug causing FQSEN names or namespaces to be converted to lowercase even if they were never lowercase in the codebase being analyzed (#3583)

--- a/tests/plugin_test/.phan/config.php
+++ b/tests/plugin_test/.phan/config.php
@@ -146,5 +146,6 @@ return [
         'LoopVariableReusePlugin',
         'RedundantAssignmentPlugin',
         'UnknownClassElementAccessPlugin',
+        'DuplicateConstantPlugin',
     ],
 ];

--- a/tests/plugin_test/expected/174_duplicate_constants.php.expected
+++ b/tests/plugin_test/expected/174_duplicate_constants.php.expected
@@ -1,0 +1,7 @@
+src/174_duplicate_constants.php:3 PhanUnreferencedConstant Possibly zero references to global constant \S174
+src/174_duplicate_constants.php:4 PhanUnreferencedConstant Possibly zero references to global constant \T174
+src/174_duplicate_constants.php:5 PhanUnreferencedConstant Possibly zero references to global constant \U174
+src/174_duplicate_constants.php:5 PhanUnreferencedConstant Possibly zero references to global constant \V174
+src/174_duplicate_constants.php:6 PhanPluginDuplicateConstant Constant S174 was previously declared at line 3 - the previous declaration will be used instead
+src/174_duplicate_constants.php:7 PhanPluginDuplicateConstant Constant T174 was previously declared at line 4 - the previous declaration will be used instead
+src/174_duplicate_constants.php:8 PhanPluginDuplicateConstant Constant V174 was previously declared at line 5 - the previous declaration will be used instead

--- a/tests/plugin_test/src/174_duplicate_constants.php
+++ b/tests/plugin_test/src/174_duplicate_constants.php
@@ -1,0 +1,8 @@
+<?php
+// Tests of DuplicateConstantPlugin
+define('S174', 'value');
+define('T174', 'value');
+const U174 = 'value', V174 = [];
+define('S174', 'value');
+define('T174', 'other value');
+const V174 = [123];


### PR DESCRIPTION
(only within the same statement list. Ignores inner/outer blocks)