### PR TITLE
Automatically inherit @throws annotations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@ Phan NEWS
 
 ??? ?? 2023, Phan 5.4.3 (dev)
 -----------------------
+New Features(Analysis):
+- Automatically inherit `@throws` types from parent methods if `enable_phpdoc_types` is true (which it is by default). (#4757)
 
 
 Mar 03 2023, Phan 5.4.2

--- a/src/Phan/Language/Element/FunctionInterface.php
+++ b/src/Phan/Language/Element/FunctionInterface.php
@@ -419,9 +419,18 @@ interface FunctionInterface extends AddressableElementInterface
     public function hasTentativeReturnType(): bool;
 
     /**
-     * @return UnionType of 0 or more types from (at)throws annotations on this function-like
+     * @return UnionType of 0 or more types from (at)throws annotations on this function-like. This only includes
+     * types that are specifically mentioned in the function-like phpdoc (and not, for instance, types inherited from
+     * an ancestor method).
      */
-    public function getThrowsUnionType(): UnionType;
+    public function getOwnThrowsUnionType(): UnionType;
+
+    /**
+     * @return UnionType of 0 or more types from (at)throws annotations on this function-like. This might include types
+     * that are not specifically mentioned in the function-like phpdoc (for instance, types inherited from an
+     * ancestor method).
+     */
+    public function getFullThrowsUnionType(): UnionType;
 
     /**
      * @return bool

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -1198,10 +1198,15 @@ trait FunctionTrait
         $this->comment = $comment;
     }
 
-    public function getThrowsUnionType(): UnionType
+    public function getOwnThrowsUnionType(): UnionType
     {
         $comment = $this->comment;
         return $comment ? $comment->getThrowsUnionType() : UnionType::empty();
+    }
+
+    public function getFullThrowsUnionType(): UnionType
+    {
+        return $this->getOwnThrowsUnionType();
     }
 
     /**

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -57,6 +57,11 @@ class Method extends ClassElement implements FunctionInterface
     private $method_overrides;
 
     /**
+     * @var UnionType|null
+     */
+    private $inherited_throws_union_type;
+
+    /**
      * @param Context $context
      * The context in which the structural element lives
      *
@@ -1092,4 +1097,22 @@ class Method extends ClassElement implements FunctionInterface
             $this->reference_list[$file_ref->__toString()] = $file_ref;
         }
     }
+
+    public function getFullThrowsUnionType(): UnionType
+    {
+        $type = $this->getOwnThrowsUnionType();
+        if ($this->inherited_throws_union_type) {
+            $type = $type->withUnionType($this->inherited_throws_union_type);
+        }
+        return $type;
+    }
+
+    /**
+     * Set union type of (at)throws annotations that this method inherits.
+     */
+    public function setInheritedThrowsUnionType(UnionType $type): void
+    {
+        $this->inherited_throws_union_type = $type;
+    }
+
 }

--- a/src/Phan/Language/Type/FunctionLikeDeclarationType.php
+++ b/src/Phan/Language/Type/FunctionLikeDeclarationType.php
@@ -682,9 +682,14 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
         return $this->return_type;
     }
 
-    public function getThrowsUnionType(): UnionType
+    public function getOwnThrowsUnionType(): UnionType
     {
         return UnionType::empty();
+    }
+
+    public function getFullThrowsUnionType(): UnionType
+    {
+        return $this->getOwnThrowsUnionType();
     }
 
     public function hasFunctionCallAnalyzer(): bool

--- a/src/Phan/Plugin/Internal/ThrowAnalyzerPlugin.php
+++ b/src/Phan/Plugin/Internal/ThrowAnalyzerPlugin.php
@@ -67,7 +67,7 @@ class ThrowAnalyzerPlugin extends PluginV3 implements PostAnalyzeNodeCapability,
         if (\strcasecmp($method->getName(), '__toString') !== 0) {
             return;
         }
-        $throws_union_type = $method->getThrowsUnionType();
+        $throws_union_type = $method->getOwnThrowsUnionType();
         if ($throws_union_type->isEmpty()) {
             return;
         }
