### PR TITLE
Support `@phan-type AliasName=UnionType` annotation in inline strings or element comments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,41 @@
 Phan NEWS
 
-??? ?? 2021, Phan 5.2.2 (dev)
+??? ?? 2021, Phan 5.3.0 (dev)
 -----------------------
 
 New Features(Analysis):
 - Fix false positive PhanPossiblyUndeclaredVariable warning when a `try` block unconditionally returns/throws/exits (#4419)
 - Fix false positive warnings when analyzing enums, infer that automatically generated methods of enums exist. (#4313)
 - Properly resolve template type when `getIterator` returns an `Iterator` that includes a template. (#4556)
+- Support `@phan-type AliasName=UnionType` annotation in inline strings or element comments (#4562)
+
+  These aliases will apply to remaining statements in the current
+  **top-level namespace blocks,** similar to use statements, but can also be defined
+  in methods and apply to subsequent methods.
+
+  This can be of use in avoiding repetition of phpdoc for long type definitions.
+
+  ```php
+  // Alternate inline string version to work around php-ast limitations
+  '@phan-type UserData = array{name: string, id: int, createdAt: DateTime}';
+
+  /**
+   * @type-alias UserData = array{name: string, id: int, createdAt: DateTime}
+   * (applies to phpdoc in this and all subsequent AST nodes in the namespace block)
+   */
+  class ExampleElementWithPHPDoc {
+      /**
+       * @param UserData[] $users
+       * @return list<UserData>
+       */
+      public function filterUsers(array $values): array { /* ... */ }
+  }
+
+  // The UserData alias is still defined and can be used in other statements
+
+  namespace XYZ;
+  // The UserData alias is no longer defined in the new namespace block.
+  ```
 
 Plugins:
 - Warn about non-empty try statements that are unlikely to throw in `EmptyStatementListPlugin` (#4555)

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -4958,6 +4958,14 @@ Saw an @param annotation for ${PARAMETER}, but it was not found in the param lis
 
 e.g. [this issue](https://github.com/phan/phan/tree/v5/tests/files/expected/0373_reject_bad_type_narrowing.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/v5/tests/files/src/0373_reject_bad_type_narrowing.php#L4).
 
+## PhanCommentUnextractableTypeAlias
+
+```
+Saw a line {COMMENT} with a type alias that could not be extracted
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/v5/tests/files/expected/0966_phan_type_alias_incorrect.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/v5/tests/files/src/0966_phan_type_alias_incorrect.php#L13).
+
 ## PhanCommentUnsupportedUnionType
 
 ```
@@ -5027,6 +5035,22 @@ e.g. [this issue](https://github.com/phan/phan/tree/v5/tests/plugin_test/expecte
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/v5/tests/plugin_test/expected/085_throw_type_mismatch.php.expected#L6) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/v5/tests/plugin_test/src/085_throw_type_mismatch.php#L23).
+
+## PhanTypeAliasInternalTypeConflict
+
+```
+Saw attempt to use {TYPE} as a type alias for {TYPE} but internal types cannot be redefined.
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/v5/tests/files/expected/0966_phan_type_alias_incorrect.php.expected#L5) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/v5/tests/files/src/0966_phan_type_alias_incorrect.php#L18).
+
+## PhanTypeAliasUsedOutsideComment
+
+```
+Saw a type alias {TYPE} used outside of a comment - this will refer to a class name instead of {TYPE}
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/v5/tests/files/expected/0964_phan_type_alias_inline_string.php.expected#L3) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/v5/tests/files/src/0964_phan_type_alias_inline_string.php#L19).
 
 ## PhanUnextractableAnnotation
 

--- a/src/Phan/AST/FallbackUnionTypeVisitor.php
+++ b/src/Phan/AST/FallbackUnionTypeVisitor.php
@@ -553,7 +553,7 @@ class FallbackUnionTypeVisitor extends KindVisitorImplementation
         // If the constant is referring to the current
         // class, return that as a type
         if (Type::isSelfTypeString($constant_name) || Type::isStaticTypeString($constant_name)) {
-            return Type::fromStringInContext($constant_name, $this->context, Type::FROM_NODE)->asRealUnionType();
+            return Type::fromStringInContext($constant_name, $this->context, Type::FROM_NODE, $this->code_base)->asRealUnionType();
         }
 
         try {

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -611,7 +611,8 @@ class UnionTypeVisitor extends AnalysisVisitor
                 return Type::fromStringInContext(
                     $name,
                     $this->context,
-                    Type::FROM_NODE
+                    Type::FROM_NODE,
+                    $this->code_base
                 )->asRealUnionType();
             }
 
@@ -2584,7 +2585,7 @@ class UnionTypeVisitor extends AnalysisVisitor
         // If the constant is referring to the current
         // class, return that as a type
         if (Type::isSelfTypeString($constant_name) || Type::isStaticTypeString($constant_name)) {
-            return Type::fromStringInContext($constant_name, $this->context, Type::FROM_NODE)->asRealUnionType();
+            return Type::fromStringInContext($constant_name, $this->context, Type::FROM_NODE, $this->code_base)->asRealUnionType();
         }
 
         try {
@@ -3610,7 +3611,8 @@ class UnionTypeVisitor extends AnalysisVisitor
             $type = Type::fromStringInContext(
                 $class_name,
                 $context,
-                Type::FROM_NODE
+                Type::FROM_NODE,
+                $code_base
             );
         } elseif ($node->flags & \ast\flags\NAME_RELATIVE) {
             // Relative to current namespace

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -491,6 +491,16 @@ class BlockAnalysisVisitor extends AnalysisVisitor
                 }
             }
         }
+        // @phan-suppress-next-line PhanAccessClassConstantInternal
+        if (\preg_match_all(Builder::PHAN_TYPE_ALIAS_REGEX, $text, $matches, \PREG_SET_ORDER) > 0) {
+            $has_known_annotations = true;
+            foreach ($matches as $group) {
+                $alias_name = $group[1];
+                $union_type_string = $group[2];
+                // @phan-suppress-next-line PhanAccessMethodInternal
+                Builder::addTypeAliasMapping($this->code_base, $this->context, $alias_name, $union_type_string);
+            }
+        }
 
         if (!$has_known_annotations && preg_match('/@phan-.*/', $text, $match) > 0) {
             Issue::maybeEmit(

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -83,7 +83,7 @@ class CLI
     /**
      * This should be updated to x.y.z-dev after every release, and x.y.z before a release.
      */
-    public const PHAN_VERSION = '5.2.2-dev';
+    public const PHAN_VERSION = '5.3.0-dev';
 
     /**
      * List of short flags passed to getopt

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -651,6 +651,9 @@ class Issue
     public const CommentDuplicateMagicProperty    = 'PhanCommentDuplicateMagicProperty';
     public const CommentObjectInClassConstantType = 'PhanCommentObjectInClassConstantType';
     public const CommentUnsupportedUnionType      = 'PhanCommentUnsupportedUnionType';
+    public const CommentUnextractableTypeAlias    = 'PhanCommentUnextractableTypeAlias';
+    public const TypeAliasUsedOutsideComment      = 'PhanTypeAliasUsedOutsideComment';
+    public const TypeAliasInternalTypeConflict    = 'PhanTypeAliasInternalTypeConflict';
     // phpcs:enable Generic.NamingConventions.UpperCaseConstantName.ClassConstantNotUpperCase
     // end of issue name constants
 
@@ -5594,6 +5597,30 @@ class Issue
                 "Saw a union type {TYPE} with more than 1 type in a location that does not support union types",
                 self::REMEDIATION_B,
                 16027
+            ),
+            new Issue(
+                self::CommentUnextractableTypeAlias,
+                self::CATEGORY_COMMENT,
+                self::SEVERITY_NORMAL,
+                "Saw a line {COMMENT} with a type alias that could not be extracted",
+                self::REMEDIATION_B,
+                16028
+            ),
+            new Issue(
+                self::TypeAliasUsedOutsideComment,
+                self::CATEGORY_COMMENT,
+                self::SEVERITY_NORMAL,
+                "Saw a type alias {TYPE} used outside of a comment - this will refer to a class name instead of {TYPE}",
+                self::REMEDIATION_B,
+                16029
+            ),
+            new Issue(
+                self::TypeAliasInternalTypeConflict,
+                self::CATEGORY_COMMENT,
+                self::SEVERITY_NORMAL,
+                "Saw attempt to use {TYPE} as a type alias for {TYPE} but internal types cannot be redefined.",
+                self::REMEDIATION_B,
+                16030
             ),
         ];
         // phpcs:enable Generic.Files.LineLength

--- a/src/Phan/Language/Type/GenericMultiType.php
+++ b/src/Phan/Language/Type/GenericMultiType.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phan\Language\Type;
+
+use InvalidArgumentException;
+use Phan\CodeBase;
+use Phan\Debug\Frame;
+use Phan\Exception\RecursionDepthException;
+use Phan\Language\Type;
+use Phan\Language\UnionType;
+use Phan\Language\UnionTypeBuilder;
+
+/**
+ * A temporary representation of `array<KeyType, T1|T2...>`
+ *
+ * Callers should split this up into multiple GenericArrayType instances.
+ *
+ * This is generated from phpdoc `array<int, T1|T2>` where callers expect a subclass of Type.
+ * @phan-pure
+ */
+final class GenericMultiType extends Type implements MultiType
+{
+    private const NAME = 'mixed';
+
+    /**
+     * @var non-empty-list<Type>
+     * The list of possible types of every element in this array (2 or more)
+     */
+    private $types;
+
+
+    /**
+     * @param non-empty-list<Type> $types
+     * The 2 or more possible types of every element in this array
+     *
+     * @throws InvalidArgumentException if there are less than 2 types in $types
+     */
+    protected function __construct(array $types) {
+        if (\count($types) < 2) {
+            throw new InvalidArgumentException('Expected $types to have at least 2 types');
+        }
+        // Could de-duplicate, but callers should be able to do that as well when converting to UnionType.
+        // E.g. array<int|int> is int[].
+        parent::__construct('\\', self::NAME, [], false);
+        $this->types = $types;
+    }
+
+    /**
+     * Create a Type or GenericMultiType from a type set
+     * @param list<Type> $type_set
+     */
+    public static function fromTypeSet(array $type_set): Type
+    {
+        if (\count($type_set) === 1) {
+            return \reset($type_set);
+        } else if (!$type_set) {
+            throw new InvalidArgumentException('Expected $types to have at least 1 type');
+        }
+        return new self($type_set);
+    }
+    /**
+     * @param bool $is_nullable
+     * Set to true if the type should be nullable, else pass
+     * false
+     *
+     * @return Type
+     * A new type that is a copy of this type but with the
+     * given nullability value.
+     */
+    public function withIsNullable(bool $is_nullable): Type
+    {
+        $result = [];
+        foreach ($this->types as $type) {
+            if ($is_nullable) {
+                $result[] = $type->withIsNullable(true);
+            } elseif (!$type instanceof NullType && !$type instanceof VoidType) {
+                $result[] = $type->withIsNullable(false);
+            }
+        }
+        return self::fromTypeSet($result);
+    }
+
+    /**
+     * @return non-empty-list<Type>
+     * @override
+     */
+    public function asIndividualTypeInstances(): array
+    {
+        return $this->types;
+    }
+
+    /**
+     * @return bool
+     * True if this Type can be cast to the given Type
+     * cleanly
+     */
+    protected function canCastToNonNullableType(Type $type, CodeBase $code_base): bool
+    {
+        foreach ($this->types as $inner) {
+            if ($inner->canCastToNonNullableType($type, $code_base)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    protected function canCastToNonNullableTypeWithoutConfig(Type $type, CodeBase $code_base): bool
+    {
+        foreach ($this->types as $inner) {
+            if ($inner->canCastToNonNullableTypeWithoutConfig($type, $code_base)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public function __toString(): string
+    {
+        return '(' . \implode('|', $this->types) . ')';
+    }
+
+    /**
+     * @param CodeBase $code_base
+     * The code base to use in order to find super classes, etc.
+     *
+     * @param $recursion_depth
+     * This thing has a tendency to run-away on me. This tracks
+     * how bad I messed up by seeing how far the expanded types
+     * go
+     *
+     * @return UnionType
+     * Expands class types to all inherited classes returning
+     * a superset of this type.
+     * @override
+     */
+    public function asExpandedTypes(
+        CodeBase $code_base,
+        int $recursion_depth = 0
+    ): UnionType {
+        // We're going to assume that if the type hierarchy
+        // is taller than some value we probably messed up
+        // and should bail out.
+        if ($recursion_depth >= 20) {
+            throw new RecursionDepthException("Recursion has gotten out of hand: " . Frame::getExpandedTypesDetails());
+        }
+
+        // TODO: Use UnionType::merge from a future change?
+        $result = new UnionTypeBuilder();
+        try {
+            foreach ($this->types as $type) {
+                $result->addUnionType($type->asExpandedTypes($code_base, $recursion_depth + 1));
+            }
+        } catch (RecursionDepthException $_) {
+            return MixedType::instance(false)->asPHPDocUnionType();
+        }
+        return $result->getPHPDocUnionType();
+    }
+
+    /**
+     * @param CodeBase $code_base
+     * The code base to use in order to find super classes, etc.
+     *
+     * @param $recursion_depth
+     * This thing has a tendency to run-away on me. This tracks
+     * how bad I messed up by seeing how far the expanded types
+     * go
+     *
+     * @return UnionType
+     * Expands class types to all inherited classes returning
+     * a superset of this type.
+     * @override
+     */
+    public function asExpandedTypesPreservingTemplate(
+        CodeBase $code_base,
+        int $recursion_depth = 0
+    ): UnionType {
+        // We're going to assume that if the type hierarchy
+        // is taller than some value we probably messed up
+        // and should bail out.
+        if ($recursion_depth >= 20) {
+            throw new RecursionDepthException("Recursion has gotten out of hand: " . Frame::getExpandedTypesDetails());
+        }
+
+        // TODO: Use UnionType::merge from a future change?
+        $result = new UnionTypeBuilder();
+        try {
+            foreach ($this->types as $type) {
+                $result->addUnionType($type->asExpandedTypesPreservingTemplate($code_base, $recursion_depth + 1));
+            }
+        } catch (RecursionDepthException $_) {
+            return MixedType::instance(false)->asPHPDocUnionType();
+        }
+        return $result->getPHPDocUnionType();
+    }
+}

--- a/tests/Phan/Language/TypeTest.php
+++ b/tests/Phan/Language/TypeTest.php
@@ -51,7 +51,7 @@ final class TypeTest extends CodeBaseAwareTest
     private function makePHPDocType(string $type_string): Type
     {
         $this->assertRegExp('@^' . Type::type_regex_or_this . '$@', $type_string, "Failed to parse '$type_string'");
-        return Type::fromStringInContext($type_string, new Context(), Type::FROM_PHPDOC);
+        return Type::fromStringInContext($type_string, new Context(), Type::FROM_PHPDOC, $this->code_base);
     }
 
     public function testBracketedTypes(): void

--- a/tests/files/expected/0963_phan_type_alias.php.expected
+++ b/tests/files/expected/0963_phan_type_alias.php.expected
@@ -1,0 +1,2 @@
+%s:26 PhanTypeMismatchArgument Argument 1 ($data) is ['name'=>'test','id'=>'invalid'] of type array{name:'test',id:'invalid'} but \UserModel::__construct() takes array{name:string,id:int} defined at %s:15
+%s:27 PhanDebugAnnotation @phan-debug-var requested for variable $data - it has union type array{name:string,id:int}(real=array)

--- a/tests/files/expected/0964_phan_type_alias_inline_string.php.expected
+++ b/tests/files/expected/0964_phan_type_alias_inline_string.php.expected
@@ -1,0 +1,7 @@
+%s:15 PhanDebugAnnotation @phan-debug-var requested for variable $result - it has union type array<int,string>
+%s:15 PhanTypeMismatchArgument Argument 1 ($data) is ['key'=>'value'] of type array{key:'value'} but \test1() takes array<string,int> defined at %s:12
+%s:19 PhanTypeAliasUsedOutsideComment Saw a type alias ArrayIS used outside of a comment - this will refer to a class name instead of array<int,string>
+%s:19 PhanUndeclaredTypeReturnType Return type of test2() is undeclared type \ArrayIS (Did you mean array)
+%s:20 PhanUndeclaredTypeParameter Parameter $data has undeclared type \ArraySI (Did you mean array)
+%s:22 PhanTypeAliasUsedOutsideComment Saw a type alias ArrayIS used outside of a comment - this will refer to a class name instead of array<int,string>
+%s:22 PhanUndeclaredClassMethod Call to method __construct from undeclared class \ArrayIS

--- a/tests/files/expected/0965_phan_type_alias_union.php.expected
+++ b/tests/files/expected/0965_phan_type_alias_union.php.expected
@@ -1,0 +1,2 @@
+%s:11 PhanTypeMismatchReturnProbablyReal Returning false of type false but getResults() is declared to return list<array<string,mixed>>|list<false> (no real type) (the inferred real return type has nothing in common with the declared phpdoc return type)
+%s:20 PhanDebugAnnotation @phan-debug-var requested for variable $results - it has union type list<array<string,mixed>>|list<false>

--- a/tests/files/expected/0966_phan_type_alias_incorrect.php.expected
+++ b/tests/files/expected/0966_phan_type_alias_incorrect.php.expected
@@ -1,0 +1,7 @@
+%s:7 PhanTypeAliasInternalTypeConflict Saw attempt to use false as a type alias for true but internal types cannot be redefined.
+%s:8 PhanTypeAliasInternalTypeConflict Saw attempt to use true as a type alias for false but internal types cannot be redefined.
+%s:9 PhanTypeAliasInternalTypeConflict Saw attempt to use void as a type alias for A but internal types cannot be redefined.
+%s:13 PhanCommentUnextractableTypeAlias Saw a line * @phan-type D = with a type alias that could not be extracted
+%s:14 PhanCommentUnextractableTypeAlias Saw a line * @phan-type E with a type alias that could not be extracted
+%s:18 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type \A
+%s:18 PhanDebugAnnotation @phan-debug-var requested for variable $y - it has union type \A

--- a/tests/files/src/0963_phan_type_alias.php
+++ b/tests/files/src/0963_phan_type_alias.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * NOTE: Due to a limitation of the php-ast parser, 'phan-type' annotations must be on element doc comments such as classlikes, functions, etc.
+ * @phan-type UserData = array{name:string, id:int}
+ */
+class UserModel {
+    /**
+     * @var UserData
+     */
+    private $data;
+    /**
+     * @param UserData $data
+     */
+    public function __construct(array $data) {
+        $this->data = $data;
+    }
+
+    /** @return UserData */
+    public function getData(): array {
+        return $this->data;
+    }
+}
+
+// should warn about 'id'
+$value = new UserModel(['name' => 'test', 'id' => 'invalid']);
+$data = $value->getData();
+
+'@phan-debug-var $data';

--- a/tests/files/src/0964_phan_type_alias_inline_string.php
+++ b/tests/files/src/0964_phan_type_alias_inline_string.php
@@ -1,0 +1,23 @@
+<?php
+
+<<<EOT
+@phan-type ArraySI = array<string, int>
+@phan-type ArrayIS = array<int, string>
+EOT;
+
+/**
+ * @phan-param ArraySI $data
+ * @phan-return ArrayIS
+ */
+function test1(array $data) {
+    return array_flip($data);
+}
+$result = test1(['key' => 'value']);
+'@phan-debug-var $result';
+
+// Should warn
+function test2(
+    ArraySI $data
+): ArrayIS {
+    return new ArrayIS();
+}

--- a/tests/files/src/0965_phan_type_alias_union.php
+++ b/tests/files/src/0965_phan_type_alias_union.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * @phan-type Result=array<string,mixed>|false
+ */
+class X {
+    /**
+     * @return list<Result>
+     */
+    public static function getResults(bool $buggy) {
+        if ($buggy) {
+            return false;
+        }
+        return [
+            ['key' => 'value'],
+            false,
+        ];
+    }
+}
+
+$results = X::getResults(false);
+'@phan-debug-var $results';

--- a/tests/files/src/0966_phan_type_alias_incorrect.php
+++ b/tests/files/src/0966_phan_type_alias_incorrect.php
@@ -1,0 +1,21 @@
+<?php
+
+class A {
+}
+
+/**
+ * @phan-type false = true
+ * @phan-type true = false
+ * @phan-type void = A
+ * @phan-type B = A
+ * @phan-type C = B
+ * @phan-type B = C
+ * @phan-type D =
+ * @phan-type E
+ * @param C $x
+ * @param B $y
+ */
+function example($x, $y): void {
+    '@phan-debug-var $x, $y';
+}
+example(new A(), new A());


### PR DESCRIPTION
These aliases will apply to remaining statements in the current
**top-level namespace blocks,** similar to use statements, but can also be defined
in methods and apply to subsequent methods.

This can be of use in avoiding repetition of phpdoc for long type definitions.

```php
/**
 * @type-alias UserData = array{name: string, id: int, createdAt: DateTime}
 * (applies to this and all subsequent AST nodes in the namespace block)
 */
class ExampleElementWithPHPDoc {
}

// Alternate inline string version to work around php-ast limitations
'@phan-type UserData = array{name: string, id: int, createdAt: DateTime}';

// The UserData alias is still defined and can be used in other statements

namespace XYZ;
// The UserData alias is no longer defined in the new namespace block.
```

Closes #4562