### PR TITLE
Clone PassByReferenceVariable's in AssignmentVisitor::visitVar

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@ New features(Analysis):
 + Avoid false positives in `--constant-variable-detection` for `++`/`--`
 + Make `if (!$nullableValue) { }` removes truthy literal scalar values such as `'value'` and `1` and `1.0` when they're nullable
 + Emit `PhanTypeVoidArgument` when passing a void return value as a function argument (#3961)
++ Correctly merge the possible union types of pass-by-reference variables (#3959)
 
 Plugins:
 + Add `ConstantVariablePlugin` to point out places where variables are read when they have only one possible scalar value. (#3953)

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -26,7 +26,6 @@ use Phan\Language\Context;
 use Phan\Language\Element\Clazz;
 use Phan\Language\Element\FunctionInterface;
 use Phan\Language\Element\Method;
-use Phan\Language\Element\Parameter;
 use Phan\Language\Element\PassByReferenceVariable;
 use Phan\Language\Element\Property;
 use Phan\Language\Element\TypedElementInterface;

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -1580,15 +1580,9 @@ class AssignmentVisitor extends AnalysisVisitor
         }
         // Check to see if the variable already exists
         if ($variable) {
-            // If the variable isn't a pass-by-reference parameter
-            // we clone it so as to not disturb its previous types
+            // We clone the variable so as to not disturb its previous types
             // as we replace it.
-            // TODO: Do a better job of analyzing references
-            if ($variable instanceof Parameter) {
-                $variable = clone($variable);
-            } elseif (!($variable instanceof PassByReferenceVariable)) {
-                $variable = clone($variable);
-            }
+            $variable = clone($variable);
 
             // If we're assigning to an array element then we don't
             // know what the array structure of the parameter is

--- a/tests/files/expected/0887_merge_reference_types.php.expected
+++ b/tests/files/expected/0887_merge_reference_types.php.expected
@@ -1,0 +1,3 @@
+%s:30 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type 42|array{}|true
+%s:36 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type array{}|true
+%s:42 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type 42

--- a/tests/files/src/0887_merge_reference_types.php
+++ b/tests/files/src/0887_merge_reference_types.php
@@ -1,0 +1,44 @@
+<?php
+
+function maybeModifyReferenceType(int &$arg): void {
+    if ( rand() ) {
+        $arg = [];
+    } elseif ( rand() ) { // @phan-suppress-current-line PhanPluginDuplicateIfCondition
+        $arg = true;
+    }
+}
+
+function alwaysModifyReferenceType(int &$arg): void {
+    if ( rand() ) {
+        $arg = [];
+    } else {
+        $arg = true;
+    }
+}
+
+function neverModifyReferenceType(int &$arg) {
+    if ( rand() ) {
+        $foo = true;
+    } else {
+        $foo = $arg;
+    }
+    return $foo;
+}
+
+function test887_1() { // @phan-suppress-current-line PhanUnreferencedFunction 
+    $x = 42;
+    maybeModifyReferenceType($x);
+    '@phan-debug-var $x';
+}
+
+function test887_2() { // @phan-suppress-current-line PhanUnreferencedFunction 
+    $x = 42;
+    alwaysModifyReferenceType($x);
+    '@phan-debug-var $x';
+}
+
+function test887_3() { // @phan-suppress-current-line PhanUnreferencedFunction 
+    $x = 42;
+    neverModifyReferenceType($x);
+    '@phan-debug-var $x';
+}

--- a/tests/files/src/0887_merge_reference_types.php
+++ b/tests/files/src/0887_merge_reference_types.php
@@ -3,7 +3,7 @@
 function maybeModifyReferenceType(int &$arg): void {
     if ( rand() ) {
         $arg = [];
-    } elseif ( rand() ) { // @phan-suppress-current-line PhanPluginDuplicateIfCondition
+    } elseif ( rand() ) {
         $arg = true;
     }
 }

--- a/tests/files/src/0887_merge_reference_types.php
+++ b/tests/files/src/0887_merge_reference_types.php
@@ -1,6 +1,6 @@
 <?php
 
-function maybeModifyReferenceType(int &$arg): void {
+function maybeModifyReferenceType(&$arg): void {
     if ( rand() ) {
         $arg = [];
     } elseif ( rand() ) {
@@ -8,7 +8,7 @@ function maybeModifyReferenceType(int &$arg): void {
     }
 }
 
-function alwaysModifyReferenceType(int &$arg): void {
+function alwaysModifyReferenceType(&$arg): void {
     if ( rand() ) {
         $arg = [];
     } else {
@@ -16,7 +16,7 @@ function alwaysModifyReferenceType(int &$arg): void {
     }
 }
 
-function neverModifyReferenceType(int &$arg) {
+function neverModifyReferenceType(&$arg) {
     if ( rand() ) {
         $foo = true;
     } else {


### PR DESCRIPTION
Fixes #3959.

This allows ContextMergeVisitor to merge the possible union types of the reference.