### PR TITLE
Improve support for constructor property promotion

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,9 @@ Nov 26 2020, Phan 3.2.6 (dev)
 
 New features (Analysis):
 + Update many more real parameter names to match php 8.0's parameter names for php's own internal methods. (#4263)
++ Infer that an instance property exists for PHP 8.0 constructor property promotion. (#3938)
++ Emit `PhanInvalidNode` and `PhanRedefineProperty` when misusing syntax for constructor property promotion. (#3938)
++ Emit `PhanCompatibleConstructorPropertyPromotion` when the project's `minimum_target_php_version` is older than `8.0` (#3938)
 
 Nov 26 2020, Phan 3.2.5
 -----------------------

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -427,6 +427,14 @@ Declaring an autoloader with function __autoload() was deprecated in PHP 7.2 and
 
 e.g. [this issue](https://github.com/phan/phan/tree/3.0.3/tests/plugin_test/expected/000_plugins.php.expected#L21) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/3.0.3/tests/plugin_test/src/000_plugins.php#L64).
 
+## PhanCompatibleConstructorPropertyPromotion
+
+```
+Cannot use constructor property promotion before php 8.0 for {PARAMETER} of {METHOD}
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/php80_files/expected/032_variadic_promoted_property.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/php80_files/src/032_variadic_promoted_property.php#L3).
+
 ## PhanCompatibleDefaultEqualsNull
 
 ```

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -82,6 +82,27 @@ class ParameterTypesAnalyzer
         // are valid
         $is_optional_seen = false;
         foreach ($method->getParameterList() as $i => $parameter) {
+            if ($parameter->getFlags() & Parameter::PARAM_MODIFIER_VISIBILITY_FLAGS) {
+                if ($method instanceof Method && strcasecmp($method->getName(), '__construct') === 0) {
+                    Issue::maybeEmit(
+                        $code_base,
+                        $parameter->createContext($method),
+                        Issue::CompatibleConstructorPropertyPromotion,
+                        $parameter->getFileRef()->getLineNumberStart(),
+                        $parameter,
+                        $method->getRepresentationForIssue(true)
+                    );
+                } else {
+                    // emit an InvalidNode warning for non-constructors (closures, global functions, other methods)
+                    Issue::maybeEmit(
+                        $code_base,
+                        $parameter->createContext($method),
+                        Issue::InvalidNode,
+                        $parameter->getFileRef()->getLineNumberStart(),
+                        "Cannot use visibility modifier on parameter $parameter of non-constructor " . $method->getRepresentationForIssue(true)
+                    );
+                }
+            }
             $union_type = $parameter->getUnionType();
 
             if ($parameter->isOptional()) {

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -567,6 +567,7 @@ class Issue
     public const CompatibleNamedArgument            = 'PhanCompatibleNamedArgument';
     public const CompatibleTrailingCommaArgumentList = 'PhanCompatibleTrailingCommaArgumentList';
     public const CompatibleTrailingCommaParameterList = 'PhanCompatibleTrailingCommaParameterList';
+    public const CompatibleConstructorPropertyPromotion = 'PhanCompatibleConstructorPropertyPromotion';
 
     // Issue::CATEGORY_GENERIC
     public const TemplateTypeConstant       = 'PhanTemplateTypeConstant';
@@ -4264,6 +4265,7 @@ class Issue
                 self::REMEDIATION_B,
                 8005
             ),
+            // FIXME: It's redundant to include the first FILE:LINE of the declaration in the full issue message
             new Issue(
                 self::RedefineClassAlias,
                 self::CATEGORY_REDEFINE,
@@ -4902,6 +4904,14 @@ class Issue
                 "Cannot use trailing commas in argument lists before php 7.3 in {CODE}. NOTE: THIS ISSUE CAN ONLY DETECTED BY THE POLYFILL.",
                 self::REMEDIATION_B,
                 3037
+            ),
+            new Issue(
+                self::CompatibleConstructorPropertyPromotion,
+                self::CATEGORY_COMPATIBLE,
+                self::SEVERITY_NORMAL,
+                "Cannot use constructor property promotion before php 8.0 for {PARAMETER} of {METHOD}",
+                self::REMEDIATION_B,
+                3038
             ),
 
             // Issue::CATEGORY_GENERIC

--- a/src/Phan/Language/Element/Parameter.php
+++ b/src/Phan/Language/Element/Parameter.php
@@ -46,6 +46,9 @@ class Parameter extends Variable
     public const REFERENCE_WRITE_ONLY = 3;
     public const REFERENCE_IGNORED = 4;
 
+    public const PARAM_MODIFIER_VISIBILITY_FLAGS = ast\flags\PARAM_MODIFIER_PUBLIC | ast\flags\PARAM_MODIFIER_PRIVATE | ast\flags\PARAM_MODIFIER_PROTECTED;
+
+
     // __construct(Context $context, string $name, UnionType $type, int $flags) inherited from Variable
 
     /**
@@ -588,6 +591,11 @@ class Parameter extends Variable
     public function __toString(): string
     {
         $string = '';
+        $flags = $this->getFlags();
+        if ($flags & self::PARAM_MODIFIER_VISIBILITY_FLAGS) {
+            $string .= $flags & ast\flags\PARAM_MODIFIER_PUBLIC ? 'public ' :
+                        ($flags & ast\flags\PARAM_MODIFIER_PROTECTED ? 'protected ' : 'private ');
+        }
 
         $union_type = $this->getNonVariadicUnionType();
         if (!$union_type->isEmpty()) {

--- a/tests/Phan/Internal/UnitTestRecord.php
+++ b/tests/Phan/Internal/UnitTestRecord.php
@@ -59,9 +59,10 @@ class UnitTestRecord
 
     private static function getContents(string $filename): string
     {
-        $contents = file_get_contents($filename);
+        // Suppress error so that the failure message is understandable
+        $contents = @file_get_contents($filename);
         if (!is_string($contents)) {
-            throw new RuntimeException("Failed to read $filename");
+            throw new RuntimeException("Failed to read file $filename that's expected to exist in a unit test: " . (\error_get_last()['message'] ?? 'unknown'));
         }
         return $contents;
     }

--- a/tests/php80_files/expected/021_constructor_promotion.php.expected
+++ b/tests/php80_files/expected/021_constructor_promotion.php.expected
@@ -1,3 +1,9 @@
+%s:5 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for private ?\MissingClass $other = null of \FIXME_IMPLEMENT_CONSTRUCTOR_PROMOTION21::__construct(int $value, ?\MissingClass $other = null)
+%s:5 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for public int $value of \FIXME_IMPLEMENT_CONSTRUCTOR_PROMOTION21::__construct(int $value, ?\MissingClass $other = null)
+%s:5 PhanUndeclaredTypeParameter Parameter $other has undeclared type ?\MissingClass
+%s:5 PhanUndeclaredTypeProperty Property \FIXME_IMPLEMENT_CONSTRUCTOR_PROMOTION21->other has undeclared type ?\MissingClass
 %s:7 PhanTypeArraySuspicious Suspicious array access to $value of type int
-%s:10 PhanTypeMismatchArgumentReal Argument 1 ($value) is 'invalid' of type 'invalid' but \FIXME_IMPLEMENT_CONSTRUCTOR_PROMOTION21::__construct() takes int defined at %s:4
-%s:11 PhanUndeclaredProperty Reference to undeclared property \FIXME_IMPLEMENT_CONSTRUCTOR_PROMOTION21->value
+%s:10 PhanTypeMismatchArgumentReal Argument 1 ($value) is 'invalid' of type 'invalid' but \FIXME_IMPLEMENT_CONSTRUCTOR_PROMOTION21::__construct() takes int defined at %s:5
+%s:11 PhanTypeMismatchArgumentInternal Argument 1 ($string) is $x->value of type int but \strlen() takes string
+%s:14 PhanCompatibleTypedProperty Cannot use typed properties before php 7.4. This property group has type int
+%s:17 PhanRedefineProperty Property $value defined at %s:17 was previously defined at %s:14

--- a/tests/php80_files/expected/032_variadic_promoted_property.php.expected
+++ b/tests/php80_files/expected/032_variadic_promoted_property.php.expected
@@ -1,0 +1,9 @@
+%s:3 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for public ...$rest of \VariadicPromotedProperty::__construct(int $value, ...$rest)
+%s:3 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for public int $value of \VariadicPromotedProperty::__construct(int $value, ...$rest)
+%s:3 PhanInvalidNode Cannot declare variadic promoted property
+%s:6 PhanInvalidNode Cannot use visibility modifier on parameter public int $foo of non-constructor \VariadicPromotedProperty::other(int $foo)
+%s:6 PhanPluginUseReturnValueNoopVoid The function/method \VariadicPromotedProperty::other() is declared to return (empty union type) and it has no side effects
+%s:9 PhanCompatibleArrowFunction Cannot use arrow functions before php 7.4 in (fn)
+%s:9 PhanInvalidNode Cannot use visibility modifier on parameter public int $x of non-constructor Closure(int $x)
+%s:10 PhanInvalidNode Cannot use visibility modifier on parameter public $var of non-constructor \fn32($var)
+%s:10 PhanPluginUseReturnValueNoopVoid The function/method \fn32() is declared to return void and it has no side effects

--- a/tests/php80_files/expected/033_trait_promoted_property.php.expected
+++ b/tests/php80_files/expected/033_trait_promoted_property.php.expected
@@ -1,0 +1,4 @@
+%s:3 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for private int $x of \T32::__construct(int $x)
+%s:3 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for private int $x of \Y32::__construct(int $x)
+%s:9 PhanTypeMismatchReturnReal Returning $this->x of type int but getX() is declared to return \stdClass
+%s:14 PhanAccessPropertyPrivate Cannot access private property \Y32->x defined at %s:3 (Did you mean \Y32::getX())

--- a/tests/php80_files/src/021_constructor_promotion.php
+++ b/tests/php80_files/src/021_constructor_promotion.php
@@ -1,11 +1,19 @@
 <?php
-
+// Still not finished
 class FIXME_IMPLEMENT_CONSTRUCTOR_PROMOTION21 {
     public function __construct(
-        public int $value
+        public int $value, private MissingClass $other = null
     ) {
         echo $value[0];
     }
 }
 $x = new FIXME_IMPLEMENT_CONSTRUCTOR_PROMOTION21('invalid');
 echo strlen($x->value);
+
+class DuplicatePromotedProperty {
+    public int $value;
+
+    /** @suppress PhanCompatibleConstructorPropertyPromotion suppressions should work on the method */
+    public function __construct(public int $value) {
+    }
+}

--- a/tests/php80_files/src/032_variadic_promoted_property.php
+++ b/tests/php80_files/src/032_variadic_promoted_property.php
@@ -1,0 +1,10 @@
+<?php
+class VariadicPromotedProperty {
+    public function __CONSTRUCT(public int $value, public ...$rest) {
+    }
+
+    public function other(public int $foo) {
+    }
+}
+$c = fn(public int $x) => 123;
+function fn32(public $var) {}

--- a/tests/php80_files/src/033_trait_promoted_property.php
+++ b/tests/php80_files/src/033_trait_promoted_property.php
@@ -1,0 +1,14 @@
+<?php
+trait T32 {
+    public function __construct(private int $x) {}
+}
+class Y32 {
+    use T32;
+    // Should infer the private property from the trait is accessible from within the class
+    public function getX(): stdClass {
+        return $this->x;
+    }
+}
+$y = new Y32(32);
+var_export($y->getX());
+var_export($y->x);  // inaccessible


### PR DESCRIPTION
For #3938

+ Infer that an instance property exists for PHP 8.0 constructor
  property promotion.
+ Emit `PhanInvalidNode` and `PhanRedefineProperty` when misusing syntax
  for constructor property promotion.
+ Emit `PhanCompatibleConstructorPropertyPromotion` when the project's
  `minimum_target_php_version` is older than `8.0`

ParseVisitor changes used mkosiedowski's comment as a starting point:
https://github.com/phan/phan/issues/3938#issuecomment-734769404