### PR TITLE
PHP8 Mixed Type Not Being Detected As Nullable

### DIFF
--- a/src/Phan/Language/Element/Func.php
+++ b/src/Phan/Language/Element/Func.php
@@ -442,7 +442,11 @@ class Func extends AddressableElement implements FunctionInterface
 
         $return_type = $this->real_return_type;
         if ($return_type && !$return_type->isEmpty()) {
-            $stub .= ' : ' . (string)$return_type;
+            $return_type_string = (string)$return_type;
+            if (\PHP_VERSION_ID >= 80000 && $return_type_string === '?mixed') {
+                $return_type_string = 'mixed';
+            }
+            $stub .= ' : ' . $return_type_string;
         }
         $stub .= " {}\n";
         $namespace = \ltrim($fqsen->getNamespace(), '\\');

--- a/src/Phan/Language/Element/Parameter.php
+++ b/src/Phan/Language/Element/Parameter.php
@@ -599,7 +599,11 @@ class Parameter extends Variable
 
         $union_type = $this->getNonVariadicUnionType();
         if (!$union_type->isEmpty()) {
-            $string .= $union_type->__toString() . ' ';
+            $type_string = $union_type->__toString();
+            if (\PHP_VERSION_ID >= 80000 && $type_string === '?mixed') {
+                $type_string = 'mixed';
+            }
+            $string .= $type_string . ' ';
         }
 
         if ($this->isPassByReference()) {
@@ -631,7 +635,11 @@ class Parameter extends Variable
 
         $union_type = $this->getNonVariadicUnionType();
         if (!$union_type->isEmpty()) {
-            $string .= $union_type->__toString() . ' ';
+            $type_string = $union_type->__toString();
+            if (\PHP_VERSION_ID >= 80000 && $type_string === '?mixed') {
+                $type_string = 'mixed';
+            }
+            $string .= $type_string . ' ';
         }
 
         if ($this->isPassByReference()) {
@@ -790,6 +798,9 @@ class Parameter extends Variable
 
         // TODO: hide template types, generic array or real array types
         $union_type_string = $union_type->__toString();
+        if (\PHP_VERSION_ID >= 80000 && $union_type_string === '?mixed') {
+            return 'mixed';
+        }
         if ($union_type_string === 'mixed') {
             return '';
         }

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -894,9 +894,6 @@ class Type
         if ($reflection_type instanceof \ReflectionNamedType) {
             $reflection_type_string = $reflection_type->getName();
             if ($reflection_type->allowsNull()) {
-                if (\PHP_VERSION_ID >= 80000 && $reflection_type_string === 'mixed') {
-                    return 'mixed';
-                }
                 return "?" . $reflection_type_string;
             }
             return $reflection_type_string;

--- a/tests/php80_files/expected/024_named_arg_missing.php.expected
+++ b/tests/php80_files/expected/024_named_arg_missing.php.expected
@@ -1,20 +1,20 @@
 %s:7 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (other: true)
-%s:7 PhanMissingNamedArgument Missing named argument for int $requiredInt in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, ?mixed $other = null) defined at %s:3
-%s:7 PhanMissingNamedArgument Missing named argument for string $requiredString in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, ?mixed $other = null) defined at %s:3
-%s:7 PhanParamTooFew Call with 1 arg(s) to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, ?mixed $other = null) which requires 2 arg(s) defined at %s:3
+%s:7 PhanMissingNamedArgument Missing named argument for int $requiredInt in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, mixed $other = null) defined at %s:3
+%s:7 PhanMissingNamedArgument Missing named argument for string $requiredString in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, mixed $other = null) defined at %s:3
+%s:7 PhanParamTooFew Call with 1 arg(s) to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, mixed $other = null) which requires 2 arg(s) defined at %s:3
 %s:8 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (optionalFlag: true)
-%s:8 PhanMissingNamedArgument Missing named argument for string $requiredString in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, ?mixed $other = null) defined at %s:3
+%s:8 PhanMissingNamedArgument Missing named argument for string $requiredString in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, mixed $other = null) defined at %s:3
 %s:9 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (optionalFlag: true)
 %s:9 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (other: 123)
-%s:9 PhanMissingNamedArgument Missing named argument for string $requiredString in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, ?mixed $other = null) defined at %s:3
+%s:9 PhanMissingNamedArgument Missing named argument for string $requiredString in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, mixed $other = null) defined at %s:3
 %s:10 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (optionalFlag: true)
 %s:10 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (other: 123)
 %s:10 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (requiredInt: 0)
