### PR TITLE
Support AST version 80 for Phan 4.0.0-dev

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,16 +17,16 @@ environment:
     - PHP_EXT_VERSION: '7.4'
       PHP_VERSION: '7.4.9'
       VC_VERSION: 15
-      PHP_AST_VERSION: 1.0.8
+      PHP_AST_VERSION: 1.0.9
       PHAN_RUN_INTEGRATION_TEST: 1
     - PHP_EXT_VERSION: '7.3'
       PHP_VERSION: '7.3.21'
       VC_VERSION: 15
-      PHP_AST_VERSION: 1.0.4
+      PHP_AST_VERSION: 1.0.7
     - PHP_EXT_VERSION: '7.2'
       PHP_VERSION: '7.2.33'
       VC_VERSION: 15
-      PHP_AST_VERSION: 1.0.4
+      PHP_AST_VERSION: 1.0.7
 
 init:
     - SET PATH=c:\projects\php;C:\projects\composer;%PATH%

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 Phan NEWS
 
+??? ?? 202?, Phan 4.0.0 (dev)
+-----------------------
+
+Backwards incompatible changes:
++ Switch from AST version 70 to AST version 80.
+  `php-ast` should be upgraded to version 1.0.10-dev or newer.
++ Support analyzing PHP 8.0 attributes.
++ Drop the no-op `--polyfill-parse-all-doc-comments` flag.
+
 ??? ?? 2020, Phan 3.2.1 (dev)
 -----------------------
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ and can track values in a few use cases (e.g. arrays, integers, and strings).
 [![Latest Stable Version](https://img.shields.io/packagist/v/phan/phan.svg)](https://packagist.org/packages/phan/phan)
 [![License](https://img.shields.io/packagist/l/phan/phan.svg)](https://github.com/phan/phan/blob/master/LICENSE)
 
+This is the branch for Phan 4.0.0-dev.
+
 # Getting Started
 
 The easiest way to use Phan is via Composer.
@@ -21,7 +23,7 @@ composer require phan/phan
 With Phan installed, you'll want to [create a `.phan/config.php` file](https://github.com/phan/phan/wiki/Getting-Started#creating-a-config-file) in
 your project to tell Phan how to analyze your source code. Once configured, you can run it via `./vendor/bin/phan`.
 
-Phan depends on PHP 7.2+ with the [php-ast](https://github.com/nikic/php-ast) extension (1.0.1+) and supports analyzing PHP version 7.0-7.4 syntax.
+Phan depends on PHP 7.2+ with the [php-ast](https://github.com/nikic/php-ast) extension (1.0.7+) and supports analyzing PHP version 7.0-7.4 syntax.
 Installation instructions for php-ast can be found [here](https://github.com/nikic/php-ast#installation).
 (Phan can be used without php-ast by using the CLI option `--allow-polyfill-parser`, but there are slight differences in the parsing of doc comments)
 

--- a/phan
+++ b/phan
@@ -2,7 +2,7 @@
 <?php
 // @phan-file-suppress PhanPluginRemoveDebugAny
 if (PHP_VERSION_ID < 70000) {
-    fwrite(STDERR, "ERROR: Phan 3.x requires PHP 7.2+, but it is being run with PHP " . PHP_VERSION . PHP_EOL);
+    fwrite(STDERR, "ERROR: Phan 4.x requires PHP 7.2+, but it is being run with PHP " . PHP_VERSION . PHP_EOL);
     fwrite(STDERR, "PHP 5.6 reached its end of life in December 2018." . PHP_EOL);
     fwrite(STDERR, "Exiting without analyzing code." . PHP_EOL);
     exit(1);

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -1869,6 +1869,9 @@ class ContextNode
         }
 
         $constant_name = $node->children['const'];
+        if (!is_string($constant_name)) {
+            throw new AssertionError('$constant_name must be a string');
+        }
         if (!\strcasecmp($constant_name, 'class')) {
             $constant_name = 'class';
         }

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -109,8 +109,8 @@ Shim::load();
 class TolerantASTConverter
 {
     // The latest stable version of php-ast.
-    // For something != 70, update the library's release.
-    public const AST_VERSION = 70;
+    // For something != 80, update the library's release.
+    public const AST_VERSION = 80;
 
     // The versions that this supports
     public const SUPPORTED_AST_VERSIONS = [self::AST_VERSION];
@@ -750,6 +750,7 @@ class TolerantASTConverter
                             $return_line
                         ),
                         'returnType' => $ast_return_type,
+                        'attributes' => null,  // TODO implement
                     ],
                     $start_line,
                     static::resolveDocCommentForClosure($n),
@@ -1289,6 +1290,7 @@ class TolerantASTConverter
                         'params' => static::phpParserParamsToAstParams($n->parameters, $start_line),
                         'stmts' => static::phpParserStmtlistToAstNode($statements, self::getStartLine($statements), true),
                         'returnType' => $ast_return_type,
+                        'attributes' => null,  // TODO: implement
                     ],
                     $start_line,
                     $n->getDocCommentText(),
@@ -1939,6 +1941,8 @@ class TolerantASTConverter
                 'type' => $type,
                 'name' => $name,
                 'default' => $default,
+                'attributes' => null,
+                'docComment' => null,
             ],
             $line
         );
@@ -2109,6 +2113,7 @@ class TolerantASTConverter
                 'uses' => $uses,
                 'stmts' => $stmts,
                 'returnType' => $return_type,
+                'attributes' => null,  // TODO implement
             ],
             $start_line,
             $doc_comment,
@@ -2140,6 +2145,7 @@ class TolerantASTConverter
                 'params' => $params,
                 'stmts' => $stmts,
                 'returnType' => $return_type,
+                'attributes' => null,
             ],
             $line,
             $doc_comment,
@@ -2215,6 +2221,7 @@ class TolerantASTConverter
                 'extends'    => null,
                 'implements' => $extends,
                 'stmts'      => $stmts,
+                'attributes' => null,  // TODO implement
             ];
         } else {
             if ($implements !== null) {
@@ -2242,6 +2249,7 @@ class TolerantASTConverter
                 'extends'    => $extends,
                 'implements' => $ast_implements,
                 'stmts'      => $stmts,
+                'attributes' => null,  // TODO: implement
             ];
         }
 
