### PR TITLE
Intersection type parsing and type checking support

### DIFF
--- a/.phan/plugins/MoreSpecificElementTypePlugin.php
+++ b/.phan/plugins/MoreSpecificElementTypePlugin.php
@@ -109,7 +109,7 @@ class MoreSpecificElementTypePlugin extends PluginV3 implements
         if ($declared_return_type->isStrictSubtypeOf($code_base, $actual_type)) {
             return false;
         }
-        if (!$actual_type->asExpandedTypes($code_base)->canCastToUnionType($declared_return_type)) {
+        if (!$actual_type->canCastToUnionType($declared_return_type, $code_base)) {
             // Don't warn here about type mismatches such as int->string or object->array, but do warn about SubClass->BaseClass.
             // Phan should warn elsewhere about those mismatches
             return false;

--- a/.phan/plugins/PHPUnitAssertionPlugin.php
+++ b/.phan/plugins/PHPUnitAssertionPlugin.php
@@ -180,7 +180,7 @@ class PHPUnitAssertionPlugin extends PluginV3 implements AnalyzeFunctionCallCapa
                                 return $result;
 
                             case 'callable':
-                                $result = $original_type->callableTypes();
+                                $result = $original_type->callableTypes($code_base);
                                 if ($result->isEmpty()) {
                                     return UnionType::fromFullyQualifiedPHPDocString('callable');
                                 }

--- a/.phan/plugins/PregRegexCheckerPlugin.php
+++ b/.phan/plugins/PregRegexCheckerPlugin.php
@@ -267,18 +267,20 @@ class PregRegexCheckerPlugin extends PluginV3 implements AnalyzeFunctionCallCapa
 
     /**
      * @param CodeBase $code_base @phan-unused-param
-     * @return array<string, Closure(CodeBase,Context,Func,array):void>
+     * @return array<string, Closure(CodeBase,Context,Func,array,?Node):void>
      */
     public function getAnalyzeFunctionCallClosures(CodeBase $code_base): array
     {
         /**
          * @param list<Node|string|int|float> $args the nodes for the arguments to the invocation
+         * @unused-param $node
          */
         $preg_pattern_callback = static function (
             CodeBase $code_base,
             Context $context,
             Func $function,
-            array $args
+            array $args,
+            ?Node $node = null
         ): void {
             if (count($args) < 1) {
                 return;
@@ -294,12 +296,14 @@ class PregRegexCheckerPlugin extends PluginV3 implements AnalyzeFunctionCallCapa
 
         /**
          * @param list<Node|int|string|float> $args
+         * @unused-param $node
          */
         $preg_pattern_or_array_callback = static function (
             CodeBase $code_base,
             Context $context,
             Func $function,
-            array $args
+            array $args,
+            ?Node $node = null
         ): void {
             if (count($args) < 1) {
                 return;
@@ -312,12 +316,14 @@ class PregRegexCheckerPlugin extends PluginV3 implements AnalyzeFunctionCallCapa
 
         /**
          * @param list<Node|int|string|float> $args
+         * @unused-param $node
          */
         $preg_pattern_and_replacement_callback = static function (
             CodeBase $code_base,
             Context $context,
             Func $function,
-            array $args
+            array $args,
+            ?Node $node = null
         ): void {
             if (count($args) < 1) {
                 return;
@@ -338,12 +344,14 @@ class PregRegexCheckerPlugin extends PluginV3 implements AnalyzeFunctionCallCapa
 
         /**
          * @param list<Node|string|int|float> $args the nodes for the arguments to the invocation
+         * @unused-param $node
          */
         $preg_replace_callback_array_callback = static function (
             CodeBase $code_base,
             Context $context,
             Func $function,
-            array $args
+            array $args,
+            ?Node $node = null
         ): void {
             if (count($args) < 1) {
                 return;

--- a/.phan/plugins/PrintfCheckerPlugin.php
+++ b/.phan/plugins/PrintfCheckerPlugin.php
@@ -595,7 +595,7 @@ class PrintfCheckerPlugin extends PluginV3 implements AnalyzeFunctionCallCapabil
                     // @phan-suppress-next-line PhanThrowTypeAbsentForCall getExpectedUnionTypeName should only return valid union types
                     $expected_union_type = $expected_union_type->withType(Type::fromFullyQualifiedString($type_name));
                 }
-                if ($actual_union_type->canCastToUnionType($expected_union_type)) {
+                if ($actual_union_type->canCastToUnionType($expected_union_type, $code_base)) {
                     continue;
                 }
                 if (isset($expected_set['string'])) {
@@ -603,7 +603,7 @@ class PrintfCheckerPlugin extends PluginV3 implements AnalyzeFunctionCallCapabil
                     // Allow passing objects with __toString() to printf whether or not strict types are used in the caller.
                     // TODO: Move into a common helper method?
                     try {
-                        foreach ($actual_union_type->asExpandedTypes($code_base)->asClassList($code_base, $context) as $clazz) {
+                        foreach ($actual_union_type->asClassList($code_base, $context) as $clazz) {
                             if ($clazz->hasMethodWithName($code_base, '__toString', true)) {
                                 $can_cast_to_string = true;
                                 break;
@@ -618,7 +618,7 @@ class PrintfCheckerPlugin extends PluginV3 implements AnalyzeFunctionCallCapabil
                 }
 
                 $expected_union_type_string = (string)$expected_union_type;
-                if (self::canWeakCast($actual_union_type, $expected_set)) {
+                if (self::canWeakCast($actual_union_type, $expected_set, $code_base)) {
                     // This can be resolved by casting the arg to (string) manually in printf.
                     $emit_issue(
                         'PhanPluginPrintfIncompatibleArgumentTypeWeak',
@@ -676,14 +676,14 @@ class PrintfCheckerPlugin extends PluginV3 implements AnalyzeFunctionCallCapabil
     /**
      * @param array<string,true> $expected_set the types being checked for the ability to weakly cast to
      */
-    private static function canWeakCast(UnionType $actual_union_type, array $expected_set): bool
+    private static function canWeakCast(UnionType $actual_union_type, array $expected_set, CodeBase $code_base): bool
     {
         if (isset($expected_set['string'])) {
             static $string_weak_types;
             if ($string_weak_types === null) {
                 $string_weak_types = UnionType::fromFullyQualifiedPHPDocString('int|string|float');
             }
-            return $actual_union_type->canCastToUnionType($string_weak_types);
+            return $actual_union_type->canCastToUnionType($string_weak_types, $code_base);
         }
         // We already allow int->float conversion
         return false;

--- a/.phan/plugins/RemoveDebugStatementPlugin.php
+++ b/.phan/plugins/RemoveDebugStatementPlugin.php
@@ -34,7 +34,7 @@ class RemoveDebugStatementPlugin extends PluginV3 implements
 
     /**
      * @param CodeBase $code_base @phan-unused-param
-     * @return array<string, Closure(CodeBase,Context,Func,array):void>
+     * @return array<string, Closure(CodeBase,Context,Func,array,?Node=):void>
      */
     public function getAnalyzeFunctionCallClosures(CodeBase $code_base): array
     {
@@ -54,7 +54,8 @@ class RemoveDebugStatementPlugin extends PluginV3 implements
             CodeBase $code_base,
             Context $context,
             Func $function,
-            array $unused_args
+            array $unused_args,
+            ?Node $unused_node = null
         ) use ($warn_remove_debug_call): void {
             if (self::shouldSuppressDebugIssues($code_base, $context)) {
                 return;
@@ -69,7 +70,8 @@ class RemoveDebugStatementPlugin extends PluginV3 implements
             CodeBase $code_base,
             Context $context,
             Func $function,
-            array $args
+            array $args,
+            ?Node $unused_node = null
         ) use ($warn_remove_debug_call): void {
             if (self::shouldSuppressDebugIssues($code_base, $context)) {
                 return;
@@ -92,7 +94,8 @@ class RemoveDebugStatementPlugin extends PluginV3 implements
             CodeBase $code_base,
             Context $context,
             Func $function,
-            array $args
+            array $args,
+            ?Node $unused_node = null
         ) use ($warn_remove_debug_call): void {
             $file = $args[0] ?? null;
             // @phan-suppress-next-line PhanPossiblyUndeclaredProperty

--- a/.phan/plugins/StrictComparisonPlugin.php
+++ b/.phan/plugins/StrictComparisonPlugin.php
@@ -38,22 +38,24 @@ class StrictComparisonPlugin extends PluginV3 implements
 
     /**
      * @param CodeBase $code_base @phan-unused-param
-     * @return array<string, Closure(CodeBase,Context,Func,array):void>
+     * @return array<string, Closure(CodeBase,Context,Func,array,?Node=):void>
      */
     public function getAnalyzeFunctionCallClosures(CodeBase $code_base): array
     {
         /**
-         * @return Closure(CodeBase,Context,Func,array):void
+         * @return Closure(CodeBase,Context,Func,array,?Node=):void
          */
         $make_callback = static function (int $index, string $index_name, int $min_args): Closure {
             /**
              * @param list<Node|string|int|float> $args the nodes for the arguments to the invocation
+             * @unused-param $node
              */
             return static function (
                 CodeBase $code_base,
                 Context $context,
                 Func $func,
-                array $args
+                array $args,
+                ?Node $node = null
             ) use (
                 $index,
                 $index_name,

--- a/.phan/plugins/SuspiciousParamOrderPlugin.php
+++ b/.phan/plugins/SuspiciousParamOrderPlugin.php
@@ -183,7 +183,7 @@ class SuspiciousParamOrderVisitor extends PluginAwarePostAnalysisVisitor
                 $j = $cycle[($array_index + 1) % count($cycle)];
                 $type = UnionTypeVisitor::unionTypeFromNode($this->code_base, $this->context, $args[$i]);
                 // echo "Checking if $type can cast to $parameters[$j]\n";
-                if (!$type->asExpandedTypes($this->code_base)->canCastToUnionType($parameters[$j]->getUnionType())) {
+                if (!$type->canCastToUnionType($parameters[$j]->getUnionType(), $this->code_base)) {
                     continue 2;
                 }
             }

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,8 @@ Phan NEWS
 ??? ?? 2021, Phan 5.0.0 (dev)
 -----------------------
 
-Support intersection types
++ Support parsing intersection types in phpdoc and checking if intersection types satisfy type comparisons
++ Support intersection types
 
 May 19 2021, Phan 4.0.7 (dev)
 -----------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 Phan NEWS
 
+??? ?? 2021, Phan 5.0.0 (dev)
+-----------------------
+
+Support intersection types
+
 May 19 2021, Phan 4.0.7 (dev)
 -----------------------
 

--- a/src/Phan/AST/InferPureSnippetVisitor.php
+++ b/src/Phan/AST/InferPureSnippetVisitor.php
@@ -102,6 +102,7 @@ class InferPureSnippetVisitor extends InferPureVisitor
         throw new NodeException($node);
     }
 
+    // TODO: Return all classes in union and intersection types instead
     protected function getClassForVariable(Node $expr): Clazz
     {
         if ($expr->kind !== ast\AST_VAR) {
@@ -120,7 +121,8 @@ class InferPureSnippetVisitor extends InferPureVisitor
 
             $union_type = $variable->getUnionType()->asNormalizedTypes();
             $known_fqsen = null;
-            foreach ($union_type->getTypeSet() as $type) {
+
+            foreach ($union_type->getUniqueFlattenedTypeSet() as $type) {
                 if (!$type->isObjectWithKnownFQSEN()) {
                     continue;
                 }

--- a/src/Phan/AST/InferPureVisitor.php
+++ b/src/Phan/AST/InferPureVisitor.php
@@ -567,6 +567,7 @@ class InferPureVisitor extends AnalysisVisitor
         } catch (Exception $_) {
             throw new NodeException($class, 'could not get type');
         }
+        // TODO: Check all classes in union and intersection types instead up to a limit?
         if ($union_type->typeCount() !== 1) {
             throw new NodeException($class);
         }

--- a/src/Phan/AST/TolerantASTConverter/PhpParserNodeEntry.php
+++ b/src/Phan/AST/TolerantASTConverter/PhpParserNodeEntry.php
@@ -16,7 +16,7 @@ use Microsoft\PhpParser\Diagnostic;
  */
 class PhpParserNodeEntry
 {
-    /** @var PhpParser\Node the node generated for the given file contents */
+    /** @var PhpParser\Node\SourceFileNode the node generated for the given file contents */
     public $node;
     /** @var Diagnostic[] the list of diagnostics generated for the given file contents */
     public $errors;
@@ -24,7 +24,7 @@ class PhpParserNodeEntry
     /**
      * @param Diagnostic[] $errors
      */
-    public function __construct(PhpParser\Node $node, array $errors)
+    public function __construct(PhpParser\Node\SourceFileNode $node, array $errors)
     {
         $this->node = $node;
         $this->errors = $errors;

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -617,6 +617,7 @@ class TolerantASTConverter
      * @return array<string,Closure(object,int):(\ast\Node|int|string|float|null)>
      *
      * NOTE: Make sure that the only caller of this is TolerantASTConverterTrait
+     * @suppress PhanTypeMismatchReturn todo: why?
      */
     protected static function initHandleMap(): array
     {

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1201,8 +1201,10 @@ class UnionTypeVisitor extends AnalysisVisitor
         }
         if (!$builder || $builder->isEmpty()) {
             if (!$has_key) {
+                // @phan-suppress-next-line PhanTypeMismatchReturn
                 return UnionType::typeSetFromString('list');
             }
+            // @phan-suppress-next-line PhanTypeMismatchReturn
             return UnionType::typeSetFromString($has_exclusively_int_keys ? 'array<int,mixed>' : 'array');
         }
         $real_types = [];

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -2206,7 +2206,7 @@ class UnionTypeVisitor extends AnalysisVisitor
         // If we have generics, we're all set
         try {
             if ($generic_types->isEmpty()) {
-                if (!$union_type->asExpandedTypes($this->code_base)->hasIterable() && !$union_type->hasTypeMatchingCallback(static function (Type $type): bool {
+                if (!$union_type->hasIterable($this->code_base) && !$union_type->hasTypeMatchingCallback(static function (Type $type): bool {
                     return !$type->isNullableLabeled() && $type instanceof MixedType;
                 })) {
                     throw new IssueException(
@@ -2239,7 +2239,7 @@ class UnionTypeVisitor extends AnalysisVisitor
         // Treat foo(...$associativeArgs) as invalid unless the minimum target php version is 8.0 (i.e. array unpacking is supported)
         if (!$is_array_spread && $minimum_target_php_version_id < 80000) {
             foreach ($union_type->getTypeSet() as $type) {
-                if ($type->isIterable()) {
+                if ($type->isIterable($this->code_base)) {
                     if ($type instanceof AssociativeArrayType) {
                         $is_invalid_because_associative = true;
                     } else {

--- a/src/Phan/Analysis/ArgumentType.php
+++ b/src/Phan/Analysis/ArgumentType.php
@@ -985,8 +985,8 @@ final class ArgumentType
     {
         // Expand it to include all parent types up the chain
         try {
-            $argument_type_expanded_resolved =
-                $argument_type->withStaticResolvedInContext($context)->asExpandedTypes($code_base);
+            $argument_type_resolved = $argument_type->withStaticResolvedInContext($context);
+            $argument_type_expanded_resolved = $argument_type_resolved->asExpandedTypes($code_base);
         } catch (RecursionDepthException $_) {
             return;
         }
@@ -1025,15 +1025,15 @@ final class ArgumentType
             // the codebase must be passed into canCastToUnionType (instead of expanding types), because ArrayAccess|Countable is not a type that casts to ArrayAccess&Countable
             //
             // TODO: Stop expanding the argument type
-            if ($argument_type_expanded_resolved->canCastToUnionType($alternate_parameter_type, $code_base)) {
+            if ($argument_type_resolved->canCastToUnionType($alternate_parameter_type, $code_base)) {
                 if ($alternate_parameter_type->hasRealTypeSet() && $argument_type->hasRealTypeSet()) {
                     $real_parameter_type = $alternate_parameter_type->getRealUnionType();
                     $real_argument_type = $argument_type->getRealUnionType();
-                    $real_argument_type_expanded_resolved = $real_argument_type->withStaticResolvedInContext($context)->asExpandedTypes($code_base);
-                    if (!$real_argument_type_expanded_resolved->canCastToDeclaredType($code_base, $context, $real_parameter_type)) {
-                        $real_argument_type_expanded_resolved_nonnull = $real_argument_type_expanded_resolved->nonNullableClone();
-                        if ($real_argument_type_expanded_resolved_nonnull->isEmpty() ||
-                            !$real_argument_type_expanded_resolved_nonnull->canCastToDeclaredType($code_base, $context, $real_parameter_type)) {
+                    $real_argument_type_resolved = $real_argument_type->withStaticResolvedInContext($context);
+                    if (!$real_argument_type_resolved->canCastToDeclaredType($code_base, $context, $real_parameter_type)) {
+                        $real_argument_type_resolved_nonnull = $real_argument_type_resolved->nonNullableClone();
+                        if ($real_argument_type_resolved_nonnull->isEmpty() ||
+                            !$real_argument_type_resolved_nonnull->canCastToDeclaredType($code_base, $context, $real_parameter_type)) {
                             // We know that the inferred real types don't match with the strict_types setting of the caller
                             // (e.g. null -> any non-null type)
                             // Try checking any other alternates, and emit PhanTypeMismatchArgumentReal if that fails.
@@ -1093,7 +1093,7 @@ final class ArgumentType
             // and the argument we are passing has a __toString method then it is ok
             if (!$context->isStrictTypes() && $alternate_parameter_type->hasNonNullStringType()) {
                 try {
-                    foreach ($argument_type_expanded_resolved->asClassList($code_base, $context) as $clazz) {
+                    foreach ($argument_type_resolved->asClassList($code_base, $context) as $clazz) {
                         if ($clazz->hasMethodWithName($code_base, "__toString", true)) {
                             return;
                         }

--- a/src/Phan/Analysis/AssignOperatorAnalysisVisitor.php
+++ b/src/Phan/Analysis/AssignOperatorAnalysisVisitor.php
@@ -388,7 +388,8 @@ class AssignOperatorAnalysisVisitor extends FlagVisitorImplementation
 
                 if ($left_is_array
                     && !$right->canCastToUnionType(
-                        ArrayType::instance(false)->asPHPDocUnionType()
+                        ArrayType::instance(false)->asPHPDocUnionType(),
+                        $code_base
                     )
                 ) {
                     $this->emitIssue(
@@ -396,7 +397,7 @@ class AssignOperatorAnalysisVisitor extends FlagVisitorImplementation
                         $node->lineno ?? 0
                     );
                     return UnionType::empty();
-                } elseif ($right_is_array && !$left->canCastToUnionType($array_type->asPHPDocUnionType())) {
+                } elseif ($right_is_array && !$left->canCastToUnionType($array_type->asPHPDocUnionType(), $code_base)) {
                     $this->emitIssue(
                         Issue::TypeInvalidLeftOperand,
                         $node->lineno ?? 0

--- a/src/Phan/Analysis/AssignOperatorFlagVisitor.php
+++ b/src/Phan/Analysis/AssignOperatorFlagVisitor.php
@@ -319,7 +319,8 @@ class AssignOperatorFlagVisitor extends FlagVisitorImplementation
 
         if ($left_is_array
             && !$right->canCastToUnionType(
-                ArrayType::instance(false)->asPHPDocUnionType()
+                ArrayType::instance(false)->asPHPDocUnionType(),
+                $this->code_base
             )
         ) {
             Issue::maybeEmit(
@@ -330,7 +331,10 @@ class AssignOperatorFlagVisitor extends FlagVisitorImplementation
             );
             return $unknown_type;
         } elseif ($right_is_array
-            && !$left->canCastToUnionType(ArrayType::instance(false)->asPHPDocUnionType())
+            && !$left->canCastToUnionType(
+                ArrayType::instance(false)->asPHPDocUnionType(),
+                $this->code_base
+            )
         ) {
             Issue::maybeEmit(
                 $this->code_base,

--- a/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
+++ b/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
@@ -534,11 +534,13 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
         $right_is_array_like = $right->isExclusivelyArrayLike();
 
         $left_can_cast_to_array = $left->canCastToUnionType(
-            ArrayType::instance(false)->asPHPDocUnionType()
+            ArrayType::instance(false)->asPHPDocUnionType(),
+            $this->code_base
         );
 
         $right_can_cast_to_array = $right->canCastToUnionType(
-            ArrayType::instance(false)->asPHPDocUnionType()
+            ArrayType::instance(false)->asPHPDocUnionType(),
+            $this->code_base
         );
 
         if ($left_is_array_like
@@ -550,7 +552,7 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
         ) {
             $this->emitIssue(
                 Issue::TypeComparisonFromArray,
-                $node->lineno ?? 0,
+                $node->lineno,
                 (string)$right->asNonLiteralType()
             );
         } elseif ($right_is_array_like
@@ -562,7 +564,7 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
         ) {
             $this->emitIssue(
                 Issue::TypeComparisonToArray,
-                $node->lineno ?? 0,
+                $node->lineno,
                 (string)$left->asNonLiteralType()
             );
         }
@@ -791,7 +793,8 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
 
             if ($left_is_array
                 && !$right->canCastToUnionType(
-                    ArrayType::instance(false)->asPHPDocUnionType()
+                    ArrayType::instance(false)->asPHPDocUnionType(),
+                    $code_base
                 )
             ) {
                 $this->emitIssue(
@@ -799,7 +802,7 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
                     $node->lineno ?? 0
                 );
                 return $probably_unknown_type;
-            } elseif ($right_is_array && !$left->canCastToUnionType($array_type->asPHPDocUnionType())) {
+            } elseif ($right_is_array && !$left->canCastToUnionType($array_type->asPHPDocUnionType(), $code_base)) {
                 $this->emitIssue(
                     Issue::TypeInvalidLeftOperand,
                     $node->lineno ?? 0

--- a/src/Phan/Analysis/CompositionAnalyzer.php
+++ b/src/Phan/Analysis/CompositionAnalyzer.php
@@ -110,9 +110,10 @@ class CompositionAnalyzer
                     // No need to warn about incompatible composition of trait with another ancestor if the property's default was overridden
                     continue;
                 }
+                // TODO: Why expand?
                 $can_cast =
-                    $property_union_type->canCastToExpandedUnionType(
-                        $inherited_property_union_type,
+                    $property_union_type->canCastToUnionType(
+                        $inherited_property_union_type->asExpandedTypes($code_base),
                         $code_base
                     );
 

--- a/src/Phan/Analysis/ConditionVisitorUtil.php
+++ b/src/Phan/Analysis/ConditionVisitorUtil.php
@@ -1232,7 +1232,7 @@ trait ConditionVisitorUtil
         }
         if (!is_string($expr_value)) {
             $expr_type = UnionTypeVisitor::unionTypeFromNode($this->code_base, $this->context, $expr_node);
-            if (!$expr_type->canCastToUnionType(UnionType::fromFullyQualifiedPHPDocString('string|false'))) {
+            if (!$expr_type->canCastToUnionType(UnionType::fromFullyQualifiedPHPDocString('string|false'), $this->code_base)) {
                 Issue::maybeEmit(
                     $this->code_base,
                     $this->context,
@@ -1338,7 +1338,7 @@ trait ConditionVisitorUtil
             if ($int_or_string_type === null) {
                 $int_or_string_type = UnionType::fromFullyQualifiedPHPDocString('?int|?string');
             }
-            if (!$name_node_type->canCastToUnionType($int_or_string_type)) {
+            if (!$name_node_type->canCastToUnionType($int_or_string_type, $this->code_base)) {
                 Issue::maybeEmit($this->code_base, $context, Issue::TypeSuspiciousIndirectVariable, $var_name_node->lineno ?? 0, (string)$name_node_type);
             }
 
@@ -1442,7 +1442,7 @@ trait ConditionVisitorUtil
             return $affected_type;
         }
         return $affected_type->makeFromFilter(static function (Type $type) use ($code_base, $excluded_type): bool {
-            return $type instanceof MixedType || !$type->asExpandedTypes($code_base)->canCastToUnionType($excluded_type);
+            return $type instanceof MixedType || !$type->asPHPDocUnionType()->canCastToUnionType($excluded_type, $code_base);
         });
     }
 

--- a/src/Phan/Analysis/NegatedConditionVisitor.php
+++ b/src/Phan/Analysis/NegatedConditionVisitor.php
@@ -509,7 +509,7 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
             return null;
         }
         $right_hand_type = $right_hand_union_type->getTypeSet()[0];
-        if (!$right_hand_type->isObjectWithKnownFQSEN()) {
+        if (!$right_hand_type->hasObjectWithKnownFQSEN()) {
             return null;
         }
         return $union_type->withoutSubclassesOf($this->code_base, $right_hand_type);
@@ -599,9 +599,9 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
             return $type->isInBoolFamily();
         });
         /** @param list<Node|mixed> $unused_args */
-        $remove_callable_callback = static function (CodeBase $unused_code_base, Context $unused_context, Variable $variable, array $unused_args): void {
-            $variable->setUnionType($variable->getUnionType()->asMappedListUnionType(/** @return list<Type> */ static function (Type $type): array {
-                if ($type->isCallable()) {
+        $remove_callable_callback = static function (CodeBase $code_base, Context $unused_context, Variable $variable, array $unused_args): void {
+            $variable->setUnionType($variable->getUnionType()->asMappedListUnionType(/** @return list<Type> */ static function (Type $type) use ($code_base): array {
+                if ($type->isCallable($code_base)) {
                     if ($type->isNullable()) {
                         static $null_type_set;
                         return $null_type_set ?? ($null_type_set = UnionType::typeSetFromString('null'));

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -959,7 +959,7 @@ class ParameterTypesAnalyzer
                     // For example, allow `foo(): SubClass` to override `foo(): BaseClass`
                     // in php 8.1, allow `foo(): never` to override any base type
                     $is_exception_to_rule = (Config::get_closest_minimum_target_php_version_id() >= 70400 && $overridden_parameter_union_type->isStrictSubtypeOf($code_base, $parameter_union_type)) ||
-                        ($parameter_union_type->hasIterable() && $overridden_parameter_union_type->hasIterable() &&
+                        ($overridden_parameter_union_type->hasIterable($code_base) &&
                             ($parameter_union_type->hasType(IterableType::instance(true)) ||
                              $parameter_union_type->hasType(IterableType::instance(false)) && !$overridden_parameter_union_type->containsNullable()));
 
@@ -1000,9 +1000,10 @@ class ParameterTypesAnalyzer
                 //
                 // For example, allow `foo(): SubClass` to override `foo(): BaseClass`
                 // in php 8.1, allow `foo(): never` to override any base type
+                //
+                // TODO: Narrow this to check for non-objects?
                 $is_exception_to_rule = (Config::get_closest_minimum_target_php_version_id() >= 70400 && $return_union_type->isStrictSubtypeOf($code_base, $overridden_return_union_type)) ||
-                    ($return_union_type->hasIterable() &&
-                    $overridden_return_union_type->hasIterable() &&
+                    ($return_union_type->hasIterable($code_base) &&
                     ($overridden_return_union_type->hasType(IterableType::instance(true)) ||
                      $overridden_return_union_type->hasType(IterableType::instance(false)) && !$return_union_type->containsNullable()));
                 if (!$is_exception_to_rule) {

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -193,7 +193,7 @@ class ParameterTypesAnalyzer
             }
             $union_type = $parameter->getUnionType();
 
-            foreach ($union_type->getTypeSet() as $type) {
+            foreach ($union_type->getUniqueFlattenedTypeSet() as $type) {
                 if (!$type->isObjectWithKnownFQSEN()) {
                     continue;
                 }
@@ -703,8 +703,9 @@ class ParameterTypesAnalyzer
         // E.g. there is no issue if the overridden return type is empty.
         // See https://github.com/phan/phan/issues/1397
         if (!$overridden_return_union_type->isEmptyOrMixed()) {
-            if (!$method->getUnionType()->asExpandedTypes($code_base)->canCastToUnionType(
-                $overridden_return_union_type
+            if (!$method->getUnionType()->canCastToUnionType(
+                $overridden_return_union_type,
+                $code_base
             )) {
                 $signatures_match = false;
             }
@@ -791,7 +792,7 @@ class ParameterTypesAnalyzer
     private static function canWeakCast(CodeBase $code_base, UnionType $overridden_type, UnionType $type): bool
     {
         $expanded_overridden_type = $overridden_type->asExpandedTypes($code_base);
-        return $expanded_overridden_type->canCastToUnionType($type) &&
+        return $expanded_overridden_type->canCastToUnionType($type, $code_base) &&
                     $expanded_overridden_type->hasAnyTypeOverlap($code_base, $type);
     }
     /**

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -791,9 +791,8 @@ class ParameterTypesAnalyzer
 
     private static function canWeakCast(CodeBase $code_base, UnionType $overridden_type, UnionType $type): bool
     {
-        $expanded_overridden_type = $overridden_type->asExpandedTypes($code_base);
-        return $expanded_overridden_type->canCastToUnionType($type, $code_base) &&
-                    $expanded_overridden_type->hasAnyTypeOverlap($code_base, $type);
+        return $overridden_type->canCastToUnionType($type, $code_base) &&
+                    $overridden_type->hasAnyTypeOverlap($code_base, $type);
     }
     /**
      * Previously, Phan bases the analysis off of phpdoc.

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -1917,7 +1917,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             return $context;
         }
         $yield_from_expanded_type = $yield_from_type->withStaticResolvedInContext($this->context)->asExpandedTypes($code_base);
-        if (!$yield_from_expanded_type->hasIterable() && !$yield_from_expanded_type->hasTraversable()) {
+        if (!$yield_from_expanded_type->hasIterable($code_base) && !$yield_from_expanded_type->hasTraversable()) {
             $this->emitIssue(
                 Issue::TypeInvalidYieldFrom,
                 $node->lineno,

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -2016,11 +2016,9 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 return false;
             }
         }
-        // We allow base classes to cast to subclasses, and subclasses to cast to base classes,
-        // but don't allow subclasses to cast to subclasses on a separate branch of the inheritance tree
         try {
-            return $expression_type->asExpandedTypes($this->code_base)->canCastToUnionType($method_return_type, $this->code_base) ||
-                $expression_type->canCastToUnionType($method_return_type->asExpandedTypes($this->code_base), $this->code_base);
+            // Stop allowing base classes to cast to subclasses
+            return $expression_type->canCastToUnionType($method_return_type, $this->code_base);
         } catch (RecursionDepthException $_) {
             return false;
         }

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -676,8 +676,8 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
         if (!$func->isReturnTypeUndefined()) {
             $func_return_type = $func->getUnionType();
             try {
-                $func_return_type_can_cast = $func_return_type->canCastToExpandedUnionType(
-                    Type::fromNamespaceAndName('\\', 'Generator', false)->asPHPDocUnionType(),
+                $func_return_type_can_cast = Type::fromNamespaceAndName('\\', 'Generator', false)->asPHPDocUnionType()->canCastToUnionType(
+                    $func_return_type,
                     $this->code_base
                 );
             } catch (RecursionDepthException $_) {

--- a/src/Phan/Analysis/RedundantCondition.php
+++ b/src/Phan/Analysis/RedundantCondition.php
@@ -199,7 +199,8 @@ class RedundantCondition
         }
         if ($node->kind === ast\AST_DIM) {
             // Surprisingly, $str[$invalidOffset] is the empty string instead of null, and isset($str[$invalid]) is false.
-            return UnionTypeVisitor::unionTypeFromNode($code_base, $context, $node->children['expr'], false)->canCastToUnionType(StringType::instance(true)->asPHPDocUnionType());
+            return UnionTypeVisitor::unionTypeFromNode($code_base, $context, $node->children['expr'], false)
+                ->canCastToUnionType(StringType::instance(true)->asPHPDocUnionType(), $code_base);
         }
         return false;
     }

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -37,6 +37,7 @@ use Phan\Language\Scope\BranchScope;
 use Phan\Language\Scope\GlobalScope;
 use Phan\Language\Scope\PropertyScope;
 use Phan\Language\Type;
+use Phan\Language\Type\IterableType;
 use Phan\Language\Type\ArrayType;
 use Phan\Language\UnionType;
 use Phan\Library\StringUtil;
@@ -1101,7 +1102,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
         if ($union_type->isEmpty()) {
             return;
         }
-        if (!$union_type->hasPossiblyObjectTypes() && !$union_type->hasIterable()) {
+        if (!$union_type->hasPossiblyObjectTypes() && !$union_type->hasIterable($this->code_base)) {
             $this->emitIssue(
                 Issue::TypeMismatchForeach,
                 $node->children['expr']->lineno ?? $node->lineno,
@@ -1176,7 +1177,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
             if ($type->isPossiblyObject()) {
                 return false;
             }
-            if (!$type->isIterable()) {
+            if (!$type instanceof IterableType) {
                 continue;
             }
             if ($type->isPossiblyTruthy()) {

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -1111,10 +1111,11 @@ class BlockAnalysisVisitor extends AnalysisVisitor
         }
         $has_object = false;
         foreach ($union_type->getTypeSet() as $type) {
-            if (!$type->isObjectWithKnownFQSEN()) {
+            if (!$type->hasObjectWithKnownFQSEN()) {
                 continue;
             }
             try {
+                // e.g. don't warn about ArrayObject&CustomInterface because the expanded type set includes Traversable
                 if ($type->asExpandedTypes($this->code_base)->hasTraversable()) {
                     continue;
                 }
@@ -2550,7 +2551,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
 
             $catch_line = $catch_node->lineno;
 
-            foreach ($union_type->getTypeSet() as $type) {
+            foreach ($union_type->getUniqueFlattenedTypeSet() as $type) {
                 foreach ($type->asExpandedTypes($code_base)->getTypeSet() as $ancestor_type) {
                     // Check if any of the ancestors were already caught by a previous catch statement
                     $line = $caught_union_types[\spl_object_id($ancestor_type)] ?? null;

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -83,7 +83,7 @@ class CLI
     /**
      * This should be updated to x.y.z-dev after every release, and x.y.z before a release.
      */
-    public const PHAN_VERSION = '4.0.7-dev';
+    public const PHAN_VERSION = '5.0.0-dev';
 
     /**
      * List of short flags passed to getopt

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -649,7 +649,7 @@ class CodeBase
     }
 
     /**
-     * @param array{clone:CodeBase,callbacks:?(Closure():void)[]} $restore_point
+     * @param array{clone:CodeBase,callbacks:(?Closure():void)[]} $restore_point
      */
     public function restoreFromRestorePoint(array $restore_point): void
     {
@@ -1183,7 +1183,7 @@ class CodeBase
     {
         $set = clone($this->method_set);
         foreach ($this->fqsen_func_map as $value) {
-            // @phan-suppress-next-line PhanTypeMismatchArgument deliberately adding different class instances to an existing set
+            // @phan-suppress-next-line PhanTypeMismatchArgument, PhanPartialTypeMismatchArgument deliberately adding different class instances to an existing set
             $set->attach($value);
         }
         return $set;

--- a/src/Phan/Language/Element/ClassConstant.php
+++ b/src/Phan/Language/Element/ClassConstant.php
@@ -82,6 +82,7 @@ class ClassConstant extends ClassElement implements ConstantInterface
      * @return FullyQualifiedClassConstantName
      * The fully-qualified structural element name of this
      * structural element
+     * @suppress PhanTypeMismatchReturn (FQSEN on declaration)
      */
     public function getFQSEN(): FQSEN
     {

--- a/src/Phan/Language/Element/ClassElement.php
+++ b/src/Phan/Language/Element/ClassElement.php
@@ -277,13 +277,13 @@ abstract class ClassElement extends AddressableElement
         // then the subclasses of the defining class can access it.
         try {
             foreach ($accessing_class_type->asExpandedTypes($code_base)->getTypeSet() as $type) {
-                if ($type->canCastToType($type_of_class_of_property)) {
+                if ($type->canCastToType($type_of_class_of_property, $code_base)) {
                     return true;
                 }
             }
             // and base classes of the defining class can access it
             foreach ($type_of_class_of_property->asExpandedTypes($code_base)->getTypeSet() as $type) {
-                if ($type->canCastToType($accessing_class_type)) {
+                if ($type->canCastToType($accessing_class_type, $code_base)) {
                     return true;
                 }
             }

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -3708,14 +3708,14 @@ class Clazz extends AddressableElement
     }
 
     /**
-     * @return list<Closure(list<mixed>, Context):UnionType>
+     * @return list<Closure(list<Node|string|int|float|UnionType>, Context):UnionType>
      */
     public function getGenericConstructorBuilder(CodeBase $code_base): array
     {
         return $this->memoize(
             'template_type_resolvers',
             /**
-             * @return list<Closure(list<mixed>):UnionType>
+             * @return list<Closure(list<Node|string|int|float|UnionType>, Context):UnionType>
              */
             function () use ($code_base): array {
                 // Get the constructor so that we can figure out what

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -2394,6 +2394,7 @@ class Clazz extends AddressableElement
 
     /**
      * @return FullyQualifiedClassName
+     * @suppress PhanTypeMismatchReturn (FQSEN on declaration)
      */
     public function getFQSEN()
     {

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -1861,7 +1861,7 @@ class Clazz extends AddressableElement
         if ($method->hasYield()) {
             // There's no phpdoc standard for template types of Generators at the moment.
             $new_type = UnionType::fromFullyQualifiedRealString('\\Generator');
-            if (!$new_type->canCastToUnionType($method->getUnionType())) {
+            if (!$new_type->canCastToUnionType($method->getUnionType(), $code_base)) {
                 $method->setUnionType($new_type);
             }
         }

--- a/src/Phan/Language/Element/Func.php
+++ b/src/Phan/Language/Element/Func.php
@@ -318,6 +318,9 @@ class Func extends AddressableElement implements FunctionInterface
         return $func;
     }
 
+    /**
+     * @suppress PhanTypeMismatchReturn FunctionInterface->Method
+     */
     public function getFQSEN(): FullyQualifiedFunctionName
     {
         return $this->fqsen;

--- a/src/Phan/Language/Element/FunctionFactory.php
+++ b/src/Phan/Language/Element/FunctionFactory.php
@@ -26,6 +26,7 @@ class FunctionFactory
      * One or more (alternate) functions begotten from
      * reflection info and internal functions data
      * @suppress PhanUndeclaredMethod
+     * @suppress PhanTypeMismatchReturn FunctionInterface->Method
      */
     public static function functionListFromReflectionFunction(
         FullyQualifiedFunctionName $fqsen,
@@ -76,6 +77,7 @@ class FunctionFactory
      * @return list<Func>
      * One or more (alternate) methods begotten from
      * reflection info and internal method data
+     * @suppress PhanTypeMismatchReturn FunctionInterface->Method
      */
     public static function functionListFromSignature(
         FullyQualifiedFunctionName $fqsen,
@@ -107,6 +109,7 @@ class FunctionFactory
     /**
      * @return list<Method> a list of 1 or more method signatures from a ReflectionMethod
      * and Phan's alternate signatures for that method's FQSEN in FunctionSignatureMap.
+     * @suppress PhanTypeMismatchReturn FunctionInterface->Method
      */
     public static function methodListFromReflectionClassAndMethod(
         Context $context,

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -887,7 +887,8 @@ trait FunctionTrait
             // issue.
             if (!$default_is_null) {
                 if (!$default_type->canCastToUnionType(
-                    $parameter->getUnionType()
+                    $parameter->getUnionType(),
+                    $code_base
                 )) {
                     Issue::maybeEmit(
                         $code_base,
@@ -1511,7 +1512,7 @@ trait FunctionTrait
                 }
             }
         }
-        foreach ($real_return_type->getTypeSet() as $type) {
+        foreach ($real_return_type->getUniqueFlattenedTypeSet() as $type) {
             if (!$type->isObjectWithKnownFQSEN()) {
                 continue;
             }

--- a/src/Phan/Language/Element/GlobalConstant.php
+++ b/src/Phan/Language/Element/GlobalConstant.php
@@ -70,6 +70,7 @@ class GlobalConstant extends AddressableElement implements ConstantInterface
      * @return FullyQualifiedGlobalConstantName
      * The fully-qualified structural element name of this
      * structural element
+     * @suppress PhanTypeMismatchReturn TODO: different low severity issue type for base class to subclass cast
      */
     public function getFQSEN(): FullyQualifiedGlobalConstantName
     {

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -976,6 +976,7 @@ class Method extends ClassElement implements FunctionInterface
         }
         $expected_type = $defining_fqsen->asType();
 
+        // TODO: Handle intersection types?
         foreach ($object_union_type->getTypeSet() as $type) {
             if (!$type->hasTemplateParameterTypes()) {
                 continue;

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -698,6 +698,7 @@ class Method extends ClassElement implements FunctionInterface
         return parent::getUnionType();
     }
 
+    /** @suppress PhanTypeMismatchReturn */
     public function getFQSEN(): FullyQualifiedMethodName
     {
         return $this->fqsen;

--- a/src/Phan/Language/Element/Parameter.php
+++ b/src/Phan/Language/Element/Parameter.php
@@ -494,9 +494,9 @@ class Parameter extends Variable
      *
      * If this parameter is not variadic, returns $this.
      *
-     * @return static (usually $this)
+     * @return Parameter (usually $this)
      */
-    public function asNonVariadic()
+    public function asNonVariadic(): Parameter
     {
         return $this;
     }

--- a/src/Phan/Language/Element/Property.php
+++ b/src/Phan/Language/Element/Property.php
@@ -437,6 +437,7 @@ class Property extends ClassElement
     {
         $union_type = $this->getUnionType();
         foreach ($union_type->getTypeSet() as $type) {
+            // TODO: Replace $old in intersection types as well?
             if (!$type->isObjectWithKnownFQSEN()) {
                 continue;
             }

--- a/src/Phan/Language/Element/Property.php
+++ b/src/Phan/Language/Element/Property.php
@@ -197,6 +197,7 @@ class Property extends ClassElement
      * @return FullyQualifiedPropertyName
      * The fully-qualified structural element name of this
      * structural element
+     * @suppress PhanTypeMismatchReturn
      */
     public function getFQSEN(): FullyQualifiedPropertyName
     {

--- a/src/Phan/Language/Element/VariadicParameter.php
+++ b/src/Phan/Language/Element/VariadicParameter.php
@@ -88,10 +88,9 @@ class VariadicParameter extends Parameter
      *
      * If this parameter is not variadic, returns $this.
      *
-     * @return static
      * @override
      */
-    public function asNonVariadic()
+    public function asNonVariadic(): Parameter
     {
         // TODO: Is it possible to cache this while maintaining
         //       correctness? PostOrderAnalysisVisitor clones the

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -487,8 +487,9 @@ final class EmptyUnionType extends UnionType
     /**
      * @return bool
      * True if this type has any subtype of `iterable` type (e.g. Traversable, Array).
+     * @unused-param $code_base
      */
-    public function hasIterable(): bool
+    public function hasIterable(CodeBase $code_base): bool
     {
         return false;
     }

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -58,6 +58,17 @@ final class EmptyUnionType extends UnionType
     }
 
     /**
+     * @return list<Type>
+     * The list of simple types associated with this
+     * union type. Keys are consecutive. Intersection types are flattened.
+     */
+    public function getUniqueFlattenedTypeSet(): array
+    {
+        return [];
+    }
+
+
+    /**
      * Add a type name to the list of types
      * @override
      */
@@ -555,13 +566,15 @@ final class EmptyUnionType extends UnionType
      * i.e. int->float is allowed  while float->int is not.
      */
     public function canCastToUnionType(
-        UnionType $target
+        UnionType $target,
+        CodeBase $code_base
     ): bool {
         return true;  // Empty can cast to anything. See parent implementation.
     }
 
     public function canCastToUnionTypeWithoutConfig(
-        UnionType $target
+        UnionType $target,
+        CodeBase $code_base
     ): bool {
         return true;  // Empty can cast to anything. See parent implementation.
     }
@@ -574,17 +587,10 @@ final class EmptyUnionType extends UnionType
      * @internal
      * @override
      */
-    public function canCastToUnionTypeIfNonNull(UnionType $target): bool
+    public function canCastToUnionTypeIfNonNull(UnionType $target, CodeBase $code_base): bool
     {
         // TODO: Better check for isPossiblyNonNull
-        return UnionType::fromFullyQualifiedRealString('non-null-mixed')->canCastToUnionType($target);
-    }
-
-    public function canCastToUnionTypeHandlingTemplates(
-        UnionType $target,
-        CodeBase $code_base
-    ): bool {
-        return true;
+        return UnionType::fromFullyQualifiedRealString('non-null-mixed')->canCastToUnionType($target, $code_base);
     }
 
     /**
@@ -859,8 +865,9 @@ final class EmptyUnionType extends UnionType
      * A UnionType with known callable types kept, other types filtered out.
      *
      * @see nonGenericArrayTypes
+     * @unused-param $code_base
      */
-    public function callableTypes(): UnionType
+    public function callableTypes(CodeBase $code_base): UnionType
     {
         return $this;
     }
@@ -875,10 +882,11 @@ final class EmptyUnionType extends UnionType
      * A UnionType with known callable types kept, other types filtered out.
      *
      * @see self::callableTypes()
+     * @unused-param $code_base
      *
      * @override
      */
-    public function hasCallableType(): bool
+    public function hasCallableType(CodeBase $code_base): bool
     {
         return false;  // has no types
     }
@@ -942,8 +950,9 @@ final class EmptyUnionType extends UnionType
      * A UnionType with known callable types kept, other types filtered out.
      *
      * @see nonGenericArrayTypes
+     * @unused-param $code_base
      */
-    public function isExclusivelyCallable(): bool
+    public function isExclusivelyCallable(CodeBase $code_base): bool
     {
         return true; // !$this->hasTypeMatchingCallback(empty)
     }
@@ -1503,12 +1512,18 @@ final class EmptyUnionType extends UnionType
         return false;
     }
 
-    public function containsDefiniteNonCallableType(): bool
+    /**
+     * @unused-param $code_base
+     */
+    public function containsDefiniteNonCallableType(CodeBase $code_base): bool
     {
         return false;
     }
 
-    public function hasPossiblyCallableType(): bool
+    /**
+     * @unused-param $code_base
+     */
+    public function hasPossiblyCallableType(CodeBase $code_base): bool
     {
         return true;
     }
@@ -1665,7 +1680,7 @@ final class EmptyUnionType extends UnionType
         return false;
     }
 
-    public function hasSubtypeOf(UnionType $type): bool
+    public function hasSubtypeOf(UnionType $type, CodeBase $code_base): bool
     {
         return true;
     }

--- a/src/Phan/Language/FQSEN/FullyQualifiedFunctionName.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedFunctionName.php
@@ -70,6 +70,7 @@ class FullyQualifiedFunctionName extends FullyQualifiedGlobalStructuralElement i
 
         // Check for a name map
         if ($context->hasNamespaceMapFor(static::getNamespaceMapType(), $fqsen_string)) {
+            // @phan-suppress-next-line PhanTypeMismatchReturn
             return $context->getNamespaceMapFor(
                 static::getNamespaceMapType(),
                 $fqsen_string

--- a/src/Phan/Language/Type/ArrayShapeType.php
+++ b/src/Phan/Language/Type/ArrayShapeType.php
@@ -190,6 +190,7 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
                 );
             }
         }
+        // @phan-suppress-next-line PhanTypeMismatchReturn
         return $union_type_builder->getTypeSet();
     }
 
@@ -652,6 +653,7 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
                 }
                 $result_fields[$key] = $expanded_field_type;
             }
+            // TODO: if the expanded types are different from the original type, maybe include both?
             return ArrayShapeType::fromFieldTypes($result_fields, $this->is_nullable)->asPHPDocUnionType();
         });
     }
@@ -738,6 +740,7 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
                 );
             }
         }
+        // @phan-suppress-next-line PhanTypeMismatchReturn
         return $union_type_builder->getTypeSet();
     }
 
@@ -1148,5 +1151,56 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
         foreach ($this->field_types as $type) {
             yield from $type->getTypesRecursively();
         }
+    }
+
+    public function isSubtypeOf(Type $type, CodeBase $code_base): bool
+    {
+        // Check to see if we have an exact object match
+        if ($this === $type) {
+            return true;
+        }
+        if (\in_array($type, $this->asExpandedTypes($code_base)->getTypeSet(), true)) {
+            return true;
+        }
+
+        $other_is_nullable = $type->isNullable();
+        // A nullable type is not a subtype of a non-nullable type
+        if ($this->is_nullable && !$other_is_nullable) {
+            return false;
+        }
+        if ($type instanceof ArrayShapeType) {
+            foreach ($type->field_types as $field_name => $field_type) {
+                $field_type_of_this = $this->field_types[$field_name] ?? null;
+                if (!$field_type_of_this) {
+                    return false;
+                }
+                if (!$field_type_of_this->isStrictSubtypeOf($code_base, $field_type)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        if ($type instanceof MixedType) {
+            // e.g. ?int is a subtype of mixed, but ?int is not a subtype of non-empty-mixed/non-null-mixed
+            // (check isNullable first)
+            // This is not NullType; it has to be truthy to cast to non-empty-mixed.
+            return \get_class($type) !== NonEmptyMixedType::class || $this->isPossiblyTruthy();
+        }
+
+        // Get a non-null version of the type we're comparing
+        // against.
+        if ($other_is_nullable) {
+            $type = $type->withIsNullable(false);
+
+            // Check one more time to see if the types are equal
+            if ($this === $type) {
+                return true;
+            }
+        }
+
+        // Test to see if we are a subtype of the non-nullable version
+        // of the target type.
+        return $this->isSubtypeOfNonNullableType($type, $code_base);
     }
 }

--- a/src/Phan/Language/Type/ArrayType.php
+++ b/src/Phan/Language/Type/ArrayType.php
@@ -298,16 +298,16 @@ class ArrayType extends IterableType
         ];
     }
 
-    protected function canCastToNonNullableType(Type $type): bool
+    protected function canCastToNonNullableType(Type $type, CodeBase $code_base): bool
     {
         // CallableDeclarationType is not a native type, we check separately here
-        return parent::canCastToNonNullableType($type) || $type instanceof ArrayType || $type instanceof CallableDeclarationType;
+        return parent::canCastToNonNullableType($type, $code_base) || $type instanceof ArrayType || $type instanceof CallableDeclarationType;
     }
 
-    protected function canCastToNonNullableTypeWithoutConfig(Type $type): bool
+    protected function canCastToNonNullableTypeWithoutConfig(Type $type, CodeBase $code_base): bool
     {
         // CallableDeclarationType is not a native type, we check separately here
-        return parent::canCastToNonNullableTypeWithoutConfig($type) || $type instanceof ArrayType || $type instanceof CallableDeclarationType;
+        return parent::canCastToNonNullableTypeWithoutConfig($type, $code_base) || $type instanceof ArrayType || $type instanceof CallableDeclarationType;
     }
 
     /**
@@ -320,7 +320,7 @@ class ArrayType extends IterableType
         if ($other instanceof IterableType || $other instanceof MixedType || $other instanceof TemplateType) {
             return true;
         }
-        if ($this->isDefiniteNonCallableType()) {
+        if ($this->isDefiniteNonCallableType($code_base)) {
             return false;
         }
         return $other instanceof CallableDeclarationType || $other instanceof CallableType;
@@ -365,8 +365,11 @@ class ArrayType extends IterableType
         return parent::performComparison([], $scalar, $flags);
     }
 
-    // There are more specific checks in GenericArrayType and ArrayShapeType
-    public function asCallableType(): ?Type
+    /**
+     * There are more specific checks in GenericArrayType and ArrayShapeType
+     * @unused-param $code_base
+     */
+    public function asCallableType(CodeBase $code_base): ?Type
     {
         return CallableArrayType::instance(false);
     }

--- a/src/Phan/Language/Type/ArrayType.php
+++ b/src/Phan/Language/Type/ArrayType.php
@@ -451,13 +451,14 @@ class ArrayType extends IterableType
         if (\in_array($type, $this->asExpandedTypes($code_base)->getTypeSet(), true)) {
             return true;
         }
-        if ($type instanceof ArrayShapeType && \get_class($this) === ArrayType::class) {
+        if ($type instanceof ArrayShapeType) {
+            // isSubtypeOf is overridden by ArrayShapeType
             return false;
         }
 
         $other_is_nullable = $type->isNullable();
         // A nullable type is not a subtype of a non-nullable type
-        if ($this->isNullable() && !$other_is_nullable) {
+        if ($this->is_nullable && !$other_is_nullable) {
             return false;
         }
 

--- a/src/Phan/Language/Type/AssociativeArrayType.php
+++ b/src/Phan/Language/Type/AssociativeArrayType.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phan\Language\Type;
 
+use Phan\CodeBase;
 use Phan\Language\Type;
 
 /**
@@ -57,16 +58,16 @@ class AssociativeArrayType extends GenericArrayType
      * True if this Type can be cast to the given Type
      * cleanly
      */
-    protected function canCastToNonNullableType(Type $type): bool
+    protected function canCastToNonNullableType(Type $type, CodeBase $code_base): bool
     {
         return $this->canCastToTypeCommon($type) &&
-            parent::canCastToNonNullableType($type);
+            parent::canCastToNonNullableType($type, $code_base);
     }
 
-    protected function canCastToNonNullableTypeWithoutConfig(Type $type): bool
+    protected function canCastToNonNullableTypeWithoutConfig(Type $type, CodeBase $code_base): bool
     {
         return $this->canCastToTypeCommon($type) &&
-            parent::canCastToNonNullableTypeWithoutConfig($type);
+            parent::canCastToNonNullableTypeWithoutConfig($type, $code_base);
     }
 
     private function canCastToTypeCommon(Type $type): bool

--- a/src/Phan/Language/Type/BoolType.php
+++ b/src/Phan/Language/Type/BoolType.php
@@ -105,6 +105,15 @@ final class BoolType extends ScalarType
         return self::performComparison(false, $scalar, $flags) ||
             self::performComparison(true, $scalar, $flags);
     }
+
+    /**
+     * @unused-param $code_base
+     */
+    public function isSubtypeOf(Type $type, CodeBase $code_base): bool
+    {
+        return $type instanceof BoolType || $type instanceof ScalarRawType || $type instanceof MixedType;
+    }
+
 }
 
 // Temporary hack to load FalseType and TrueType before BoolType::instance() is called

--- a/src/Phan/Language/Type/CallableArrayType.php
+++ b/src/Phan/Language/Type/CallableArrayType.php
@@ -64,7 +64,7 @@ class CallableArrayType extends ArrayType
 
     public function canCastToDeclaredType(CodeBase $code_base, Context $context, Type $other): bool
     {
-        if ($other->isDefiniteNonCallableType()) {
+        if ($other->isDefiniteNonCallableType($code_base)) {
             return false;
         }
         if ($other instanceof IterableType) {

--- a/src/Phan/Language/Type/CallableDeclarationType.php
+++ b/src/Phan/Language/Type/CallableDeclarationType.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phan\Language\Type;
 
+use Phan\CodeBase;
 use Phan\Language\Type;
 
 /**
@@ -22,30 +23,27 @@ final class CallableDeclarationType extends FunctionLikeDeclarationType implemen
      * True if this Type can be cast to the given Type
      * cleanly
      */
-    public function canCastToNonNullableType(Type $type): bool
+    public function canCastToNonNullableType(Type $type, CodeBase $code_base): bool
     {
-        if ($type->isCallable()) {
-            if ($type instanceof FunctionLikeDeclarationType) {
-                // TODO: Weaker mode to allow callable to cast to Closure
-                return $type instanceof CallableDeclarationType && $this->canCastToNonNullableFunctionLikeDeclarationType($type);
-            }
-            return true;
-        }
-
-        return parent::canCastToNonNullableType($type);
+        return $this->isCompatibleCallable($type, $code_base) ?? parent::canCastToNonNullableType($type, $code_base);
     }
 
-    public function canCastToNonNullableTypeWithoutConfig(Type $type): bool
+    public function canCastToNonNullableTypeWithoutConfig(Type $type, CodeBase $code_base): bool
     {
-        if ($type->isCallable()) {
+        return $this->isCompatibleCallable($type, $code_base) ?? parent::canCastToNonNullableTypeWithoutConfig($type, $code_base);
+    }
+
+    private function isCompatibleCallable(Type $type, CodeBase $code_base): ?bool
+    {
+        if ($type->isCallable($code_base)) {
+            // TODO: More precise intersection type support
             if ($type instanceof FunctionLikeDeclarationType) {
                 // TODO: Weaker mode to allow callable to cast to Closure
-                return $type instanceof CallableDeclarationType && $this->canCastToNonNullableFunctionLikeDeclarationType($type);
+                return $type instanceof CallableDeclarationType && $this->canCastToNonNullableFunctionLikeDeclarationType($type, $code_base);
             }
             return true;
         }
-
-        return parent::canCastToNonNullableTypeWithoutConfig($type);
+        return null;
     }
 
     /**

--- a/src/Phan/Language/Type/CallableObjectType.php
+++ b/src/Phan/Language/Type/CallableObjectType.php
@@ -26,7 +26,7 @@ final class CallableObjectType extends ObjectType
         parent::__construct('\\', self::NAME, [], $is_nullable);
     }
 
-    protected function canCastToNonNullableType(Type $type): bool
+    protected function canCastToNonNullableType(Type $type, CodeBase $code_base): bool
     {
         // Inverse of check in Type->canCastToNullableType
         if (!$type->isPossiblyObject()) {
@@ -35,10 +35,10 @@ final class CallableObjectType extends ObjectType
         if ($type instanceof CallableInterface) {
             return true;
         }
-        return parent::canCastToNonNullableType($type);
+        return parent::canCastToNonNullableType($type, $code_base);
     }
 
-    protected function canCastToNonNullableTypeWithoutConfig(Type $type): bool
+    protected function canCastToNonNullableTypeWithoutConfig(Type $type, CodeBase $code_base): bool
     {
         // Inverse of check in Type->canCastToNullableType
         if (!$type->isPossiblyObject()) {
@@ -47,15 +47,16 @@ final class CallableObjectType extends ObjectType
         if ($type instanceof CallableInterface) {
             return true;
         }
-        return parent::canCastToNonNullableTypeWithoutConfig($type);
+        return parent::canCastToNonNullableTypeWithoutConfig($type, $code_base);
     }
 
     /**
      * @return bool
      * True if this type is a callable
      * @override
+     * @unused-param $code_base
      */
-    public function isCallable(): bool
+    public function isCallable(CodeBase $code_base): bool
     {
         return true;  // Overridden in various subclasses
     }

--- a/src/Phan/Language/Type/CallableStringType.php
+++ b/src/Phan/Language/Type/CallableStringType.php
@@ -25,30 +25,32 @@ final class CallableStringType extends StringType implements CallableInterface
     /**
      * @return bool
      * True if this type is a callable or a Closure.
+     * @unused-param $code_base
      */
-    public function isCallable(): bool
+    public function isCallable(CodeBase $code_base): bool
     {
         return true;
     }
 
-    protected function canCastToNonNullableType(Type $type): bool
+    protected function canCastToNonNullableType(Type $type, CodeBase $code_base): bool
     {
         // CallableDeclarationType is not a native type, we check separately here
-        return parent::canCastToNonNullableType($type) || $type instanceof CallableDeclarationType;
+        return parent::canCastToNonNullableType($type, $code_base) || $type instanceof CallableDeclarationType;
     }
 
-    protected function canCastToNonNullableTypeWithoutConfig(Type $type): bool
+    protected function canCastToNonNullableTypeWithoutConfig(Type $type, CodeBase $code_base): bool
     {
         // CallableDeclarationType is not a native type, we check separately here
-        return parent::canCastToNonNullableTypeWithoutConfig($type) || $type instanceof CallableDeclarationType;
+        return parent::canCastToNonNullableTypeWithoutConfig($type, $code_base) || $type instanceof CallableDeclarationType;
     }
 
     /**
      * Returns true if this contains a type that is definitely non-callable
      * e.g. returns true for false, array, int
      *      returns false for callable, string, array, object, iterable, T, etc.
+     * @unused-param $code_base
      */
-    public function isDefiniteNonCallableType(): bool
+    public function isDefiniteNonCallableType(CodeBase $code_base): bool
     {
         return false;
     }

--- a/src/Phan/Language/Type/CallableType.php
+++ b/src/Phan/Language/Type/CallableType.php
@@ -24,30 +24,32 @@ final class CallableType extends NativeType implements CallableInterface
     /**
      * @return bool
      * True if this type is a callable or a Closure.
+     * @unused-param $code_base
      */
-    public function isCallable(): bool
+    public function isCallable(CodeBase $code_base): bool
     {
         return true;
     }
 
-    protected function canCastToNonNullableType(Type $type): bool
+    protected function canCastToNonNullableType(Type $type, CodeBase $code_base): bool
     {
         // CallableDeclarationType is not a native type, we check separately here
-        return parent::canCastToNonNullableType($type) || $type instanceof CallableDeclarationType;
+        return parent::canCastToNonNullableType($type, $code_base) || $type instanceof CallableDeclarationType;
     }
 
-    protected function canCastToNonNullableTypeWithoutConfig(Type $type): bool
+    protected function canCastToNonNullableTypeWithoutConfig(Type $type, CodeBase $code_base): bool
     {
         // CallableDeclarationType is not a native type, we check separately here
-        return parent::canCastToNonNullableTypeWithoutConfig($type) || $type instanceof CallableDeclarationType;
+        return parent::canCastToNonNullableTypeWithoutConfig($type, $code_base) || $type instanceof CallableDeclarationType;
     }
 
     /**
      * Returns true if this contains a type that is definitely non-callable
      * e.g. returns true for false, array, int
      *      returns false for callable, string, array, object, iterable, T, etc.
+     * @unused-param $code_base
      */
-    public function isDefiniteNonCallableType(): bool
+    public function isDefiniteNonCallableType(CodeBase $code_base): bool
     {
         return false;
     }
@@ -79,7 +81,7 @@ final class CallableType extends NativeType implements CallableInterface
     public function canCastToDeclaredType(CodeBase $code_base, Context $context, Type $other): bool
     {
         if ($other instanceof IterableType) {
-            return !$other->isDefiniteNonCallableType();
+            return !$other->isDefiniteNonCallableType($code_base);
         }
         // TODO: More specific.
         return $other instanceof StringType

--- a/src/Phan/Language/Type/ClassStringType.php
+++ b/src/Phan/Language/Type/ClassStringType.php
@@ -60,6 +60,7 @@ final class ClassStringType extends StringType
         if (!$template_union_type) {
             return UnionType::empty();
         }
+        // TODO: Update uses to support intersection types?
         return $template_union_type->makeFromFilter(static function (Type $type): bool {
             return $type instanceof TemplateType || $type->isObjectWithKnownFQSEN();
         });

--- a/src/Phan/Language/Type/ClosureDeclarationParameter.php
+++ b/src/Phan/Language/Type/ClosureDeclarationParameter.php
@@ -101,7 +101,7 @@ final class ClosureDeclarationParameter
      *
      * @see \Phan\Analysis\ParameterTypesAnalyzer::analyzeOverrideSignatureForOverriddenMethod() - Similar logic using LSP
      */
-    public function canCastToParameterIgnoringVariadic(ClosureDeclarationParameter $other): bool
+    public function canCastToParameterIgnoringVariadic(ClosureDeclarationParameter $other, CodeBase $code_base): bool
     {
         if ($this->is_reference !== $other->is_reference) {
             return false;
@@ -111,7 +111,7 @@ final class ClosureDeclarationParameter
             return false;
         }
         // TODO: stricter? (E.g. shouldn't allow int|string to cast to int)
-        return $this->type->canCastToUnionType($other->type);
+        return $this->type->canCastToUnionType($other->type, $code_base);
     }
 
     /**
@@ -132,7 +132,7 @@ final class ClosureDeclarationParameter
             return false;
         }
         // TODO: stricter? (E.g. shouldn't allow int|string to cast to int)
-        return $this->type->canCastToUnionTypeHandlingTemplates($other->type, $code_base);
+        return $this->type->canCastToUnionType($other->type, $code_base);
     }
 
     /**

--- a/src/Phan/Language/Type/ClosureDeclarationType.php
+++ b/src/Phan/Language/Type/ClosureDeclarationType.php
@@ -25,28 +25,28 @@ final class ClosureDeclarationType extends FunctionLikeDeclarationType
      * True if this Type can be cast to the given Type
      * cleanly
      */
-    public function canCastToNonNullableType(Type $type): bool
+    public function canCastToNonNullableType(Type $type, CodeBase $code_base): bool
     {
-        if ($type->isCallable()) {
+        if ($type->isCallable($code_base)) {
             if ($type instanceof FunctionLikeDeclarationType) {
-                return $this->canCastToNonNullableFunctionLikeDeclarationType($type);
+                return $this->canCastToNonNullableFunctionLikeDeclarationType($type, $code_base);
             }
             return true;
         }
 
-        return parent::canCastToNonNullableType($type);
+        return parent::canCastToNonNullableType($type, $code_base);
     }
 
-    public function canCastToNonNullableTypeWithoutConfig(Type $type): bool
+    public function canCastToNonNullableTypeWithoutConfig(Type $type, CodeBase $code_base): bool
     {
-        if ($type->isCallable()) {
+        if ($type->isCallable($code_base)) {
             if ($type instanceof FunctionLikeDeclarationType) {
-                return $this->canCastToNonNullableFunctionLikeDeclarationType($type);
+                return $this->canCastToNonNullableFunctionLikeDeclarationType($type, $code_base);
             }
             return true;
         }
 
-        return parent::canCastToNonNullableTypeWithoutConfig($type);
+        return parent::canCastToNonNullableTypeWithoutConfig($type, $code_base);
     }
 
     /**
@@ -68,8 +68,11 @@ final class ClosureDeclarationType extends FunctionLikeDeclarationType
         if (!$other->isPossiblyObject()) {
             return false;
         }
-        if ($other->isObjectWithKnownFQSEN()) {
-            return $other instanceof FunctionLikeDeclarationType || $other instanceof ClosureType || $other->asFQSEN()->__toString() === '\Closure';
+        if ($other->hasObjectWithKnownFQSEN()) {
+            // Probably overkill to check for intersection types for closure
+            return $other->anyTypePartsMatchCallback(static function (Type $part): bool {
+                return $part instanceof FunctionLikeDeclarationType || $part instanceof ClosureType || $part->asFQSEN()->__toString() === '\Closure';
+            });
         }
         return true;
     }

--- a/src/Phan/Language/Type/ClosureType.php
+++ b/src/Phan/Language/Type/ClosureType.php
@@ -34,7 +34,10 @@ final class ClosureType extends Type
      */
     private $func;
 
-    // Same as instance(), but guaranteed not to have memoized state.
+    /**
+     * Same as instance(), but guaranteed not to have memoized state.
+     * @suppress PhanTypeMismatchReturn
+     */
     private static function closureInstance(): ClosureType
     {
         static $instance = null;

--- a/src/Phan/Language/Type/ClosureType.php
+++ b/src/Phan/Language/Type/ClosureType.php
@@ -130,6 +130,26 @@ final class ClosureType extends Type
 
     /**
      * @return bool
+     * True if this Type can be cast to the given Type
+     * cleanly
+     */
+    protected function canCastToNonNullableTypeHandlingTemplates(Type $type, CodeBase $code_base): bool
+    {
+        if ($type->isCallable($code_base)) {
+            if ($type instanceof FunctionLikeDeclarationType) {
+                // Check if the function declaration is known and available. It's not available for the generic \Closure.
+                if ($this->func) {
+                    return $this->func->asFunctionLikeDeclarationType()->canCastToNonNullableFunctionLikeDeclarationType($type, $code_base);
+                }
+            }
+            return true;
+        }
+
+        return parent::canCastToNonNullableTypeHandlingTemplates($type, $code_base);
+    }
+
+    /**
+     * @return bool
      * True if this type is a callable or a Closure.
      * @unused-param $code_base
      */
@@ -188,5 +208,13 @@ final class ClosureType extends Type
             });
         }
         return true;
+    }
+
+    public function isSubtypeOf(Type $type, CodeBase $code_base): bool
+    {
+        if ($type instanceof FunctionLikeDeclarationType) {
+            return false;
+        }
+        return parent::isSubtypeOf($type, $code_base);
     }
 }

--- a/src/Phan/Language/Type/GenericIterableType.php
+++ b/src/Phan/Language/Type/GenericIterableType.php
@@ -499,4 +499,13 @@ final class GenericIterableType extends IterableType
             Type::FROM_TYPE
         );
     }
+
+    public function isSubtypeOf(Type $type, CodeBase $code_base): bool
+    {
+        if ($type instanceof GenericIterableType) {
+            return $this->key_union_type->isStrictSubtypeOf($code_base, $type->key_union_type) &&
+                $this->element_union_type->isStrictSubtypeOf($code_base, $type->element_union_type);
+        }
+        return \get_class($type) === IterableType::class || $type instanceof MixedType;
+    }
 }

--- a/src/Phan/Language/Type/GenericIterableType.php
+++ b/src/Phan/Language/Type/GenericIterableType.php
@@ -115,33 +115,33 @@ final class GenericIterableType extends IterableType
         return $cache[$key] ?? ($cache[$key] = new self($key_union_type, $element_union_type, $is_nullable));
     }
 
-    public function canCastToNonNullableType(Type $type): bool
+    public function canCastToNonNullableType(Type $type, CodeBase $code_base): bool
     {
         if ($type instanceof GenericIterableType) {
             // TODO: Account for scalar key casting config?
-            if (!$this->key_union_type->canCastToUnionType($type->key_union_type)) {
+            if (!$this->key_union_type->canCastToUnionType($type->key_union_type, $code_base)) {
                 return false;
             }
-            if (!$this->element_union_type->canCastToUnionType($type->element_union_type)) {
+            if (!$this->element_union_type->canCastToUnionType($type->element_union_type, $code_base)) {
                 return false;
             }
             return true;
         }
-        return parent::canCastToNonNullableType($type);
+        return parent::canCastToNonNullableType($type, $code_base);
     }
 
-    public function canCastToNonNullableTypeWithoutConfig(Type $type): bool
+    public function canCastToNonNullableTypeWithoutConfig(Type $type, CodeBase $code_base): bool
     {
         if ($type instanceof GenericIterableType) {
-            if (!$this->key_union_type->canCastToUnionTypeWithoutConfig($type->key_union_type)) {
+            if (!$this->key_union_type->canCastToUnionTypeWithoutConfig($type->key_union_type, $code_base)) {
                 return false;
             }
-            if (!$this->element_union_type->canCastToUnionTypeWithoutConfig($type->element_union_type)) {
+            if (!$this->element_union_type->canCastToUnionTypeWithoutConfig($type->element_union_type, $code_base)) {
                 return false;
             }
             return true;
         }
-        return parent::canCastToNonNullableTypeWithoutConfig($type);
+        return parent::canCastToNonNullableTypeWithoutConfig($type, $code_base);
     }
     /**
      * Returns true for `T` and `T[]` and `\MyClass<T>`, but not `\MyClass<\OtherClass>` or `false`
@@ -306,6 +306,7 @@ final class GenericIterableType extends IterableType
         }
 
         return $this->memoize(__METHOD__, function () use ($code_base, $recursion_depth): UnionType {
+            // TODO: convert (A&B)[] to (A&B)[]|A[]|B[]
             $element_types = $this->element_union_type->getTypeSet();
             if (count($element_types) >= 2) {
                 $union_type_builder = new UnionTypeBuilder();
@@ -399,6 +400,7 @@ final class GenericIterableType extends IterableType
         }
 
         return $this->memoize(__METHOD__, function () use ($code_base, $recursion_depth): UnionType {
+            // TODO: convert (A&B)[] to (A&B)[]|A[]|B[]
             $element_types = $this->element_union_type->getTypeSet();
             if (count($element_types) >= 2) {
                 $union_type_builder = new UnionTypeBuilder();

--- a/src/Phan/Language/Type/GenericMultiArrayType.php
+++ b/src/Phan/Language/Type/GenericMultiArrayType.php
@@ -170,11 +170,12 @@ final class GenericMultiArrayType extends ArrayType implements MultiType, Generi
      * True if this Type can be cast to the given Type
      * cleanly
      */
-    protected function canCastToNonNullableType(Type $type): bool
+    protected function canCastToNonNullableType(Type $type, CodeBase $code_base): bool
     {
         if ($type instanceof GenericArrayType) {
             return $this->genericArrayElementUnionType()->canCastToUnionType(
-                $type->genericArrayElementUnionType()
+                $type->genericArrayElementUnionType(),
+                $code_base
             );
         }
 
@@ -192,14 +193,15 @@ final class GenericMultiArrayType extends ArrayType implements MultiType, Generi
             return true;
         }
 
-        return parent::canCastToNonNullableType($type);
+        return parent::canCastToNonNullableType($type, $code_base);
     }
 
-    protected function canCastToNonNullableTypeWithoutConfig(Type $type): bool
+    protected function canCastToNonNullableTypeWithoutConfig(Type $type, CodeBase $code_base): bool
     {
         if ($type instanceof GenericArrayType) {
             return $this->genericArrayElementUnionType()->canCastToUnionType(
-                $type->genericArrayElementUnionType()
+                $type->genericArrayElementUnionType(),
+                $code_base
             );
         }
 
@@ -217,7 +219,7 @@ final class GenericMultiArrayType extends ArrayType implements MultiType, Generi
             return true;
         }
 
-        return parent::canCastToNonNullableTypeWithoutConfig($type);
+        return parent::canCastToNonNullableTypeWithoutConfig($type, $code_base);
     }
 
     public function isGenericArray(): bool

--- a/src/Phan/Language/Type/IntersectionType.php
+++ b/src/Phan/Language/Type/IntersectionType.php
@@ -1,0 +1,386 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phan\Language\Type;
+
+use AssertionError;
+use Closure;
+use Generator;
+use Phan\CodeBase;
+use Phan\Language\Context;
+use Phan\Language\Type;
+use Phan\Language\UnionType;
+use Phan\Language\UnionTypeBuilder;
+
+use function implode;
+use function in_array;
+use function count;
+use function get_debug_type;
+use function reset;
+
+/**
+ * Represents the intersection of two or more object types
+ * TODO: Forbid non-object types when creating this IntersectionType?
+ * @phan-pure
+ */
+final class IntersectionType extends Type
+{
+    /** @var non-empty-list<Type> the parts of the intersection type */
+    protected $type_parts;
+
+    /** @param non-empty-list<Type> $type_parts */
+    private function __construct(array $type_parts)
+    {
+        if (\count($type_parts) < 2) {
+            throw new AssertionError("Too few type_parts in intersection type (" . implode('&', $type_parts) . ')') ;
+        }
+        // an intersection type is nullable if all type_parts it contains are nullable.
+        // FIXME: Normalize (?A)&B
+        $is_nullable = true;
+        foreach ($type_parts as $type) {
+            if (!$type instanceof Type) {
+                throw new AssertionError("IntersectionType expected all arguments to be type_parts, got " . get_debug_type($type));
+            } elseif ($type instanceof IntersectionType) {
+                throw new AssertionError("Intersection type_parts must contain atomic type_parts");
+            }
+            $is_nullable = $is_nullable && $type->isNullable();
+        }
+        $this->type_parts = $type_parts;
+        parent::__construct('\\', '', [], $is_nullable);
+    }
+
+    /**
+     * @return non-empty-list<Type> the list of parts of this intersection type.
+     */
+    public function getTypeParts(): array
+    {
+        return $this->type_parts;
+    }
+
+    /**
+     * @return IntersectionType
+     * @override
+     */
+    public function withIsNullable(bool $is_nullable): Type {
+        if ($this->is_nullable === $is_nullable) {
+            return $this;
+        }
+        $new_types = [];
+        foreach ($this->type_parts as $type) {
+            $new_types[] = $type->withIsNullable($is_nullable);
+        }
+        return new self($new_types);
+    }
+
+    /**
+     * Create an intersection type from a list of type_parts
+     *
+     * @param non-empty-list<Type|UnionType> $types
+     * @param ?CodeBase $code_base
+     * @param ?Context $context @unused-param
+     */
+    public static function createFromTypes(array $types, ?CodeBase $code_base, ?Context $context): Type
+    {
+        $new_types = self::flattenTypes($types);
+        if (!$new_types) {
+            throw new AssertionError('Saw empty list of type_parts in intersection type');
+        }
+        if (count($new_types) === 1) {
+            return reset($new_types);
+        }
+        // NOTE: This is not useful for intersection types created in the parse phase,
+        // because those were already parsed
+        if ($code_base) {
+            foreach ($new_types as $i => $type) {
+                if (!isset($new_types[$i])) {
+                    continue;
+                }
+                foreach ($new_types as $j => $other) {
+                    if ($j === $i) {
+                        continue;
+                    }
+                    // For example, ArrayObject is a subtype of Countable, so Countable is redundant to add to an intersection type
+                    if ($type->isSubtypeOf($other, $code_base)) {
+                        unset($new_types[$j]);
+                    }
+                }
+            }
+            if (count($new_types) === 1) {
+                // @phan-suppress-next-line PhanPossiblyFalseTypeReturn
+                return reset($new_types);
+            }
+            $new_types = \array_values($new_types);
+        }
+        // avoid storing an equivalent copy of an array that may already be referenced elsewhere
+        // to reduce memory usage
+        if ($types !== $new_types) {
+            // @phan-suppress-next-line PhanPartialTypeMismatchArgument
+            return new self($new_types);
+        }
+        // @phan-suppress-next-line PhanPartialTypeMismatchArgument
+        return new self($types);
+    }
+
+    /**
+     * Convert a list of types and union types (e.g. from phpdoc)
+     * into a list of Types that are not IntersectionType instances
+     *
+     * @param non-empty-list<Type|UnionType> $types
+     * @return non-empty-list<Type>
+     */
+    public static function flattenTypes(array $types): array
+    {
+        $new_types = [];
+        foreach ($types as $type) {
+            if ($type instanceof UnionType) {
+                $type_set = $type->getTypeSet();
+                if (count($type_set) !== 1) {
+                    throw new AssertionError("Expected union type_parts to contain a single type");
+                }
+                $type = reset($type_set);
+            }
+            foreach ($type instanceof IntersectionType ? $type->type_parts : [$type] as $part) {
+                // TODO: if ($type instanceof IntersectionType)
+                if (!in_array($part, $new_types, true)) {
+                    $new_types[] = $part;
+                }
+            }
+        }
+        if (!$new_types) {
+            throw new AssertionError("Did not expect empty list of types for intersection type");
+        }
+        // @phan-suppress-next-line PhanPartialTypeMismatchReturn
+        return $new_types;
+    }
+
+    /**
+     * @override
+     */
+    public function __toString(): string
+    {
+        return $this->memoize(__METHOD__, function (): string {
+            return implode('&', $this->type_parts);
+        });
+    }
+
+    /**
+     * @return Generator<mixed,Type> ($outer_type => $inner_type)
+     *
+     * This includes classes, StaticType (and "self"), and TemplateType.
+     * This includes duplicate definitions
+     * TODO: Warn about Closure Declarations with invalid parameters...
+     *
+     * TODO: Use different helper for GoToDefinitionRequest
+     * @override
+     */
+    public function getReferencedClasses(): Generator
+    {
+        foreach ($this->type_parts as $outer_type) {
+            foreach ($outer_type->getReferencedClasses() as $type) {
+                yield $outer_type => $type;
+            }
+        }
+    }
+
+    /**
+     * This is not an object with a single known fqsen, it is one with multiple fqsens
+     * @override
+     */
+    public function isObjectWithKnownFQSEN(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @override
+     */
+    protected function computeExpandedTypes(CodeBase $code_base, int $recursion_depth): UnionType
+    {
+        $recursive_union_type_builder = new UnionTypeBuilder();
+        $recursive_union_type_builder->addType($this);
+        foreach ($this->type_parts as $type) {
+            $recursive_union_type_builder->addUnionType($type->asExpandedTypes($code_base, $recursion_depth + 1));
+        }
+
+        return $recursive_union_type_builder->getPHPDocUnionType();
+    }
+
+    /**
+     * @return bool
+     * True if this Type can be cast to the given Type
+     * cleanly (accounting for templates)
+     * @override
+     */
+    public function canCastToType(Type $type, CodeBase $code_base): bool
+    {
+        // Handle intersection -> intersection cast
+        return $this->anyTypePartsMatchOtherTypePartsCallback(static function (Type $part, Type $other_part) use ($code_base): bool {
+            return $part->canCastToType($other_part, $code_base);
+        }, $type);
+    }
+
+    /**
+     * @return bool
+     * True if this Type can be cast to the given Type
+     * cleanly without config settings.
+     * @override
+     */
+    public function canCastToTypeWithoutConfig(Type $type, CodeBase $code_base): bool
+    {
+        // TODO: Handle intersection -> intersection cast
+        return $this->anyTypePartsMatchOtherTypePartsCallback(static function (Type $part, Type $other_part) use ($code_base): bool {
+            return $part->canCastToTypeWithoutConfig($other_part, $code_base);
+        }, $type);
+    }
+
+    /**
+     * @override
+     * @deprecated
+     */
+    protected function canCastToNonNullableType(Type $type, CodeBase $code_base): bool
+    {
+        // TODO: Handle intersection -> intersection cast
+        return $this->anyTypePartsMatchOtherTypePartsCallback(static function (Type $part, Type $other_part) use ($code_base): bool {
+            return $part->canCastToNonNullableType($other_part, $code_base);
+        }, $type);
+    }
+
+    /**
+     * @override
+     */
+    public function canCastToNonNullableTypeHandlingTemplates(Type $type, CodeBase $code_base): bool
+    {
+        // TODO: Handle intersection -> intersection cast
+        return $this->anyTypePartsMatchOtherTypePartsCallback(static function (Type $part, Type $other_part) use($code_base): bool {
+            return $part->canCastToNonNullableTypeHandlingTemplates($other_part, $code_base);
+        }, $type);
+    }
+
+    /**
+     * @override
+     */
+    protected function canCastToNonNullableTypeWithoutConfig(Type $type, CodeBase $code_base): bool
+    {
+        return $this->anyTypePartsMatchOtherTypePartsCallback(static function (Type $part, Type $other_part) use ($code_base): bool {
+            return $part->canCastToNonNullableTypeWithoutConfig($other_part, $code_base);
+        }, $type);
+    }
+
+    /**
+     * @override
+     */
+    public function isSubtypeOf(Type $type, CodeBase $code_base): bool
+    {
+        return $this->anyTypePartsMatchOtherTypePartsCallback(static function (Type $part, Type $other_part) use ($code_base): bool {
+            return $part->isSubtypeOf($other_part, $code_base);
+        }, $type);
+    }
+
+    /**
+     * @override
+     */
+    public function isSubtypeOfNonNullableType(Type $type, CodeBase $code_base): bool
+    {
+        return $this->anyTypePartsMatchOtherTypePartsCallback(static function (Type $part, Type $other_part) use ($code_base): bool {
+            return $part->isSubtypeOfNonNullableType($other_part, $code_base);
+        }, $type);
+    }
+
+    /**
+     * Returns true if each of the types in this IntersectionType made $matcher_callback return true
+     * @param Closure(Type): bool $matcher_callback
+     */
+    public function allTypePartsMatchCallback(Closure $matcher_callback): bool
+    {
+        foreach ($this->type_parts as $type) {
+            if (!$matcher_callback($type)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Returns true if any of the types in this IntersectionType made $matcher_callback return true
+     * @param Closure(Type): bool $matcher_callback
+     * @override
+     */
+    public function anyTypePartsMatchCallback(Closure $matcher_callback): bool
+    {
+        foreach ($this->type_parts as $type) {
+            if ($matcher_callback($type)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns true if any of the types in this IntersectionType made $matcher_callback return true for all parts of $other
+     * @param Closure(Type, Type): bool $matcher_callback
+     * @param Type $other (can be IntersectionType)
+     */
+    public function anyTypePartsMatchOtherTypePartsCallback(Closure $matcher_callback, Type $other): bool
+    {
+        if ($other instanceof IntersectionType) {
+            foreach ($other->type_parts as $other_part) {
+                if (!$this->anyTypePartsMatchOtherTypePartsCallback($matcher_callback, $other_part)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        foreach ($this->type_parts as $type) {
+            if ($matcher_callback($type, $other)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Creates a type or intersection type by transforming this intersection type
+     * @param Closure(Type): Type $mapping_callback
+     */
+    public function mapTypeParts(Closure $mapping_callback): Type
+    {
+        $new_types = [];
+        foreach ($this->type_parts as $type) {
+            $new_types[] = $mapping_callback($type);
+        }
+        if ($new_types === $this->type_parts) {
+            return $this;
+        }
+        return self::createFromTypes($new_types, null, null);
+    }
+
+    /**
+     * Convert `\MyClass<T>` and `\MyClass<\OtherClass>` to just `\MyClass`.
+     *
+     * TODO: Override in subclasses such as generic arrays, generic iterables, and array shapes.
+     * @override
+     */
+    public function eraseTemplatesRecursive(): Type
+    {
+        return $this->mapTypeParts(static function (Type $part): Type {
+            return $part->eraseTemplatesRecursive();
+        });
+    }
+
+    public function canUseInRealSignature(): bool
+    {
+        // TODO: Enable when supported for php 8.1 and minimum_target_php_version_id is satisfied and all parts work
+        return false;
+    }
+
+    public function hasObjectWithKnownFQSEN(): bool
+    {
+        foreach ($this->type_parts as $type) {
+            if ($type->hasObjectWithKnownFQSEN()) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/Phan/Language/Type/IterableType.php
+++ b/src/Phan/Language/Type/IterableType.php
@@ -21,7 +21,10 @@ class IterableType extends NativeType
     /** @phan-override */
     public const NAME = 'iterable';
 
-    public function isIterable(): bool
+    /**
+     * @unused-param $code_base
+     */
+    public function isIterable(CodeBase $code_base): bool
     {
         return true;
     }
@@ -34,7 +37,6 @@ class IterableType extends NativeType
     {
         // TODO: Check if $other is final and non-iterable
         return $other instanceof IterableType ||
-            $other instanceof GenericIterableType ||
             $other instanceof CallableDeclarationType ||
             $other->isPossiblyObject();
     }

--- a/src/Phan/Language/Type/IterableType.php
+++ b/src/Phan/Language/Type/IterableType.php
@@ -34,8 +34,17 @@ class IterableType extends NativeType
     {
         // TODO: Check if $other is final and non-iterable
         return $other instanceof IterableType ||
+            $other instanceof GenericIterableType ||
             $other instanceof CallableDeclarationType ||
             $other->isPossiblyObject();
+    }
+
+    /**
+     * @unused-param $code_base
+     */
+    public function isSubtypeOf(Type $type, CodeBase $code_base): bool
+    {
+        return \get_class($type) === IterableType::class || $type instanceof MixedType;
     }
 
     /**

--- a/src/Phan/Language/Type/ListType.php
+++ b/src/Phan/Language/Type/ListType.php
@@ -26,6 +26,7 @@ class ListType extends GenericArrayType
 
     /**
      * @unused-param $key_type
+     * @return ListType
      */
     public static function fromElementType(
         Type $type,

--- a/src/Phan/Language/Type/ListType.php
+++ b/src/Phan/Language/Type/ListType.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phan\Language\Type;
 
+use Phan\CodeBase;
 use Phan\Language\Type;
 use Phan\Language\UnionType;
 
@@ -59,16 +60,16 @@ class ListType extends GenericArrayType
      * True if this Type can be cast to the given Type
      * cleanly
      */
-    protected function canCastToNonNullableType(Type $type): bool
+    protected function canCastToNonNullableType(Type $type, CodeBase $code_base): bool
     {
         return $this->canCastToTypeCommon($type) &&
-            parent::canCastToNonNullableType($type);
+            parent::canCastToNonNullableType($type, $code_base);
     }
 
-    protected function canCastToNonNullableTypeWithoutConfig(Type $type): bool
+    protected function canCastToNonNullableTypeWithoutConfig(Type $type, CodeBase $code_base): bool
     {
         return $this->canCastToTypeCommon($type) &&
-            parent::canCastToNonNullableTypeWithoutConfig($type);
+            parent::canCastToNonNullableTypeWithoutConfig($type, $code_base);
     }
 
     private function canCastToTypeCommon(Type $type): bool

--- a/src/Phan/Language/Type/LiteralFloatType.php
+++ b/src/Phan/Language/Type/LiteralFloatType.php
@@ -136,7 +136,7 @@ final class LiteralFloatType extends FloatType implements LiteralTypeInterface
      * True if this Type can be cast to the given Type
      * cleanly
      */
-    protected function canCastToNonNullableType(Type $type): bool
+    protected function canCastToNonNullableType(Type $type, CodeBase $code_base): bool
     {
         if ($type instanceof ScalarType) {
             switch ($type::NAME) {
@@ -175,7 +175,7 @@ final class LiteralFloatType extends FloatType implements LiteralTypeInterface
             }
         }
 
-        return parent::canCastToNonNullableType($type);
+        return parent::canCastToNonNullableType($type, $code_base);
     }
 
     /**
@@ -183,7 +183,7 @@ final class LiteralFloatType extends FloatType implements LiteralTypeInterface
      * True if this Type can be cast to the given Type
      * cleanly, ignoring permissive config casting rules
      */
-    protected function canCastToNonNullableTypeWithoutConfig(Type $type): bool
+    protected function canCastToNonNullableTypeWithoutConfig(Type $type, CodeBase $code_base): bool
     {
         if ($type instanceof ScalarType) {
             switch ($type::NAME) {
@@ -197,7 +197,7 @@ final class LiteralFloatType extends FloatType implements LiteralTypeInterface
             }
         }
 
-        return parent::canCastToNonNullableType($type);
+        return parent::canCastToNonNullableType($type, $code_base);
     }
 
     /**
@@ -205,7 +205,7 @@ final class LiteralFloatType extends FloatType implements LiteralTypeInterface
      * True if this Type can be cast to the given Type
      * cleanly
      */
-    protected function isSubtypeOfNonNullableType(Type $type): bool
+    protected function isSubtypeOfNonNullableType(Type $type, CodeBase $code_base): bool
     {
         if ($type instanceof ScalarType) {
             if ($type::NAME === 'float') {
@@ -217,7 +217,7 @@ final class LiteralFloatType extends FloatType implements LiteralTypeInterface
             return false;
         }
 
-        return parent::isSubtypeOfNonNullableType($type);
+        return parent::isSubtypeOfNonNullableType($type, $code_base);
     }
 
     /**

--- a/src/Phan/Language/Type/LiteralFloatType.php
+++ b/src/Phan/Language/Type/LiteralFloatType.php
@@ -39,7 +39,7 @@ final class LiteralFloatType extends FloatType implements LiteralTypeInterface
     }
 
     /**
-     * @return LiteralFloatType a unique LiteralFloatType for $value (and the nullability)
+     * @return FloatType a unique LiteralFloatType for $value if $value is finite (and sets nullability)
      */
     public static function instanceForValue(float $value, bool $is_nullable): FloatType
     {

--- a/src/Phan/Language/Type/LiteralIntType.php
+++ b/src/Phan/Language/Type/LiteralIntType.php
@@ -130,7 +130,7 @@ final class LiteralIntType extends IntType implements LiteralTypeInterface
      * True if this Type can be cast to the given Type
      * cleanly
      */
-    protected function canCastToNonNullableType(Type $type): bool
+    protected function canCastToNonNullableType(Type $type, CodeBase $code_base): bool
     {
         if ($type instanceof ScalarType) {
             switch ($type::NAME) {
@@ -174,7 +174,7 @@ final class LiteralIntType extends IntType implements LiteralTypeInterface
             }
         }
 
-        return parent::canCastToNonNullableType($type);
+        return parent::canCastToNonNullableType($type, $code_base);
     }
 
     /**
@@ -182,7 +182,7 @@ final class LiteralIntType extends IntType implements LiteralTypeInterface
      * True if this Type can be cast to the given Type
      * cleanly
      */
-    protected function canCastToNonNullableTypeWithoutConfig(Type $type): bool
+    protected function canCastToNonNullableTypeWithoutConfig(Type $type, CodeBase $code_base): bool
     {
         if ($type instanceof ScalarType) {
             switch ($type::NAME) {
@@ -203,14 +203,14 @@ final class LiteralIntType extends IntType implements LiteralTypeInterface
             }
         }
 
-        return parent::canCastToNonNullableType($type);
+        return parent::canCastToNonNullableType($type, $code_base);
     }
 
     /**
      * @return bool
      * True if this Type is a subtype of the given type
      */
-    protected function isSubtypeOfNonNullableType(Type $type): bool
+    protected function isSubtypeOfNonNullableType(Type $type, CodeBase $code_base): bool
     {
         if ($type instanceof ScalarType) {
             if ($type instanceof IntType) {
@@ -225,7 +225,7 @@ final class LiteralIntType extends IntType implements LiteralTypeInterface
             return false;
         }
 
-        return parent::canCastToNonNullableType($type);
+        return parent::canCastToNonNullableType($type, $code_base);
     }
 
     /**

--- a/src/Phan/Language/Type/LiteralStringType.php
+++ b/src/Phan/Language/Type/LiteralStringType.php
@@ -228,7 +228,7 @@ final class LiteralStringType extends StringType implements LiteralTypeInterface
      * True if this Type can be cast to the given Type
      * cleanly
      */
-    protected function canCastToNonNullableType(Type $type): bool
+    protected function canCastToNonNullableType(Type $type, CodeBase $code_base): bool
     {
         if ($type instanceof ScalarType) {
             switch ($type::NAME) {
@@ -269,7 +269,7 @@ final class LiteralStringType extends StringType implements LiteralTypeInterface
             }
         }
 
-        return parent::canCastToNonNullableType($type);
+        return parent::canCastToNonNullableType($type, $code_base);
     }
 
     /**
@@ -316,7 +316,7 @@ final class LiteralStringType extends StringType implements LiteralTypeInterface
      * cleanly without config overrides
      * @override
      */
-    protected function canCastToNonNullableTypeWithoutConfig(Type $type): bool
+    protected function canCastToNonNullableTypeWithoutConfig(Type $type, CodeBase $code_base): bool
     {
         if ($type instanceof ScalarType) {
             switch ($type::NAME) {
@@ -332,14 +332,14 @@ final class LiteralStringType extends StringType implements LiteralTypeInterface
             }
         }
 
-        return parent::canCastToNonNullableType($type);
+        return parent::canCastToNonNullableType($type, $code_base);
     }
 
     /**
      * @return bool
      * True if this Type is a subtype of the given type.
      */
-    protected function isSubtypeOfNonNullableType(Type $type): bool
+    protected function isSubtypeOfNonNullableType(Type $type, CodeBase $code_base): bool
     {
         if ($type instanceof ScalarType) {
             if ($type instanceof StringType) {
@@ -353,7 +353,7 @@ final class LiteralStringType extends StringType implements LiteralTypeInterface
             return false;
         }
 
-        return parent::canCastToNonNullableType($type);
+        return parent::canCastToNonNullableType($type, $code_base);
     }
 
     /**

--- a/src/Phan/Language/Type/MixedType.php
+++ b/src/Phan/Language/Type/MixedType.php
@@ -90,7 +90,7 @@ class MixedType extends NativeType
      */
     public function isSubtypeOf(Type $type, CodeBase $code_base): bool
     {
-        return $type instanceof MixedType;
+        return \get_class($type) === MixedType::class;
     }
 
     /**
@@ -98,7 +98,7 @@ class MixedType extends NativeType
      */
     public function isSubtypeOfNonNullableType(Type $type, CodeBase $code_base): bool
     {
-        return $type instanceof MixedType;
+        return \get_class($type) === MixedType::class;
     }
 
     /**

--- a/src/Phan/Language/Type/MixedType.php
+++ b/src/Phan/Language/Type/MixedType.php
@@ -29,18 +29,20 @@ class MixedType extends NativeType
      * For purposes of analysis, there's usually no difference between mixed and nullable mixed.
      *
      * @unused-param $type
+     * @unused-param $code_base
      * @override
      */
-    public function canCastToType(Type $type): bool
+    public function canCastToType(Type $type, CodeBase $code_base): bool
     {
         return true;
     }
 
     /**
      * @param Type[] $target_type_set 1 or more types @phan-unused-param
+     * @unused-param $code_base
      * @override
      */
-    public function canCastToAnyTypeInSet(array $target_type_set): bool
+    public function canCastToAnyTypeInSet(array $target_type_set, CodeBase $code_base): bool
     {
         return true;
     }
@@ -48,9 +50,10 @@ class MixedType extends NativeType
     /**
      * Overridden in NonNullMixedType and NonEmptyMixedType
      * @unused-param $type
+     * @unused-param $code_base
      * @override
      */
-    public function canCastToTypeWithoutConfig(Type $type): bool
+    public function canCastToTypeWithoutConfig(Type $type, CodeBase $code_base): bool
     {
         return true;
     }
@@ -60,9 +63,10 @@ class MixedType extends NativeType
      * For purposes of analysis, there's usually no difference between mixed and nullable mixed.
      *
      * @unused-param $type
+     * @unused-param $code_base
      * @override
      */
-    protected function canCastToNonNullableType(Type $type): bool
+    protected function canCastToNonNullableType(Type $type, CodeBase $code_base): bool
     {
         return true;
     }
@@ -72,20 +76,27 @@ class MixedType extends NativeType
      * For purposes of analysis, there's usually no difference between mixed and nullable mixed.
      *
      * @unused-param $type
+     * @unused-param $code_base
      * @override
      */
-    protected function canCastToNonNullableTypeWithoutConfig(Type $type): bool
+    protected function canCastToNonNullableTypeWithoutConfig(Type $type, CodeBase $code_base): bool
     {
         return true;
     }
 
     // FIXME: non-empty-mixed/non-null-mixed is a subtype of mixed, but not vice versa?
-    public function isSubtypeOf(Type $type): bool
+    /**
+     * @unused-param $code_base
+     */
+    public function isSubtypeOf(Type $type, CodeBase $code_base): bool
     {
         return $type instanceof MixedType;
     }
 
-    public function isSubtypeOfNonNullableType(Type $type): bool
+    /**
+     * @unused-param $code_base
+     */
+    public function isSubtypeOfNonNullableType(Type $type, CodeBase $code_base): bool
     {
         return $type instanceof MixedType;
     }
@@ -160,7 +171,10 @@ class MixedType extends NativeType
         return false;
     }
 
-    public function isDefiniteNonCallableType(): bool
+    /**
+     * @unused-param $code_base
+     */
+    public function isDefiniteNonCallableType(CodeBase $code_base): bool
     {
         return false;
     }

--- a/src/Phan/Language/Type/NativeType.php
+++ b/src/Phan/Language/Type/NativeType.php
@@ -86,7 +86,7 @@ abstract class NativeType extends Type
      * True if this Type can be cast to the given Type
      * cleanly
      */
-    protected function canCastToNonNullableType(Type $type): bool
+    protected function canCastToNonNullableType(Type $type, CodeBase $code_base): bool
     {
         // Anything can cast to mixed or ?mixed
         // Not much of a distinction in nullable mixed, except to emphasize in comments that it definitely can be null.
@@ -99,7 +99,7 @@ abstract class NativeType extends Type
             || $this instanceof GenericArrayType
             || $type instanceof GenericArrayType
         ) {
-            return parent::canCastToNonNullableType($type);
+            return parent::canCastToNonNullableType($type, $code_base);
         }
 
         static $matrix;
@@ -109,7 +109,7 @@ abstract class NativeType extends Type
 
         // Both this and $type are NativeType and getName() isn't needed
         return $matrix[$this->name][$type->name]
-            ?? parent::canCastToNonNullableType($type);
+            ?? parent::canCastToNonNullableType($type, $code_base);
     }
 
     /**
@@ -117,7 +117,7 @@ abstract class NativeType extends Type
      * True if this Type can be cast to the given Type
      * cleanly
      */
-    protected function canCastToNonNullableTypeWithoutConfig(Type $type): bool
+    protected function canCastToNonNullableTypeWithoutConfig(Type $type, CodeBase $code_base): bool
     {
         // Anything can cast to mixed or ?mixed
         // Not much of a distinction in nullable mixed, except to emphasize in comments that it definitely can be null.
@@ -130,7 +130,7 @@ abstract class NativeType extends Type
             || $this instanceof GenericArrayType
             || $type instanceof GenericArrayType
         ) {
-            return parent::canCastToNonNullableTypeWithoutConfig($type);
+            return parent::canCastToNonNullableTypeWithoutConfig($type, $code_base);
         }
 
         static $matrix;
@@ -140,10 +140,10 @@ abstract class NativeType extends Type
 
         // Both this and $type are NativeType and getName() isn't needed
         return $matrix[$this->name][$type->name]
-            ?? parent::canCastToNonNullableTypeWithoutConfig($type);
+            ?? parent::canCastToNonNullableTypeWithoutConfig($type, $code_base);
     }
 
-    protected function isSubtypeOfNonNullableType(Type $type): bool
+    protected function isSubtypeOfNonNullableType(Type $type, CodeBase $code_base): bool
     {
         // Anything is a subtype of mixed or ?mixed
         if ($type instanceof MixedType) {
@@ -154,7 +154,7 @@ abstract class NativeType extends Type
             || $this instanceof GenericArrayType
             || $type instanceof GenericArrayType
         ) {
-            return parent::canCastToNonNullableType($type);
+            return parent::canCastToNonNullableType($type, $code_base);
         }
 
         static $matrix;
@@ -164,7 +164,7 @@ abstract class NativeType extends Type
 
         // Both this and $type are NativeType and getName() isn't needed
         return $matrix[$this->name][$type->name]
-            ?? parent::canCastToNonNullableType($type);
+            ?? parent::canCastToNonNullableType($type, $code_base);
     }
 
     /**

--- a/src/Phan/Language/Type/NativeType.php
+++ b/src/Phan/Language/Type/NativeType.php
@@ -43,6 +43,15 @@ abstract class NativeType extends Type
     /**
      * @unused-param $code_base
      */
+    public function isIterable(CodeBase $code_base): bool
+    {
+        // overridden in subclasses
+        return false;
+    }
+
+    /**
+     * @unused-param $code_base
+     */
     public function isArrayOrArrayAccessSubType(CodeBase $code_base): bool
     {
         return false;

--- a/src/Phan/Language/Type/NeverType.php
+++ b/src/Phan/Language/Type/NeverType.php
@@ -115,8 +115,9 @@ final class NeverType extends NativeType
      */
     public function canCastToType(Type $type, CodeBase $code_base): bool
     {
-        // Check to see if we have an exact object match
-        return $this === $type;
+        // never can cast to any type.
+        // Plugins should be used to warn about using the result of an expression returning never
+        return true;
     }
 
     /**

--- a/src/Phan/Language/Type/NeverType.php
+++ b/src/Phan/Language/Type/NeverType.php
@@ -68,7 +68,7 @@ final class NeverType extends NativeType
      * `never` is a subtype of every type
      * @unused-param $type
      */
-    public function isSubtypeOf(Type $type): bool
+    public function isSubtypeOf(Type $type, CodeBase $code_base): bool
     {
         return true;
     }
@@ -78,7 +78,7 @@ final class NeverType extends NativeType
      *
      * @unused-param $type
      */
-    public function isSubtypeOfNonNullableType(Type $type): bool
+    public function isSubtypeOfNonNullableType(Type $type, CodeBase $code_base): bool
     {
         return true;
     }
@@ -93,19 +93,7 @@ final class NeverType extends NativeType
         return true;
     }
 
-    /**
-     * @return bool
-     * True if this Type can be cast to the given Type
-     * cleanly
-     *
-     * never can cast to any type, but other types cannot cast to never
-     */
-    public function canCastToType(Type $type): bool
-    {
-        return true;
-    }
-
-    public function canCastToTypeWithoutConfig(Type $type): bool
+    public function canCastToTypeWithoutConfig(Type $type, CodeBase $code_base): bool
     {
         return true;
     }
@@ -115,7 +103,7 @@ final class NeverType extends NativeType
      * e.g. returns true false, array, int
      *      returns false for callable, object, iterable, T, etc.
      */
-    public function isDefiniteNonCallableType(): bool
+    public function isDefiniteNonCallableType(CodeBase $code_base): bool
     {
         return true;
     }
@@ -123,9 +111,9 @@ final class NeverType extends NativeType
     /**
      * @return bool
      * True if this Type can be cast to the given Type
-     * cleanly (accounting for templates)
+     * cleanly.
      */
-    public function canCastToTypeHandlingTemplates(Type $type, CodeBase $code_base): bool
+    public function canCastToType(Type $type, CodeBase $code_base): bool
     {
         // Check to see if we have an exact object match
         return $this === $type;
@@ -135,7 +123,7 @@ final class NeverType extends NativeType
      * @unused-param $type
      * @override
      */
-    public function canCastToNonNullableType(Type $type): bool
+    public function canCastToNonNullableType(Type $type, CodeBase $code_base): bool
     {
         return true;
     }
@@ -144,7 +132,7 @@ final class NeverType extends NativeType
      * @unused-param $type
      * @override
      */
-    public function canCastToNonNullableTypeWithoutConfig(Type $type): bool
+    public function canCastToNonNullableTypeWithoutConfig(Type $type, CodeBase $code_base): bool
     {
         return true;
     }

--- a/src/Phan/Language/Type/NonEmptyAssociativeArrayType.php
+++ b/src/Phan/Language/Type/NonEmptyAssociativeArrayType.php
@@ -109,8 +109,8 @@ final class NonEmptyAssociativeArrayType extends AssociativeArrayType implements
     }
 
     /**
-     * @return ListType
-     * @phan-real-return AssociativeArrayType
+     * @return GenericArrayType
+     * @phan-real-return GenericArrayType signature variance isn't supported until php 7.4
      */
     public function asPossiblyEmptyArrayType(): ArrayType
     {

--- a/src/Phan/Language/Type/NonEmptyAssociativeArrayType.php
+++ b/src/Phan/Language/Type/NonEmptyAssociativeArrayType.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phan\Language\Type;
 
+use Phan\CodeBase;
 use Phan\Language\Type;
 
 /**
@@ -52,12 +53,12 @@ final class NonEmptyAssociativeArrayType extends AssociativeArrayType implements
         return $map->offsetGet($type);
     }
 
-    protected function canCastToNonNullableType(Type $type): bool
+    protected function canCastToNonNullableType(Type $type, CodeBase $code_base): bool
     {
         if (!$type->isPossiblyTruthy()) {
             return false;
         }
-        return parent::canCastToNonNullableType($type);
+        return parent::canCastToNonNullableType($type, $code_base);
     }
 
     /** @override */

--- a/src/Phan/Language/Type/NonEmptyGenericArrayType.php
+++ b/src/Phan/Language/Type/NonEmptyGenericArrayType.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phan\Language\Type;
 
+use Phan\CodeBase;
 use Phan\Language\Type;
 
 /**
@@ -52,12 +53,12 @@ final class NonEmptyGenericArrayType extends GenericArrayType implements NonEmpt
         return $map->offsetGet($type);
     }
 
-    protected function canCastToNonNullableType(Type $type): bool
+    protected function canCastToNonNullableType(Type $type, CodeBase $code_base): bool
     {
         if (!$type->isPossiblyTruthy()) {
             return false;
         }
-        return parent::canCastToNonNullableType($type);
+        return parent::canCastToNonNullableType($type, $code_base);
     }
 
     /** @override */

--- a/src/Phan/Language/Type/NonEmptyListType.php
+++ b/src/Phan/Language/Type/NonEmptyListType.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phan\Language\Type;
 
+use Phan\CodeBase;
 use Phan\Language\Type;
 
 /**
@@ -53,12 +54,12 @@ final class NonEmptyListType extends ListType implements NonEmptyArrayInterface
         return $map->offsetGet($type);
     }
 
-    protected function canCastToNonNullableType(Type $type): bool
+    protected function canCastToNonNullableType(Type $type, CodeBase $code_base): bool
     {
         if (!$type->isPossiblyTruthy()) {
             return false;
         }
-        return parent::canCastToNonNullableType($type);
+        return parent::canCastToNonNullableType($type, $code_base);
     }
 
     /** @override */

--- a/src/Phan/Language/Type/NonEmptyMixedType.php
+++ b/src/Phan/Language/Type/NonEmptyMixedType.php
@@ -136,4 +136,20 @@ final class NonEmptyMixedType extends MixedType
     {
         return $is_nullable === $this->is_nullable ? $this : self::instance($is_nullable);
     }
+
+    /**
+     * @unused-param $code_base
+     */
+    public function isSubtypeOf(Type $type, CodeBase $code_base): bool
+    {
+        return $type instanceof MixedType;
+    }
+
+    /**
+     * @unused-param $code_base
+     */
+    public function isSubtypeOfNonNullableType(Type $type, CodeBase $code_base): bool
+    {
+        return $type instanceof MixedType;
+    }
 }

--- a/src/Phan/Language/Type/NonEmptyMixedType.php
+++ b/src/Phan/Language/Type/NonEmptyMixedType.php
@@ -21,7 +21,10 @@ final class NonEmptyMixedType extends MixedType
     /** @phan-override */
     public const NAME = 'non-empty-mixed';
 
-    public function canCastToType(Type $type): bool
+    /**
+     * @unused-param $code_base
+     */
+    public function canCastToType(Type $type, CodeBase $code_base): bool
     {
         return $type->isPossiblyTruthy() || ($this->is_nullable && $type->is_nullable);
     }
@@ -29,31 +32,37 @@ final class NonEmptyMixedType extends MixedType
     /**
      * @override
      */
-    public function canCastToTypeWithoutConfig(Type $type): bool
+    public function canCastToTypeWithoutConfig(Type $type, CodeBase $code_base): bool
     {
-        return $this->canCastToType($type);
+        return $this->canCastToType($type, $code_base);
     }
 
     /**
      * @param Type[] $target_type_set 1 or more types @phan-unused-param
      * @override
      */
-    public function canCastToAnyTypeInSet(array $target_type_set): bool
+    public function canCastToAnyTypeInSet(array $target_type_set, CodeBase $code_base): bool
     {
         foreach ($target_type_set as $t) {
-            if ($this->canCastToType($t)) {
+            if ($this->canCastToType($t, $code_base)) {
                 return true;
             }
         }
         return (bool)$target_type_set;
     }
 
-    protected function canCastToNonNullableType(Type $type): bool
+    /**
+     * @unused-param $code_base
+     */
+    protected function canCastToNonNullableType(Type $type, CodeBase $code_base): bool
     {
         return $type->isPossiblyTruthy();
     }
 
-    protected function canCastToNonNullableTypeWithoutConfig(Type $type): bool
+    /**
+     * @unused-param $code_base
+     */
+    protected function canCastToNonNullableTypeWithoutConfig(Type $type, CodeBase $code_base): bool
     {
         return $type->isPossiblyTruthy();
     }

--- a/src/Phan/Language/Type/NonEmptyStringType.php
+++ b/src/Phan/Language/Type/NonEmptyStringType.php
@@ -53,7 +53,7 @@ final class NonEmptyStringType extends StringType
      * True if this Type can be cast to the given Type
      * cleanly
      */
-    protected function canCastToNonNullableType(Type $type): bool
+    protected function canCastToNonNullableType(Type $type, CodeBase $code_base): bool
     {
         if ($type instanceof ScalarType) {
             switch ($type::NAME) {
@@ -70,7 +70,7 @@ final class NonEmptyStringType extends StringType
             }
         }
 
-        return parent::canCastToNonNullableType($type);
+        return parent::canCastToNonNullableType($type, $code_base);
     }
 
     /**
@@ -99,7 +99,7 @@ final class NonEmptyStringType extends StringType
      * cleanly without config overrides
      * @override
      */
-    protected function canCastToNonNullableTypeWithoutConfig(Type $type): bool
+    protected function canCastToNonNullableTypeWithoutConfig(Type $type, CodeBase $code_base): bool
     {
         if ($type instanceof ScalarType) {
             switch ($type::NAME) {
@@ -115,14 +115,14 @@ final class NonEmptyStringType extends StringType
             }
         }
 
-        return parent::canCastToNonNullableType($type);
+        return parent::canCastToNonNullableType($type, $code_base);
     }
 
     /**
      * @return bool
      * True if this Type is a subtype of the given type.
      */
-    protected function isSubtypeOfNonNullableType(Type $type): bool
+    protected function isSubtypeOfNonNullableType(Type $type, CodeBase $code_base): bool
     {
         if ($type instanceof ScalarType) {
             if ($type instanceof StringType) {
@@ -134,7 +134,7 @@ final class NonEmptyStringType extends StringType
             return false;
         }
 
-        return parent::canCastToNonNullableType($type);
+        return parent::canCastToNonNullableType($type, $code_base);
     }
 
     public function asSignatureType(): Type

--- a/src/Phan/Language/Type/NonNullMixedType.php
+++ b/src/Phan/Language/Type/NonNullMixedType.php
@@ -34,7 +34,10 @@ final class NonNullMixedType extends MixedType
         return $instance ?? ($instance = static::make('\\', self::NAME, [], false, Type::FROM_NODE));
     }
 
-    public function canCastToType(Type $type): bool
+    /**
+     * @unused-param $code_base
+     */
+    public function canCastToType(Type $type, CodeBase $code_base): bool
     {
         return !($type instanceof NullType || $type instanceof VoidType);
     }
@@ -43,10 +46,10 @@ final class NonNullMixedType extends MixedType
      * @param Type[] $target_type_set 1 or more types @phan-unused-param
      * @override
      */
-    public function canCastToAnyTypeInSet(array $target_type_set): bool
+    public function canCastToAnyTypeInSet(array $target_type_set, CodeBase $code_base): bool
     {
         foreach ($target_type_set as $t) {
-            if ($this->canCastToType($t)) {
+            if ($this->canCastToType($t, $code_base)) {
                 return true;
             }
         }
@@ -55,8 +58,9 @@ final class NonNullMixedType extends MixedType
 
     /**
      * @override
+     * @unused-param $code_base
      */
-    public function canCastToTypeWithoutConfig(Type $type): bool
+    public function canCastToTypeWithoutConfig(Type $type, CodeBase $code_base): bool
     {
         return !$type->isNullable();
     }
@@ -72,7 +76,7 @@ final class NonNullMixedType extends MixedType
      */
     public function canCastToDeclaredType(CodeBase $code_base, Context $context, Type $other): bool
     {
-        return $this->canCastToType($other);
+        return $this->canCastToType($other, $code_base);
     }
 
     public function asObjectType(): ?Type

--- a/src/Phan/Language/Type/NonNullMixedType.php
+++ b/src/Phan/Language/Type/NonNullMixedType.php
@@ -62,7 +62,7 @@ final class NonNullMixedType extends MixedType
      */
     public function canCastToTypeWithoutConfig(Type $type, CodeBase $code_base): bool
     {
-        return !$type->isNullable();
+        return !($type instanceof NullType || $type instanceof VoidType);
     }
 
     public function asGenericArrayType(int $key_type): Type
@@ -121,5 +121,21 @@ final class NonNullMixedType extends MixedType
     public function withIsNullable(bool $is_nullable): Type
     {
         return $is_nullable ? MixedType::instance(true) : $this;
+    }
+
+    /**
+     * @unused-param $code_base
+     */
+    public function isSubtypeOf(Type $type, CodeBase $code_base): bool
+    {
+        return $type instanceof MixedType && !($type instanceof NonEmptyMixedType);
+    }
+
+    /**
+     * @unused-param $code_base
+     */
+    public function isSubtypeOfNonNullableType(Type $type, CodeBase $code_base): bool
+    {
+        return $type instanceof MixedType && !($type instanceof NonEmptyMixedType);
     }
 }

--- a/src/Phan/Language/Type/NonZeroIntType.php
+++ b/src/Phan/Language/Type/NonZeroIntType.php
@@ -56,7 +56,7 @@ final class NonZeroIntType extends IntType
      * True if this Type can be cast to the given Type
      * cleanly
      */
-    protected function canCastToNonNullableType(Type $type): bool
+    protected function canCastToNonNullableType(Type $type, CodeBase $code_base): bool
     {
         if ($type instanceof ScalarType) {
             switch ($type::NAME) {
@@ -96,7 +96,7 @@ final class NonZeroIntType extends IntType
             }
         }
 
-        return parent::canCastToNonNullableType($type);
+        return parent::canCastToNonNullableType($type, $code_base);
     }
 
     /**
@@ -104,7 +104,7 @@ final class NonZeroIntType extends IntType
      * True if this Type can be cast to the given Type
      * cleanly
      */
-    protected function canCastToNonNullableTypeWithoutConfig(Type $type): bool
+    protected function canCastToNonNullableTypeWithoutConfig(Type $type, CodeBase $code_base): bool
     {
         if ($type instanceof ScalarType) {
             switch ($type::NAME) {
@@ -123,14 +123,14 @@ final class NonZeroIntType extends IntType
             }
         }
 
-        return parent::canCastToNonNullableType($type);
+        return parent::canCastToNonNullableType($type, $code_base);
     }
 
     /**
      * @return bool
      * True if this Type is a subtype of the given type
      */
-    protected function isSubtypeOfNonNullableType(Type $type): bool
+    protected function isSubtypeOfNonNullableType(Type $type, CodeBase $code_base): bool
     {
         if ($type instanceof ScalarType) {
             if ($type instanceof IntType) {
@@ -142,7 +142,7 @@ final class NonZeroIntType extends IntType
             return false;
         }
 
-        return parent::canCastToNonNullableType($type);
+        return parent::canCastToNonNullableType($type, $code_base);
     }
 
     public function asSignatureType(): Type

--- a/src/Phan/Language/Type/NullType.php
+++ b/src/Phan/Language/Type/NullType.php
@@ -50,12 +50,12 @@ final class NullType extends ScalarType implements LiteralTypeInterface
         );
     }
 
-    public function canCastToNonNullableType(Type $type): bool
+    public function canCastToNonNullableType(Type $type, CodeBase $code_base): bool
     {
         // null_casts_as_any_type means that null or nullable can cast to any type?
         return Config::get_null_casts_as_any_type()
             || (Config::get_null_casts_as_array() && $type->isArrayLike())
-            || parent::canCastToNonNullableType($type);
+            || parent::canCastToNonNullableType($type, $code_base);
     }
 
     /**
@@ -68,16 +68,20 @@ final class NullType extends ScalarType implements LiteralTypeInterface
         return $other->isNullable() || $other instanceof TemplateType;
     }
 
-    public function isSubtypeOf(Type $type): bool
+    /**
+     * @unused-param $code_base
+     */
+    public function isSubtypeOf(Type $type, CodeBase $code_base): bool
     {
         return $type->isNullable();
     }
 
     /**
      * @unused-param $type
+     * @unused-param $code_base
      * @override
      */
-    public function isSubtypeOfNonNullableType(Type $type): bool
+    public function isSubtypeOfNonNullableType(Type $type, CodeBase $code_base): bool
     {
         return false;
     }
@@ -86,45 +90,9 @@ final class NullType extends ScalarType implements LiteralTypeInterface
      * @return bool
      * True if this Type can be cast to the given Type
      * cleanly
+     * @unused-param $code_base
      */
-    public function canCastToType(Type $type): bool
-    {
-        // Check to see if we have an exact object match
-        if ($this === $type) {
-            return true;
-        }
-
-        // Null can cast to a nullable type.
-        if ($type->isNullable()) {
-            return true;
-        }
-
-        if (Config::get_null_casts_as_any_type()) {
-            return true;
-        }
-
-        // NullType is a sub-type of ScalarType. So it's affected by scalar_implicit_cast.
-        if ($type->isScalar()) {
-            if (Config::getValue('scalar_implicit_cast')) {
-                return true;
-            }
-            $scalar_implicit_partial = Config::getValue('scalar_implicit_partial');
-            // check if $type->getName() is in the list of permitted types $this->getName() can cast to.
-            if (\count($scalar_implicit_partial) > 0 &&
-                \in_array($type->getName(), $scalar_implicit_partial['null'] ?? [], true)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * @return bool
-     * True if this Type can be cast to the given Type
-     * cleanly
-     */
-    public function canCastToTypeWithoutConfig(Type $type): bool
+    public function canCastToTypeWithoutConfig(Type $type, CodeBase $code_base): bool
     {
         // Check to see if we have an exact object match
         if ($this === $type) {
@@ -138,9 +106,10 @@ final class NullType extends ScalarType implements LiteralTypeInterface
     /**
      * @return bool
      * True if this Type can be cast to the given Type
-     * cleanly (accounting for templates)
+     * cleanly (accounting for templates, intersection types, etc.)
+     * @unused-param $code_base
      */
-    public function canCastToTypeHandlingTemplates(Type $type, CodeBase $code_base): bool
+    public function canCastToType(Type $type, CodeBase $code_base): bool
     {
         // Check to see if we have an exact object match
         if ($this === $type) {
@@ -171,7 +140,7 @@ final class NullType extends ScalarType implements LiteralTypeInterface
 
         // Test to see if we can cast to the non-nullable version
         // of the target type.
-        return parent::canCastToNonNullableTypeHandlingTemplates($type, $code_base);
+        return false;
     }
 
     /**

--- a/src/Phan/Language/Type/ObjectType.php
+++ b/src/Phan/Language/Type/ObjectType.php
@@ -19,25 +19,26 @@ class ObjectType extends NativeType
     /** @phan-override */
     public const NAME = 'object';
 
-    protected function canCastToNonNullableType(Type $type): bool
+    protected function canCastToNonNullableType(Type $type, CodeBase $code_base): bool
     {
         // Inverse of check in Type->canCastToNullableType
         if (!$type->isNativeType() && !($type instanceof ArrayType)) {
             return true;
         }
-        return parent::canCastToNonNullableType($type);
+        return parent::canCastToNonNullableType($type, $code_base);
     }
 
-    protected function canCastToNonNullableTypeWithoutConfig(Type $type): bool
+    protected function canCastToNonNullableTypeWithoutConfig(Type $type, CodeBase $code_base): bool
     {
         // Inverse of check in Type->canCastToNullableType
         if (!$type->isNativeType() && !($type instanceof ArrayType)) {
             return true;
         }
-        return parent::canCastToNonNullableTypeWithoutConfig($type);
+        return parent::canCastToNonNullableTypeWithoutConfig($type, $code_base);
     }
 
-    protected function isSubtypeOfNonNullableType(Type $type): bool
+    /** @unused-param $code_base */
+    protected function isSubtypeOfNonNullableType(Type $type, CodeBase $code_base): bool
     {
         return $type instanceof ObjectType || $type instanceof MixedType;
     }
@@ -92,7 +93,10 @@ class ObjectType extends NativeType
         return $this->withIsNullable(false);
     }
 
-    public function asCallableType(): ?Type
+    /**
+     * @unused-param $code_base
+     */
+    public function asCallableType(CodeBase $code_base): ?Type
     {
         return CallableObjectType::instance(false);
     }

--- a/src/Phan/Language/Type/ScalarType.php
+++ b/src/Phan/Language/Type/ScalarType.php
@@ -62,7 +62,7 @@ abstract class ScalarType extends NativeType
      * True if this Type can be cast to the given Type
      * cleanly
      */
-    protected function canCastToNonNullableType(Type $type): bool
+    protected function canCastToNonNullableType(Type $type, CodeBase $code_base): bool
     {
         // Scalars may be configured to always cast to each other.
         // NOTE: This deliberately includes NullType, which doesn't satisfy `is_scalar()`
@@ -80,7 +80,7 @@ abstract class ScalarType extends NativeType
             }
         }
 
-        return parent::canCastToNonNullableType($type);
+        return parent::canCastToNonNullableType($type, $code_base);
     }
 
     // inherit canCastToNonNullableTypeWithoutConfig
@@ -95,7 +95,7 @@ abstract class ScalarType extends NativeType
         Context $context,
         CodeBase $code_base
     ): bool {
-        return $union_type->hasType($this) || $this->asPHPDocUnionType()->canCastToUnionType($union_type);
+        return $union_type->hasType($this) || $this->asPHPDocUnionType()->canCastToUnionType($union_type, $code_base);
     }
 
     /**
@@ -160,8 +160,9 @@ abstract class ScalarType extends NativeType
      * Returns true if this contains a type that is definitely nullable or a non-object.
      * e.g. returns true false, array, int
      *      returns false for callable, object, iterable, T, etc.
+     * @unused-param $code_base
      */
-    public function isDefiniteNonCallableType(): bool
+    public function isDefiniteNonCallableType(CodeBase $code_base): bool
     {
         return true;
     }

--- a/src/Phan/Language/Type/ScalarType.php
+++ b/src/Phan/Language/Type/ScalarType.php
@@ -42,11 +42,6 @@ abstract class ScalarType extends NativeType
         return false;
     }
 
-    public function isIterable(): bool
-    {
-        return false;
-    }
-
     public function isArrayLike(): bool
     {
         return false;

--- a/src/Phan/Language/Type/StringType.php
+++ b/src/Phan/Language/Type/StringType.php
@@ -22,19 +22,22 @@ class StringType extends ScalarType
     /** @phan-override */
     public const NAME = 'string';
 
-    protected function canCastToNonNullableType(Type $type): bool
+    protected function canCastToNonNullableType(Type $type, CodeBase $code_base): bool
     {
         // CallableDeclarationType is not a native type, we check separately here
-        return parent::canCastToNonNullableType($type) || $type instanceof CallableDeclarationType;
+        return parent::canCastToNonNullableType($type, $code_base) || $type instanceof CallableDeclarationType;
     }
 
-    protected function canCastToNonNullableTypeWithoutConfig(Type $type): bool
+    protected function canCastToNonNullableTypeWithoutConfig(Type $type, CodeBase $code_base): bool
     {
         // CallableDeclarationType is not a native type, we check separately here
-        return parent::canCastToNonNullableTypeWithoutConfig($type) || $type instanceof CallableDeclarationType;
+        return parent::canCastToNonNullableTypeWithoutConfig($type, $code_base) || $type instanceof CallableDeclarationType;
     }
 
-    protected function isSubtypeOfNonNullableType(Type $type): bool
+    /**
+     * @unused-param $code_base
+     */
+    protected function isSubtypeOfNonNullableType(Type $type, CodeBase $code_base): bool
     {
         return \get_class($type) === self::class || $type instanceof MixedType;
     }
@@ -60,8 +63,9 @@ class StringType extends ScalarType
      * Returns true if this contains a type that is definitely non-callable
      * e.g. returns true for false, array, int
      *      returns false for callable, string, array, object, iterable, T, etc.
+     * @unused-param $code_base
      */
-    public function isDefiniteNonCallableType(): bool
+    public function isDefiniteNonCallableType(CodeBase $code_base): bool
     {
         return false;
     }
@@ -106,7 +110,10 @@ class StringType extends ScalarType
         return false;
     }
 
-    public function asCallableType(): ?Type
+    /**
+     * @unused-param $code_base
+     */
+    public function asCallableType(CodeBase $code_base): ?Type
     {
         return CallableStringType::instance(false);
     }

--- a/src/Phan/Language/Type/TemplateType.php
+++ b/src/Phan/Language/Type/TemplateType.php
@@ -206,8 +206,11 @@ final class TemplateType extends Type
         return true;
     }
 
-    /** @param list<Type> $target_type_set @unused-param */
-    public function canCastToAnyTypeInSetWithoutConfig(array $target_type_set): bool
+    /**
+     * @param list<Type> $target_type_set
+     * @suppress PhanUnusedPublicFinalMethodParameter
+     */
+    public function canCastToAnyTypeInSetWithoutConfig(array $target_type_set, CodeBase $code_base): bool
     {
         // Always possible until we support inferring `@template T as ConcreteType`
         return true;

--- a/src/Phan/Language/Type/VoidType.php
+++ b/src/Phan/Language/Type/VoidType.php
@@ -60,7 +60,10 @@ final class VoidType extends NativeType implements LiteralTypeInterface
         return $other->isNullable() || $other instanceof TemplateType;
     }
 
-    public function isSubtypeOf(Type $type): bool
+    /**
+     * @suppress PhanUnusedPublicFinalMethodParameter
+     */
+    public function isSubtypeOf(Type $type, CodeBase $code_base): bool
     {
         return $type->isNullable();
     }
@@ -68,9 +71,9 @@ final class VoidType extends NativeType implements LiteralTypeInterface
     /**
      * void cannot be a subtype of a non-nullable type
      *
-     * @unused-param $type
+     * @suppress PhanUnusedPublicFinalMethodParameter
      */
-    public function isSubtypeOfNonNullableType(Type $type): bool
+    public function isSubtypeOfNonNullableType(Type $type, CodeBase $code_base): bool
     {
         return false;
     }
@@ -86,44 +89,9 @@ final class VoidType extends NativeType implements LiteralTypeInterface
     }
 
     /**
-     * @return bool
-     * True if this Type can be cast to the given Type
-     * cleanly
+     * @suppress PhanUnusedPublicFinalMethodParameter
      */
-    public function canCastToType(Type $type): bool
-    {
-        // Check to see if we have an exact object match
-        if ($this === $type) {
-            return true;
-        }
-
-        // Null(void) can cast to a nullable type.
-        if ($type->isNullable()) {
-            return true;
-        }
-
-        // TODO Make this more strict with real types, somehow?
-        if (Config::get_null_casts_as_any_type()) {
-            return true;
-        }
-
-        // NullType is a sub-type of ScalarType. So it's affected by scalar_implicit_cast.
-        if ($type->isScalar()) {
-            if (Config::getValue('scalar_implicit_cast')) {
-                return true;
-            }
-            $scalar_implicit_partial = Config::getValue('scalar_implicit_partial');
-            // check if $type->getName() is in the list of permitted types $this->getName() can cast to.
-            if (\count($scalar_implicit_partial) > 0 &&
-                \in_array($type->getName(), $scalar_implicit_partial['null'] ?? [], true)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    public function canCastToTypeWithoutConfig(Type $type): bool
+    public function canCastToTypeWithoutConfig(Type $type, CodeBase $code_base): bool
     {
         // Check to see if we have an exact object match
         if ($this === $type) {
@@ -138,8 +106,9 @@ final class VoidType extends NativeType implements LiteralTypeInterface
      * Returns true if this contains a type that is definitely nullable or a non-object.
      * e.g. returns true false, array, int
      *      returns false for callable, object, iterable, T, etc.
+     * @unused-param $code_base
      */
-    public function isDefiniteNonCallableType(): bool
+    public function isDefiniteNonCallableType(CodeBase $code_base): bool
     {
         return true;
     }
@@ -147,9 +116,9 @@ final class VoidType extends NativeType implements LiteralTypeInterface
     /**
      * @return bool
      * True if this Type can be cast to the given Type
-     * cleanly (accounting for templates)
+     * cleanly (accounting for templates, intersection types, etc)
      */
-    public function canCastToTypeHandlingTemplates(Type $type, CodeBase $code_base): bool
+    public function canCastToType(Type $type, CodeBase $code_base): bool
     {
         // Check to see if we have an exact object match
         if ($this === $type) {
@@ -189,8 +158,9 @@ final class VoidType extends NativeType implements LiteralTypeInterface
     /**
      * @unused-param $type
      * @override
+     * @suppress PhanUnusedPublicFinalMethodParameter
      */
-    public function canCastToNonNullableType(Type $type): bool
+    public function canCastToNonNullableType(Type $type, CodeBase $code_base): bool
     {
         // null_casts_as_any_type means that null or nullable can cast to any type?
         // But don't allow it for void?
@@ -198,10 +168,10 @@ final class VoidType extends NativeType implements LiteralTypeInterface
     }
 
     /**
-     * @unused-param $type
      * @override
+     * @suppress PhanUnusedPublicFinalMethodParameter
      */
-    public function canCastToNonNullableTypeWithoutConfig(Type $type): bool
+    public function canCastToNonNullableTypeWithoutConfig(Type $type, CodeBase $code_base): bool
     {
         return false;
     }

--- a/src/Phan/Language/TypePart.php
+++ b/src/Phan/Language/TypePart.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phan\Language;
+
+/**
+ * A part of a type extracted from phpdoc
+ * @phan-pure
+ */
+class TypePart {
+    /** @var string the type string */
+    public $type;
+    /** @var string the separator before the type string */
+    public $separator;
+    public function __construct(string $type, string $separator)
+    {
+        $this->type = $type;
+        $this->separator = $separator;
+    }
+
+    /**
+     * Combine a list of type parts into a new type part instance.
+     * @param non-empty-list<TypePart> $parts
+     */
+    public static function combine(array $parts): TypePart
+    {
+        $result = null;
+        $separator = '';
+        foreach ($parts as $part) {
+            if ($result === null) {
+                $result = $part->type;
+                $separator = $part->separator;
+                continue;
+            }
+            $result .= $part->separator . $part->type;
+        }
+        return new TypePart($result, $separator);
+    }
+}

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -2082,10 +2082,10 @@ class UnionType implements Serializable, Stringable
      * @return bool
      * True if this type has any subtype of the `iterable` type (e.g. `Traversable`, `Array`).
      */
-    public function hasIterable(): bool
+    public function hasIterable(CodeBase $code_base): bool
     {
-        return $this->hasTypeMatchingCallback(static function (Type $type): bool {
-            return $type->isIterable();
+        return $this->hasTypeMatchingCallback(static function (Type $type) use($code_base): bool {
+            return $type->isIterable($code_base);
         });
     }
 
@@ -5700,6 +5700,8 @@ class UnionType implements Serializable, Stringable
     {
         if (!$type_set) {
             // Can be int|string
+            // TODO: Add a plugin to infer the result of typeSetFromString on union types of literals
+            // @phan-suppress-next-line PhanTypeMismatchReturn
             return UnionType::typeSetFromString($is_real ? 'int|string' : 'int');
         }
         $result = [];
@@ -5886,6 +5888,7 @@ class UnionType implements Serializable, Stringable
             }
         }
         if (!$result) {
+            // @phan-suppress-next-line PhanTypeMismatchReturn
             return UnionType::typeSetFromString('int|float');
         }
         return $result;

--- a/src/Phan/Library/Map.php
+++ b/src/Phan/Library/Map.php
@@ -15,7 +15,7 @@ use SplObjectStorage;
  * @template V
  * @suppress PhanTemplateTypeNotDeclaredInFunctionParams
  * @phan-file-suppress PhanParamSignaturePHPDocMismatchHasParamType, PhanParamSignaturePHPDocMismatchParamType, PhanParamSignatureMismatchInternal
- * TODO: Add a way to indicate in Phan that T is subtype of object
+ * TODO: Add a way to indicate in Phan that T is subtype of object for keys K
  *
  * @method void attach(K $object,V $data = null)
  * @method void detach(K $object)

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -679,10 +679,11 @@ class ParseVisitor extends ScopeVisitor
                 }
             }
 
+            // XXX during the parse phase, parent classes may be missing.
             if ($default_node !== null &&
                 !$original_union_type->isType(NullType::instance(false)) &&
-                !$variable->getUnionType()->asExpandedTypes($this->code_base)->canCastToUnionType($original_union_type) &&
-                !$original_union_type->asExpandedTypes($this->code_base)->canCastToUnionType($variable->getUnionType()) &&
+                !$variable->getUnionType()->canCastToUnionType($original_union_type, $this->code_base) &&
+                !$original_union_type->canCastToUnionType($variable->getUnionType(), $this->code_base) &&
                 !$property->checkHasSuppressIssueAndIncrementCount(Issue::TypeMismatchPropertyDefault)
             ) {
                 $this->emitIssue(

--- a/src/Phan/Plugin/Internal/CallableParamPlugin.php
+++ b/src/Phan/Plugin/Internal/CallableParamPlugin.php
@@ -131,7 +131,7 @@ final class CallableParamPlugin extends PluginV3 implements
 
     /**
      * @return array<string,\Closure>
-     * @phan-return array<string,Closure(CodeBase,Context,FunctionInterface,array):void>
+     * @phan-return array<string,Closure(CodeBase,Context,FunctionInterface,array,?Node):void>
      */
     private static function getAnalyzeFunctionCallClosuresStatic(CodeBase $code_base): array
     {

--- a/src/Phan/Plugin/Internal/CallableParamPlugin.php
+++ b/src/Phan/Plugin/Internal/CallableParamPlugin.php
@@ -130,8 +130,7 @@ final class CallableParamPlugin extends PluginV3 implements
     }
 
     /**
-     * @return array<string,\Closure>
-     * @phan-return array<string,Closure(CodeBase,Context,FunctionInterface,array,?Node):void>
+     * @return array<string,Closure(CodeBase,Context,FunctionInterface,array,?Node):void>
      */
     private static function getAnalyzeFunctionCallClosuresStatic(CodeBase $code_base): array
     {
@@ -204,7 +203,7 @@ final class CallableParamPlugin extends PluginV3 implements
     }
 
     /**
-     * @return array<string,Closure(CodeBase,Context,FunctionInterface,array):void>
+     * @return array<string,Closure(CodeBase,Context,FunctionInterface,array,?Node):void>
      * @override
      */
     public function getAnalyzeFunctionCallClosures(CodeBase $code_base): array

--- a/src/Phan/Plugin/Internal/CompactPlugin.php
+++ b/src/Phan/Plugin/Internal/CompactPlugin.php
@@ -27,7 +27,7 @@ final class CompactPlugin extends PluginV3 implements
 
     /**
      * @param CodeBase $code_base @phan-unused-param
-     * @return array<string,Closure(CodeBase,Context,FunctionInterface,array,?Node):void>
+     * @return array<string,Closure(CodeBase,Context,FunctionInterface,list<mixed>,?Node):void>
      */
     public function getAnalyzeFunctionCallClosures(CodeBase $code_base): array
     {

--- a/src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php
@@ -220,7 +220,7 @@ final class DependentReturnTypeOverridePlugin extends PluginV3 implements
             }
             $union_type = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $args[2]);
             $has_array = $union_type->hasArray();
-            if ($union_type->canCastToUnionType($string_union_type)) {
+            if ($union_type->canCastToUnionType($string_union_type, $code_base)) {
                 return $has_array ? $str_replace_types : $string_union_type;
             }
             return $has_array ? $str_array_type : $str_replace_types;

--- a/src/Phan/Plugin/Internal/IssueFixingPlugin/IssueFixer.php
+++ b/src/Phan/Plugin/Internal/IssueFixingPlugin/IssueFixer.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Phan\Plugin\Internal\IssueFixingPlugin;
 
 use Closure;
-use Microsoft\PhpParser;
 use Microsoft\PhpParser\Node\NamespaceUseClause;
 use Microsoft\PhpParser\Node\QualifiedName;
 use Microsoft\PhpParser\Node\Statement\NamespaceUseDeclaration;
@@ -255,7 +254,7 @@ class IssueFixer
     }
 
     /**
-     * @param list<Closure(CodeBase,string,PhpParser\Node):(?FileEditSet)> $fixers one or more fixers. These return 0 edits if nothing works.
+     * @param list<Closure(CodeBase,FileCacheEntry):(?FileEditSet)>  $fixers one or more fixers. These return 0 edits if nothing works.
      */
     private static function attemptFixForIssues(
         CodeBase $code_base,

--- a/src/Phan/Plugin/Internal/MiscParamPlugin.php
+++ b/src/Phan/Plugin/Internal/MiscParamPlugin.php
@@ -503,7 +503,8 @@ final class MiscParamPlugin extends PluginV3 implements
                 if ($arg1_type->isExclusivelyArray()) {
                     $did_warn = false;
                     if (!$arg2_type->canCastToUnionType(
-                        StringType::instance(false)->asPHPDocUnionType()
+                        StringType::instance(false)->asPHPDocUnionType(),
+                        $code_base
                     )) {
                         $did_warn = true;
                         Issue::maybeEmit(
@@ -549,7 +550,8 @@ final class MiscParamPlugin extends PluginV3 implements
                     throw $stop_exception;
                 } elseif ($arg1_type->isNonNullStringType()) {
                     if (!$arg2_type->canCastToUnionType(
-                        ArrayType::instance(false)->asPHPDocUnionType()
+                        ArrayType::instance(false)->asPHPDocUnionType(),
+                        $code_base
                     )) {
                         Issue::maybeEmit(
                             $code_base,
@@ -1248,9 +1250,7 @@ final class MiscParamPlugin extends PluginV3 implements
         );
 
         // See if it can be cast to the given type
-        $can_cast = $node_type->canCastToUnionType(
-            $cast_type
-        );
+        $can_cast = $node_type->canCastToUnionType($cast_type, $code_base);
 
         // If it can't, emit the log message
         if (!$can_cast) {
@@ -1304,7 +1304,8 @@ final class MiscParamPlugin extends PluginV3 implements
     private static function canCastToStringArrayLike(CodeBase $code_base, Context $context, UnionType $union_type): bool
     {
         if ($union_type->canCastToUnionType(
-            UnionType::fromFullyQualifiedPHPDocString('string[]|int[]')
+            UnionType::fromFullyQualifiedPHPDocString('string[]|int[]'),
+            $code_base
         )) {
             return true;
         }

--- a/src/Phan/Plugin/Internal/MiscParamPlugin.php
+++ b/src/Phan/Plugin/Internal/MiscParamPlugin.php
@@ -1216,8 +1216,7 @@ final class MiscParamPlugin extends PluginV3 implements
 
     /**
      * @param Codebase $code_base @phan-unused-param
-     * @return array<string,Closure>
-     * @phan-return array<string,Closure(CodeBase,Context,FunctionInterface,array):void>
+     * @return array<string,Closure(CodeBase,Context,FunctionInterface,array,?Node):void>
      */
     public function getAnalyzeFunctionCallClosures(CodeBase $code_base): array
     {

--- a/src/Phan/Plugin/Internal/RedundantConditionCallPlugin.php
+++ b/src/Phan/Plugin/Internal/RedundantConditionCallPlugin.php
@@ -205,8 +205,8 @@ final class RedundantConditionCallPlugin extends PluginV3 implements
                 return self::_IS_REASONABLE_CONDITION;
             }, $expected_type);
         };
-        $callable_callback = $make_first_arg_checker(static function (UnionType $type): int {
-            $new_real_type = $type->callableTypes();
+        $callable_callback = $make_codebase_aware_first_arg_checker(static function (UnionType $type, CodeBase $code_base): int {
+            $new_real_type = $type->callableTypes($code_base);
             if ($new_real_type->isEmpty()) {
                 return self::_IS_IMPOSSIBLE;
             }

--- a/src/Phan/Plugin/Internal/RequireExistsPlugin.php
+++ b/src/Phan/Plugin/Internal/RequireExistsPlugin.php
@@ -54,7 +54,7 @@ class RequireExistsVisitor extends PluginAwarePostAnalysisVisitor
 
         if (!\is_string($path)) {
             $type = UnionTypeVisitor::unionTypeFromNode($this->code_base, $this->context, $expr);
-            if (!$type->canCastToUnionType(StringType::instance(false)->asPHPDocUnionType())) {
+            if (!$type->canCastToUnionType(StringType::instance(false)->asPHPDocUnionType(), $this->code_base)) {
                 $this->emitIssue(
                     Issue::TypeInvalidRequire,
                     $expr->lineno ?? $node->lineno,
@@ -70,7 +70,7 @@ class RequireExistsVisitor extends PluginAwarePostAnalysisVisitor
     {
         $expr = $node->children['expr'];
         $type = UnionTypeVisitor::unionTypeFromNode($this->code_base, $this->context, $expr);
-        if (!$type->canCastToUnionType(StringType::instance(false)->asPHPDocUnionType())) {
+        if (!$type->canCastToUnionType(StringType::instance(false)->asPHPDocUnionType(), $this->code_base)) {
             $this->emitIssue(
                 Issue::TypeInvalidEval,
                 $expr->lineno ?? $node->lineno,

--- a/src/Phan/Plugin/Internal/ThrowAnalyzerPlugin.php
+++ b/src/Phan/Plugin/Internal/ThrowAnalyzerPlugin.php
@@ -140,7 +140,7 @@ class ThrowVisitor extends PluginAwarePostAnalysisVisitor
                 // @phan-suppress-next-line PhanThrowTypeAbsentForCall hopefully impossible to see for this AST
                 $caught_union_type = UnionTypeVisitor::unionTypeFromClassNode($code_base, $context, $catch_node->children['class']);
                 foreach ($union_type->getTypeSet() as $type) {
-                    if (!$type->asExpandedTypes($code_base)->canCastToUnionType($caught_union_type)) {
+                    if (!$type->asPHPDocUnionType()->canCastToUnionType($caught_union_type, $code_base)) {
                         $union_type = $union_type->withoutType($type);
                         if ($union_type->isEmpty()) {
                             return;
@@ -179,7 +179,7 @@ class ThrowVisitor extends PluginAwarePostAnalysisVisitor
                 // @phan-suppress-next-line PhanThrowTypeAbsentForCall hopefully impossible to see for this AST
                 $caught_union_type = UnionTypeVisitor::unionTypeFromClassNode($this->code_base, $this->context, $catch_node->children['class']);
                 foreach ($union_type->getTypeSet() as $type) {
-                    if ($type->asExpandedTypes($this->code_base)->canCastToUnionType($caught_union_type)) {
+                    if ($type->asPHPDocUnionType()->canCastToUnionType($caught_union_type, $this->code_base)) {
                         $union_type = $union_type->withoutType($type);
                         if ($union_type->isEmpty()) {
                             return $union_type;
@@ -242,7 +242,7 @@ class ThrowVisitor extends PluginAwarePostAnalysisVisitor
                 }
                 continue;
             }
-            if (!$expanded_type->canCastToUnionType($throws_union_type)) {
+            if (!$expanded_type->canCastToUnionType($throws_union_type, $this->code_base)) {
                 if ($call !== null) {
                     $this->emitIssue(
                         Issue::ThrowTypeMismatchForCall,
@@ -316,7 +316,7 @@ class ThrowVisitor extends PluginAwarePostAnalysisVisitor
         if ($ignore_union_type->isEmpty()) {
             return true;
         }
-        return !$expanded_type->canCastToUnionType($ignore_union_type);
+        return !$expanded_type->canCastToUnionType($ignore_union_type, $this->code_base);
     }
 }
 

--- a/src/Phan/PluginV3/AnalyzeFunctionCallCapability.php
+++ b/src/Phan/PluginV3/AnalyzeFunctionCallCapability.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Phan\PluginV3;
 
-use ast\Node;
 use Closure;
 use Phan\CodeBase;
 use Phan\Language\Context;
@@ -19,7 +18,7 @@ use Phan\Language\Element\FunctionInterface;
 interface AnalyzeFunctionCallCapability
 {
     /**
-     * @return array<string,Closure(CodeBase,Context,FunctionInterface,list<mixed>,?Node)>
+     * @return array<string,Closure(CodeBase,Context,FunctionInterface,list<mixed>,array)>
      * maps FQSEN of function or method to a closure used to analyze the function in question.
      * '\A::foo' or 'A::foo' as a key will override a method, and '\foo' or 'foo' as a key will override a function.
      * Closure Type: function(CodeBase $code_base, Context $context, Func|Method $function, array $args, ?Node $node) : void {...}

--- a/src/Phan/PluginV3/AnalyzeFunctionCallCapability.php
+++ b/src/Phan/PluginV3/AnalyzeFunctionCallCapability.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phan\PluginV3;
 
+use ast\Node;
 use Closure;
 use Phan\CodeBase;
 use Phan\Language\Context;
@@ -18,7 +19,7 @@ use Phan\Language\Element\FunctionInterface;
 interface AnalyzeFunctionCallCapability
 {
     /**
-     * @return array<string,Closure(CodeBase,Context,FunctionInterface,list<mixed>,array)>
+     * @return array<string,Closure(CodeBase,Context,FunctionInterface,list<mixed>,?Node)>
      * maps FQSEN of function or method to a closure used to analyze the function in question.
      * '\A::foo' or 'A::foo' as a key will override a method, and '\foo' or 'foo' as a key will override a function.
      * Closure Type: function(CodeBase $code_base, Context $context, Func|Method $function, array $args, ?Node $node) : void {...}

--- a/tests/Phan/Language/TypeTest.php
+++ b/tests/Phan/Language/TypeTest.php
@@ -37,7 +37,7 @@ use Phan\Language\Type\StringType;
 use Phan\Language\Type\TrueType;
 use Phan\Language\Type\VoidType;
 use Phan\Language\UnionType;
-use Phan\Tests\BaseTest;
+use Phan\Tests\CodeBaseAwareTest;
 
 use function get_class;
 
@@ -45,7 +45,7 @@ use function get_class;
  * Unit tests of Type
  * @phan-file-suppress PhanThrowTypeAbsentForCall
  */
-final class TypeTest extends BaseTest
+final class TypeTest extends CodeBaseAwareTest
 {
     private function makePHPDocType(string $type_string): Type
     {
@@ -343,8 +343,8 @@ final class TypeTest extends BaseTest
         $this->assertSame(get_class($expected_closure_type), get_class($parsed_closure_type), "expected closure/callable class for $normalized_type_string");
         $this->assertSame($normalized_type_string, (string)$parsed_closure_type, "failed parsing $union_type_string");
         $this->assertSame($normalized_type_string, (string)$expected_closure_type, "Bad precondition for $expected_closure_type");
-        $this->assertTrue($expected_closure_type->canCastToType($parsed_closure_type), "failed casting $union_type_string");
-        $this->assertTrue($parsed_closure_type->canCastToType($expected_closure_type), "failed casting $union_type_string");
+        $this->assertTrue($expected_closure_type->canCastToType($parsed_closure_type, $this->code_base), "failed casting $union_type_string");
+        $this->assertTrue($parsed_closure_type->canCastToType($expected_closure_type, $this->code_base), "failed casting $union_type_string");
     }
 
     public function testClosureAnnotation(): void
@@ -461,7 +461,7 @@ final class TypeTest extends BaseTest
     {
         $from_type = self::makePHPDocType($from_type_string);
         $to_type = self::makePHPDocType($to_type_string);
-        $this->assertTrue($from_type->canCastToType($to_type), "expected $from_type_string to be able to cast to $to_type_string");
+        $this->assertTrue($from_type->canCastToType($to_type, $this->code_base), "expected $from_type_string to be able to cast to $to_type_string");
     }
 
     /** @return list<list> */
@@ -480,6 +480,13 @@ final class TypeTest extends BaseTest
             ["?'a string'", "?'a string'"],
             ['int', 'float'],
             ['int', 'mixed'],
+            ['ArrayObject', 'Countable'],
+            ['ArrayObject', 'ArrayObject'],
+            ['ArrayObject', 'iterable'],
+            ['ArrayObject', '?iterable'],
+            ['ArrayObject', '?Countable'],
+            ['?ArrayObject', '?Countable'],
+            ['?Exception', '?Throwable'],
             ['mixed', 'int'],
             ['null', 'mixed'],
             ['null[]', 'mixed[]'],
@@ -489,6 +496,7 @@ final class TypeTest extends BaseTest
             ['?Closure(\'0,2\'):int', '?Closure(string):int'],
             ['?callable(int):int', '?callable'],
             ['?callable', '?callable(int):int'],
+            ['\'literal\'', 'string'],
         ];
     }
 
@@ -499,7 +507,7 @@ final class TypeTest extends BaseTest
     {
         $from_type = self::makePHPDocType($from_type_string);
         $to_type = self::makePHPDocType($to_type_string);
-        $this->assertFalse($from_type->canCastToType($to_type), "expected $from_type_string to be unable to cast to $to_type_string");
+        $this->assertFalse($from_type->canCastToType($to_type, $this->code_base), "expected $from_type_string to be unable to cast to $to_type_string");
     }
 
     /** @return list<list> */
@@ -530,8 +538,33 @@ final class TypeTest extends BaseTest
             ['?object', 'object'],
             ['?iterable', 'iterable'],
             ['?array', 'array'],
+            ['Countable', 'ArrayObject'],
+            ['iterable', 'ArrayObject'],
+            ['?iterable', '?ArrayObject'],
+            ['?Countable', '?ArrayObject'],
+            ['\'literal\'', '?int'],
             // not sure about desired semantics of ['?mixed', 'mixed'],
         ];
+    }
+
+    /** @return list<list> */
+    public function declaredTypeProvider(): array
+    {
+        return [
+            [false, "'literal'", '?int'],
+            [true, "'literal'", '?string'],
+            [true, "'literal'", 'mixed'],
+        ];
+    }
+
+    /**
+     * @dataProvider declaredTypeProvider
+     */
+    public function testCanCastToDeclaredType(bool $expected, string $from_type_string, string $to_type_string): void
+    {
+        $from_type = self::makePHPDocType($from_type_string);
+        $to_type = self::makePHPDocType($to_type_string);
+        $this->assertSame($expected, $from_type->canCastToDeclaredType($this->code_base, new Context(), $to_type), "unexpected canCastToDeclaredType result for $from_type_string to $to_type_string");
     }
 
     /**
@@ -662,12 +695,12 @@ final class TypeTest extends BaseTest
 
     private function assertCannotCastToType(Type $source, Type $target, string $details): void
     {
-        $this->assertFalse($source->canCastToType($target), "expected type $source not to be able to cast to type $target when $details");
+        $this->assertFalse($source->canCastToType($target, $this->code_base), "expected type $source not to be able to cast to type $target when $details");
     }
 
     private function assertCanCastToType(Type $source, Type $target, string $details): void
     {
-        $this->assertTrue($source->canCastToType($target), "expected type $source to be able to cast to type $target when $details");
+        $this->assertTrue($source->canCastToType($target, $this->code_base), "expected type $source to be able to cast to type $target when $details");
     }
 
     public function testCastingLiteralStringToInt(): void

--- a/tests/Phan/Language/TypeTest.php
+++ b/tests/Phan/Language/TypeTest.php
@@ -585,6 +585,11 @@ final class TypeTest extends CodeBaseAwareTest
             [true, 'ArrayObject<int>', 'ArrayObject'],
             [false, 'ArrayObject<int>', 'ArrayObject<string>'],
             [false, 'Traversable<int,int>', 'Traversable<string,int>'],
+            [true, 'iterable<string>', 'iterable'],
+            [true, 'array{}', 'array'],
+            [true, 'string[]', 'array'],
+            [true, 'array{}', 'iterable'],
+            [true, 'iterable<string>', 'iterable<mixed>'],
         ];
     }
 

--- a/tests/Phan/Language/TypeTest.php
+++ b/tests/Phan/Language/TypeTest.php
@@ -567,6 +567,42 @@ final class TypeTest extends CodeBaseAwareTest
         $this->assertSame($expected, $from_type->canCastToDeclaredType($this->code_base, new Context(), $to_type), "unexpected canCastToDeclaredType result for $from_type_string to $to_type_string");
     }
 
+    /** @return list<list> */
+    public function isSubtypeOfProvider(): array
+    {
+        return [
+            [false, 'ArrayObject', 'stdClass'],
+            [true, 'ArrayObject', 'mixed'],
+            [true, 'non-null-mixed', 'mixed'],
+            [true, 'non-empty-mixed', 'non-null-mixed'],
+            [false, 'false', 'true'],
+            [true, 'false', 'bool'],
+            [true, 'true', 'bool'],
+            [true, 'false', '?bool'],
+            [true, "Closure(int):int", 'Closure'],
+            [false, "Closure(int):int", 'Closure(string):int'],
+            [true, 'never', 'Closure(int):int'],
+            [true, 'ArrayObject<int>', 'ArrayObject'],
+            [false, 'ArrayObject<int>', 'ArrayObject<string>'],
+            [false, 'Traversable<int,int>', 'Traversable<string,int>'],
+        ];
+    }
+
+    /**
+     * @dataProvider isSubtypeOfProvider
+     */
+    public function testIsSubtypeOf(bool $expected, string $from_type_string, string $to_type_string): void
+    {
+        $from_type = self::makePHPDocType($from_type_string);
+        $to_type = self::makePHPDocType($to_type_string);
+        $this->assertTrue($from_type->isSubtypeOf($from_type, $this->code_base), "unexpected result for $from_type_string isSubtypeOf itself");
+        $this->assertSame($expected, $from_type->isSubtypeOf($to_type, $this->code_base), "unexpected result for $from_type_string isSubtypeOf $to_type_string");
+        $this->assertSame($expected, $from_type->canCastToType($to_type, $this->code_base), "unexpected result for $from_type_string canCastToType $to_type_string");
+        $this->assertSame($expected, $from_type->canCastToTypeWithoutConfig($to_type, $this->code_base), "unexpected result for $from_type_string canCastToTypeWithoutConfig $to_type_string");
+        if ($expected) {
+            $this->assertFalse($to_type->isSubtypeOf($from_type, $this->code_base), "unexpected result for $to_type_string isSubtypeOf $from_type_string");
+        }
+    }
     /**
      * @dataProvider arrayShapeProvider
      */

--- a/tests/Phan/Language/UnionTypeTest.php
+++ b/tests/Phan/Language/UnionTypeTest.php
@@ -848,6 +848,9 @@ final class UnionTypeTest extends BaseTest
             [true, 'ArrayObject', 'Countable'],
             [true, 'ArrayObject', 'object'],
             [false, 'ArrayAccess', 'ArrayObject'],
+            [true, 'Closure(int):int', 'Closure'],
+            [false, 'Closure', 'Closure(int):int'],
+            [false, 'Closure(string):int', 'Closure(int):int'],
         ];
     }
 
@@ -858,7 +861,7 @@ final class UnionTypeTest extends BaseTest
     {
         $from_type = self::makePHPDocUnionType($from_type_string);
         $to_type = self::makePHPDocUnionType($to_type_string);
-        $this->assertSame($expected, $from_type->isStrictSubtypeOf(self::$code_base, $to_type), "unexpected isStrictSubtypeOf result for $from_type_string to $to_type_string");
+        $this->assertSame($expected, $from_type->isStrictSubtypeOf(self::$code_base, $to_type), "unexpected isStrictSubtypeOf result for checking if $from_type_string isStrictSubtypeOf $to_type_string");
     }
 
 }

--- a/tests/Phan/Language/UnionTypeTest.php
+++ b/tests/Phan/Language/UnionTypeTest.php
@@ -19,6 +19,7 @@ use Phan\Language\Type\FalseType;
 use Phan\Language\Type\FloatType;
 use Phan\Language\Type\GenericArrayType;
 use Phan\Language\Type\IntType;
+use Phan\Language\Type\IntersectionType;
 use Phan\Language\Type\IterableType;
 use Phan\Language\Type\MixedType;
 use Phan\Language\Type\ObjectType;
@@ -761,33 +762,103 @@ final class UnionTypeTest extends BaseTest
         $this->assertSame('', $errors);
     }
 
+    public function testIntersectionTypeExplicit(): void
+    {
+        $type = self::makePHPDocUnionType('and<MyClass, MyInterfaceUTT>');
+        $this->assertSame(1, $type->typeCount());
+        $this->assertSame('\MyClass&\MyInterfaceUTT', (string)$type);
+        $this->assertInstanceOf(IntersectionType::class, $type->getTypeSet()[0]);
+    }
+
     public function testIntersectionTypeFallback(): void
     {
         $type = self::makePHPDocUnionType('MyClass&MyInterfaceUTT');
+        $this->assertSame(1, $type->typeCount());
+        $this->assertSame('\MyClass&\MyInterfaceUTT', (string)$type);
+        $this->assertInstanceOf(IntersectionType::class, $type->getTypeSet()[0]);
+    }
+
+    public function testIntersectionTypeWithUnionType(): void
+    {
+        $type = self::makePHPDocUnionType('int|MyClass&MyInterfaceUTT');
         $this->assertSame(2, $type->typeCount());
-        $this->assertSame('\MyClass|\MyInterfaceUTT', (string)$type);
+        $this->assertSame('\MyClass&\MyInterfaceUTT|int', (string)$type);
+        $this->assertInstanceOf(IntType::class, $type->getTypeSet()[0]);
+        $this->assertInstanceOf(IntersectionType::class, $type->getTypeSet()[1]);
     }
 
     public function testIntersectionTypeInArrayFallback(): void
     {
         $type = self::makePHPDocUnionType('(MyClass&MyInterfaceUTT)[]');
-        $this->assertSame(2, $type->typeCount());
-        $this->assertSame('\MyClass[]|\MyInterfaceUTT[]', (string)$type);
+        $this->assertSame(1, $type->typeCount());
+        $this->assertSame('(\MyClass&\MyInterfaceUTT)[]', (string)$type);
+        // @phan-suppress-next-line PhanUndeclaredMethod
+        $this->assertInstanceOf(IntersectionType::class, $type->getTypeSet()[0]->genericArrayElementType());
     }
+
     public function testIntersectionTypeInShapeFallback(): void
     {
         $type = self::makePHPDocUnionType('array{keyName:MyClass&MyInterfaceUTT,other:array}');
         $this->assertSame(1, $type->typeCount());
-        $this->assertSame('array{keyName:\MyClass|\MyInterfaceUTT,other:array}', (string)$type);
+        $this->assertSame('array{keyName:\MyClass&\MyInterfaceUTT,other:array}', (string)$type);
         $array_shape_type = $type->getTypeSet()[0];
         $this->assertInstanceof(ArrayShapeType::class, $array_shape_type);
         $this->assertSame(2, \count($array_shape_type->getFieldTypes()));
+        $this->assertInstanceOf(IntersectionType::class, $array_shape_type->getFieldTypes()['keyName']->getTypeSet()[0]);
     }
 
-    public function testIntersectionTypeInAngleBracketsFallback(): void
+    public function testIntersectionTypeCasting(): void
     {
-        $type = self::makePHPDocUnionType('list<\MyClass&NS\MyInterfaceUTT>');
-        $this->assertSame(2, $type->typeCount());
-        $this->assertSame('list<\MyClass>|list<\NS\MyInterfaceUTT>', (string)$type);
+        $code_base = self::$code_base;
+        $intersection1 = self::makePHPDocUnionType('Countable&ArrayAccess');
+        $intersection2 = self::makePHPDocUnionType('\ArrayAccess&\Countable');
+        $this->assertSame(1, $intersection1->typeCount());
+        $this->assertSame('\ArrayAccess|\Countable|\Countable&\ArrayAccess', $intersection1->asExpandedTypes($code_base)->__toString());
+
+        $this->assertTrue($intersection1->canCastToUnionType($intersection2, $code_base), 'expected intersection type to cast to itself');
+        $this->assertTrue($intersection1->hasSubtypeOf($intersection2, $code_base), 'expect hasSubtypeOf to be true for intersection type');
+        $this->assertTrue($intersection1->canStrictCastToUnionType($code_base, $intersection2), 'expected intersection type to strictly cast to itself');
+
+        $countable = self::makePHPDocUnionType('Countable');
+        $this->assertTrue($intersection1->canCastToUnionType($countable, $code_base), 'expected intersection type to cast to component');
+        $this->assertTrue($intersection1->hasSubtypeOf($countable, $code_base), 'expect hasSubtypeOf to be true for component type');
+        $this->assertTrue($intersection1->canStrictCastToUnionType($code_base, $countable), 'expected intersection type to strictly cast to component');
+
+        $traversable = self::makePHPDocUnionType('Traversable');
+        $this->assertFalse($intersection1->canCastToUnionType($traversable, $code_base), 'expected intersection type not to cast to non-component');
+        $this->assertFalse($intersection1->hasSubtypeOf($traversable, $code_base), 'expect hasSubtypeOf to be false for unrelated type');
+        $this->assertFalse($intersection1->canStrictCastToUnionType($code_base, $traversable));
+
+        $intersection_narrowed = self::makePHPDocUnionType('\ArrayAccess&\Countable&\Traversable');
+        $this->assertTrue($intersection_narrowed->canCastToUnionType($intersection1, $code_base));
+        $this->assertFalse($intersection1->canCastToUnionType($intersection_narrowed, $code_base));
     }
+
+    /** @return list<list> */
+    public function isStrictSubtypeOfProvider(): array
+    {
+        return [
+            [false, "'literal'", '?int'],
+            [false, 'int|string', 'int'],
+            [true, "'literal'", '?string'],
+            [true, "'literal'", 'mixed'],
+            [true, 'ArrayObject', 'ArrayAccess'],
+            [true, 'ArrayObject', 'ArrayAccess&Countable'],
+            [false, 'ArrayAccess&Countable', 'ArrayObject'],
+            [true, 'ArrayObject', 'Countable'],
+            [true, 'ArrayObject', 'object'],
+            [false, 'ArrayAccess', 'ArrayObject'],
+        ];
+    }
+
+    /**
+     * @dataProvider isStrictSubtypeOfProvider
+     */
+    public function testIsStrictSubtypeOf(bool $expected, string $from_type_string, string $to_type_string): void
+    {
+        $from_type = self::makePHPDocUnionType($from_type_string);
+        $to_type = self::makePHPDocUnionType($to_type_string);
+        $this->assertSame($expected, $from_type->isStrictSubtypeOf(self::$code_base, $to_type), "unexpected isStrictSubtypeOf result for $from_type_string to $to_type_string");
+    }
+
 }

--- a/tests/files/expected/0474_typed_iterable.php.expected
+++ b/tests/files/expected/0474_typed_iterable.php.expected
@@ -4,6 +4,8 @@
 %s:19 PhanTypeMismatchArgumentInternal Argument 1 ($num1) is $k of type string but \intdiv() takes int
 %s:28 PhanTypeMismatchArgument Argument 1 ($tsi) is $tii of type \Traversable|\Traversable<int,int>|iterable but \expect_traversable_string_int() takes \Traversable<string,int> defined at %s:16
 %s:30 PhanTypeMismatchArgument Argument 1 ($tsi) is $tss of type \Traversable|\Traversable<string,string>|iterable but \expect_traversable_string_int() takes \Traversable<string,int> defined at %s:16
+%s:32 PhanTypeMismatchArgument Argument 1 ($isi) is $tii of type \Traversable|\Traversable<int,int>|iterable but \expect_iterable_string_int() takes iterable<string,int> defined at %s:6
+%s:34 PhanTypeMismatchArgument Argument 1 ($isi) is $tss of type \Traversable|\Traversable<string,string>|iterable but \expect_iterable_string_int() takes iterable<string,int> defined at %s:6
 %s:39 PhanTypeMismatchArgument Argument 1 ($isi) is [$s=>$s] of type non-empty-array<string,string> but \expect_iterable_string_int() takes iterable<string,int> defined at %s:6
 %s:40 PhanTypeMismatchArgument Argument 1 ($isi) is [$i=>$s] of type non-empty-associative-array<int,string> but \expect_iterable_string_int() takes iterable<string,int> defined at %s:6
 %s:42 PhanTypeMismatchArgumentReal Argument 1 ($tsi) is [$s=>$i] of type non-empty-array<string,int> (real type non-empty-array<mixed,int>) but \expect_traversable_string_int() takes \Traversable<string,int> (real type \Traversable) defined at %s:16

--- a/tests/files/expected/0858_intersection_type_phpdoc_fallback.php.expected
+++ b/tests/files/expected/0858_intersection_type_phpdoc_fallback.php.expected
@@ -1,4 +1,8 @@
 %s:20 PhanUndeclaredMethod Call to undeclared method \MyClass858::missingMethod
-%s:30 PhanTypeMismatchArgument Argument 1 ($param) is $x of type \ArrayAccess but \test() takes \Countable|\MyClass858 defined at %s:17
+%s:28 PhanTypeMismatchArgument Argument 1 ($param) is $x of type \Countable but \test() takes \MyClass858&\Countable defined at %s:17
+%s:30 PhanTypeMismatchArgument Argument 1 ($param) is $x of type \ArrayAccess but \test() takes \MyClass858&\Countable defined at %s:17
 %s:41 PhanUndeclaredMethod Call to undeclared method \MyClass858::otherMissingMethod
-%s:44 PhanTypeMismatchArgument Argument 1 ($values) is [new stdClass()] of type array{0:\stdClass} but \test_list() takes list<\Countable>|list<\MyClass858> defined at %s:37
+%s:44 PhanTypeMismatchArgument Argument 1 ($param) is new stdClass() of type \stdClass but \test() takes \MyClass858&\Countable defined at %s:17
+%s:45 PhanTypeMismatchArgument Argument 1 ($param) is new MyClass858() of type \MyClass858 but \test() takes \MyClass858&\Countable defined at %s:17
+%s:47 PhanTypeMismatchArgument Argument 1 ($values) is [new stdClass()] of type array{0:\stdClass} but \test_list() takes list<\MyClass858&\Countable> defined at %s:37
+%s:48 PhanTypeMismatchArgument Argument 1 ($values) is [new MyClass858()] of type array{0:\MyClass858} but \test_list() takes list<\MyClass858&\Countable> defined at %s:37

--- a/tests/files/src/0474_typed_iterable.php
+++ b/tests/files/src/0474_typed_iterable.php
@@ -28,7 +28,7 @@ function expect_traversables(Traversable $tii, Traversable $tsi, Traversable $ts
     expect_traversable_string_int($tii);
     expect_traversable_string_int($tsi);
     expect_traversable_string_int($tss);
-    // TODO: Make a subset of the below casts to iterable<TKey,TValue> emit appropriate warnings
+    // These also warn
     expect_iterable_string_int($tii);
     expect_iterable_string_int($tsi);
     expect_iterable_string_int($tss);

--- a/tests/files/src/0858_intersection_type_phpdoc_fallback.php
+++ b/tests/files/src/0858_intersection_type_phpdoc_fallback.php
@@ -4,7 +4,7 @@ class MyClass858 {
     }
 }
 
-class MyCountableClass implements Countable {
+class MyCountableClass extends MyClass858 implements Countable {
     public function count() {
         return 0;
     }
@@ -25,10 +25,10 @@ function test($param) {
 // This tests that the fallback does something reasonable, and doesn't crash.
 function test_infer(MyClass858 $x) {
     if ($x instanceof Countable) {
-        test($x);
+        test($x); // should warn
     } elseif ($x instanceof ArrayAccess) {
-        test($x);
-    }
+        test($x); // should warn
+    } // TODO: Type combinations should narrow
 }
 
 /**
@@ -41,5 +41,9 @@ function test_list(array $values) {
         $value->otherMissingMethod();
     }
 }
+test(new stdClass());
+test(new MyClass858());
+test(new MyCountableClass()); // This is a valid cast.
 test_list([new stdClass()]);
-test_list([new MyCountableClass()]);
+test_list([new MyClass858()]);
+test_list([new MyCountableClass()]); // This is a valid cast.


### PR DESCRIPTION
For #1629

Previously, intersection types were parsed for compatibility, but
`A&B` was treated as an alias for `A|B` because there was no support in
the type system for intersection types

There is a LOT more work remaining to actually support the type casting
logic for intersection types.

The union type parsing is done with a regular expression, and it may be
better to replace it with a real parser at some point.

As a workaround, support `and<T1, T2, T3>` in phpdoc for union types and
translate to that.
(TODO: Change to `phan-intersection-type<T1, T2, T3>` if intersection
types work well enough in phpdoc)

TODOs:

- Update everything that checks for types that correspond to a single fqsen
  to also check for intersection types (partly done)
- Support getting method signatures from intersection types
  (to start, just look for the first method that implements it)
- Eliminate redundant types from intersection types
  (E.g. ArrayObject&Countable -> ArrayObject)
- Handle self/static (resolve in context, etc)
- Throw an IssueException for non-interfaces or non-classes
- Infer intersection types from conditions narrowing interface/class
  types and fix test failures or update expected messages
- Implement actual checks to allow casting A&B&C to A&B
- Allow casting ArrayObject to ArrayAccess|Countable
  (i.e. if it inherits all types) (DONE)

  This may or may not require refactoring
- Override various methods implemented on atomic types
- ~~For compatibility, add a config setting to temporarily turn this off
  for projects that rely on the old behavior or that encounter issues
  with the intersection type logic.~~