### PR TITLE
Fix bug on codeclimate plugin

### DIFF
--- a/plugins/codeclimate/engine
+++ b/plugins/codeclimate/engine
@@ -90,9 +90,8 @@ call_user_func(static function () : void {
             }
         }
     };
-    $include_paths = $codeclimate_config['include_paths'] ?? [];
 
-    foreach (is_array($include_paths) ? $include_paths : [] as $path) {
+    foreach ($codeclimate_config['include_paths'] as $path) {
         if (is_dir('/code/' . $path)) {
             $queue_with_include_paths('/code/' . $path);
         } else {


### PR DESCRIPTION
At codeclimate we have recently updated the `phan` version that our engines are using. Prior to this update we were running version `1.2.7`, after creating a new `beta` channel with the latest `phan` version our customers reported us that the plugin was not working anymore. 

I have looked over the changes and I find out that changes introduced [here](https://github.com/phan/phan/commit/6c7b9a3f6d5d3536888e6b1a739cdd4ab7fb57fa#diff-84a32fdd3457ffac00819f581b2ab9b1eaa3ac7aa78cca536540b3f140d74c31) (some time ago) had broken the integration. Checking the code I found no strong reason to keep those changes so I have opened a new PR removing them, considering that removing them makes the integration work again. 

I would love to add some tests but we are running with very limited time this days, so sorry for not including some checks here as well.