### PR TITLE
pcntl_waitpid is broken with ext-grpc

### DIFF
--- a/src/Phan/ForkPool.php
+++ b/src/Phan/ForkPool.php
@@ -354,7 +354,7 @@ class ForkPool
                 if ($last_error !== 0) {
                     \error_log(\posix_strerror($last_error));
                 }
-                usleep(50000);
+                \usleep(50000);
                 continue;
             }
 

--- a/src/Phan/ForkPool.php
+++ b/src/Phan/ForkPool.php
@@ -349,8 +349,13 @@ class ForkPool
 
         // Wait for all children to return
         foreach ($this->child_pid_list as $child_pid) {
-            if (\pcntl_waitpid($child_pid, $status) < 0) {
-                \error_log(\posix_strerror(\posix_get_last_error()));
+            if (\pcntl_waitpid($child_pid, $status, \WNOHANG) < 0) {
+                $last_error = \posix_get_last_error();
+                if ($last_error !== 0) {
+                    \error_log(\posix_strerror($last_error));
+                }
+                usleep(50000);
+                continue;
             }
 
             // Check to see if the child died a graceful death


### PR DESCRIPTION
https://bugs.php.net/bug.php?id=78717
https://github.com/grpc/grpc/issues/20994#issuecomment-552624880

Basically the process will lock up and wait forever.
We avoid the issue by letting `pcntl_waitpid` fall trough, but sleeping for 0.05 of a second after every iteration.

This is annoying AF to add workarounds against someone else's borked extension, therefore another option is to detect `grpc.enable_fork_support` is not enabled, and bail. This alternative will work for me just fine.

Phan version: 5.2.1