### PR TITLE
Fix crash seen parsing intersection types containing union types

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,7 @@ Bug fixes:
 - Fix false positive `PhanPossiblyUndefinedGlobalVariable*` instance when `global $var` is used within a conditional. (#4539)
 - Fix false positive `PhanPluginRedundantAssignmentInLoop` instance when a variable is modified in a catch statement with a break/continue. (#4542)
 - Fix some incorrect line numbers in some plugin issues.
+- Fix crash seen when parsing intersection types containing union types such as `non-empty-array&array<'a'|'b'>` (#4544)
 
 Maintenance:
 - Fix old return type signature for `get_headers` (#3273)

--- a/composer.lock
+++ b/composer.lock
@@ -1782,33 +1782,33 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.13.0",
+            "version": "1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "be1996ed8adc35c3fd795488a653f4b518be70ea"
+                "reference": "d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/be1996ed8adc35c3fd795488a653f4b518be70ea",
-                "reference": "be1996ed8adc35c3fd795488a653f4b518be70ea",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e",
+                "reference": "d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.2",
-                "php": "^7.2 || ~8.0, <8.1",
+                "php": "^7.2 || ~8.0, <8.2",
                 "phpdocumentor/reflection-docblock": "^5.2",
                 "sebastian/comparator": "^3.0 || ^4.0",
                 "sebastian/recursion-context": "^3.0 || ^4.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^6.0",
+                "phpspec/phpspec": "^6.0 || ^7.0",
                 "phpunit/phpunit": "^8.0 || ^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.11.x-dev"
+                    "dev-master": "1.x-dev"
                 }
             },
             "autoload": {
@@ -1843,9 +1843,9 @@
             ],
             "support": {
                 "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/1.13.0"
+                "source": "https://github.com/phpspec/prophecy/tree/1.14.0"
             },
-            "time": "2021-03-17T13:42:18+00:00"
+            "time": "2021-09-10T09:02:12+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -4958,6 +4958,12 @@ Saw an @param annotation for ${PARAMETER}, but it was not found in the param lis
 
 e.g. [this issue](https://github.com/phan/phan/tree/v5/tests/files/expected/0373_reject_bad_type_narrowing.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/v5/tests/files/src/0373_reject_bad_type_narrowing.php#L4).
 
+## PhanCommentUnsupportedUnionType
+
+```
+Saw a union type {TYPE} with more than 1 type in a location that does not support union types
+```
+
 ## PhanCommentVarInsteadOfParam
 
 ```

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -650,6 +650,7 @@ class Issue
     public const CommentDuplicateMagicMethod      = 'PhanCommentDuplicateMagicMethod';
     public const CommentDuplicateMagicProperty    = 'PhanCommentDuplicateMagicProperty';
     public const CommentObjectInClassConstantType = 'PhanCommentObjectInClassConstantType';
+    public const CommentUnsupportedUnionType      = 'PhanCommentUnsupportedUnionType';
     // phpcs:enable Generic.NamingConventions.UpperCaseConstantName.ClassConstantNotUpperCase
     // end of issue name constants
 
@@ -5585,6 +5586,14 @@ class Issue
                 "Impossible phpdoc declaration that a class constant {CONST} has a type {TYPE} containing objects. This type is ignored during analysis.",
                 self::REMEDIATION_B,
                 16021
+            ),
+            new Issue(
+                self::CommentUnsupportedUnionType,
+                self::CATEGORY_COMMENT,
+                self::SEVERITY_LOW,
+                "Saw a union type {TYPE} with more than 1 type in a location that does not support union types",
+                self::REMEDIATION_B,
+                16027
             ),
         ];
         // phpcs:enable Generic.Files.LineLength

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -997,6 +997,15 @@ final class EmptyUnionType extends UnionType
 
     /**
      * @return bool
+     * True if this is non-empty and exclusively object types.
+     */
+    public function isObject(): bool
+    {
+        return false;  // empty
+    }
+
+    /**
+     * @return bool
      * True if any of the types in this UnionType made $matcher_callback return true
      */
     public function hasTypeMatchingCallback(Closure $matcher_callback): bool

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -1283,7 +1283,7 @@ class Type implements Stringable
         ?CodeBase $code_base,
         ?Context $context
     ): Type {
-        $result = IntersectionType::createFromTypes($template_parameter_type_list, $code_base, $context);
+        $result = IntersectionType::createFromTypes($template_parameter_type_list, $code_base, $context, true);
         return $is_nullable ? $result->withIsNullable(true) : $result;
     }
 

--- a/src/Phan/Language/Type/CallableStringType.php
+++ b/src/Phan/Language/Type/CallableStringType.php
@@ -153,6 +153,6 @@ final class CallableStringType extends StringType implements CallableInterface
      */
     protected function isSubtypeOfNonNullableType(Type $type, CodeBase $code_base): bool
     {
-        return $type instanceof CallableType || \get_class($type) === StringType::class || $type instanceof MixedType;
+        return $type instanceof CallableType || \in_array(\get_class($type), [StringType::class, NonEmptyStringType::class], true) || $type instanceof MixedType;
     }
 }

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -3840,6 +3840,21 @@ class UnionType implements Serializable, Stringable
 
     /**
      * @return bool
+     * True if this is non-empty and exclusively object types
+     */
+    public function isObject(): bool
+    {
+        if ($this->isEmpty()) {
+            return false;
+        }
+
+        return $this->allTypesMatchCallback(static function (Type $type): bool {
+            return $type->isObject();
+        });
+    }
+
+    /**
+     * @return bool
      * True if any of the types in this UnionType made $matcher_callback return true
      */
     public function hasTypeMatchingCallback(Closure $matcher_callback): bool

--- a/tests/php80_files/expected/041_intersection_type_phpdoc.php.expected
+++ b/tests/php80_files/expected/041_intersection_type_phpdoc.php.expected
@@ -1,7 +1,7 @@
 %s:8 PhanDebugAnnotation @phan-debug-var requested for variable $a - it has union type callable-object
-%s:8 PhanDebugAnnotation @phan-debug-var requested for variable $b - it has union type callable-array&string[]
+%s:8 PhanDebugAnnotation @phan-debug-var requested for variable $b - it has union type callable-array&non-empty-array<mixed,string>
 %s:8 PhanDebugAnnotation @phan-debug-var requested for variable $c - it has union type callable-string
 %s:16 PhanUnreferencedPublicMethod Possibly zero references to public method \A41::method()
 %s:22 PhanTypeMismatchArgumentProbablyReal Argument 1 ($a) is [A41::class,'method'] of type array{0:'A41',1:'method'} but \test41() takes callable-object (no real type) defined at %s:8 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
-%s:22 PhanTypeMismatchArgumentProbablyReal Argument 2 ($b) is 'A41::method' of type 'A41::method' but \test41() takes callable-array&string[] (no real type) defined at %s:8 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
+%s:22 PhanTypeMismatchArgumentProbablyReal Argument 2 ($b) is 'A41::method' of type 'A41::method' but \test41() takes callable-array&non-empty-array<mixed,string> (no real type) defined at %s:8 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
 %s:22 PhanTypeMismatchArgumentProbablyReal Argument 3 ($c) is (function) of type Closure():void but \test41() takes callable-string (no real type) defined at %s:8 (the inferred real argument type has nothing in common with the parameter's phpdoc type)


### PR DESCRIPTION
e.g. `non-empty-array&array<'a'|'b'>`

Closes #4544