### PR TITLE
`mixed` should be treated as nullable

### DIFF
--- a/.phan/plugins/DuplicateArrayKeyPlugin.php
+++ b/.phan/plugins/DuplicateArrayKeyPlugin.php
@@ -171,7 +171,7 @@ class DuplicateArrayKeyVisitor extends PluginAwarePostAnalysisVisitor
             if ($old_index !== null) {
                 $this->emitPluginIssue(
                     $this->code_base,
-                    clone($this->context)->withLineNumberStart($children[$i]->lineno),
+                    (clone($this->context))->withLineNumberStart($children[$i]->lineno),
                     'PhanPluginDuplicateSwitchCaseLooseEquality',
                     "Switch case({STRING_LITERAL}) is loosely equivalent (==) to an earlier case ({STRING_LITERAL}) in switch statement - the earlier entry may be chosen instead.",
                     [self::normalizeSwitchKey($values_to_check[$i]), self::normalizeSwitchKey($values_to_check[$old_index])],

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@ New features (Analysis):
 + Raise the severity of some php 8.0 incompatibility issues to critical.
 + Fix handling of references after renaming variadic reference parameters of `fscanf`/`scanf`/`mb_convert_variables`
 + Mention if PhanUndeclaredFunction is potentially caused by the target php version being too old. (#4230)
++ Support a `non-null-mixed` type and change the way analysis involving nullability is checked for `mixed` (phpdoc and real). (#4278, #4276)
 
 Nov 27 2020, Phan 3.2.6
 -----------------------

--- a/internal/lib/IncompatibleRealStubsSignatureDetector.php
+++ b/internal/lib/IncompatibleRealStubsSignatureDetector.php
@@ -554,7 +554,7 @@ class IncompatibleRealStubsSignatureDetector extends IncompatibleSignatureDetect
              */
             try {
                 $new_signatures[$method_name] = $this->updateSignatureParamNames($method_name, $arguments);
-            } catch (InvalidArgumentException|FQSENException $e) {
+            } catch (InvalidArgumentException | FQSENException $e) {
                 fwrite(STDERR, "Unexpected invalid signature for $method_name, skipping: $e\n");
             }
         }
@@ -575,7 +575,7 @@ class IncompatibleRealStubsSignatureDetector extends IncompatibleSignatureDetect
                      */
                     try {
                         $delta_contents[$section][$method_name] = $this->updateSignatureParamNames($method_name, $arguments);
-                    } catch (InvalidArgumentException|FQSENException $e) {
+                    } catch (InvalidArgumentException | FQSENException $e) {
                         fwrite(STDERR, "Unexpected invalid signature for $method_name for $delta_path, skipping: $e\n");
                     }
                 }

--- a/internal/lib/IncompatibleSignatureDetectorBase.php
+++ b/internal/lib/IncompatibleSignatureDetectorBase.php
@@ -214,7 +214,7 @@ EOT;
             }
             try {
                 $new_signatures[$method_name] = static::updateSignature($method_name, $arguments);
-            } catch (FQSENException|InvalidArgumentException $e) {
+            } catch (FQSENException | InvalidArgumentException $e) {
                 static::info("Skipping invalid signature for $method_name: $e\n");
                 $new_signatures[$method_name] = $arguments;
             }

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -1467,7 +1467,7 @@ class ContextNode
             foreach ($union_type->getTypeSet() as $type) {
                 if (!$type->isPossiblyObject()) {
                     $invalid = $invalid->withType($type);
-                } elseif ($type->isNullable()) {
+                } elseif ($type->isNullableLabeled()) {
                     $invalid = $invalid->withType(NullType::instance(false));
                 }
             }
@@ -1476,15 +1476,21 @@ class ContextNode
                     $invalid = $invalid->nonNullableClone();
                 }
                 if (!$invalid->isEmpty()) {
-                    $this->emitIssue(
-                        Issue::PossiblyUndeclaredProperty,
-                        $node->lineno,
-                        $property_name,
-                        $union_type,
-                        $invalid
-                    );
-                    if ($property) {
-                        return $property;
+                    foreach ($invalid->getTypeset() as $type) {
+                        if (!$type->isNullableLabeled()) {
+                            continue;
+                        }
+                        $this->emitIssue(
+                            Issue::PossiblyUndeclaredProperty,
+                            $node->lineno,
+                            $property_name,
+                            $union_type,
+                            $invalid
+                        );
+                        if ($property) {
+                            return $property;
+                        }
+                        break;
                     }
                 }
             }

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -755,7 +755,7 @@ class ContextNode
                 || (!$union_type->isEmpty()
                     && $union_type->isNativeType()
                     && !$union_type->hasTypeMatchingCallback(static function (Type $type): bool {
-                        return !$type->isNullable() && ($type instanceof MixedType || $type instanceof ObjectType);
+                        return !$type->isNullableLabeled() && ($type instanceof MixedType || $type instanceof ObjectType);
                     })
                     // reject `$stringVar->method()` but not `$stringVar::method()` and not (`new $stringVar()`
                     && !(($is_static || $is_new_expression) && $union_type->hasNonNullStringType())

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1707,7 +1707,7 @@ class UnionTypeVisitor extends AnalysisVisitor
         // If we have generics, we're all set
         if (!$generic_types->isEmpty()) {
             $generic_types = $generic_types->asNormalizedTypes();
-            if (!($node->flags & self::FLAG_IGNORE_NULLABLE) && $union_type->containsNullable()) {
+            if (!($node->flags & self::FLAG_IGNORE_NULLABLE) && $union_type->containsNonMixedNullable()) {
                 $this->emitIssue(
                     Issue::TypeArraySuspiciousNullable,
                     $node->lineno,

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1988,9 +1988,35 @@ class UnionTypeVisitor extends AnalysisVisitor
             }
             // $union_type is exclusively array shape types, but those don't contain the field $dim_value.
             // It's undefined (which becomes null)
-            return NullType::instance(false)->asPHPDocUnionType();
+            if (self::couldRealTypesHaveKey($union_type->getRealTypeSet(), $dim_value)) {
+                return NullType::instance(false)->asPHPDocUnionType();
+            }
+            return NullType::instance(false)->asRealUnionType();
         }
         return $resulting_element_type;
+    }
+
+    /**
+     * @param list<Type> $real_type_set
+     * @param int|string|float $dim_value
+     */
+    private static function couldRealTypesHaveKey(array $real_type_set, $dim_value): bool
+    {
+        foreach ($real_type_set as $type) {
+            if ($type instanceof ArrayShapeType) {
+                if (\array_key_exists($dim_value, $type->getFieldTypes())) {
+                    return true;
+                }
+            } elseif ($type instanceof ListType) {
+                $filtered = \is_int($dim_value) ? $dim_value : \filter_var($dim_value, \FILTER_VALIDATE_INT);
+                if (\is_int($filtered) && $filtered >= 0) {
+                    return true;
+                }
+            } else {
+                return true;
+            }
+        }
+        return \count($real_type_set) === 0;
     }
 
     /**
@@ -2139,7 +2165,7 @@ class UnionTypeVisitor extends AnalysisVisitor
         try {
             if ($generic_types->isEmpty()) {
                 if (!$union_type->asExpandedTypes($this->code_base)->hasIterable() && !$union_type->hasTypeMatchingCallback(static function (Type $type): bool {
-                    return !$type->isNullable() && $type instanceof MixedType;
+                    return !$type->isNullableLabeled() && $type instanceof MixedType;
                 })) {
                     throw new IssueException(
                         Issue::fromType(Issue::TypeMismatchUnpackValue)(

--- a/src/Phan/Analysis/ArgumentType.php
+++ b/src/Phan/Analysis/ArgumentType.php
@@ -1113,7 +1113,7 @@ final class ArgumentType
                 return null;
             }
             // @phan-suppress-next-line PhanAccessMethodInternal
-            if (!$argument_type_expanded_resolved->canCastToUnionTypeIfNonNull($alternate_parameter_type)) {
+            if ($argument_type_expanded_resolved->isNull() || !$argument_type_expanded_resolved->canCastToUnionTypeIfNonNull($alternate_parameter_type)) {
                 if ($argument_type->hasRealTypeSet() && $alternate_parameter_type->hasRealTypeSet()) {
                     $real_arg_type = $argument_type->getRealUnionType();
                     $real_parameter_type = $alternate_parameter_type->getRealUnionType();

--- a/src/Phan/Analysis/AssignOperatorAnalysisVisitor.php
+++ b/src/Phan/Analysis/AssignOperatorAnalysisVisitor.php
@@ -574,7 +574,7 @@ class AssignOperatorAnalysisVisitor extends FlagVisitorImplementation
             $this->warnAboutInvalidUnionType(
                 $node,
                 static function (Type $type): bool {
-                    return ($type instanceof IntType || $type instanceof StringType || $type instanceof MixedType) && !$type->isNullable();
+                    return ($type instanceof IntType || $type instanceof StringType || $type instanceof MixedType) && !$type->isNullableLabeled();
                 },
                 $left_type,
                 $right_type,
@@ -720,7 +720,7 @@ class AssignOperatorAnalysisVisitor extends FlagVisitorImplementation
         $this->warnAboutInvalidUnionType(
             $node,
             static function (Type $type): bool {
-                return ($type instanceof IntType || $type instanceof MixedType) && !$type->isNullable();
+                return ($type instanceof IntType || $type instanceof MixedType) && !$type->isNullableLabeled();
             },
             $left,
             $right,

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -1878,9 +1878,9 @@ class AssignmentVisitor extends AnalysisVisitor
                     }
                 }
             } elseif (!$assign_type->hasTypeMatchingCallback(static function (Type $type) use ($simple_xml_element_type): bool {
-                return !$type->isNullable() && ($type instanceof MixedType || $type === $simple_xml_element_type);
+                return !$type->isNullableLabeled() && ($type instanceof MixedType || $type === $simple_xml_element_type);
             })) {
-                // Imitate the check in UnionTypeVisitor, don't warn for mixed, etc.
+                // Imitate the check in UnionTypeVisitor, don't warn for mixed (but warn for `?mixed`), etc.
                 $this->emitIssue(
                     Issue::TypeArraySuspicious,
                     $node->lineno,

--- a/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
+++ b/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
@@ -838,8 +838,6 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
         }
         $common_left_fields = null;
         foreach ($left->getRealTypeSet() as $type) {
-            // if ($type->isNullable()) { return; }
-
             if (!$type instanceof ArrayShapeType) {
                 if ($type instanceof ListType) {
                     continue;

--- a/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
+++ b/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
@@ -1058,6 +1058,9 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
         // On the left side, remove null and replace '?T' with 'T'
         // Don't bother if the right side contains null.
         if (!$right_type->isEmpty() && $left_type->containsNullable() && !$right_type->containsNullable()) {
+            if ($left_type->getRealUnionType()->isRealTypeNullOrUndefined()) {
+                return $right_type;
+            }
             $left_type = $left_type->nonNullableClone();
         }
 

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -855,10 +855,12 @@ class ConditionVisitor extends KindVisitorImplementation implements ConditionVis
                     // FIXME move this to PostOrderAnalysisVisitor so that all expressions can be analyzed, not just variables?
                     $new_type = $default_if_empty;
                 } else {
-                    $new_type = $new_type->nonNullableClone();
+                    // Add the missing type set before making the non-nullable clone.
+                    // Otherwise, it'd have the real type set non-null-mixed.
                     if (!$new_type->hasRealTypeSet()) {
                         $new_type = $new_type->withRealTypeSet($default_if_empty->getRealTypeSet());
                     }
+                    $new_type = $new_type->nonNullableClone();
                     if (!$allow_undefined) {
                         $new_type = $new_type->withIsPossiblyUndefined(false);
                     }

--- a/src/Phan/Analysis/ConditionVisitorUtil.php
+++ b/src/Phan/Analysis/ConditionVisitorUtil.php
@@ -496,6 +496,8 @@ trait ConditionVisitorUtil
                 };
             }
         } else {
+            // Remove loosely equal types.
+            // TODO: Does this properly remove null for `$var != 0`?
             $cb = static function (Type $type) use ($value): bool {
                 return $type instanceof LiteralTypeInterface && $type->getValue() == $value;
             };

--- a/src/Phan/Analysis/NegatedConditionVisitor.php
+++ b/src/Phan/Analysis/NegatedConditionVisitor.php
@@ -573,6 +573,7 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
                 // Add types which are not scalars
                 foreach ($union_type->getTypeSet() as $type) {
                     if ($type_filter($type)) {
+                        // e.g. mixed|SomeClass can be null because mixed can be null.
                         $has_null = $has_null || $type->isNullable();
                         continue;
                     }
@@ -583,6 +584,7 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
                 if ($has_null && !$has_other_nullable_types) {
                     $new_type_builder->addType(NullType::instance(false));
                 }
+                // TODO: Infer real type sets as well?
                 $variable->setUnionType($new_type_builder->getPHPDocUnionType());
             };
         };

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -238,7 +238,7 @@ class ParameterTypesAnalyzer
             foreach ($real_parameter->getUnionType()->getTypeSet() as $type) {
                 $type_class = \get_class($type);
                 if ($php70_checks) {
-                    if ($type->isNullable()) {
+                    if ($type->isNullableLabeled()) {
                         if ($real_parameter->isUsingNullableSyntax()) {
                             Issue::maybeEmit(
                                 $code_base,
@@ -315,15 +315,15 @@ class ParameterTypesAnalyzer
                             (string)$type
                         );
                     } else {
-                        if ($type->isNullable()) {
+                        if ($type->isNullableLabeled()) {
                             // Don't emit CompatibleNullableTypePHP70 for `void`.
-                                Issue::maybeEmit(
-                                    $code_base,
-                                    $method->getContext(),
-                                    Issue::CompatibleNullableTypePHP70,
-                                    $method->getFileRef()->getLineNumberStart(),
-                                    (string)$type
-                                );
+                            Issue::maybeEmit(
+                                $code_base,
+                                $method->getContext(),
+                                Issue::CompatibleNullableTypePHP70,
+                                $method->getFileRef()->getLineNumberStart(),
+                                (string)$type
+                            );
                         }
                         if ($type_class === IterableType::class) {
                             Issue::maybeEmit(

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -1655,7 +1655,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             // Suppressing TypeMismatchReturnReal also suppresses less severe return type mismatches
             return;
         }
-        if ($this->checkCanCastToReturnTypeIfWasNonNullInstead($expression_type, $method_return_type)) {
+        if (!$expression_type->isNull() && $this->checkCanCastToReturnTypeIfWasNonNullInstead($expression_type, $method_return_type)) {
             if ($this->shouldSuppressIssue(Issue::TypeMismatchReturn, $lineno)) {
                 // Suppressing TypeMismatchReturn also suppresses TypeMismatchReturnNullable
                 return;

--- a/src/Phan/Language/AnnotatedUnionType.php
+++ b/src/Phan/Language/AnnotatedUnionType.php
@@ -107,6 +107,16 @@ class AnnotatedUnionType extends UnionType
         return $this->is_possibly_undefined === self::DEFINITELY_UNDEFINED;
     }
 
+    public function isNull(): bool
+    {
+        return $this->is_possibly_undefined === self::DEFINITELY_UNDEFINED || parent::isNull();
+    }
+
+    public function isRealTypeNullOrUndefined(): bool
+    {
+        return $this->is_possibly_undefined === self::DEFINITELY_UNDEFINED || parent::isRealTypeNullOrUndefined();
+    }
+
     public function __toString(): string
     {
         $result = parent::__toString();

--- a/src/Phan/Language/Element/Property.php
+++ b/src/Phan/Language/Element/Property.php
@@ -429,6 +429,7 @@ class Property extends ClassElement
             if (!$type->isObjectWithKnownFQSEN()) {
                 continue;
             }
+            // $type is the name of a class - replace it with $new and preserve nullability.
             if (FullyQualifiedClassName::fromType($type) === $old) {
                 $union_type = $union_type
                     ->withoutType($type)

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -351,7 +351,7 @@ final class EmptyUnionType extends UnionType
     /** @override */
     public function nonNullableClone(): UnionType
     {
-        return $this;
+        return UnionType::fromFullyQualifiedRealString('non-null-mixed');
     }
 
     /** @override */
@@ -369,7 +369,7 @@ final class EmptyUnionType extends UnionType
     /** @override */
     public function withIsNullable(bool $is_nullable): UnionType
     {
-        return $this;
+        return $is_nullable ? $this : $this->nonNullableClone();
     }
 
     /**
@@ -553,10 +553,13 @@ final class EmptyUnionType extends UnionType
      * @internal
      * @override
      */
+    /**
+     * No longer a special case
     public function canCastToUnionTypeIfNonNull(UnionType $target): bool
     {
         return false;
     }
+     */
 
     public function canCastToUnionTypeHandlingTemplates(
         UnionType $target,

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -320,6 +320,14 @@ final class EmptyUnionType extends UnionType
     }
 
     /**
+     * @override
+     */
+    public function containsNonMixedNullable(): bool
+    {
+        return false;
+    }
+
+    /**
      * @return bool - True if not empty and at least one type is NullType or mixed.
      */
     public function containsNullableOrMixed(): bool
@@ -336,6 +344,11 @@ final class EmptyUnionType extends UnionType
     }
 
     public function isNull(): bool
+    {
+        return false;
+    }
+
+    public function isRealTypeNullOrUndefined(): bool
     {
         return false;
     }
@@ -553,13 +566,11 @@ final class EmptyUnionType extends UnionType
      * @internal
      * @override
      */
-    /**
-     * No longer a special case
     public function canCastToUnionTypeIfNonNull(UnionType $target): bool
     {
-        return false;
+        // TODO: Better check for isPossiblyNonNull
+        return UnionType::fromFullyQualifiedRealString('non-null-mixed')->canCastToUnionType($target);
     }
-     */
 
     public function canCastToUnionTypeHandlingTemplates(
         UnionType $target,

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -1793,9 +1793,21 @@ class Type
     /**
      * Is this nullable?
      *
-     * E.g. returns true for `?array`, `null`, etc.
+     * E.g. returns true for `?array`, `null`, `mixed`, etc.
      */
     public function isNullable(): bool
+    {
+        return $this->is_nullable;
+    }
+
+    /**
+     * Is this nullable in a way that Phan would emit warnings about nullable?
+     *
+     * E.g. returns true for `?array`, `null`, `?mixed` (but not `mixed`), etc.
+     *
+     * Currently, the only difference between this and isNullable() is for `?mixed` vs `mixed`
+     */
+    public function isNullableLabeled(): bool
     {
         return $this->is_nullable;
     }

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -56,6 +56,7 @@ use Phan\Language\Type\NonEmptyGenericArrayType;
 use Phan\Language\Type\NonEmptyListType;
 use Phan\Language\Type\NonEmptyMixedType;
 use Phan\Language\Type\NonEmptyStringType;
+use Phan\Language\Type\NonNullMixedType;
 use Phan\Language\Type\NonZeroIntType;
 use Phan\Language\Type\NullType;
 use Phan\Language\Type\ObjectType;
@@ -241,6 +242,7 @@ class Type
         'non-empty-array' => true,
         'non-empty-associative-array' => true,
         'non-empty-mixed' => true,
+        'non-null-mixed' => true,
         'non-empty-list'  => true,
         'non-empty-string' => true,
         'non-empty-lowercase-string' => true,
@@ -815,6 +817,8 @@ class Type
                 return MixedType::instance($is_nullable);
             case 'non-empty-mixed':
                 return NonEmptyMixedType::instance($is_nullable);
+            case 'non-null-mixed':
+                return NonNullMixedType::instance($is_nullable);
             case 'non-empty-array':
                 return NonEmptyGenericArrayType::fromElementType(MixedType::instance(false), $is_nullable, GenericArrayType::KEY_MIXED);
             case 'non-empty-associative-array':

--- a/src/Phan/Language/Type/ArrayType.php
+++ b/src/Phan/Language/Type/ArrayType.php
@@ -220,6 +220,7 @@ class ArrayType extends IterableType
     /**
      * @param non-empty-list<Type> $right_types the original types being added to
      * @return list<ArrayType>
+     * @suppress PhanPartialTypeMismatchArgument UnionType::typeSetFromString is list<Type>
      */
     private static function computeRealTypeSetFromArrayTypeLists(array $right_types, bool $is_assignment): array
     {
@@ -230,6 +231,7 @@ class ArrayType extends IterableType
             }
         }
         static $array_type_set;
+        // @phan-suppress-next-line PhanPartialTypeMismatchReturn Type cannot cast to ArrayType
         return $array_type_set ?? ($array_type_set = UnionType::typeSetFromString('array'));
     }
 

