### PR TITLE
Add Instantiations to Dependency Graph Plugin

### DIFF
--- a/src/Phan/Plugin/Internal/DependencyGraphPlugin.php
+++ b/src/Phan/Plugin/Internal/DependencyGraphPlugin.php
@@ -723,6 +723,10 @@ class DependencyGraphVisitor extends PluginAwarePostAnalysisVisitor
         DependencyGraphPlugin::$static_calls[] = [$fqsen => ['class' => (string)$class_fqsen,'file' => $context->getFile(),'lineno' => $context->getLineNumberStart()]];
     }
 
+    /**
+     * When we hit an AST_NEW
+     * @throws Exception
+     */
     public function visitNew(Node $node): void
     {
         $context = $this->context;

--- a/src/Phan/Plugin/Internal/DependencyGraphPlugin.php
+++ b/src/Phan/Plugin/Internal/DependencyGraphPlugin.php
@@ -728,7 +728,7 @@ class DependencyGraphVisitor extends PluginAwarePostAnalysisVisitor
             return;
         }
         $called_class_name = (string)$called_class->children['name'];
-        if (\in_array(strtolower($called_class_name), ['self', 'parent', 'class', 'static'], true)) {
+        if (\in_array(\strtolower($called_class_name), ['self', 'parent', 'class', 'static'], true)) {
             return;
         }
         $fqsen = (string)FullyQualifiedClassName::fromStringInContext($called_class_name, $context);

--- a/src/Phan/Plugin/Internal/DependencyGraphPlugin.php
+++ b/src/Phan/Plugin/Internal/DependencyGraphPlugin.php
@@ -701,7 +701,7 @@ class DependencyGraphVisitor extends PluginAwarePostAnalysisVisitor
         }
         $called_class_name = (string)$called_class->children['name'];
         // None of these add any dependency data we don't already have, so ignore them
-        if (\in_array($called_class_name, ['self', 'parent', 'class', 'static'], true)) {
+        if (\in_array(\strtolower($called_class_name), ['self', 'parent', 'class', 'static'], true)) {
             return;
         }
         $fqsen = (string)FullyQualifiedClassName::fromStringInContext($called_class_name, $context);
@@ -728,7 +728,7 @@ class DependencyGraphVisitor extends PluginAwarePostAnalysisVisitor
             return;
         }
         $called_class_name = (string)$called_class->children['name'];
-        if (\in_array($called_class_name, ['self', 'parent', 'class', 'static'], true)) {
+        if (\in_array(strtolower($called_class_name), ['self', 'parent', 'class', 'static'], true)) {
             return;
         }
         $fqsen = (string)FullyQualifiedClassName::fromStringInContext($called_class_name, $context);
@@ -756,7 +756,7 @@ class DependencyGraphVisitor extends PluginAwarePostAnalysisVisitor
         }
         $called_class_name = (string)$called_class->children['name'];
         // None of these add any dependency data we don't already have, so ignore them
-        if (\in_array($called_class_name, ['self', 'parent', 'class', 'static'], true)) {
+        if (\in_array(\strtolower($called_class_name), ['self', 'parent', 'class', 'static'], true)) {
             return;
         }
         $fqsen = (string)FullyQualifiedClassName::fromStringInContext($called_class_name, $context);

--- a/src/Phan/Plugin/Internal/DependencyGraphPlugin.php
+++ b/src/Phan/Plugin/Internal/DependencyGraphPlugin.php
@@ -281,6 +281,9 @@ final class DependencyGraphPlugin extends PluginV3 implements
                 $this->fgraph[$fnode][$c[$cnode]['file']]  = 'v:' . $c[$cnode]['lineno'];
                 $this->cgraph[$cnode][$c[$cnode]['class']] = 'v:' . $c[$cnode]['lineno'];
             }
+        }
+
+        if (!($flags & \PDEP_IGNORE_NEW)) {
             foreach (self::$instantiations as $c) {
                 $cnode = \key($c);
                 if ($cnode === null) {
@@ -294,6 +297,7 @@ final class DependencyGraphPlugin extends PluginV3 implements
                 $this->cgraph[$cnode][$c[$cnode]['class']] = 'i:' . $c[$cnode]['lineno'];
             }
         }
+
         $this->processGraph();
     }
 
@@ -395,10 +399,11 @@ final class DependencyGraphPlugin extends PluginV3 implements
             // Don't overlap stdout with the progress bar on stderr.
             \fwrite(\STDERR, "\n");
         }
