### PR TITLE
Also check provided path against project realpath

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,8 @@ Miscellaneous:
 Bug fixes:
 + Suppress `PhanParamNameIndicatingUnused` in files loaded from `autoload_internal_extension_signatures`
 + Improve compatibility of polyfill/fallback parser with php 8.0
++ Also try to check against the realpath() of the current working directory when converting absolute paths
+  to relative paths.
 
 Jul 31 2020, Phan 3.1.1
 -----------------------

--- a/src/Phan/Language/FileRef.php
+++ b/src/Phan/Language/FileRef.php
@@ -73,9 +73,13 @@ class FileRef implements \Serializable
      */
     public static function getProjectRelativePathForPath(string $cwd_relative_path): string
     {
+        if ($cwd_relative_path === '') {
+            return '';
+        }
         // Get a path relative to the project root
         // e.g. if the path is /my-project, then strip the beginning of "/my-project/src/a.php" to "src/a.php" but should not change /my-project-unrelated-src/a.php
         // And don't strip subdirectories of the same name, e.g. should convert "/my-project/subdir/my-project/file.php" to "subdir/my-project/file.php"
+        // And convert "/my-project/.//src/a.php" to "src/a.php"
         $path = \realpath($cwd_relative_path) ?: $cwd_relative_path;
         $root_directory = Config::getProjectRootDirectory();
         $n = \strlen($root_directory);
@@ -84,6 +88,24 @@ class FileRef implements \Serializable
                 $path = (string)\substr($path, $n + 1);
                 // Strip any extra beginning directory separators
                 $path = \ltrim($path, '/' . \DIRECTORY_SEPARATOR);
+                return $path;
+            }
+        }
+
+        // Deal with a wide variety of cases
+        // E.g. the project in question is a symlink,
+        // or uses directory separators that were converted to Windows directory by the call to realpath.
+        // (On Windows, 'c:/Project/Xyz/./other' gets normalized to 'C:\Project\Xyz\other' (uppercase drive letter))
+        $root_directory_realpath = (string)\realpath($root_directory);
+        if ($root_directory_realpath !== '' && $root_directory_realpath !== $root_directory) {
+            $n = \strlen($root_directory_realpath);
+            if (\strncmp($path, $root_directory_realpath, $n) === 0) {
+                if (\in_array($path[$n] ?? '', [\DIRECTORY_SEPARATOR, '/'], true)) {
+                    $path = (string)\substr($path, $n + 1);
+                    // Strip any extra beginning directory separators
+                    $path = \ltrim($path, '/' . \DIRECTORY_SEPARATOR);
+                    return $path;
+                }
             }
         }
 


### PR DESCRIPTION
This affects the language server on Windows
when the drive letter is lowercase.

This may also affect plugins for phan that use getProjectRelativePath
for the real path.

Related to https://github.com/phan/phan/pull/4136 .
Some projects may be symlinks, AND rely on `../../` in their
.phan/config.php the way users have set up the project,
so try to continue to accommodate that.
(Alternately, manually normalize "./", "//", etc. without resolving
symlinks if the input wasn't an absolute path.

TODO: Or figure out how to correctly normalize non-symlinks in
case-insensitive filesystems, or even just the drive letter
from realpath().