--- a/src/Phan/Language/Type/LiteralStringType.php
+++ b/src/Phan/Language/Type/LiteralStringType.php
@@ -442,6 +442,12 @@ final class LiteralStringType extends StringType implements LiteralTypeInterface
     {
         return $this->value ? NullType::instance(false) : $this;
     }
+
+    /** @override */
+    public function isPossiblyNumeric(): bool
+    {
+        return \is_numeric($this->value);
+    }
 }
 
 LiteralStringType::init();

--- a/src/Phan/Language/Type/MixedType.php
+++ b/src/Phan/Language/Type/MixedType.php
@@ -181,5 +181,18 @@ class MixedType extends NativeType
     {
         return NonEmptyMixedType::instance(false);
     }
+
+    /** Overridden by NonEmptyMixedType */
+    public function isNullable(): bool
+    {
+        return true;
+    }
+
+    /** Overridden by NonEmptyMixedType */
+    public function __toString(): string
+    {
+        return $this->is_nullable ? '?mixed' : 'mixed';
+    }
 }
 class_exists(NonEmptyMixedType::class);
+class_exists(NonNullMixedType::class);

--- a/src/Phan/Language/Type/MixedType.php
+++ b/src/Phan/Language/Type/MixedType.php
@@ -188,6 +188,11 @@ class MixedType extends NativeType
         return true;
     }
 
