### PR TITLE
Improve read-only/write-only property detection for assign op.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@ New Features(Analysis):
 - Fix false positives such as `PhanTypeMismatchArgumentNullable` analyzing recursive call with parameter set to literal, without real type information. (#4550)
   (e.g. `function ($retry = true) { if ($retry) {/*...*/} some_call_using_retry($retry); }`)
 - Properly detect `PhanUnusedVariable` in try-catch where catch always rethrows. (#4567)
+- Make read-only/write-only property detection more accurate for assignment operations (e.g. `+=`, `??=`) and increment/decrement operations. (#4570)
 - Support `@phan-type AliasName=UnionType` annotation in inline strings or element comments (#4562)
 
   These aliases will apply to remaining statements in the current

--- a/tests/plugin_test/expected/014_unreferenced_constant.php.expected
+++ b/tests/plugin_test/expected/014_unreferenced_constant.php.expected
@@ -1,3 +1,4 @@
 src/014_unreferenced_constant.php:6 PhanUnreferencedPublicClassConstant Possibly zero references to public class constant \A14::unreferencedconst
+src/014_unreferenced_constant.php:9 PhanWriteOnlyPublicProperty Possibly zero read references to public property \A14::$prop
 src/014_unreferenced_constant.php:10 PhanUnreferencedPublicProperty Possibly zero references to public property \A14::$prop2
 src/014_unreferenced_constant.php:12 PhanUnreferencedPublicMethod Possibly zero references to public method \A14::foo_unused()

--- a/tests/plugin_test/src/014_unreferenced_constant.php
+++ b/tests/plugin_test/src/014_unreferenced_constant.php
@@ -20,5 +20,5 @@ $b = new B14();
 // Reference base class's elements from a subclass.
 $y = B14::myotherconst;
 B14::$prop++;
-A14::$prop3++;
+var_dump(A14::$prop3++);
 B14::foo();


### PR DESCRIPTION
Make it more accurate for assignment operations (e.g. `+=`, `??=`) and
increment/decrement operations.

Closes #4570