### PR TITLE
Cache plugin instances in ConfigPluginSet

### DIFF
--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -119,7 +119,7 @@ final class ConfigPluginSet extends PluginV3 implements
     private $plugin_set;
 
     /** @var list<PluginV3>|null - Shared cache of plugin instances to avoid requiring class files more than once. */
-    private $plugin_instances_cache;
+    private static $plugin_instances_cache;
 
     /**
      * @var associative-array<int, Closure(CodeBase,Context,Node|int|string|float):void> - plugins to analyze nodes in pre-order

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -118,8 +118,8 @@ final class ConfigPluginSet extends PluginV3 implements
     /** @var list<PluginV3>|null - Cached plugin set for this instance. Lazily generated. */
     private $plugin_set;
 
-    /** @var list<PluginV3>|null - Shared cache of plugin instances to avoid requiring class files more than once. */
-    private static $plugin_instances_cache;
+    /** @var array<string,PluginV3> - Shared cache of plugin instances to avoid requiring class files more than once. */
+    private static $plugin_instances_cache = [];
 
     /**
      * @var associative-array<int, Closure(CodeBase,Context,Node|int|string|float):void> - plugins to analyze nodes in pre-order

--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -118,6 +118,9 @@ final class ConfigPluginSet extends PluginV3 implements
     /** @var list<PluginV3>|null - Cached plugin set for this instance. Lazily generated. */
     private $plugin_set;
 
+    /** @var list<PluginV3>|null - Shared cache of plugin instances to avoid requiring class files more than once. */
+    private $plugin_instances_cache;
+
     /**
      * @var associative-array<int, Closure(CodeBase,Context,Node|int|string|float):void> - plugins to analyze nodes in pre-order
      */
@@ -920,6 +923,10 @@ final class ConfigPluginSet extends PluginV3 implements
             }
             $loaded_plugin_files[$plugin_file_name] = true;
 
+            if (isset(self::$plugin_instances_cache[$plugin_file_name])) {
+                return clone(self::$plugin_instances_cache[$plugin_file_name]);
+            }
+
             try {
                 $plugin_instance = require($plugin_file_name);
             } catch (UnloadablePluginException $e) {
@@ -949,6 +956,7 @@ final class ConfigPluginSet extends PluginV3 implements
                 throw new AssertionError("Plugins must extend \Phan\PluginV3. The plugin at $plugin_file_name does not.");
             }
 
+            self::$plugin_instances_cache[$plugin_file_name] = $plugin_instance;
             return $plugin_instance;
         };
         // Add user-defined plugins.


### PR DESCRIPTION
This is mainly useful in tests, and in general it avoids fatal errors due to `require`ing the same plugin file twice.

Closes #4350