### PR TITLE
Properly detect `PhanUnusedVariable` in try-catch

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@ New Features(Analysis):
 - Properly resolve template type when `getIterator` returns an `Iterator` that includes a template. (#4556)
 - Fix false positives such as `PhanTypeMismatchArgumentNullable` analyzing recursive call with parameter set to literal, without real type information. (#4550)
   (e.g. `function ($retry = true) { if ($retry) {/*...*/} some_call_using_retry($retry); }`)
+- Properly detect `PhanUnusedVariable` in try-catch where catch always rethrows. (#4567)
 - Support `@phan-type AliasName=UnionType` annotation in inline strings or element comments (#4562)
 
   These aliases will apply to remaining statements in the current

--- a/tests/files/expected/0968_unused_in_catch.php.expected
+++ b/tests/files/expected/0968_unused_in_catch.php.expected
@@ -1,0 +1,4 @@
+%s:5 PhanUnusedVariable Unused definition of variable $x
+%s:10 PhanUnusedVariable Unused definition of variable $var
+%s:20 PhanUnusedVariable Unused definition of variable $x
+%s:22 PhanUnusedVariableCaughtException Unused definition of variable $e as a caught exception

--- a/tests/files/src/0968_unused_in_catch.php
+++ b/tests/files/src/0968_unused_in_catch.php
@@ -1,0 +1,29 @@
+<?php
+
+function example968() {
+    $var = 123;  // properly warns
+    $x = null;
+    $value = 123;
+    try {
+        $x = 123;
+    } catch (Exception $e) {
+        $var = 123;
+        var_dump($value);
+        throw $e;
+    }
+    var_dump($var);
+    return $x;
+}
+
+function example968b($x) {
+    try {
+        $x = 123;
+        return;
+    } catch (Exception $e) {
+        $x = 456;
+    }
+    var_dump($x);
+}
+
+example968();
+example968b(2);


### PR DESCRIPTION
where catch always rethrows/returns or try always rethrows/returns.

Closes #4567