### PR TITLE
Ignore links (symlinks/hardlinks)

### DIFF
--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -2139,6 +2139,11 @@ EOB
                         // Exclude '.' and '..'
                         return false;
                     }
+                    if ($file_info->isLink()) {
+                        // Ignore links
+                        return false;
+                    }
+                    
                     if ($file_info->isDir()) {
                         if (!$iterator->hasChildren()) {
                             return false;

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -2143,7 +2143,6 @@ EOB
                         // Ignore links
                         return false;
                     }
-                    
                     if ($file_info->isDir()) {
                         if (!$iterator->hasChildren()) {
                             return false;


### PR DESCRIPTION
I use symlinks in my projects to open the same file in multiple tabs in VSCode ( ref https://stackoverflow.com/a/73994770/1067003 for why i need to use symlinks), 
 which causes Phan to crash like
```
$ ./vendor/bin/phan
ERROR: Unable to read file /home/hans/projects/easyad/classes/Controller/System/VitecBooking.2ln.php: SplFileInfo->isFile() is false for SplFileInfo->getType() == 'link'
```

the easy fix is to just ignore links.