### PR TITLE
Warn about possibly infinite loops

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,9 @@ New features (Analysis):
 + Don't compare parameter types against alternate method signatures which have too many required parameters.
   (e.g. warn about `max([])` but not `max([], [1])`)
 + Support `/** @unused-param $param_name */` in doc comments as an additional way to support suppressing warnings about individual parameters being unused.
++ Warn about loop conditions that potentially don't change due to the body of the loop.
+  This check uses heuristics and is prone to false positives.
+  New issue types: `PhanPossiblyInfiniteLoop`
 
 Plugins:
 + Warn about `#` comments in `PHPDocInWrongCommentPlugin` if they're not used for the expected `#[` syntax of php 8.0 attributes.

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -2665,6 +2665,19 @@ Returning {CODE} of type {TYPE} but {FUNCTIONLIKE} is declared to return {TYPE} 
 
 e.g. [this issue](https://github.com/phan/phan/tree/3.0.3/tests/plugin_test/expected/026_strict_return_checks.php.expected#L4) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/3.0.3/tests/plugin_test/src/026_strict_return_checks.php#L31).
 
+## PhanPossiblyInfiniteLoop
+
+This check uses heuristics and is prone to various false positives.
+False positives should be suppressed with a comment explaining why the loop condition changes or why the loop will terminate.
+
+This is only checked for inside of function bodies.
+
+```
+The loop condition {CODE} does not seem to change within the loop and nothing seems to exit the loop
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/plugin_test/expected/119_increment_decrement_unused.php.expected#L7) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/plugin_test/src/119_increment_decrement_unused.php#L13).
+
 ## PhanPossiblyInfiniteRecursionSameParams
 
 Note that when there are 1 or more parameters, this is only emitted when unused variable detection is enabled (needed to check for reassignments)

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -244,6 +244,7 @@ class Issue
     public const RedundantConditionInLoop          = 'PhanRedundantConditionInLoop';
     public const RedundantConditionInGlobalScope   = 'PhanRedundantConditionInGlobalScope';
     public const InfiniteLoop                      = 'PhanInfiniteLoop';
+    public const PossiblyInfiniteLoop              = 'PhanPossiblyInfiniteLoop';
     public const ImpossibleTypeComparison          = 'PhanImpossibleTypeComparison';
     public const ImpossibleTypeComparisonInLoop    = 'PhanImpossibleTypeComparisonInLoop';
     public const ImpossibleTypeComparisonInGlobalScope = 'PhanImpossibleTypeComparisonInGlobalScope';
@@ -2582,6 +2583,14 @@ class Issue
                 "The loop condition {CODE} of type {TYPE} is always {TYPE} and nothing seems to exit the loop",
                 self::REMEDIATION_B,
                 10135
+            ),
+            new Issue(
+                self::PossiblyInfiniteLoop,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_CRITICAL,
+                "The loop condition {CODE} does not seem to change within the loop and nothing seems to exit the loop",
+                self::REMEDIATION_B,
+                10169
             ),
             new Issue(
                 self::ImpossibleTypeComparison,

--- a/src/Phan/Plugin/Internal/MiscParamPlugin.php
+++ b/src/Phan/Plugin/Internal/MiscParamPlugin.php
@@ -41,6 +41,7 @@ use Phan\Language\Type\StringType;
 use Phan\Language\UnionType;
 use Phan\Parse\ParseVisitor;
 use Phan\PluginV3;
+use Phan\Plugin\Internal\VariableTracker\VariableTrackerVisitor;
 use Phan\PluginV3\AnalyzeFunctionCallCapability;
 use Phan\PluginV3\StopParamAnalysisException;
 
@@ -766,6 +767,7 @@ final class MiscParamPlugin extends PluginV3 implements
             if (!$variable) {
                 return;
             }
+            VariableTrackerVisitor::markVariableAsModifiedByReference($arg_node);
             $variable = clone($variable);
             $context->addScopeVariable($variable);
             $old_type = $variable->getUnionType();

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableGraph.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableGraph.php
@@ -56,6 +56,8 @@ final class VariableGraph
     public const IS_LOOP_DEF       = 1 << 3;
     // Is this a caught exception
     public const IS_CAUGHT_EXCEPTION = 1 << 4;
+    public const IS_UNSET          = 1 << 5;
+    public const IS_DISABLED_WARNINGS = 1 << 6;
 
     public const IS_REFERENCE_OR_GLOBAL_OR_STATIC = self::IS_REFERENCE | self::IS_GLOBAL | self::IS_STATIC;
 
@@ -174,6 +176,30 @@ final class VariableGraph
     }
 
     /**
+     * Marks something as being an unset variable `$v` in `unset($v)`
+     *
+     * @param Node|string|int|float|null $node
+     */
+    public function markAsUnset($node): void
+    {
+        if ($node instanceof Node) {
+            $this->def_bitset[spl_object_id($node)] = self::IS_UNSET;
+        }
+    }
+
+    /**
+     * Indicates that warnings about unused definitions should be disabled
+     *
+     * @param Node|string|int|float|null $node
+     */
+    public function markAsDisabledWarnings($node): void
+    {
+        if ($node instanceof Node) {
+            $this->def_bitset[spl_object_id($node)] = self::IS_DISABLED_WARNINGS;
+        }
+    }
+
+    /**
      * Checks if the node for this id is defined as the value in a foreach over keys of an array.
      */
     public function isLoopValueDefinitionId(int $definition_id): bool
@@ -199,7 +225,7 @@ final class VariableGraph
      */
     public function isCaughtException(int $definition_id): bool
     {
-        return ($this->def_bitset[$definition_id] ?? 0) === self::IS_CAUGHT_EXCEPTION;
+        return (($this->def_bitset[$definition_id] ?? 0) & self::IS_CAUGHT_EXCEPTION) !== 0;
     }
 
     /**
@@ -220,7 +246,7 @@ final class VariableGraph
      */
     public function isGlobal(int $definition_id): bool
     {
-        return ($this->def_bitset[$definition_id] ?? 0) === self::IS_GLOBAL;
+        return (($this->def_bitset[$definition_id] ?? 0) & self::IS_GLOBAL) !== 0;
     }
 
     private function markBitForVariableName(string $name, int $bit): void
@@ -250,5 +276,27 @@ final class VariableGraph
             }
         }
         return $combined_def_use_map;
+    }
+
+    /**
+     * @return associative-array<int,associative-array<int,true>>
+     * Returns the combination of all use-def sets for all node ids.
+     * Marks globals, references, and static variables as defined with the placeholder of -1
+     */
+    public function computeCombinedUseDefs(): array
+    {
+        $combined_use_def_map = [];
+        foreach ($this->def_uses as $var_name => $def_use_map) {
+            $is_used_by_shared_state = (($this->variable_types[$var_name] ?? 0) & self::IS_REFERENCE_OR_GLOBAL_OR_STATIC) !== 0;
+            foreach ($def_use_map as $def_id => $use_set) {
+                foreach ($use_set as $use_id => $_) {
+                    if ($is_used_by_shared_state) {
+                        $combined_use_def_map[$use_id][self::USE_ID_FOR_SHARED_STATE] = true;
+                    }
+                    $combined_use_def_map[$use_id][$def_id] = true;
+                }
+            }
+        }
+        return $combined_use_def_map;
     }
 }

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
@@ -826,6 +826,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
                 $this->top_level_statement = $top_level_statement;
             }
         }
+        $inner_scope = $this->analyzeWhenValidNode($inner_scope, $node->children['cond']);
 
         // Merge inner scope into outer scope
         // @phan-suppress-next-line PhanTypeMismatchArgument

--- a/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
+++ b/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
@@ -144,6 +144,11 @@ final class VariableTrackerElementVisitor extends PluginAwarePostAnalysisVisitor
             if ($cond instanceof Node) {
                 $id_set_in_loop = self::extractNodeIdSet($cond);
                 if ($id_set_in_loop) {
+                    foreach ($id_set_in_loop as $id => $_) {
+                        if (isset($combined_use_defs[$id][VariableGraph::USE_ID_FOR_SHARED_STATE])) {
+                            continue 2;
+                        }
+                    }
                     $stmts_node = $loop_node->children['stmts'];
                     $id_set_of_stmts = $stmts_node instanceof Node ? self::extractNodeIdSet($stmts_node) : [];
                     if (isset($loop_node->children['loop'])) {
@@ -393,7 +398,7 @@ final class VariableTrackerElementVisitor extends PluginAwarePostAnalysisVisitor
                     // Don't warn if there's at least one usage of that definition
                     continue;
                 }
-                if (($graph->def_bitset[$definition_id] ?? 0) & VariableGraph::IS_UNSET) {
+                if (($graph->def_bitset[$definition_id] ?? 0) & (VariableGraph::IS_UNSET|VariableGraph::IS_DISABLED_WARNINGS)) {
                     // Don't warn about unset($x)
                     continue;
                 }

--- a/tests/files/expected/0311_condition_visitor_throw.php.expected
+++ b/tests/files/expected/0311_condition_visitor_throw.php.expected
@@ -23,23 +23,30 @@
 %s:27 PhanUndeclaredVariable Variable $unaryMissing1 is undeclared
 %s:28 PhanTypeInvalidUnaryOperandNumeric Invalid operator: unary operand of - is null= (expected number)
 %s:28 PhanUndeclaredVariable Variable $unaryMissing2 is undeclared
+%s:30 PhanPossiblyInfiniteLoop The loop condition ~$unaryMissing3 does not seem to change within the loop and nothing seems to exit the loop
 %s:30 PhanSideEffectFreeWhileBody Saw a while loop which probably has no side effects
 %s:30 PhanTypeInvalidUnaryOperandBitwiseNot Invalid operator: unary operand of ~ is null (expected number that can fit in an int, or string)
 %s:30 PhanUndeclaredVariable Variable $unaryMissing3 is undeclared
 %s:31 PhanCoalescingAlwaysNullInLoop Using $c2 of type null as the left hand side of a null coalescing (??) operation. The left hand side may be unnecessary. (in a loop body - this is likely a false positive)
+%s:31 PhanPossiblyInfiniteLoop The loop condition ($c2 ?? false) does not seem to change within the loop and nothing seems to exit the loop
 %s:31 PhanSideEffectFreeWhileBody Saw a while loop which probably has no side effects
 %s:31 PhanUndeclaredVariable Variable $c2 is undeclared
 %s:32 PhanSideEffectFreeWhileBody Saw a while loop which probably has no side effects
 %s:33 PhanSideEffectFreeWhileBody Saw a while loop which probably has no side effects
 %s:33 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is $str of type string but \intdiv() takes int
+%s:35 PhanPossiblyInfiniteLoop The loop condition ~$unaryMissing3 does not seem to change within the loop and nothing seems to exit the loop
 %s:35 PhanSideEffectFreeForBody Saw a for loop which probably has no side effects
 %s:35 PhanTypeInvalidUnaryOperandBitwiseNot Invalid operator: unary operand of ~ is null (expected number that can fit in an int, or string)
 %s:35 PhanUndeclaredVariable Variable $unaryMissing3 is undeclared
 %s:36 PhanCoalescingAlwaysNullInLoop Using $c2 of type null as the left hand side of a null coalescing (??) operation. The left hand side may be unnecessary. (in a loop body - this is likely a false positive)
+%s:36 PhanPossiblyInfiniteLoop The loop condition ($c2 ?? false) does not seem to change within the loop and nothing seems to exit the loop
 %s:36 PhanSideEffectFreeForBody Saw a for loop which probably has no side effects
 %s:36 PhanUndeclaredVariable Variable $c2 is undeclared
+%s:37 PhanPossiblyInfiniteLoop The loop condition (is_string($str) && (strlen($str) > 0)) does not seem to change within the loop and nothing seems to exit the loop
 %s:37 PhanSideEffectFreeForBody Saw a for loop which probably has no side effects
+%s:38 PhanPossiblyInfiniteLoop The loop condition (is_string($str) && (intdiv($str, 10) > 0)) does not seem to change within the loop and nothing seems to exit the loop
 %s:38 PhanSideEffectFreeForBody Saw a for loop which probably has no side effects
 %s:38 PhanTypeMismatchArgumentInternal Argument 1 ($numerator) is $str of type string but \intdiv() takes int
+%s:39 PhanPossiblyInfiniteLoop The loop condition ($y && $x3) does not seem to change within the loop and nothing seems to exit the loop
 %s:39 PhanSideEffectFreeForBody Saw a for loop which probably has no side effects
 %s:39 PhanUndeclaredVariable Variable $x3 is undeclared

--- a/tests/files/expected/0441_unset_basic.php.expected
+++ b/tests/files/expected/0441_unset_basic.php.expected
@@ -1,3 +1,4 @@
+%s:5 PhanUnusedVariable Unused definition of variable $myVar
 %s:7 PhanTypeSuspiciousEcho Suspicious argument $myVar of type null= for an echo/print statement
 %s:7 PhanUndeclaredVariable Variable $myVar is undeclared
-%s:11 PhanTypeMismatchArgumentInternal%SReal Argument 1 ($string) is $x of type array{b:list<string>} but \strlen() takes string
+%s:11 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($string) is $x of type array{b:list<string>} but \strlen() takes string

--- a/tests/plugin_test/expected/119_increment_decrement_unused.php.expected
+++ b/tests/plugin_test/expected/119_increment_decrement_unused.php.expected
@@ -4,6 +4,7 @@ src/119_increment_decrement_unused.php:5 PhanUnusedVariable Unused definition of
 src/119_increment_decrement_unused.php:6 PhanNoopVariable Unused variable
 src/119_increment_decrement_unused.php:6 PhanUnusedVariable Unused definition of variable $z
 src/119_increment_decrement_unused.php:8 PhanPluginConstantVariableScalar Variable $z is probably constant with a value of 2
+src/119_increment_decrement_unused.php:13 PhanPossiblyInfiniteLoop The loop condition ($other < $n) does not seem to change within the loop and nothing seems to exit the loop
 src/119_increment_decrement_unused.php:15 PhanUnusedVariable Unused definition of variable $i
 src/119_increment_decrement_unused.php:15 PhanUnusedVariable Unused definition of variable $j
 src/119_increment_decrement_unused.php:21 PhanPluginUseReturnValueNoopVoid The function/method \test_loop119b() is declared to return void and it has no side effects

--- a/tests/plugin_test/expected/191_infinite_loops.php.expected
+++ b/tests/plugin_test/expected/191_infinite_loops.php.expected
@@ -1,0 +1,2 @@
+src/191_infinite_loops.php:4 PhanPossiblyInfiniteLoop The loop condition B191 does not seem to change within the loop and nothing seems to exit the loop
+src/191_infinite_loops.php:5 PhanPossiblyInfiniteLoop The loop condition !B191 does not seem to change within the loop and nothing seems to exit the loop

--- a/tests/plugin_test/expected/192_loop.php.expected
+++ b/tests/plugin_test/expected/192_loop.php.expected
@@ -1,0 +1,1 @@
+src/192_loop.php:8 PhanPluginConstantVariableBool Variable $loop is probably constant with a value of false

--- a/tests/plugin_test/src/191_infinite_loops.php
+++ b/tests/plugin_test/src/191_infinite_loops.php
@@ -1,0 +1,7 @@
+<?php
+define('B191', rand(0, 1));
+function main191() {
+    while (B191) { echo "."; }  // should warn
+    while (!B191) { echo "x"; }  // should warn
+}
+main191();

--- a/tests/plugin_test/src/192_loop.php
+++ b/tests/plugin_test/src/192_loop.php
@@ -1,0 +1,10 @@
+<?php
+function test192() {
+    $loop = true;
+    for(;$loop;) {
+        echo "test\n";
+        $loop = false;
+    }
+    return $loop;
+}
+test192();


### PR DESCRIPTION
This checks if the initial type of the expression determines
whether or not the loop will stay infinite.
e.g. `while (UNKNOWN_BOOL){}`