### PR TITLE
Fix -z,--signature-compatibility CLI option to be set correctly

### DIFF
--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -655,7 +655,7 @@ class CLI
                     break;
                 case 'z':
                 case 'signature-compatibility':
-                    Config::setValue('analyze_signature_compatibility', (bool)$value);
+                    Config::setValue('analyze_signature_compatibility', true);
                     break;
                 case 'y':
                 case 'minimum-severity':


### PR DESCRIPTION
CLI option `-z,--signature-compatibility` actually disables the config `analyze_signature_compatibilty`.

Since this CLI option doesn't take a parameter, `$value` is always false.
Therefore the option disables the `analyze_signature_compatibilty` setting against expectations.