### PR TITLE
Fixes type of Lua::call

### DIFF
--- a/src/Phan/Language/Internal/FunctionSignatureMap.php
+++ b/src/Phan/Language/Internal/FunctionSignatureMap.php
@@ -7410,7 +7410,7 @@ return [
 'Lua::__call' => ['mixed', 'lua_func'=>'callable', 'args='=>'array', 'use_self='=>'int'],
 'Lua::__construct' => ['void', 'lua_script_file'=>'string'],
 'Lua::assign' => ['?Lua', 'name'=>'string', 'value'=>'mixed'],
-'Lua::call' => ['mixed', 'lua_func'=>'callable', 'args='=>'array', 'use_self='=>'int'],
+'Lua::call' => ['mixed', 'lua_func'=>'string', 'args='=>'array', 'use_self='=>'int'],
 'Lua::eval' => ['mixed', 'statements'=>'string'],
 'Lua::getVersion' => ['string'],
 'Lua::include' => ['mixed', 'file'=>'string'],


### PR DESCRIPTION
https://www.php.net/manual/en/lua.call.php

The type given for $lua_func in the php docs is correct in some sense, but wrong for the purpose of static analysis: while it is a callable, $lua_func isn't a *php* function name, it's a *lua* function name. If Phan tries to process it as a PHP callable, Phan will emite a PhanUndeclaredFunctionInCallable lint.