### PR TITLE
Support remaining php 8.2 features in the fallback/polyfill parser

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@ Miscellaneous:
 Maintenance:
 - Require php-ast 1.1.0 or newer in PHP 8.2+ if php-ast is installed.
   This release of php-ast makes the parsing of `AST_ARROW_FUNC` in php 8.2 match older php versions.
+- Support parsing of PHP 8.2 syntax such as disjunctive normal form types and `readonly` classes in the polyfill/fallback parser.
+- Fix bugs parsing `__halt_compiler()` in the polyfill/fallback parser.
 
 Aug 25 2022, Phan 5.4.1
 -----------------------

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "composer/semver": "^1.4|^2.0|^3.0",
         "composer/xdebug-handler": "^2.0|^3.0",
         "felixfbecker/advanced-json-rpc": "^3.0.4",
-        "microsoft/tolerant-php-parser": "0.1.1",
+        "microsoft/tolerant-php-parser": "0.1.2",
         "netresearch/jsonmapper": "^1.6.0|^2.0|^3.0|^4.0",
         "sabre/event": "^5.1.3",
         "symfony/console": "^3.2|^4.0|^5.0|^6.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "62f4c0f1a6e50535b7c03182832d5c4e",
+    "content-hash": "301a32dbdfef414765074fc7e60effbb",
     "packages": [
         {
             "name": "composer/pcre",
@@ -271,16 +271,16 @@
         },
         {
             "name": "microsoft/tolerant-php-parser",
-            "version": "v0.1.1",
+            "version": "v0.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/microsoft/tolerant-php-parser.git",
-                "reference": "6a965617cf484355048ac6d2d3de7b6ec93abb16"
+                "reference": "3eccfd273323aaf69513e2f1c888393f5947804b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/microsoft/tolerant-php-parser/zipball/6a965617cf484355048ac6d2d3de7b6ec93abb16",
-                "reference": "6a965617cf484355048ac6d2d3de7b6ec93abb16",
+                "url": "https://api.github.com/repos/microsoft/tolerant-php-parser/zipball/3eccfd273323aaf69513e2f1c888393f5947804b",
+                "reference": "3eccfd273323aaf69513e2f1c888393f5947804b",
                 "shasum": ""
             },
             "require": {
@@ -310,9 +310,9 @@
             "description": "Tolerant PHP-to-AST parser designed for IDE usage scenarios",
             "support": {
                 "issues": "https://github.com/microsoft/tolerant-php-parser/issues",
-                "source": "https://github.com/microsoft/tolerant-php-parser/tree/v0.1.1"
+                "source": "https://github.com/microsoft/tolerant-php-parser/tree/v0.1.2"
             },
-            "time": "2021-07-16T21:28:12+00:00"
+            "time": "2022-10-05T17:30:19+00:00"
         },
         {
             "name": "netresearch/jsonmapper",
@@ -691,16 +691,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.4.12",
+            "version": "v5.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "c072aa8f724c3af64e2c7a96b796a4863d24dba1"
+                "reference": "3f97f6c7b7e26848a90c0c0cfb91eeb2bb8618be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/c072aa8f724c3af64e2c7a96b796a4863d24dba1",
-                "reference": "c072aa8f724c3af64e2c7a96b796a4863d24dba1",
+                "url": "https://api.github.com/repos/symfony/console/zipball/3f97f6c7b7e26848a90c0c0cfb91eeb2bb8618be",
+                "reference": "3f97f6c7b7e26848a90c0c0cfb91eeb2bb8618be",
                 "shasum": ""
             },
             "require": {
@@ -770,7 +770,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.12"
+                "source": "https://github.com/symfony/console/tree/v5.4.13"
             },
             "funding": [
                 {
@@ -786,7 +786,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-08-17T13:18:05+00:00"
+            "time": "2022-08-26T13:50:20+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -1432,16 +1432,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v5.4.12",
+            "version": "v5.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "2fc515e512d721bf31ea76bd02fe23ada4640058"
+                "reference": "2900c668a32138a34118740de3e4d5a701801f53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/2fc515e512d721bf31ea76bd02fe23ada4640058",
-                "reference": "2fc515e512d721bf31ea76bd02fe23ada4640058",
+                "url": "https://api.github.com/repos/symfony/string/zipball/2900c668a32138a34118740de3e4d5a701801f53",
+                "reference": "2900c668a32138a34118740de3e4d5a701801f53",
                 "shasum": ""
             },
             "require": {
@@ -1498,7 +1498,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.4.12"
+                "source": "https://github.com/symfony/string/tree/v5.4.13"
             },
             "funding": [
                 {
@@ -1514,7 +1514,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-08-12T17:03:11+00:00"
+            "time": "2022-09-01T01:52:16+00:00"
         },
         {
             "name": "tysonandre/var_representation_polyfill",
@@ -2177,16 +2177,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "8.5.29",
+            "version": "8.5.30",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "e8c563c47a9a303662955518ca532b022b337f4d"
+                "reference": "4fd448df9affda65a5faa58f8b93087d415216ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e8c563c47a9a303662955518ca532b022b337f4d",
-                "reference": "e8c563c47a9a303662955518ca532b022b337f4d",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/4fd448df9affda65a5faa58f8b93087d415216ce",
+                "reference": "4fd448df9affda65a5faa58f8b93087d415216ce",
                 "shasum": ""
             },
             "require": {
@@ -2205,10 +2205,10 @@
                 "phpunit/php-file-iterator": "^2.0.4",
                 "phpunit/php-text-template": "^1.2.1",
                 "phpunit/php-timer": "^2.1.2",
-                "sebastian/comparator": "^3.0.2",
+                "sebastian/comparator": "^3.0.5",
                 "sebastian/diff": "^3.0.2",
                 "sebastian/environment": "^4.2.3",
-                "sebastian/exporter": "^3.1.2",
+                "sebastian/exporter": "^3.1.5",
                 "sebastian/global-state": "^3.0.0",
                 "sebastian/object-enumerator": "^3.0.3",
                 "sebastian/resource-operations": "^2.0.1",
@@ -2254,7 +2254,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/8.5.29"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/8.5.30"
             },
             "funding": [
                 {
@@ -2264,9 +2264,13 @@
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2022-08-22T13:59:39+00:00"
+            "time": "2022-09-25T03:43:00+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",

--- a/tests/Phan/AST/TolerantASTConverter/ConversionTest.php
+++ b/tests/Phan/AST/TolerantASTConverter/ConversionTest.php
@@ -211,7 +211,10 @@ final class ConversionTest extends BaseTest
             $this->markTestIncomplete('php-ast cannot parse php8.0 syntax when running in php7.4 or older');
         }
         if (\PHP_VERSION_ID < 80100 && $test_folder_name === 'php81_or_newer') {
-            $this->markTestIncomplete('php-ast cannot parse php8.0 syntax when running in php7.4 or older');
+            $this->markTestIncomplete('php-ast cannot parse php8.1 syntax when running in php8.0 or older');
+        }
+        if (\PHP_VERSION_ID < 80200 && $test_folder_name === 'php82_or_newer') {
+            $this->markTestIncomplete('php-ast cannot parse php8.2 syntax when running in php8.1 or older');
         }
         if (\PHP_VERSION_ID >= 80000 && \basename($file_name) === 'use_simple.php') {
             $this->markTestIncomplete('php-ast cannot parse php8.0 syntax when running in php7.4 or older');

--- a/tests/misc/fallback_ast_src/README.md
+++ b/tests/misc/fallback_ast_src/README.md
@@ -1,0 +1,1 @@
+This directory is used by tests/Phan/AST/TolerantASTConverter/ConversionTest.php

--- a/tests/misc/fallback_ast_src/halt_compiler.php
+++ b/tests/misc/fallback_ast_src/halt_compiler.php
@@ -1,0 +1,3 @@
+<?php
+__halt_compiler();
+Example data.

--- a/tests/misc/fallback_ast_src/php82_or_newer/dnfTypesParameter1.php
+++ b/tests/misc/fallback_ast_src/php82_or_newer/dnfTypesParameter1.php
@@ -1,0 +1,2 @@
+<?php
+function foo ((A&B)|C $x): (A&B)|C|(D&E) {}

--- a/tests/misc/fallback_ast_src/php82_or_newer/dnfTypesProperty1.php
+++ b/tests/misc/fallback_ast_src/php82_or_newer/dnfTypesProperty1.php
@@ -1,0 +1,4 @@
+<?php
+class C {
+    public A|(B&C) $x;
+}

--- a/tests/misc/fallback_ast_src/php82_or_newer/readonlyClass.php
+++ b/tests/misc/fallback_ast_src/php82_or_newer/readonlyClass.php
@@ -1,0 +1,4 @@
+<?php
+readonly class X {
+    public int $x;
+}

--- a/tests/misc/fallback_ast_src/php82_or_newer/readonlyClass2.php
+++ b/tests/misc/fallback_ast_src/php82_or_newer/readonlyClass2.php
@@ -1,0 +1,5 @@
+<?php
+readonly final class RF {
+}
+abstract readonly class AR {
+}

--- a/tests/misc/fallback_test/expected/079_dnf.php.expected
+++ b/tests/misc/fallback_test/expected/079_dnf.php.expected
@@ -1,0 +1,4 @@
+src/079_dnf.php:2 PhanCompatibleUnionType Cannot use union types (string|Countable) before php 8.0
+src/079_dnf.php:2 PhanSyntaxError syntax error, unexpected '|', expecting variable (T_VARIABLE) (at column 22)
+src/079_dnf.php:2 PhanUnusedGlobalFunctionParameter Parameter $x is never used
+src/079_dnf.php:4 PhanTypeMismatchArgumentReal Argument 1 ($x) is null of type null but \foo79() takes \Countable|string defined at src/079_dnf.php:2

--- a/tests/misc/fallback_test/expected/079_dnf.php.expected80
+++ b/tests/misc/fallback_test/expected/079_dnf.php.expected80
@@ -1,0 +1,4 @@
+src/079_dnf.php:2 PhanCompatibleUnionType Cannot use union types (string|Countable) before php 8.0
+src/079_dnf.php:2 PhanSyntaxError syntax error, unexpected token "("
+src/079_dnf.php:2 PhanUnusedGlobalFunctionParameter Parameter $x is never used
+src/079_dnf.php:4 PhanTypeMismatchArgumentReal Argument 1 ($x) is null of type null but \foo79() takes \Countable|string defined at src/079_dnf.php:2

--- a/tests/misc/fallback_test/expected/079_dnf.php.expected82
+++ b/tests/misc/fallback_test/expected/079_dnf.php.expected82
@@ -1,0 +1,4 @@
+src/079_dnf.php:2 PhanCompatibleUnionType Cannot use union types (string|Countable) before php 8.0
+src/079_dnf.php:2 PhanSyntaxError syntax error, unexpected token ")"
+src/079_dnf.php:2 PhanUnusedGlobalFunctionParameter Parameter $x is never used
+src/079_dnf.php:4 PhanTypeMismatchArgumentReal Argument 1 ($x) is null of type null but \foo79() takes \Countable|string defined at src/079_dnf.php:2

--- a/tests/misc/fallback_test/src/079_dnf.php
+++ b/tests/misc/fallback_test/src/079_dnf.php
@@ -1,0 +1,4 @@
+<?php
+function foo79(string|(Countable&) $x) {
+}
+foo79(null);

--- a/tests/misc/fallback_test/test.sh
+++ b/tests/misc/fallback_test/test.sh
@@ -22,6 +22,12 @@ for path in $(echo expected/*.php.expected | LC_ALL=C sort); do
             path="$alternate_path"
         fi
     fi
+    if [[ "$PHP_VERSION_ID" -ge 80200 ]]; then
+        alternate_path=${original_path/.expected/.expected82}
+        if [ -f "$alternate_path" ]; then
+            path="$alternate_path"
+        fi
+    fi
     cat $path;
 done > $EXPECTED_PATH
 


### PR DESCRIPTION
- Support dnf types (union types of intersection types)
- Support the php 8.2 readonly keyword on classes (e.g. `readonly class X`, `readonly final class Y`)

