### PR TITLE
Consistently emit PhanTypeModifyImmutableObjectProperty

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@ New Features(Analysis):
 - Support php 8.2 class constants on trait RFC. (#4687)
   Emit `PhanCompatibleTraitConstant` when using constants on traits with a `minimum_target_php_version` below `'8.2'`
   Emit `PhanAccessClassConstantOfTraitDirectly` when directly referencing the class constant on the trait declaration.
+- Emit `PhanTypeModifyImmutableObjectProperty` for PHP 8.1 `readonly` properties when modified anywhere outside of the
+  declaring class's scope. (#4710)
 
 Aug 08 2022, Phan 5.4.0
 -----------------------

--- a/src/Phan/Language/Element/Property.php
+++ b/src/Phan/Language/Element/Property.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phan\Language\Element;
 
+use ast;
 use Closure;
 use Phan\AST\ASTReverter;
 use Phan\Exception\IssueException;
@@ -395,6 +396,14 @@ class Property extends ClassElement
     public function isReadOnly(): bool
     {
         return $this->getPhanFlagsHasState(Flags::IS_READ_ONLY);
+    }
+
+    /**
+     * Is this property declared with the PHP 8.1+ `readonly` modifier?
+     */
+    public function isReadOnlyReal(): bool
+    {
+        return ($this->getFlags() & ast\flags\MODIFIER_READONLY) !== 0;
     }
 
     /**

--- a/tests/php81_files/expected/017_readonly_property.php.expected
+++ b/tests/php81_files/expected/017_readonly_property.php.expected
@@ -1,2 +1,2 @@
-%s:6 PhanAccessReadOnlyProperty Cannot modify read-only property \Point->x defined at %s:3
+%s:6 PhanTypeModifyImmutableObjectProperty Saw attempt to modify class \Point's property $x declared at %s:3 (immutability of properties is enforced at runtime)
 %s:7 PhanTypeMismatchArgumentInternalReal Argument 1 ($object) is $p->x of type int but \spl_object_id() takes object

--- a/tests/php81_files/expected/024_readonly_property_warning.php.expected
+++ b/tests/php81_files/expected/024_readonly_property_warning.php.expected
@@ -4,4 +4,4 @@
 %s:7 PhanUnreferencedPublicProperty Possibly zero references to public property \NS24\Foo->readonlyMissingTypeDeclaration
 %s:10 PhanTypeMismatchPropertyReal Assigning $baz of type int to property but \NS24\Foo->baz is string
 %s:13 PhanParamTooFew Call with 1 arg(s) to \NS24\Foo::__construct(int $bar, int $baz) which requires 2 arg(s) defined at %s:8
-%s:14 PhanAccessReadOnlyProperty Cannot modify read-only property \NS24\Foo->bar defined at %s:5
+%s:14 PhanTypeModifyImmutableObjectProperty Saw attempt to modify class \NS24\Foo's property $bar declared at %s:5 (immutability of properties is enforced at runtime)

--- a/tests/php81_files/expected/025_readonly_property_scope.php.expected
+++ b/tests/php81_files/expected/025_readonly_property_scope.php.expected
@@ -1,0 +1,4 @@
+%s:2 PhanPluginUnknownArrayPropertyType Property \X->x has an array type, but does not specify any key types or value types
+%s:2 PhanWriteOnlyPublicProperty Possibly zero read references to public property \X->x
+%s:5 PhanTypeModifyImmutableObjectProperty Saw attempt to modify class \Y's property $x declared at %s:2 (immutability of properties is enforced at runtime)
+%s:7 PhanTypeModifyImmutableObjectProperty Saw attempt to modify class \Y's property $x declared at %s:2 (immutability of properties is enforced at runtime)

--- a/tests/php81_files/src/025_readonly_property_scope.php
+++ b/tests/php81_files/src/025_readonly_property_scope.php
@@ -1,0 +1,7 @@
+<?php
+class X { public readonly array $x; }
+// Should emit PhanTypeModifyImmutableObjectProperty. At runtime this throws
+// > Error: Cannot initialize readonly property X::$x from scope Y
+class Y extends X { public function __construct() { $this->x = []; } }
+$y = new Y();
+$y->x[] = 123;

--- a/tests/php82_files/expected/003_readonly_class.php.expected
+++ b/tests/php82_files/expected/003_readonly_class.php.expected
@@ -3,6 +3,6 @@
 %s:6 PhanUnreferencedPublicProperty Possibly zero references to public property \NS3\Foo->readonlyMissingTypeDeclaration
 %s:9 PhanTypeModifyImmutableObjectProperty Saw attempt to modify class \NS3\Foo's property $undeclared2 declared at %s:4 (immutability of properties is enforced at runtime)
 %s:9 PhanUndeclaredProperty Reference to undeclared property \NS3\Foo->undeclared2
-%s:13 PhanAccessReadOnlyProperty Cannot modify read-only property \NS3\Foo->bar defined at %s:5
+%s:13 PhanTypeModifyImmutableObjectProperty Saw attempt to modify class \NS3\Foo's property $bar declared at %s:5 (immutability of properties is enforced at runtime)
 %s:14 PhanTypeModifyImmutableObjectProperty Saw attempt to modify class \NS3\Foo's property $undeclaredProperty declared at %s:4 (immutability of properties is enforced at runtime)
 %s:14 PhanUndeclaredProperty Reference to undeclared property \NS3\Foo->undeclaredProperty


### PR DESCRIPTION
This should have been emitted for assignments made anywhere outside of
the declaring class's scope

Closes #4710