### PR TITLE
Support php 8.2 class constants on trait RFC

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,13 +15,18 @@ platform: x86
 environment:
   matrix:
     # This major release of Phan (5.0) requires php-ast 1.0.7+
-    # Note: Less convenient to test in 8.1
+    # Note: Less convenient to test in php 8.2
     - PHP_EXT_VERSION: '8.0'
-      PHP_VERSION: '8.0.12'
+      PHP_VERSION: '8.0.22'
       PHP_AST_VERSION: 1.0.13
       VC: vs16
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       PHAN_RUN_INTEGRATION_TEST: 1
+    - PHP_EXT_VERSION: '8.1'
+      PHP_VERSION: '8.1.9'
+      PHP_AST_VERSION: 1.0.16
+      VC: vs16
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
     # NOTE: 1.0.11 is the minimum php-ast version needed for ast version 85.
     # https://pecl.php.net/package/ast/1.0.11/windows does not supply dlls for 7.2
     # because pecl.php.net dropped support for building dlls for php 7.2, which no longer has security support.
@@ -39,7 +44,7 @@ environment:
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       PHP_AST_VERSION: 1.0.11
     - PHP_EXT_VERSION: '7.4'
-      PHP_VERSION: '7.4.24'
+      PHP_VERSION: '7.4.30'
       VC_VERSION: 15
       VC: vc15
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,7 @@ jobs:
          - PHP_VERSION: '7.4'
          - PHP_VERSION: '8.0'
          - PHP_VERSION: '8.1'
+         - PHP_VERSION: '8.2.0beta2'
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,10 @@ Phan NEWS
 -----------------------
 
 New Features(Analysis):
