### PR TITLE
(#3996) Added installation instructions for easy setup via Docker and phpexperts/docker-phan

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,18 +12,24 @@ and can track values in a few use cases (e.g. arrays, integers, and strings).
 
 # Getting Started
 
-The easiest way to use Phan is via Composer.
+The easiest way to install Phan for any PHP project, regardless of its version, if you have Docker installed:
 
 ```
-composer require phan/phan
+composer require --dev phpexperts/docker-phan
 ```
 
-With Phan installed, you'll want to [create a `.phan/config.php` file](https://github.com/phan/phan/wiki/Getting-Started#creating-a-config-file) in
-your project to tell Phan how to analyze your source code. Once configured, you can run it via `./vendor/bin/phan`.
+The traditional way to install Phan is via Composer:
+
+```
+composer require --dev phan/phan
+```
 
 Phan depends on PHP 7.2+ with the [php-ast](https://github.com/nikic/php-ast) extension (1.0.1+) and supports analyzing PHP version 7.0-7.4 syntax.
 Installation instructions for php-ast can be found [here](https://github.com/nikic/php-ast#installation).
 (Phan can be used without php-ast by using the CLI option `--allow-polyfill-parser`, but there are slight differences in the parsing of doc comments)
+
+With Phan installed, you'll want to [create a `.phan/config.php` file](https://github.com/phan/phan/wiki/Getting-Started#creating-a-config-file) in
+your project to tell Phan how to analyze your source code. Once configured, you can run it via `./vendor/bin/phan`.
 
 * **Alternative Installation Methods**<br />
   See [Getting Started](https://github.com/phan/phan/wiki/Getting-Started) for alternative methods of using


### PR DESCRIPTION
See Issue #3996.

Since this is by far the easiest way to get phan up and running, and because Docker is reaching near-ubiquity on development boxes, I put it as the first option.

If you want, you are encouraged to fork [**phpexperts/docker-phan**](https://github.com/phpexperts/docker-phan) and simply link to it instead.

Here's the 1 minute installation video showing frickin simple it is:

https://youtu.be/M32VDy5K_xU

Cheers!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/phan/phan/3997)
<!-- Reviewable:end -->