+    public function isNullableLabeled(): bool
+    {
+        return $this->is_nullable;
+    }
+
     /** Overridden by NonEmptyMixedType */
     public function __toString(): string
     {

--- a/src/Phan/Language/Type/NonNullMixedType.php
+++ b/src/Phan/Language/Type/NonNullMixedType.php
@@ -19,12 +19,16 @@ final class NonNullMixedType extends MixedType
     /** @phan-override */
     public const NAME = 'non-null-mixed';
 
+    /**
+     * @suppress PhanPartialTypeMismatchArgument static::make() is Type, not mixed
+     */
     public static function instance(bool $is_nullable)
     {
         if ($is_nullable) {
             return MixedType::instance(true);
         }
         static $instance = null;
+        // @phan-suppress-next-line PhanPartialTypeMismatchReturn Type can't cast to NonNullMixedType
         return $instance ?? ($instance = static::make('\\', self::NAME, [], false, Type::FROM_NODE));
     }
 

--- a/src/Phan/Language/Type/NullType.php
+++ b/src/Phan/Language/Type/NullType.php
@@ -63,7 +63,7 @@ final class NullType extends ScalarType
      */
     public function canCastToDeclaredType(CodeBase $code_base, Context $context, Type $other): bool
     {
-        return $other->isNullable() || $other instanceof MixedType || $other instanceof TemplateType;
+        return $other->isNullable() || $other instanceof TemplateType;
     }
 
     public function isSubtypeOf(Type $type): bool
@@ -93,7 +93,7 @@ final class NullType extends ScalarType
         }
 
         // Null can cast to a nullable type.