-- Support parsing php 8.2's disjunctive normal form types (e.g. `A|(B&C)` (https://wiki.php.net/rfc/dnf_types).
+- Support parsing php 8.2's disjunctive normal form types (e.g. `A|(B&C)` (https://wiki.php.net/rfc/dnf_types). (#4699)
+- Support php 8.2 class constants on trait RFC. (#4687)
+  Emit `PhanCompatibleTraitConstant` when using constants on traits with a `minimum_target_php_version` below `'8.2'`
+  Emit `PhanAccessClassConstantOfTraitDirectly` when directly referencing the class constant on the trait declaration.
 
 Aug 08 2022, Phan 5.4.0
 -----------------------

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -17,6 +17,14 @@ This category of issue is emitted when you're trying to access things that you c
 Note: in this document, "`@internal`" refers to user-defined elements with `/** @internal */` in their PHPDoc,
 while "internal" refers to classes, functions, methods, etc.  that are built into PHP and PHP modules (e.g. `is_string`, `stdClass`, etc)
 
+## PhanAccessClassConstantOfTraitDirectly
+
+```
+Cannot directly access class constant {CONST} of trait {TRAIT} defined at {FILE}:{LINE}
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/v5/tests/files/expected/0977_trait_constant.php.expected#L6) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/v5/tests/files/src/0977_trait_constant.php#L25).
+
 ## PhanAccessClassConstantPrivate
 
 This issue comes up when there is an attempt to access a private class constant outside of the scope in which it's defined.
@@ -748,6 +756,14 @@ Cannot use trailing commas in parameter or closure use lists before php 8.0 in d
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/v5/tests/misc/fallback_test/expected/073_trailing_commas.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/v5/tests/misc/fallback_test/src/073_trailing_commas.php#L8).
+
+## PhanCompatibleTraitConstant
+
+```
+Trait {TRAIT} declares constant {CONST} which is only allowed in 8.2+
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/v5/tests/files/expected/0977_trait_constant.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/v5/tests/files/src/0977_trait_constant.php#L3).
 
 ## PhanCompatibleTrueType
 

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -2429,7 +2429,7 @@ class ContextNode
                 $new_node = $constant->getNodeForValue();
                 if (is_object($new_node)) {
                     // Avoid infinite recursion, only resolve once
-                    $new_node = (new ContextNode($this->code_base, $constant->getContext(), $new_node))->getEquivalentPHPValueForNode($new_node, $flags & ~(self::RESOLVE_CONSTANTS|self::RESOLVE_ONLY_CONSTANT_VARS|self::RESOLVE_DONT_USE_VARS));
+                    $new_node = (new ContextNode($this->code_base, $constant->getContext(), $new_node))->getEquivalentPHPValueForNode($new_node, $flags & ~(self::RESOLVE_CONSTANTS | self::RESOLVE_ONLY_CONSTANT_VARS | self::RESOLVE_DONT_USE_VARS));
                 }
                 return $new_node;
             case ast\AST_CLASS_CONST:

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -3349,7 +3349,8 @@ class TolerantASTConverter
     /**
      * @param ast\Node|string|int|float|null $node
      */
-    private static function setDeprecatedEncapsVar($node): void {
+    private static function setDeprecatedEncapsVar($node): void
+    {
         if ($node instanceof ast\Node && \in_array($node->kind, [ast\AST_VAR, ast\AST_DIM], true)) {
             if (PHP_VERSION_ID >= 80200) {
                 // Make flags identical to native ast version for unit tests.

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -1352,7 +1352,6 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 $this->context,
                 $node
             ))->getClassConst();
-
             // Mark that this class constant has been referenced
             // from this context
             $constant->addReference($this->context);
@@ -1406,6 +1405,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
     {
         $class = $this->context->getClassInScope($this->code_base);
 
+
         foreach ($node->children as $child_node) {
             if (!$child_node instanceof Node) {
                 throw new AssertionError('expected class const element to be a Node');
@@ -1414,6 +1414,9 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             if (!\is_string($name)) {
                 throw new AssertionError('expected class const name to be a string');
             }
+            if ($class->isTrait() && Config::get_closest_minimum_target_php_version_id() < 80200) {
+                $this->emitIssue(Issue::CompatibleTraitConstant, $node->lineno, $class->getFQSEN(), $name);
+            };
             try {
                 $const_decl = $class->getConstantByNameInContext($this->code_base, $name, $this->context);
                 $const_decl->getUnionType();

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -1416,7 +1416,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             }
             if ($class->isTrait() && Config::get_closest_minimum_target_php_version_id() < 80200) {
                 $this->emitIssue(Issue::CompatibleTraitConstant, $node->lineno, $class->getFQSEN(), $name);
-            };
+            }
             try {
                 $const_decl = $class->getConstantByNameInContext($this->code_base, $name, $this->context);
                 $const_decl->getUnionType();

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -35,9 +35,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Terminal;
 
+use function array_key_exists;
 use function array_map;
 use function array_merge;
-use function array_key_exists;
 use function array_slice;
 use function array_unique;
 use function array_values;

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -551,6 +551,7 @@ class Issue
     public const AccessNonStaticToStaticProperty = 'PhanAccessNonStaticToStaticProperty';
     public const AccessClassConstantPrivate      = 'PhanAccessClassConstantPrivate';
     public const AccessClassConstantProtected    = 'PhanAccessClassConstantProtected';
+    public const AccessClassConstantOfTraitDirectly = 'PhanAccessClassConstantOfTraitDirectly';
     public const AccessPropertyStaticAsNonStatic = 'PhanAccessPropertyStaticAsNonStatic';
     public const AccessPropertyNonStaticAsStatic = 'PhanAccessPropertyNonStaticAsStatic';
     public const AccessOwnConstructor            = 'PhanAccessOwnConstructor';
@@ -623,6 +624,7 @@ class Issue
     public const CompatibleAccessMethodOnTraitDefinition = 'PhanCompatibleAccessMethodOnTraitDefinition';
     public const CompatibleAccessPropertyOnTraitDefinition  = 'PhanCompatibleAccessPropertyOnTraitDefinition';
     public const CompatibleAbstractPrivateMethodInTrait    = 'PhanCompatibleAbstractPrivateMethodInTrait';
+    public const CompatibleTraitConstant                 = 'PhanCompatibleTraitConstant';
 
     // Issue::CATEGORY_GENERIC
     public const TemplateTypeConstant       = 'PhanTemplateTypeConstant';
@@ -4845,6 +4847,14 @@ class Issue
                 1009
             ),
             new Issue(
+                self::AccessClassConstantOfTraitDirectly,
+                self::CATEGORY_ACCESS,
+                self::SEVERITY_CRITICAL,
+                "Cannot directly access class constant {CONST} of trait {TRAIT} defined at {FILE}:{LINE}",
+                self::REMEDIATION_B,
+                1036
+            ),
+            new Issue(
                 self::AccessPropertyStaticAsNonStatic,
                 self::CATEGORY_ACCESS,
                 self::SEVERITY_CRITICAL,
@@ -5386,6 +5396,14 @@ class Issue
                 'Trait {TRAIT} declares abstract private function {FUNCTION} which is only allowed in 8.0+',
                 self::REMEDIATION_B,
                 3049
+            ),
+            new Issue(
+                self::CompatibleTraitConstant,
+                self::CATEGORY_COMPATIBLE,
+                self::SEVERITY_NORMAL,
+                'Trait {TRAIT} declares constant {CONST} which is only allowed in 8.2+',
+                self::REMEDIATION_B,
+                3052
             ),
 
             // Issue::CATEGORY_GENERIC

--- a/src/Phan/Language/Element/ClassConstant.php
+++ b/src/Phan/Language/Element/ClassConstant.php
@@ -76,12 +76,12 @@ class ClassConstant extends ClassElement implements ConstantInterface
     {
         $constant_fqsen = FullyQualifiedClassConstantName::make(
             $clazz->getFQSEN(),
-            $this->getName()
+            $this->name
         );
 
         $constant = new ClassConstant(
             $this->getContext(),
-            $this->getName(),
+            $this->name,
             $this->getUnionType(),
             $this->getFlags(),
             $constant_fqsen

--- a/src/Phan/Language/Element/ClassConstant.php
+++ b/src/Phan/Language/Element/ClassConstant.php
@@ -65,6 +65,37 @@ class ClassConstant extends ClassElement implements ConstantInterface
     }
 
     /**
+     * Create an alias from a trait use, which is treated as though it was defined in $clazz
+     * E.g. if you import a trait's class constant as private/protected, it becomes private/protected **to the class which used the trait**
+     *
+     * The resulting alias doesn't inherit the Node of the method body, so aliases won't have a redundant analysis step.
+     *
+     * @param Clazz $clazz - The class to treat as the defining class of the alias. (i.e. the inheriting class)
+     */
+    public function createUseAlias(Clazz $clazz): ClassConstant
+    {
+        $constant_fqsen = FullyQualifiedClassConstantName::make(
+            $clazz->getFQSEN(),
+            $this->getName()
+        );
+
+        $constant = new ClassConstant(
+            $this->getContext(),
+            $this->getName(),
+            $this->getUnionType(),
+            $this->getFlags(),
+            $constant_fqsen
+        );
+        $constant->setPhanFlags($this->getPhanFlags() & ~(Flags::IS_OVERRIDE | Flags::IS_OVERRIDDEN_BY_ANOTHER));
+
+        $defining_fqsen = $this->getDefiningFQSEN();
+        if ($constant->isPublic()) {
+            $constant->setDefiningFQSEN($defining_fqsen);
+        }
+        return $constant;
+    }
+
+    /**
      * Override the default getter to fill in a future
      * union type if available.
      */

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -1516,7 +1516,7 @@ class Clazz extends AddressableElement
         }
         if ($constant->getClass($code_base)->isTrait()) {
             $constant = $constant->createUseAlias($this);
-        } else if ($constant->getFQSEN() !== $constant_fqsen) {
+        } elseif ($constant->getFQSEN() !== $constant_fqsen) {
             // Update the FQSEN if it's not associated with this
             // class yet (always true)
             $constant = clone($constant);

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -1765,7 +1765,7 @@ class Clazz extends AddressableElement
                     $context->getLineNumberStart(),
                     [
                         $constant_fqsen,
-                        $this->getFQSEN(),
+                        $this->fqsen,
                         $constant->getContext()->getFile(),
                         $constant->getContext()->getLineNumberStart()
                     ]

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -266,6 +266,7 @@ class Clazz extends AddressableElement
         } elseif ($class->isTrait()) {
             $flags = \ast\flags\CLASS_TRAIT;
         }
+        // FIXME readonly flag
         if ($class->isAbstract()) {
             $flags |= \ast\flags\CLASS_ABSTRACT;
         }
@@ -1513,10 +1514,11 @@ class Clazz extends AddressableElement
                 '@abstract'
             );
         }
-
-        // Update the FQSEN if it's not associated with this
-        // class yet (always true)
-        if ($constant->getFQSEN() !== $constant_fqsen) {
+        if ($constant->getClass($code_base)->isTrait()) {
+            $constant = $constant->createUseAlias($this);
+        } else if ($constant->getFQSEN() !== $constant_fqsen) {
+            // Update the FQSEN if it's not associated with this
+            // class yet (always true)
             $constant = clone($constant);
             $constant->setFQSEN($constant_fqsen);
         }
@@ -1543,6 +1545,7 @@ class Clazz extends AddressableElement
             );
         }
         // Traits don't have constants, thankfully, so the logic is simple.
+        // FIXME now they do
         if ($inherited_constant->isStrictlyMoreVisibleThan($overriding_constant)) {
             if ($inherited_constant->isPHPInternal()) {
                 if (!$overriding_constant->checkHasSuppressIssueAndIncrementCount(Issue::ConstantAccessSignatureMismatchInternal)) {
@@ -1743,20 +1746,31 @@ class Clazz extends AddressableElement
             );
         }
 
-        $constant = $code_base->getClassConstantByFQSEN(
-            $constant_fqsen
-        );
+        $constant = $code_base->getClassConstantByFQSEN($constant_fqsen);
 
-        if ($constant->isPublic()) {
-            // Most constants are public, check that first.
+        if ($constant->isPublic() && !$this->isTrait()) {
+            // Most constants are public and declared outside of traits, check that after checking if the declaring class was a trait
             return $constant;
         }
-
-        // Visibility checks for private/protected class constants:
 
         $accessing_class = $context->getClassFQSENOrNull();
         if ($accessing_class && $constant->isAccessibleFromClass($code_base, $accessing_class)) {
             return $constant;
+        }
+        // Visibility checks for private/protected class constants:
+        if ($this->isTrait()) {
+            throw new IssueException(
+                Issue::fromType(Issue::AccessClassConstantOfTraitDirectly)(
+                    $context->getFile(),
+                    $context->getLineNumberStart(),
+                    [
+                        $constant_fqsen,
+                        $this->getFQSEN(),
+                        $constant->getContext()->getFile(),
+                        $constant->getContext()->getLineNumberStart()
+                    ]
+                )
+            );
         }
 
         if ($constant->isPrivate()) {
@@ -1766,7 +1780,7 @@ class Clazz extends AddressableElement
                     $context->getFile(),
                     $context->getLineNumberStart(),
                     [
-                        (string)$constant_fqsen,
+                        $constant_fqsen,
                         $constant->getContext()->getFile(),
                         $constant->getContext()->getLineNumberStart()
                     ]
@@ -1780,7 +1794,7 @@ class Clazz extends AddressableElement
                 $context->getFile(),
                 $context->getLineNumberStart(),
                 [
-                    (string)$constant_fqsen,
+                    $constant_fqsen,
                     $constant->getContext()->getFile(),
                     $constant->getContext()->getLineNumberStart()
                 ]

--- a/src/Phan/Language/Element/Comment/Builder.php
+++ b/src/Phan/Language/Element/Comment/Builder.php
@@ -405,7 +405,6 @@ final class Builder
         // https://secure.php.net/manual/en/regexp.reference.internal-options.php
         // (?i) makes this case-sensitive, (?-1) makes it case-insensitive
         // phpcs:ignore Generic.Files.LineLength.MaxExceeded
-        //
         // Support both regular tags ("@something") and inline versions of tags ("optional_prefix {@something}").
         if (\preg_match('/(?:^|{)@((?i)param|deprecated|var|return|throws|throw|returns|inherits|extends|suppress|unused-param|no-named-arguments|phan-[a-z0-9_-]*(?-i)|method|property|property-read|property-write|abstract|template(?:-covariant)?|PhanClosureScope|readonly|mixin|seal-(?:methods|properties))(?:[^a-zA-Z0-9_\x7f-\xff-]|$)/D', $trimmed, $matches)) {
             $case_sensitive_type = $matches[1];

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -1,6 +1,6 @@
 ARG PHP_VERSION
 FROM php:$PHP_VERSION
-RUN pecl install ast-1.0.16 && docker-php-ext-enable ast
+RUN pecl install ast-1.1.0 && docker-php-ext-enable ast
 RUN curl https://getcomposer.org/download/latest-2.x/composer.phar -o /usr/bin/composer.phar && chmod a+x /usr/bin/composer.phar
 WORKDIR /phan
 RUN apt-get update && apt-get install -y unzip parallel colordiff && apt-get clean

--- a/tests/files/expected/0977_trait_constant.php.expected
+++ b/tests/files/expected/0977_trait_constant.php.expected
@@ -1,0 +1,10 @@
+%s:3 PhanCompatibleTraitConstant Trait \T977 declares constant PUBLIC_CONST which is only allowed in 8.2+
+%s:4 PhanCompatibleTraitConstant Trait \T977 declares constant PRIVATE_CONST which is only allowed in 8.2+
+%s:5 PhanCompatibleTraitConstant Trait \T977 declares constant PROTECTED_CONST which is only allowed in 8.2+
+%s:19 PhanAccessClassConstantPrivate Cannot access private class constant \C977::PRIVATE_CONST defined at %s:4
+%s:20 PhanAccessClassConstantProtected Cannot access protected class constant \C977::PROTECTED_CONST defined at %s:5
+%s:25 PhanAccessClassConstantOfTraitDirectly Cannot directly access class constant \T977::PUBLIC_CONST of trait \T977 defined at %s:3
+%s:27 PhanAccessClassConstantOfTraitDirectly Cannot directly access class constant \T977::PRIVATE_CONST of trait \T977 defined at %s:4
+%s:28 PhanAccessClassConstantPrivate Cannot access private class constant \C977::PRIVATE_CONST defined at %s:4
+%s:29 PhanAccessClassConstantOfTraitDirectly Cannot directly access class constant \T977::PROTECTED_CONST of trait \T977 defined at %s:5
+%s:30 PhanAccessClassConstantProtected Cannot access protected class constant \C977::PROTECTED_CONST defined at %s:5

--- a/tests/files/src/0977_trait_constant.php
+++ b/tests/files/src/0977_trait_constant.php
@@ -1,0 +1,31 @@
+<?php
+trait T977 {
+    const PUBLIC_CONST = 123;
+    private const PRIVATE_CONST = 2;
+    protected const PROTECTED_CONST = 2;
+}
+class C977 {
+    use T977;
+    public static function inner() {
+        // Does not warn: PhanAccessClassConstantOfTraitDirectly private constants in traits become private to the scope of the class using the traits
+        echo self::PUBLIC_CONST;
+        echo self::PRIVATE_CONST;
+        echo self::PROTECTED_CONST;
+    }
+}
+class Other {
+    public static function inner() {
+        echo C977::PUBLIC_CONST;
+        echo C977::PRIVATE_CONST; // should warn
+        echo C977::PROTECTED_CONST; // should warn
+    }
+}
+C977::inner();
+function global_fn() {
+    echo T977::PUBLIC_CONST;  // should warn, direct access to trait constants is forbidden
+    echo C977::PUBLIC_CONST;  // allowed
+    echo T977::PRIVATE_CONST;  // should warn, direct access to trait constants is forbidden
+    echo C977::PRIVATE_CONST;  // should warn, direct access to private constants is forbidden here
+    echo T977::PROTECTED_CONST;  // should warn, direct access to trait constants is forbidden
+    echo C977::PROTECTED_CONST;  // should warn, direct access to protected constants is forbidden here
+}

--- a/tests/plugin_test/expected/007_printf.php.expected
+++ b/tests/plugin_test/expected/007_printf.php.expected
@@ -5,7 +5,7 @@ src/007_printf.php:6 PhanPluginPrintfNonexistentArgument Format string "%d dolla
 src/007_printf.php:6 PhanPluginPrintfNotPercent Format string "%d dollars 100% down\n" contains something that is not a percent sign, it will be treated as a format string '% d' with padding of " " and alignment of '' but no width. Use %% for a literal percent sign, or '%2$d' to be less ambiguous
 src/007_printf.php:7 PhanPluginPrintfNoSpecifiers None of the formatting arguments passed alongside format string "Not using args" are used
 src/007_printf.php:8 PhanPluginPrintfNoSpecifiers None of the formatting arguments passed alongside format string "Not using args\n" are used
-src/007_printf.php:9 PhanPluginDuplicateAdjacentStatement Statement printf(('Not using' . " args\n"), 3) is a duplicate of the statement on the above line. Suppress this issue instance if there's a good reason for this.
+src/007_printf.php:9 PhanPluginDuplicateAdjacentStatement Statement printf("Not using args\n", 3) is a duplicate of the statement on the above line. Suppress this issue instance if there's a good reason for this.
 src/007_printf.php:9 PhanPluginPrintfNoSpecifiers None of the formatting arguments passed alongside format string "Not using args\n" are used
 src/007_printf.php:10 PhanPluginPrintfNoSpecifiers None of the formatting arguments passed alongside format string "Not using args\n" are used
 src/007_printf.php:11 PhanPluginDuplicateAdjacentStatement Statement printf("Not using args\n", 3, 4) is a duplicate of the statement on the above line. Suppress this issue instance if there's a good reason for this.

--- a/tests/plugin_test/src/169_include_repr.php
+++ b/tests/plugin_test/src/169_include_repr.php
@@ -10,5 +10,5 @@ function test169(int $i, int $j) : void {
         include_once __DIR__ . '/000_plugins.php',
         eval('echo "test";'),
     ]);
-    echo intdiv("{$i}2${j}", 2);
+    echo intdiv("{$i}2{$j}", 2);
 }

--- a/tests/plugin_test/test.sh
+++ b/tests/plugin_test/test.sh
@@ -39,6 +39,7 @@ sed -i -e 's/^\(src.020_bool.php.*of type\) [0-9]\+ \(evaluated\)/\1 int \2/g' \
     -e 's/\\\(Exception\|Error\)|\\Stringable|\\Throwable/\\\1|\\Throwable/g' \
     -e 's/strlen(): Argument #1 (\$string) must be of type string/strlen() expects parameter 1 to be string/g' \
     -e 's/alphanumeric, backslash, or NUL$/alphanumeric or backslash/g' \
+    -e 's/'\''Not using'\'' . " args\\n"/"Not using args\\n"/g' \
     $ACTUAL_PATH
 
 if type colordiff >/dev/null; then

--- a/tests/plugin_test/test.sh
+++ b/tests/plugin_test/test.sh
@@ -39,7 +39,7 @@ sed -i -e 's/^\(src.020_bool.php.*of type\) [0-9]\+ \(evaluated\)/\1 int \2/g' \
     -e 's/\\\(Exception\|Error\)|\\Stringable|\\Throwable/\\\1|\\Throwable/g' \
     -e 's/strlen(): Argument #1 (\$string) must be of type string/strlen() expects parameter 1 to be string/g' \
     -e 's/alphanumeric, backslash, or NUL$/alphanumeric or backslash/g' \
-    -e 's/'\''Not using'\'' . " args\\n"/"Not using args\\n"/g' \
+    -e 's/('\''Not using'\'' . " args\\n")/"Not using args\\n"/g' \
     $ACTUAL_PATH
 
 if type colordiff >/dev/null; then


### PR DESCRIPTION
1. Emit compatibility warning for using constants on traits before 8.1
2. Handle change to fqsen when inheriting constants from traits.