### PR TITLE
Add light_high_contrast color scheme

### DIFF
--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -1523,7 +1523,7 @@ $init_help
   Add colors to the outputted issues.
   This is recommended for only --output-mode=text (the default) and 'verbose'
 
-  [--color-scheme={default,code,light,eclipse_dark,vim}]
+  [--color-scheme={default,code,light,eclipse_dark,vim,light_high_contrast}]
     This (or the environment variable PHAN_COLOR_SCHEME) can be used to set the color scheme for emitted issues.
 
  -p, --progress-bar, --no-progress-bar, --long-progress-bar

--- a/src/Phan/Output/ColorScheme/LightHighContrast.php
+++ b/src/Phan/Output/ColorScheme/LightHighContrast.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phan\Output\ColorScheme;
+
+/**
+ * Contains colors suitable for output on a white background.
+ * @suppress PhanUnreferencedClass this is used dynamically
+ */
+class LightHighContrast
+{
+    /** @suppress PhanUnreferencedPublicClassConstant this is used dynamically */
+    public const DEFAULT_COLOR_FOR_TEMPLATE = [
+        'CLASS'         => 'blue',
+        'CLASSLIKE'     => 'blue',
+        'CODE'          => 'magenta',
+        'COMMENT'       => 'dark_gray',
+        'CONST'         => 'blue',
+        'COUNT'         => 'blue',
+        'DETAILS'       => 'dark_gray',
+        'FILE'          => 'light_magenta',
+        'FUNCTIONLIKE'  => 'green',
+        'FUNCTION'      => 'green',
+        'INDEX'         => 'blue',
+        'INTERFACE'     => 'blue',
+        'ISSUETYPE'     => 'blue',  // used by Phan\Output\Printer, for minor issues
+        'ISSUETYPE_CRITICAL' => 'red',  // for critical issues, e.g. "PhanUndeclaredMethod"
+        'ISSUETYPE_NORMAL' => 'bg_yellow',  // for normal issues
+        'LINE'          => 'dark_gray',
+        'METHOD'        => 'green',
+        'NAMESPACE'     => 'dark_gray',
+        'OPERATOR'      => 'dark_gray',
+        'PARAMETER'     => 'magenta',
+        'PROPERTY'      => 'blue',
+        'SCALAR'        => 'green',
+        'STRING_LITERAL' => 'green',
+        'SUGGESTION'    => 'dark_gray',
+        'TYPE'          => 'blue',
+        'TRAIT'         => 'blue',
+        'VARIABLE'      => 'bg_yellow',
+    ];
+}

--- a/src/Phan/Output/Colorizing.php
+++ b/src/Phan/Output/Colorizing.php
@@ -226,6 +226,7 @@ class Colorizing
         'eclipse_dark' => \Phan\Output\ColorScheme\EclipseDark::class,
         'light' => \Phan\Output\ColorScheme\Light::class,
         'vim' => \Phan\Output\ColorScheme\Vim::class,
+        'light_high_contrast' => \Phan\Output\ColorScheme\LightHighContrast::class,
     ];
 
     /**


### PR DESCRIPTION
This is based on the eclipse_dark theme, with colors adjusted for high contrast on white backgrounds. Here's the map old -> new colors, with an estimate of the contrast ratio for each color:

 - light_blue: 4.55 --> blue 11.98
 - red: 5.48 --> acceptable
 - light_gray: 1.53 --> dark_gray --> 7.1
 - magenta: 5.02 --> acceptable
 - light_green --> green (see below)
 - green: 2.48 --> not quite acceptable...
 - light_cyan: 1.21 --> light_magenta: 2.81 (still subpar)
 - ligh_yellow: 1.06 --> bg_yellow (seemed the best choice)
 - yellow: 1.96 --> bg_yellow (seemed the best choice)

Some choices are not optimal, but it's still better than the other themes on a white background.

Closes #4203