### PR TITLE
Do not emit PhanIncompatibleRealPropertyType for private base property

### DIFF
--- a/src/Phan/Analysis/CompositionAnalyzer.php
+++ b/src/Phan/Analysis/CompositionAnalyzer.php
@@ -87,7 +87,8 @@ class CompositionAnalyzer
                 } catch (IssueException $_) {
                     $inherited_property_union_type = UnionType::empty();
                 }
-                if (!$property->isDynamicOrFromPHPDoc()) {
+                // Don't complain about incompatible types if the base property is private, #4426
+                if (!$property->isDynamicOrFromPHPDoc() && !$inherited_property->isPrivate()) {
                     $real_property_type = $property->getRealUnionType()->asNormalizedTypes();
                     $real_inherited_property_type = $inherited_property->getRealUnionType()->asNormalizedTypes();
                     if (!$real_property_type->isEqualTo($real_inherited_property_type)) {

--- a/tests/php74_files/expected/005_typed_properties.php.expected
+++ b/tests/php74_files/expected/005_typed_properties.php.expected
@@ -1,4 +1,4 @@
-%s:17 PhanParamTooFew Call with 0 arg(s) to \TypedProperties\A::__construct(?int $a, string $b, \TypedProperties\SubClass $c) which requires 3 arg(s) defined at %s:10
-%s:18 PhanTypeMismatchArgumentInternal%SReal Argument 1 ($value) is $a->a of type ?int but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array%S
-%s:19 PhanTypeMismatchArgumentInternal%SReal Argument 1 ($value) is $a->b of type string but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array%S
-%s:20 PhanTypeMismatchArgumentInternal Argument 1 ($value) is $a->c of type \TypedProperties\A|\TypedProperties\SubClass but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array
+%s:19 PhanParamTooFew Call with 0 arg(s) to \TypedProperties\A::__construct(?int $a, string $b, \TypedProperties\SubClass $c) which requires 3 arg(s) defined at %s:10
+%s:20 PhanTypeMismatchArgumentInternal%SReal Argument 1 ($value) is $a->a of type ?int but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array%S
+%s:21 PhanTypeMismatchArgumentInternal%SReal Argument 1 ($value) is $a->b of type string but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array%S
+%s:22 PhanTypeMismatchArgumentInternal Argument 1 ($value) is $a->c of type \TypedProperties\A|\TypedProperties\SubClass but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array

--- a/tests/php74_files/expected/005_typed_properties.php.expected
+++ b/tests/php74_files/expected/005_typed_properties.php.expected
@@ -1,4 +1,4 @@
-%s:19 PhanParamTooFew Call with 0 arg(s) to \TypedProperties\A::__construct(?int $a, string $b, \TypedProperties\SubClass $c) which requires 3 arg(s) defined at %s:10
+%s:19 PhanParamTooFew Call with 0 arg(s) to \TypedProperties\A::__construct(?int $a, string $b, \TypedProperties\SubClass $c) which requires 3 arg(s) defined at %s:11
 %s:20 PhanTypeMismatchArgumentInternal%SReal Argument 1 ($value) is $a->a of type ?int but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array%S
 %s:21 PhanTypeMismatchArgumentInternal%SReal Argument 1 ($value) is $a->b of type string but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array%S
 %s:22 PhanTypeMismatchArgumentInternal Argument 1 ($value) is $a->c of type \TypedProperties\A|\TypedProperties\SubClass but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array

--- a/tests/php74_files/src/005_typed_properties.php
+++ b/tests/php74_files/src/005_typed_properties.php
@@ -7,11 +7,13 @@ class A {
     /** @var string description of this string */
     public string $b;
     public A $c;
+    private int $d;
     public function __construct(?int $a, string $b, SubClass $c) {
         $this->a = $a;
         $this->b = $b;
         $this->c = $c;
         $this->c = $this;
+        $this->d = 5;
     }
 }
 $a = new A();
@@ -20,4 +22,6 @@ echo count($a->b);
 echo count($a->c);
 
 class SubClass extends A {
+    /** Regression test for #4426 - should not trigger warnings about incompatible types since A::$d is private */
+    private $d;
 }

--- a/tests/php80_files/expected/044_constructor_promotion_incompatible.php.expected
+++ b/tests/php80_files/expected/044_constructor_promotion_incompatible.php.expected
@@ -1,23 +1,23 @@
-%:4 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for public int $a of \A::__construct(int $a, ?int $b, string $c, ?string $d, bool $e, ?bool $f)
-%:4 PhanWriteOnlyPublicProperty Possibly zero read references to public property \A->a
-%:5 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for public ?int $b of \A::__construct(int $a, ?int $b, string $c, ?string $d, bool $e, ?bool $f)
-%:5 PhanWriteOnlyPublicProperty Possibly zero read references to public property \A->b
-%:6 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for protected string $c of \A::__construct(int $a, ?int $b, string $c, ?string $d, bool $e, ?bool $f)
-%:6 PhanWriteOnlyProtectedProperty Possibly zero read references to protected property \A->c
-%:7 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for protected ?string $d of \A::__construct(int $a, ?int $b, string $c, ?string $d, bool $e, ?bool $f)
-%:7 PhanWriteOnlyProtectedProperty Possibly zero read references to protected property \A->d
-%:8 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for private bool $e of \A::__construct(int $a, ?int $b, string $c, ?string $d, bool $e, ?bool $f)
-%:8 PhanWriteOnlyPrivateProperty Possibly zero read references to private property \A->e
-%:9 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for private ?bool $f of \A::__construct(int $a, ?int $b, string $c, ?string $d, bool $e, ?bool $f)
-%:9 PhanWriteOnlyPrivateProperty Possibly zero read references to private property \A->f
-%:13 PhanUnreferencedClass Possibly zero references to class \B
-%:15 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for public int $a of \B::__construct(int $a, int $b, string $c, string $d, \stdClass $e, \stdClass $f)
-%:16 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for public int $b of \B::__construct(int $a, int $b, string $c, string $d, \stdClass $e, \stdClass $f)
-%:16 PhanIncompatibleRealPropertyType Declaration of \B::b of real type int is incompatible with inherited property \A::b of real type ?int defined at %:5
-%:17 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for protected string $c of \B::__construct(int $a, int $b, string $c, string $d, \stdClass $e, \stdClass $f)
-%:18 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for protected string $d of \B::__construct(int $a, int $b, string $c, string $d, \stdClass $e, \stdClass $f)
-%:18 PhanIncompatibleRealPropertyType Declaration of \B::d of real type string is incompatible with inherited property \A::d of real type ?string defined at %:7
-%:19 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for private \stdClass $e of \B::__construct(int $a, int $b, string $c, string $d, \stdClass $e, \stdClass $f)
-%:19 PhanWriteOnlyPrivateProperty Possibly zero read references to private property \B->e
-%:20 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for private \stdClass $f of \B::__construct(int $a, int $b, string $c, string $d, \stdClass $e, \stdClass $f)
-%:20 PhanWriteOnlyPrivateProperty Possibly zero read references to private property \B->f
+%s:4 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for public int $a of \A::__construct(int $a, ?int $b, string $c, ?string $d, bool $e, ?bool $f)
+%s:4 PhanWriteOnlyPublicProperty Possibly zero read references to public property \A->a
+%s:5 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for public ?int $b of \A::__construct(int $a, ?int $b, string $c, ?string $d, bool $e, ?bool $f)
+%s:5 PhanWriteOnlyPublicProperty Possibly zero read references to public property \A->b
+%s:6 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for protected string $c of \A::__construct(int $a, ?int $b, string $c, ?string $d, bool $e, ?bool $f)
+%s:6 PhanWriteOnlyProtectedProperty Possibly zero read references to protected property \A->c
+%s:7 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for protected ?string $d of \A::__construct(int $a, ?int $b, string $c, ?string $d, bool $e, ?bool $f)
+%s:7 PhanWriteOnlyProtectedProperty Possibly zero read references to protected property \A->d
+%s:8 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for private bool $e of \A::__construct(int $a, ?int $b, string $c, ?string $d, bool $e, ?bool $f)
+%s:8 PhanWriteOnlyPrivateProperty Possibly zero read references to private property \A->e
+%s:9 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for private ?bool $f of \A::__construct(int $a, ?int $b, string $c, ?string $d, bool $e, ?bool $f)
+%s:9 PhanWriteOnlyPrivateProperty Possibly zero read references to private property \A->f
+%s:13 PhanUnreferencedClass Possibly zero references to class \B
+%s:15 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for public int $a of \B::__construct(int $a, int $b, string $c, string $d, \stdClass $e, \stdClass $f)
+%s:16 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for public int $b of \B::__construct(int $a, int $b, string $c, string $d, \stdClass $e, \stdClass $f)
+%s:16 PhanIncompatibleRealPropertyType Declaration of \B::b of real type int is incompatible with inherited property \A::b of real type ?int defined at %s:5
+%s:17 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for protected string $c of \B::__construct(int $a, int $b, string $c, string $d, \stdClass $e, \stdClass $f)
+%s:18 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for protected string $d of \B::__construct(int $a, int $b, string $c, string $d, \stdClass $e, \stdClass $f)
+%s:18 PhanIncompatibleRealPropertyType Declaration of \B::d of real type string is incompatible with inherited property \A::d of real type ?string defined at %s:7
+%s:19 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for private \stdClass $e of \B::__construct(int $a, int $b, string $c, string $d, \stdClass $e, \stdClass $f)
+%s:19 PhanWriteOnlyPrivateProperty Possibly zero read references to private property \B->e
+%s:20 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for private \stdClass $f of \B::__construct(int $a, int $b, string $c, string $d, \stdClass $e, \stdClass $f)
+%s:20 PhanWriteOnlyPrivateProperty Possibly zero read references to private property \B->f

--- a/tests/php80_files/expected/044_constructor_promotion_incompatible.php.expected
+++ b/tests/php80_files/expected/044_constructor_promotion_incompatible.php.expected
@@ -1,0 +1,11 @@
+%:4: PhanWriteOnlyPublicProperty Possibly zero read references to public property \A->a
+%:5: PhanWriteOnlyPublicProperty Possibly zero read references to public property \A->b
+%:6: PhanWriteOnlyProtectedProperty Possibly zero read references to protected property \A->c
+%:7: PhanWriteOnlyProtectedProperty Possibly zero read references to protected property \A->d
+%:8: PhanWriteOnlyPrivateProperty Possibly zero read references to private property \A->e
+%:9: PhanWriteOnlyPrivateProperty Possibly zero read references to private property \A->f
+%:13: PhanUnreferencedClass Possibly zero references to class \B
+%:16: PhanIncompatibleRealPropertyType Declaration of \B::b of real type int is incompatible with inherited property \A::b of real type ?int defined at %:5
+%:18: PhanIncompatibleRealPropertyType Declaration of \B::d of real type string is incompatible with inherited property \A::d of real type ?string defined at %:7
+%:19: PhanWriteOnlyPrivateProperty Possibly zero read references to private property \B->e
+%:20: PhanWriteOnlyPrivateProperty Possibly zero read references to private property \B->f

--- a/tests/php80_files/expected/044_constructor_promotion_incompatible.php.expected
+++ b/tests/php80_files/expected/044_constructor_promotion_incompatible.php.expected
@@ -1,11 +1,23 @@
-%:4: PhanWriteOnlyPublicProperty Possibly zero read references to public property \A->a
-%:5: PhanWriteOnlyPublicProperty Possibly zero read references to public property \A->b
-%:6: PhanWriteOnlyProtectedProperty Possibly zero read references to protected property \A->c
-%:7: PhanWriteOnlyProtectedProperty Possibly zero read references to protected property \A->d
-%:8: PhanWriteOnlyPrivateProperty Possibly zero read references to private property \A->e
-%:9: PhanWriteOnlyPrivateProperty Possibly zero read references to private property \A->f
-%:13: PhanUnreferencedClass Possibly zero references to class \B
-%:16: PhanIncompatibleRealPropertyType Declaration of \B::b of real type int is incompatible with inherited property \A::b of real type ?int defined at %:5
-%:18: PhanIncompatibleRealPropertyType Declaration of \B::d of real type string is incompatible with inherited property \A::d of real type ?string defined at %:7
-%:19: PhanWriteOnlyPrivateProperty Possibly zero read references to private property \B->e
-%:20: PhanWriteOnlyPrivateProperty Possibly zero read references to private property \B->f
+%:4 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for public int $a of \A::__construct(int $a, ?int $b, string $c, ?string $d, bool $e, ?bool $f)
+%:4 PhanWriteOnlyPublicProperty Possibly zero read references to public property \A->a
+%:5 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for public ?int $b of \A::__construct(int $a, ?int $b, string $c, ?string $d, bool $e, ?bool $f)
+%:5 PhanWriteOnlyPublicProperty Possibly zero read references to public property \A->b
+%:6 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for protected string $c of \A::__construct(int $a, ?int $b, string $c, ?string $d, bool $e, ?bool $f)
+%:6 PhanWriteOnlyProtectedProperty Possibly zero read references to protected property \A->c
+%:7 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for protected ?string $d of \A::__construct(int $a, ?int $b, string $c, ?string $d, bool $e, ?bool $f)
+%:7 PhanWriteOnlyProtectedProperty Possibly zero read references to protected property \A->d
+%:8 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for private bool $e of \A::__construct(int $a, ?int $b, string $c, ?string $d, bool $e, ?bool $f)
+%:8 PhanWriteOnlyPrivateProperty Possibly zero read references to private property \A->e
+%:9 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for private ?bool $f of \A::__construct(int $a, ?int $b, string $c, ?string $d, bool $e, ?bool $f)
+%:9 PhanWriteOnlyPrivateProperty Possibly zero read references to private property \A->f
+%:13 PhanUnreferencedClass Possibly zero references to class \B
+%:15 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for public int $a of \B::__construct(int $a, int $b, string $c, string $d, \stdClass $e, \stdClass $f)
+%:16 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for public int $b of \B::__construct(int $a, int $b, string $c, string $d, \stdClass $e, \stdClass $f)
+%:16 PhanIncompatibleRealPropertyType Declaration of \B::b of real type int is incompatible with inherited property \A::b of real type ?int defined at %:5
+%:17 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for protected string $c of \B::__construct(int $a, int $b, string $c, string $d, \stdClass $e, \stdClass $f)
+%:18 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for protected string $d of \B::__construct(int $a, int $b, string $c, string $d, \stdClass $e, \stdClass $f)
+%:18 PhanIncompatibleRealPropertyType Declaration of \B::d of real type string is incompatible with inherited property \A::d of real type ?string defined at %:7
+%:19 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for private \stdClass $e of \B::__construct(int $a, int $b, string $c, string $d, \stdClass $e, \stdClass $f)
+%:19 PhanWriteOnlyPrivateProperty Possibly zero read references to private property \B->e
+%:20 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for private \stdClass $f of \B::__construct(int $a, int $b, string $c, string $d, \stdClass $e, \stdClass $f)
+%:20 PhanWriteOnlyPrivateProperty Possibly zero read references to private property \B->f

--- a/tests/php80_files/src/044_constructor_promotion_incompatible.php
+++ b/tests/php80_files/src/044_constructor_promotion_incompatible.php
@@ -1,0 +1,22 @@
+<?php
+class A {
+   public function __construct(
+       public int $a,
+       public ?int $b,
+       protected string $c,
+       protected ?string $d,
+       private bool $e,
+       private ?bool $f
+    ) {}
+}
+
+class B extends A {
+    public function __construct(
+        public int $a,
+        public int $b,
+        protected string $c,
+        protected string $d,
+        private stdClass $e,
+        private stdClass $f
+    ) {}
+}


### PR DESCRIPTION
Skips private base properties when deciding to emit the issue.
Add tests for the new expected behavior for both php7.4 normal typed properties and php8 constructor promotion
Closes #4426