@@ -2723,6 +2731,7 @@ class TolerantASTConverter
         return new ast\Node(ast\AST_PROP_GROUP, $flags, [
             'type' => static::phpParserUnionTypeToAstNode($n->typeDeclaration, $n->otherTypeDeclarations, $type_line),
             'props' => $prop_decl,
+            'attributes' => null,  // TODO: Implement
         ], $line);
     }
 
@@ -2738,8 +2747,17 @@ class TolerantASTConverter
             $const_elems[] = static::phpParserConstelemToAstConstelem($const_elem, $i === 0 ? $doc_comment : null);
         }
         $flags = static::phpParserVisibilityToAstVisibility($n->modifiers);
-
-        return new ast\Node(ast\AST_CLASS_CONST_DECL, $flags, $const_elems, $const_elems[0]->lineno ?? $start_line);
+        $const_start_line = $const_elems[0]->lineno ?? $start_line;
+        $const_list_node = new ast\Node(ast\AST_CLASS_CONST_DECL, 0, $const_elems, $const_start_line);
+        return new ast\Node(
+            ast\AST_CLASS_CONST_GROUP,
+            $flags,
+            [
+                'const' => $const_list_node,
+                'attributes' => null,  // TODO implement
+            ],
+            $const_start_line
+        );
     }
 
     /**

--- a/src/Phan/AST/TolerantASTConverter/ast_shim.php
+++ b/src/Phan/AST/TolerantASTConverter/ast_shim.php
@@ -12,11 +12,12 @@ declare(strict_types=1);
  * With modifications to be a functional replacement for the data
  * structures and global constants of ext-ast. (for class ast\Node)
  *
- * This supports AST version 70
+ * This supports AST version 80
  *
  * However, this file does not define any global functions such as
  * ast\parse_code() and ast\parse_file(). (to avoid confusion)
  *
+ * TODO: Add remaining constants
  *
  * @phan-file-suppress PhanUnreferencedConstant, UnusedPluginFileSuppression - Plugins may reference some of these constants
  * @phan-file-suppress PhanPluginUnknownArrayPropertyType, PhanPluginUnknownArrayMethodParamType this is a stub

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -83,7 +83,7 @@ class CLI
     /**
      * This should be updated to x.y.z-dev after every release, and x.y.z before a release.
      */
