### PR TITLE
Make phan aware of `never` return type's impact on control flow

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,10 @@ New Features (Analysis):
 + Support casting `iterable<K, V>` to `Traversable<K, V>` with `is_object` or `!is_array` checks
 + Detect more types of expressions that never return when inferring types (e.g. when analyzing `?:`, `??` opertors)
 
+Dead code detection:
++ Infer that functions with a return type of `never` (or phpdoc aliases such as `no-return`) are unreachable when performing control flow analysis.
+  This can be disabled by setting `dead_code_detection_treat_never_type_as_unreachable` to false
+
 Plugins:
 + In `UseReturnValuePlugin`, also start warning about when using the result of an expression that evaluates to `never`
   New issue types: `PhanUseReturnValueOfNever`

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,8 @@ Dead code detection:
 + Infer that functions with a return type of `never` (or phpdoc aliases such as `no-return`) are unreachable when performing control flow analysis.
   This can be disabled by setting `dead_code_detection_treat_never_type_as_unreachable` to false
 
+  Note that control flow is only affected when `UseReturnValuePlugin` is enabled.
+
 Plugins:
 + In `UseReturnValuePlugin`, also start warning about when using the result of an expression that evaluates to `never`
   New issue types: `PhanUseReturnValueOfNever`

--- a/internal/Phan-Config-Settings.md
+++ b/internal/Phan-Config-Settings.md
@@ -902,6 +902,15 @@ have to be made about what references what.
 
 (Default: `true`)
 
+## dead_code_detection_treat_never_type_as_unreachable
+
+When this is true, treat a phpdoc or real type
+of 'never' as unreachable.
+
+Disabling this may avoid some false positives.
+
+(Default: `true`)
+
 ## force_tracking_references
 
 Set to true in order to force tracking references to elements

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -1343,7 +1343,7 @@ class ContextNode
                 $property_name = (string)$property_name;
             }
             if (!\is_string($property_name)) {
-                throw $this->createExceptionForInvalidPropertyName($node, $is_static);
+                $this->throwExceptionForInvalidPropertyName($node, $is_static);
             }
         }
 
@@ -1592,19 +1592,20 @@ class ContextNode
     }
 
     /**
-     * @return NodeException|IssueException
+     * @throws NodeException|IssueException
+     * @return no-return
      */
