### PR TITLE
Add PhanSuspiciousNamedArgumentVariadicInternal

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,8 @@ New features (Analysis):
 + Mention if PhanUndeclaredFunction is potentially caused by the target php version being too old. (#4230)
 + Support a `non-null-mixed` type and change the way analysis involving nullability is checked for `mixed` (phpdoc and real). (#4278, #4276)
 + Improve real type inference for conditionals on literal types (#4288)
++ Emit `PhanSuspiciousNamedArgumentVariadicInternal` when using named arguments with variadic parameters of internal functions that are
+  not among the few reflection functions known to support named arguments. (#4284)
 
 Nov 27 2020, Phan 3.2.6
 -----------------------

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -2211,6 +2211,14 @@ Passing named argument to a variadic parameter ${PARAMETER} of the same name in 
 
 e.g. [this issue](https://github.com/phan/phan/tree/3.2.2/tests/php80_files/expected/029_named_variadic.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/3.2.2/tests/php80_files/src/029_named_variadic.php#L5).
 
+## PhanSuspiciousNamedArgumentVariadicInternal
+
+```
+Passing named argument {CODE} to the variadic parameter of the internal function {METHOD}. Except for a few internal methods that call methods/constructors dynamically, this is usually not supported by internal functions.
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/master/tests/php80_files/expected/036_named_variadic.php.expected#L4) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/master/tests/php80_files/src/036_named_variadic.php#L6).
+
 ## PhanUndeclaredNamedArgument
 
 ```

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -368,6 +368,7 @@ class Issue
     public const MissingNamedArgument                                        = 'PhanMissingNamedArgument';
     public const MissingNamedArgumentInternal                                = 'PhanMissingNamedArgumentInternal';
     public const SuspiciousNamedArgumentForVariadic                          = 'PhanSuspiciousNamedArgumentForVariadic';
+    public const SuspiciousNamedArgumentVariadicInternal                     = 'PhanSuspiciousNamedArgumentVariadicInternal';
 
     // Issue::CATEGORY_NOOP
     public const NoopArray                     = 'PhanNoopArray';
@@ -3443,6 +3444,14 @@ class Issue
                 self::REMEDIATION_B,
                 7061
             ),
+            new Issue(
+                self::SuspiciousNamedArgumentVariadicInternal,
+                self::CATEGORY_PARAMETER,
+                self::SEVERITY_NORMAL,
+                'Passing named argument {CODE} to the variadic parameter of the internal function {METHOD}. Except for a few internal methods that call methods/constructors dynamically, this is usually not supported by internal functions.',
+                self::REMEDIATION_B,
+                7062
+            ),
 
             // Issue::CATEGORY_NOOP
             new Issue(
@@ -4819,7 +4828,7 @@ class Issue
             new Issue(
                 self::CompatibleScalarTypePHP56,
                 self::CATEGORY_COMPATIBLE,
-                self::SEVERITY_NORMAL,
+                self::SEVERITY_CRITICAL,
                 "In PHP 5.6, scalar types such as {TYPE} in type signatures are treated like class names",
                 self::REMEDIATION_B,
                 3024
@@ -4827,7 +4836,7 @@ class Issue
             new Issue(
                 self::CompatibleAnyReturnTypePHP56,
                 self::CATEGORY_COMPATIBLE,
-                self::SEVERITY_NORMAL,
+                self::SEVERITY_CRITICAL,
                 "In PHP 5.6, return types ({TYPE}) are not supported",
                 self::REMEDIATION_B,
                 3025

--- a/tests/php80_files/expected/036_named_variadic.php.expected
+++ b/tests/php80_files/expected/036_named_variadic.php.expected
@@ -1,0 +1,5 @@
+%s:5 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (arg: 123)
+%s:6 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (foo: 'test')
+%s:6 PhanPluginUseReturnValueInternalKnown Expected to use the return value of the internal function/method \sprintf
+%s:6 PhanSuspiciousNamedArgumentVariadicInternal Passing named argument foo: 'test' to the variadic parameter of the internal function \sprintf(string $format, ...$values). Except for a few internal methods that call methods/constructors dynamically, this is usually not supported by internal functions.
+%s:8 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (arg: 123)

--- a/tests/php80_files/src/035_non_null_mixed.php
+++ b/tests/php80_files/src/035_non_null_mixed.php
@@ -1,0 +1,4 @@
+<?php
+function decode_or_default(string $json) {
+    return json_decode($json) ?? 'default';
+}

--- a/tests/php80_files/src/036_named_variadic.php
+++ b/tests/php80_files/src/036_named_variadic.php
@@ -1,0 +1,8 @@
+<?php
+function test36(int $arg) {
+    var_export($arg);
+}
+call_user_func('test36', arg: 123);
+sprintf("foo=%s\n", foo: 'test');
+$c = Closure::fromCallable('test36');
+$c->call(arg: 123);


### PR DESCRIPTION
Warn about code such as `sprintf('foo=%s', foo: 'value')`

Fixes #4284