### PR TITLE
Fix false positive possibly undefined variable warning for `global $var`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
          - PHP_VERSION: '7.3'
          - PHP_VERSION: '7.4'
          - PHP_VERSION: '8.0'
-         - PHP_VERSION: '8.1.0beta3'
+         - PHP_VERSION: '8.1.0RC1'
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,7 @@ Bug fixes:
   Return statements can be omitted if a function unconditionally exits.
 
   Also, check for the real `never` return type when emitting issues
+- Fix false positive `PhanPossiblyUndefinedGlobalVariable*` instance when `global $var` is used within a conditional. (#4539)
 
 Maintenance:
 - Fix old return type signature for `get_headers` (#3273)

--- a/src/Phan/Language/AnnotatedUnionType.php
+++ b/src/Phan/Language/AnnotatedUnionType.php
@@ -121,7 +121,7 @@ class AnnotatedUnionType extends UnionType
     {
         $result = parent::__toString();
         if ($this->is_possibly_undefined) {
-            return $result . '=';
+            return ($result !== '' ? $result : 'mixed') . '=';
         }
         return $result;
     }

--- a/src/Phan/Language/Element/GlobalVariable.php
+++ b/src/Phan/Language/Element/GlobalVariable.php
@@ -23,6 +23,7 @@ class GlobalVariable extends Variable
     {
         $this->type = $type;
         // Always merge the type on the actual global.
-        $this->element->setUnionType($this->element->getUnionType()->withUnionType($type->eraseRealTypeSetRecursively()));
+        // Convert undefined to null before merging in the type.
+        $this->element->setUnionType($this->element->getUnionType()->withUnionType($type->eraseRealTypeSetRecursively())->withIsPossiblyUndefined(false));
     }
 }

--- a/src/Phan/Language/Element/Variable.php
+++ b/src/Phan/Language/Element/Variable.php
@@ -290,7 +290,7 @@ class Variable extends UnaddressableTypedElement implements TypedElementInterfac
     {
         $string = '';
 
-        if (!$this->type->isEmpty()) {
+        if (!$this->type->isEmpty() || $this->type->isPossiblyUndefined()) {
             $string .= "{$this->type->getDebugRepresentation()} ";
         }
 

--- a/tests/plugin_test/src/203_global_false_positive.php
+++ b/tests/plugin_test/src/203_global_false_positive.php
@@ -1,0 +1,11 @@
+<?php
+
+function a203($arg) {
+    if ( rand() > 0 ) {
+        global $myGlobal;
+        var_dump( $arg, $myGlobal );
+    }
+}
+
+a203(true);
+a203(false);

--- a/tests/run_all_tests_dockerized
+++ b/tests/run_all_tests_dockerized
@@ -11,6 +11,6 @@ fi
 set -xeu
 PHP_VERSION=$1
 
-DOCKER_IMAGE=phan-$PHP_VERSION-test-runner
+DOCKER_IMAGE="phan-test-runner:$PHP_VERSION"
 docker build --network=host --build-arg="PHP_VERSION=$PHP_VERSION" --tag="$DOCKER_IMAGE" -f tests/docker/Dockerfile .
 docker run --rm $DOCKER_IMAGE tests/run_all_tests


### PR DESCRIPTION
This is seen when the `global $var` is found in a conditional branch
and there are multiple analysis of functions using `global $var`

Importing an undefined global variable will convert that variable's type
to a reference to null.

Closes #4539