### PR TITLE
Update CodeClimate Dockerfile in order to start supporting php8 syntax properly

### DIFF
--- a/plugins/codeclimate/Dockerfile
+++ b/plugins/codeclimate/Dockerfile
@@ -24,7 +24,7 @@
 # SOFTWARE.
 
 
-FROM alpine:3.12
+FROM php:8.0.6-fpm-alpine3.13
 
 WORKDIR /usr/src/app
 
@@ -32,68 +32,63 @@ RUN adduser -u 9000 -D app
 
 ENV LAST_MODIFIED_DATE 2020-09-13
 
-ENV PHP_AST_VERSION=1.0.10
+ENV PHP_AST_VERSION=1.0.12
 
 RUN apk add --no-cache \
-	php7 && \
-	test -d /etc/php7/conf.d || ((test -e /etc/php7/conf.d && rm /etc/php7/conf.d) && mkdir /etc/php7/conf.d)	&& \
+	php8 && \
+	test -d /etc/php8/conf.d || ((test -e /etc/php8/conf.d && rm /etc/php8/conf.d) && mkdir /etc/php8/conf.d)	&& \
 	apk add --no-cache \
-	php7-bcmath \
-	php7-ctype \
-	php7-curl \
-	php7-gd \
-	php7-gettext \
-	php7-iconv \
-	php7-intl \
-	php7-json \
-	php7-ldap \
-	php7-mbstring \
-	php7-mcrypt \
-	php7-mysqlnd \
-	php7-opcache \
-	php7-openssl \
-	php7-pdo_mysql \
-	php7-pdo_pgsql \
-	php7-pdo_sqlite \
-	php7-pgsql \
-	php7-phar \
-	php7-session \
-	php7-soap \
-	php7-sockets \
-	php7-sqlite3 \
-	php7-tidy \
-	php7-tokenizer \
-	php7-xml \
-	php7-xmlreader \
-	php7-xmlrpc \
-	php7-xsl \
-	php7-zip \
-	php7-zlib
+	php8-bcmath \
+	php8-ctype \
+	php8-curl \
+	php8-gd \
+	php8-gettext \
+	php8-iconv \
+	php8-intl \
+	php8-json \
+	php8-ldap \
+	php8-mbstring \
+	php8-mysqlnd \
+	php8-opcache \
+	php8-openssl \
+	php8-pdo_mysql \
+	php8-pdo_pgsql \
+	php8-pdo_sqlite \
+	php8-pgsql \
+	php8-phar \
+	php8-session \
+	php8-soap \
+	php8-sockets \
+	php8-sqlite3 \
+	php8-tidy \
+	php8-tokenizer \
+	php8-xml \
+	php8-xmlreader \
+	php8-xsl \
+	php8-zip \
+	php8-zlib
+
+RUN apk add git
 
 RUN apk add --no-cache bash \
       autoconf \
       openssl \
       make \
       build-base \
-      php7-dev \
-      wget && \
-    wget -O php-ast.tar.gz https://github.com/nikic/php-ast/archive/v${PHP_AST_VERSION}.tar.gz && \
-    tar -zxvf php-ast.tar.gz && \
-    cd php-ast-${PHP_AST_VERSION} && \
-    export CFLAGS=-O2 && \
-    phpize7 && \
-    ./configure --prefix=/usr --with-php-config=/usr/bin/php-config7 && \
-    make -j3 && \
-    make test && \
-    make install && \
-    cd .. && \
-    rm -Rf php-ast-${PHP_AST_VERSION} php-ast.tar.gz && \
+      php8-dev \
+	&&  git clone https://github.com/nikic/php-ast.git \
+    && cd php-ast \
+    && phpize8 \
+    && ./configure \
+    && make install \
+    && echo 'extension=ast.so' >/usr/local/etc/php/php.ini \
+    && cd .. && rm -rf php-ast \
     apk del bash \
       autoconf \
       openssl \
       make \
       build-base \
-      php7-dev \
+      php8-dev \
       wget
 
 COPY composer.json composer.lock ./
@@ -106,7 +101,7 @@ RUN apk add --no-cache curl && \
 COPY .phan .phan
 COPY src src
 
-COPY plugins/codeclimate/ast.ini /etc/php7/conf.d/
+COPY plugins/codeclimate/ast.ini /etc/php8/conf.d/
 COPY plugins/codeclimate/engine /usr/src/app/plugins/codeclimate/engine
 
 USER app


### PR DESCRIPTION
Change image to use php 8.0.6 fpm alpine.
Upgrade ast version to last.
Change php7 for php8
Change the way of installation of ast in docker file.