### PR TITLE
Add a getter for PassByReferenceVariable::parameter

### DIFF
--- a/src/Phan/Language/Element/PassByReferenceVariable.php
+++ b/src/Phan/Language/Element/PassByReferenceVariable.php
@@ -146,6 +146,7 @@ class PassByReferenceVariable extends Variable
     }
 
     /**
+     * Get the parameter that this PassByReferenceVariable was passed into.
      * @suppress PhanUnreferencedPublicMethod this may be called by plugins
      */
     public function getParameter(): Variable

--- a/src/Phan/Language/Element/PassByReferenceVariable.php
+++ b/src/Phan/Language/Element/PassByReferenceVariable.php
@@ -144,4 +144,12 @@ class PassByReferenceVariable extends Variable
     {
         return $this->element instanceof AddressableElement && $this->element->isPHPInternal();
     }
+
+    /**
+     * @suppress PhanUnreferencedPublicMethod this may be called by plugins
+     */
+    public function getParameter(): Variable
+    {
+        return $this->parameter;
+    }
 }


### PR DESCRIPTION
I'd like to be able to use this in plugins, so I can proxy calls of plugin methods to the underlying parameter.