### PR TITLE
Infer `self` refers to class context in namespaces outside classes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ Bug fixes:
 + Fix a few parameter names for issue messages (#4316)
 + Fix bug that could cause Phan not to warn about `SomeClassWithoutConstruct::__construct`
   in some edge cases. (#4323)
++ Properly infer `self` is referring to the current object context even when the object context is unknown in namespaces. (#4070)
 
 Dec 23 2020, Phan 3.2.8
 -----------------------

--- a/tests/files/expected/0098_undef.php.expected
+++ b/tests/files/expected/0098_undef.php.expected
@@ -15,4 +15,4 @@
 %s:40 PhanParentlessClass Reference to parent of class \G98 that does not extend anything
 %s:43 PhanUndeclaredExtendedClass Class extends undeclared class \Undef
 %s:46 PhanUndeclaredTypeReturnType Return type of j() is undeclared type \Undef
-%s:49 PhanUndeclaredTypeReturnType Return type of k() is undeclared type \self
+%s:49 PhanUndeclaredTypeReturnType Return type of k() is undeclared type self

--- a/tests/files/expected/0922_namespace_context_not_object.php.expected
+++ b/tests/files/expected/0922_namespace_context_not_object.php.expected
@@ -1,0 +1,3 @@
+%s:3 PhanContextNotObject Cannot access self when not in object context
+%s:4 PhanUndeclaredClassMethod Call to method foo from undeclared class \NS922\self
+%s:5 PhanUndeclaredClassMethod Call to method foo from undeclared class \X\Another\self

--- a/tests/files/src/0922_namespace_context_not_object.php
+++ b/tests/files/src/0922_namespace_context_not_object.php
@@ -1,0 +1,5 @@
+<?php
+namespace X;
+self::foo();
+\NS922\self::foo();
+Another\self::foo();


### PR DESCRIPTION
Fixes #4070