### PR TITLE
Support marking class elements as `@phan-abstract`

### DIFF
--- a/.phan/plugins/InvokePHPNativeSyntaxCheckPlugin.php
+++ b/.phan/plugins/InvokePHPNativeSyntaxCheckPlugin.php
@@ -142,7 +142,6 @@ class InvokePHPNativeSyntaxCheckPlugin extends PluginV3 implements
         }
         $check_error_message = preg_replace(self::STDIN_FILENAME_REGEX, '', $check_error_message);
 
-
         self::emitIssue(
             $code_base,
             clone($context)->withLineNumberStart($lineno),

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,17 @@ New features (CLI, Config):
 
 New features (Analysis):
 + Infer that `parent::someMethodReturningStaticType()` is a subtype of the current class, not just the parent class. (#4202)
++ Support phpdoc `@abstract` or `@phan-abstract` on non-abstract class constants, properties, and methods
+  to indicate that the intent is for non-abstract subclasses to override the definition. (#2278, #2285)
+  New issue types: `PhanCommentAbstractOnInheritedConstant`, `PhanCommentAbstractOnInheritedProperty`, `PhanCommentOverrideOnNonOverrideProperty`
+
+  For example, code using `static::SOME_CONST` or `static::$SOME_PROPERTY` or `$this->someMethod()`
+  may declare a placeholder `@abstract` constant/property/method,
+  and use this annotation to ensure that all non-abstract subclasses override the constant/property/method
+  (if using real abstract methods is not practical for a use case)
++ Warn about `@override` on properties that do not override an ancestor's property definition.
+  New issue type: `PhanCommentOverrideOnNonOverrideProperty`.
+  (Phan already warns for constants and methods)
 
 Bug fixes:
 + Properly analyze the right hand side for `$cond || throw ...;` (e.g. emit `PhanCompatibleThrowException`) (#4199)

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -4560,6 +4560,30 @@ e.g. [this issue](https://github.com/phan/phan/tree/3.0.3/tests/files/expected/0
 
 This is emitted for some (but not all) comments which Phan thinks are invalid or unparsable.
 
+## PhanCommentAbstractOnInheritedConstant
+
+```
+Class {CLASS} inherits a class constant {CONST} declared at {FILE}:{LINE} marked as {COMMENT} in phpdoc but does not override it
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0907_abstract_class_constant.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0907_abstract_class_constant.php#L16).
+
+## PhanCommentAbstractOnInheritedMethod
+
+```
+Class {CLASS} inherits a method {METHOD} declared at {FILE}:{LINE} marked as {COMMENT} in phpdoc but does not override it
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0909_phpdoc_abstract_method.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0909_phpdoc_abstract_method.php#L20).
+
+## PhanCommentAbstractOnInheritedProperty
+
+```
+Class {CLASS} inherits a property {PROPERTY} declared at {FILE}:{LINE} marked as {COMMENT} in phpdoc but does not override it
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0908_abstract_property.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0908_abstract_property.php#L16).
+
 ## PhanCommentAmbiguousClosure
 
 ```
@@ -4615,6 +4639,14 @@ Saw an @override annotation for method {METHOD}, but could not find an overridde
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/3.0.3/tests/files/expected/0355_namespace_relative.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/3.0.3/tests/files/src/0355_namespace_relative.php#L34).
+
+## PhanCommentOverrideOnNonOverrideProperty
+
+```
+Saw an @override annotation for property {PROPERTY}, but could not find an overridden property
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/files/expected/0908_abstract_property.php.expected#L4) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/files/src/0908_abstract_property.php#L31).
 
 ## PhanCommentParamAssertionWithoutRealParam
 

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -590,6 +590,10 @@ class Issue
     public const CommentParamOnEmptyParamList     = 'PhanCommentParamOnEmptyParamList';
     public const CommentOverrideOnNonOverrideMethod = 'PhanCommentOverrideOnNonOverrideMethod';
     public const CommentOverrideOnNonOverrideConstant = 'PhanCommentOverrideOnNonOverrideConstant';
+    public const CommentOverrideOnNonOverrideProperty = 'PhanCommentOverrideOnNonOverrideProperty';
+    public const CommentAbstractOnInheritedConstant = 'PhanCommentAbstractOnInheritedConstant';
+    public const CommentAbstractOnInheritedProperty = 'PhanCommentAbstractOnInheritedProperty';
+    public const CommentAbstractOnInheritedMethod = 'PhanCommentAbstractOnInheritedMethod';
     public const CommentParamOutOfOrder           = 'PhanCommentParamOutOfOrder';
     public const CommentVarInsteadOfParam         = 'PhanCommentVarInsteadOfParam';
     public const ThrowTypeAbsent                  = 'PhanThrowTypeAbsent';
@@ -5089,6 +5093,38 @@ class Issue
                 "Saw an @override annotation for class constant {CONST}, but could not find an overridden constant",
                 self::REMEDIATION_B,
                 16007
+            ),
+            new Issue(
+                self::CommentOverrideOnNonOverrideProperty,
+                self::CATEGORY_COMMENT,
+                self::SEVERITY_LOW,
+                "Saw an @override annotation for property {PROPERTY}, but could not find an overridden property",
+                self::REMEDIATION_B,
+                16026
+            ),
+            new Issue(
+                self::CommentAbstractOnInheritedConstant,
+                self::CATEGORY_COMMENT,
+                self::SEVERITY_LOW,
+                "Class {CLASS} inherits a class constant {CONST} declared at {FILE}:{LINE} marked as {COMMENT} in phpdoc but does not override it",
+                self::REMEDIATION_B,
+                16023
+            ),
+            new Issue(
+                self::CommentAbstractOnInheritedProperty,
+                self::CATEGORY_COMMENT,
+                self::SEVERITY_LOW,
+                "Class {CLASS} inherits a property {PROPERTY} declared at {FILE}:{LINE} marked as {COMMENT} in phpdoc but does not override it",
+                self::REMEDIATION_B,
+                16024
+            ),
+            new Issue(
+                self::CommentAbstractOnInheritedMethod,
+                self::CATEGORY_COMMENT,
+                self::SEVERITY_LOW,
+                "Class {CLASS} inherits a method {METHOD} declared at {FILE}:{LINE} marked as {COMMENT} in phpdoc but does not override it",
+                self::REMEDIATION_B,
+                16025
             ),
             new Issue(
                 self::CommentParamOutOfOrder,

--- a/src/Phan/Language/Element/ClassConstant.php
+++ b/src/Phan/Language/Element/ClassConstant.php
@@ -103,31 +103,6 @@ class ClassConstant extends ClassElement implements ConstantInterface
             $this->name;
     }
 
-    /**
-     * @return bool
-     * True if this class constant is intended to be an override of another class constant (contains (at)override)
-     */
-    public function isOverrideIntended(): bool
-    {
-        return $this->getPhanFlagsHasState(Flags::IS_OVERRIDE_INTENDED);
-    }
-
-    /**
-     * Records whether or not this class constant is intended to be an override of another class constant (contains (at)override in PHPDoc)
-     * @param bool $is_override_intended
-
-     */
-    public function setIsOverrideIntended(bool $is_override_intended): void
-    {
-        $this->setPhanFlags(
-            Flags::bitVectorWithState(
-                $this->getPhanFlags(),
-                Flags::IS_OVERRIDE_INTENDED,
-                $is_override_intended
-            )
-        );
-    }
-
     public function getMarkupDescription(): string
     {
         $string = '';

--- a/src/Phan/Language/Element/ClassElement.php
+++ b/src/Phan/Language/Element/ClassElement.php
@@ -291,4 +291,52 @@ abstract class ClassElement extends AddressableElement
         }
         return false;
     }
+
+    /**
+     * @return bool
+     * True if this class constant is intended to be overridden in non-abstract classes.
+     */
+    public function isPHPDocAbstract(): bool
+    {
+        return $this->getPhanFlagsHasState(Flags::IS_PHPDOC_ABSTRACT);
+    }
+
+    /**
+     * Records whether or not this class constant is intended to be abstract
+     */
+    public function setIsPHPDocAbstract(bool $is_abstract): void
+    {
+        $this->setPhanFlags(
+            Flags::bitVectorWithState(
+                $this->getPhanFlags(),
+                Flags::IS_PHPDOC_ABSTRACT,
+                $is_abstract
+            )
+        );
+    }
+
+    /**
+     * @return bool
+     * True if this method is intended to be an override of another method (contains (at)override)
+     */
+    public function isOverrideIntended(): bool
+    {
+        return $this->getPhanFlagsHasState(Flags::IS_OVERRIDE_INTENDED);
+    }
+
+    /**
+     * Sets whether this method is intended to be an override of another method (contains (at)override)
+     * @param bool $is_override_intended
+
+     */
+    public function setIsOverrideIntended(bool $is_override_intended): void
+    {
+        $this->setPhanFlags(
+            Flags::bitVectorWithState(
+                $this->getPhanFlags(),
+                Flags::IS_OVERRIDE_INTENDED,
+                $is_override_intended
+            )
+        );
+    }
 }

--- a/src/Phan/Language/Element/Comment.php
+++ b/src/Phan/Language/Element/Comment.php
@@ -445,6 +445,15 @@ class Comment
 
     /**
      * @return bool
+     * Set to true if the comment contains an 'abstract' directive.
+     */
+    public function isPHPDocAbstract(): bool
+    {
+        return ($this->comment_flags & Flags::IS_PHPDOC_ABSTRACT) !== 0;
+    }
+
+    /**
+     * @return bool
      * Set to true if the comment contains an 'internal'
      * directive.
      */
@@ -464,7 +473,13 @@ class Comment
         return ($this->comment_flags & Flags::IS_SIDE_EFFECT_FREE) === Flags::IS_SIDE_EFFECT_FREE;
     }
 
-    private const FLAGS_FOR_PROPERTY = Flags::IS_NS_INTERNAL | Flags::IS_DEPRECATED | Flags::IS_READ_ONLY | Flags::IS_WRITE_ONLY;
+    private const FLAGS_FOR_PROPERTY =
+        Flags::IS_NS_INTERNAL |
+        Flags::IS_DEPRECATED |
+        Flags::IS_READ_ONLY |
+        Flags::IS_WRITE_ONLY |
+        Flags::IS_PHPDOC_ABSTRACT |
+        Flags::IS_OVERRIDE_INTENDED;
 
     /**
      * Gets the subset of the bitmask that applies to properties.
@@ -494,7 +509,9 @@ class Comment
         Flags::IS_NS_INTERNAL |
         Flags::IS_DEPRECATED |
         Flags::HARDCODED_RETURN_TYPE |
-        Flags::IS_SIDE_EFFECT_FREE;
+        Flags::IS_SIDE_EFFECT_FREE |
+        Flags::IS_PHPDOC_ABSTRACT |
+        Flags::IS_OVERRIDE_INTENDED;
 
     /**
      * Gets the subset of the bitmask that applies to methods.

--- a/src/Phan/Language/Element/Flags.php
+++ b/src/Phan/Language/Element/Flags.php
@@ -69,6 +69,8 @@ class Flags
     public const IS_FAKE_CONSTRUCTOR = (1 << 27);
     public const IS_EXTERNAL_MUTATION_FREE = (1 << 28);
     public const IS_SIDE_EFFECT_FREE = self::IS_READ_ONLY | self::IS_EXTERNAL_MUTATION_FREE;
+    // @abstract tag on class constants or other elements
+    public const IS_PHPDOC_ABSTRACT = (1 << 29);
 
     /**
      * Either enable or disable the given flag on

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -158,31 +158,6 @@ class Method extends ClassElement implements FunctionInterface
     }
 
     /**
-     * @return bool
-     * True if this method is intended to be an override of another method (contains (at)override)
-     */
-    public function isOverrideIntended(): bool
-    {
-        return $this->getPhanFlagsHasState(Flags::IS_OVERRIDE_INTENDED);
-    }
-
-    /**
-     * Sets whether this method is intended to be an override of another method (contains (at)override)
-     * @param bool $is_override_intended
-
-     */
-    public function setIsOverrideIntended(bool $is_override_intended): void
-    {
-        $this->setPhanFlags(
-            Flags::bitVectorWithState(
-                $this->getPhanFlags(),
-                Flags::IS_OVERRIDE_INTENDED,
-                $is_override_intended
-            )
-        );
-    }
-
-    /**
      * Returns true if this element is overridden by at least one other element
      */
     public function isOverriddenByAnother(): bool

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -284,7 +284,10 @@ class Type
     /** For types copied from phpdoc, e.g. `(at)param integer $x` */
     public const FROM_PHPDOC = 2;
 
-    /** To distinguish NativeType subclasses and classes with the same name. Overridden in subclasses */
+    /**
+     * To distinguish NativeType subclasses and classes with the same name.
+     * Overridden in some subclasses but not others.
+     */
     public const KEY_PREFIX = '';
 
     /** To normalize combinations of union types */
@@ -402,6 +405,8 @@ class Type
      * A single canonical instance of the given type.
      *
      * @suppress PhanThrowTypeAbsent
+     *
+     * Overridden in some subclasses but not others.
      */
     protected static function make(
         string $namespace,
@@ -4040,8 +4045,8 @@ class Type
     /**
      * Returns true if this is referring to the throwable interface exactly
      */
-    public function isThrowableInterface(): bool {
+    public function isThrowableInterface(): bool
+    {
         return $this->name === 'Throwable' && $this->namespace === '\\';
     }
-
 }

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -733,6 +733,7 @@ class ParseVisitor extends ScopeVisitor
             $constant->setIsDeprecated($comment->isDeprecated());
             $constant->setIsNSInternal($comment->isNSInternal());
             $constant->setIsOverrideIntended($comment->isOverrideIntended());
+            $constant->setIsPHPDocAbstract($comment->isPHPDocAbstract());
             $constant->setSuppressIssueSet($comment->getSuppressIssueSet());
             $value_node = $child_node->children['value'];
             if ($value_node instanceof Node) {

--- a/src/Phan/Plugin/Internal/MiscParamPlugin.php
+++ b/src/Phan/Plugin/Internal/MiscParamPlugin.php
@@ -40,8 +40,8 @@ use Phan\Language\Type\ScalarType;
 use Phan\Language\Type\StringType;
 use Phan\Language\UnionType;
 use Phan\Parse\ParseVisitor;
-use Phan\PluginV3;
 use Phan\Plugin\Internal\VariableTracker\VariableTrackerVisitor;
+use Phan\PluginV3;
 use Phan\PluginV3\AnalyzeFunctionCallCapability;
 use Phan\PluginV3\StopParamAnalysisException;
 

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
@@ -979,8 +979,8 @@ final class VariableTrackerVisitor extends AnalysisVisitor
                 $block_exit_status = (new BlockExitStatusChecker())->__invoke($stmts_node);
                 if (($block_exit_status & BlockExitStatusChecker::STATUS_THROW_OR_RETURN_BITMASK) === $block_exit_status) {
                     $inner_exiting_scope_list[] = $inner_scope;
-                } else if ($block_exit_status !== BlockExitStatusChecker::STATUS_PROCEED ||
-                        $i === \count($node->children) - 1)  {
+                } elseif ($block_exit_status !== BlockExitStatusChecker::STATUS_PROCEED ||
+                        $i === \count($node->children) - 1) {
                     $inner_scope_list[] = $inner_scope;
                 }
                 if (!($block_exit_status & BlockExitStatusChecker::STATUS_PROCEED)) {

--- a/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
+++ b/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
@@ -408,7 +408,7 @@ final class VariableTrackerElementVisitor extends PluginAwarePostAnalysisVisitor
                     // Don't warn if there's at least one usage of that definition
                     continue;
                 }
-                if (($graph->def_bitset[$definition_id] ?? 0) & (VariableGraph::IS_UNSET|VariableGraph::IS_DISABLED_WARNINGS)) {
+                if (($graph->def_bitset[$definition_id] ?? 0) & (VariableGraph::IS_UNSET | VariableGraph::IS_DISABLED_WARNINGS)) {
                     // Don't warn about unset($x)
                     continue;
                 }

--- a/tests/files/expected/0907_abstract_class_constant.php.expected
+++ b/tests/files/expected/0907_abstract_class_constant.php.expected
@@ -1,0 +1,3 @@
+%s:16 PhanCommentAbstractOnInheritedConstant Class \NA\NA\Bar inherits a class constant \NA\NA\Foo::X1 declared at %s:7 marked as @abstract in phpdoc but does not override it
+%s:20 PhanCommentAbstractOnInheritedConstant Class \NA\NA\Bas inherits a class constant \NA\NA\Foo::X2 declared at %s:10 marked as @abstract in phpdoc but does not override it
+%s:27 PhanCommentAbstractOnInheritedConstant Class \NA\NA\Bat inherits a class constant \NA\NA\Foo::X2 declared at %s:10 marked as @abstract in phpdoc but does not override it

--- a/tests/files/expected/0908_abstract_property.php.expected
+++ b/tests/files/expected/0908_abstract_property.php.expected
@@ -1,0 +1,4 @@
+%s:16 PhanCommentAbstractOnInheritedProperty Class \NA\NA\NA\Bar inherits a property \NA\NA\NA\Foo::X1 declared at %s:7 marked as @abstract in phpdoc but does not override it
+%s:20 PhanCommentAbstractOnInheritedProperty Class \NA\NA\NA\Bas inherits a property \NA\NA\NA\Foo::x2 declared at %s:10 marked as @abstract in phpdoc but does not override it
+%s:27 PhanCommentAbstractOnInheritedProperty Class \NA\NA\NA\Bat inherits a property \NA\NA\NA\Foo::x2 declared at %s:10 marked as @abstract in phpdoc but does not override it
+%s:31 PhanCommentOverrideOnNonOverrideProperty Saw an @override annotation for property \NA\NA\NA\Bat::notAnOverride, but could not find an overridden property

--- a/tests/files/expected/0909_phpdoc_abstract_method.php.expected
+++ b/tests/files/expected/0909_phpdoc_abstract_method.php.expected
@@ -1,0 +1,2 @@
+%s:20 PhanCommentAbstractOnInheritedMethod Class \NS909\C1 inherits a method \NS909\Base::test declared at %s:9 marked as @abstract in phpdoc but does not override it
+%s:21 PhanCommentAbstractOnInheritedMethod Class \NS909\C2 inherits a method \NS909\T::other declared at %s:15 marked as @abstract in phpdoc but does not override it

--- a/tests/files/src/0907_abstract_class_constant.php
+++ b/tests/files/src/0907_abstract_class_constant.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace NA\NA;
+
+class Foo {
+    /** @abstract should warn */
+    const X1 = '';
+
+    /** @phan-abstract */
+    const X2 = '';
+
+    /** @abstract should not warn */
+    private const Y = 123;
+}
+
+class Bar extends Foo {
+    const X2 = 'man';
+}
+
+class Bas extends Foo {
+    const X1 = 'soon';
+}
+
+abstract class AbstractBase extends Foo {
+}
+
+class Bat extends AbstractBase {
+    /** @override */
+    const X1 = 'man';
+}

--- a/tests/files/src/0908_abstract_property.php
+++ b/tests/files/src/0908_abstract_property.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace NA\NA\NA;
+
+class Foo {
+    /** @abstract should warn */
+    protected static $X1 = '';
+
+    /** @phan-abstract */
+    public $x2 = '';
+
+    /** @abstract should not warn */
+    private $y = 123;
+}
+
+class Bar extends Foo {
+    public $x2 = 'man';
+}
+
+class Bas extends Foo {
+    protected static $X1 = 'soon';
+}
+
+abstract class AbstractBase extends Foo {
+}
+
+class Bat extends AbstractBase {
+    /** @override */
+    protected static $X1 = 'man';
+    /** @override */
+    protected static $notAnOverride;
+    /**
+     * @override
+     * @suppress PhanCommentOverrideOnNonOverrideProperty
+     */
+    protected static $notAnOverride2;
+}

--- a/tests/files/src/0909_phpdoc_abstract_method.php
+++ b/tests/files/src/0909_phpdoc_abstract_method.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace NS909;
+
+use BadMethodCallException;
+
+class Base {
+    /** @abstract e.g. legacy code */
+    public static function test(): string {
+        throw new BadMethodCallException("unimplemented");
+    }
+}
+trait T {
+    /** @abstract e.g. legacy code */
+    public static function other(): string {
+        throw new BadMethodCallException("unimplemented");
+    }
+}
+
+class C1 extends Base {}
+class C2 extends Base {
+    use T;
+    public static function test(): string {
+        return 'fail';
+    }
+}
+abstract class C3 extends Base {
+    use T;
+}

--- a/tests/infer_missing_types_test/test.sh
+++ b/tests/infer_missing_types_test/test.sh
@@ -24,8 +24,10 @@ echo "Comparing the output:"
 
 # Normalize PHP_VERSION_ID
 # and remove php 8.0 warnings
+# Seeing ArrayAccess as a suggestion in some php versions
 sed -i \
     -e 's/\(to cast array_key_exists.* of type \)bool /\1?bool /' \
+    -e 's/ or interface \\ArrayAccess//' \
     $ACTUAL_PATH
 
 if type colordiff >/dev/null; then

--- a/tests/php80_files/expected/024_named_arg_missing.php.expected
+++ b/tests/php80_files/expected/024_named_arg_missing.php.expected
@@ -18,6 +18,12 @@
 %s:11 PhanTypeMismatchArgument Argument 2 ($requiredString) is 0 of type 0 but \C24::main() takes string defined at %s:3
 %s:12 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (definitelyInvalidFlag: 'value')
 %s:12 PhanUndeclaredNamedArgumentInternal Saw a call with undeclared named argument (definitelyInvalidFlag: 'value') to \strlen(string $string)
-%s:13 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (divisor: 123)
-%s:13 PhanMissingNamedArgumentInternal Missing named argument for int $dividend in call to \intdiv(int $numerator, int $divisor)
-%s:13 PhanParamTooFewInternal Call with 1 arg(s) to \intdiv(int $numerator, int $divisor) which requires 2 arg(s)
+%s:13 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (flags: 123)
+%s:13 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (value: [])
+%s:14 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (flags: 123)
+%s:14 PhanMissingNamedArgumentInternal Missing named argument for mixed $value in call to \json_encode($data, int $options = 0, int $depth = 512)
+%s:15 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (array: 123)
+%s:15 PhanMissingNamedArgumentInternal Missing named argument for ?callable $callback in call to \array_map(?callable $callback, array $input1, array ...$args)
+%s:15 PhanParamTooFewInternal Call with 1 arg(s) to \array_map(?callable $callback, array $input1, array ...$args) which requires 2 arg(s)
+%s:15 PhanTypeConversionFromArray array to string conversion
+%s:15 PhanTypeMismatchArgumentInternalReal Argument 2 ($input1) is 123 of type 123 but \array_map() takes array

--- a/tests/php80_files/expected/025_named_arg_callable_missing.php.expected
+++ b/tests/php80_files/expected/025_named_arg_callable_missing.php.expected
@@ -17,8 +17,7 @@
 %s:12 PhanMissingNamedArgument Missing named argument for int $requiredInt in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, ?mixed $other = null) defined at %s:4
 %s:13 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (definitelyInvalidFlag: 'value')
 %s:13 PhanUndeclaredNamedArgumentInternal Saw a call with undeclared named argument (definitelyInvalidFlag: 'value') to \strlen(string $string)
-%s:14 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (dividend: 1000)
-%s:14 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (divisor: 123)
-%s:15 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (divisor: 123)
-%s:15 PhanMissingNamedArgumentInternal Missing named argument for int $dividend in call to \intdiv(int $numerator, int $divisor)
-%s:15 PhanParamTooFewCallable Call with 1 arg(s) to \intdiv(int $numerator, int $divisor) (as a provided callable) which requires 2 arg(s) defined at internal:0
+%s:14 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (flags: 123)
+%s:14 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (value: 1000)
+%s:15 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (flags: 123)
+%s:15 PhanMissingNamedArgumentInternal Missing named argument for mixed $value in call to \json_encode($data, int $options = 0, int $depth = 512)

--- a/tests/php80_files/src/024_named_arg_missing.php
+++ b/tests/php80_files/src/024_named_arg_missing.php
@@ -10,4 +10,6 @@ C24::main(1, optionalFlag: true, other: 123);
 C24::main(requiredInt: 0, optionalFlag: true, other: 123);
 C24::main(requiredString: 0, optionalFlag: true, other: 123);
 echo strlen(definitelyInvalidFlag: 'value');
-echo intdiv(divisor: 123);
+echo json_encode(value: [], flags: 123);
+echo json_encode(flags: 123);
+echo array_map(array: 123);  // missing callback. hopefully this doesn't change parameter names

--- a/tests/php80_files/src/025_named_arg_callable_missing.php
+++ b/tests/php80_files/src/025_named_arg_callable_missing.php
@@ -11,5 +11,5 @@ call_user_func('C24::main', 1, optionalFlag: true, other: 123);
 call_user_func('C24::main', requiredInt: 0, optionalFlag: true, other: 123);
 call_user_func('C24::main', requiredString: 0, optionalFlag: true, other: 123);
 echo call_user_func('strlen', definitelyInvalidFlag: 'value');
-echo call_user_func('intdiv', dividend: 1000, divisor: 123);
-echo call_user_func('intdiv', divisor: 123);
+echo call_user_func('json_encode', value: 1000, flags: 123);
+echo call_user_func('json_encode', flags: 123);

--- a/tests/plugin_test/expected/156_parent_type.php_crash.expected
+++ b/tests/plugin_test/expected/156_parent_type.php_crash.expected
@@ -1,6 +1,5 @@
 src/156_parent_type.php_crash:8 PhanUnusedPublicNoOverrideMethodParameter Parameter $args is never used
 src/156_parent_type.php_crash:8 PhanUnusedPublicNoOverrideMethodParameter Parameter $method is never used
-src/156_parent_type.php_crash:14 PhanReadOnlyPHPDocProperty Possibly zero write references to PHPDoc @property \D156->declared
 src/156_parent_type.php_crash:24 PhanPluginPossiblyStaticClosure Closure() can be static
 src/156_parent_type.php_crash:27 PhanUndeclaredProperty Reference to undeclared property \A156->prop
 src/156_parent_type.php_crash:33 PhanTypeMismatchArgumentInternal Argument 1 ($string) is $c->declared of type int but \strlen() takes string

--- a/tests/plugin_test/src/156_parent_type.php_crash
+++ b/tests/plugin_test/src/156_parent_type.php_crash
@@ -11,7 +11,7 @@ class B156 extends B156 {
 class C156 extends D156 {
 }
 /**
- * @property int $declared
+ * @property int $declared NOTE: Phan has false positives/negatives because this is a circular dependency, which would throw an Error if this file was run in php
  */
 class D156 extends C156 {
     public function __get($name) {

--- a/tests/tool_test/json_stubs.expected80
+++ b/tests/tool_test/json_stubs.expected80
@@ -18,8 +18,8 @@ interface JsonSerializable {
     function jsonSerialize();
 }
 
-function json_decode(string $json, ?bool $assoc = null, int $depth = 512, int $options = 0) : mixed {}
-function json_encode(mixed $value, int $options = 0, int $depth = 512) : false|string {}
+function json_decode(string $json, ?bool $associative = null, int $depth = 512, int $flags = 0) : mixed {}
+function json_encode(mixed $value, int $flags = 0, int $depth = 512) : false|string {}
 function json_last_error() : int {}
 function json_last_error_msg() : string {}
 const JSON_BIGINT_AS_STRING = 2;


### PR DESCRIPTION
(or `@abstract`)

Fixes #2285
Closes #2278

Also, support `@phan-override`/`@override` on property