### PR TITLE
Require symfony/console 3.2 or greater

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "microsoft/tolerant-php-parser": "0.0.23",
         "netresearch/jsonmapper": ">=1.6.0",
         "sabre/event": "^5.0",
-        "symfony/console": "^2.3|^3.0|^4.0|^5.0",
+        "symfony/console": "^3.2|^4.0|^5.0",
         "symfony/polyfill-mbstring": "^1.11.0"
     },
     "suggest": {


### PR DESCRIPTION
This is a follow-up for 9731c39.

Fixes #4217.