### PR TITLE
Add pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+- id: phan
+  name: phan
+  description: runs the Phan static analyzer for PHP.
+  language: script
+  entry: .pre-commit.sh
+  files: '[^/]\.php$'
+  pass_filenames: false

--- a/.pre-commit.sh
+++ b/.pre-commit.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+phan="$(dirname "$0")"
+
+if [[ ! -f "$phan/vendor/autoload.php" ]]; then
+	composer install --quiet --working-dir="$phan"
+fi
+
+exec "$phan/phan"


### PR DESCRIPTION
This makes it easy to add Phan to a project using the [pre-commit] framework.

If pre-commit, PHP and Composer are installed, only a file `.pre-commit-config.yaml` is needed in the project:

~~~yaml
repos:
- repo: git://github.com/phan/phan
  rev: e56968f2b00d19c3c8d3ee113b9d7255eca7cccd
  hooks:
  - id: phan
~~~

[pre-commit]: https://pre-commit.com/