@@ -220,7 +220,7 @@ class ThrowVisitor extends PluginAwarePostAnalysisVisitor
             if ($type->hasTemplateTypeRecursive()) {
                 continue;
             }
-            $throws_union_type = $analyzed_function->getThrowsUnionType();
+            $throws_union_type = $analyzed_function->getFullThrowsUnionType();
             if ($throws_union_type->isEmpty()) {
                 if ($call !== null) {
                     $this->emitIssue(
@@ -353,7 +353,7 @@ class ThrowRecursiveVisitor extends ThrowVisitor
                 $this->warnAboutPossiblyThrownType(
                     $node,
                     $analyzed_function,
-                    $this->withoutCaughtUnionTypes($invoked_function->getThrowsUnionType(), false)
+                    $this->withoutCaughtUnionTypes($invoked_function->getOwnThrowsUnionType(), false)
                 );
             }
         } catch (CodeBaseException $_) {
@@ -407,7 +407,7 @@ class ThrowRecursiveVisitor extends ThrowVisitor
         $this->warnAboutPossiblyThrownType(
             $node,
             $analyzed_function,
-            $this->withoutCaughtUnionTypes($invoked_method->getThrowsUnionType(), false),
+            $this->withoutCaughtUnionTypes($invoked_method->getOwnThrowsUnionType(), false),
             $invoked_method
         );
     }
@@ -451,7 +451,7 @@ class ThrowRecursiveVisitor extends ThrowVisitor
         $this->warnAboutPossiblyThrownType(
             $node,
             $analyzed_function,
-            $this->withoutCaughtUnionTypes($invoked_method->getThrowsUnionType(), false),
+            $this->withoutCaughtUnionTypes($invoked_method->getOwnThrowsUnionType(), false),
             $invoked_method
         );
     }

--- a/tests/infer_missing_types_test/src/006_inherit_throws.php
+++ b/tests/infer_missing_types_test/src/006_inherit_throws.php
@@ -1,0 +1,46 @@
+<?php
+
+// @phan-file-suppress PhanUnreferencedPublicMethod, PhanUnreferencedClass, PhanUnreferencedFunction
+
+namespace NS978;
+
+use RuntimeException;
+
+class BaseClass {
+    /**
+     * @throws RuntimeException
+     */
+    public function foo(): void {
+        throw new RuntimeException( 'A' );
+    }
+}
+
+class ChildClass extends BaseClass {
+    public function foo(): void {
+        // With inherit_phpdoc_types, the method should inherit @throws from the parent and
+        // this line should NOT emit PhanThrowTypeAbsent
+        throw new RuntimeException( 'B' );
+    }
+}
+
+class BaseClassThatThrows {
+    /**
+     * @throws RuntimeException
+     */
+    public function foo(): void {
+        throw new RuntimeException( 'A' );
+    }
+}
+
+class ChildClassThatDoesNotThrow extends BaseClassThatThrows {
+    public function foo(): void {
+        // This method also inherit @throws from the parent, but we do not emit any issue if callers
+        // of this method do not catch the exception.
+        echo "this method definitely does not throw any exceptions";
+    }
+}
+
+function doTest() {
+    $c = new ChildClassThatDoesNotThrow();
+    $c->foo();// Phan should NOT emit PhanThrowTypeAbsentForCall here
+}

--- a/tests/infer_missing_types_test/test.sh
+++ b/tests/infer_missing_types_test/test.sh
@@ -2,7 +2,7 @@
 EXPECTED_PATH=expected/all_output.expected
 ACTUAL_PATH=all_output.actual
 if [ ! -d expected  ]; then
-	echo "Error: must run this script from tests/infer_real_types_test folder" 1>&2
+	echo "Error: must run this script from tests/infer_missing_types_test folder" 1>&2
 	exit 1
 fi
 echo "Generating test cases"


### PR DESCRIPTION
Functions now have two separate properties for thrown types, one that includes inherited types and one that doesn't. This way we don't warn about missing try...catch if a type is only inherited.

Fixes #4757 