### PR TITLE
Ignore phpdoc comment tags not at start of line or inline

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 Phan NEWS
 
-??? ?? 202?, Phan 5.3.2 (dev)
+??? ?? 2022, Phan 5.3.2 (dev)
 -----------------------
 
 New Features(Analysis):
@@ -11,6 +11,10 @@ New Features(Analysis):
 Bug fixes:
 - Fix dead code detection for PHP 8.0 non-capturing catch statements. (#4633)
   This should still analyze the catch body even if there is no caught exception variable.
+- Ignore phpdoc comment tags that don't start at the start of a line of the doc comment (`* @sometag`) or aren't an inline tag (`* something {@sometag}`). (#4640)
+  See https://docs.phpdoc.org/3.0/guide/references/phpdoc/tags/internal.html and https://docs.phpdoc.org/2.9/guides/docblocks.html
+
+  E.g. `* This is not @abstract.` is no longer treated as an abstract method.
 
 Dec 14 2021, Phan 5.3.1
 -----------------------

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -2275,6 +2275,8 @@ class ContextNode
     // This currently only supports static variables.
     // When disabled, all variables will be resolved.
     public const RESOLVE_ONLY_CONSTANT_VARS = (1 << 7);
+    // Don't use variables.
+    public const RESOLVE_DONT_USE_VARS = (1 << 8);
 
     public const RESOLVE_DEFAULT =
         self::RESOLVE_ARRAYS |
@@ -2407,7 +2409,7 @@ class ContextNode
                 $new_node = $constant->getNodeForValue();
                 if (is_object($new_node)) {
                     // Avoid infinite recursion, only resolve once
-                    $new_node = (new ContextNode($this->code_base, $constant->getContext(), $new_node))->getEquivalentPHPValueForNode($new_node, $flags & ~self::RESOLVE_CONSTANTS);
+                    $new_node = (new ContextNode($this->code_base, $constant->getContext(), $new_node))->getEquivalentPHPValueForNode($new_node, $flags & ~(self::RESOLVE_CONSTANTS|self::RESOLVE_ONLY_CONSTANT_VARS|self::RESOLVE_DONT_USE_VARS));
                 }
                 return $new_node;
             case ast\AST_CLASS_CONST:

--- a/tests/files/expected/0974_phpdoc_start_of_line.php.expected
+++ b/tests/files/expected/0974_phpdoc_start_of_line.php.expected
@@ -1,0 +1,1 @@
+%s:12 PhanCommentAbstractOnInheritedMethod Class \B974 inherits a method \A974::test declared at %s:4 marked as @abstract in phpdoc but does not override it

--- a/tests/files/src/0974_phpdoc_start_of_line.php
+++ b/tests/files/src/0974_phpdoc_start_of_line.php
@@ -1,0 +1,13 @@
+<?php
+class A974 {
+    /** @abstract */
+    public function test() {
+        echo "in test\n";
+    }
+    /** This is not @abstract */
+    public function test2() {
+        echo "in test2\n";
+    }
+}
+class B974 extends A974 {
+}


### PR DESCRIPTION
Ignore phpdoc comment tags that don't start at the start of a line of the doc
comment (`* @sometag`) or aren't an inline tag (`* something {@sometag}`).

Closes #4640

See https://docs.phpdoc.org/3.0/guide/references/phpdoc/tags/internal.html
and https://docs.phpdoc.org/2.9/guides/docblocks.html

E.g. `* This is not @abstract.` is no longer treated as an abstract method.