### PR TITLE
Add stricter options for PregRegexCheckerPlugin

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -512,6 +512,10 @@ return [
 
         // Automatically infer which methods are pure (i.e. should have no side effects) in UseReturnValuePlugin.
         'infer_pure_methods' => true,
+
+        // Warn if newline is allowed before end of string for `$` (the default unless the `S` modifier (`PCRE_DOLLAR_ENDONLY`) is passed in).
+        // This is specific to coding styles.
+        'regex_warn_if_newline_allowed_at_end' => true,
     ],
 
     // A list of plugin files to execute

--- a/.phan/plugins/InvokePHPNativeSyntaxCheckPlugin.php
+++ b/.phan/plugins/InvokePHPNativeSyntaxCheckPlugin.php
@@ -36,7 +36,7 @@ class InvokePHPNativeSyntaxCheckPlugin extends PluginV3 implements
     BeforeAnalyzeFileCapability,
     FinalizeProcessCapability
 {
-    private const LINE_NUMBER_REGEX = "@ on line ([1-9][0-9]*)$@";
+    private const LINE_NUMBER_REGEX = "@ on line ([1-9][0-9]*)$@S";
     private const STDIN_FILENAME_REGEX = "@ in (Standard input code|-)@";
 
     /**

--- a/.phan/plugins/README.md
+++ b/.phan/plugins/README.md
@@ -82,6 +82,8 @@ This plugin is able to resolve literals, global constants, and class constants a
 
 - **PhanPluginInvalidPregRegex**: The provided regex is invalid, according to PHP.
 - **PhanPluginInvalidPregRegexReplacement**: The replacement string template of `preg_replace` refers to a match group that doesn't exist. (e.g. `preg_replace('/x(a)/', 'y$2', $strVal)`)
+- **PhanPluginRegexDollarAllowsNewline**: `Call to {FUNCTION} used \'$\' in {STRING_LITERAL}, which allows a newline character \'\n\' before the end of the string. Add S to qualifiers to forbid the newline, m to match any newline, or suppress this issue if this is deliberate`
+  (This issue type is specific to coding style, and only checked for when configuration includes `['plugin_config' => ['regex_warn_if_newline_allowed_at_end' => true]]`)
 
 #### PrintfCheckerPlugin
 

--- a/.phan/plugins/WhitespacePlugin.php
+++ b/.phan/plugins/WhitespacePlugin.php
@@ -46,7 +46,7 @@ class WhitespacePlugin extends PluginV3 implements
         string $file_contents,
         Node $node
     ): void {
-        if (!preg_match('/[\r\t]|[ \t]\r?$/m', $file_contents)) {
+        if (!preg_match('/[\r\t]|[ \t]\r?$/mS', $file_contents)) {
             // Typical case: no errors
             return;
         }
@@ -68,7 +68,7 @@ class WhitespacePlugin extends PluginV3 implements
                 'The first occurrence of a tab was seen here. Running "expand" can fix that.'
             );
         }
-        if (preg_match('/[ \t]\r?$/m', $file_contents, $match, PREG_OFFSET_CAPTURE)) {
+        if (preg_match('/[ \t]\r?$/mS', $file_contents, $match, PREG_OFFSET_CAPTURE)) {
             self::emitIssue(
                 $code_base,
                 clone($context)->withLineNumberStart(self::calculateLine($file_contents, $match[0][1])),

--- a/.phan/plugins/WhitespacePlugin/fixers.php
+++ b/.phan/plugins/WhitespacePlugin/fixers.php
@@ -77,7 +77,7 @@ return [
         foreach (explode("\n", $raw_contents) as $line_contents) {
             $new_byte_offset = $byte_offset + strlen($line_contents) + 1;
             $line_contents = rtrim($line_contents, "\r");
-            if (preg_match('/\s+$/', $line_contents, $matches)) {
+            if (preg_match('/\s+$/S', $line_contents, $matches)) {
                 $len = strlen($matches[0]);
                 $offset = $byte_offset + strlen($line_contents) - $len;
                 // Remove 1 or more bytes of trailing whitespace from each line

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@ Miscellaneous:
 
 Plugins:
 + Add `AnalyzeLiteralStatementCapability` for plugins to analyze no-op string literals (#3911)
++ In `PregRegexCheckerPlugin`, warn if `$` allows an optional newline before the end of the string
+  when configuration includes `['plugin_config' => ['regex_warn_if_newline_allowed_at_end' => true]]`) (#3915)
 
 May 09 2020, Phan 3.0.0
 -----------------------
@@ -75,7 +77,7 @@ New features(Analysis):
   (e.g. `is_string($arg) || throw new InvalidArgumentException()`)
   Emit `PhanCompatibleThrowException` when `throw` is used as an expression instead of a statement.
 
-Plugins
+Plugins:
 + Emit `PhanPluginDuplicateCatchStatementBody` in `DuplicateExpressionPlugin` when a catch statement has the same body and variable name as an adjacent catch statement.
   (This should be suppressed in projects that support php 7.0 or older)
 + Add `PHP53CompatibilityPlugin` as a demo plugin to catch common incompatibilities with PHP 5.3. (#915)

--- a/internal/lib/IncompatibleXMLSignatureDetector.php
+++ b/internal/lib/IncompatibleXMLSignatureDetector.php
@@ -220,7 +220,7 @@ class IncompatibleXMLSignatureDetector extends IncompatibleSignatureDetectorBase
                         $remaining_folders[] = $path;
                         continue;
                     }
-                    if (!preg_match('/\.xml$/', $basename)) {
+                    if (!preg_match('/\.xml$/S', $basename)) {
                         continue;
                     }
                     $contents = (string)$this->fileGetContents($path);

--- a/internal/sanitycheck.php
+++ b/internal/sanitycheck.php
@@ -202,7 +202,7 @@ function check_fields(string $function_name, array $fields, array $signatures): 
     }
 
     $original_function_name = $function_name;
-    $function_name = preg_replace("/'\\d+$/", "", $function_name);
+    $function_name = preg_replace("/'\\d+$/S", "", $function_name);
     // echo $function_name . "\n";
     try {
         $function = load_internal_function($function_name);

--- a/src/Phan/AST/InferPureVisitor.php
+++ b/src/Phan/AST/InferPureVisitor.php
@@ -397,7 +397,7 @@ class InferPureVisitor extends AnalysisVisitor
         } elseif ($var->kind === ast\AST_PROP) {
             // Functions that assign to properties aren't pure,
             // unless assigning to $this->prop in a constructor.
-            if (\preg_match('/::__construct$/i', $this->function_fqsen_label)) {
+            if (\preg_match('/::__construct$/iS', $this->function_fqsen_label)) {
                 $name = $var->children['expr'];
                 if ($name instanceof Node && $name->kind === ast\AST_VAR && $name->children['name'] === 'this') {
                     return;

--- a/src/Phan/AST/Parser.php
+++ b/src/Phan/AST/Parser.php
@@ -280,7 +280,7 @@ class Parser
         $message = $native_parse_error->getMessage();
         if (!\preg_match("/ unexpected '(.+)' \((T_\w+)\)/", $message, $matches)) {
             if (!\preg_match("/ unexpected '(.+)', expecting/", $message, $matches)) {
-                if (!\preg_match("/ unexpected '(.+)'$/", $message, $matches)) {
+                if (!\preg_match("/ unexpected '(.+)'$/S", $message, $matches)) {
                     return 0;
                 }
             }

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -1065,7 +1065,7 @@ class TolerantASTConverter
                     '@phan-var Token $part';
                     $imploded_parts = static::tokenToString($part);
                     if ($part->kind === TokenKind::Name) {
-                        if (\preg_match('@^__(LINE|FILE|DIR|FUNCTION|CLASS|TRAIT|METHOD|NAMESPACE)__$@i', $imploded_parts) > 0) {
+                        if (\preg_match('@^__(LINE|FILE|DIR|FUNCTION|CLASS|TRAIT|METHOD|NAMESPACE)__$@iS', $imploded_parts) > 0) {
                             return new ast\Node(
                                 ast\AST_MAGIC_CONST,
                                 self::MAGIC_CONST_LOOKUP[\strtoupper($imploded_parts)],
@@ -1110,7 +1110,7 @@ class TolerantASTConverter
                     if ($as_int !== false) {
                         return $as_int;
                     }
-                    if (\preg_match('/^0[0-7]+$/', $text)) {
+                    if (\preg_match('/^0[0-7]+$/S', $text)) {
                         // this is octal - FILTER_VALIDATE_FLOAT would treat it like decimal
                         return \intval($text, 8);
                     }

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -848,7 +848,7 @@ class CLI
                     Config::setValue('__parser_keep_original_node', true);
                     break;
                 case 'memory-limit':
-                    if (\preg_match('@^([1-9][0-9]*)([KMG])?$@', $value, $match)) {
+                    if (\preg_match('@^([1-9][0-9]*)([KMG])?$@S', $value, $match)) {
                         \ini_set('memory_limit', $value);
                     } else {
                         fwrite(STDERR, "Invalid --memory-limit '$value', ignoring\n");
@@ -1020,7 +1020,7 @@ class CLI
             $opt_set['-' . \rtrim($opt, ':')] = true;
         }
         foreach (array_slice($argv, 1) as $arg) {
-            $arg = \preg_replace('/=.*$/', '', $arg);
+            $arg = \preg_replace('/=.*$/S', '', $arg);
             if (\array_key_exists($arg, $opt_set)) {
                 self::printHelpSection(
                     "WARNING: Saw suspicious CLI arg '$arg' (did you mean '-$arg')\n",

--- a/src/Phan/Config/Initializer.php
+++ b/src/Phan/Config/Initializer.php
@@ -485,7 +485,7 @@ EOT;
                 }
                 $composer_lib_relative_path = \trim(\str_replace(\DIRECTORY_SEPARATOR, '/', $composer_lib_relative_path), '/');
 
-                $composer_lib_relative_path = \preg_replace('@(/+\.)+$@', '', $composer_lib_relative_path);
+                $composer_lib_relative_path = \preg_replace('@(/+\.)+$@S', '', $composer_lib_relative_path);
                 if (\is_dir($composer_lib_absolute_path)) {
                     $directory_list[] = \trim($composer_lib_relative_path, '/');
                 } elseif (\is_file($composer_lib_relative_path)) {

--- a/src/Phan/Daemon/Request.php
+++ b/src/Phan/Daemon/Request.php
@@ -241,7 +241,7 @@ class Request
             // $len = strlen($line ?? ''); fwrite(STDERR, "Looking at $line : $position of $len\n");
             if (is_string($line) && strlen($line) === $position->character + 1 && $position->character > 0) {
                 // fwrite(STDERR, "cursor at the end of the line\n");
-                if (\preg_match('/(::|->)$/', $line, $matches)) {
+                if (\preg_match('/(::|->)$/S', $line, $matches)) {
                     // fwrite(STDERR, "Updating the file\n");
                     if ($matches[1] === '::') {
                         $addition = TolerantASTConverter::INCOMPLETE_CLASS_CONST;

--- a/src/Phan/Language/Element/AddressableElement.php
+++ b/src/Phan/Language/Element/AddressableElement.php
@@ -328,7 +328,7 @@ abstract class AddressableElement extends TypedElement implements AddressableEle
             if (!\preg_match('/@deprecated\b/', $this->doc_comment, $matches, \PREG_OFFSET_CAPTURE)) {
                 return '';
             }
-            $doc_comment = \preg_replace('@(^/\*)|(\*/$)@', '', $this->doc_comment);
+            $doc_comment = \preg_replace('@(^/\*)|(\*/$)@S', '', $this->doc_comment);
             $lines = \explode("\n", $doc_comment);
             foreach ($lines as $i => $line) {
                 $line = MarkupDescription::trimLine($line);

--- a/src/Phan/Language/Element/Comment/Builder.php
+++ b/src/Phan/Language/Element/Comment/Builder.php
@@ -155,7 +155,7 @@ final class Builder
                 if ($is_var && $variable_name === '' && $this->comment_type === Comment::ON_PROPERTY) {
                     $end_offset = (int)\strpos($line, $match[0]) + \strlen($match[0]);
                     $char_at_end_offset = $line[$end_offset] ?? ' ';
-                    if (\ord($char_at_end_offset) > 32 && !\preg_match('@^\*+/$@', (string)\substr($line, $end_offset))) {  // Not a control character or space
+                    if (\ord($char_at_end_offset) > 32 && !\preg_match('@^\*+/$@S', (string)\substr($line, $end_offset))) {  // Not a control character or space
                         $this->emitIssue(
                             Issue::UnextractableAnnotationSuffix,
                             $this->guessActualLineLocation($i),
@@ -234,7 +234,7 @@ final class Builder
             $raw_match = $match[0];
             $end_offset = (int)\strpos($line, $raw_match) + \strlen($raw_match);
             $char_at_end_offset = $line[$end_offset] ?? ' ';
-            if (\ord($char_at_end_offset) > 32 && !\preg_match('@^\*+/$@', (string)\substr($line, $end_offset))) {  // Not a control character or space
+            if (\ord($char_at_end_offset) > 32 && !\preg_match('@^\*+/$@S', (string)\substr($line, $end_offset))) {  // Not a control character or space
                 $this->emitIssue(
                     Issue::UnextractableAnnotationSuffix,
                     $this->guessActualLineLocation($i),
@@ -372,7 +372,7 @@ final class Builder
         // https://secure.php.net/manual/en/regexp.reference.internal-options.php
         // (?i) makes this case-sensitive, (?-1) makes it case-insensitive
         // phpcs:ignore Generic.Files.LineLength.MaxExceeded
-        if (\preg_match('/@((?i)param|deprecated|var|return|throws|throw|returns|inherits|extends|suppress|phan-[a-z0-9_-]*(?-i)|method|property|property-read|property-write|template|PhanClosureScope|readonly|mixin|seal-(?:methods|properties))(?:[^a-zA-Z0-9_\x7f-\xff-]|$)/', $line, $matches)) {
+        if (\preg_match('/@((?i)param|deprecated|var|return|throws|throw|returns|inherits|extends|suppress|phan-[a-z0-9_-]*(?-i)|method|property|property-read|property-write|template|PhanClosureScope|readonly|mixin|seal-(?:methods|properties))(?:[^a-zA-Z0-9_\x7f-\xff-]|$)/S', $line, $matches)) {
             $case_sensitive_type = $matches[1];
             $type = \strtolower($case_sensitive_type);
 

--- a/src/Phan/Language/Element/GlobalConstant.php
+++ b/src/Phan/Language/Element/GlobalConstant.php
@@ -152,7 +152,7 @@ class GlobalConstant extends AddressableElement implements ConstantInterface
             $comment = '  // could not find';
         }
         $namespace = \ltrim($this->getFQSEN()->getNamespace(), '\\');
-        if (\preg_match('@^[a-zA-Z_\x7f-\xff\\\][a-zA-Z0-9_\x7f-\xff\\\]*$@', $name)) {
+        if (\preg_match('@^[a-zA-Z_\x7f-\xff\\\][a-zA-Z0-9_\x7f-\xff\\\]*$@S', $name)) {
             $string = "const $name = $repr;$comment\n";
         } else {
             // Internal extension defined a constant with an invalid identifier.

--- a/src/Phan/Language/Element/MarkupDescription.php
+++ b/src/Phan/Language/Element/MarkupDescription.php
@@ -271,13 +271,13 @@ class MarkupDescription
         //
         // We leave in the second `*` of `/**` so that every single non-empty line
         // of a typical doc comment will begin with a `*`
-        $doc_comment = \preg_replace('@(^/\*)|(\*/$)@', '', $doc_comment);
+        $doc_comment = \preg_replace('@(^/\*)|(\*/$)@S', '', $doc_comment);
 
         $results = [];
         $lines = \explode("\n", $doc_comment);
         foreach ($lines as $i => $line) {
             $line = self::trimLine($line);
-            if (\preg_match('/^\s*@param(\s|$)/', $line) > 0) {
+            if (\preg_match('/^\s*@param(\s|$)/S', $line) > 0) {
                 // Extract all of the (at)param annotations.
                 $param_tag_summary = self::extractTagSummary($lines, $i);
                 if (\end($param_tag_summary) === '') {
@@ -324,7 +324,7 @@ class MarkupDescription
         //
         // We leave in the second `*` of `/**` so that every single non-empty line
         // of a typical doc comment will begin with a `*`
-        $doc_comment = \preg_replace('@(^/\*)|(\*/$)@', '', $doc_comment);
+        $doc_comment = \preg_replace('@(^/\*)|(\*/$)@S', '', $doc_comment);
 
         $lines = \explode("\n", $doc_comment);
         $lines = \array_map('trim', $lines);
@@ -351,7 +351,7 @@ class MarkupDescription
         //
         // We leave in the second `*` of `/**` so that every single non-empty line
         // of a typical doc comment will begin with a `*`
-        $doc_comment = \preg_replace('@(^/\*)|(\*/$)@', '', $doc_comment);
+        $doc_comment = \preg_replace('@(^/\*)|(\*/$)@S', '', $doc_comment);
 
         $results = [];
         $lines = \explode("\n", $doc_comment);
@@ -379,7 +379,7 @@ class MarkupDescription
                     } elseif (\in_array($comment_category, Comment::FUNCTION_LIKE, true)) {
                         // Treat `@return T description of return value` as a valid single-line comment of closures, functions, and methods.
                         // Variables don't currently have associated comments
-                        if (\preg_match('/^\s*@return(\s|$)/', $line) > 0) {
+                        if (\preg_match('/^\s*@return(\s|$)/S', $line) > 0) {
                             $new_lines = self::extractTagSummary($lines, $i);
                             if (isset($new_lines[0])) {
                                 // @phan-suppress-next-line PhanAccessClassConstantInternal

--- a/src/Phan/Language/FQSEN/FullyQualifiedClassName.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedClassName.php
@@ -50,7 +50,7 @@ class FullyQualifiedClassName extends FullyQualifiedGlobalStructuralElement
         );
     }
 
-    public const VALID_CLASS_REGEX = '/^\\\\?[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*(\\\\[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)*$/';
+    public const VALID_CLASS_REGEX = '/^\\\\?[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*(\\\\[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)*$/S';
 
     /**
      * Asserts that something is a valid class FQSEN in PHPDoc.

--- a/src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php
@@ -71,9 +71,9 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN
     }
 
     /** @internal */
-    public const VALID_STRUCTURAL_ELEMENT_REGEX = '/^\\\\?[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*(\\\\[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)*$/';
+    public const VALID_STRUCTURAL_ELEMENT_REGEX = '/^\\\\?[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*(\\\\[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)*$/S';
     /** @internal */
-    public const VALID_STRUCTURAL_ELEMENT_REGEX_PART = '/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/';
+    public const VALID_STRUCTURAL_ELEMENT_REGEX_PART = '/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/S';
 
     /**
      * Construct a fully-qualified global structural element from a namespace and name.

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -947,7 +947,7 @@ class Type
         $template_parameter_type_name_list = $tuple->_2;
         $is_nullable = $tuple->_3;
         $shape_components = $tuple->_4;
-        if (\preg_match('/^(' . self::noncapturing_literal_regex . ')$/', $type_name)) {
+        if (\preg_match('/^(' . self::noncapturing_literal_regex . ')$/S', $type_name)) {
             return self::fromEscapedLiteralScalar($type_name);
         }
         if (\is_array($shape_components)) {
@@ -1340,7 +1340,7 @@ class Type
         $shape_components = $tuple->_4;
 
 
-        if (\preg_match('/^(' . self::noncapturing_literal_regex . ')$/', $type_name)) {
+        if (\preg_match('/^(' . self::noncapturing_literal_regex . ')$/S', $type_name)) {
             return self::fromEscapedLiteralScalar($type_name);
         }
 
@@ -2008,7 +2008,7 @@ class Type
     ): bool {
         // Note: While 'self' and 'parent' are case-insensitive, '$this' is case-sensitive
         // Not sure if that should extend to phpdoc.
-        return \preg_match('/^\\\\?([sS][eE][lL][fF]|[pP][aA][rR][eE][nN][tT]|\$this)$/', $type_string) > 0;
+        return \preg_match('/^\\\\?([sS][eE][lL][fF]|[pP][aA][rR][eE][nN][tT]|\$this)$/S', $type_string) > 0;
     }
 
     /**
@@ -2026,7 +2026,7 @@ class Type
     ): bool {
         // Note: While 'self' and 'parent' are case-insensitive, '$this' is case-sensitive
         // Not sure if that should extend to phpdoc.
-        return \preg_match('/^\\\\?([sS][tT][aA][tT][iI][cC]|\\$this)$/', $type_string) > 0;
+        return \preg_match('/^\\\\?([sS][tT][aA][tT][iI][cC]|\\$this)$/S', $type_string) > 0;
     }
 
     /**
@@ -3488,7 +3488,7 @@ class Type
         $result = [];
         foreach (self::extractNameList($shape_component_string) as $shape_component) {
             // Because these can be nested, there may be more than one ':'. Only consider the first.
-            if (preg_match('/^(' . self::shape_key_regex . ')\s*:\s*(.*)$/', $shape_component, $parts)) {
+            if (preg_match('/^(' . self::shape_key_regex . ')\s*:\s*(.*)$/S', $shape_component, $parts)) {
                 $field_name = $parts[1];
                 $field_value = \trim($parts[2]);
                 if ($field_value === '') {

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -451,7 +451,7 @@ class UnionType implements Serializable
         foreach (self::extractTypeParts($type_string) as $type_name) {
             // Exclude empty type names
             // Exclude namespaces without type names (e.g. `\`, `\NS\`)
-            if ($type_name === '' || \preg_match('@\\\\[\[\]]*$@', $type_name)) {
+            if ($type_name === '' || \preg_match('@\\\\[\[\]]*$@S', $type_name)) {
                 $parts[] = $type_name;
                 continue;
             }
@@ -3436,7 +3436,7 @@ class UnionType implements Serializable
         $is_possibly_string = false;
         foreach ($type_set as $type) {
             if ($type instanceof LiteralStringType) {
-                if (!\preg_match(FullyQualifiedClassName::VALID_CLASS_REGEX, $type->getValue()) && !\preg_match('/^\\\\?oci-(lob|collection)$/i', $type->getValue())) {
+                if (!\preg_match(FullyQualifiedClassName::VALID_CLASS_REGEX, $type->getValue()) && !\preg_match('/^\\\\?oci-(lob|collection)$/iS', $type->getValue())) {
                     continue;
                 }
                 $result[] = $type->withIsNullable(false);

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -841,7 +841,7 @@ final class ConfigPluginSet extends PluginV3 implements
      */
     public static function normalizePluginPath(string $plugin_file_name): string
     {
-        if (\preg_match('@^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$@', $plugin_file_name) > 0) {
+        if (\preg_match('@^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$@S', $plugin_file_name) > 0) {
             $plugin_file_name = self::getBuiltinPluginDirectory() . '/' . $plugin_file_name . '.php';
         }
         if (\preg_match('@^phar://@', $plugin_file_name)) {

--- a/src/Phan/Plugin/Internal/UseReturnValuePlugin.php
+++ b/src/Phan/Plugin/Internal/UseReturnValuePlugin.php
@@ -136,7 +136,7 @@ class UseReturnValuePlugin extends PluginV3 implements PostAnalyzeNodeCapability
             if ($unused_count > 0 && $used_percentage >= $threshold_percentage) {
                 $percentage_string = \number_format($used_percentage, 2);
                 foreach ($counter->unused_locations as $key => $context) {
-                    if (!\preg_match('/:(\d+)$/', $key, $matches)) {
+                    if (!\preg_match('/:(\d+)$/S', $key, $matches)) {
                         \fprintf(\STDERR, "Failed to extract line number from %s\n", $key);
                         continue;
                     }

--- a/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
+++ b/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
@@ -326,7 +326,7 @@ final class VariableTrackerElementVisitor extends PluginAwarePostAnalysisVisitor
             if ($variable_name === 'this') {
                 continue;
             }
-            if (\preg_match('/^(_$|(unused|raii))/i', $variable_name) > 0) {
+            if (\preg_match('/^(_$|(unused|raii))/iS', $variable_name) > 0) {
                 // Skip over $_, $unused*, and $raii*
                 continue;
             }

--- a/tests/Phan/AbstractPhanFileTest.php
+++ b/tests/Phan/AbstractPhanFileTest.php
@@ -81,7 +81,7 @@ abstract class AbstractPhanFileTest extends CodeBaseAwareTest
             \scandir($source_dir) ?: [],
             static function (string $filename): bool {
                 // Ignore directories and hidden files.
-                return !in_array($filename, ['.', '..'], true) && \substr($filename, 0, 1) !== '.' && \preg_match('@\.php$@', $filename);
+                return !in_array($filename, ['.', '..'], true) && \substr($filename, 0, 1) !== '.' && \preg_match('@\.php$@S', $filename);
             }
         );
 

--- a/tests/Phan/Internal/ConfigEntry.php
+++ b/tests/Phan/Internal/ConfigEntry.php
@@ -200,7 +200,7 @@ class ConfigEntry
     {
         $result = '';
         foreach ($this->lines as $line) {
-            $line = preg_replace('@^//( |$)@', '', trim($line));
+            $line = preg_replace('@^//( |$)@S', '', trim($line));
             $result .= $line . "\n";
         }
         $result = preg_replace_callback(

--- a/tests/Phan/Internal/WikiIssueTypesTest.php
+++ b/tests/Phan/Internal/WikiIssueTypesTest.php
@@ -219,7 +219,7 @@ EOT;
         );
         $records = [];
         foreach ($files as $expected_filename) {
-            $src_filename = preg_replace('@/expected/(.*\.php)\.expected$@', '/src/\1', $expected_filename);
+            $src_filename = preg_replace('@/expected/(.*\.php)\.expected$@S', '/src/\1', $expected_filename);
             // try {
             $records[] = new UnitTestRecord($src_filename, $expected_filename);
             // } catch (RuntimeException $e) { fwrite(STDERR, $e->getMessage()); }
@@ -235,7 +235,7 @@ EOT;
             $issues = $record->getIssues();
             krsort($issues);
             foreach ($issues as $expected_file_lineno => [$ref, $issue_name, $unused_description]) {
-                if (preg_match('/[0-9]+$/', $ref, $matches)) {
+                if (preg_match('/[0-9]+$/S', $ref, $matches)) {
                     $src_file_lineno = (int)$matches[0];
                     $examples[$issue_name] = [$record, $src_file_lineno, $expected_file_lineno];
                 }

--- a/tests/Phan/Language/Internal/FunctionSignatureMapTest.php
+++ b/tests/Phan/Language/Internal/FunctionSignatureMapTest.php
@@ -18,11 +18,11 @@ use function is_string;
  */
 final class FunctionSignatureMapTest extends CodeBaseAwareTest
 {
-    private const FUNCTION_KEY_REGEX = '/^[a-z_][a-z0-9_]*(\\\\[a-z_][a-z0-9_]*)*(::[a-z_][a-z0-9_]*)?(\'[1-9][0-9]*)?$/i';
-    private const PARAM_KEY_REGEX = '/^\&?(\.\.\.)?[a-z_][a-z0-9_]*=?$/i';
+    private const FUNCTION_KEY_REGEX = '/^[a-z_][a-z0-9_]*(\\\\[a-z_][a-z0-9_]*)*(::[a-z_][a-z0-9_]*)?(\'[1-9][0-9]*)?$/iS';
+    private const PARAM_KEY_REGEX = '/^\&?(\.\.\.)?[a-z_][a-z0-9_]*=?$/iS';
 
     // Matches a union type of 0 or more parts.
-    private const ONLY_UNION_TYPE_REGEX = '/^(' . UnionType::union_type_regex . ')?$/';
+    private const ONLY_UNION_TYPE_REGEX = '/^(' . UnionType::union_type_regex . ')?$/S';
 
     /**
      * @dataProvider phpVersionIdProvider

--- a/tests/Phan/Language/Internal/PropertyMapTest.php
+++ b/tests/Phan/Language/Internal/PropertyMapTest.php
@@ -16,12 +16,12 @@ use function is_string;
  */
 final class PropertyMapTest extends BaseTest
 {
-    private const CLASS_NAME_LOWER_REGEX = '/^([a-z_][a-z0-9_]*(\\\\[a-z_][a-z0-9_]*)*|\*)$/';
+    private const CLASS_NAME_LOWER_REGEX = '/^([a-z_][a-z0-9_]*(\\\\[a-z_][a-z0-9_]*)*|\*)$/S';
 
-    private const PROPERTY_KEY_REGEX = '/^([a-z_][a-z0-9_]*|\*)$/i';
+    private const PROPERTY_KEY_REGEX = '/^([a-z_][a-z0-9_]*|\*)$/iS';
 
     // Matches a union type of 0 or more parts.
-    private const ONLY_UNION_TYPE_REGEX = '/^(' . UnionType::union_type_regex . ')?$/';
+    private const ONLY_UNION_TYPE_REGEX = '/^(' . UnionType::union_type_regex . ')?$/S';
 
     public function testPropertySignatureMap(): void
     {

--- a/tests/Phan/PluginV3Test.php
+++ b/tests/Phan/PluginV3Test.php
@@ -19,7 +19,7 @@ final class PluginV3Test extends BaseTest
 
         $capabilities = [];
         foreach (\scandir(\dirname(__DIR__, 2) . '/src/Phan/PluginV3') as $file) {
-            if (!\preg_match('/^(\w+Capability)\.php$/', $file, $matches)) {
+            if (!\preg_match('/^(\w+Capability)\.php$/S', $file, $matches)) {
                 continue;
             }
             $capabilities[] = $matches[1];


### PR DESCRIPTION
Be strict about matching the end of strings in regexes

By default, `$` will allow an optional `\n` character before the end of
the string.

Because of that, `preg_replace('/thing$/', '', "something\n")` is `"some\n"`,
which is unexpected for Phan's use cases.

Fixes #3915