### PR TITLE
Fix code completions for `::` and `->` on files with Windows line endings

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,26 +11,31 @@ platform: x86
 # Test with a given PHP version
 # 1. (PHP_VERSION is the only version tested of PHP_EXT_VERSION, and it can only be built with VC_VERSION)
 # 2. Also, run tests with a variety of supported php-ast versions. Phan should work properly with php-ast 1.0.1+
+# See https://www.appveyor.com/docs/build-environment/#using-multiple-images-for-the-same-build for APPVEYOR_BUILD_WORKER_IMAGE details
 environment:
   matrix:
     # This major release of Phan (4.0) requires php-ast 1.0.7+
     - PHP_EXT_VERSION: '8.0'
       PHP_VERSION: '8.0.1'
-      VC_VERSION_STRING: vs16
       PHP_AST_VERSION: 1.0.10
+      VC: vs16
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       PHAN_RUN_INTEGRATION_TEST: 1
     - PHP_EXT_VERSION: '7.2'
       PHP_VERSION: '7.2.33'
-      VC_VERSION_STRING: vc15
+      VC: vc15
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       PHP_AST_VERSION: 1.0.7
     - PHP_EXT_VERSION: '7.3'
       PHP_VERSION: '7.3.24'
-      VC_VERSION_STRING: vc15
+      VC: vc15
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       PHP_AST_VERSION: 1.0.7
     - PHP_EXT_VERSION: '7.4'
       PHP_VERSION: '7.4.14'
       VC_VERSION: 15
-      VC_VERSION_STRING: vc15
+      VC: vc15
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       PHP_AST_VERSION: 1.0.10
       PHAN_RUN_INTEGRATION_TEST: 1
 
@@ -57,7 +62,7 @@ build_script:
 
     cd C:\projects\php
 
-    SET PHP_ZIP_BASENAME=php-%PHP_VERSION%-nts-Win32-%VC_VERSION_STRING%-x86.zip
+    SET PHP_ZIP_BASENAME=php-%PHP_VERSION%-nts-Win32-%VC%-x86.zip
 
     curl -fsS https://windows.php.net/downloads/releases/archives/%PHP_ZIP_BASENAME% -o %PHP_ZIP_BASENAME% || curl -fsS https://windows.php.net/downloads/releases/%PHP_ZIP_BASENAME% -o %PHP_ZIP_BASENAME%
 
@@ -67,7 +72,7 @@ build_script:
 
     cd C:\projects\php\ext
 
-    SET AST_ZIP_BASENAME=php_ast-%PHP_AST_VERSION%-%PHP_EXT_VERSION%-nts-%VC_VERSION_STRING%-x86.zip
+    SET AST_ZIP_BASENAME=php_ast-%PHP_AST_VERSION%-%PHP_EXT_VERSION%-nts-%VC%-x86.zip
 
     curl -fsS https://windows.php.net/downloads/pecl/releases/ast/%PHP_AST_VERSION%/%AST_ZIP_BASENAME% -o %AST_ZIP_BASENAME%
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,4 @@
-# This tests against the supported versions of Phan 1.x.y (PHP 7.0, 7.1, 7.2)
+# This tests against the supported versions of Phan 4.x.y (PHP 7.2-8.0)
 # The project name is the same as the build id used, e.g. https://www.appveyor.com/docs/environment-variables/
 
 version: '{branch}.{build}'
@@ -13,25 +13,31 @@ platform: x86
 # 2. Also, run tests with a variety of supported php-ast versions. Phan should work properly with php-ast 1.0.1+
 environment:
   matrix:
-    # This major release of Phan (2.0) requires php-ast 1.0.1+
-    - PHP_EXT_VERSION: '7.4'
-      PHP_VERSION: '7.4.10'
-      VC_VERSION: 15
+    # This major release of Phan (4.0) requires php-ast 1.0.7+
+    - PHP_EXT_VERSION: '8.0'
+      PHP_VERSION: '8.0.1'
+      VC_VERSION_STRING: vs16
       PHP_AST_VERSION: 1.0.10
       PHAN_RUN_INTEGRATION_TEST: 1