-    public const PHAN_VERSION = '3.2.1-dev';
+    public const PHAN_VERSION = '4.0.0-dev';
 
     /**
      * List of short flags passed to getopt
@@ -175,7 +175,6 @@ class CLI
         'output:',
         'output-mode:',
         'parent-constructor-required:',
-        'polyfill-parse-all-element-doc-comments',
         'plugin:',
         'print-memory-usage-summary',
         'processes:',
@@ -676,10 +675,6 @@ class CLI
                 case 'minimum-target-php-version':
                     Config::setValue('minimum_target_php_version', $value);
                     break;
-                case 'polyfill-parse-all-element-doc-comments':
-                    // TODO: Drop in Phan 3
-                    fwrite(STDERR, "--polyfill-parse-all-element-doc-comments is a no-op and will be removed in a future Phan release (no longer needed since PHP 7.0 support was dropped)\n");
-                    break;
                 case 'd':
                 case 'project-root-directory':
                     // We handle this flag before parsing options so
@@ -858,7 +853,8 @@ class CLI
                         break;
                     }
                     $ast_version = (new ReflectionExtension('ast'))->getVersion();
-                    if (\version_compare($ast_version, '1.0.0') <= 0) {
+                    // In order to parse with AST version 80, 1.0.7+ is required
+                    if (\version_compare($ast_version, '1.0.6') <= 0) {
                         Config::setValue('use_polyfill_parser', true);
                         break;
                     }
@@ -2754,13 +2750,10 @@ EOB
                 // Seen in php 7.3 with file_cache when ast is initially enabled but later disabled, due to the result of extension_loaded being assumed to be a constant by opcache.
                 fwrite(STDERR, "ERROR: extension_loaded('ast') is true, but phpversion('ast') is the empty string. You probably need to clear opcache (opcache.file_cache='" . \ini_get('opcache.file_cache') . "')" . PHP_EOL);
             }
-            // TODO: Change this to a warning for 0.1.5 - 1.0.0. (https://github.com/phan/phan/issues/2954)
-            // 0.1.5 introduced the ast\Node constructor, which is required by the polyfill
-            //
             // NOTE: We haven't loaded the autoloader yet, so these issue messages can't be colorized.
             \fprintf(
                 STDERR,
-                "ERROR: Phan 3.x requires php-ast 1.0.1+ because it depends on AST version 70. php-ast '%s' is installed." . PHP_EOL,
+                "ERROR: Phan 3.x requires php-ast 1.0.7+ because it depends on AST version 80. php-ast '%s' is installed." . PHP_EOL,
                 $ast_version
             );
             require_once __DIR__ . '/Bootstrap.php';

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -41,12 +41,12 @@ class Config
      * The version of the AST (defined in php-ast) that we're using.
      * @see https://github.com/nikic/php-ast#ast-versioning
      */
-    public const AST_VERSION = 70;
+    public const AST_VERSION = 80;
 
     /**
      * The minimum AST extension version in the oldest php version supported by Phan.
      */
-    public const MINIMUM_AST_EXTENSION_VERSION = '1.0.1';
+    public const MINIMUM_AST_EXTENSION_VERSION = '1.0.7';
 
     /**
      * The version of the Phan plugin system.

--- a/src/Phan/Debug.php
+++ b/src/Phan/Debug.php
@@ -444,6 +444,11 @@ class Debug
                     flags\MODIFIER_PROTECTED => 'MODIFIER_PROTECTED',
                     flags\MODIFIER_PRIVATE => 'MODIFIER_PRIVATE',
                 ],
+                ast\AST_CLASS_CONST_GROUP => [
+                    flags\MODIFIER_PUBLIC => 'MODIFIER_PUBLIC',
+                    flags\MODIFIER_PROTECTED => 'MODIFIER_PROTECTED',
+                    flags\MODIFIER_PRIVATE => 'MODIFIER_PRIVATE',
+                ],
                 ast\AST_PROP_GROUP => $property_modifiers,
                 ast\AST_TRAIT_ALIAS => $property_modifiers,
                 ast\AST_DIM => [

--- a/src/Phan/Language/Internal/PropertyMap.php
+++ b/src/Phan/Language/Internal/PropertyMap.php
@@ -13,7 +13,7 @@ $ast_node_shape_inner = \implode(',', [
     "catches?:ast\Node",
     "class?:ast\Node",
     "cond?:$ordinary_ast_node",
-    "const?:string",
+    "const?:string|ast\Node",
     "dim?:$ordinary_ast_node",
     "declares?:ast\Node",
     "docComment?:?string",

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -665,7 +665,7 @@ class ParseVisitor extends ScopeVisitor
     }
 
     /**
-     * Visit a node with kind `\ast\AST_CLASS_CONST_DECL`
+     * Visit a node with kind `\ast\AST_CLASS_CONST_GROUP`
      *
      * @param Node $node
      * A node to parse
@@ -675,11 +675,12 @@ class ParseVisitor extends ScopeVisitor
      * parsing the node
      *
      */
