### PR TITLE
ConfigPluginSet: don't nest each variable info closure

### DIFF
--- a/src/Phan/Plugin/ConfigPluginSet.php
+++ b/src/Phan/Plugin/ConfigPluginSet.php
@@ -1076,12 +1076,24 @@ final class ConfigPluginSet extends PluginV3 implements
             $closures[] = $plugin->getMergeVariableInfoClosure();
         }
 
-        // Combine closures from all of the plugins into a single closure to run
+        // If we have no plugins registering closures, no overall closure is needed
+        if (!$closures) {
+            self::$mergeVariableInfoClosure = null;
+            return;
+        }
+
+        // If we have only one plugin registering a closure, just use that
+        if (count($closures) === 1) {
+            self::$mergeVariableInfoClosure = reset($closures);
+            return;
+        }
+
+        // If we have multiple plugins registering closures, combine them
         /**
          * @param list<Scope> $child_scopes
          */
         self::$mergeVariableInfoClosure = static function (Variable $variable, array $child_scopes, bool $var_exists_in_all_branches) use ($closures): void {
-            foreach ( $closures as $c ) {
+            foreach ($closures as $c) {
                 $c($variable, $child_scopes, $var_exists_in_all_branches);
             }
         };


### PR DESCRIPTION
The old code would, for each plugin that wanted to register a mergeVariableInfoClosure, replace the $mergeVariableInfoClosure with a new function that called the plugin's closure, as well as the old $mergeVariableInfoClosure. This meant that a new level of nesting was introduced for each plugin registering such a closure after the first.
Instead, use a single closure for all plugins.