-    - PHP_EXT_VERSION: '7.3'
-      PHP_VERSION: '7.3.22'
-      VC_VERSION: 15
-      PHP_AST_VERSION: 1.0.7
     - PHP_EXT_VERSION: '7.2'
       PHP_VERSION: '7.2.33'
-      VC_VERSION: 15
+      VC_VERSION_STRING: vc15
       PHP_AST_VERSION: 1.0.7
+    - PHP_EXT_VERSION: '7.3'
+      PHP_VERSION: '7.3.24'
+      VC_VERSION_STRING: vc15
+      PHP_AST_VERSION: 1.0.7
+    - PHP_EXT_VERSION: '7.4'
+      PHP_VERSION: '7.4.14'
+      VC_VERSION: 15
+      VC_VERSION_STRING: vc15
+      PHP_AST_VERSION: 1.0.10
+      PHAN_RUN_INTEGRATION_TEST: 1
 
 init:
     - SET PATH=c:\projects\php;C:\projects\composer;%PATH%
 
-# There are more than one version of php and php-ast that could be installed (for php 7.1 and 7.2),
+# There are more than one version of php and php-ast that could be installed,
 # so I'm not sure how to cache those.
 cache:
     - '%LOCALAPPDATA%\Composer\files -> composer.lock'
@@ -51,7 +57,7 @@ build_script:
 
     cd C:\projects\php
 
-    SET PHP_ZIP_BASENAME=php-%PHP_VERSION%-nts-Win32-VC%VC_VERSION%-x86.zip
+    SET PHP_ZIP_BASENAME=php-%PHP_VERSION%-nts-Win32-%VC_VERSION_STRING%-x86.zip
 
     curl -fsS https://windows.php.net/downloads/releases/archives/%PHP_ZIP_BASENAME% -o %PHP_ZIP_BASENAME% || curl -fsS https://windows.php.net/downloads/releases/%PHP_ZIP_BASENAME% -o %PHP_ZIP_BASENAME%
 
@@ -61,7 +67,7 @@ build_script:
 
     cd C:\projects\php\ext
 
-    SET AST_ZIP_BASENAME=php_ast-%PHP_AST_VERSION%-%PHP_EXT_VERSION%-nts-vc%VC_VERSION%-x86.zip
+    SET AST_ZIP_BASENAME=php_ast-%PHP_AST_VERSION%-%PHP_EXT_VERSION%-nts-%VC_VERSION_STRING%-x86.zip
 
     curl -fsS https://windows.php.net/downloads/pecl/releases/ast/%PHP_AST_VERSION%/%AST_ZIP_BASENAME% -o %AST_ZIP_BASENAME%
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 Phan NEWS
 
