### PR TITLE
ExtendedDependentReturnTypeOverridePlugin: add missing indentation

### DIFF
--- a/src/Phan/Plugin/Internal/ExtendedDependentReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ExtendedDependentReturnTypeOverridePlugin.php
@@ -118,7 +118,7 @@ final class ExtendedDependentReturnTypeOverridePlugin extends PluginV3 implement
             ) use (
                 $cb,
                 $cb_fallback
-): UnionType {
+            ): UnionType {
                 $result = $cb($code_base, $context, $function_decl, $args);
                 if ($result !== $function_decl->getUnionType()) {
                     return $result;


### PR DESCRIPTION
To align the closing ) of a use block with the opening, instead of putting it all the way at the start of the line