### PR TITLE
Release Phan 4.0.6

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 Phan NEWS
 
-??? ?? 2021, Phan 4.0.6 (dev)
+May 19 2021, Phan 4.0.6
 -----------------------
 
 New Features (Analysis):

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -83,7 +83,7 @@ class CLI
     /**
      * This should be updated to x.y.z-dev after every release, and x.y.z before a release.
      */
-    public const PHAN_VERSION = '4.0.6-dev';
+    public const PHAN_VERSION = '4.0.6';
 
     /**
      * List of short flags passed to getopt

--- a/tests/files/expected/0166_is_a.php.expected
+++ b/tests/files/expected/0166_is_a.php.expected
@@ -16,8 +16,8 @@
 %s:35 PhanTypeMismatchArgumentProbablyReal Argument 1 ($var) is $var of type float but \emitType() takes resource (no real type) defined at %s:3 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
 %s:37 PhanTypeMismatchArgumentReal Argument 1 ($var) is $var of type resource but \emitResourceType() takes string defined at %s:5
 %s:38 PhanDebugAnnotation @phan-debug-var requested for variable $var - it has union type non-null-mixed(real=non-null-mixed)
-%s:40 PhanDebugAnnotation @phan-debug-var requested for variable $var - it has union type scalar(real=scalar)
-%s:41 PhanTypeMismatchArgumentProbablyReal Argument 1 ($var) is $var of type scalar but \emitType() takes resource (no real type) defined at %s:3 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
+%s:40 PhanDebugAnnotation @phan-debug-var requested for variable $var - it has union type bool|float|int|string(real=bool|float|int|string)
+%s:41 PhanTypeMismatchArgumentProbablyReal Argument 1 ($var) is $var of type bool|float|int|string but \emitType() takes resource (no real type) defined at %s:3 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
 %s:43 PhanTypeMismatchArgumentProbablyReal Argument 1 ($var) is $var of type string but \emitType() takes resource (no real type) defined at %s:3 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
 %s:45 PhanTypeMismatchArgumentProbablyReal Argument 1 ($var) is $var of type iterable but \emitType() takes resource (no real type) defined at %s:3 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
 %s:46 PhanUnusedVariable Unused definition of variable $v


### PR DESCRIPTION
And fix some type casting rules noticed when spot checking

Expand `scalar` to component types after a type assertion of is_scalar(mixed)

Infer there's overlap between ?int and non-null-mixed despite types not
casting to each other - the overlap is `int`