### PR TITLE
Fix checking file path suppressed by baseline on Windows

### DIFF
--- a/src/Phan/Plugin/Internal/BaselineLoadingPlugin.php
+++ b/src/Phan/Plugin/Internal/BaselineLoadingPlugin.php
@@ -74,9 +74,6 @@ final class BaselineLoadingPlugin extends PluginV3 implements
      */
     public function shouldSuppressIssueTypeInFile(string $issue_type, string $file): bool
     {
-        // Replace backslashes on Windows
-        $file = \str_replace('\\', '/', $file);
-
         $suppressed_by_file = \in_array($issue_type, $this->file_suppressions[$file] ?? [], true);
         if ($suppressed_by_file) {
             return true;
@@ -84,6 +81,13 @@ final class BaselineLoadingPlugin extends PluginV3 implements
 
         // Support suppressing '.' in a baseline (may be useful when plugins affecting type inference get enabled)
         $normalized_file = self::normalizeDirectoryPathString($file);
+
+        // Check normalized path to suppress file paths with backslashes on Windows
+        $suppressed_by_normalized_file = \in_array($issue_type, $this->file_suppressions[$normalized_file] ?? [], true);
+        if ($suppressed_by_normalized_file) {
+            return true;
+        }
+
         if (\in_array($issue_type, $this->directory_suppressions[''] ?? [], true)) {
             if (!Paths::isAbsolutePath($issue_type) && \substr($normalized_file, 0, 3) !== '../') {
                 return true;
@@ -92,8 +96,7 @@ final class BaselineLoadingPlugin extends PluginV3 implements
 
         // Not suppressed by file, check for suppression by directory
 
-        $parts = self::normalizeDirectoryPathString($file);
-        $parts = \explode('/', $parts);
+        $parts = \explode('/', $normalized_file);
         \array_pop($parts); // Remove file name
 
         $dirPath = '';

--- a/src/Phan/Plugin/Internal/BaselineLoadingPlugin.php
+++ b/src/Phan/Plugin/Internal/BaselineLoadingPlugin.php
@@ -75,7 +75,7 @@ final class BaselineLoadingPlugin extends PluginV3 implements
     public function shouldSuppressIssueTypeInFile(string $issue_type, string $file): bool
     {
         // Replace backslashes on Windows
-        $file = \str_replace(\DIRECTORY_SEPARATOR, '/', $file);
+        $file = \str_replace('\\', '/', $file);
 
         $suppressed_by_file = \in_array($issue_type, $this->file_suppressions[$file] ?? [], true);
         if ($suppressed_by_file) {

--- a/src/Phan/Plugin/Internal/BaselineLoadingPlugin.php
+++ b/src/Phan/Plugin/Internal/BaselineLoadingPlugin.php
@@ -74,6 +74,9 @@ final class BaselineLoadingPlugin extends PluginV3 implements
      */
     public function shouldSuppressIssueTypeInFile(string $issue_type, string $file): bool
     {
+        // Replace backslashes on Windows
+        $file = \str_replace(\DIRECTORY_SEPARATOR, '/', $file);
+
         $suppressed_by_file = \in_array($issue_type, $this->file_suppressions[$file] ?? [], true);
         if ($suppressed_by_file) {
             return true;

--- a/tests/Phan/Plugin/Internal/BaselineLoadingPluginTest.php
+++ b/tests/Phan/Plugin/Internal/BaselineLoadingPluginTest.php
@@ -21,6 +21,7 @@ final class BaselineLoadingPluginTest extends BaseTest
         };
         $assertShouldSuppressIssueEquals(false, 'src/test.php.php', 'PhanUndeclaredMethod');
         $assertShouldSuppressIssueEquals(true, 'src/test.php', 'PhanUndeclaredMethod');
+        $assertShouldSuppressIssueEquals(true, 'src\\test.php', 'PhanUndeclaredMethod');
 
         // directory suppressions
         $assertShouldSuppressIssueEquals(false, 'src/test.php', 'PhanNoopConstant');


### PR DESCRIPTION
shouldSuppressIssueTypeInFile() can take $file with backslashes, we need to convert them to slashes.
Linked to issues #3933 , #4149