### PR TITLE
Support PHP 8.1's `never` return type, php 7.4 contravariant parameters&covariant return types

### DIFF
--- a/.phan/plugins/StaticVariableMisusePlugin.php
+++ b/.phan/plugins/StaticVariableMisusePlugin.php
@@ -6,8 +6,8 @@ use ast\Node;
 use Phan\AST\ASTReverter;
 use Phan\Issue;
 use Phan\PluginV3;
-use Phan\PluginV3\PostAnalyzeNodeCapability;
 use Phan\PluginV3\PluginAwarePostAnalysisVisitor;
+use Phan\PluginV3\PostAnalyzeNodeCapability;
 
 /**
  * NOTE: This is automatically loaded by phan. Do not include it in a config.
@@ -31,11 +31,13 @@ final class StaticVariableMisusePlugin extends PluginV3 implements
  * Checks node kinds that can be used to access the inherited class
  * for conflicts with uses of static variables.
  */
-final class StaticVariableMisuseVisitor extends PluginAwarePostAnalysisVisitor {
+final class StaticVariableMisuseVisitor extends PluginAwarePostAnalysisVisitor
+{
     /**
      * @override
      */
-    public function visitVar(Node $node): void {
+    public function visitVar(Node $node): void
+    {
         $name = $node->children['name'];
         if ($name !== 'this') {
             return;
@@ -46,7 +48,8 @@ final class StaticVariableMisuseVisitor extends PluginAwarePostAnalysisVisitor {
     /**
      * @override
      */
-    public function visitName(Node $node): void {
+    public function visitName(Node $node): void
+    {
         $context = $this->context;
         if (!$context->isInClassScope() || !$context->isInFunctionLikeScope()) {
             return;

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,18 @@ New Features (Analysis):
   (infer the real type is the class type, that they cannot be instantiated, that enum values cannot be reused, and that class constants will exist for enum cases)
 
   New issue types: `PhanReusedEnumCaseValue`, `PhanTypeInstantiateEnum`, `PhanTypeInvalidEnumCaseType`, `PhanSyntaxInconsistentEnum`
++ Support php 7.4 covariant return types and contravariant parameter types when the configured or inferred `minimum_target_php_version` is `'7.4'` or newer (#3795)
++ Add initial support for the php 8.1 `never` type (in real return types and phpdoc). (#4380)
+  Also add support for the phpdoc aliases `no-return`, `never-return`, and `never-returns`
++ Support casting `iterable<K, V>` to `Traversable<K, V>` with `is_object` or `!is_array` checks
+
+Bug fixes:
++ As part of the work on php 7.4 contravariant parameter types,
+  don't automatically inherit inferred parameter types from ancestor classlikes when (1) there is no `@param` tag with a type for the parameter on the overriding method and (2) the ancestor parameter types are a subtype of the real parameter types unless
+
+  1. `@inheritDoc` is used.
+  2. This is a generic array type such as `array<string,mixed>` that is a specialization of an array type.
+     If you want to indicate that the overriding method can be any array type, add `@param array $paramName`.
 
 Apr 29 2021, Phan 4.0.5
 -----------------------

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -562,6 +562,14 @@ Using negative string offsets is not supported before PHP 7.1 (emits an 'Uniniti
 
 e.g. [this issue](https://github.com/phan/phan/tree/4.0.0/tests/php70_files/expected/009_negative_string_offset.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/4.0.0/tests/php70_files/src/009_negative_string_offset.php#L5).
 
+## PhanCompatibleNeverType
+
+```
+Return type '{TYPE}' means that a function will not return normally starting in PHP 8.1. In PHP 8.0, 'never' refers to a class/interface with the name 'never'
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/v4/tests/plugin_test/expected/199_never_type_and_plugins.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/v4/tests/plugin_test/src/199_never_type_and_plugins.php#L3).
+
 ## PhanCompatibleNonCapturingCatch
 
 ```
@@ -5041,6 +5049,12 @@ Syntax error: Function {FUNCTIONLIKE} with return type {TYPE} must return a valu
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/4.0.0/tests/files/expected/0242_void_71.php.expected#L6) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/4.0.0/tests/files/src/0242_void_71.php#L6).
+
+## PhanSyntaxReturnStatementInNever
+
+```
+Syntax error: function {FUNCTIONLIKE} has return type {TYPE}, meaning it must not contain return statements (it should exit, throw, or run forever)
+```
 
 ## PhanSyntaxReturnValueInVoid
 

--- a/src/Phan/AST/TolerantASTConverter/Shim.php
+++ b/src/Phan/AST/TolerantASTConverter/Shim.php
@@ -96,6 +96,9 @@ class Shim
         if (!defined('ast\flags\TYPE_MIXED')) {
             define('ast\flags\TYPE_MIXED', \PHP_MAJOR_VERSION >= 80000 ? 16 : 21);
         }
+        if (!defined('ast\flags\TYPE_NEVER')) {
+            define('ast\flags\TYPE_NEVER', \PHP_MAJOR_VERSION >= 80000 ? 17 : 22);
+        }
         if (!defined('ast\flags\CLASS_ENUM')) {
             define('ast\flags\CLASS_ENUM', 0x10000000);
         }

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -2066,7 +2066,7 @@ class TolerantASTConverter
      * @suppress UnusedSuppression, TypeMismatchProperty
      * @internal
      */
-    public static final function astStub(object $parser_node): ast\Node
+    final public static function astStub(object $parser_node): ast\Node
     {
         // Debugging code.
         if (\getenv(self::ENV_AST_THROW_INVALID)) {

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverterTrait.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverterTrait.php
@@ -6,8 +6,8 @@ namespace Phan\AST\TolerantASTConverter;
 
 use ast;
 use Closure;
-use Exception;
 use Error;
+use Exception;
 use InvalidArgumentException;
 use Microsoft\PhpParser;
 use Microsoft\PhpParser\Token;
@@ -20,7 +20,7 @@ trait TolerantASTConverterTrait
     /**
      * @return array<string,Closure(object,int):(\ast\Node|int|string|float|null)>
      */
-    protected static abstract function initHandleMap(): array;
+    abstract protected static function initHandleMap(): array;
 
     /**
      * @param PhpParser\Node|Token $n - The node from PHP-Parser
@@ -91,5 +91,4 @@ trait TolerantASTConverterTrait
         }
         return $result;
     }
-
 }

--- a/src/Phan/AST/TolerantASTConverter/ast_shim.php
+++ b/src/Phan/AST/TolerantASTConverter/ast_shim.php
@@ -177,6 +177,7 @@ const TYPE_VOID = 14;
 const TYPE_ITERABLE = 13;
 const TYPE_STATIC = 15;
 const TYPE_MIXED = 16;
+const TYPE_NEVER = 17;
 const UNARY_BOOL_NOT = 14;
 const UNARY_BITWISE_NOT = 13;
 const UNARY_SILENCE = 260;

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -56,6 +56,7 @@ use Phan\Language\Type\ListType;
 use Phan\Language\Type\LiteralIntType;
 use Phan\Language\Type\LiteralStringType;
 use Phan\Language\Type\MixedType;
+use Phan\Language\Type\NeverType;
 use Phan\Language\Type\NonEmptyMixedType;
 use Phan\Language\Type\NullType;
 use Phan\Language\Type\ObjectType;
@@ -675,6 +676,8 @@ class UnionTypeVisitor extends AnalysisVisitor
                 return StaticType::instance(false)->asRealUnionType();
             case \ast\flags\TYPE_MIXED:
                 return MixedType::instance(false)->asRealUnionType();
+            case \ast\flags\TYPE_NEVER:
+                return NeverType::instance(false)->asRealUnionType();
             default:
                 \Phan\Debug::printNode($node);
                 throw new AssertionError("All flags must match. Found ($node->flags) "
@@ -3332,7 +3335,7 @@ class UnionTypeVisitor extends AnalysisVisitor
      */
     public function visitThrow(Node $node): UnionType
     {
-        return VoidType::instance(false)->asRealUnionType();
+        return NeverType::instance(false)->asRealUnionType();
     }
 
     private function classTypesForNonName(Node $node): UnionType

--- a/src/Phan/Analysis/NegatedConditionVisitor.php
+++ b/src/Phan/Analysis/NegatedConditionVisitor.php
@@ -711,9 +711,10 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
 
             $has_other_nullable_types = $has_other_nullable_types || $type->isNullable();
 
-            if (\get_class($type) === IterableType::class) {
+            if ($type instanceof IterableType) {
                 // An iterable that is not an object must be an array
-                $new_types[] = Type::traversableInstance()->withIsNullable($type->isNullable());
+                $has_null = $has_null || $type->isNullable();
+                $new_types[] = $type->asObjectType();
                 continue;
             }
             $new_types[] = $type;

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -41,6 +41,7 @@ class Issue
     public const SyntaxMixedKeyNoKeyArrayDestructuring = 'PhanSyntaxMixedKeyNoKeyArrayDestructuring';
     public const SyntaxReturnExpectedValue      = 'PhanSyntaxReturnExpectedValue';
     public const SyntaxReturnValueInVoid        = 'PhanSyntaxReturnValueInVoid';
+    public const SyntaxReturnStatementInNever   = 'PhanSyntaxReturnStatementInNever';
     public const SyntaxInconsistentEnum         = 'PhanSyntaxInconsistentEnum';
 
     // Issue::CATEGORY_UNDEFINED
@@ -552,6 +553,7 @@ class Issue
     public const CompatibleShortArrayAssignPHP70    = 'PhanCompatibleShortArrayAssignPHP70';
     public const CompatibleKeyedArrayAssignPHP70    = 'PhanCompatibleKeyedArrayAssignPHP70';
     public const CompatibleVoidTypePHP70            = 'PhanCompatibleVoidTypePHP70';
+    public const CompatibleNeverType                 = 'PhanCompatibleNeverType';
     public const CompatibleIterableTypePHP70        = 'PhanCompatibleIterableTypePHP70';
     public const CompatibleObjectTypePHP71          = 'PhanCompatibleObjectTypePHP71';
     public const CompatibleMixedType                = 'PhanCompatibleMixedType';
@@ -959,6 +961,14 @@ class Issue
                 'Syntax error: {TYPE} function {FUNCTIONLIKE} must not return a value (did you mean "{CODE}" instead of "{CODE}"?)',
                 self::REMEDIATION_A,
                 17014
+            ),
+            new Issue(
+                self::SyntaxReturnStatementInNever,
+                self::CATEGORY_SYNTAX,
+                self::SEVERITY_CRITICAL,
+                'Syntax error: function {FUNCTIONLIKE} has return type {TYPE}, meaning it must not contain return statements (it should exit, throw, or run forever)',
+                self::REMEDIATION_A,
+                17017
             ),
             new Issue(
                 self::SyntaxReturnExpectedValue,
@@ -4427,7 +4437,7 @@ class Issue
                 self::ReusedEnumCaseValue,
                 self::CATEGORY_REDEFINE,
                 self::SEVERITY_CRITICAL,
-                'Enum case {CONST} has the same value({SCALAR}) as a previous declared enum case {CONST} defined at {FILE}:{LINE}' ,
+                'Enum case {CONST} has the same value({SCALAR}) as a previous declared enum case {CONST} defined at {FILE}:{LINE}',
                 self::REMEDIATION_B,
                 8013
             ),
@@ -4762,6 +4772,14 @@ class Issue
                 "Return type '{TYPE}' means the absence of a return value starting in PHP 7.1. In PHP 7.0, void refers to a class/interface with the name 'void'",
                 self::REMEDIATION_B,
                 3005
+            ),
+            new Issue(
+                self::CompatibleNeverType,
+                self::CATEGORY_COMPATIBLE,
+                self::SEVERITY_CRITICAL,
+                "Return type '{TYPE}' means that a function will not return normally starting in PHP 8.1. In PHP 8.0, 'never' refers to a class/interface with the name 'never'",
+                self::REMEDIATION_B,
+                3043
             ),
             new Issue(
                 self::CompatibleIterableTypePHP70,

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -1531,7 +1531,8 @@ class Clazz extends AddressableElement
     /**
      * Add an enum case (this is a specialization of a class constant)
      */
-    public function addEnumCase(CodeBase $code_base, ClassConstant $constant): void {
+    public function addEnumCase(CodeBase $code_base, ClassConstant $constant): void
+    {
         $this->addConstant($code_base, $constant);
 
         // TODO need to update minimum enum version to get enum's declared type

--- a/src/Phan/Language/Element/FunctionInterface.php
+++ b/src/Phan/Language/Element/FunctionInterface.php
@@ -353,7 +353,7 @@ interface FunctionInterface extends AddressableElementInterface
      *
      * @param CodeBase $code_base
      * @param Context $context
-     * @param list<Node|int|string> $args
+     * @param list<Node|int|string|float> $args
      * @param ?Node $node - the node causing the call. This may be dynamic, e.g. call_user_func_array. This will be required in Phan 3.
      */
     public function analyzeFunctionCall(CodeBase $code_base, Context $context, array $args, Node $node = null): void;

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -1533,6 +1533,11 @@ final class EmptyUnionType extends UnionType
         return false;
     }
 
+    public function isNeverType(): bool
+    {
+        return false;
+    }
+
     public function withRealType(Type $type): UnionType
     {
         return $type->asRealUnionType();

--- a/src/Phan/Language/NamespaceMapEntry.php
+++ b/src/Phan/Language/NamespaceMapEntry.php
@@ -78,7 +78,8 @@ class NamespaceMapEntry implements \Serializable
      * @param array{0:string, 1:string, 2:string, 3:int, 4:bool} $representation
      * @suppress PhanAccessReadOnlyProperty TODO fix #3179
      */
-    public function __unserialize(array $representation): void {
+    public function __unserialize(array $representation): void
+    {
         [$fqsen_class, $fqsen, $this->original_name, $this->lineno, $this->is_used] = $representation;
         if (!\is_string($fqsen_class)) {
             throw new RuntimeException("Failed to unserialize a string from the representation");

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -51,6 +51,7 @@ use Phan\Language\Type\LiteralIntType;
 use Phan\Language\Type\LiteralStringType;
 use Phan\Language\Type\MixedType;
 use Phan\Language\Type\NativeType;
+use Phan\Language\Type\NeverType;
 use Phan\Language\Type\NonEmptyAssociativeArrayType;
 use Phan\Language\Type\NonEmptyGenericArrayType;
 use Phan\Language\Type\NonEmptyListType;
@@ -257,6 +258,10 @@ class Type implements Stringable
         'string'          => true,
         'true'            => true,
         'void'            => true,
+        'never'           => true,
+        'no-return'       => true,
+        'never-return'    => true,
+        'never-returns'   => true,
     ];
 
     /**
@@ -784,10 +789,8 @@ class Type implements Stringable
             );
         }
 
-        $type_name =
-            self::canonicalNameFromName($type_name);
+        $type_name = self::canonicalNameFromName($type_name);
 
-        // TODO: Is this worth optimizing into a lookup table?
         switch (strtolower($type_name)) {
             case 'array':
                 return ArrayType::instance($is_nullable);
@@ -847,6 +850,11 @@ class Type implements Stringable
                 return TrueType::instance($is_nullable);
             case 'void':
                 return VoidType::instance(false);
+            case 'never':
+            case 'no-return':
+            case 'never-return':
+            case 'never-returns':
+                return NeverType::instance(false);
             case 'iterable':
                 return IterableType::instance($is_nullable);
             case 'static':
@@ -2131,7 +2139,6 @@ class Type implements Stringable
     {
         return $this->withIsNullable(false);
     }
-
 
     /**
      * @return bool

--- a/src/Phan/Language/Type/FunctionLikeDeclarationType.php
+++ b/src/Phan/Language/Type/FunctionLikeDeclarationType.php
@@ -420,6 +420,7 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
 
     /**
      * @override
+     * @param list<Node|int|string|float> $args
      */
     public function analyzeFunctionCall(CodeBase $code_base, Context $context, array $args, Node $node = null): void
     {
@@ -484,7 +485,10 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
         return '';
     }
 
-    /** @override */
+    /**
+     * @override
+     * @param list<Node|int|string|float> $args
+     */
     public function getDependentReturnType(CodeBase $code_base, Context $context, array $args): UnionType
     {
         throw new \AssertionError('unexpected call to ' . __METHOD__);

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -935,5 +935,4 @@ class GenericArrayType extends ArrayType implements GenericArrayInterface
     {
         return ListType::fromElementType($this->element_type, $this->is_nullable)->asPHPDocUnionType();
     }
-
 }

--- a/src/Phan/Language/Type/GenericIterableType.php
+++ b/src/Phan/Language/Type/GenericIterableType.php
@@ -486,4 +486,15 @@ final class GenericIterableType extends IterableType
         yield from $this->key_union_type->getReferencedClasses();
         yield from $this->element_union_type->getReferencedClasses();
     }
+
+    public function asObjectType(): ?Type
+    {
+        return Type::make(
+            '\\',
+            'Traversable',
+            $this->key_union_type->isEmpty() ? [$this->element_union_type] : [$this->key_union_type, $this->element_union_type],
+            false,
+            Type::FROM_TYPE
+        );
+    }
 }

--- a/src/Phan/Language/Type/NativeType.php
+++ b/src/Phan/Language/Type/NativeType.php
@@ -190,6 +190,7 @@ abstract class NativeType extends Type
                 IntType::NAME      => in_array(IntType::NAME, $permitted_cast_type_names, true),
                 // TODO: Handle other subtypes of mixed?
                 MixedType::NAME    => true,
+                NeverType::NAME => in_array(NeverType::NAME, $permitted_cast_type_names, true),
                 NullType::NAME     => in_array(NullType::NAME, $permitted_cast_type_names, true),
                 ObjectType::NAME   => in_array(ObjectType::NAME, $permitted_cast_type_names, true),
                 ResourceType::NAME => in_array(ResourceType::NAME, $permitted_cast_type_names, true),
@@ -217,6 +218,7 @@ abstract class NativeType extends Type
             IntType::NAME      => $generate_row(IntType::NAME, FloatType::NAME, ScalarRawType::NAME),
             IterableType::NAME => $generate_row(IterableType::NAME),
             MixedType::NAME    => $generate_row(MixedType::NAME),  // MixedType overrides the methods which would use this
+            NeverType::NAME => $generate_row(NeverType::NAME),  // NeverType also overrides methods which would use this
             NullType::NAME     => $generate_row(NullType::NAME),
             ObjectType::NAME   => $generate_row(ObjectType::NAME),
             ResourceType::NAME => $generate_row(ResourceType::NAME),

--- a/src/Phan/Language/Type/NativeTypeTrait.php
+++ b/src/Phan/Language/Type/NativeTypeTrait.php
@@ -70,7 +70,7 @@ trait NativeTypeTrait
      *
      * Overridden in some subclasses but not others.
      */
-    protected abstract static function make(
+    abstract protected static function make(
         string $namespace,
         string $type_name,
         array $template_parameter_type_list,

--- a/src/Phan/Language/Type/NeverType.php
+++ b/src/Phan/Language/Type/NeverType.php
@@ -1,0 +1,245 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phan\Language\Type;
+
+use Phan\CodeBase;
+use Phan\Language\Context;
+use Phan\Language\Type;
+use Phan\Language\UnionType;
+
+/**
+ * Represents the return type `never` in phpdoc signatures (and in php 8.1 in https://wiki.php.net/rfc/never_type)
+ *
+ * > In type theory never would be called a "bottom" type.
+ * > That means it's effectively a subtype of every other type in PHP’s type system, including void.
+ *
+ * @phan-pure
+ *
+ * @phan-file-suppress PhanUnusedPublicFinalMethodParameter
+ */
+final class NeverType extends NativeType
+{
+    use NativeTypeTrait;
+
+    /** @phan-override */
+    public const NAME = 'never';
+
+    /**
+     * @param string $namespace
+     * The (optional) namespace of the type such as '\'
+     * or '\Phan\Language'.
+     *
+     * @param string $name
+     * The name of the type such as 'int' or 'MyClass'
+     *
+     * @param list<UnionType> $template_parameter_type_list @phan-unused-param
+     * A (possibly empty) list of template parameter types
+     *
+     * @param bool $is_nullable (@phan-unused-param)
+     */
+    protected function __construct(
+        string $namespace,
+        string $name,
+        $template_parameter_type_list,
+        bool $is_nullable
+    ) {
+        parent::__construct(
+            $namespace,
+            $name,
+            [],
+            false
+        );
+    }
+
+    /**
+     * @unused-param $code_base
+     * @unused-param $context
+     * @unused-param $other
+     * @override
+     */
+    public function canCastToDeclaredType(CodeBase $code_base, Context $context, Type $other): bool
+    {
+        return true;
+    }
+
+    /**
+     * `never` is a subtype of every type
+     * @unused-param $type
+     */
+    public function isSubtypeOf(Type $type): bool
+    {
+        return true;
+    }
+
+    /**
+     * `never` is a subtype of every type
+     *
+     * @unused-param $type
+     */
+    public function isSubtypeOfNonNullableType(Type $type): bool
+    {
+        return true;
+    }
+
+    /**
+     * Returns true if this contains a type that is definitely nullable or a non-object.
+     * e.g. returns true false, array, int
+     *      returns false for callable, object, iterable, T, etc.
+     */
+    public function isDefiniteNonObjectType(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return bool
+     * True if this Type can be cast to the given Type
+     * cleanly
+     *
+     * never can cast to any type, but other types cannot cast to never
+     */
+    public function canCastToType(Type $type): bool
+    {
+        return true;
+    }
+
+    public function canCastToTypeWithoutConfig(Type $type): bool
+    {
+        return true;
+    }
+
+    /**
+     * Returns true if this contains a type that is definitely nullable or a non-object.
+     * e.g. returns true false, array, int
+     *      returns false for callable, object, iterable, T, etc.
+     */
+    public function isDefiniteNonCallableType(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return bool
+     * True if this Type can be cast to the given Type
+     * cleanly (accounting for templates)
+     */
+    public function canCastToTypeHandlingTemplates(Type $type, CodeBase $code_base): bool
+    {
+        // Check to see if we have an exact object match
+        return $this === $type;
+    }
+
+    /**
+     * @unused-param $type
+     * @override
+     */
+    public function canCastToNonNullableType(Type $type): bool
+    {
+        return true;
+    }
+
+    /**
+     * @unused-param $type
+     * @override
+     */
+    public function canCastToNonNullableTypeWithoutConfig(Type $type): bool
+    {
+        return true;
+    }
+
+    /**
+     * @unused-param $is_nullable
+     * @override
+     */
+    public function withIsNullable(bool $is_nullable): Type
+    {
+        return $is_nullable ? NullType::instance(false) : $this;
+    }
+
+    public function __toString(): string
+    {
+        return self::NAME;
+    }
+
+    public function isNullable(): bool
+    {
+        return false;
+    }
+
+    public function isNullableLabeled(): bool
+    {
+        return false;
+    }
+
+    public function isPossiblyFalsey(): bool
+    {
+        return false;
+    }
+
+    public function isPossiblyTruthy(): bool
+    {
+        return false;
+    }
+
+    public function isAlwaysFalsey(): bool
+    {
+        return false;
+    }
+
+    public function isAlwaysTruthy(): bool
+    {
+        return false;
+    }
+
+    public function isPrintableScalar(): bool
+    {
+        return false;
+    }
+
+    public function isValidBitwiseOperand(): bool
+    {
+        return false;
+    }
+
+    public function isValidNumericOperand(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Check if this type can satisfy a comparison (<, <=, >, >=)
+     * @param int|string|float|bool|null $scalar @unused-param
+     * @param int $flags (e.g. \ast\flags\BINARY_IS_SMALLER) @unused-param
+     * @internal
+     */
+    public function canSatisfyComparison($scalar, int $flags): bool
+    {
+        return false;
+    }
+
+    /**
+     * Returns the type after an expression such as `++$x`
+     */
+    public function getTypeAfterIncOrDec(): UnionType
+    {
+        return UnionType::empty();
+    }
+
+    // TODO: Emit an issue if used for a parameter/property type.
+    public function canUseInRealSignature(): bool
+    {
+        return true;
+    }
+
+    public function asScalarType(): ?Type
+    {
+        return null;
+    }
+
+    public function isScalar(): bool
+    {
+        return false;
+    }
+}

--- a/src/Phan/Language/Type/NonNullMixedType.php
+++ b/src/Phan/Language/Type/NonNullMixedType.php
@@ -114,7 +114,8 @@ final class NonNullMixedType extends MixedType
     /**
      * @override
      */
-    public function withIsNullable(bool $is_nullable): Type {
+    public function withIsNullable(bool $is_nullable): Type
+    {
         return $is_nullable ? MixedType::instance(true) : $this;
     }
 }

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -41,6 +41,7 @@ use Phan\Language\Type\LiteralStringType;
 use Phan\Language\Type\LiteralTypeInterface;
 use Phan\Language\Type\MixedType;
 use Phan\Language\Type\MultiType;
+use Phan\Language\Type\NeverType;
 use Phan\Language\Type\NonEmptyArrayInterface;
 use Phan\Language\Type\NonEmptyAssociativeArrayType;
 use Phan\Language\Type\NonEmptyListType;
@@ -6223,6 +6224,19 @@ class UnionType implements Serializable, Stringable
             return false;
         }
         return \reset($type_set) instanceof VoidType;
+    }
+
+    /**
+     * @return bool
+     * True if this is the never type
+     */
+    public function isNeverType(): bool
+    {
+        $type_set = $this->type_set;
+        if (\count($type_set) !== 1) {
+            return false;
+        }
+        return \reset($type_set) instanceof NeverType;
     }
 
     /**

--- a/src/Phan/Plugin/Internal/UseReturnValuePlugin.php
+++ b/src/Phan/Plugin/Internal/UseReturnValuePlugin.php
@@ -55,6 +55,7 @@ class UseReturnValuePlugin extends PluginV3 implements PostAnalyzeNodeCapability
     public const UseReturnValueInternalKnown = 'PhanPluginUseReturnValueInternalKnown';
     public const UseReturnValueNoopVoid = 'PhanPluginUseReturnValueNoopVoid';
     public const UseReturnValueGenerator = 'PhanPluginUseReturnValueGenerator';
+    public const UseReturnValueOfNever = 'PhanUseReturnValueOfNever';
     // phpcs:enable Generic.NamingConventions.UpperCaseConstantName.ClassConstantNotUpperCase
 
     public const DEFAULT_THRESHOLD_PERCENTAGE = 98;

--- a/tests/Phan/AbstractPhanFileTest.php
+++ b/tests/Phan/AbstractPhanFileTest.php
@@ -115,7 +115,7 @@ abstract class AbstractPhanFileTest extends CodeBaseAwareTest
         );
     }
 
-    protected static function getFileForPHPVersion(string $path, string... $suffixes): string
+    protected static function getFileForPHPVersion(string $path, string...$suffixes): string
     {
         foreach ($suffixes as $suffix) {
             $suffix_path = $path . $suffix;

--- a/tests/files/expected/0302_trait_abstract_signature.php.expected
+++ b/tests/files/expected/0302_trait_abstract_signature.php.expected
@@ -1,3 +1,3 @@
 %s:13 PhanUnusedVariable Unused definition of variable $args
 %s:18 PhanUnusedVariable Unused definition of variable $args
-%s:28 PhanTypeMismatchArgumentProbablyReal Argument 1 ($x) is 'incompatible' of type 'incompatible' but \C::fn2() takes int (no real type) defined at %s:17 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
+%s:28 PhanTypeMismatchArgumentReal Argument 1 ($x) is 'incompatible' of type 'incompatible' but \C::fn2() takes int defined at %s:17

--- a/tests/files/expected/0370_callable_edge_cases.php.expected
+++ b/tests/files/expected/0370_callable_edge_cases.php.expected
@@ -2,11 +2,11 @@
 %s:33 PhanUndeclaredClassInCallable Reference to undeclared class \parent in callable \parent::foo
 %s:34 PhanUndeclaredClassInCallable Reference to undeclared class \static in callable \static::foo
 %s:35 PhanUndeclaredClassInCallable Reference to undeclared class \self in callable \self::foo
-%s:37 PhanTypeMismatchArgumentProbablyReal Argument 1 ($x) is [] of type array{} but \C370::foo() takes int (no real type) defined at %s:41 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
-%s:38 PhanTypeMismatchArgumentProbablyReal Argument 1 ($x) is [] of type array{} but \C370::foo() takes int (no real type) defined at %s:41 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
-%s:39 PhanTypeMismatchArgumentProbablyReal Argument 1 ($x) is [] of type array{} but \C370::foo() takes int (no real type) defined at %s:41 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
+%s:37 PhanTypeMismatchArgumentReal Argument 1 ($x) is [] of type array{} but \C370::foo() takes int defined at %s:41
+%s:38 PhanTypeMismatchArgumentReal Argument 1 ($x) is [] of type array{} but \C370::foo() takes int defined at %s:41
+%s:39 PhanTypeMismatchArgumentReal Argument 1 ($x) is [] of type array{} but \C370::foo() takes int defined at %s:41
 %s:47 PhanContextNotObjectInCallable Cannot access self when not in object context, but code is using callable self::foo
 %s:48 PhanContextNotObjectInCallable Cannot access static when not in object context, but code is using callable static::foo
 %s:49 PhanContextNotObjectInCallable Cannot access parent when not in object context, but code is using callable parent::foo
-%s:50 PhanTypeMismatchArgumentProbablyReal Argument 1 ($x) is new stdClass() of type \stdClass but \C370::foo() takes int (no real type) defined at %s:41 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
-%s:51 PhanTypeMismatchArgumentProbablyReal Argument 1 ($x) is new stdClass() of type \stdClass but \C370::foo() takes int (no real type) defined at %s:41 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
+%s:50 PhanTypeMismatchArgumentReal Argument 1 ($x) is new stdClass() of type \stdClass but \C370::foo() takes int defined at %s:41
+%s:51 PhanTypeMismatchArgumentReal Argument 1 ($x) is new stdClass() of type \stdClass but \C370::foo() takes int defined at %s:41

--- a/tests/files/expected/0629_comment.php.expected
+++ b/tests/files/expected/0629_comment.php.expected
@@ -1,4 +1,4 @@
-%s:21 PhanTypeMismatchArgumentInternal Argument 1 ($string) is $orderBy of type array<string,string>|null but \strlen() takes string
+%s:21 PhanTypeMismatchArgumentInternal%SReal Argument 1 ($string) is $orderBy of type array<string,string>|null (real type ?array) but \strlen() takes string
 %s:45 PhanTypeMismatchArgumentInternal%SReal Argument 1 ($string) is $x of type \stdClass[] (real type array) but \strlen() takes string
 %s:46 PhanTypeMismatchReturn Returning ['key'=>2] of type array{key:2} but acceptList() is declared to return array<int,\stdClass>
 %s:53 PhanTypeMismatchReturn Returning [count($x)] of type array{0:int} but acceptList() is declared to return array<int,\stdClass>

--- a/tests/files/expected/0934_never_phpdoc.php.expected
+++ b/tests/files/expected/0934_never_phpdoc.php.expected
@@ -1,0 +1,4 @@
+%s:11 PhanTypeMismatchReturn Returning $value of type mixed but shouldReturnNever() is declared to return never
+%s:13 PhanTypeMismatchReturnProbablyReal Returning void of type void but shouldReturnNever() is declared to return never (no real type) (the inferred real return type has nothing in common with the declared phpdoc return type)
+%s:15 PhanTypeMismatchReturnProbablyReal Returning null of type null but shouldReturnNever() is declared to return never (no real type) (the inferred real return type has nothing in common with the declared phpdoc return type)
+%s:30 PhanTypeMismatchReturn Returning $value of type mixed but shouldReturnVoid() is declared to return void

--- a/tests/files/src/0934_never_phpdoc.php
+++ b/tests/files/src/0934_never_phpdoc.php
@@ -1,0 +1,31 @@
+<?php
+namespace NS934;
+
+/**
+ * @param mixed $value
+ * @return never
+ */
+function shouldReturnNever($value) {
+    // these are all invalid
+    if (rand(0, 1)) {
+        return $value;
+    } elseif ($value) {
+        return;
+    }
+    return null;
+}
+
+/**
+ * @return never this is valid
+ */
+function neverExceptional() {
+    throw new \RuntimeException();
+}
+
+/**
+ * @param mixed $value
+ * @return void
+ */
+function shouldReturnVoid($value) {
+    return $value;  // should warn
+}

--- a/tests/php74_files/expected/0031_covariant_return_type.php.expected
+++ b/tests/php74_files/expected/0031_covariant_return_type.php.expected
@@ -1,0 +1,1 @@
+%s:28 PhanUnusedPublicMethodParameter Parameter $o is never used

--- a/tests/php74_files/src/0031_covariant_return_type.php
+++ b/tests/php74_files/src/0031_covariant_return_type.php
@@ -1,0 +1,37 @@
+<?php
+
+// Phan supports php 7.4's covariant return types
+// when the configured 'closest_minimum_target_php_version' is '7.4' or newer.
+// (it looks for the version range in composer.json as a fallback)
+namespace NS31;
+
+declare(strict_types=1);
+
+
+class SubClass {
+
+}
+
+class BaseClass extends SubClass {
+
+}
+
+interface FooFactoryInterface {
+    public function build(BaseClass $o): SubClass;
+}
+
+interface BarFactorInterface extends FooFactoryInterface {
+    public function build(SubClass $o): BaseClass;
+}
+
+class BarFactory implements FooFactoryInterface {
+    public function build(SubClass $o): BaseClass {
+        return new BaseClass();
+    }
+}
+
+if (is_a((new BarFactory)->build(new SubClass()), BaseClass::class)) {
+    echo "\nSUCCESS\n";
+} else {
+    echo "\nFAIL\n";
+}

--- a/tests/php80_files/expected/007_throw_expression.php.expected
+++ b/tests/php80_files/expected/007_throw_expression.php.expected
@@ -3,7 +3,6 @@
 %s:8 PhanCompatibleThrowExpression Cannot use throw as an expression before php 8.0 in ($nullableValue ?? (throw new InvalidArgumentException()))
 %s:8 PhanUnusedVariable Unused definition of variable $value
 %s:9 PhanCompatibleThrowExpression Cannot use throw as an expression before php 8.0 in ($x = (throw new Exception()))
-%s:9 PhanTypeVoidAssignment Cannot assign void return value
 %s:9 PhanUnusedVariable Unused definition of variable $x
 %s:12 PhanCompatibleThrowExpression Cannot use throw as an expression before php 8.0 in ($falsableValue ?: (throw new InvalidArgumentException()))
 %s:12 PhanUnusedVariable Unused definition of variable $value
@@ -21,10 +20,9 @@
 %s:27 PhanCompatibleThrowExpression Cannot use throw as an expression before php 8.0 in ($condition || (throw new Exception()))
 %s:27 PhanImpossibleCondition Impossible attempt to cast $condition of type ?''|?'0'|?0|?0.0|?array{}|?false to truthy
 %s:29 PhanCompatibleThrowExpression Cannot use throw as an expression before php 8.0 in (throw (throw new Exception()))
-%s:29 PhanTypeInvalidThrowStatementNonThrowable \test_throw_expression() can throw (throw new Exception()) of type void here which can't cast to \Throwable
 %s:31 PhanCompatibleThrowExpression Cannot use throw as an expression before php 8.0 in (throw new Exception('loop'))
 %s:31 PhanSuspiciousValueComparisonInLoop Suspicious attempt to compare $i of type 0 to 10 of type 10 with operator '<' in a loop (likely a false positive)
 %s:34 PhanCompatibleArrowFunction Cannot use arrow functions before php 7.4 in (fn)
 %s:34 PhanCompatibleThrowExpression Cannot use throw as an expression before php 8.0 in return (throw new RuntimeException('unimplemented'));
-%s:34 PhanPluginUnknownClosureReturnType Closure Closure() has no declared or inferred return type (Types inferred after analysis: void)
+%s:34 PhanPluginUnknownClosureReturnType Closure Closure() has no declared or inferred return type (Types inferred after analysis: never)
 %s:34 PhanUnreferencedClosure Possibly zero references to Closure()

--- a/tests/php81_files/expected/006_noreturn.php.expected
+++ b/tests/php81_files/expected/006_noreturn.php.expected
@@ -1,0 +1,7 @@
+%s:17 PhanUnreferencedClass Possibly zero references to class \Point\Of\Up
+%s:23 PhanUnreferencedClass Possibly zero references to class \Point\Of\BadJoke
+%s:24 PhanParamSignatureMismatch Declaration of function joke() : string should be compatible with function joke() : never defined in %s:12
+%s:24 PhanParamSignatureRealMismatchReturnType Declaration of function joke() : string should be compatible with function joke() : never (method where the return type in the real signature is 'string' cannot override method where the return type in the real signature is 'never') defined in %s:12
+%s:29 PhanUnreferencedFunction Possibly zero references to function \Point\Of\up()
+%s:31 PhanSyntaxReturnStatementInNever Syntax error: function up() has return type never, meaning it must not contain return statements (it should exit, throw, or run forever)
+%s:33 PhanSyntaxReturnStatementInNever Syntax error: function up() has return type never, meaning it must not contain return statements (it should exit, throw, or run forever)

--- a/tests/php81_files/src/006_noreturn.php
+++ b/tests/php81_files/src/006_noreturn.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Point\Of;
+
+abstract class Joke {
+    abstract public function joke(): string;
+}
+
+// Note that minimum_target_php_version must be '7.4' or newer
+// in order for a method to be overridden with a subtype
+class AntiJoke extends Joke {
+    public function joke(): never {  // this is valid in php 8.1
+        exit(1);
+    }
+}
+
+class Up extends AntiJoke {
+    public function joke(): never {
+        throw new \Exception('Up: going to give you "never"');
+    }
+}
+
+class BadJoke extends AntiJoke {
+    public function joke(): string {  // it is an error to replace a return type of never in an override
+        return 'run around';
+    }
+}
+
+function up(): never {
+    if (rand(0, 1)) {
+        return 'dog';
+    }
+    return;
+}

--- a/tests/plugin_test/expected/199_never_type_and_plugins.php.expected
+++ b/tests/plugin_test/expected/199_never_type_and_plugins.php.expected
@@ -1,0 +1,2 @@
+src/199_never_type_and_plugins.php:3 PhanCompatibleNeverType Return type 'never' means that a function will not return normally starting in PHP 8.1. In PHP 8.0, 'never' refers to a class/interface with the name 'never'
+src/199_never_type_and_plugins.php:6 PhanUseReturnValueOfNever Saw use of value of expression up('goodbye') which likely uses the function \up(string $message) with a return type of 'never' - this will not return normally

--- a/tests/plugin_test/src/199_never_type_and_plugins.php
+++ b/tests/plugin_test/src/199_never_type_and_plugins.php
@@ -1,0 +1,6 @@
+<?php
+
+function up(string $message): never {
+    exit($message);
+}
+throw up('goodbye');


### PR DESCRIPTION
And the aliases `@return no-return`, `never-return`, `never-returns`

Fixes #4380 - subsequent issues should be filed for improvements

Fixes #3795

Support php 7.4 contravariant parameters and covariant return types
when `minimum_target_php_version` is 7.4 or newer

https://wiki.php.net/rfc/covariant-returns-and-contravariant-parameters