-        if ($type->is_nullable) {
+        if ($type->isNullable()) {
             return true;
         }
 
@@ -112,9 +112,6 @@ final class NullType extends ScalarType
                 \in_array($type->getName(), $scalar_implicit_partial['null'] ?? [], true)) {
                 return true;
             }
-        }
-        if (\get_class($type) === MixedType::class) {
-            return true;
         }
 
         return false;
@@ -132,16 +129,8 @@ final class NullType extends ScalarType
             return true;
         }
 
-        // Null can cast to a nullable type or mixed.
-        if ($type->is_nullable) {
-            return true;
-        }
-
-        if (\get_class($type) === MixedType::class) {
-            return true;
-        }
-
-        return false;
+        // Null can cast to a nullable type or mixed (but not non-null-mixed).
+        return $type->isNullable();
     }
 
     /**
@@ -157,7 +146,7 @@ final class NullType extends ScalarType
         }
 
         // Null can cast to a nullable type.
-        if ($type->is_nullable) {
+        if ($type->isNullable()) {
             return true;
         }
 
@@ -176,9 +165,6 @@ final class NullType extends ScalarType
                 \in_array($type->getName(), $scalar_implicit_partial['null'] ?? [], true)) {
                 return true;
             }
-        }
-        if ($type instanceof MixedType) {
-            return $type->isPossiblyFalsey();
         }
 
         // Test to see if we can cast to the non-nullable version
@@ -206,6 +192,11 @@ final class NullType extends ScalarType
     }
 
     public function isNullable(): bool
+    {
+        return true;
+    }
+
+    public function isNullableLabeled(): bool
     {
         return true;
     }

--- a/src/Phan/Language/Type/SelfType.php
+++ b/src/Phan/Language/Type/SelfType.php
@@ -111,7 +111,8 @@ final class SelfType extends StaticOrSelfType
      * Either this or 'self' resolved in the given context.
      * @suppress PhanAccessReadOnlyProperty
      */
-    public function withStaticResolvedInContext(Context $context): Type {
+    public function withStaticResolvedInContext(Context $context): Type
+    {
         // TODO: Special handling of self<static>, if needed?
         return $this->withSelfResolvedInContext($context);
     }
@@ -123,7 +124,8 @@ final class SelfType extends StaticOrSelfType
      *
      * TODO: Handle `(at)return OtherType<self>`
      */
-    public function withSelfResolvedInContext(Context $context): Type {
+    public function withSelfResolvedInContext(Context $context): Type
+    {
         // If the context isn't in a class scope, there's nothing
         // we can do
         if (!$context->isInClassScope()) {

--- a/src/Phan/Language/Type/VoidType.php
+++ b/src/Phan/Language/Type/VoidType.php
@@ -100,6 +100,7 @@ final class VoidType extends NativeType
             return true;
         }
 
+        // TODO Make this more strict with real types, somehow?
         if (Config::get_null_casts_as_any_type()) {
             return true;
         }

--- a/src/Phan/Language/Type/VoidType.php
+++ b/src/Phan/Language/Type/VoidType.php
@@ -55,7 +55,7 @@ final class VoidType extends NativeType
      */
     public function canCastToDeclaredType(CodeBase $code_base, Context $context, Type $other): bool
     {
-        return $other->isNullable() || $other instanceof MixedType || $other instanceof TemplateType;
+        return $other->isNullable() || $other instanceof TemplateType;
     }
 
     public function isSubtypeOf(Type $type): bool
@@ -96,7 +96,7 @@ final class VoidType extends NativeType
         }
 
         // Null(void) can cast to a nullable type.
-        if ($type->is_nullable) {
+        if ($type->isNullable()) {
             return true;
         }
 
@@ -116,9 +116,6 @@ final class VoidType extends NativeType
                 return true;
             }
         }
-        if (\get_class($type) === MixedType::class) {
-            return true;
-        }
 
         return false;
     }
@@ -130,16 +127,8 @@ final class VoidType extends NativeType
             return true;
         }
 
-        // Null(void) can cast to a nullable type or mixed.
-        if ($type->is_nullable) {
-            return true;
-        }
-
-        if (\get_class($type) === MixedType::class) {
-            return true;
-        }
-
-        return false;
+        // Null(void) can cast to a nullable type or mixed (but not non-null-mixed).
+        return $type->isNullable();
     }
 
     /**
@@ -186,7 +175,7 @@ final class VoidType extends NativeType
             }
         }
         if ($type instanceof MixedType) {
-            return !$type instanceof NonEmptyMixedType;
+            return $type->isNullable();
         }
 
         // Test to see if we can cast to the non-nullable version
@@ -229,6 +218,11 @@ final class VoidType extends NativeType
     }
 
     public function isNullable(): bool
+    {
+        return true;
+    }
+
+    public function isNullableLabeled(): bool
     {
         return true;
     }

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -1437,6 +1437,19 @@ class UnionType implements Serializable
     }
 
     /**
+     * Returns true if !isset(expr) is unconditionally true for the real types
+     */
+    public function isRealTypeNullOrUndefined(): bool
+    {
+        foreach ($this->real_type_set as $type) {
+            if (!($type instanceof NullType) && !($type instanceof VoidType)) {
+                return false;
+            }
+        }
+        return \count($this->type_set) !== 0;
+    }
+
+    /**
      * @return UnionType a clone of this that does not include null,
      *                   and has the non-null equivalents of any nullable types in this UnionType
      */
