### PR TITLE
Improve type inference of in_array conditional, use intersection type

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 Phan NEWS
 
+??? ?? 202?, Phan 5.3.2 (dev)
+-----------------------
+
+New Features(Analysis):
+- Use intersection type of original variable value and array elements when inferring type of `$var` in `in_array($var, $array)`
+  instead of just the type of the array elements (#4630)
+
 Dec 14 2021, Phan 5.3.1
 -----------------------
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,10 @@ New Features(Analysis):
 - Use intersection type of original variable value and array elements when inferring type of `$var` in `in_array($var, $array)`
   instead of just the type of the array elements (#4630)
 
+Bug fixes:
+- Fix dead code detection for PHP 8.0 non-capturing catch statements. (#4633)
+  This should still analyze the catch body even if there is no caught exception variable.
+
 Dec 14 2021, Phan 5.3.1
 -----------------------
 

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -1194,8 +1194,10 @@ class ConditionVisitor extends KindVisitorImplementation implements ConditionVis
         if ($element_type->isEmptyOrMixed()) {
             return $context;
         }
+        $var_type = UnionTypeVisitor::unionTypeFromNode($this->code_base, $this->context, $var_node);
+        $new_type = self::calculateNarrowedUnionType($this->code_base, $this->context, $var_type, $element_type);
         $is_strict = isset($args[2]) && UnionTypeVisitor::checkCondUnconditionalTruthiness($args[2]) === true;
-        return $this->updateVariableWithNewType($var_node, $context, $element_type, true, $is_strict);
+        return $this->updateVariableWithNewType($var_node, $context, $new_type, true, $is_strict);
     }
 
     /**

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -83,7 +83,7 @@ class CLI
     /**
      * This should be updated to x.y.z-dev after every release, and x.y.z before a release.
      */
-    public const PHAN_VERSION = '5.3.1';
+    public const PHAN_VERSION = '5.3.2-dev';
 
     /**
      * List of short flags passed to getopt

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
@@ -1103,13 +1103,9 @@ final class VariableTrackerVisitor extends AnalysisVisitor
     public function visitCatch(Node $node): VariableTrackingScope
     {
         $var_node = $node->children['var'];
-        if (!$var_node instanceof Node) {
-            // This is a non-capturing catch. Or it could be an invalid node from the polyfill.
-            return $this->scope;
-        }
-
         $scope = $this->scope;
-        if ($var_node->kind === \ast\AST_VAR) {
+        // handle php 8.0 non-capturing catches
+        if ($var_node instanceof Node && $var_node->kind === \ast\AST_VAR) {
             $name = $var_node->children['name'];
             if (is_string($name)) {
                 self::$variable_graph->recordVariableDefinition($name, $var_node, $scope, null);

--- a/tests/php74_files/expected/033_in_array_narrowing.php.expected
+++ b/tests/php74_files/expected/033_in_array_narrowing.php.expected
@@ -1,0 +1,7 @@
+%s:23 PhanPluginUseReturnValueNoopVoid The function/method \Test974\Test::test() is declared to return (empty union type) and it has no side effects
+%s:30 PhanDebugAnnotation @phan-debug-var requested for variable $type - it has union type \Test974\Bar(real=\Test974\Bar)
+%s:30 PhanUnusedVariable Unused definition of variable $type
+%s:38 PhanDebugAnnotation @phan-debug-var requested for variable $type - it has union type \Test974\Bar&\Test974\Foo2(real=\Test974\Bar)
+%s:38 PhanUnusedVariable Unused definition of variable $type
+%s:42 PhanPluginUseReturnValueNoopVoid The function/method \Test974\Test::somethingWithBar() is declared to return (empty union type) and it has no side effects
+%s:42 PhanUnusedPublicNoOverrideMethodParameter Parameter $bar is never used

--- a/tests/php74_files/src/033_in_array_narrowing.php
+++ b/tests/php74_files/src/033_in_array_narrowing.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Test974;
+
+interface Foo {}
+interface Foo2 {}
+
+class Bar implements Foo {}
+
+class Test
+{
+    /**
+     * @var array<Foo>
+     */
+    public array $foos;
+    /**
+     * @var array<Foo2>
+     */
+    public array $foo2s;
+
+    public Bar $bar;
+
+    public function test()
+    {
+        if (!in_array($this->bar, $this->foos)) {
+            return;
+        }
+
+        $this->somethingWithBar($this->bar);
+        $type = $this->bar;
+        '@phan-debug-var $type';
+
+        if (!in_array($this->bar, $this->foo2s)) {
+            return;
+        }
+
+        $this->somethingWithBar($this->bar);
+        $type = $this->bar;
+        '@phan-debug-var $type';
+    }
+
+    public function somethingWithBar(Bar $bar)
+    {
+        // Do something
+    }
+}

--- a/tests/php80_files/expected/048_non_capturing_catch.php.expected
+++ b/tests/php80_files/expected/048_non_capturing_catch.php.expected
@@ -1,0 +1,4 @@
+%s:3 PhanUnreferencedClass Possibly zero references to class \Test48
+%s:4 PhanUnreferencedPublicMethod Possibly zero references to public method \Test48::connect()
+%s:4 PhanUnusedPublicNoOverrideMethodParameter Parameter $u is never used
+%s:7 PhanCompatibleNonCapturingCatch Catching exceptions without a variable is not supported before PHP 8.0 in catch (Exception)

--- a/tests/php80_files/src/048_non_capturing_catch.php
+++ b/tests/php80_files/src/048_non_capturing_catch.php
@@ -1,0 +1,15 @@
+<?php
+
+class Test48 {
+    public function connect(string $t, string $u): void{
+        try{
+            mysqli_connect();
+        } catch (Exception){
+            self::save($t);
+        }
+    }
+
+    private function save(string $t): void{
+        echo $t;
+    }
+}


### PR DESCRIPTION
Use intersection type of original variable value and array elements
when inferring type of `$var` in `in_array($var, $array)`
instead of just the type of the array elements

Closes #4630