-        if (($flags & \PDEP_IGNORE_STATIC) && $cached_graph) {
+        if ($cached_graph && (($flags & \PDEP_IGNORE_STATIC) || ($flags & \PDEP_IGNORE_NEW))) {
             foreach ($graph as $node => $els) {
                 foreach ($els as $el => $val) {
-                    if (\substr((string)$val, 0, 2) === 'v:' || \substr((string)$val, 0, 2) === 's:') {
+                    $s = \substr((string)$val, 0, 2);
+                    if ($s === 'v:' || $s  === 's:' || $s === 'i:') {
                         unset($graph[$node][$el]);
                     }
                 }

--- a/src/Phan/Plugin/Internal/DependencyGraphPlugin.php
+++ b/src/Phan/Plugin/Internal/DependencyGraphPlugin.php
@@ -400,13 +400,13 @@ final class DependencyGraphPlugin extends PluginV3 implements
             \fwrite(\STDERR, "\n");
         }
         if ($cached_graph) {
-            $ignore_static = ($flags & \PDEP_IGNORE_STATIC);
-            $ignore_new = ($flags & \PDEP_IGNORE_NEW);
+            $ignore_static = $flags & \PDEP_IGNORE_STATIC;
+            $ignore_new = $flags & \PDEP_IGNORE_NEW;
             if ($ignore_static || $ignore_new) {
                 foreach ($graph as $node => $els) {
                     foreach ($els as $el => $val) {
                         $s = \substr((string)$val, 0, 2);
-                        if ($ignore_static && ($s === 'v:' || $s  === 's:') {
+                        if ($ignore_static && ($s === 'v:' || $s  === 's:')) {
                             unset($graph[$node][$el]);
                         }
                         if ($ignore_new && $s === 'i:') {

--- a/src/Phan/Plugin/Internal/DependencyGraphPlugin.php
+++ b/src/Phan/Plugin/Internal/DependencyGraphPlugin.php
@@ -399,12 +399,19 @@ final class DependencyGraphPlugin extends PluginV3 implements
             // Don't overlap stdout with the progress bar on stderr.
             \fwrite(\STDERR, "\n");
         }
-        if ($cached_graph && (($flags & \PDEP_IGNORE_STATIC) || ($flags & \PDEP_IGNORE_NEW))) {
-            foreach ($graph as $node => $els) {
-                foreach ($els as $el => $val) {
-                    $s = \substr((string)$val, 0, 2);
-                    if ($s === 'v:' || $s  === 's:' || $s === 'i:') {
-                        unset($graph[$node][$el]);
+        if ($cached_graph) {
+            $ignore_static = ($flags & \PDEP_IGNORE_STATIC);
+            $ignore_new = ($flags & \PDEP_IGNORE_NEW);
+            if ($ignore_static || $ignore_new) {
+                foreach ($graph as $node => $els) {
+                    foreach ($els as $el => $val) {
+                        $s = \substr((string)$val, 0, 2);
+                        if ($ignore_static && ($s === 'v:' || $s  === 's:') {
+                            unset($graph[$node][$el]);
+                        }
+                        if ($ignore_new && $s === 'i:') {
+                            unset($graph[$node][$el]);
+                        }
                     }
                 }
             }

--- a/tool/pdep
+++ b/tool/pdep
@@ -8,6 +8,7 @@ use Phan\Phan;
 
 define("PDEP_IGNORE_STATIC", 1 << 0);
 define("PDEP_HIDE_LABELS", 1 << 1);
+define("PDEP_IGNORE_NEW", 1 << 2);
 
 /** Prints a usage message for 'pdep' and exits. */
 function pdep_usage(int $status) : void {
@@ -25,6 +26,7 @@ Usage: {$argv[0]} [options] [files or classes...]
  -m, --graphml       GraphML output
      --hide-labels   Labels are hidden - hover in yEd to see them
      --ignore-static Don't include static calls and static var dependencies
+     --ignore-new    Don't include instantiation dependencies
  -d, --depth <depth_level>
     When walking the dependency graph, limit it to this depth. For
     example,
@@ -67,6 +69,7 @@ call_user_func(static function () : void {
             'graph',
             'graphml',
             'ignore-static',
+            'ignore-new',
             'hide-labels',
             'find-classes',
             'find-files',
@@ -133,6 +136,9 @@ call_user_func(static function () : void {
                 break;
             case 'ignore-static':
                 $graph_flags |= \PDEP_IGNORE_STATIC;
+                break;
+            case 'ignore-new':
+                $graph_flags |= \PDEP_IGNORE_NEW;
                 break;
             case 'hide-labels':
                 $graph_flags |= \PDEP_HIDE_LABELS;


### PR DESCRIPTION
[DependencyGraphPlugin](https://github.com/phan/phan/blob/c1f2e52abc831757019cf8ff2ae14da855a85659/src/Phan/Plugin/Internal/DependencyGraphPlugin.php) currently tracks class references from static method calls and class consts. This change introduces tracking of instantiations, e.g. `new Foo()`. This is used for visualization in https://github.com/rlerdorf/pdep .