### PR TITLE
Fix parameter definition for Grpc\ChannelCredentials::createSsl

### DIFF
--- a/src/Phan/Language/Internal/FunctionSignatureMap.php
+++ b/src/Phan/Language/Internal/FunctionSignatureMap.php
@@ -4470,7 +4470,7 @@ return [
 'Grpc\ChannelCredentials::createComposite' => ['Grpc\ChannelCredentials', 'cred1'=>'Grpc\ChannelCredentials', 'cred2'=>'Grpc\CallCredentials'],
 'Grpc\ChannelCredentials::createDefault' => ['Grpc\ChannelCredentials'],
 'Grpc\ChannelCredentials::createInsecure' => ['null'],
-'Grpc\ChannelCredentials::createSsl' => ['Grpc\ChannelCredentials', 'pem_root_certs'=>'string', 'pem_private_key='=>'string', 'pem_cert_chain='=>'string'],
+'Grpc\ChannelCredentials::createSsl' => ['Grpc\ChannelCredentials', 'pem_root_certs='=>'string|null', 'pem_private_key='=>'string|null', 'pem_cert_chain='=>'string|null'],
 'Grpc\ChannelCredentials::invalidateDefaultRootsPem' => [''],
 'Grpc\ChannelCredentials::isDefaultRootsPemSet' => [''],
 'Grpc\ChannelCredentials::setDefaultRootsPem' => ['', 'pem_roots'=>'string'],


### PR DESCRIPTION
This PR contains two fixes.

## `pem_root_certs` to optional
1st argument `$pem_root_certs` has been changed to optional with this commit
https://github.com/grpc/grpc/commit/52931a4e1ac9fdd6de40be7101f85a7cd4d71a8b#diff-d4d5d67134d6592b600cfc6179b56863f7d7b198c86384fb9bf0a86a5d20b765R142

## all parameters to nullable
It is not nullable on PhpDoc, but the actual source code is nullable.
( And the behavior changes between null and the empty string🥺

PhpDoc fix is currently under review

https://github.com/grpc/grpc/pull/27283