-??? ?? 2021, Phan 4.0.2 (dev)
+Jan 09 2021, Phan 4.0.2
 -----------------------
 
 New Features:

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,10 @@ Phan NEWS
 New Features:
 + Improve suggestions for `PhanUndeclaredThis` inside of static methods/closures (#4336)
 
+Language Server/Daemon mode:
++ Properly generate code completions for `::` and `->` at the end of a line on files using Windows line endings(`\r\n`) instead of Unix newlines(`\n`) on any OS (#4345)
+  Previously, those were not completed.
+
 Bug fixes:
 + Fix false positive `PhanParamSignatureMismatch` for variadic overriding a function using `func_get_args()` (#4340)
 + Don't emit PhanTypeNoPropertiesForeach for the Countable interface on its own. (#4342)

--- a/src/Phan/Bootstrap.php
+++ b/src/Phan/Bootstrap.php
@@ -61,7 +61,9 @@ function phan_output_ast_installation_instructions(): void
         $extension_dir .= ' (extension directory does not exist and may need to be changed)';
     }
     if (DIRECTORY_SEPARATOR === '\\') {
-        if (PHP_VERSION_ID < 70500 || !preg_match('/[a-zA-Z]/', PHP_VERSION)) {
+        if (PHP_VERSION_ID < 80100 || !preg_match('/[a-zA-Z]/', PHP_VERSION)) {
+            // e.g. https://windows.php.net/downloads/pecl/releases/ast/1.0.10/php_ast-1.0.10-8.0-nts-vs16-x64.zip for php 8.0, 64-bit non thread safe
+            // e.g. https://windows.php.net/downloads/pecl/releases/ast/1.0.10/php_ast-1.0.10-7.4-ts-vc15-x86.zip for php 7.4, 32-bit thread safe
             fprintf(
                 STDERR,
                 PHP_EOL . "Windows users can download php-ast from https://windows.php.net/downloads/pecl/releases/ast/%s/php_ast-%s-%s-%s-%s-%s.zip" . PHP_EOL,
@@ -69,7 +71,7 @@ function phan_output_ast_installation_instructions(): void
                 LATEST_KNOWN_PHP_AST_VERSION,
                 PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION,
                 PHP_ZTS ? 'ts' : 'nts',
-                'vc15',
+                PHP_VERSION_ID >= 80100 ? 'vc16' : 'vc15',
                 PHP_INT_SIZE == 4 ? 'x86' : 'x64'
             );
             fwrite(STDERR, "(if that link doesn't work, check https://windows.php.net/downloads/pecl/releases/ast/ )" . PHP_EOL);

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -83,7 +83,7 @@ class CLI
     /**
      * This should be updated to x.y.z-dev after every release, and x.y.z before a release.
      */
-    public const PHAN_VERSION = '4.0.2-dev';
+    public const PHAN_VERSION = '4.0.2';
 
     /**
      * List of short flags passed to getopt

--- a/src/Phan/Output/Collector/ParallelChildCollector.php
+++ b/src/Phan/Output/Collector/ParallelChildCollector.php
@@ -38,7 +38,7 @@ class ParallelChildCollector implements IssueCollectorInterface
      * @return resource the result of msg_get_queue()
      * @throws AssertionError if this could not create a resource with msg_get_queue.
      * @internal
-     * @suppress PhanTypeMismatchReturnProbablyReal different type in php 8.0+
+     * @suppress PhanTypeMismatchReturnProbablyReal, PhanTypeMismatchReturn different type in php 8.0+, the emitted issue depends on whether sysvmsg is installed
      */
     public static function getQueueForProcessGroup()
     {

--- a/tests/Phan/LanguageServer/LanguageServerIntegrationTest.php
+++ b/tests/Phan/LanguageServer/LanguageServerIntegrationTest.php
@@ -907,6 +907,7 @@ EOT;
         // TODO: Extract the parameter defaults from php 8.0's stub files
         // so they can be used in error messages for php 7?
         $parse_code_default = \PHP_VERSION_ID >= 80000 ? "'string code'" : 'unknown';
+        $error_default_message = \PHP_VERSION_ID >= 80000 ? "''" : 'unknown';
         $error_default_code = \PHP_VERSION_ID >= 80000 ? "0" : 'unknown';
         // Refers to elements defined in ../../misc/lsp/src/definitions.php
         $example_file_contents = <<<'EOT'
@@ -1144,7 +1145,7 @@ EOT
                 new Position(28, 45),  // AssertionError
                 <<<"EOT"
 ```php
-public function __construct(string \$message = unknown, int \$code = $error_default_code, ?\Error|?\Throwable \$previous = null): void
+public function __construct(string \$message = $error_default_message, int \$code = $error_default_code, ?\Error|?\Throwable \$previous = null): void
 ```
 
 Construct an instance of `\AssertionError`.


### PR DESCRIPTION
Fixes #4345