### PR TITLE
Fix new false positive nullable warnings for arrays

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,11 +9,14 @@ New features (Analysis):
 + Raise the severity of some php 8.0 incompatibility issues to critical.
 + Fix handling of references after renaming variadic reference parameters of `fscanf`/`scanf`/`mb_convert_variables`
 + Mention if PhanUndeclaredFunction is potentially caused by the target php version being too old. (#4230)
-+ Support a `non-null-mixed` type and change the way analysis involving nullability is checked for `mixed` (phpdoc and real). (#4278, #4276)
 + Improve real type inference for conditionals on literal types (#4288)
 + Change the way the real type set of array access is inferred for mixes of array shapes and arrays (#4296)
 + Emit `PhanSuspiciousNamedArgumentVariadicInternal` when using named arguments with variadic parameters of internal functions that are
   not among the few reflection functions known to support named arguments. (#4284)
++ Don't suggest instance properties as alternatives to undefined variables inside of static methods.
+
+Bug fixes:
++ Support a `non-null-mixed` type and change the way analysis involving nullability is checked for `mixed` (phpdoc and real). (#4278, #4276)
 
 Nov 27 2020, Phan 3.2.6
 -----------------------

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -2098,7 +2098,8 @@ class UnionTypeVisitor extends AnalysisVisitor
             }
         }
         if (!$resulting_element_type->containsNullableOrUndefined() && $union_type->containsNullableOrUndefined()) {
-            $resulting_element_type = $resulting_element_type->nullableClone();
+            // Here, this uses Foo|null instead of ?Foo to only warn when strict types are used.
+            $resulting_element_type = $resulting_element_type->withType(NullType::instance(false));
         }
         if (!$is_computing_real_type_set) {
             $resulting_real_element_type = self::resolveArrayShapeElementTypesForOffset($union_type->getRealUnionType(), $dim_value, true);

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -904,6 +904,8 @@ class ConditionVisitor extends KindVisitorImplementation implements ConditionVis
 
         return [
             'class_exists' => $class_exists_callback,
+            'interface_exists' => $class_exists_callback,  // Currently, there's just class-string, not trait-string or interface-string.
+            'trait_exists' => $class_exists_callback,
             'method_exists' => $method_exists_callback,
             'is_a' => $is_a_callback,
             'is_array' => $array_callback,

--- a/tests/files/expected/0916_null_unknown.php.expected
+++ b/tests/files/expected/0916_null_unknown.php.expected
@@ -1,0 +1,11 @@
+%s:3 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type array{0:int,1:int,2:int,3:int|string,4:int|string,5:int|string}(real=array{0:int,1:int,2:int,3:int|string,4:int|string,5:int|string})
+%s:4 PhanTypeInvalidBitwiseBinaryOperator Invalid non-int/non-string operand provided to operator '|' between types null and true
+%s:4 PhanTypeInvalidLeftOperandOfBitwiseOp Invalid operator: left operand of | is null (expected int|string)
+%s:4 PhanTypeInvalidRightOperandOfBitwiseOp Invalid operator: right operand of | is true (expected int|string)
+%s:5 PhanTypeInvalidBitwiseBinaryOperator Invalid non-int/non-string operand provided to operator '^' between types null and 1
+%s:5 PhanTypeInvalidLeftOperandOfBitwiseOp Invalid operator: left operand of ^ is null (expected int|string)
+%s:6 PhanTypeInvalidBitwiseBinaryOperator Invalid non-int/non-string operand provided to operator '&' between types null and 123
+%s:6 PhanTypeInvalidLeftOperandOfBitwiseOp Invalid operator: left operand of & is null (expected int|string)
+%s:8 PhanTypeInvalidUnaryOperandBitwiseNot Invalid operator: unary operand of ~ is false (expected number that can fit in an int, or string)
+%s:9 PhanTypeInvalidUnaryOperandBitwiseNot Invalid operator: unary operand of ~ is true (expected number that can fit in an int, or string)
+%s:10 PhanTypeInvalidUnaryOperandBitwiseNot Invalid operator: unary operand of ~ is null (expected number that can fit in an int, or string)

--- a/tests/files/expected/0918_suggest_static.php.expected
+++ b/tests/files/expected/0918_suggest_static.php.expected
@@ -1,0 +1,2 @@
+%s:6 PhanUndeclaredVariable Variable $foo is undeclared
+%s:9 PhanUndeclaredVariable Variable $foo is undeclared (Did you mean $this->foo)

--- a/tests/files/expected/0919_false_positive_class_string.php.expected
+++ b/tests/files/expected/0919_false_positive_class_string.php.expected
@@ -1,0 +1,1 @@
+%s:5 PhanDebugAnnotation @phan-debug-var requested for variable $package - it has union type array{class:class-string}|non-empty-mixed(real=array{class:class-string}|non-null-mixed)

--- a/tests/files/src/0916_null_unknown.php
+++ b/tests/files/src/0916_null_unknown.php
@@ -1,0 +1,14 @@
+<?php
+function test916(): array {
+    $x = [
+        null|true,
+        null^1,
+        null&123,
+        // these are runtime errors, Phan should not crash
+        ~false,
+        ~true,
+        ~null,
+    ];
+    '@phan-debug-var $x';
+    return $x;
+}

--- a/tests/files/src/0918_suggest_static.php
+++ b/tests/files/src/0918_suggest_static.php
@@ -1,0 +1,11 @@
+<?php
+namespace NS918;
+class example918 {
+    public $foo;
+    public static function main() {
+        return $foo;  // should not suggest the instance property $this->foo
+    }
+    public function instanceMethod() {
+        return $foo;  // should suggest the instance property $this->foo
+    }
+}

--- a/tests/files/src/0919_false_positive_class_string.php
+++ b/tests/files/src/0919_false_positive_class_string.php
@@ -1,0 +1,11 @@
+<?php
+function foo919(array $foo): array
+{
+    foreach ($foo as $package) {
+        if (class_exists($package['class']) || interface_exists($package['class'])) {
+            '@phan-debug-var $package';
+            return $package;
+        }
+    }
+    return [];
+}

--- a/tests/plugin_test/expected/070_suggest_global_constant.php.expected
+++ b/tests/plugin_test/expected/070_suggest_global_constant.php.expected
@@ -11,5 +11,5 @@ src/070_suggest_global_constant.php:20 PhanUnreferencedPublicClassConstant Possi
 src/070_suggest_global_constant.php:21 PhanUnreferencedPublicProperty Possibly zero references to public property \TestNS\Foo70::$AST_BINARY_OP
 src/070_suggest_global_constant.php:22 PhanUnreferencedPrivateProperty Possibly zero references to private property \TestNS\Foo70->SOME_LOWERCASE_CONSTANT
 src/070_suggest_global_constant.php:24 PhanUndeclaredConstant Reference to undeclared constant \AST_BINARY_OP. This will cause a thrown Error in php 8.0+. (Did you mean \ast\AST_BINARY_OP or self::$AST_BINARY_OP or self::AST_BINARY_OP)
-src/070_suggest_global_constant.php:25 PhanUndeclaredConstant Reference to undeclared constant \SOME_LOWERCASE_CONSTANT. This will cause a thrown Error in php 8.0+. (Did you mean $this->SOME_LOWERCASE_CONSTANT or \TestNS\SOME_lowercase_constant)
+src/070_suggest_global_constant.php:25 PhanUndeclaredConstant Reference to undeclared constant \SOME_LOWERCASE_CONSTANT. This will cause a thrown Error in php 8.0+. (Did you mean \TestNS\SOME_lowercase_constant)
 src/070_suggest_global_constant.php:26 PhanUndeclaredConstant Reference to undeclared constant \SOME_CONSTANT_NAME. This will cause a thrown Error in php 8.0+. (Did you mean self::SOME_CONSTANT_NAME)

--- a/tests/plugin_test/src/070_suggest_global_constant.php
+++ b/tests/plugin_test/src/070_suggest_global_constant.php
@@ -22,7 +22,7 @@ class Foo70 {
     private $SOME_LOWERCASE_CONSTANT = 'xx';
     public static function main() {
         var_export(AST_BINARY_OP);
-        var_export(SOME_LOWERCASE_CONSTANT);
+        var_export(SOME_LOWERCASE_CONSTANT);  // should not suggest instance property
         return SOME_CONSTANT_NAME;
     }
 }


### PR DESCRIPTION
(caused by recent refactorings to handling of mixed)

And stop suggesting instance properties as alternatives for undeclared
variables/constants inside of static methods
