### PR TITLE
Pass-by-ref vars don't account for early-outing; should merge types instead of overwriting

### DIFF
--- a/src/Phan/Language/Element/PassByReferenceVariable.php
+++ b/src/Phan/Language/Element/PassByReferenceVariable.php
@@ -123,7 +123,11 @@ class PassByReferenceVariable extends Variable
             );
             return;
         }
-        $this->element->setUnionType($type->eraseRealTypeSetRecursively());
+        $new_element_type = UnionType::merge([
+            $type->eraseRealTypeSetRecursively(),
+            $this->element->getUnionType()
+        ]);
+        $this->element->setUnionType($new_element_type);
     }
 
     /**

--- a/tests/files/expected/0383_output_reference.php.expected
+++ b/tests/files/expected/0383_output_reference.php.expected
@@ -1,1 +1,1 @@
-%s:17 PhanTypeMismatchArgumentInternal Argument 1 ($num1) is $x of type 'value' but \intdiv() takes int
+%s:17 PhanTypeMismatchArgumentInternal Argument 1 ($num1) is $x of type 'value'|string but \intdiv() takes int

--- a/tests/files/expected/0887_merge_reference_types.php.expected
+++ b/tests/files/expected/0887_merge_reference_types.php.expected
@@ -1,3 +1,3 @@
 %s:30 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type 42|array{}|true
-%s:36 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type array{}|true
+%s:36 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type 42|array{}|true
 %s:42 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type 42

--- a/tests/files/expected/0970_ref_param_types.php.expected
+++ b/tests/files/expected/0970_ref_param_types.php.expected
@@ -1,0 +1,6 @@
+%s:13 PhanDebugAnnotation @phan-debug-var requested for variable $var - it has union type 1|2|3
+%s:29 PhanDebugAnnotation @phan-debug-var requested for variable $var2 - it has union type 4|5|6
+%s:44 PhanDebugAnnotation @phan-debug-var requested for variable $var3 - it has union type 7|8|9
+%s:60 PhanDebugAnnotation @phan-debug-var requested for variable $var4 - it has union type 10|11|12
+%s:71 PhanDebugAnnotation @phan-debug-var requested for variable $var5 - it has union type 13|14
+%s:95 PhanDebugAnnotation @phan-debug-var requested for variable $var6 - it has union type 15|16

--- a/tests/files/src/0970_ref_param_types.php
+++ b/tests/files/src/0970_ref_param_types.php
@@ -1,0 +1,96 @@
+<?php 
+
+function try_ref(&$var) {
+	try {
+		$var = 1;
+	} catch (PDOException $_) {
+		$var = 2;
+	} catch (Exception $_) {
+		$var = 3;
+	}
+}
+
+try_ref($var);
+'@phan-debug-var $var';
+
+function try_ref_ret(&$var) {
+	try {
+		$var = 4;
+		return;
+	} catch (PDOException $_) {
+		$var = 5;
+		return;
+	} catch (Exception $_) {
+		$var = 6;
+		return;
+	}
+}
+
+try_ref_ret($var2);
+'@phan-debug-var $var2';
+
+function try_ref_mixed(&$var) {
+	try {
+		$var = 7;
+	} catch (PDOException $_) {
+		$var = 8;
+		return;
+	} catch (Exception $_) {
+		$var = 9;
+		return;
+	}
+}
+
+try_ref_mixed($var3);
+'@phan-debug-var $var3';
+
+function if_ref(&$var) {
+	if (rand(0,1)) {
+		$var = 10;
+		return;
+	} elseif (rand(0,2)) {
+		$var = 11;
+		return;
+	} else {
+		$var = 12;
+		return;
+	}
+}
+
+if_ref($var4);
+'@phan-debug-var $var4';
+
+function early_ret(&$var) {
+	if (rand(0,1)) {
+		return;
+	}
+	$var = 14;
+}
+
+$var5 = 13;
+early_ret($var5);
+'@phan-debug-var $var5';
+
+function inner() {
+	if (rand(0,1)) {
+		throw new Exception();
+	}
+}
+
+function middle(&$var) {
+	inner();
+	$var = 16;
+}
+
+function outer() {
+	$var = 15;
+	try {
+		middle($var);
+		return $var;
+	} catch (Exception $_) {
+		return $var;
+	}
+}
+
+$var6 = outer();
+'@phan-debug-var $var6';

--- a/tests/rasmus_files/expected/0022_ref_params.php.expected
+++ b/tests/rasmus_files/expected/0022_ref_params.php.expected
@@ -1,1 +1,1 @@
-%s:15 PhanTypeMismatchArgument Argument 1 ($farg2) is $arg1 of type 1.5 but \B::test2() takes int defined at %s:8
+%s:15 PhanTypeMismatchArgument Argument 1 ($farg2) is $arg1 of type 1.5|array{0:1,1:2,2:3} but \B::test2() takes int defined at %s:8


### PR DESCRIPTION
Here's the current output for 0970_ref_param_types.php.expected:

```
ref.php:13 PhanDebugAnnotation @phan-debug-var requested for variable $var - it has union type 1|2|3
ref.php:29 PhanDebugAnnotation @phan-debug-var requested for variable $var2 - it has union type 6
ref.php:44 PhanDebugAnnotation @phan-debug-var requested for variable $var3 - it has union type 9
ref.php:60 PhanDebugAnnotation @phan-debug-var requested for variable $var4 - it has union type 12
ref.php:71 PhanDebugAnnotation @phan-debug-var requested for variable $var5 - it has union type 14
ref.php:93 PhanDebugAnnotation @phan-debug-var requested for variable $var6 - it has union type 16
```

As-is, PassByReferenceVariable doesn't account for early-outing; it assumes that pass-by-ref variables take on the types the last time it was written to (or the merged value for multiple branches which don't early-out).

I'd explored instead deferring updating $this->element's type until the function's end, a return, or a throw, and wiping any previous values if all possible exit paths modified the variable; the problem with that is illustrated with $var6 in the test cases- an exception can interrupt execution even in a function that doesn't directly throw or catch it.

There are two cases where this will introduce bugs; I am assuming it's better for the UnionType to have false positives than false negatives.

```
$var6 = outer();
'@phan-debug-var $var6';

function simple(&$var) {
	$var = 18;
}

$var7 = 17;
simple($var7);
'@phan-debug-var $var7'; // 17|18; should be 18

function dupe(&$var) {
	$var = 19;
	$var = 20;
}

dupe($var8);
'@phan-debug-var $var8'; // 19|20; should be 20
```