### PR TITLE
Add xdebug-handler version 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "ext-json": "*",
         "ext-tokenizer": "*",
         "composer/semver": "^1.4|^2.0|^3.0",
-        "composer/xdebug-handler": "^1.3.2|^2.0.0",
+        "composer/xdebug-handler": "^2.0|^3.0",
         "felixfbecker/advanced-json-rpc": "^3.0.4",
         "microsoft/tolerant-php-parser": "^0.1.0",
         "netresearch/jsonmapper": "^1.6.0|^2.0|^3.0|^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "23f4fdd14fb1fcbcb7da0455da6528dc",
+    "content-hash": "a25a462a4cd34b100e48880f9315638b",
     "packages": [
         {
             "name": "composer/pcre",
@@ -160,27 +160,27 @@
         },
         {
             "name": "composer/xdebug-handler",
-            "version": "2.0.3",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "6555461e76962fd0379c444c46fd558a0fcfb65e"
+                "reference": "ec6aa897c8b6cab05ebaeddade62bb6e4a69ef38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/6555461e76962fd0379c444c46fd558a0fcfb65e",
-                "reference": "6555461e76962fd0379c444c46fd558a0fcfb65e",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/ec6aa897c8b6cab05ebaeddade62bb6e4a69ef38",
+                "reference": "ec6aa897c8b6cab05ebaeddade62bb6e4a69ef38",
                 "shasum": ""
             },
             "require": {
                 "composer/pcre": "^1",
-                "php": "^5.3.2 || ^7.0 || ^8.0",
+                "php": "^7.2.5 || ^8.0",
                 "psr/log": "^1 || ^2 || ^3"
             },
             "require-dev": {
                 "phpstan/phpstan": "^1.0",
                 "phpstan/phpstan-strict-rules": "^1.1",
-                "symfony/phpunit-bridge": "^4.2 || ^5.0 || ^6.0"
+                "symfony/phpunit-bridge": "^6.0"
             },
             "type": "library",
             "autoload": {
@@ -206,7 +206,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/xdebug-handler/issues",
-                "source": "https://github.com/composer/xdebug-handler/tree/2.0.3"
+                "source": "https://github.com/composer/xdebug-handler/tree/3.0.0"
             },
             "funding": [
                 {
@@ -222,7 +222,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-08T13:07:32+00:00"
+            "time": "2021-12-23T21:03:16+00:00"
         },
         {
             "name": "felixfbecker/advanced-json-rpc",
@@ -3118,5 +3118,5 @@
     "platform-overrides": {
         "php": "7.2.24"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/src/Phan/Library/Restarter.php
+++ b/src/Phan/Library/Restarter.php
@@ -42,11 +42,11 @@ class Restarter extends XdebugHandler
     }
 
     /**
-     * @param bool $loaded
-     * @return bool
+     * No type hint to allow xdebug-handler v2 usage
+     * @param bool $default
      * @override
      */
-    protected function requiresRestart($loaded)
+    protected function requiresRestart($default): bool
     {
         $excluded_extensions = array_filter(
             $this->disabledExtensions,
@@ -65,15 +65,15 @@ class Restarter extends XdebugHandler
             );
         }
 
-        return $loaded || $this->required;
+        return $default || $this->required;
     }
 
     /**
+     * No type hint to allow xdebug-handler v2 usage
      * @param list<string> $command
-     * @return void
      * @override
      */
-    protected function restart($command)
+    protected function restart($command): void
     {
         // @phan-suppress-next-line PhanSuspiciousTruthyString
         if ($this->required && $this->tmpIni) {
@@ -88,7 +88,6 @@ class Restarter extends XdebugHandler
             file_put_contents($this->tmpIni, $content);
         }
 
-        /** @psalm-suppress MixedArgument */
         parent::restart($command);
     }
 }


### PR DESCRIPTION
composer/xdebug-handler version 3 provides the same functionality as version 2 but removes support for older PHP versions (< 7.2.25). It will be shipped with the impending Composer 2.3 release.

xdebug-handler version 2 will be supported for the lifetime of [Composer 2.2 LTS](https://blog.packagist.com/composer-2-2/).