### PR TITLE
Fix analysis of `count($arr) > 0`, `count($arr) >= 1`, etc.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,9 @@ Phan NEWS
 New Features:
 - Fix false positive PhanPossiblyUndeclaredVariable warning when a `try` block unconditionally returns/throws/exits (#4419)
 
+Bug fixes:
+- Fix off-by-one error when inferring from comparison conditions such as `count($arr) > 0` and `count($arr) >= 1` that the array is non-empty. (#4551)
+
 Sep 14 2021, Phan 5.2.1
 -----------------------
 

--- a/src/Phan/Analysis/ConditionVisitor/ComparisonCondition.php
+++ b/src/Phan/Analysis/ConditionVisitor/ComparisonCondition.php
@@ -77,14 +77,19 @@ class ComparisonCondition implements BinaryCondition
      */
     private function assertsPositiveNumber($value): bool {
         if ($this->flags === ast\flags\BINARY_IS_GREATER) {
-            return $value > 0;
-        } elseif ($this->flags === ast\flags\BINARY_IS_GREATER_OR_EQUAL) {
             return $value >= 0;
+        } elseif ($this->flags === ast\flags\BINARY_IS_GREATER_OR_EQUAL) {
+            return $value > 0;
         }
         return false;
     }
 
     /**
+     * Returns true if, given a non-negative integer, an assertion of the comparison operation against this value
+     * would only return true of that integer were 0.
+     *
+     * (e.g. to check if count($arr) implies $arr is the empty array)
+     *
      * @param bool|int|float|string|null $value
      */
     private function assertsZeroOrLess($value): bool {

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -1072,7 +1072,7 @@ class CodeBase
      */
     public function getInternalClassMap(): Map
     {
-        if (\count($this->fqsen_class_map_reflection) > 0) {
+        if ($this->fqsen_class_map_reflection->count() > 0) {
             $fqsen_class_map_reflection = $this->fqsen_class_map_reflection;
             // Free up memory used by old class map. Prevent it from being freed before we can load it manually.
             $this->fqsen_class_map_reflection = new Map();

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -6024,7 +6024,7 @@ class Issue
         // If a white-list of allowed issue types is defined,
         // only emit issues on the white-list
         $whitelist_issue_types = Config::getValue('whitelist_issue_types') ?? [];
-        if (\count($whitelist_issue_types) > 0 &&
+        if (\is_array($whitelist_issue_types) && \count($whitelist_issue_types) > 0 &&
             !\in_array($issue_type, $whitelist_issue_types, true)) {
             return true;
         }

--- a/tests/files/expected/0767_literal_count.php.expected
+++ b/tests/files/expected/0767_literal_count.php.expected
@@ -2,5 +2,3 @@
 %s:5 PhanTypeMismatchArgumentInternal%SReal Argument 1 ($object) is count(['x'=>'y','w'=>'z']) of type 2 but \spl_object_hash() takes object
 %s:6 PhanTypeMismatchArgumentInternal%SReal Argument 1 ($object) is count(['x'=>'y','x'=>2]) of type 1 but \spl_object_hash() takes object
 %s:10 PhanSuspiciousValueComparison Suspicious attempt to compare count($my_value) of type 0 to 0 of type 0 with operator '>'
-%s:16 PhanSuspiciousValueComparisonInLoop Suspicious attempt to compare count($my_value) of type 0 to 0 of type 0 with operator '>' in a loop (likely a false positive)
-%s:19 PhanSuspiciousValueComparisonInLoop Suspicious attempt to compare count($my_value) of type 0 to 0 of type 0 with operator '>' in a loop (likely a false positive)

--- a/tests/files/expected/0894_compound_with_else.php.expected
+++ b/tests/files/expected/0894_compound_with_else.php.expected
@@ -1,1 +1,1 @@
-%s:6 PhanDebugAnnotation @phan-debug-var requested for variable $b - it has union type array
+%s:6 PhanDebugAnnotation @phan-debug-var requested for variable $b - it has union type non-empty-array<mixed,mixed>(real=\Countable|non-empty-array<mixed,mixed>)

--- a/tests/files/expected/0894_compound_with_else.php.expected80
+++ b/tests/files/expected/0894_compound_with_else.php.expected80
@@ -1,1 +1,1 @@
-%s:6 PhanDebugAnnotation @phan-debug-var requested for variable $b - it has union type array(real=array)
+%s:6 PhanDebugAnnotation @phan-debug-var requested for variable $b - it has union type non-empty-array<mixed,mixed>(real=non-empty-array<mixed,mixed>)

--- a/tests/files/src/0767_literal_count.php
+++ b/tests/files/src/0767_literal_count.php
@@ -13,7 +13,7 @@ function test767() {
             $built_value[] = ',';
         }
         echo "#$i\n";
-        if (count($my_value) > 0) {  // should warn
+        if (count($my_value) > 0) {  // should warn (EDIT: but now can't, because phan now infers this implies the array can be non-empty in a branch and merges the implication into the context after the loop)
             echo "An element was somehow added to my_value\n";
         }
         var_export(count($my_value) > 0);


### PR DESCRIPTION
Fix off-by-one error when inferring from comparison conditions such as
`count($arr) > 0` and `count($arr) >= 1` or flipped versions that the array is
non-empty. (#4551)

Rewrite some conditions to work around false positives from strict type checking
inferring `non-empty-array|Countable` without original real types.