### PR TITLE
Be stricter when checking if `__construct` exists

### DIFF
--- a/.phan/plugins/PHPUnitNotDeadCodePlugin.php
+++ b/.phan/plugins/PHPUnitNotDeadCodePlugin.php
@@ -113,7 +113,7 @@ class PHPUnitNotDeadPluginVisitor extends PluginAwarePostAnalysisVisitor
     {
         if (preg_match('/@dataProvider\s+' . self::WORD_REGEX . '/', $method->getNode()->children['docComment'] ?? '', $match)) {
             $data_provider_name = $match[1];
-            if ($class->hasMethodWithName($this->code_base, $data_provider_name)) {
+            if ($class->hasMethodWithName($this->code_base, $data_provider_name, true)) {
                 $class->getMethodByName($this->code_base, $data_provider_name)->addReference($this->context);
             }
         }

--- a/.phan/plugins/PrintfCheckerPlugin.php
+++ b/.phan/plugins/PrintfCheckerPlugin.php
@@ -604,7 +604,7 @@ class PrintfCheckerPlugin extends PluginV3 implements AnalyzeFunctionCallCapabil
                     // TODO: Move into a common helper method?
                     try {
                         foreach ($actual_union_type->asExpandedTypes($code_base)->asClassList($code_base, $context) as $clazz) {
-                            if ($clazz->hasMethodWithName($code_base, '__toString')) {
+                            if ($clazz->hasMethodWithName($code_base, '__toString', true)) {
                                 $can_cast_to_string = true;
                                 break;
                             }

--- a/.phan/plugins/SuspiciousParamOrderPlugin.php
+++ b/.phan/plugins/SuspiciousParamOrderPlugin.php
@@ -387,7 +387,7 @@ class SuspiciousParamOrderVisitor extends PluginAwarePostAnalysisVisitor
                 $this->code_base,
                 $this->context,
                 $node
-            ))->getMethod($method_name, false);
+            ))->getMethod($method_name, false, true);
         } catch (Exception $_) {
             return;
         }

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@ Phan NEWS
 
 Bug fixes:
 + Fix a few parameter names for issue messages (#4316)
++ Fix bug that could cause Phan not to warn about `SomeClassWithoutConstruct::__construct`
+  in some edge cases. (#4323)
 
 Dec 23 2020, Phan 3.2.8
 -----------------------

--- a/src/Phan/AST/FallbackUnionTypeVisitor.php
+++ b/src/Phan/AST/FallbackUnionTypeVisitor.php
@@ -676,7 +676,7 @@ class FallbackUnionTypeVisitor extends KindVisitorImplementation
         try {
             $possible_types = null;
             foreach (UnionTypeVisitor::classListFromNodeAndContext($this->code_base, $this->context, $class_node) as $class) {
-                if (!$class->hasMethodWithName($this->code_base, $method_name)) {
+                if (!$class->hasMethodWithName($this->code_base, $method_name, true)) {
                     return UnionType::empty();
                 }
                 $method = $class->getMethodByName($this->code_base, $method_name);
@@ -724,7 +724,7 @@ class FallbackUnionTypeVisitor extends KindVisitorImplementation
         }
         try {
             $class = $this->context->getClassInScope($this->code_base);
-            if (!$class->hasMethodWithName($this->code_base, $method_name)) {
+            if (!$class->hasMethodWithName($this->code_base, $method_name, true)) {
                 return UnionType::empty();
             }
             $method = $class->getMethodByName($this->code_base, $method_name);

--- a/src/Phan/AST/InferPureVisitor.php
+++ b/src/Phan/AST/InferPureVisitor.php
@@ -474,7 +474,7 @@ class InferPureVisitor extends AnalysisVisitor
                 // TODO build a list of internal classes where result of new() is often unused.
                 continue;
             }
-            if (!$class->hasMethodWithName($this->code_base, '__construct')) {
+            if (!$class->hasMethodWithName($this->code_base, '__construct', true)) {
                 throw new NodeException($name_node, 'no __construct found');
             }
             $this->checkCalledFunction($node, $class->getMethodByName($this->code_base, '__construct'));
@@ -586,7 +586,7 @@ class InferPureVisitor extends AnalysisVisitor
         } catch (Exception $_) {
             throw new NodeException($node);
         }
-        if (!$class->hasMethodWithName($this->code_base, $method)) {
+        if (!$class->hasMethodWithName($this->code_base, $method, true)) {
             throw new NodeException($node, 'no method');
         }
 
@@ -610,7 +610,7 @@ class InferPureVisitor extends AnalysisVisitor
             throw new NodeException($node);
         }
         $class = $this->getClassForVariable($expr);
-        if (!$class->hasMethodWithName($this->code_base, $method_name)) {
+        if (!$class->hasMethodWithName($this->code_base, $method_name, true)) {
             throw new NodeException($expr, 'does not have method');
         }
         $this->checkCalledFunction($node, $class->getMethodByName($this->code_base, $method_name));

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -2955,11 +2955,7 @@ class UnionTypeVisitor extends AnalysisVisitor
             }
             $combined_union_type = null;
             foreach ($this->classListFromNode($class_node) as $class) {
-                if (!$class->hasMethodWithName(
-                    $this->code_base,
-                    $method_name
-                )
-                ) {
+                if (!$class->hasMethodWithName($this->code_base, $method_name, true)) {
                     continue;
                 }
 
@@ -3721,7 +3717,7 @@ class UnionTypeVisitor extends AnalysisVisitor
                 continue;
             }
             $class = $code_base->getClassByFQSEN($class_fqsen);
-            if (!$class->hasMethodWithName($code_base, $method_name)) {
+            if (!$class->hasMethodWithName($code_base, $method_name, true)) {
                 // emit error below
                 continue;
             }
@@ -3883,7 +3879,7 @@ class UnionTypeVisitor extends AnalysisVisitor
             return [];
         }
         $class = $code_base->getClassByFQSEN($class_fqsen);
-        if (!$class->hasMethodWithName($code_base, $method_name)) {
+        if (!$class->hasMethodWithName($code_base, $method_name, true)) {
             $this->emitIssue(
                 Issue::UndeclaredStaticMethodInCallable,
                 $context->getLineNumberStart(),

--- a/src/Phan/Analysis/ArgumentType.php
+++ b/src/Phan/Analysis/ArgumentType.php
@@ -1085,7 +1085,7 @@ final class ArgumentType
             if (!$context->isStrictTypes() && $alternate_parameter_type->hasNonNullStringType()) {
                 try {
                     foreach ($argument_type_expanded_resolved->asClassList($code_base, $context) as $clazz) {
-                        if ($clazz->hasMethodWithName($code_base, "__toString")) {
+                        if ($clazz->hasMethodWithName($code_base, "__toString", true)) {
                             return;
                         }
                     }
@@ -1445,7 +1445,8 @@ final class ArgumentType
                     ) as $class) {
                         if (!$class->hasMethodWithName(
                             $code_base,
-                            $method_name
+                            $method_name,
+                            true
                         )) {
                             continue;
                         }

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -193,7 +193,7 @@ class AssignmentVisitor extends AnalysisVisitor
                 $this->code_base,
                 $this->context,
                 $node
-            ))->getMethod($method_name, false);
+            ))->getMethod($method_name, false, true);
             $this->checkAssignmentToFunctionResult($node, [$method]);
         } catch (Exception $_) {
             // ignore it
@@ -983,7 +983,7 @@ class AssignmentVisitor extends AnalysisVisitor
             // Check to see if this class has the property or
             // a setter
             if (!$clazz->hasPropertyWithName($this->code_base, $property_name)) {
-                if (!$clazz->hasMethodWithName($this->code_base, '__set')) {
+                if (!$clazz->hasMethodWithName($this->code_base, '__set', true)) {
                     continue;
                 }
             }

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -499,7 +499,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             // Check for __toString(), stringable variables/expressions in encapsulated strings work whether or not strict_types is set
             try {
                 foreach ($type->withStaticResolvedInContext($context)->asExpandedTypes($code_base)->asClassList($code_base, $context) as $clazz) {
-                    if ($clazz->hasMethodWithName($code_base, "__toString")) {
+                    if ($clazz->hasMethodWithName($code_base, "__toString", true)) {
                         return;
                     }
                 }
@@ -695,7 +695,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             if (!$context->isStrictTypes()) {
                 try {
                     foreach ($type->withStaticResolvedInContext($context)->asExpandedTypes($code_base)->asClassList($code_base, $context) as $clazz) {
-                        if ($clazz->hasMethodWithName($code_base, "__toString")) {
+                        if ($clazz->hasMethodWithName($code_base, "__toString", true)) {
                             return $context;
                         }
                     }
@@ -3109,7 +3109,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 $this->code_base,
                 $this->context,
                 $node
-            ))->getMethod($method_name, false);
+            ))->getMethod($method_name, false, true);
         } catch (IssueException $exception) {
             Issue::maybeEmitInstance(
                 $this->code_base,
@@ -3752,7 +3752,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         }
         if ($method->isPrivate()) {
             $has_call_magic_method = !$method->isStatic()
-                && $method->getDefiningClass($this->code_base)->hasMethodWithName($this->code_base, '__call');
+                && $method->getDefiningClass($this->code_base)->hasMethodWithName($this->code_base, '__call', true);
 
             $this->emitIssue(
                 $has_call_magic_method ?
@@ -3767,7 +3767,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 return;
             }
             $has_call_magic_method = !$method->isStatic()
-                && $method->getDefiningClass($this->code_base)->hasMethodWithName($this->code_base, '__call');
+                && $method->getDefiningClass($this->code_base)->hasMethodWithName($this->code_base, '__call', true);
 
             $this->emitIssue(
                 $has_call_magic_method ?
@@ -4877,7 +4877,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         if ($class->isClass()
             && ($class->getElementNamespace() ?: "\\") === "\\"
             && \strcasecmp($class->getName(), $method->getName()) === 0
-            && $class->hasMethodWithName($this->code_base, "__construct")
+            && $class->hasMethodWithName($this->code_base, "__construct", false)  // return true for the fake constructor
         ) {
             try {
                 $constructor = $class->getMethodByName($this->code_base, "__construct");

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -157,7 +157,8 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
 
         if (!$clazz->hasMethodWithName(
             $code_base,
-            $method_name
+            $method_name,
+            true
         )) {
             throw new CodeBaseException(
                 null,

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -2209,8 +2209,9 @@ class CodeBase
         if (!$class->isClass()) {
             return null;
         }
-        if (!$class->hasMethodWithName($this, '__construct')) {
-            return null;
+        if (!$class->hasMethodWithName($this, '__construct', true)) {
+            // Allow both the constructor and the absence of a constructor
+            return $fqsen;
         }
         $class_fqsen_in_current_scope = IssueFixSuggester::maybeGetClassInCurrentScope($context);
         if ($class->getMethodByName($this, '__construct')->isAccessibleFromClass($this, $class_fqsen_in_current_scope)) {

--- a/src/Phan/IssueFixSuggester.php
+++ b/src/Phan/IssueFixSuggester.php
@@ -348,7 +348,7 @@ class IssueFixSuggester
                 $suggestions[] = $class->getFQSEN() . '::' . $wanted_property_name;
             }
         }
-        if ($class->hasMethodWithName($code_base, $wanted_property_name)) {
+        if ($class->hasMethodWithName($code_base, $wanted_property_name, true)) {
             $method = $class->getMethodByName($code_base, $wanted_property_name);
             $suggestions[] = $class->getFQSEN() . ($method->isStatic() ? '::' : '->') . $wanted_property_name . '()';
         }

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -933,7 +933,7 @@ class Clazz extends AddressableElement
                 $flags |= \ast\flags\MODIFIER_STATIC;
             }
             $method_name = $comment_method->getName();
-            if ($this->hasMethodWithName($code_base, $method_name)) {
+            if ($this->hasMethodWithName($code_base, $method_name, true)) {
                 // No point, and this would hurt inference accuracy.
                 continue;
             }
@@ -1083,7 +1083,7 @@ class Clazz extends AddressableElement
 
         // Check to see if we can use a __get magic method
         // TODO: What about __set?
-        if (!$is_static && $this->hasMethodWithName($code_base, '__get')) {
+        if (!$is_static && $this->hasMethodWithName($code_base, '__get', true)) {
             $method = $this->getMethodByName($code_base, '__get');
 
             // Make sure the magic method is accessible
@@ -1810,6 +1810,7 @@ class Clazz extends AddressableElement
     }
 
     /**
+     * @param bool $is_direct_invocation @phan-mandatory-param
      * @return bool
      * True if this class has a method with the given name
      */
@@ -1898,7 +1899,7 @@ class Clazz extends AddressableElement
      */
     public function hasCallMethod(CodeBase $code_base): bool
     {
-        return $this->hasMethodWithName($code_base, '__call');
+        return $this->hasMethodWithName($code_base, '__call', true);
     }
 
     /**
@@ -1955,7 +1956,7 @@ class Clazz extends AddressableElement
      */
     public function hasCallStaticMethod(CodeBase $code_base): bool
     {
-        return $this->hasMethodWithName($code_base, '__callStatic');
+        return $this->hasMethodWithName($code_base, '__callStatic', true);
     }
 
     /**
@@ -1996,7 +1997,7 @@ class Clazz extends AddressableElement
      */
     public function hasGetMethod(CodeBase $code_base): bool
     {
-        return $this->hasMethodWithName($code_base, '__get');
+        return $this->hasMethodWithName($code_base, '__get', true);
     }
 
     /**
@@ -2009,7 +2010,7 @@ class Clazz extends AddressableElement
      */
     public function hasSetMethod(CodeBase $code_base): bool
     {
-        return $this->hasMethodWithName($code_base, '__set');
+        return $this->hasMethodWithName($code_base, '__set', true);
     }
 
     /**
@@ -2451,7 +2452,7 @@ class Clazz extends AddressableElement
                 // Skip __invoke, and private/protected methods
                 continue;
             }
-            if ($this->hasMethodWithName($code_base, $name)) {
+            if ($this->hasMethodWithName($code_base, $name, true)) {
                 continue;
             }
             // Treat it as if all of the methods were added, with their real and phpdoc union types.
@@ -2852,7 +2853,7 @@ class Clazz extends AddressableElement
     ): void {
         foreach ($trait_adaptations->alias_methods ?? [] as $alias_method_name => $original_trait_alias_source) {
             $source_method_name = $original_trait_alias_source->getSourceMethodName();
-            if ($class->hasMethodWithName($code_base, $source_method_name)) {
+            if ($class->hasMethodWithName($code_base, $source_method_name, true)) {
                 $source_method = $class->getMethodByName($code_base, $source_method_name);
             } else {
                 $source_method = null;
@@ -3607,7 +3608,7 @@ class Clazz extends AddressableElement
         $ancestor_class = $code_base->getClassByFQSEN($ancestor_fqsen);
         $name = $element->getName();
         if ($element instanceof Method) {
-            if (!$ancestor_class->hasMethodWithName($code_base, $name)) {
+            if (!$ancestor_class->hasMethodWithName($code_base, $name, true)) {
                 return null;
             }
             return $ancestor_class->getMethodByName($code_base, $name);

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -259,6 +259,14 @@ class Method extends ClassElement implements FunctionInterface
     }
 
     /**
+     * Returns true if this is a placeholder for the `__construct` method that was never declared
+     */
+    public function isFakeConstructor(): bool
+    {
+        return ($this->getPhanFlags() & Flags::IS_FAKE_CONSTRUCTOR) !== 0;
+    }
+
+    /**
      * Returns true if this is the magic `__call` method
      */
     public function isMagicCall(): bool
@@ -284,7 +292,7 @@ class Method extends ClassElement implements FunctionInterface
         Clazz $clazz,
         CodeBase $code_base
     ): Method {
-        if ($clazz->getFQSEN()->getNamespace() === '\\' && $clazz->hasMethodWithName($code_base, $clazz->getName())) {
+        if ($clazz->getFQSEN()->getNamespace() === '\\' && $clazz->hasMethodWithName($code_base, $clazz->getName(), true)) {
             $old_style_constructor = $clazz->getMethodByName($code_base, $clazz->getName());
         } else {
             $old_style_constructor = null;
@@ -312,7 +320,7 @@ class Method extends ClassElement implements FunctionInterface
             $method->setUnionType($old_style_constructor->getUnionType());
         }
 
-        $method->setPhanFlags(Flags::IS_FAKE_CONSTRUCTOR);
+        $method->setPhanFlags($method->getPhanFlags() | Flags::IS_FAKE_CONSTRUCTOR);
 
         return $method;
     }
@@ -740,7 +748,7 @@ class Method extends ClassElement implements FunctionInterface
             // TODO: Handle edge cases in traits.
             // A trait may be earlier in $ancestor_class_list than the parent, but the parent may define abstract classes.
             // TODO: What about trait aliasing rules?
-            if ($ancestor_class->hasMethodWithName($code_base, $this->name)) {
+            if ($ancestor_class->hasMethodWithName($code_base, $this->name, true)) {
                 $method = $ancestor_class->getMethodByName(
                     $code_base,
                     $this->name

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -2354,7 +2354,7 @@ class Type
         // Given an IteratorAggregate implementation with getIterator, determine the class of the Iterator if possible.
         if ($expanded_types->hasTypeWithFQSEN($iterator_aggregate_fqsen)) {
             $class = $code_base->getClassByFQSEN($fqsen);
-            if (!$class->hasMethodWithName($code_base, 'getIterator')) {
+            if (!$class->hasMethodWithName($code_base, 'getIterator', true)) {
                 // Should be impossible
                 return null;
             }
@@ -2380,7 +2380,7 @@ class Type
         // Given an Iterator, return the type of the key
         if ($expanded_types->hasTypeWithFQSEN($iterator_fqsen)) {
             $class = $code_base->getClassByFQSEN($fqsen);
-            if (!$class->hasMethodWithName($code_base, 'key')) {
+            if (!$class->hasMethodWithName($code_base, 'key', true)) {
                 // Should be impossible
                 return null;
             }
@@ -2431,7 +2431,7 @@ class Type
         // Given an IteratorAggregate implementation with getIterator, determine the class of the Iterator if possible.
         if ($expanded_types->hasTypeWithFQSEN($iterator_aggregate_fqsen)) {
             $class = $code_base->getClassByFQSEN($fqsen);
-            if (!$class->hasMethodWithName($code_base, 'getIterator')) {
+            if (!$class->hasMethodWithName($code_base, 'getIterator', true)) {
                 // Should be impossible
                 return null;
             }
@@ -2457,7 +2457,7 @@ class Type
         // Given an Iterator, return the type of the value (from ->current())
         if ($expanded_types->hasTypeWithFQSEN($iterator_fqsen)) {
             $class = $code_base->getClassByFQSEN($fqsen);
-            if (!$class->hasMethodWithName($code_base, 'current')) {
+            if (!$class->hasMethodWithName($code_base, 'current', true)) {
                 // Should be impossible
                 return null;
             }
@@ -3962,7 +3962,7 @@ class Type
             return null;
         }
         $class = $code_base->getClassByFQSEN($fqsen);
-        if (!$class->hasMethodWithName($code_base, '__invoke')) {
+        if (!$class->hasMethodWithName($code_base, '__invoke', true)) {
             Issue::maybeEmit(
                 $code_base,
                 $context,

--- a/src/Phan/Language/Type/ArrayShapeType.php
+++ b/src/Phan/Language/Type/ArrayShapeType.php
@@ -998,7 +998,7 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
             }
             if ($code_base->hasClassWithFQSEN($fqsen)) {
                 $class = $code_base->getClassByFQSEN($fqsen);
-                if ($class->hasMethodWithName($code_base, $method_name)) {
+                if ($class->hasMethodWithName($code_base, $method_name, true)) {
                     return $class->getMethodByName($code_base, $method_name);
                 }
             }

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -5482,7 +5482,10 @@ class UnionType implements Serializable
     {
         try {
             foreach ($this->asClassList($code_base, $context) as $clazz) {
-                if ($clazz->hasMethodWithName($code_base, "__toString")) {
+                // NOTE: It's possible for an internal class to cast to string without implementing __toString.
+                // (PHP 8 implements that in more places)
+                // The $is_direct to hasMethodWithName currently doesn't matter one way or another for that.
+                if ($clazz->hasMethodWithName($code_base, "__toString", false)) {
                     return true;
                 }
             }

--- a/src/Phan/LanguageServer/DefinitionResolver.php
+++ b/src/Phan/LanguageServer/DefinitionResolver.php
@@ -365,6 +365,9 @@ class DefinitionResolver
         }
     }
 
+    /**
+     * Locate a definition given a direct call to an instance or static method
+     */
     public static function locateMethodDefinition(GoToDefinitionRequest $request, CodeBase $code_base, Context $context, Node $node): void
     {
         $is_static = $node->kind === ast\AST_STATIC_CALL;
@@ -373,7 +376,7 @@ class DefinitionResolver
             return;
         }
         try {
-            $method = (new ContextNode($code_base, $context, $node))->getMethod($method_name, $is_static);
+            $method = (new ContextNode($code_base, $context, $node))->getMethod($method_name, $is_static, true);
         } catch (IssueException | NodeException $_) {
             // ignore
             return;

--- a/src/Phan/Plugin/Internal/UseReturnValuePlugin/UseReturnValueVisitor.php
+++ b/src/Phan/Plugin/Internal/UseReturnValuePlugin/UseReturnValueVisitor.php
@@ -227,7 +227,7 @@ class UseReturnValueVisitor extends PluginAwarePostAnalysisVisitor
                 $this->code_base,
                 $this->context,
                 $node
-            ))->getMethod($method_name, false);
+            ))->getMethod($method_name, false, true);
         } catch (Exception $_) {
             return;
         }

--- a/tests/Phan/AnalyzerTest.php
+++ b/tests/Phan/AnalyzerTest.php
@@ -89,7 +89,7 @@ final class AnalyzerTest extends BaseTest
             $this->code_base->getClassByFQSEN($class_fqsen);
 
         self::assertTrue(
-            $clazz->hasMethodWithName($this->code_base, 'c'),
+            $clazz->hasMethodWithName($this->code_base, 'c', true),
             "Method with FQSEN not found"
         );
     }


### PR DESCRIPTION
Noticed when investigating #4320 that InferPureVisitor
would cause the placeholder method to be created (depending on config
settings), which would cause the warning about a missing constructor to
fail to be emitted, even with no conditionals.

The original bug report had `is_callable`, which Phan currently does not
use to infer the existence of methods. See #4186