### PR TITLE
Fix what Context is passed to analyzeLoopBeforeBody

### DIFF
--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -981,7 +981,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
         // Give plugins a chance to analyze the loop condition now
         ConfigPluginSet::instance()->analyzeLoopBeforeBody(
             $code_base,
-            $context,
+            $inner_context,
             $node
         );
 


### PR DESCRIPTION
I mistakenly used $context, but that's the same Context that was passed to PreAnalysisVisitor, not the updated one.