### PR TITLE
Fix false positive PhanPluginRedundantAssignmentInLoop

### DIFF
--- a/.phan/plugins/AvoidableGetterPlugin.php
+++ b/.phan/plugins/AvoidableGetterPlugin.php
@@ -116,7 +116,7 @@ class AvoidableGetterVisitor extends PluginAwarePostAnalysisVisitor
 
         $this->emitPluginIssue(
             $this->code_base,
-            (clone($this->context))->withLineNumberStart($node->lineno),
+            (clone $this->context)->withLineNumberStart($node->lineno),
             $issue_name,
             "Can replace {METHOD} with {PROPERTY}",
             [ASTReverter::toShortString($node), '$this->' . $property_name]

--- a/.phan/plugins/DuplicateArrayKeyPlugin.php
+++ b/.phan/plugins/DuplicateArrayKeyPlugin.php
@@ -95,7 +95,7 @@ class DuplicateArrayKeyVisitor extends PluginAwarePostAnalysisVisitor
                 $normalized_case_cond = is_object($case_cond) ? ASTReverter::toShortString($case_cond) : self::normalizeSwitchKey($case_cond);
                 $this->emitPluginIssue(
                     $this->code_base,
-                    clone($this->context)->withLineNumberStart($case_node->lineno),
+                    (clone $this->context)->withLineNumberStart($case_node->lineno),
                     'PhanPluginDuplicateSwitchCase',
                     "Duplicate/Equivalent switch case({STRING_LITERAL}) detected in switch statement - the later entry will be ignored in favor of case {CODE} at line {LINE}.",
                     [$normalized_case_cond, ASTReverter::toShortString($case_constant_set[$cond_key]->children['cond']), $case_constant_set[$cond_key]->lineno],
@@ -171,7 +171,7 @@ class DuplicateArrayKeyVisitor extends PluginAwarePostAnalysisVisitor
             if ($old_index !== null) {
                 $this->emitPluginIssue(
                     $this->code_base,
-                    (clone($this->context))->withLineNumberStart($children[$i]->lineno),
+                    (clone $this->context)->withLineNumberStart($children[$i]->lineno),
                     'PhanPluginDuplicateSwitchCaseLooseEquality',
                     "Switch case({STRING_LITERAL}) is loosely equivalent (==) to an earlier case ({STRING_LITERAL}) in switch statement - the earlier entry may be chosen instead.",
                     [self::normalizeSwitchKey($values_to_check[$i]), self::normalizeSwitchKey($values_to_check[$old_index])],
@@ -227,7 +227,7 @@ class DuplicateArrayKeyVisitor extends PluginAwarePostAnalysisVisitor
                     $normalized_arm_expr_cond = ASTReverter::toShortString($arm_expr_cond);
                     $this->emitPluginIssue(
                         $this->code_base,
-                        clone($this->context)->withLineNumberStart($lineno),
+                        (clone $this->context)->withLineNumberStart($lineno),
                         'PhanPluginDuplicateMatchArmExpression',
                         "Duplicate match arm expression({STRING_LITERAL}) detected in match expression - the later entry will be ignored in favor of expression {CODE} at line {LINE}.",
                         [$normalized_arm_expr_cond, ASTReverter::toShortString($arm_expr_constant_set[$cond_key][0]), $arm_expr_constant_set[$cond_key][1]],
@@ -302,7 +302,7 @@ class DuplicateArrayKeyVisitor extends PluginAwarePostAnalysisVisitor
         if (is_string($key) && strncmp($key, self::HASH_PREFIX, strlen(self::HASH_PREFIX)) === 0) {
             $this->emitPluginIssue(
                 $this->code_base,
-                clone($this->context)->withLineNumberStart($entry->lineno),
+                (clone $this->context)->withLineNumberStart($entry->lineno),
                 'PhanPluginDuplicateArrayKeyExpression',
                 "Duplicate dynamic array key expression ({CODE}) detected in array - the earlier entry at line {LINE} will be ignored if the expression had the same value.",
                 [ASTReverter::toShortString($entry->children['key']), $old_entry->lineno],
@@ -315,7 +315,7 @@ class DuplicateArrayKeyVisitor extends PluginAwarePostAnalysisVisitor
         $normalized_key = self::normalizeKey($key);
         $this->emitPluginIssue(
             $this->code_base,
-            clone($this->context)->withLineNumberStart($entry->lineno),
+            (clone $this->context)->withLineNumberStart($entry->lineno),
             'PhanPluginDuplicateArrayKey',
             "Duplicate/Equivalent array key value({STRING_LITERAL}) detected in array - the earlier entry {CODE} at line {LINE} will be ignored.",
             [$normalized_key, ASTReverter::toShortString($old_entry->children['key']), $old_entry->lineno],

--- a/.phan/plugins/DuplicateExpressionPlugin.php
+++ b/.phan/plugins/DuplicateExpressionPlugin.php
@@ -351,7 +351,7 @@ class RedundantNodePostAnalysisVisitor extends PluginAwarePostAnalysisVisitor
             if ($hash === $prev_hash) {
                 $this->emitPluginIssue(
                     $this->code_base,
-                    (clone($this->context))->withLineNumberStart($child->lineno ?? $node->lineno),
+                    (clone $this->context)->withLineNumberStart($child->lineno ?? $node->lineno),
                     'PhanPluginDuplicateAdjacentStatement',
                     "Statement {CODE} is a duplicate of the statement on the above line. Suppress this issue instance if there's a good reason for this.",
                     [ASTReverter::toShortString($child)]
@@ -476,7 +476,7 @@ class RedundantNodePreAnalysisVisitor extends PluginAwarePreAnalysisVisitor
             if (isset($condition_set[$cond_hash])) {
                 $this->emitPluginIssue(
                     $this->code_base,
-                    clone($this->context)->withLineNumberStart($cond->lineno ?? $children[$i]->lineno),
+                    (clone $this->context)->withLineNumberStart($cond->lineno ?? $children[$i]->lineno),
                     'PhanPluginDuplicateIfCondition',
                     'Saw the same condition {CODE} in an earlier if/elseif statement',
                     [ASTReverter::toShortString($cond)]
@@ -490,7 +490,7 @@ class RedundantNodePreAnalysisVisitor extends PluginAwarePreAnalysisVisitor
             if (($stmts->children ?? null) && ASTHasher::hash($stmts) === ASTHasher::hash($children[$N - 2]->children['stmts'])) {
                 $this->emitPluginIssue(
                     $this->code_base,
-                    clone($this->context)->withLineNumberStart($children[$N - 1]->lineno),
+                    (clone $this->context)->withLineNumberStart($children[$N - 1]->lineno),
                     'PhanPluginDuplicateIfStatements',
                     'The statements of the else duplicate the statements of the previous if/elseif statement with condition {CODE}',
                     [ASTReverter::toShortString($children[$N - 2]->children['cond'])]
@@ -522,7 +522,7 @@ class RedundantNodePreAnalysisVisitor extends PluginAwarePreAnalysisVisitor
             if ($prev_hash === $cur_hash) {
                 $this->emitPluginIssue(
                     $this->code_base,
-                    clone($this->context)->withLineNumberStart($catches[$i]->lineno),
+                    (clone $this->context)->withLineNumberStart($catches[$i]->lineno),
                     'PhanPluginDuplicateCatchStatementBody',
                     'The implementation of catch({CODE}) and catch({CODE}) are identical, and can be combined if the application only needs to supports php 7.1 and newer',
                     [

--- a/.phan/plugins/EmptyStatementListPlugin.php
+++ b/.phan/plugins/EmptyStatementListPlugin.php
@@ -111,7 +111,7 @@ final class EmptyStatementListVisitor extends PluginAwarePostAnalysisVisitor
 
         $this->emitPluginIssue(
             $this->code_base,
-            (clone($this->context))->withLineNumberStart($last_if_elem->children['stmts']->lineno ?? $last_if_elem->lineno),
+            (clone $this->context)->withLineNumberStart($last_if_elem->children['stmts']->lineno ?? $last_if_elem->lineno),
             'PhanPluginEmptyStatementIf',
             'Empty statement list statement detected for the last if/elseif statement',
             []
@@ -188,7 +188,7 @@ final class EmptyStatementListVisitor extends PluginAwarePostAnalysisVisitor
         }
         $this->emitPluginIssue(
             $this->code_base,
-            clone($this->context)->withLineNumberStart($stmts_node->lineno ?? $node->lineno),
+            (clone $this->context)->withLineNumberStart($stmts_node->lineno ?? $node->lineno),
             'PhanPluginEmptyStatementForLoop',
             'Empty statement list statement detected for the for loop',
             []
@@ -216,7 +216,7 @@ final class EmptyStatementListVisitor extends PluginAwarePostAnalysisVisitor
         }
         $this->emitPluginIssue(
             $this->code_base,
-            clone($this->context)->withLineNumberStart($stmts_node->lineno ?? $node->lineno),
+            (clone $this->context)->withLineNumberStart($stmts_node->lineno ?? $node->lineno),
             'PhanPluginEmptyStatementWhileLoop',
             'Empty statement list statement detected for the while loop',
             []
@@ -244,7 +244,7 @@ final class EmptyStatementListVisitor extends PluginAwarePostAnalysisVisitor
         }
         $this->emitPluginIssue(
             $this->code_base,
-            clone($this->context)->withLineNumberStart($stmts_node->lineno),
+            (clone $this->context)->withLineNumberStart($stmts_node->lineno),
             'PhanPluginEmptyStatementDoWhileLoop',
             'Empty statement list statement detected for the do-while loop',
             []
@@ -273,7 +273,7 @@ final class EmptyStatementListVisitor extends PluginAwarePostAnalysisVisitor
         }
         $this->emitPluginIssue(
             $this->code_base,
-            clone($this->context)->withLineNumberStart($stmts_node->lineno),
+            (clone $this->context)->withLineNumberStart($stmts_node->lineno),
             'PhanPluginEmptyStatementForeachLoop',
             'Empty statement list statement detected for the foreach loop',
             []
@@ -292,7 +292,7 @@ final class EmptyStatementListVisitor extends PluginAwarePostAnalysisVisitor
             if (!$this->hasTODOComment($try_node->lineno, $node, $node->children['catches']->children[0]->lineno ?? $finally_node->lineno ?? null)) {
                 $this->emitPluginIssue(
                     $this->code_base,
-                    clone($this->context)->withLineNumberStart($try_node->lineno),
+                    (clone $this->context)->withLineNumberStart($try_node->lineno),
                     'PhanPluginEmptyStatementTryBody',
                     'Empty statement list statement detected for the try statement\'s body',
                     []
@@ -303,7 +303,7 @@ final class EmptyStatementListVisitor extends PluginAwarePostAnalysisVisitor
             if (!$this->hasTODOComment($finally_node->lineno, $node)) {
                 $this->emitPluginIssue(
                     $this->code_base,
-                    clone($this->context)->withLineNumberStart($finally_node->lineno),
+                    (clone $this->context)->withLineNumberStart($finally_node->lineno),
                     'PhanPluginEmptyStatementTryFinally',
                     'Empty statement list statement detected for the try\'s finally body',
                     []
@@ -348,7 +348,7 @@ final class EmptyStatementListVisitor extends PluginAwarePostAnalysisVisitor
         }
         $this->emitPluginIssue(
             $this->code_base,
-            clone($this->context)->withLineNumberStart($node->lineno),
+            (clone $this->context)->withLineNumberStart($node->lineno),
             'PhanPluginEmptyStatementSwitch',
             'No side effects seen for any cases of this switch statement',
             []

--- a/.phan/plugins/InlineHTMLPlugin.php
+++ b/.phan/plugins/InlineHTMLPlugin.php
@@ -126,7 +126,7 @@ class InlineHTMLPlugin extends PluginV3 implements
         }
         $this->emitIssue(
             $code_base,
-            clone($context)->withLineNumberStart($token[2]),
+            (clone $context)->withLineNumberStart($token[2]),
             $issue,
             $message,
             [StringUtil::jsonEncode(self::truncate($token[1]))]

--- a/.phan/plugins/InvokePHPNativeSyntaxCheckPlugin.php
+++ b/.phan/plugins/InvokePHPNativeSyntaxCheckPlugin.php
@@ -144,7 +144,7 @@ class InvokePHPNativeSyntaxCheckPlugin extends PluginV3 implements
 
         self::emitIssue(
             $code_base,
-            clone($context)->withLineNumberStart($lineno),
+            (clone $context)->withLineNumberStart($lineno),
             'PhanNativePHPSyntaxCheckPlugin',
             'Saw error or notice for {FILE} --syntax-check: {DETAILS}',
             [
@@ -193,7 +193,7 @@ class InvokeExecutionPromise
 
     public function __construct(string $binary, string $file_contents, Context $context)
     {
-        $this->context = clone($context);
+        $this->context = clone $context;
         $new_file_contents = Parser::removeShebang($file_contents);
         // TODO: Use symfony process
         // Note: We might have invalid utf-8, ensure that the streams are opened in binary mode.

--- a/.phan/plugins/NotFullyQualifiedUsagePlugin.php
+++ b/.phan/plugins/NotFullyQualifiedUsagePlugin.php
@@ -134,7 +134,7 @@ class NotFullyQualifiedUsageVisitor extends PluginAwarePostAnalysisVisitor
         }
         $this->emitPluginIssue(
             $this->code_base,
-            clone($this->context)->withLineNumberStart($expression->lineno),
+            (clone $this->context)->withLineNumberStart($expression->lineno),
             $issue_type,
             $issue_msg,
             [$function_name, $this->context->getNamespace()]
@@ -185,7 +185,7 @@ class NotFullyQualifiedUsageVisitor extends PluginAwarePostAnalysisVisitor
     {
         $this->emitPluginIssue(
             $this->code_base,
-            clone($this->context)->withLineNumberStart($expression->lineno),
+            (clone $this->context)->withLineNumberStart($expression->lineno),
             self::NotFullyQualifiedGlobalConstant,
             'Expected usage of {CONST} to be fully qualified or have a use statement but none were found in namespace {NAMESPACE}',
             [$constant_name, $this->context->getNamespace()]

--- a/.phan/plugins/PHPDocInWrongCommentPlugin.php
+++ b/.phan/plugins/PHPDocInWrongCommentPlugin.php
@@ -55,7 +55,7 @@ class PHPDocInWrongCommentPlugin extends PluginV3 implements
                 if ($comment_string[0] === '#' && substr($comment_string, 1, 1) !== '[') {
                     $this->emitIssue(
                         $code_base,
-                        (clone($context))->withLineNumberStart($token[2]),
+                        (clone $context)->withLineNumberStart($token[2]),
                         'PhanPluginPHPDocHashComment',
                         'Saw comment starting with {COMMENT} in {COMMENT} - consider using {COMMENT} instead to avoid confusion with php 8.0 {COMMENT} attributes',
                         ['#', StringUtil::jsonEncode(self::truncate(trim($comment_string))), '//', '#[']
@@ -76,7 +76,7 @@ class PHPDocInWrongCommentPlugin extends PluginV3 implements
             }
             $this->emitIssue(
                 $code_base,
-                (clone($context))->withLineNumberStart($token[2]),
+                (clone $context)->withLineNumberStart($token[2]),
                 'PhanPluginPHPDocInWrongComment',
                 'Saw possible phpdoc annotation in ordinary block comment {COMMENT}. PHPDoc comments should start with "/**" (followed by whitespace), not "/*"',
                 [StringUtil::jsonEncode(self::truncate($comment_string))]

--- a/.phan/plugins/RedundantAssignmentPlugin.php
+++ b/.phan/plugins/RedundantAssignmentPlugin.php
@@ -121,7 +121,7 @@ class RedundantAssignmentPreAnalysisVisitor extends PluginAwarePreAnalysisVisito
             $issue_name = 'PhanPluginRedundantAssignment';
         }
         if ($this->context->isInLoop()) {
-            $this->context->deferCheckToOutermostLoop(function (Context $context_after_loop) use ($issue_name, $var_name, $variable_type): void {
+            $this->context->deferCheckToOutermostLoop(function (Context $context_after_loop) use ($issue_name, $var_name, $variable_type, $var): void {
                 $new_variable = $context_after_loop->getScope()->getVariableByNameOrNull($var_name);
                 if (!$new_variable) {
                     return;
@@ -135,7 +135,7 @@ class RedundantAssignmentPreAnalysisVisitor extends PluginAwarePreAnalysisVisito
                 }
                 $this->emitPluginIssue(
                     $this->code_base,
-                    $this->context,
+                    (clone $this->context)->withLineNumberStart($var->lineno),
                     $issue_name,
                     'Assigning {TYPE} to variable ${VARIABLE} which already has that value',
                     [$variable_type, $var_name]
@@ -145,7 +145,7 @@ class RedundantAssignmentPreAnalysisVisitor extends PluginAwarePreAnalysisVisito
         }
         $this->emitPluginIssue(
             $this->code_base,
-            $this->context,
+            (clone $this->context)->withLineNumberStart($var->lineno),
             $issue_name,
             'Assigning {TYPE} to variable ${VARIABLE} which already has that value',
             [$expr_type, $var_name]

--- a/.phan/plugins/SleepCheckerPlugin.php
+++ b/.phan/plugins/SleepCheckerPlugin.php
@@ -149,7 +149,7 @@ class SleepCheckerVisitor extends PluginAwarePostAnalysisVisitor
      */
     private function analyzeReturnValue($expr_node, int $lineno, array &$sleep_properties): void
     {
-        $context = clone($this->context)->withLineNumberStart($lineno);
+        $context = (clone $this->context)->withLineNumberStart($lineno);
         if (!($expr_node instanceof Node)) {
             $this->emitPluginIssue(
                 $this->code_base,

--- a/.phan/plugins/SuspiciousParamOrderPlugin.php
+++ b/.phan/plugins/SuspiciousParamOrderPlugin.php
@@ -201,7 +201,7 @@ class SuspiciousParamOrderVisitor extends PluginAwarePostAnalysisVisitor
             if ($function->isPHPInternal()) {
                 $this->emitPluginIssue(
                     $this->code_base,
-                    clone($this->context)->withLineNumberStart($node->lineno),
+                    (clone $this->context)->withLineNumberStart($node->lineno),
                     self::SuspiciousParamOrderInternal,
                     'Suspicious order for arguments named {DETAILS} - These are being passed to parameters {DETAILS} of {FUNCTION}',
                     [
@@ -213,7 +213,7 @@ class SuspiciousParamOrderVisitor extends PluginAwarePostAnalysisVisitor
             } else {
                 $this->emitPluginIssue(
                     $this->code_base,
-                    clone($this->context)->withLineNumberStart($node->lineno),
+                    (clone $this->context)->withLineNumberStart($node->lineno),
                     self::SuspiciousParamOrder,
                     'Suspicious order for arguments named {DETAILS} - These are being passed to parameters {DETAILS} of {FUNCTION} defined at {FILE}:{LINE}',
                     [
@@ -280,7 +280,7 @@ class SuspiciousParamOrderVisitor extends PluginAwarePostAnalysisVisitor
             if ($function->isPHPInternal()) {
                 $this->emitPluginIssue(
                     $this->code_base,
-                    (clone($this->context))->withLineNumberStart($args[$i]->lineno ?? $node->lineno),
+                    (clone $this->context)->withLineNumberStart($args[$i]->lineno ?? $node->lineno),
                     self::SuspiciousParamPositionInternal,
                     'Suspicious order for argument {DETAILS} - This is getting passed to parameter {DETAILS} of {FUNCTION}',
                     [
@@ -292,7 +292,7 @@ class SuspiciousParamOrderVisitor extends PluginAwarePostAnalysisVisitor
             } else {
                 $this->emitPluginIssue(
                     $this->code_base,
-                    clone($this->context)->withLineNumberStart($args[$i]->lineno ?? $node->lineno),
+                    (clone $this->context)->withLineNumberStart($args[$i]->lineno ?? $node->lineno),
                     self::SuspiciousParamPosition,
                     'Suspicious order for argument {DETAILS} - This is getting passed to parameter {DETAILS} of {FUNCTION} defined at {FILE}:{LINE}',
                     [

--- a/.phan/plugins/UnreachableCodePlugin.php
+++ b/.phan/plugins/UnreachableCodePlugin.php
@@ -93,7 +93,6 @@ final class UnreachableCodeVisitor extends PluginAwarePostAnalysisVisitor
                         continue;
                     }
                 }
-                $context = clone($this->context)->withLineNumberStart($next_node->lineno);
                 if ($this->context->isInFunctionLikeScope()) {
                     if ($this->context->getFunctionLikeInScope($this->code_base)->checkHasSuppressIssueAndIncrementCount('PhanPluginUnreachableCode')) {
                         // don't emit the below issue.
@@ -102,7 +101,7 @@ final class UnreachableCodeVisitor extends PluginAwarePostAnalysisVisitor
                 }
                 $this->emitPluginIssue(
                     $this->code_base,
-                    $context,
+                    (clone $this->context)->withLineNumberStart($next_node->lineno),
                     'PhanPluginUnreachableCode',
                     'Unreachable statement detected',
                     []

--- a/.phan/plugins/WhitespacePlugin.php
+++ b/.phan/plugins/WhitespacePlugin.php
@@ -54,7 +54,7 @@ class WhitespacePlugin extends PluginV3 implements
         if ($newline_position !== false) {
             self::emitIssue(
                 $code_base,
-                clone($context)->withLineNumberStart(self::calculateLine($file_contents, $newline_position)),
+                (clone $context)->withLineNumberStart(self::calculateLine($file_contents, $newline_position)),
                 self::CarriageReturn,
                 'The first occurrence of a carriage return ("\r") was seen here. Running "dos2unix" can fix that.'
             );
@@ -63,7 +63,7 @@ class WhitespacePlugin extends PluginV3 implements
         if ($tab_position !== false) {
             self::emitIssue(
                 $code_base,
-                clone($context)->withLineNumberStart(self::calculateLine($file_contents, $tab_position)),
+                (clone $context)->withLineNumberStart(self::calculateLine($file_contents, $tab_position)),
                 self::Tab,
                 'The first occurrence of a tab was seen here. Running "expand" can fix that.'
             );
@@ -71,7 +71,7 @@ class WhitespacePlugin extends PluginV3 implements
         if (preg_match('/[ \t]\r?$/mS', $file_contents, $match, PREG_OFFSET_CAPTURE)) {
             self::emitIssue(
                 $code_base,
-                clone($context)->withLineNumberStart(self::calculateLine($file_contents, $match[0][1])),
+                (clone $context)->withLineNumberStart(self::calculateLine($file_contents, $match[0][1])),
                 self::WhitespaceTrailing,
                 'The first occurrence of trailing whitespace was seen here.'
             );

--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,7 @@ Bug fixes:
 
   Also, check for the real `never` return type when emitting issues
 - Fix false positive `PhanPossiblyUndefinedGlobalVariable*` instance when `global $var` is used within a conditional. (#4539)
+- Fix false positive `PhanPluginRedundantAssignmentInLoop` instance when a variable is modified in a catch statement with a break/continue. (#4542)
 
 Maintenance:
 - Fix old return type signature for `get_headers` (#3273)

--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,7 @@ Bug fixes:
   Also, check for the real `never` return type when emitting issues
 - Fix false positive `PhanPossiblyUndefinedGlobalVariable*` instance when `global $var` is used within a conditional. (#4539)
 - Fix false positive `PhanPluginRedundantAssignmentInLoop` instance when a variable is modified in a catch statement with a break/continue. (#4542)
+- Fix some incorrect line numbers in some plugin issues.
 
 Maintenance:
 - Fix old return type signature for `get_headers` (#3273)

--- a/composer.lock
+++ b/composer.lock
@@ -2146,16 +2146,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "8.5.19",
+            "version": "8.5.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "496281b64ec781856ed0a583483b5923b4033722"
+                "reference": "9deefba183198398a09b927a6ac6bc1feb0b7b70"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/496281b64ec781856ed0a583483b5923b4033722",
-                "reference": "496281b64ec781856ed0a583483b5923b4033722",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9deefba183198398a09b927a6ac6bc1feb0b7b70",
+                "reference": "9deefba183198398a09b927a6ac6bc1feb0b7b70",
                 "shasum": ""
             },
             "require": {
@@ -2227,7 +2227,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/8.5.19"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/8.5.20"
             },
             "funding": [
                 {
@@ -2239,7 +2239,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-07-31T15:15:06+00:00"
+            "time": "2021-08-31T06:44:38+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -2865,6 +2865,7 @@
                     "type": "github"
                 }
             ],
+            "abandoned": true,
             "time": "2020-11-30T07:30:19+00:00"
         },
         {

--- a/src/Phan/AST/InferPureVisitor.php
+++ b/src/Phan/AST/InferPureVisitor.php
@@ -685,7 +685,7 @@ class InferPureVisitor extends AnalysisVisitor
     public function visitClosure(Node $node): void
     {
         $closure_fqsen = FullyQualifiedFunctionName::fromClosureInContext(
-            (clone($this->context))->withLineNumberStart($node->lineno),
+            (clone $this->context)->withLineNumberStart($node->lineno),
             $node
         );
         if (!$this->code_base->hasFunctionWithFQSEN($closure_fqsen)) {

--- a/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
+++ b/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
@@ -93,7 +93,7 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
      */
     private function handleMissing(Node $node): void
     {
-        throw new AssertionError("All flags must match. Found kind=" . Debug::nodeName($node) . ', flags=' . Element::flagDescription($node) . ' raw flags=' . $node->flags . ' at ' . $this->context->withLineNumberStart((int)$node->lineno));
+        throw new AssertionError("All flags must match. Found kind=" . Debug::nodeName($node) . ', flags=' . Element::flagDescription($node) . ' raw flags=' . $node->flags . ' at ' . (clone $this->context)->withLineNumberStart((int)$node->lineno));
     }
 
     /**

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -297,7 +297,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 }
                 return $type;
             });
-            $variable = clone($variable);
+            $variable = clone $variable;
             $context->addScopeVariable($variable);
             $variable->setUnionType($union_type);
             /*
@@ -307,7 +307,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                         $union_type = $union_type->withoutType($type)->withType(
                             GenericArrayType::fromElementType($type->genericArrayElementType(), false, $type->getKeyType())
                         );
-                        $variable = clone($variable);
+                        $variable = clone $variable;
                         $context->addScopeVariable($variable);
                         $variable->setUnionType($union_type);
                     }
@@ -617,7 +617,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 // TODO: Support @global?
                 $actual_global_variable = $scope->getGlobalVariableByName($variable_name);
             }
-            $scope_global_variable = $actual_global_variable instanceof GlobalVariable ? clone($actual_global_variable) : new GlobalVariable($actual_global_variable);
+            $scope_global_variable = $actual_global_variable instanceof GlobalVariable ? (clone $actual_global_variable) : new GlobalVariable($actual_global_variable);
             // Importing an undefined global by reference will make an undefined value a reference to null.
             $scope_global_variable->setUnionType($actual_global_variable->getUnionType()->eraseRealTypeSetRecursively()->withIsPossiblyUndefined(false));
         }
@@ -1247,7 +1247,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             } catch (IssueException | NodeException $_) {
                 return $this->context;
             }
-            $variable = clone($variable);
+            $variable = clone $variable;
             $variable->setUnionType($new_type);
             $this->context->addScopeVariable($variable);
             return $this->context;
@@ -1997,7 +1997,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             RedundantCondition::emitInstance(
                 $expr,
                 $this->code_base,
-                (clone($this->context))->withLineNumberStart($expr->lineno ?? $node->lineno),
+                (clone $this->context)->withLineNumberStart($expr->lineno ?? $node->lineno),
                 Issue::EmptyYieldFrom,
                 [(string)$yield_from_type],
                 Closure::fromCallable([BlockAnalysisVisitor::class, 'isEmptyIterable'])
@@ -4201,7 +4201,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         if ($variable) {
             $set_variable_type = static function (UnionType $new_type) use ($code_base, $context, $variable, $argument): void {
                 if ($variable instanceof Variable) {
-                    $variable = clone($variable);
+                    $variable = clone $variable;
                     AssignmentVisitor::analyzeSetUnionTypeInContext($code_base, $context, $variable, $new_type, $argument);
                     $context->addScopeVariable($variable);
                 } else {
@@ -4346,12 +4346,12 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         }
 
         $original_method_scope = $method->getInternalScope();
-        $method->setInternalScope(clone($original_method_scope));
+        $method->setInternalScope(clone $original_method_scope);
         try {
             // Even though we don't modify the parameter list, we still need to know the types
             // -- as an optimization, we don't run quick mode again if the types didn't change?
             $parameter_list = \array_map(static function (Parameter $parameter): Parameter {
-                return clone($parameter);
+                return clone $parameter;
             }, $method->getParameterList());
 
             foreach ($parameter_list as $i => $parameter_clone) {
@@ -4433,7 +4433,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
     ): void {
         $method = $this->findDefiningMethod($method);
         $original_method_scope = $method->getInternalScope();
-        $method->setInternalScope(clone($original_method_scope));
+        $method->setInternalScope(clone $original_method_scope);
         $method_context = $method->getContext();
 
         try {

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -1177,7 +1177,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
             RedundantCondition::emitInstance(
                 $node->children['expr'],
                 $this->code_base,
-                (clone($this->context))->withLineNumberStart($node->children['expr']->lineno ?? $node->lineno),
+                (clone $this->context)->withLineNumberStart($node->children['expr']->lineno ?? $node->lineno),
                 Issue::EmptyForeach,
                 [(string)$union_type],
                 Closure::fromCallable([self::class, 'isEmptyIterable'])
@@ -1188,7 +1188,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
                 RedundantCondition::emitInstance(
                     $node->children['expr'],
                     $this->code_base,
-                    (clone($this->context))->withLineNumberStart($node->children['expr']->lineno ?? $node->lineno),
+                    (clone $this->context)->withLineNumberStart($node->children['expr']->lineno ?? $node->lineno),
                     Issue::EmptyForeachBody,
                     [(string)$union_type],
                     Closure::fromCallable([self::class, 'isDefinitelyNotObject'])
@@ -2898,7 +2898,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
             RedundantCondition::emitInstance(
                 $left_node,
                 $this->code_base,
-                (clone($context))->withLineNumberStart($node->lineno),
+                (clone $context)->withLineNumberStart($node->lineno),
                 Issue::CoalescingNeverNull,
                 [
                     ASTReverter::toShortString($left_node),
@@ -2914,7 +2914,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
             RedundantCondition::emitInstance(
                 $left_node,
                 $this->code_base,
-                (clone($context))->withLineNumberStart($node->lineno),
+                (clone $context)->withLineNumberStart($node->lineno),
                 Issue::CoalescingAlwaysNull,
                 [
                     ASTReverter::toShortString($left_node),

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -2535,6 +2535,13 @@ class BlockAnalysisVisitor extends AnalysisVisitor
             // Step into each catch node and get an
             // updated context for the node
             $catch_context = $this->analyzeAndGetUpdatedContext($catch_context, $node, $catch_node);
+            $catch_stmts_node = $catch_node->children['stmts'];
+            if ($catch_stmts_node instanceof Node && BlockExitStatusChecker::willUnconditionallySkipRemainingStatements($catch_stmts_node)) {
+                // e.g. "} catch (Exception $e) { break; }"
+                if (!BlockExitStatusChecker::willUnconditionallyThrowOrReturn($catch_stmts_node)) {
+                    $this->recordLoopContextForBreakOrContinue($catch_context);
+                }
+            }
             // NOTE: We let ContextMergeVisitor->mergeCatchContext decide if the block exit status is valid.
             $catch_context_list[] = $catch_context;
         }

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -932,7 +932,7 @@ class Clazz extends AddressableElement
             $original_union_type = $comment_parameter->getUnionType();
             $union_type = $original_union_type->withStaticResolvedInContext($context);
             $property = new Property(
-                (clone($context))->withLineNumberStart($comment_parameter->getLine()),
+                (clone $context)->withLineNumberStart($comment_parameter->getLine()),
                 $property_name,
                 $union_type,
                 0,
@@ -981,7 +981,7 @@ class Clazz extends AddressableElement
                 $class_fqsen,
                 $method_name
             );
-            $method_context = (clone($context))->withLineNumberStart($comment_method->getLine());
+            $method_context = (clone $context)->withLineNumberStart($comment_method->getLine());
             $real_parameter_list = \array_map(static function (\Phan\Language\Element\Comment\Parameter $parameter) use ($method_context): Parameter {
                 return $parameter->asRealParameter($method_context);
             }, $comment_method->getParameterList());

--- a/src/Phan/Language/Element/Parameter.php
+++ b/src/Phan/Language/Element/Parameter.php
@@ -382,7 +382,7 @@ class Parameter extends Variable
             );
         }
         $parameter = Parameter::create(
-            (clone($context))->withLineNumberStart($node->lineno),
+            (clone $context)->withLineNumberStart($node->lineno),
             $parameter_name,
             $union_type,
             $node->flags
@@ -448,7 +448,7 @@ class Parameter extends Variable
                 if (!$has_error) {
                     $parameter->setDefaultValueFutureType(new FutureUnionType(
                         $code_base,
-                        (clone($context))->withLineNumberStart($default_node->lineno ?? 0),
+                        (clone $context)->withLineNumberStart($default_node->lineno ?? 0),
                         $default_node
                     ));
                 }

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -329,7 +329,7 @@ class ParseVisitor extends ScopeVisitor
         }
 
         $method = Method::fromNode(
-            clone($context),
+            clone $context,
             $code_base,
             $node,
             $method_fqsen,
@@ -388,7 +388,7 @@ class ParseVisitor extends ScopeVisitor
         Node $parameter_node
     ): void {
         $lineno = $parameter_node->lineno;
-        $context = (clone($this->context))->withLineNumberStart($lineno);
+        $context = (clone $this->context)->withLineNumberStart($lineno);
         if ($parameter_node->flags & ast\flags\PARAM_VARIADIC) {
             $this->emitIssue(
                 Issue::InvalidNode,
@@ -514,7 +514,7 @@ class ParseVisitor extends ScopeVisitor
                     . 'Got '
                     . \print_r($property_name, true)
                     . ' at '
-                    . (clone($this->context))->withLineNumberStart($child_node->lineno)
+                    . (clone $this->context)->withLineNumberStart($child_node->lineno)
                 );
             }
             $this->addProperty(
@@ -549,7 +549,7 @@ class ParseVisitor extends ScopeVisitor
         // type and try to figure it out later
         $future_union_type_node = null;
 
-        $context_for_property = (clone($this->context))->withLineNumberStart($lineno);
+        $context_for_property = (clone $this->context)->withLineNumberStart($lineno);
         $real_type_set = $real_union_type->getTypeSet();
 
         if ($default_node === null) {

--- a/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
@@ -550,7 +550,7 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
                 RedundantCondition::emitInstance(
                     $args[0],
                     $code_base,
-                    (clone($context))->withLineNumberStart($args[0]->lineno ?? $context->getLineNumberStart()),
+                    (clone $context)->withLineNumberStart($args[0]->lineno ?? $context->getLineNumberStart()),
                     Issue::RedundantArrayValuesCall,
                     [
                         $union_type->asRealUnionType(),

--- a/src/Phan/Plugin/Internal/LoopVariableReuseVisitor.php
+++ b/src/Phan/Plugin/Internal/LoopVariableReuseVisitor.php
@@ -146,7 +146,7 @@ class LoopVariableReuseVisitor extends PluginAwarePostAnalysisVisitor
             $inner_node = $variables[$variable_name];
             $this->emitPluginIssue(
                 $this->code_base,
-                (clone($this->context))->withLineNumberStart($inner_node->lineno),
+                (clone $this->context)->withLineNumberStart($inner_node->lineno),
                 'PhanPluginLoopVariableReuse',
                 'Variable ${VARIABLE} used in loop was also used in an outer loop on line {LINE}',
                 [$variable_name, $node->lineno]

--- a/src/Phan/Plugin/Internal/RedundantConditionVisitor.php
+++ b/src/Phan/Plugin/Internal/RedundantConditionVisitor.php
@@ -494,7 +494,7 @@ class RedundantConditionVisitor extends PluginAwarePostAnalysisVisitor
             RedundantCondition::emitInstance(
                 $var_node,
                 $this->code_base,
-                (clone($this->context))->withLineNumberStart($node->lineno),
+                (clone $this->context)->withLineNumberStart($node->lineno),
                 Issue::RedundantCondition,
                 [
                     ASTReverter::toShortString($var_node),
@@ -509,7 +509,7 @@ class RedundantConditionVisitor extends PluginAwarePostAnalysisVisitor
             RedundantCondition::emitInstance(
                 $var_node,
                 $this->code_base,
-                (clone($this->context))->withLineNumberStart($node->lineno),
+                (clone $this->context)->withLineNumberStart($node->lineno),
                 Issue::ImpossibleCondition,
                 [
                     ASTReverter::toShortString($var_node),
@@ -597,7 +597,7 @@ class RedundantConditionVisitor extends PluginAwarePostAnalysisVisitor
             RedundantCondition::emitInstance(
                 $expr_node,
                 $code_base,
-                (clone($this->context))->withLineNumberStart($node->lineno),
+                (clone $this->context)->withLineNumberStart($node->lineno),
                 Issue::RedundantCondition,
                 [
                     ASTReverter::toShortString($expr_node),
@@ -612,7 +612,7 @@ class RedundantConditionVisitor extends PluginAwarePostAnalysisVisitor
             RedundantCondition::emitInstance(
                 $expr_node,
                 $code_base,
-                (clone($this->context))->withLineNumberStart($node->lineno),
+                (clone $this->context)->withLineNumberStart($node->lineno),
                 Issue::ImpossibleCondition,
                 [
                     ASTReverter::toShortString($expr_node),

--- a/src/Phan/Plugin/Internal/UseReturnValuePlugin.php
+++ b/src/Phan/Plugin/Internal/UseReturnValuePlugin.php
@@ -148,7 +148,7 @@ class UseReturnValuePlugin extends PluginV3 implements PostAnalyzeNodeCapability
                         continue;
                     }
                     $line = (int)$matches[1];
-                    $context = (clone($context))->withLineNumberStart($line);
+                    $context = (clone $context)->withLineNumberStart($line);
                     if ($known_must_use_return_value) {
                         self::emitIssue(
                             $code_base,

--- a/src/Phan/Plugin/Internal/UseReturnValuePlugin/UseReturnValueVisitor.php
+++ b/src/Phan/Plugin/Internal/UseReturnValuePlugin/UseReturnValueVisitor.php
@@ -135,7 +135,7 @@ class UseReturnValueVisitor extends PluginAwarePostAnalysisVisitor
         // To reduce false positives, only emit this issue if all functions have the same return type
         $this->emitPluginIssue(
             $this->code_base,
-            (clone($this->context))->withLineNumberStart($node->lineno),
+            (clone $this->context)->withLineNumberStart($node->lineno),
             UseReturnValuePlugin::UseReturnValueOfNever,
             "Saw use of value of expression {CODE} which likely uses the {CODE} statement with a return type of '{TYPE}' - this will not return normally",
             [ASTReverter::toShortString($node), 'exit', 'never']
@@ -233,7 +233,7 @@ class UseReturnValueVisitor extends PluginAwarePostAnalysisVisitor
         // To reduce false positives, only emit this issue if all functions have the same return type
         $this->emitPluginIssue(
             $this->code_base,
-            (clone($this->context))->withLineNumberStart($node->lineno),
+            (clone $this->context)->withLineNumberStart($node->lineno),
             UseReturnValuePlugin::UseReturnValueOfNever,
             "Saw use of value of expression {CODE} which likely uses the function {FUNCTIONLIKE} with a return type of '{TYPE}' - this will not return normally",
             [ASTReverter::toShortString($node), $function->getRepresentationForIssue(true), 'never']
@@ -367,7 +367,7 @@ class UseReturnValueVisitor extends PluginAwarePostAnalysisVisitor
     {
         $this->emitPluginIssue(
             $this->code_base,
-            (clone($this->context))->withLineNumberStart($node->lineno),
+            (clone $this->context)->withLineNumberStart($node->lineno),
             UseReturnValuePlugin::UseReturnValueCallableConvert,
             'Expected to use the Closure created from {CODE}',
             [ASTReverter::toShortString($node)]
@@ -437,7 +437,7 @@ class UseReturnValueVisitor extends PluginAwarePostAnalysisVisitor
         if ($function->hasYield() || $function->getUnionType()->isExclusivelyGenerators()) {
             $this->emitPluginIssue(
                 $this->code_base,
-                (clone($this->context))->withLineNumberStart($node->lineno),
+                (clone $this->context)->withLineNumberStart($node->lineno),
                 UseReturnValuePlugin::UseReturnValueGenerator,
                 'Expected to use the return value of the function/method {FUNCTION} returning a generator of type {TYPE}',
                 [$function->getRepresentationForIssue(true), $function->getUnionType()]
@@ -541,7 +541,7 @@ class UseReturnValueVisitor extends PluginAwarePostAnalysisVisitor
         if ($method->isPHPInternal()) {
             $this->emitPluginIssue(
                 $this->code_base,
-                (clone($this->context))->withLineNumberStart($node->lineno),
+                (clone $this->context)->withLineNumberStart($node->lineno),
                 UseReturnValuePlugin::UseReturnValueInternalKnown,
                 'Expected to use the return value of the internal function/method {FUNCTION}',
                 [$fqsen]
@@ -554,7 +554,7 @@ class UseReturnValueVisitor extends PluginAwarePostAnalysisVisitor
         }
         $this->emitPluginIssue(
             $this->code_base,
-            (clone($this->context))->withLineNumberStart($node->lineno),
+            (clone $this->context)->withLineNumberStart($node->lineno),
             UseReturnValuePlugin::UseReturnValueKnown,
             'Expected to use the return value of the user-defined function/method {FUNCTION} defined at {FILE}:{LINE}',
             [$method->getRepresentationForIssue(), $method->getContext()->getFile(), $method->getContext()->getLineNumberStart()]

--- a/tests/plugin_test/expected/003_suppress_on_property.php.expected
+++ b/tests/plugin_test/expected/003_suppress_on_property.php.expected
@@ -1,3 +1,3 @@
 src/003_suppress_on_property.php:7 PhanReadOnlyPublicProperty Possibly zero write references to public property \A3->x
-src/003_suppress_on_property.php:10 PhanPluginMixedKeyNoKey Should not mix array entries of the form [key => value,] with entries of the form [value,].
+src/003_suppress_on_property.php:8 PhanPluginMixedKeyNoKey Should not mix array entries of the form [key => value,] with entries of the form [value,].
 src/003_suppress_on_property.php:19 PhanPluginDuplicateArrayKey Duplicate/Equivalent array key value('key') detected in array - the earlier entry 'key' at line 18 will be ignored.

--- a/tests/plugin_test/expected/204_redundant_assignment.php.expected
+++ b/tests/plugin_test/expected/204_redundant_assignment.php.expected
@@ -1,0 +1,2 @@
+src/204_redundant_assignment.php:3 PhanUnreferencedClass Possibly zero references to class \TestClass
+src/204_redundant_assignment.php:4 PhanUnreferencedPrivateMethod Possibly zero references to private method \TestClass::task()

--- a/tests/plugin_test/src/204_redundant_assignment.php
+++ b/tests/plugin_test/src/204_redundant_assignment.php
@@ -1,0 +1,22 @@
+<?php
+
+class TestClass {
+    private static function task( ): void {
+        $consecutiveErrors = 0;
+        while ( rand(0, 1) > 0 ) {
+            try {
+                $status = rand(0, 1);
+            } catch ( \Exception $_ ) {
+                if ( ++$consecutiveErrors > 3 ) {
+                    exit(1);
+                }
+                continue;
+            }
+            $consecutiveErrors = 0;
+
+            if ( $status > 0 ) {
+                sleep( 10 );
+            }
+        }
+    }
+}


### PR DESCRIPTION
`catch` should be treated like an if statement branch for identifying
`break`/`continue` calls at the level of that branch.

Closes #4542

Fix some incorrect line numbers in plugin issues