-%s:10 PhanMissingNamedArgument Missing named argument for string $requiredString in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, ?mixed $other = null) defined at %s:3
+%s:10 PhanMissingNamedArgument Missing named argument for string $requiredString in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, mixed $other = null) defined at %s:3
 %s:11 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (optionalFlag: true)
 %s:11 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (other: 123)
 %s:11 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (requiredString: 0)
-%s:11 PhanMissingNamedArgument Missing named argument for int $requiredInt in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, ?mixed $other = null) defined at %s:3
+%s:11 PhanMissingNamedArgument Missing named argument for int $requiredInt in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, mixed $other = null) defined at %s:3
 %s:11 PhanTypeMismatchArgument Argument 2 ($requiredString) is 0 of type 0 but \C24::main() takes string defined at %s:3
 %s:12 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (definitelyInvalidFlag: 'value')
 %s:12 PhanUndeclaredNamedArgumentInternal Saw a call with undeclared named argument (definitelyInvalidFlag: 'value') to \strlen(string $string)

--- a/tests/php80_files/expected/025_named_arg_callable_missing.php.expected
+++ b/tests/php80_files/expected/025_named_arg_callable_missing.php.expected
@@ -1,20 +1,20 @@
 %s:8 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (other: true)
-%s:8 PhanMissingNamedArgument Missing named argument for int $requiredInt in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, ?mixed $other = null) defined at %s:4
-%s:8 PhanMissingNamedArgument Missing named argument for string $requiredString in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, ?mixed $other = null) defined at %s:4
-%s:8 PhanParamTooFewCallable Call with 1 arg(s) to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, ?mixed $other = null) (as a provided callable) which requires 2 arg(s) defined at %s:4
+%s:8 PhanMissingNamedArgument Missing named argument for int $requiredInt in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, mixed $other = null) defined at %s:4
+%s:8 PhanMissingNamedArgument Missing named argument for string $requiredString in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, mixed $other = null) defined at %s:4
+%s:8 PhanParamTooFewCallable Call with 1 arg(s) to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, mixed $other = null) (as a provided callable) which requires 2 arg(s) defined at %s:4
 %s:9 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (optionalFlag: true)
-%s:9 PhanMissingNamedArgument Missing named argument for string $requiredString in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, ?mixed $other = null) defined at %s:4
+%s:9 PhanMissingNamedArgument Missing named argument for string $requiredString in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, mixed $other = null) defined at %s:4
 %s:10 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (optionalFlag: true)
 %s:10 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (other: 123)
-%s:10 PhanMissingNamedArgument Missing named argument for string $requiredString in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, ?mixed $other = null) defined at %s:4
+%s:10 PhanMissingNamedArgument Missing named argument for string $requiredString in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, mixed $other = null) defined at %s:4
 %s:11 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (optionalFlag: true)
 %s:11 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (other: 123)
 %s:11 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (requiredInt: 0)
-%s:11 PhanMissingNamedArgument Missing named argument for string $requiredString in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, ?mixed $other = null) defined at %s:4
+%s:11 PhanMissingNamedArgument Missing named argument for string $requiredString in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, mixed $other = null) defined at %s:4
 %s:12 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (optionalFlag: true)
 %s:12 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (other: 123)
 %s:12 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (requiredString: 0)
-%s:12 PhanMissingNamedArgument Missing named argument for int $requiredInt in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, ?mixed $other = null) defined at %s:4
+%s:12 PhanMissingNamedArgument Missing named argument for int $requiredInt in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, mixed $other = null) defined at %s:4
 %s:13 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (definitelyInvalidFlag: 'value')
 %s:13 PhanUndeclaredNamedArgumentInternal Saw a call with undeclared named argument (definitelyInvalidFlag: 'value') to \strlen(string $string)
 %s:14 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (flags: 123)

--- a/tests/php80_files/src/035_mixed_type_is_always_nullable.php
+++ b/tests/php80_files/src/035_mixed_type_is_always_nullable.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+class C35{
+	/** @var array */
+	private $decodedJson;
+
+	public function decodeJson(){
+		$this->decodedJson = json_decode('{"this:"is not valid json"', true) ?? [];
+	}
+}


### PR DESCRIPTION
As far as I can tell, this PR should resolve the issue by marking it as `?mixed` internally, but then it should output as `mixed` (creating valid PHP code where applicable).

The above said, I have only worked with the repo itself for a few hours; so there is a high chance I have either missed issues this will cause and/or other affected cases. If that is the case, I am happy to try and fix if feedback is provided :)

This relates to issue 4276. I realise now that the PR might count as an issue (I am more used to Bitbucket where I need to create an issue and a PR). I won't mess further, but I am sorry if I have caused more admin!