@@ -1505,7 +1518,7 @@ class UnionType implements Serializable
     {
         $result = [];
         foreach ($type_list as $type) {
-            if ($type->isNullable()) {
+            if ($type->isNullableLabeled()) {
                 $result[] = $type;
             } else {
                 $result[] = $type->withIsNullable(true);
@@ -3601,6 +3614,7 @@ class UnionType implements Serializable
      */
     public function numericTypes(): UnionType
     {
+        // TODO: Replace mixed with int|string|float in ConditionVisitor
         return $this->makeFromFilter(static function (Type $type): bool {
             // IntType and LiteralStringType
             return $type->isPossiblyNumeric();

--- a/src/Phan/Library/DiskCache.php
+++ b/src/Phan/Library/DiskCache.php
@@ -88,7 +88,7 @@ class DiskCache implements Cache
             }
             $this->directory_exists = true;
         }
-        return $this->directory_exists ?? false;
+        return $this->directory_exists;
     }
 
     /**

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -368,7 +368,7 @@ class ParseVisitor extends ScopeVisitor
         Clazz $class,
         Parameter $parameter,
         Node $parameter_node
-    ): void  {
+    ): void {
         $code_base = $this->code_base;
         $lineno = $parameter_node->lineno;
         $context = (clone($this->context))->withLineNumberStart($lineno);

--- a/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
@@ -79,7 +79,7 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
         /**
          * @return Closure(CodeBase, Context, Func, list<Node|int|float|string>): UnionType
          */
-        $get_element_type_of_first_arg_check_nonempty_builder = static function (Type $default_type) use ($mixed_type) : Closure {
+        $get_element_type_of_first_arg_check_nonempty_builder = static function (Type $default_type) use ($mixed_type): Closure {
             /**
              * @param list<Node|int|float|string> $args
              */

--- a/src/Phan/Plugin/Internal/MethodSearcherPlugin.php
+++ b/src/Phan/Plugin/Internal/MethodSearcherPlugin.php
@@ -113,6 +113,7 @@ final class MethodSearcherPlugin extends PluginV3 implements
     }
 
     /**
+     * @param Type $type a type with the name of a class
      * @return Type[] a list of types to replace $type with
      */
     public static function getReplacementTypesForFullyQualifiedClassName(

--- a/src/Phan/Plugin/Internal/RedundantConditionCallPlugin.php
+++ b/src/Phan/Plugin/Internal/RedundantConditionCallPlugin.php
@@ -131,10 +131,11 @@ final class RedundantConditionCallPlugin extends PluginV3 implements
             $method = new ReflectionMethod(UnionType::class, $extract_types_method);
             /** @suppress PhanPluginUnknownObjectMethodCall ReflectionMethod cannot be analyzed */
             return $make_first_arg_checker(static function (UnionType $type) use ($method): int {
-                $new_real_type = $method->invoke($type)->nonNullableClone();
+                $new_real_type = $method->invoke($type);
                 if ($new_real_type->isEmpty()) {
                     return self::_IS_IMPOSSIBLE;
                 }
+                $new_real_type = $new_real_type->nonNullableClone();
                 if ($new_real_type->isEqualTo($type)) {
                     return self::_IS_REDUNDANT;
                 }
@@ -144,10 +145,11 @@ final class RedundantConditionCallPlugin extends PluginV3 implements
         $resource_callback = $make_first_arg_checker(static function (UnionType $type): int {
             $new_real_type = $type->makeFromFilter(static function (Type $type): bool {
                 return $type instanceof ResourceType;
-            })->nonNullableClone();
+            });
             if ($new_real_type->isEmpty()) {
                 return self::_IS_IMPOSSIBLE;
             }
+            $new_real_type = $new_real_type->nonNullableClone();
             if ($new_real_type->isEqualTo($type)) {
                 return self::_IS_REDUNDANT;
             }
@@ -199,10 +201,11 @@ final class RedundantConditionCallPlugin extends PluginV3 implements
             }, $expected_type);
         };
         $callable_callback = $make_first_arg_checker(static function (UnionType $type): int {
-            $new_real_type = $type->callableTypes()->nonNullableClone();
+            $new_real_type = $type->callableTypes();
             if ($new_real_type->isEmpty()) {
                 return self::_IS_IMPOSSIBLE;
             }
+            $new_real_type = $new_real_type->nonNullableClone();
             if ($new_real_type->isEqualTo($type)) {
                 if (!$new_real_type->hasTypeMatchingCallback(static function (Type $type): bool {
                     return $type instanceof ArrayShapeType;

--- a/src/Phan/Plugin/Internal/RedundantConditionCallPlugin.php
+++ b/src/Phan/Plugin/Internal/RedundantConditionCallPlugin.php
@@ -19,6 +19,7 @@ use Phan\Language\Type\ArrayShapeType;
 use Phan\Language\Type\ClassStringType;
 use Phan\Language\Type\FloatType;
 use Phan\Language\Type\IntType;
+use Phan\Language\Type\LiteralStringType;
 use Phan\Language\Type\ResourceType;
 use Phan\Language\UnionType;
 use Phan\PluginV3;
@@ -174,6 +175,10 @@ final class RedundantConditionCallPlugin extends PluginV3 implements
                 if ($type instanceof IntType || $type instanceof FloatType) {
                     $has_numeric = true;
                 } elseif ($type->isPossiblyNumeric()) {
+                    if ($type instanceof LiteralStringType) {
+                        $has_numeric = true;
+                        continue;
+                    }
                     return self::_IS_REASONABLE_CONDITION;
                 } else {
                     $has_non_numeric = true;

--- a/tests/Phan/Language/UnionTypeTest.php
+++ b/tests/Phan/Language/UnionTypeTest.php
@@ -114,7 +114,7 @@ final class UnionTypeTest extends BaseTest
         $this->assertUnionTypeStringEqual('$argc * 1.5', 'float');
         $this->assertUnionTypeStringEqual('constant($argv[0]) - constant($argv[1])', 'float|int');
         $this->assertUnionTypeStringEqual('constant($argv[0]) + constant($argv[1])', 'float|int');
-        $this->assertUnionTypeStringEqual('-constant($argv[0])', 'float|int');
+        $this->assertUnionTypeStringEqual('-constant($argv[0])', '0|float|int');
         $this->assertUnionTypeStringEqual('-(1.5)', '-1.5');
         $this->assertUnionTypeStringEqual('(rand(0,1) ? "12" : 2.5) - (rand(0,1) ? "3" : 1.5)', 'float|int');
         $this->assertUnionTypeStringEqual('(rand(0,1) ? "12" : 2.5) * (rand(0,1) ? "3" : 1.5)', 'float|int');

--- a/tests/files/expected/0166_is_a.php.expected
+++ b/tests/files/expected/0166_is_a.php.expected
@@ -8,6 +8,7 @@
 %s:23 PhanTypeMismatchArgumentProbablyReal Argument 1 ($var) is $var of type bool but \emitType() takes resource (no real type) defined at %s:3 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
 %s:25 PhanTypeMismatchArgumentProbablyReal Argument 1 ($var) is $var of type int but \emitType() takes resource (no real type) defined at %s:3 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
 %s:27 PhanTypeMismatchArgumentProbablyReal Argument 1 ($var) is $var of type null but \emitType() takes resource (no real type) defined at %s:3 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
+%s:28 PhanDebugAnnotation @phan-debug-var requested for variable $var - it has union type float|int|string(real=float|int|string)
 %s:29 PhanTypeMismatchArgumentProbablyReal Argument 1 ($var) is $var of type float|int|string but \emitType() takes resource (no real type) defined at %s:3 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
 %s:31 PhanTypeMismatchArgumentProbablyReal Argument 1 ($var) is $var of type object but \emitType() takes resource (no real type) defined at %s:3 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
 %s:33 PhanTypeMismatchArgumentProbablyReal Argument 1 ($var) is $var of type float but \emitType() takes resource (no real type) defined at %s:3 (the inferred real argument type has nothing in common with the parameter's phpdoc type)

--- a/tests/files/expected/0354_string_index.php.expected
+++ b/tests/files/expected/0354_string_index.php.expected
@@ -1,6 +1,6 @@
 %s:9 PhanTypeMismatchArgumentInternal Argument 1 ($num1) is $this->foo of type string but \intdiv() takes int
 %s:10 PhanTypeMismatchDimEmpty Assigning to an empty array index of a value of type string, but expected the index to exist and be of type int
-%s:10 PhanTypeMismatchPropertyProbablyReal Assigning ('x' as a field) of type non-empty-array<int,string> to property but \A354->foo is string (no real type) (the inferred real assigned type has nothing in common with the declared phpdoc property type)
+%s:10 PhanTypeMismatchProperty%SReal Assigning ('x' as a field) of type non-empty-array<int,string> to property but \A354->foo is string (no real type) (the inferred real assigned type has nothing in common with the declared phpdoc property type)
 %s:13 PhanTypeMismatchArgumentInternal Argument 1 ($value) is $x of type 'aaa'|non-empty-string but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array
 %s:14 PhanTypeMismatchDimEmpty Assigning to an empty array index of a value of type 'aaa'|non-empty-string, but expected the index to exist and be of type int
 %s:16 PhanTypeMismatchDimAssignment When appending to a value of type 'aaa', found an array access index of type 'offset', but expected the index to be of type int
@@ -16,5 +16,5 @@
 %s:35 PhanTypeInvalidDimOffset Invalid offset "offset2" of $arr of array type array{offset:'c'}
 %s:40 PhanTypeMismatchArgumentInternal Argument 1 ($string) is $x[1] of type 2 but \strlen() takes string
 %s:41 PhanTypeInvalidDimOffset Invalid offset 2 of $x of array type array{0:1,1:2,3:'x'}
-%s:41 PhanTypeMismatchArgumentInternal Argument 1 ($string) is $x[2] of type null but \strlen() takes string
+%s:41 PhanTypeMismatchArgumentInternal%SReal Argument 1 ($string) is $x[2] of type null but \strlen() takes string
 %s:43 PhanTypeMismatchArgumentInternal%SReal Argument 1 ($num1) is $x[3] of type 'x' but \intdiv() takes int

--- a/tests/files/expected/0460_silence_condition.php.expected
+++ b/tests/files/expected/0460_silence_condition.php.expected
@@ -1,2 +1,4 @@
-%s:11 PhanTypeMismatchArgumentInternal%SReal Argument 1 ($value) is $x of type string but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array%S
-%s:14 PhanTypeMismatchArgumentInternal Argument 1 ($value) is $y of type string but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array
+%s:9 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type array|string
+%s:11 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type string(real=string)
+%s:13 PhanTypeMismatchArgumentInternalReal Argument 1 ($value) is $x of type string but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array (real type \Countable|array)
+%s:16 PhanTypeMismatchArgumentInternal Argument 1 ($value) is $y of type string but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array

--- a/tests/files/expected/0460_silence_condition.php.expected
+++ b/tests/files/expected/0460_silence_condition.php.expected
@@ -1,4 +1,4 @@
 %s:9 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type array|string
 %s:11 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type string(real=string)
-%s:13 PhanTypeMismatchArgumentInternalReal Argument 1 ($value) is $x of type string but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array (real type \Countable|array)
+%s:13 PhanTypeMismatchArgumentInternal%SReal Argument 1 ($value) is $x of type string but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array%S
 %s:16 PhanTypeMismatchArgumentInternal Argument 1 ($value) is $y of type string but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array

--- a/tests/files/expected/0464_false_positive_nullable.php.expected
+++ b/tests/files/expected/0464_false_positive_nullable.php.expected
@@ -1,4 +1,3 @@
 %s:3 PhanTypeMismatchArgumentNullableInternal Argument 1 ($array) is $arr of type ?array but \array_values() takes array (expected type to be non-nullable)
 %s:17 PhanTypeArraySuspiciousNullable Suspicious array access to $arr2 of nullable type ?array
 %s:18 PhanTypeArraySuspiciousNullable Suspicious array access to $arr2 of nullable type ?array
-%s:18 PhanTypeArraySuspiciousNullable Suspicious array access to $arr2['other2'] of nullable type ?mixed

--- a/tests/files/expected/0567_invalid_constants.php.expected
+++ b/tests/files/expected/0567_invalid_constants.php.expected
@@ -1,9 +1,9 @@
 %s:14 PhanUndeclaredVariable Variable $undError is undeclared
 %s:15 PhanParamTooFewInternal Call with 1 arg(s) to \define(string $constant_name, $value, bool $case_insensitive = %s) which requires 2 arg(s)
-%s:16 PhanTypeMismatchArgumentInternal%sReal Argument 1 ($string) is cons2128Error of type null (real type array|bool|float|int|null|resource|string=) but \strlen() takes string
+%s:16 PhanTypeMismatchArgumentInternal%SReal Argument 1 ($string) is cons2128Error of type null (real type array|bool|float|int|null|resource|string=) but \strlen() takes string
 %s:17 PhanUndeclaredConstant Reference to undeclared constant \cons2128Error2. This will cause a thrown Error in php 8.0+. (Did you mean \cons2128Error)
 %s:18 PhanParamTooFewInternal Call with 1 arg(s) to \define(string $constant_name, $value, bool $case_insensitive = %s) which requires 2 arg(s)
-%s:18 PhanTypeMismatchArgumentInternal%sReal Argument 1 ($constant_name) is $undefVar of type null but \define() takes string
+%s:18 PhanTypeMismatchArgumentInternal%SReal Argument 1 ($constant_name) is $undefVar of type null but \define() takes string
 %s:18 PhanUndeclaredVariable Variable $undefVar is undeclared
 %s:20 PhanInvalidConstantFQSEN '' is an invalid FQSEN for a constant
 %s:25 PhanTypeMismatchArgumentInternal Argument 1 ($num1) is cons2128 of type 'a' but \intdiv() takes int

--- a/tests/files/expected/0567_invalid_constants.php.expected
+++ b/tests/files/expected/0567_invalid_constants.php.expected
@@ -1,9 +1,9 @@
 %s:14 PhanUndeclaredVariable Variable $undError is undeclared
 %s:15 PhanParamTooFewInternal Call with 1 arg(s) to \define(string $constant_name, $value, bool $case_insensitive = %s) which requires 2 arg(s)
-%s:16 PhanTypeMismatchArgumentInternal Argument 1 ($string) is cons2128Error of type null but \strlen() takes string
+%s:16 PhanTypeMismatchArgumentInternal%sReal Argument 1 ($string) is cons2128Error of type null (real type array|bool|float|int|null|resource|string=) but \strlen() takes string
 %s:17 PhanUndeclaredConstant Reference to undeclared constant \cons2128Error2. This will cause a thrown Error in php 8.0+. (Did you mean \cons2128Error)
 %s:18 PhanParamTooFewInternal Call with 1 arg(s) to \define(string $constant_name, $value, bool $case_insensitive = %s) which requires 2 arg(s)
-%s:18 PhanTypeMismatchArgumentInternal%SReal Argument 1 ($constant_name) is $undefVar of type null but \define() takes string
+%s:18 PhanTypeMismatchArgumentInternal%sReal Argument 1 ($constant_name) is $undefVar of type null but \define() takes string
 %s:18 PhanUndeclaredVariable Variable $undefVar is undeclared
 %s:20 PhanInvalidConstantFQSEN '' is an invalid FQSEN for a constant
 %s:25 PhanTypeMismatchArgumentInternal Argument 1 ($num1) is cons2128 of type 'a' but \intdiv() takes int

--- a/tests/files/src/0166_is_a.php
+++ b/tests/files/src/0166_is_a.php
@@ -26,7 +26,7 @@ function check($var) {
 	} elseif (is_null($var)) {
 		emitType($var);
 	} elseif (is_numeric($var)) {
-		emitType($var);
+		'@phan-debug-var $var';emitType($var);
 	} elseif (is_object($var)) {
 		emitType($var);
 	} elseif (is_real($var)) {

--- a/tests/files/src/0460_silence_condition.php
+++ b/tests/files/src/0460_silence_condition.php
@@ -7,7 +7,9 @@
  * The error control operator is unnecessary here
  */
 function silence460($x, $y) {
+    '@phan-debug-var $x';
     if (@is_string($x)) {
+        '@phan-debug-var $x';
         echo count($x);
     }
     if (@!is_array($y)) {

--- a/tests/multi_files/expected/3085.php.expected
+++ b/tests/multi_files/expected/3085.php.expected
@@ -1,3 +1,2 @@
 %s:12 PhanTypeVoidArgument Cannot use void return value test_void_real() as a function argument
-%s:13 PhanTypeMismatchArgumentReal Argument 1 ($x) is test_void_real() of type void but \expects_array_not_void() takes array defined at %s:6
 %s:13 PhanTypeVoidArgument Cannot use void return value test_void_real() as a function argument

--- a/tests/multi_files/expected/3085.php.expected80
+++ b/tests/multi_files/expected/3085.php.expected80
@@ -1,4 +1,2 @@
-%s:12 PhanTypeMismatchArgumentInternalReal Argument 1 ($string) is test_void_real() of type void but \strlen() takes string
 %s:12 PhanTypeVoidArgument Cannot use void return value test_void_real() as a function argument
-%s:13 PhanTypeMismatchArgumentReal Argument 1 ($x) is test_void_real() of type void but \expects_array_not_void() takes array defined at %s:6
 %s:13 PhanTypeVoidArgument Cannot use void return value test_void_real() as a function argument

--- a/tests/multi_files/src/3085.php
+++ b/tests/multi_files/src/3085.php
@@ -10,5 +10,5 @@ function expects_array_not_void(array $x) {
 function test_void_phpdoc() : void {
     // Should not cause infinite loop with null_casts_as_any_type
     echo strlen(test_void_real());
-    echo expects_array_not_void(test_void_real());
+    echo expects_array_not_void(test_void_real()); // TODO: Currently, null_casts_as_any_type applies to all type casting logic, even real types, so there's no warning. Stricten this?
 }

--- a/tests/php72_files/expected/0001_objecthint.php.expected
+++ b/tests/php72_files/expected/0001_objecthint.php.expected
@@ -1,4 +1,4 @@
-%s:9 PhanTypeMismatchReturnReal Returning null of type null but object_test() is declared to return object
+/tests/php72_files/src/0001_objecthint.php:9 PhanTypeMismatchReturnReal Returning null of type null but object_test() is declared to return object
 %s:13 PhanTypeMismatchArgumentReal Argument 1 ($x) is null of type null but \object_test() takes object defined at %s:3
 %s:14 PhanTypeMismatchArgumentReal Argument 1 ($x) is [] of type array{} but \object_test() takes object defined at %s:3
 %s:14 PhanTypeMismatchArgumentReal Argument 2 ($y) is [] of type array{} but \object_test() takes ?object defined at %s:3
@@ -7,4 +7,5 @@
 %s:30 PhanNonClassMethodCall Call to method __construct on non-class type false
 %s:30 PhanTypeExpectedObjectOrClassName Expected an object instance or the name of a class but saw expression false with type false
 %s:31 PhanUndeclaredClassMethod Call to method __construct from undeclared class \true
+%s:32 PhanNonClassMethodCall Call to method __construct on non-class type mixed
 %s:32 PhanTypeExpectedObjectOrClassName Expected an object instance or the name of a class but saw expression mixed with type mixed

--- a/tests/php72_files/expected/0001_objecthint.php.expected
+++ b/tests/php72_files/expected/0001_objecthint.php.expected
@@ -1,4 +1,4 @@
-/tests/php72_files/src/0001_objecthint.php:9 PhanTypeMismatchReturnReal Returning null of type null but object_test() is declared to return object
+%s:9 PhanTypeMismatchReturnReal Returning null of type null but object_test() is declared to return object
 %s:13 PhanTypeMismatchArgumentReal Argument 1 ($x) is null of type null but \object_test() takes object defined at %s:3
 %s:14 PhanTypeMismatchArgumentReal Argument 1 ($x) is [] of type array{} but \object_test() takes object defined at %s:3
 %s:14 PhanTypeMismatchArgumentReal Argument 2 ($y) is [] of type array{} but \object_test() takes ?object defined at %s:3
@@ -7,5 +7,4 @@
 %s:30 PhanNonClassMethodCall Call to method __construct on non-class type false
 %s:30 PhanTypeExpectedObjectOrClassName Expected an object instance or the name of a class but saw expression false with type false
 %s:31 PhanUndeclaredClassMethod Call to method __construct from undeclared class \true
-%s:32 PhanNonClassMethodCall Call to method __construct on non-class type mixed
 %s:32 PhanTypeExpectedObjectOrClassName Expected an object instance or the name of a class but saw expression mixed with type mixed

--- a/tests/php74_files/expected/000_null_assign.php.expected
+++ b/tests/php74_files/expected/000_null_assign.php.expected
@@ -2,6 +2,6 @@
 %s:6 PhanTypeMismatchArgumentInternal%SReal Argument 1 ($value) is ($b ??= $default) of type int|string but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array%S
 %s:7 PhanTypeMismatchArgumentInternal%SReal Argument 1 ($value) is $b of type int|string but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array%S
 %s:8 PhanUndeclaredVariable Variable $missing is undeclared
-%s:9 PhanTypeMismatchArgumentInternal Argument 1 ($string) is $missing of type array{0:2} but \strlen() takes string
+%s:9 PhanTypeMismatchArgumentInternal%SReal Argument 1 ($string) is $missing of type array{0:2} but \strlen() takes string
 %s:12 PhanTypeMismatchArgumentInternal%SReal Argument 1 ($string) is $arr of type array{0:int,1:2} but \strlen() takes string
 %s:16 PhanPossiblyUndeclaredVariable Variable $otherMissing is possibly undeclared

--- a/tests/php74_files/expected/024_coalesce_assign_op.php.expected
+++ b/tests/php74_files/expected/024_coalesce_assign_op.php.expected
@@ -1,1 +1,4 @@
-%s:7 PhanTypeMismatchReturnReal Returning $result of type array{x:2,y:string} but test() is declared to return bool
+%s:6 PhanDebugAnnotation @phan-debug-var requested for variable $z - it has union type null(real=null)
+%s:6 PhanTypeInvalidDimOffset Invalid offset "z" of $result of array type array{x:2}
+%s:6 PhanUnusedVariable Unused definition of variable $z
+%s:9 PhanTypeMismatchReturnReal Returning $result of type array{x:2,y:string} but test() is declared to return bool

--- a/tests/php74_files/src/024_coalesce_assign_op.php
+++ b/tests/php74_files/src/024_coalesce_assign_op.php
@@ -3,6 +3,8 @@
 function test(string $y) : bool {
     $result = ['x' => null];
     $result['x'] ??= 2;
+    $z = $result['z'];
+    '@phan-debug-var $z';
     $result['y'] ??= $y;
     return $result;
 }

--- a/tests/php80_files/expected/024_named_arg_missing.php.expected
+++ b/tests/php80_files/expected/024_named_arg_missing.php.expected
@@ -1,20 +1,20 @@
 %s:7 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (other: true)
-%s:7 PhanMissingNamedArgument Missing named argument for int $requiredInt in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, ?mixed $other = null) defined at %s:3
-%s:7 PhanMissingNamedArgument Missing named argument for string $requiredString in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, ?mixed $other = null) defined at %s:3
-%s:7 PhanParamTooFew Call with 1 arg(s) to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, ?mixed $other = null) which requires 2 arg(s) defined at %s:3
+%s:7 PhanMissingNamedArgument Missing named argument for int $requiredInt in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, $other = null) defined at %s:3
+%s:7 PhanMissingNamedArgument Missing named argument for string $requiredString in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, $other = null) defined at %s:3
+%s:7 PhanParamTooFew Call with 1 arg(s) to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, $other = null) which requires 2 arg(s) defined at %s:3
 %s:8 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (optionalFlag: true)
-%s:8 PhanMissingNamedArgument Missing named argument for string $requiredString in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, ?mixed $other = null) defined at %s:3
+%s:8 PhanMissingNamedArgument Missing named argument for string $requiredString in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, $other = null) defined at %s:3
 %s:9 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (optionalFlag: true)
 %s:9 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (other: 123)
-%s:9 PhanMissingNamedArgument Missing named argument for string $requiredString in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, ?mixed $other = null) defined at %s:3
+%s:9 PhanMissingNamedArgument Missing named argument for string $requiredString in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, $other = null) defined at %s:3
 %s:10 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (optionalFlag: true)
 %s:10 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (other: 123)
 %s:10 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (requiredInt: 0)
-%s:10 PhanMissingNamedArgument Missing named argument for string $requiredString in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, ?mixed $other = null) defined at %s:3
+%s:10 PhanMissingNamedArgument Missing named argument for string $requiredString in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, $other = null) defined at %s:3
 %s:11 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (optionalFlag: true)
 %s:11 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (other: 123)
 %s:11 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (requiredString: 0)
-%s:11 PhanMissingNamedArgument Missing named argument for int $requiredInt in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, ?mixed $other = null) defined at %s:3
+%s:11 PhanMissingNamedArgument Missing named argument for int $requiredInt in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, $other = null) defined at %s:3
 %s:11 PhanTypeMismatchArgument Argument 2 ($requiredString) is 0 of type 0 but \C24::main() takes string defined at %s:3
 %s:12 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (definitelyInvalidFlag: 'value')
 %s:12 PhanUndeclaredNamedArgumentInternal Saw a call with undeclared named argument (definitelyInvalidFlag: 'value') to \strlen(string $string)

--- a/tests/php80_files/expected/025_named_arg_callable_missing.php.expected
+++ b/tests/php80_files/expected/025_named_arg_callable_missing.php.expected
@@ -1,20 +1,20 @@
 %s:8 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (other: true)
-%s:8 PhanMissingNamedArgument Missing named argument for int $requiredInt in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, ?mixed $other = null) defined at %s:4
-%s:8 PhanMissingNamedArgument Missing named argument for string $requiredString in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, ?mixed $other = null) defined at %s:4
-%s:8 PhanParamTooFewCallable Call with 1 arg(s) to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, ?mixed $other = null) (as a provided callable) which requires 2 arg(s) defined at %s:4
+%s:8 PhanMissingNamedArgument Missing named argument for int $requiredInt in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, $other = null) defined at %s:4
+%s:8 PhanMissingNamedArgument Missing named argument for string $requiredString in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, $other = null) defined at %s:4
+%s:8 PhanParamTooFewCallable Call with 1 arg(s) to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, $other = null) (as a provided callable) which requires 2 arg(s) defined at %s:4
 %s:9 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (optionalFlag: true)