-    public function visitClassConstDecl(Node $node): Context
+    public function visitClassConstGroup(Node $node): Context
     {
         $class = $this->getContextClass();
 
-        foreach ($node->children as $child_node) {
+        // @phan-suppress-next-line PhanTypeExpectedObjectPropAccess, PhanPossiblyUndeclaredProperty
+        foreach ($node->children['const']->children as $child_node) {
             if (!$child_node instanceof Node) {
                 throw new AssertionError('expected class const element to be a Node');
             }
@@ -725,7 +726,7 @@ class ParseVisitor extends ScopeVisitor
                     ->withLineNumberEnd($child_node->endLineno ?? $line_number_start),
                 $name,
                 UnionType::empty(),
-                $node->flags ?? 0,
+                $node->flags,
                 $fqsen
             );
 

--- a/src/prep.php
+++ b/src/prep.php
@@ -29,8 +29,8 @@ $visit_node = static function (\ast\Node $node, string $file_path): void {
     if ($node->kind === \ast\AST_CLASS_CONST) {
         // Debug::printNode($node);
 
-        if (\is_string($node->children['const'])) {
-            $name = $node->children['const'];
+        $name = $node->children['const'];
+        if (\is_string($name)) {
             if (preg_match('/.*SEARCH.*/', $name)) {
                 print "$file_path:{$node->lineno} $name\n";
             }

--- a/tests/Phan/AST/TolerantASTConverter/ConversionTest.php
+++ b/tests/Phan/AST/TolerantASTConverter/ConversionTest.php
@@ -98,12 +98,12 @@ final class ConversionTest extends BaseTest
         $paths = $this->scanSourceDirForPHP($source_dir);
 
         self::sortByTokenCount($paths);
-        $supports70 = self::hasNativeASTSupport(70);
-        if (!$supports70) {
-            throw new RuntimeException("Version 70 is not natively supported");
+        $supports80 = self::hasNativeASTSupport(80);
+        if (!$supports80) {
+            throw new RuntimeException("Version 80 is not natively supported");
         }
         foreach ($paths as $path) {
-            $tests[] = [$path, 70];
+            $tests[] = [$path, 80];
         }
         return $tests;
     }

--- a/tests/Phan/AST/TolerantASTConverter/ErrorTolerantConversionTest.php
+++ b/tests/Phan/AST/TolerantASTConverter/ErrorTolerantConversionTest.php
@@ -441,11 +441,11 @@ EOT;
 
     private function runTestFallbackFromParser(string $incomplete_contents, string $valid_contents, bool $should_add_placeholders = false): void
     {
-        $supports70 = ConversionTest::hasNativeASTSupport(70);
-        if (!$supports70) {
+        $supports80 = ConversionTest::hasNativeASTSupport(80);
+        if (!$supports80) {
             $this->fail('No supported AST versions to test');
         }
-        $this->runTestFallbackFromParserForASTVersion($incomplete_contents, $valid_contents, 70, $should_add_placeholders);
+        $this->runTestFallbackFromParserForASTVersion($incomplete_contents, $valid_contents, 80, $should_add_placeholders);
     }
 
     private function runTestFallbackFromParserForASTVersion(string $incomplete_contents, string $valid_contents, int $ast_version, bool $should_add_placeholders): void

--- a/tests/php80_files/expected/030_attributes.php.expected
+++ b/tests/php80_files/expected/030_attributes.php.expected
@@ -1,5 +1,6 @@
 %s:7 PhanUnusedPublicNoOverrideMethodParameter Parameter $x is never used
 %s:26 PhanCompatibleArrowFunction Cannot use arrow functions before php 7.4 in (fn)
+%s:27 PhanUndeclaredConstant Reference to undeclared constant \MISSING_CONSTANT. This will cause a thrown Error in php 8.0+.
 %s:31 PhanCompatibleArrowFunction Cannot use arrow functions before php 7.4 in (fn)
 %s:32 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method Closure(int $x) defined at %s:26
 %s:33 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method Closure() defined at %s:31

--- a/tests/travis_setup.sh
+++ b/tests/travis_setup.sh
@@ -13,7 +13,7 @@ set -xeu
 # (it's of the form yyyymmdd, e.g. 20180731 for php 7.3.)
 PHP_VERSION_ID=$(php -r "echo PHP_VERSION_ID . '_' . PHP_DEBUG . '_' . PHP_ZTS . '_new' . md5(PHP_EXTENSION_DIR);")
 PHAN_BUILD_DIR="$HOME/.cache/phan-ast"
-EXPECTED_AST_FILE="$PHAN_BUILD_DIR/build/php-ast-$PHP_VERSION_ID.so"
+EXPECTED_AST_FILE="$PHAN_BUILD_DIR/build/php-ast-$PHP_VERSION_ID-2020-09-20.so"
 
 [[ -d "$PHAN_BUILD_DIR" ]] || mkdir -p "$PHAN_BUILD_DIR"
 


### PR DESCRIPTION
PHP 8.0 attributes support in the polyfill depends on pending changes to tolerant-php-parser.

