### PR TITLE
Fix non-posix option order in test framework

### DIFF
--- a/tests/fixer_test/test.sh
+++ b/tests/fixer_test/test.sh
@@ -13,7 +13,7 @@ if [[ $? != 0 ]]; then
 	exit 1
 fi
 echo "Running phan in '$PWD' ..."
-rm $ACTUAL_PATH -f || exit 1
+rm -f $ACTUAL_PATH || exit 1
 
 # Create a copy so we can verify the copy is changed in place
 rm -rf src_copy

--- a/tests/infer_missing_types_test/test.sh
+++ b/tests/infer_missing_types_test/test.sh
@@ -12,7 +12,7 @@ if [[ $? != 0 ]]; then
 	exit 1
 fi
 echo "Running phan in '$PWD' ..."
-rm $ACTUAL_PATH -f || exit 1
+rm -f $ACTUAL_PATH || exit 1
 
 # We use the polyfill parser because it behaves consistently in all php versions.
 ../../phan --force-polyfill-parser --memory-limit 1G --analyze-twice --plugin MoreSpecificElementTypePlugin | tee $ACTUAL_PATH

--- a/tests/misc/config_override_test/test.sh
+++ b/tests/misc/config_override_test/test.sh
@@ -12,7 +12,7 @@ if [[ $? != 0 ]]; then
 	exit 1
 fi
 echo "Running phan in '$PWD' ..."
-rm $ACTUAL_PATH -f || exit 1
+rm -f $ACTUAL_PATH || exit 1
 ../../../phan --output-mode pylint | tee $ACTUAL_PATH
 # diff returns a non-zero exit code if files differ or are missing
 echo

--- a/tests/misc/empty_methods_plugin_test/test.sh
+++ b/tests/misc/empty_methods_plugin_test/test.sh
@@ -12,7 +12,7 @@ if [[ $? != 0 ]]; then
 	exit 1
 fi
 echo "Running phan in '$PWD' ..."
-rm $ACTUAL_PATH -f || exit 1
+rm -f $ACTUAL_PATH || exit 1
 ../../../phan | tee $ACTUAL_PATH
 # diff returns a non-zero exit code if files differ or are missing
 echo

--- a/tests/misc/fallback_test/test.sh
+++ b/tests/misc/fallback_test/test.sh
@@ -30,7 +30,7 @@ if [[ $? != 0 ]]; then
 	exit 1
 fi
 echo "Running phan in '$PWD' ..."
-rm $ACTUAL_PATH -f || exit 1
+rm -f $ACTUAL_PATH || exit 1
 ../../../phan --use-fallback-parser | tee $ACTUAL_PATH
 # normalize output for https://github.com/phan/phan/issues/1130
 # This has a varying order for src/020_issue.php

--- a/tests/misc/rewriting_test/test.sh
+++ b/tests/misc/rewriting_test/test.sh
@@ -11,7 +11,7 @@ if [[ $? != 0 ]]; then
 	exit 1
 fi
 echo "Running phan in '$PWD' ..."
-rm $ACTUAL_PATH -f || exit 1
+rm -f $ACTUAL_PATH || exit 1
 # Run phan, using the fallback parser only if the AST is invalid
 ../../../phan --use-fallback-parser | tee $ACTUAL_PATH
 sed -i "s,unexpected token \"=\",unexpected '='," $ACTUAL_PATH

--- a/tests/phantasm_test/test.sh
+++ b/tests/phantasm_test/test.sh
@@ -13,7 +13,7 @@ if [[ $? != 0 ]]; then
 	exit 1
 fi
 echo "Running phan in '$PWD' ..."
-rm $ACTUAL_PATH -f || exit 1
+rm -f $ACTUAL_PATH || exit 1
 
 # Create a copy so we can verify the copy is changed in place
 rm -rf out

--- a/tests/plugin_test/test.sh
+++ b/tests/plugin_test/test.sh
@@ -12,7 +12,7 @@ if [[ $? != 0 ]]; then
 	exit 1
 fi
 echo "Running phan in '$PWD' ..."
-rm $ACTUAL_PATH -f || exit 1
+rm -f $ACTUAL_PATH || exit 1
 
 # We use the polyfill parser because it behaves consistently in all php versions.
 ../../phan --force-polyfill-parser --memory-limit 1G | tee $ACTUAL_PATH

--- a/tests/real_types_test/test.sh
+++ b/tests/real_types_test/test.sh
@@ -12,7 +12,7 @@ if [[ $? != 0 ]]; then
 	exit 1
 fi
 echo "Running phan in '$PWD' ..."
-rm $ACTUAL_PATH -f || exit 1
+rm -f $ACTUAL_PATH || exit 1
 
 # We use the polyfill parser because it behaves consistently in all php versions.
 ../../phan --strict-type-checking --force-polyfill-parser --memory-limit 1G --redundant-condition-detection | tee $ACTUAL_PATH

--- a/tests/tool_test/test.sh
+++ b/tests/tool_test/test.sh
@@ -10,7 +10,7 @@ if [ ! -e $EXPECTED_PATH  ]; then
 	exit 1
 fi
 echo "Running make_stubs in '$PWD' ..."
-rm $ACTUAL_PATH -f || exit 1
+rm -f $ACTUAL_PATH || exit 1
 ../../tool/make_stubs -e json | tee $ACTUAL_PATH
 if php -r 'exit(PHP_MAJOR_VERSION < 8 ? 0 : 1);'; then
     # Normalize output by deleting constants added in php 7.1.0+


### PR DESCRIPTION
https://unix.stackexchange.com/a/336384

POSIX requires that options precede non-option arguments; GNU coreutils allows for "rm $path -f" to work, but doesn't require it; other implementations (e.g. I was running the tests on a mac) do not support it, and coreutils also supports "rm -f $path".