### PR TITLE
Run tests under 32-bit environments in docker

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,14 +25,18 @@ jobs:
       fail-fast: false
       matrix:
        include:
-         # NOTE: If this is not quoted, the yaml parser will convert numbers such as 7.0 to the number 7,
-         # and the docker image `php:7` is the latest minor version of php 7.x (7.4).
+         # NOTE: If this is not quoted, the yaml parser will convert numbers such as 8.0 to the number 8,
+         # and the docker image `php:8` is the latest minor version of php 8.x (e.g. 8.2).
          - PHP_VERSION: '7.2'
+         - PHP_VERSION: '7.2'
+           DOCKER_ARCHITECTURE: i386
          - PHP_VERSION: '7.3'
          - PHP_VERSION: '7.4'
          - PHP_VERSION: '8.0'
          - PHP_VERSION: '8.1'
-         - PHP_VERSION: '8.2.0RC2'
+         - PHP_VERSION: '8.2.0RC3'
+         - PHP_VERSION: '8.2.0RC3'
+           DOCKER_ARCHITECTURE: i386
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -41,4 +45,4 @@ jobs:
 
       # Runs a single command using the runners shell
       - name: Build and test in docker
-        run: bash tests/run_all_tests_dockerized ${{ matrix.PHP_VERSION }}
+        run: bash tests/run_all_tests_dockerized ${{ matrix.PHP_VERSION }} ${{ matrix.DOCKER_ARCHITECTURE }}

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -1,3 +1,4 @@
+ARG PHP_IMAGE
 ARG PHP_VERSION
 FROM php:$PHP_VERSION
 RUN pecl install ast-1.1.0 && docker-php-ext-enable ast

--- a/tests/run_all_tests_dockerized
+++ b/tests/run_all_tests_dockerized
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-if [ $# != 1 ]; then
-    echo "Usage: $0 PHP_VERSION" 1>&2
+if [[ $# < 1 || $# > 2 ]]; then
+    echo "Usage: $0 PHP_VERSION [i386]" 1>&2
     echo "e.g. $0 8.0" 1>&2
     echo "The PHP_VERSION is the version of the php docker image to use" 1>&2
     exit 1
@@ -10,7 +10,16 @@ fi
 # -u fail for undefined variables
 set -xeu
 PHP_VERSION=$1
+DOCKER_ARCHITECTURE=${2:-}
+if [[ "$DOCKER_ARCHITECTURE" == i386 ]]; then
+    # Run test suites on a 32 bit build of php and confirm they have the expected results.
+    PHP_IMAGE="i386/php"
+    DOCKER_LABEL="i386-php"
+else
+    PHP_IMAGE="php"
+    DOCKER_LABEL="php"
+fi
 
-DOCKER_IMAGE="phan-test-runner:$PHP_VERSION"
-docker build --network=host --build-arg="PHP_VERSION=$PHP_VERSION" --tag="$DOCKER_IMAGE" -f tests/docker/Dockerfile .
+DOCKER_IMAGE="phan-test-runner:$DOCKER_LABEL"
+docker build --network=host --build-arg="PHP_IMAGE=$PHP_IMAGE" --build-arg="PHP_VERSION=$PHP_VERSION" --tag="$DOCKER_IMAGE" -f tests/docker/Dockerfile .
 docker run --rm $DOCKER_IMAGE tests/run_all_tests


### PR DESCRIPTION
Windows tests were switched to 64 bits to work around `Can't initialize heap`