### PR TITLE
Release 3.0.0-RC1

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -39,7 +39,7 @@ cache:
 branches:
   only:
     - master
-    - v2
+    - v3
 
 install:
 - cmd: choco feature enable -n=allowGlobalConfirmation

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,13 @@
 Phan NEWS
 
-??? ?? 2020, Phan 3.0.0 (dev)
+May 02 2020, Phan 3.0.0-RC1
 -----------------------
 
 Backwards incompatible changes:
-+ Drop php 7.1 support. Official security support for php 7.1 ended in November 2019.
++ Drop PHP 7.1 support.  PHP 7.1 reached its end of life for security support in December 2019.
+  Many of Phan's dependencies no longer publish releases supporting php 7.1,
+  which will likely become a problem running Phan with future 8.x versions
+  (e.g. in the published phar releases).
 + Drop PluginV2 support (which was deprecated in Phan 2) in favor of PluginV3.
 + Remove deprecated classes and helper methods.
 

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -79,7 +79,7 @@ class CLI
     /**
      * This should be updated to x.y.z-dev after every release, and x.y.z before a release.
      */
-    public const PHAN_VERSION = '3.0.0-dev';
+    public const PHAN_VERSION = '3.0.0-RC1';
 
     /**
      * List of short flags passed to getopt


### PR DESCRIPTION
Note that the `v3` branch will stop being used once 3.0.0 is out.

See https://github.com/phan/phan/pull/3879 and #2358