### PR TITLE
Fixed issue with Phan considering parent:: in callables to be accessing a static method.

### DIFF
--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -4068,7 +4068,7 @@ class UnionTypeVisitor extends AnalysisVisitor
             return [];
         }
         $method = $class->getMethodByName($code_base, $method_name);
-        if (!$method->isStatic()) {
+        if ($class_or_expr !== 'parent' && !$method->isStatic()) {
             $this->emitIssue(
                 Issue::StaticCallToNonStatic,
                 $context->getLineNumberStart(),

--- a/tests/files/src/2159_parent_static_call_to_non_static.php
+++ b/tests/files/src/2159_parent_static_call_to_non_static.php
@@ -1,0 +1,16 @@
+<?php
+
+class One {
+    public function test() {
+    }
+}
+
+class Two extends One {
+    public function test() {
+        if (is_callable('parent::test')) {
+            parent::test();
+        }
+    }
+}
+
+(new Two())->test();


### PR DESCRIPTION
Hello, using Phan 5.2.1 on the below file:

```
<?php

class One {
    public function test() {
    }
}

class Two extends One {
    public function test() {
        if (is_callable('parent::test')) {
            parent::test();
        }
    }
}

(new Two())->test();
```

Phan gives the output:

```
src/test.php:13 PhanStaticCallToNonStatic Static call to non-static method \Two::test defined at src/test.php:10. This is an Error in PHP 8.0+.
```

However, when ran using `3v4l` to check all the versions of PHP up to and including the 8.1 release candidate, this is a non-issue:

https://3v4l.org/n5OQd

I've made an attempt at fixing this but my understanding of Phan internals are basic and so this may be a bit greedy. Let me know if you have any suggestions. Thanks for your time.