-    private function createExceptionForInvalidPropertyName(Node $node, bool $is_static): Exception
+    private function throwExceptionForInvalidPropertyName(Node $node, bool $is_static): void
     {
         $property_type = UnionTypeVisitor::unionTypeFromNode($this->code_base, $this->context, $node->children['prop']);
         if ($property_type->canCastToUnionType(StringType::instance(false)->asPHPDocUnionType())) {
             // If we know it can be a string, throw a NodeException instead of a specific issue
-            return new NodeException(
+            throw new NodeException(
                 $node,
                 "Cannot figure out property name"
             );
         }
-        return new IssueException(
+        throw new IssueException(
             Issue::fromType($is_static ? Issue::TypeInvalidStaticPropertyName : Issue::TypeInvalidPropertyName)(
                 $this->context->getFile(),
                 $node->lineno,
@@ -1845,6 +1846,7 @@ class ContextNode
 
     /**
      * @throws IssueException
+     * @return no-return
      */
     private function throwUndeclaredGlobalConstantIssueException(CodeBase $code_base, Context $context, FullyQualifiedGlobalConstantName $fqsen): void
     {

--- a/src/Phan/Analysis/BlockExitStatusChecker.php
+++ b/src/Phan/Analysis/BlockExitStatusChecker.php
@@ -537,6 +537,42 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
         return $status;
     }
 
+    /**
+     * Determines the exit status of a static method call.
+     *
+     * @return int the corresponding status code
+     */
+    public function visitStaticCall(Node $node): int
+    {
+        // TODO: The expression or arguments might unconditionally throw, though that is rare in practice.
+        return ($node->flags & self::STATUS_BITMASK) ?: self::STATUS_PROCEED;
+    }
+
+    /**
+     * Determines the exit status of an instance method call.
+     *
+     * @return int the corresponding status code
+     * @override
+     * @see UseReturnValueVisitor::checkIfUsingFunctionThatNeverReturns()
+     */
+    public function visitMethodCall(Node $node): int
+    {
+        // TODO: The expression or arguments might unconditionally throw, though that is rare in practice.
+        return ($node->flags & self::STATUS_BITMASK) ?: self::STATUS_PROCEED;
+    }
+
+    /**
+     * Determines the exit status of an instance method call.
+     *
+     * @return int the corresponding status code
+     * @override
+     */
+    public function visitNullsafeMethodCall(Node $node): int
+    {
+        // TODO: The expression or arguments might unconditionally throw, though that is rare in practice.
+        return ($node->flags & self::STATUS_BITMASK) ?: self::STATUS_PROCEED;
+    }
+
     private static function computeStatusOfCall(Node $node): int
     {
         $expression = $node->children['expr'];
@@ -738,7 +774,7 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
             }
             $status = $this->check($child);
             if (($status & self::STATUS_PROCEED) === 0) {
-                // If it's guaranteed we won't stop after this statement,
+                // If it's guaranteed we won't proceed after this statement,
                 // then skip the subsequent statements.
                 return $status | ($maybe_status & ~self::STATUS_PROCEED);
             }

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -1324,6 +1324,10 @@ class ParameterTypesAnalyzer
      */
     public static function normalizeNarrowedParamType(UnionType $phpdoc_param_union_type, UnionType $real_param_type): ?UnionType
     {
+        if ($phpdoc_param_union_type->isNeverType()) {
+            // Return the phpdoc 'never' type so that it can override the nullable type.
+            return $phpdoc_param_union_type;
+        }
         // "@param null $x" is almost always a mistake. Forbid it for now.
         // But allow "@param T|null $x"
         $has_null = $phpdoc_param_union_type->hasType(NullType::instance(false));

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -2650,7 +2650,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
 
         if ($right_node instanceof Node) {
             $right_context = $this->analyzeAndGetUpdatedContext($context_with_left_condition, $node, $right_node);
-            if ($right_node->kind === ast\AST_THROW) {
+            if (BlockExitStatusChecker::willUnconditionallySkipRemainingStatements($right_node)) {
                 return $this->postOrderAnalyze($context_with_false_left_condition, $node);
             }
             if (ScopeImpactCheckingVisitor::hasPossibleImpact($this->code_base, $context, $right_node)) {
@@ -2719,7 +2719,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
 
         if ($right_node instanceof Node) {
             $right_context = $this->analyzeAndGetUpdatedContext($context_with_false_left_condition, $node, $right_node);
-            if ($right_node->kind === ast\AST_THROW) {
+            if (BlockExitStatusChecker::willUnconditionallySkipRemainingStatements($right_node)) {
                 return $this->postOrderAnalyze($context_with_true_left_condition, $node);
             }
             if (ScopeImpactCheckingVisitor::hasPossibleImpact($this->code_base, $context, $right_node)) {

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -545,6 +545,12 @@ class Config
         // have to be made about what references what.
         'dead_code_detection_prefer_false_negative' => true,
 
+        // When this is true, treat a phpdoc or real type
+        // of 'never' as unreachable.
+        //
+        // Disabling this may avoid some false positives.
+        'dead_code_detection_treat_never_type_as_unreachable' => true,
+
         // If true, then before analysis, try to simplify AST into a form
         // which improves Phan's type inference in edge cases.
         //
@@ -1562,6 +1568,7 @@ class Config
             'daemonize_tcp_port' => $is_int_strict,
             'dead_code_detection' => $is_bool,
             'dead_code_detection_prefer_false_negative' => $is_bool,
+            'dead_code_detection_treat_never_type_as_unreachable' => $is_bool,
             'directory_list' => $is_string_list,
             'disable_line_based_suppression' => $is_bool,
             'disable_suggestions' => $is_bool,

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -1470,7 +1470,7 @@ trait FunctionTrait
                         $real_return_type->__toString()
                     );
                 }
-                if ($is_exclusively_narrowed && Config::getValue('prefer_narrowed_phpdoc_return_type')) {
+                if ($is_exclusively_narrowed && Config::getValue('prefer_narrowed_phpdoc_return_type') && !$phpdoc_return_type->isNeverType()) {
                     $normalized_phpdoc_return_type = ParameterTypesAnalyzer::normalizeNarrowedParamType($phpdoc_return_type, $real_return_type);
                     if ($normalized_phpdoc_return_type) {
                         // TODO: How does this currently work when there are multiple types in the union type that are compatible?

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -107,17 +107,17 @@ class Type implements Stringable
      * A legal type identifier (e.g. 'int' or 'DateTime')
      */
     public const simple_type_regex =
-        '(\??)(?:callable-(?:string|object|array)|associative-array|class-string|lowercase-string|non-(?:zero-int|null-mixed|empty-(?:associative-array|array|list|string|lowercase-string|mixed))|\\\\?[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*(?:\\\\[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)*)';
+        '(\??)(?:callable-(?:string|object|array)|associative-array|class-string|lowercase-string|no-return|never-returns?|non-(?:zero-int|null-mixed|empty-(?:associative-array|array|list|string|lowercase-string|mixed))|\\\\?[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*(?:\\\\[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)*)';
 
     public const simple_noncapturing_type_regex =
-        '\\\\?(?:callable-(?:string|object|array)|associative-array|class-string|lowercase-string|non-(?:zero-int|null-mixed|empty-(?:associative-array|array|list|string|lowercase-string|mixed))|[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*(?:\\\\[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)*)';
+        '\\\\?(?:callable-(?:string|object|array)|associative-array|class-string|lowercase-string|no-return|never-returns?|non-(?:zero-int|null-mixed|empty-(?:associative-array|array|list|string|lowercase-string|mixed))|[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*(?:\\\\[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)*)';
 
     /**
      * @var string
      * A legal type identifier (e.g. 'int' or 'DateTime')
      */
     public const simple_type_regex_or_this =
-        '(\??)(callable-(?:string|object|array)|associative-array|class-string|lowercase-string|non-(?:zero-int|null-mixed|empty-(?:associative-array|array|list|string|lowercase-string|mixed))|\\\\?[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*(?:\\\\[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)*|\$this)';
+        '(\??)(callable-(?:string|object|array)|associative-array|class-string|lowercase-string|no-return|never-returns?|non-(?:zero-int|null-mixed|empty-(?:associative-array|array|list|string|lowercase-string|mixed))|\\\\?[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*(?:\\\\[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)*|\$this)';
 
     public const shape_key_regex =
         '(?:[-.\/^;$%*+_a-zA-Z0-9\x7f-\xff]|\\\\(?:[nrt\\\\]|x[0-9a-fA-F]{2}))+\??';
@@ -915,7 +915,7 @@ class Type implements Stringable
             }
             return $reflection_type_string;
         }
-        // Unreachable in php 7.1-7.4, but reachable and revertsed deprecation in php 8.0+?
+        // Unreachable in php 7.1-7.4, but reachable and reverted deprecation in php 8.0+?
         return (string)$reflection_type;
     }
 

--- a/tests/Phan/Internal/ConfigEntry.php
+++ b/tests/Phan/Internal/ConfigEntry.php
@@ -98,6 +98,7 @@ class ConfigEntry
         'force_tracking_references' => self::CATEGORY_DEAD_CODE_DETECTION,
         'constant_variable_detection' => self::CATEGORY_DEAD_CODE_DETECTION,
         'dead_code_detection_prefer_false_negative' => self::CATEGORY_DEAD_CODE_DETECTION,
+        'dead_code_detection_treat_never_type_as_unreachable' => self::CATEGORY_DEAD_CODE_DETECTION,
         'warn_about_redundant_use_namespaced_class' => self::CATEGORY_DEAD_CODE_DETECTION,
         'redundant_condition_detection' => self::CATEGORY_DEAD_CODE_DETECTION,
         'assume_real_types_for_internal_functions' => self::CATEGORY_DEAD_CODE_DETECTION,

--- a/tests/files/src/0934_never_phpdoc.php
+++ b/tests/files/src/0934_never_phpdoc.php
@@ -18,7 +18,7 @@ function shouldReturnNever($value) {
 /**
  * @return never this is valid
  */
-function neverExceptional() {
+function neverExceptional(): void {
     throw new \RuntimeException();
 }
 

--- a/tests/php81_files/expected/007_noreturn_control_flow.php.expected
+++ b/tests/php81_files/expected/007_noreturn_control_flow.php.expected
@@ -1,0 +1,2 @@
+%s:15 PhanTypeMismatchArgumentInternalReal Argument 1 ($object) is $x of type array but \spl_object_hash() takes object
+%s:18 PhanPluginUnreachableCode Unreachable statement detected

--- a/tests/php81_files/expected/008_noreturn_control_flow_extra.php.expected
+++ b/tests/php81_files/expected/008_noreturn_control_flow_extra.php.expected
@@ -1,0 +1,3 @@
+%s:10 PhanUnreferencedFunction Possibly zero references to function \test8()
+%s:15 PhanDebugAnnotation @phan-debug-var requested for variable $unknown - it has union type string(real=string)
+%s:19 PhanPluginUnreachableCode Unreachable statement detected

--- a/tests/php81_files/src/007_noreturn_control_flow.php
+++ b/tests/php81_files/src/007_noreturn_control_flow.php
@@ -1,0 +1,18 @@
+<?php
+
+class Example7 {
+    public static function custom_throws(string $message): never {
+        throw new RuntimeException(__METHOD__ . ": $message");
+    }
+}
+function custom_throws(string $message): never {
+    throw new RuntimeException($message);
+}
+if (!isset($x) || !is_array($x)) {
+    custom_throws('message');
+}
+
+echo spl_object_hash($x); // should warn, this is an array
+Example7::custom_throws('finished');
+
+echo "Unreachable\n";

--- a/tests/plugin_test/expected/199_never_type_and_plugins.php.expected
+++ b/tests/plugin_test/expected/199_never_type_and_plugins.php.expected
@@ -1,5 +1,6 @@
 src/199_never_type_and_plugins.php:3 PhanUnreferencedFunction Possibly zero references to function \exitMisuse()
 src/199_never_type_and_plugins.php:5 PhanPluginNonBoolInLogicalArith Non bool value of type never in logical arithmetic
+src/199_never_type_and_plugins.php:6 PhanPluginConstantVariableBool Variable $z is probably constant with a value of true
 src/199_never_type_and_plugins.php:6 PhanUnusedVariable Unused definition of variable $y
 src/199_never_type_and_plugins.php:7 PhanDebugAnnotation @phan-debug-var requested for variable $x1 - it has union type non-zero-int(real=non-zero-int)
 src/199_never_type_and_plugins.php:7 PhanDebugAnnotation @phan-debug-var requested for variable $y - it has union type true(real=true)

--- a/tests/plugin_test/expected/200_never_control_flow.php.expected
+++ b/tests/plugin_test/expected/200_never_control_flow.php.expected
@@ -1,0 +1,2 @@
+src/200_never_control_flow.php:13 PhanPluginUnreachableCode Unreachable statement detected
+src/200_never_control_flow.php:15 PhanTypeMismatchReturnReal Returning $x of type int but test200() is declared to return string

--- a/tests/plugin_test/src/199_never_type_and_plugins.php
+++ b/tests/plugin_test/src/199_never_type_and_plugins.php
@@ -3,7 +3,7 @@
 function exitMisuse(?int $x, bool $z): array {
     $x1 = $x ?: exit('expected nonzero');
     $z2 = $z || exit(true);
-    $y = $z ?: exit('expected nonzero');
+    $y = $z ?: exit('expected nonzero');  // above check implies $z is true
     $y3 = $x ?? exit('fail');
     '@phan-debug-var $y, $x1, $z2, $y3'; // Not worth specializing $z2 right now, using the return type would be uncommon
     $y2 = $x + exit('fail');

--- a/tests/plugin_test/src/200_never_control_flow.php
+++ b/tests/plugin_test/src/200_never_control_flow.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+/** @return never Phan should handle phpdoc 'never' return type */
+function always_exits()  {
+    exit(1);
+}
+
+function test200(?int $x): string {
+    if (!is_int($x)) {
+        always_exits();
+        echo "This is unreachable\n"; // should warn
+    }
+    return $x;  // should warn about 'int'
+}
+test200(null);


### PR DESCRIPTION
Closes #2118
Closes #4405
Related to #3602

Allow using closures, global functions, and instance/static methods as
custom exit/error functions if they have a return type of never.
Note: This may result in false positives for control flow analysis of
unreachable types if object instances with different return types are
passed in, in different invocations of methods

Start using `no-return` in Phan itself for phpdoc
(in other tools, handling on `never` depends on the php version used)

Fix parsing of new hyphenated `@return no-return|never-returns?` type.