### PR TITLE
Normalize cwd with ProjectRootDirectory for Windows

### DIFF
--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -396,6 +396,11 @@ class CLI
             fwrite(STDERR, "Failed to find current working directory\n");
             exit(1);
         }
+        $cwd = \realpath($cwd);
+        if (!is_string($cwd)) {
+            fwrite(STDERR, "Failed to find current working directory\n");
+            exit(1);
+        }
         Config::setProjectRootDirectory($cwd);
 
         if (\array_key_exists('init', $opts)) {


### PR DESCRIPTION
On Windows, return value of getcwd() is not strict case.

```sh
cd c:\
php -r "var_dump(getcwd());var_dump(realpath(getcwd()));"
# string(3) "c:\"
# string(3) "C:\"
```

Therefore, it may not be possible to convert to a relative path.

- https://github.com/phan/phan/blob/3.1.1/src/Phan/Language/FileRef.php#L80-L88

This causes, fail to match filename in LanguageServer.

- https://github.com/phan/phan/blob/3.1.1/src/Phan/LanguageServer/LanguageServer.php#L603-L604

As a result, I will see following error in LanguageServer.

```
Path 'C:\Users\ngyuki\code\src\App\Application.php' (URI 'file:///c:/Users/ngyuki/code/src/App/Application.php') not in parse list, skipping
```
