### PR TITLE
Fix crash in ArrayShapeType when the highest possible array index is used

### DIFF
--- a/src/Phan/Language/Type/ArrayShapeType.php
+++ b/src/Phan/Language/Type/ArrayShapeType.php
@@ -527,7 +527,9 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
             $key_parts[$key] = $field_union_type->generateUniqueId();
         }
         if ($is_nullable) {
-            $key_parts[] = '?';
+            $key_parts = [ '?' => $key_parts ];
+        } else {
+            $key_parts = [ ' ' => $key_parts ];
         }
         $key = \json_encode($key_parts);
 

--- a/tests/files/src/4688_php_int_max.php
+++ b/tests/files/src/4688_php_int_max.php
@@ -1,0 +1,10 @@
+<?php
+
+/**
+ * Test function where phan infers the existence of a key of type PHP_INT_MAX.
+ */
+$a = [ PHP_INT_MAX=>PHP_INT_MIN ];
+if (random_int(0,1) === 0) {
+    $a = null;
+}
+$result = $a;


### PR DESCRIPTION
Given code like:
  $a = [ PHP_INT_MAX => 42 ];
  if (random_int(0,1) === 0) {
     $a = null;
  }

We would get a crash in ArrayShapeType::fromFieldTypes when we tried
to extend the cache key used for the type with:
  $key_parts[] = '?'
Since $key_parts[PHP_INT_MAX] was already in use.

Use a different encoding for nullable types in the cache key to avoid
this crash.

Closes: #4688
