### PR TITLE
Constraint versions for jsonmapper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "composer/xdebug-handler": "^1.3.2",
         "felixfbecker/advanced-json-rpc": "^3.0.4",
         "microsoft/tolerant-php-parser": "0.0.23",
-        "netresearch/jsonmapper": ">=1.6.0",
+        "netresearch/jsonmapper": "^1.6.0|^2.0|^3.0",
         "sabre/event": "^5.0",
         "symfony/console": "^2.3|^3.0|^4.0|^5.0",
         "symfony/polyfill-mbstring": "^1.11.0"


### PR DESCRIPTION
Currently, CI tests are broken by a `composer validate` failure.

This change adheres to the Composer convention to constraint versions.

This is a follow-up for 501ccaa.