### PR TITLE
Split issues for returning/passing in supertypes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,15 @@
 Phan NEWS
 
-??? ?? 2021, Phan 5.0.0-RC1 (dev)
--------------------------
+??? ?? 2021, Phan 5.0.0 (dev)
+-----------------------
 
 New Features (Analysis):
 - Warn about implicitly nullable parameter intersection types (`function(A&B $paramName = null)`) being a compile error.
   New issue type: `PhanTypeMismatchDefaultIntersection`
+- Emit `PhanTypeMismatchArgumentSuperType` instead of `PhanTypeMismatchArgument` when passing in an object supertype (e.g. ancestor class) of an object instead of a subtype.
+  Emit `PhanTypeMismatchReturnSuperType` instead of `PhanTypeMismatchReturn` when returning an object supertype (e.g. ancestor class) of an object instead of a subtype.
+
+  Phan 5 starts warning about ancestor classes being incompatible argument or return types in cases where it previously allowed it. (#4413)
 
 Jul 24 2021, Phan 5.0.0a4
 -------------------------

--- a/composer.lock
+++ b/composer.lock
@@ -89,21 +89,21 @@
         },
         {
             "name": "composer/xdebug-handler",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "964adcdd3a28bf9ed5d9ac6450064e0d71ed7496"
+                "reference": "84674dd3a7575ba617f5a76d7e9e29a7d3891339"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/964adcdd3a28bf9ed5d9ac6450064e0d71ed7496",
-                "reference": "964adcdd3a28bf9ed5d9ac6450064e0d71ed7496",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/84674dd3a7575ba617f5a76d7e9e29a7d3891339",
+                "reference": "84674dd3a7575ba617f5a76d7e9e29a7d3891339",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3.2 || ^7.0 || ^8.0",
-                "psr/log": "^1.0"
+                "psr/log": "^1 || ^2 || ^3"
             },
             "require-dev": {
                 "phpstan/phpstan": "^0.12.55",
@@ -133,7 +133,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/xdebug-handler/issues",
-                "source": "https://github.com/composer/xdebug-handler/tree/2.0.1"
+                "source": "https://github.com/composer/xdebug-handler/tree/2.0.2"
             },
             "funding": [
                 {
@@ -149,7 +149,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-05T19:37:51+00:00"
+            "time": "2021-07-31T17:03:58+00:00"
         },
         {
             "name": "felixfbecker/advanced-json-rpc",
@@ -2143,16 +2143,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "8.5.18",
+            "version": "8.5.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "bd5fc77c869e8dd65040dacbad170f074c13796c"
+                "reference": "496281b64ec781856ed0a583483b5923b4033722"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/bd5fc77c869e8dd65040dacbad170f074c13796c",
-                "reference": "bd5fc77c869e8dd65040dacbad170f074c13796c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/496281b64ec781856ed0a583483b5923b4033722",
+                "reference": "496281b64ec781856ed0a583483b5923b4033722",
                 "shasum": ""
             },
             "require": {
@@ -2164,12 +2164,12 @@
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
                 "myclabs/deep-copy": "^1.10.0",
-                "phar-io/manifest": "^2.0.1",
+                "phar-io/manifest": "^2.0.3",
                 "phar-io/version": "^3.0.2",
                 "php": ">=7.2",
                 "phpspec/prophecy": "^1.10.3",
                 "phpunit/php-code-coverage": "^7.0.12",
-                "phpunit/php-file-iterator": "^2.0.2",
+                "phpunit/php-file-iterator": "^2.0.4",
                 "phpunit/php-text-template": "^1.2.1",
                 "phpunit/php-timer": "^2.1.2",
                 "sebastian/comparator": "^3.0.2",
@@ -2224,7 +2224,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/8.5.18"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/8.5.19"
             },
             "funding": [
                 {
@@ -2236,7 +2236,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-07-19T06:13:17+00:00"
+            "time": "2021-07-31T15:15:06+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -3698,6 +3698,14 @@ Argument {INDEX} (${PARAMETER}) is {CODE} of type {TYPE}{DETAILS} but {FUNCTIONL
 
 e.g. [this issue](https://github.com/phan/phan/tree/v5/tests/rasmus_files/expected/0035_class_const.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/v5/tests/rasmus_files/src/0035_class_const.php#L6).
 
+## PhanTypeMismatchArgumentSuperType
+
+```
+Argument {INDEX} (${PARAMETER}) is {CODE} of type {TYPE} but {FUNCTIONLIKE} takes {TYPE} defined at {FILE}:{LINE} (expected type to be the same or a subtype, but saw a supertype instead)
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/v5/tests/files/expected/0956_return_super_type.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/v5/tests/files/src/0956_return_super_type.php#L20).
+
 ## PhanTypeMismatchArrayDestructuringKey
 
 ```
@@ -3932,6 +3940,14 @@ This issue is emitted from the following code
 class G { function f() : int { return 'string'; } }
 ```
 
+
+## PhanTypeMismatchReturnSuperType
+
+```
+Returning {CODE} of type {TYPE} but {FUNCTIONLIKE} is declared to return {TYPE} (saw a supertype instead of a subtype)
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/v5/tests/files/expected/0956_return_super_type.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/v5/tests/files/src/0956_return_super_type.php#L13).
 
 ## PhanTypeMismatchUnpackKey
 

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -2835,7 +2835,7 @@ class TolerantASTConverter
             if ($prop instanceof Token) {
                 continue;
             }
-            // @phan-suppress-next-line PhanTypeMismatchArgument casting to a more specific node
+            // @phan-suppress-next-line PhanTypeMismatchArgumentSuperType casting to a more specific node
             $prop_elems[] = static::phpParserPropelemToAstPropelem($prop, $i === 0 ? $doc_comment : null);
         }
         $flags = static::phpParserVisibilityToAstVisibility($n->modifiers, false);
@@ -2858,7 +2858,7 @@ class TolerantASTConverter
             if ($const_elem instanceof Token) {
                 continue;
             }
-            // @phan-suppress-next-line PhanTypeMismatchArgument casting to a more specific node
+            // @phan-suppress-next-line PhanTypeMismatchArgumentSuperType casting to a more specific node
             $const_elems[] = static::phpParserConstelemToAstConstelem($const_elem, $i === 0 ? $doc_comment : null);
         }
         $flags = static::phpParserVisibilityToAstVisibility($n->modifiers);

--- a/src/Phan/Analysis/ArgumentType.php
+++ b/src/Phan/Analysis/ArgumentType.php
@@ -1164,6 +1164,7 @@ final class ArgumentType
         int $lineno,
         int $i
     ): void {
+        $context = (clone $context)->withLineNumberStart($lineno);
         /**
          * @return ?string
          */
@@ -1292,6 +1293,31 @@ final class ArgumentType
                     $method->getRepresentationForIssue(),
                     $alternate_parameter_type,
                     PostOrderAnalysisVisitor::toDetailsForRealTypeMismatch($alternate_parameter_type),
+                    $method->getFileRef()->getFile(),
+                    $method->getFileRef()->getLineNumberStart()
+                );
+                return;
+            }
+            if ($context->hasSuppressIssue($code_base, Issue::TypeMismatchArgument)) {
+                // Suppressing ProbablyReal also suppresses the less severe version.
+                return;
+            }
+            if (PostOrderAnalysisVisitor::doesExpressionHaveSuperClassOfTargetType(
+                $code_base,
+                $argument_type,
+                $alternate_parameter_type
+            )) {
+                Issue::maybeEmit(
+                    $code_base,
+                    $context,
+                    Issue::TypeMismatchArgumentSuperType,
+                    $lineno,
+                    ($i + 1),
+                    $alternate_parameter->getName(),
+                    ASTReverter::toShortString($argument_node),
+                    $argument_type_expanded->withUnionType($argument_type_expanded_resolved),
+                    $method->getRepresentationForIssue(),
+                    (string)$alternate_parameter_type,
                     $method->getFileRef()->getFile(),
                     $method->getFileRef()->getLineNumberStart()
                 );

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -82,7 +82,7 @@ class CLI
     /**
      * This should be updated to x.y.z-dev after every release, and x.y.z before a release.
      */
-    public const PHAN_VERSION = '5.0.0-RC1-dev';
+    public const PHAN_VERSION = '5.0.0-dev';
 
     /**
      * List of short flags passed to getopt

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -165,6 +165,7 @@ class Issue
     public const TypeMismatchArgumentInternalProbablyReal = 'PhanTypeMismatchArgumentInternalProbablyReal';
     public const TypeMismatchArgumentInternalReal       = 'PhanTypeMismatchArgumentInternalReal';
     public const TypeMismatchArgumentNullableInternal   = 'PhanTypeMismatchArgumentNullableInternal';
+    public const TypeMismatchArgumentSuperType          = 'PhanTypeMismatchArgumentSuperType';
     public const PartialTypeMismatchArgument            = 'PhanPartialTypeMismatchArgument';
     public const PartialTypeMismatchArgumentInternal    = 'PhanPartialTypeMismatchArgumentInternal';
     public const PossiblyNullTypeArgument  = 'PhanPossiblyNullTypeArgument';
@@ -196,6 +197,7 @@ class Issue
     public const TypeMismatchReturnNullable = 'PhanTypeMismatchReturnNullable';
     public const TypeMismatchReturnProbablyReal = 'PhanTypeMismatchReturnProbablyReal';
     public const TypeMismatchReturnReal     = 'PhanTypeMismatchReturnReal';
+    public const TypeMismatchReturnSuperType = 'PhanTypeMismatchReturnSuperType';
     public const PartialTypeMismatchReturn = 'PhanPartialTypeMismatchReturn';
     public const PossiblyNullTypeReturn  = 'PhanPossiblyNullTypeReturn';
     public const PossiblyFalseTypeReturn  = 'PhanPossiblyFalseTypeReturn';
@@ -1622,6 +1624,14 @@ class Issue
                 10105
             ),
             new Issue(
+                self::TypeMismatchArgumentSuperType,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_LOW,
+                'Argument {INDEX} (${PARAMETER}) is {CODE} of type {TYPE} but {FUNCTIONLIKE} takes {TYPE} defined at {FILE}:{LINE} (expected type to be the same or a subtype, but saw a supertype instead)',
+                self::REMEDIATION_B,
+                10186
+            ),
+            new Issue(
                 self::TypeMismatchArgumentInternal,
                 self::CATEGORY_TYPE,
                 self::SEVERITY_NORMAL,
@@ -1780,6 +1790,14 @@ class Issue
                 "Returning {CODE} of type {TYPE} but {FUNCTIONLIKE} is declared to return {TYPE} ({TYPE} is incompatible)",
                 self::REMEDIATION_B,
                 10060
+            ),
+            new Issue(
+                self::TypeMismatchReturnSuperType,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_LOW,
+                "Returning {CODE} of type {TYPE} but {FUNCTIONLIKE} is declared to return {TYPE} (saw a supertype instead of a subtype)",
+                self::REMEDIATION_B,
+                10176
             ),
             new Issue(
                 self::PossiblyNullTypeReturn,

--- a/src/Phan/Language/Element/VariadicParameter.php
+++ b/src/Phan/Language/Element/VariadicParameter.php
@@ -103,7 +103,7 @@ class VariadicParameter extends Parameter
         // e.g. $this->getUnionType() is of type T[]
         //      $this->non_variadic->getUnionType() is of type T
         return new Parameter(
-            // @phan-suppress-next-line PhanTypeMismatchArgument Here it's fine to pass a FileRef
+            // @phan-suppress-next-line PhanTypeMismatchArgumentSuperType Here it's fine to pass a FileRef
             $this->getFileRef(),
             $this->getName(),
             $this->type,

--- a/src/Phan/Language/FQSEN/FullyQualifiedFunctionName.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedFunctionName.php
@@ -70,7 +70,7 @@ class FullyQualifiedFunctionName extends FullyQualifiedGlobalStructuralElement i
 
         // Check for a name map
         if ($context->hasNamespaceMapFor(static::getNamespaceMapType(), $fqsen_string)) {
-            // @phan-suppress-next-line PhanTypeMismatchReturn
+            // @phan-suppress-next-line PhanTypeMismatchReturnSuperType
             return $context->getNamespaceMapFor(
                 static::getNamespaceMapType(),
                 $fqsen_string

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
@@ -750,7 +750,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
         $inner_scope = $this->analyze($this->scope, $node->children['stmts']);
 
         // Merge inner scope into outer scope
-        // @phan-suppress-next-line PhanTypeMismatchArgument
+        // @phan-suppress-next-line PhanTypeMismatchArgumentSuperType
         $outer_scope = $outer_scope->mergeInnerLoopScope($inner_scope, self::$variable_graph);
 
         return $outer_scope_unbranched->mergeWithSingleBranchScope($outer_scope);
@@ -831,7 +831,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
             }
             $this->top_level_statement = $loop_node;
             $loop_scope = $this->analyze(new VariableTrackingBranchScope($inner_scope), $loop_node);
-            // @phan-suppress-next-line PhanTypeMismatchArgument
+            // @phan-suppress-next-line PhanTypeMismatchArgumentSuperType
             $inner_scope = $inner_scope->mergeWithSingleBranchScope($loop_scope);
             $this->top_level_statement = $top_level_statement;
         }
@@ -842,7 +842,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
             if ($loop_node instanceof Node) {
                 $this->top_level_statement = $loop_node;
                 $loop_scope = $this->analyze(new VariableTrackingBranchScope($inner_scope), $loop_node);
-                // @phan-suppress-next-line PhanTypeMismatchArgument
+                // @phan-suppress-next-line PhanTypeMismatchArgumentSuperType
                 $inner_scope = $inner_scope->mergeWithSingleBranchScope($loop_scope);
                 $this->top_level_statement = $top_level_statement;
             }
@@ -850,7 +850,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
         $inner_scope = $this->analyzeCondExprList($inner_scope, $node->children['cond']);
 
         // Merge inner scope into outer scope
-        // @phan-suppress-next-line PhanTypeMismatchArgument
+        // @phan-suppress-next-line PhanTypeMismatchArgumentSuperType
         $outer_scope = $outer_scope->mergeInnerLoopScope($inner_scope, self::$variable_graph);
         return $outer_scope_unbranched->mergeWithSingleBranchScope($outer_scope);
     }
@@ -1046,7 +1046,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
         if (\count($catch_node_list) > 0) {
             $catches_scope = new VariableTrackingBranchScope($main_scope);
             $catches_scope = $this->analyze($catches_scope, $node->children['catches']);
-            // @phan-suppress-next-line PhanTypeMismatchArgument
+            // @phan-suppress-next-line PhanTypeMismatchArgumentSuperType
             $main_scope = $main_scope->mergeWithSingleBranchScope($catches_scope);
         }
         $finally_node = $node->children['finally'];

--- a/tests/files/expected/0455_closure_type_cast.php.expected
+++ b/tests/files/expected/0455_closure_type_cast.php.expected
@@ -1,26 +1,26 @@
 %s:8 PhanTypeSuspiciousEcho Suspicious argument $fn of type Closure(int):void for an echo/print statement
 %s:9 PhanTypeMismatchArgumentProbablyReal Argument 1 ($p0) is new stdClass() of type \stdClass but Closure(int):void takes int (no real type) defined at %s:6 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
 %s:10 PhanParamTooFew Call with 0 arg(s) to Closure(int):void which requires 1 arg(s) defined at %s:6
-%s:15 PhanTypeMismatchArgument Argument 1 ($fn) is (function) of type Closure(int,string):void but \expects_int_param() takes Closure(int):void defined at %s:6
-%s:17 PhanTypeMismatchArgument Argument 1 ($fn) is (function) of type Closure(int&):void but \expects_int_param() takes Closure(int):void defined at %s:6
+%s:15 PhanTypeMismatchArgumentSuperType Argument 1 ($fn) is (function) of type Closure(int,string):void but \expects_int_param() takes Closure(int):void defined at %s:6 (expected type to be the same or a subtype, but saw a supertype instead)
+%s:17 PhanTypeMismatchArgumentSuperType Argument 1 ($fn) is (function) of type Closure(int&):void but \expects_int_param() takes Closure(int):void defined at %s:6 (expected type to be the same or a subtype, but saw a supertype instead)
 %s:24 PhanTypeMismatchArgumentProbablyReal Argument 1 ($p0) is new stdClass() of type \stdClass but Closure(int=):void takes int (no real type) defined at %s:22 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
 %s:26 PhanTypeMismatchArgumentProbablyReal Argument 1 ($p0) is null of type null but Closure(int=):void takes int (no real type) defined at %s:22 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
-%s:28 PhanTypeMismatchArgument Argument 1 ($fn) is (function) of type Closure(int):void but \expects_optional_int_param() takes Closure(int=):void defined at %s:22
-%s:31 PhanTypeMismatchArgument Argument 1 ($fn) is (function) of type Closure(int,string):void but \expects_optional_int_param() takes Closure(int=):void defined at %s:22
-%s:32 PhanTypeMismatchArgument Argument 1 ($fn) is (function) of type Closure():void but \expects_optional_int_param() takes Closure(int=):void defined at %s:22
-%s:33 PhanTypeMismatchArgument Argument 1 ($fn) is (function) of type Closure(int&=):void but \expects_optional_int_param() takes Closure(int=):void defined at %s:22
+%s:28 PhanTypeMismatchArgumentSuperType Argument 1 ($fn) is (function) of type Closure(int):void but \expects_optional_int_param() takes Closure(int=):void defined at %s:22 (expected type to be the same or a subtype, but saw a supertype instead)
+%s:31 PhanTypeMismatchArgumentSuperType Argument 1 ($fn) is (function) of type Closure(int,string):void but \expects_optional_int_param() takes Closure(int=):void defined at %s:22 (expected type to be the same or a subtype, but saw a supertype instead)
+%s:32 PhanTypeMismatchArgumentSuperType Argument 1 ($fn) is (function) of type Closure():void but \expects_optional_int_param() takes Closure(int=):void defined at %s:22 (expected type to be the same or a subtype, but saw a supertype instead)
+%s:33 PhanTypeMismatchArgumentSuperType Argument 1 ($fn) is (function) of type Closure(int&=):void but \expects_optional_int_param() takes Closure(int=):void defined at %s:22 (expected type to be the same or a subtype, but saw a supertype instead)
 %s:41 PhanParamTooMany Call with 1 arg(s) to Closure():int which only takes 0 arg(s) defined at %s:40
 %s:42 PhanTypeMismatchReturn Returning $fn() of type int but expects_int_return() is declared to return \stdClass
-%s:48 PhanTypeMismatchArgument Argument 1 ($fn) is (function) of type Closure():array but \expects_int_return() takes Closure():int defined at %s:40
-%s:49 PhanTypeMismatchArgument Argument 1 ($fn) is (function) of type Closure(array):int but \expects_int_return() takes Closure():int defined at %s:40
+%s:48 PhanTypeMismatchArgumentSuperType Argument 1 ($fn) is (function) of type Closure():array but \expects_int_return() takes Closure():int defined at %s:40 (expected type to be the same or a subtype, but saw a supertype instead)
+%s:49 PhanTypeMismatchArgumentSuperType Argument 1 ($fn) is (function) of type Closure(array):int but \expects_int_return() takes Closure():int defined at %s:40 (expected type to be the same or a subtype, but saw a supertype instead)
 %s:57 PhanTypeVoidAssignment Cannot assign void return value
 %s:57 PhanUnusedVariable Unused definition of variable $result
 %s:58 PhanTypeMismatchArgument Argument 1 ($fn) is $fn of type Closure():void but \expects_int_param() takes Closure(int):void defined at %s:6
 %s:59 PhanTypeMismatchArgument Argument 1 ($fn) is $fn of type Closure():void but \expects_int_return() takes Closure():int defined at %s:40
 %s:61 PhanPossiblyInfiniteRecursionSameParams expects_void() is calling itself with the same parameters it was called with. This may cause infinite recursion (Phan does not check for changes to global or shared state).
-%s:67 PhanTypeMismatchArgument Argument 1 ($fn) is (function) of type Closure(mixed):void but \expects_void() takes Closure():void defined at %s:56
-%s:68 PhanTypeMismatchArgument Argument 1 ($fn) is (function) of type Closure():int but \expects_void() takes Closure():void defined at %s:56
-%s:69 PhanTypeMismatchArgument Argument 1 ($fn) is (function) of type Closure(int):void but \expects_void() takes Closure():void defined at %s:56
+%s:67 PhanTypeMismatchArgumentSuperType Argument 1 ($fn) is (function) of type Closure(mixed):void but \expects_void() takes Closure():void defined at %s:56 (expected type to be the same or a subtype, but saw a supertype instead)
+%s:68 PhanTypeMismatchArgumentSuperType Argument 1 ($fn) is (function) of type Closure():int but \expects_void() takes Closure():void defined at %s:56 (expected type to be the same or a subtype, but saw a supertype instead)
+%s:69 PhanTypeMismatchArgumentSuperType Argument 1 ($fn) is (function) of type Closure(int):void but \expects_void() takes Closure():void defined at %s:56 (expected type to be the same or a subtype, but saw a supertype instead)
 %s:77 PhanTypeMismatchArgumentProbablyReal Argument 1 ($p0) is ['arg'] of type array{0:'arg'} but Closure(string...):void takes string (no real type) defined at %s:74 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
-%s:80 PhanTypeMismatchArgument Argument 1 ($fn) is (function) of type Closure(int...):void but \expects_void_variadic() takes Closure(string...):void defined at %s:74
-%s:82 PhanTypeMismatchArgument Argument 1 ($fn) is (function) of type Closure(string):void but \expects_void_variadic() takes Closure(string...):void defined at %s:74
+%s:80 PhanTypeMismatchArgumentSuperType Argument 1 ($fn) is (function) of type Closure(int...):void but \expects_void_variadic() takes Closure(string...):void defined at %s:74 (expected type to be the same or a subtype, but saw a supertype instead)
+%s:82 PhanTypeMismatchArgumentSuperType Argument 1 ($fn) is (function) of type Closure(string):void but \expects_void_variadic() takes Closure(string...):void defined at %s:74 (expected type to be the same or a subtype, but saw a supertype instead)

--- a/tests/files/expected/0456_closure_return.php.expected
+++ b/tests/files/expected/0456_closure_return.php.expected
@@ -1,3 +1,3 @@
-%s:11 PhanTypeMismatchReturn Returning (function) of type Closure(int):int but return_closure() is declared to return Closure(int):string
-%s:15 PhanTypeMismatchReturn Returning Closure::fromCallable('strlen') of type Closure(string):int but return_closure() is declared to return Closure(int):string
-%s:17 PhanTypeMismatchReturn Returning (function) of type Closure():string but return_closure() is declared to return Closure(int):string
+%s:11 PhanTypeMismatchReturnSuperType Returning (function) of type Closure(int):int but return_closure() is declared to return Closure(int):string (saw a supertype instead of a subtype)
+%s:15 PhanTypeMismatchReturnSuperType Returning Closure::fromCallable('strlen') of type Closure(string):int but return_closure() is declared to return Closure(int):string (saw a supertype instead of a subtype)
+%s:17 PhanTypeMismatchReturnSuperType Returning (function) of type Closure():string but return_closure() is declared to return Closure(int):string (saw a supertype instead of a subtype)

--- a/tests/files/expected/0457_callable_type_cast.php.expected
+++ b/tests/files/expected/0457_callable_type_cast.php.expected
@@ -1,26 +1,26 @@
 %s:8 PhanTypeSuspiciousEcho Suspicious argument $fn of type callable(int):void for an echo/print statement
 %s:9 PhanTypeMismatchArgumentProbablyReal Argument 1 ($p0) is new stdClass() of type \stdClass but callable(int):void takes int (no real type) defined at %s:6 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
 %s:10 PhanParamTooFew Call with 0 arg(s) to callable(int):void which requires 1 arg(s) defined at %s:6
-%s:15 PhanTypeMismatchArgument Argument 1 ($fn) is (function) of type Closure(int,string):void but \expects_cb_int_param() takes callable(int):void defined at %s:6
-%s:17 PhanTypeMismatchArgument Argument 1 ($fn) is (function) of type Closure(int&):void but \expects_cb_int_param() takes callable(int):void defined at %s:6
+%s:15 PhanTypeMismatchArgumentSuperType Argument 1 ($fn) is (function) of type Closure(int,string):void but \expects_cb_int_param() takes callable(int):void defined at %s:6 (expected type to be the same or a subtype, but saw a supertype instead)
+%s:17 PhanTypeMismatchArgumentSuperType Argument 1 ($fn) is (function) of type Closure(int&):void but \expects_cb_int_param() takes callable(int):void defined at %s:6 (expected type to be the same or a subtype, but saw a supertype instead)
 %s:24 PhanTypeMismatchArgumentProbablyReal Argument 1 ($p0) is new stdClass() of type \stdClass but callable(int=):void takes int (no real type) defined at %s:22 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
 %s:26 PhanTypeMismatchArgumentProbablyReal Argument 1 ($p0) is null of type null but callable(int=):void takes int (no real type) defined at %s:22 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
-%s:28 PhanTypeMismatchArgument Argument 1 ($fn) is (function) of type Closure(int):void but \expects_cb_optional_int_param() takes callable(int=):void defined at %s:22
-%s:31 PhanTypeMismatchArgument Argument 1 ($fn) is (function) of type Closure(int,string):void but \expects_cb_optional_int_param() takes callable(int=):void defined at %s:22
-%s:32 PhanTypeMismatchArgument Argument 1 ($fn) is (function) of type Closure():void but \expects_cb_optional_int_param() takes callable(int=):void defined at %s:22
-%s:33 PhanTypeMismatchArgument Argument 1 ($fn) is (function) of type Closure(int&=):void but \expects_cb_optional_int_param() takes callable(int=):void defined at %s:22
+%s:28 PhanTypeMismatchArgumentSuperType Argument 1 ($fn) is (function) of type Closure(int):void but \expects_cb_optional_int_param() takes callable(int=):void defined at %s:22 (expected type to be the same or a subtype, but saw a supertype instead)
+%s:31 PhanTypeMismatchArgumentSuperType Argument 1 ($fn) is (function) of type Closure(int,string):void but \expects_cb_optional_int_param() takes callable(int=):void defined at %s:22 (expected type to be the same or a subtype, but saw a supertype instead)
+%s:32 PhanTypeMismatchArgumentSuperType Argument 1 ($fn) is (function) of type Closure():void but \expects_cb_optional_int_param() takes callable(int=):void defined at %s:22 (expected type to be the same or a subtype, but saw a supertype instead)
+%s:33 PhanTypeMismatchArgumentSuperType Argument 1 ($fn) is (function) of type Closure(int&=):void but \expects_cb_optional_int_param() takes callable(int=):void defined at %s:22 (expected type to be the same or a subtype, but saw a supertype instead)
 %s:41 PhanParamTooMany Call with 1 arg(s) to callable():int which only takes 0 arg(s) defined at %s:40
 %s:42 PhanTypeMismatchReturn Returning $fn() of type int but expects_cb_int_return() is declared to return \stdClass
-%s:48 PhanTypeMismatchArgument Argument 1 ($fn) is (function) of type Closure():array but \expects_cb_int_return() takes callable():int defined at %s:40
-%s:49 PhanTypeMismatchArgument Argument 1 ($fn) is (function) of type Closure(array):int but \expects_cb_int_return() takes callable():int defined at %s:40
+%s:48 PhanTypeMismatchArgumentSuperType Argument 1 ($fn) is (function) of type Closure():array but \expects_cb_int_return() takes callable():int defined at %s:40 (expected type to be the same or a subtype, but saw a supertype instead)
+%s:49 PhanTypeMismatchArgumentSuperType Argument 1 ($fn) is (function) of type Closure(array):int but \expects_cb_int_return() takes callable():int defined at %s:40 (expected type to be the same or a subtype, but saw a supertype instead)
 %s:55 PhanTypeVoidAssignment Cannot assign void return value
 %s:55 PhanUnusedVariable Unused definition of variable $result
 %s:56 PhanTypeMismatchArgument Argument 1 ($fn) is $fn of type callable():void but \expects_cb_int_param() takes callable(int):void defined at %s:6
 %s:57 PhanTypeMismatchArgument Argument 1 ($fn) is $fn of type callable():void but \expects_cb_int_return() takes callable():int defined at %s:40
 %s:59 PhanPossiblyInfiniteRecursionSameParams expects_cb_void() is calling itself with the same parameters it was called with. This may cause infinite recursion (Phan does not check for changes to global or shared state).
-%s:65 PhanTypeMismatchArgument Argument 1 ($fn) is (function) of type Closure(mixed):void but \expects_cb_void() takes callable():void defined at %s:54
-%s:66 PhanTypeMismatchArgument Argument 1 ($fn) is (function) of type Closure():int but \expects_cb_void() takes callable():void defined at %s:54
-%s:67 PhanTypeMismatchArgument Argument 1 ($fn) is (function) of type Closure(int):void but \expects_cb_void() takes callable():void defined at %s:54
+%s:65 PhanTypeMismatchArgumentSuperType Argument 1 ($fn) is (function) of type Closure(mixed):void but \expects_cb_void() takes callable():void defined at %s:54 (expected type to be the same or a subtype, but saw a supertype instead)
+%s:66 PhanTypeMismatchArgumentSuperType Argument 1 ($fn) is (function) of type Closure():int but \expects_cb_void() takes callable():void defined at %s:54 (expected type to be the same or a subtype, but saw a supertype instead)
+%s:67 PhanTypeMismatchArgumentSuperType Argument 1 ($fn) is (function) of type Closure(int):void but \expects_cb_void() takes callable():void defined at %s:54 (expected type to be the same or a subtype, but saw a supertype instead)
 %s:75 PhanTypeMismatchArgumentProbablyReal Argument 1 ($p0) is ['arg'] of type array{0:'arg'} but callable(string...):void takes string (no real type) defined at %s:71 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
-%s:78 PhanTypeMismatchArgument Argument 1 ($fn) is (function) of type Closure(int...):void but \expects_cb_void_variadic() takes callable(string...):void defined at %s:71
-%s:80 PhanTypeMismatchArgument Argument 1 ($fn) is (function) of type Closure(string):void but \expects_cb_void_variadic() takes callable(string...):void defined at %s:71
+%s:78 PhanTypeMismatchArgumentSuperType Argument 1 ($fn) is (function) of type Closure(int...):void but \expects_cb_void_variadic() takes callable(string...):void defined at %s:71 (expected type to be the same or a subtype, but saw a supertype instead)
+%s:80 PhanTypeMismatchArgumentSuperType Argument 1 ($fn) is (function) of type Closure(string):void but \expects_cb_void_variadic() takes callable(string...):void defined at %s:71 (expected type to be the same or a subtype, but saw a supertype instead)

--- a/tests/files/expected/0858_intersection_type_phpdoc_fallback.php.expected
+++ b/tests/files/expected/0858_intersection_type_phpdoc_fallback.php.expected
@@ -2,6 +2,6 @@
 %s:30 PhanTypeMismatchArgument Argument 1 ($param) is $x of type (\MyClass858&\ArrayAccess)|\ArrayAccess|\MyClass858 but \test() takes \MyClass858&\Countable defined at %s:17
 %s:41 PhanUndeclaredMethod Call to undeclared method \MyClass858::otherMissingMethod
 %s:44 PhanTypeMismatchArgument Argument 1 ($param) is new stdClass() of type \stdClass but \test() takes \MyClass858&\Countable defined at %s:17
-%s:45 PhanTypeMismatchArgument Argument 1 ($param) is new MyClass858() of type \MyClass858 but \test() takes \MyClass858&\Countable defined at %s:17
+%s:45 PhanTypeMismatchArgumentSuperType Argument 1 ($param) is new MyClass858() of type \MyClass858 but \test() takes \MyClass858&\Countable defined at %s:17 (expected type to be the same or a subtype, but saw a supertype instead)
 %s:47 PhanTypeMismatchArgument Argument 1 ($values) is [new stdClass()] of type array{0:\stdClass} but \test_list() takes list<\MyClass858&\Countable> defined at %s:37
 %s:48 PhanTypeMismatchArgument Argument 1 ($values) is [new MyClass858()] of type array{0:\MyClass858} but \test_list() takes list<\MyClass858&\Countable> defined at %s:37

--- a/tests/files/expected/0939_intersection_phpdoc.php.expected
+++ b/tests/files/expected/0939_intersection_phpdoc.php.expected
@@ -4,5 +4,5 @@
 %s:10 PhanImpossibleIntersectionType Intersection type int&bool contains part int which cannot cast to the declared type bool
 %s:11 PhanTypeMismatchReturn Returning $value of type int&bool but test939() is declared to return \SplObjectStorage&\Error
 %s:13 PhanTypeMismatchArgumentProbablyReal Argument 1 ($value) is 123 of type 123 but \test939() takes int&bool (no real type) defined at %s:10 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
-%s:13 PhanTypeMismatchArgument Argument 2 ($object) is new stdClass() of type \stdClass but \test939() takes \stdClass&\ArrayObject defined at %s:10
+%s:13 PhanTypeMismatchArgumentSuperType Argument 2 ($object) is new stdClass() of type \stdClass but \test939() takes \stdClass&\ArrayObject defined at %s:10 (expected type to be the same or a subtype, but saw a supertype instead)
 %s:17 PhanImpossibleIntersectionType Intersection type \stdClass&false contains part \stdClass which cannot cast to the declared type false

--- a/tests/files/expected/0956_return_super_type.php.expected
+++ b/tests/files/expected/0956_return_super_type.php.expected
@@ -1,0 +1,2 @@
+%s:14 PhanTypeMismatchReturnSuperType Returning $p of type \NS956\Base but test() is declared to return \NS956\SubClass (saw a supertype instead of a subtype)
+%s:20 PhanTypeMismatchArgumentSuperType Argument 1 ($p) is $b of type \NS956\BaseOfBase but \NS956\test() takes \NS956\Base defined at %s:13 (expected type to be the same or a subtype, but saw a supertype instead)

--- a/tests/files/src/0956_return_super_type.php
+++ b/tests/files/src/0956_return_super_type.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace NS956;
+
+class BaseOfBase { }
+class Base extends BaseOfBase { }
+class SubClass extends Base {}
+
+/**
+ * @param Base $p
+ * @return SubClass
+ */
+function test($p) {
+    return $p;
+}
+/**
+ * @param BaseOfBase $b
+ */
+function example($b) {
+    test($b);
+}

--- a/tests/php80_files/expected/042_intersection_type_phpdoc_invalid.php.expected
+++ b/tests/php80_files/expected/042_intersection_type_phpdoc_invalid.php.expected
@@ -5,5 +5,5 @@
 %s:12 PhanTypeMismatchArgumentProbablyReal Argument 1 ($p0) is new stdClass() of type \stdClass but Closure(int&string):\stdClass&\ArrayObject takes int&string (no real type) defined at %s:9 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
 %s:13 PhanDebugAnnotation @phan-debug-var requested for variable $other - it has union type int&null
 %s:13 PhanTypeMismatchArgument Argument 1 ($p0) is $other of type (int&null)|int|null but Closure(int&string):\stdClass&\ArrayObject takes int&string defined at %s:9
-%s:17 PhanTypeMismatchArgument Argument 1 ($value) is (function) of type Closure(int):\stdClass but \test42() takes Closure(int&string):\stdClass&\ArrayObject defined at %s:9
+%s:17 PhanTypeMismatchArgumentSuperType Argument 1 ($value) is (function) of type Closure(int):\stdClass but \test42() takes Closure(int&string):\stdClass&\ArrayObject defined at %s:9 (expected type to be the same or a subtype, but saw a supertype instead)
 %s:20 PhanTypeMismatchArgumentProbablyReal Argument 2 ($other) is null of type null but \test42() takes int&null (no real type) defined at %s:9 (the inferred real argument type has nothing in common with the parameter's phpdoc type)


### PR DESCRIPTION
Phan 5 starts warning about returning supertypes.

For #4413