-%s:9 PhanMissingNamedArgument Missing named argument for string $requiredString in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, ?mixed $other = null) defined at %s:4
+%s:9 PhanMissingNamedArgument Missing named argument for string $requiredString in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, $other = null) defined at %s:4
 %s:10 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (optionalFlag: true)
 %s:10 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (other: 123)
-%s:10 PhanMissingNamedArgument Missing named argument for string $requiredString in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, ?mixed $other = null) defined at %s:4
+%s:10 PhanMissingNamedArgument Missing named argument for string $requiredString in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, $other = null) defined at %s:4
 %s:11 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (optionalFlag: true)
 %s:11 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (other: 123)
 %s:11 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (requiredInt: 0)
-%s:11 PhanMissingNamedArgument Missing named argument for string $requiredString in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, ?mixed $other = null) defined at %s:4
+%s:11 PhanMissingNamedArgument Missing named argument for string $requiredString in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, $other = null) defined at %s:4
 %s:12 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (optionalFlag: true)
 %s:12 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (other: 123)
 %s:12 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (requiredString: 0)
-%s:12 PhanMissingNamedArgument Missing named argument for int $requiredInt in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, ?mixed $other = null) defined at %s:4
+%s:12 PhanMissingNamedArgument Missing named argument for int $requiredInt in call to \C24::main(int $requiredInt, string $requiredString, bool $optionalFlag = false, $other = null) defined at %s:4
 %s:13 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (definitelyInvalidFlag: 'value')
 %s:13 PhanUndeclaredNamedArgumentInternal Saw a call with undeclared named argument (definitelyInvalidFlag: 'value') to \strlen(string $string)
 %s:14 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (flags: 123)


### PR DESCRIPTION
- Work on fixing the false positives during redundant condition
  detection
- Add a separate `non-null-mixed` type
- TODO: Avoid regressions in inferred phpdoc type for array access
- TODO: Continue to infer phpdoc `?mixed` type with a `?` in issue messages
  when combining mixed with null or converting mixed to nullable.
  (and emit PhanTypeArraySuspiciousNullable)

For #4276