### PR TITLE
Update the signature of phpredis's RedisCluster::__construct

### DIFF
--- a/src/Phan/Language/Internal/FunctionSignatureMap.php
+++ b/src/Phan/Language/Internal/FunctionSignatureMap.php
@@ -11903,7 +11903,7 @@ return [
 'RedisArray::unlink' => ['int', 'key'=>'string', '...other_keys='=>'string'],
 'RedisArray::unlink\'1' => ['int', 'key'=>'string[]'],
 'RedisArray::unwatch' => [''],
-'RedisCluster::__construct' => ['void', 'name'=>'?string', 'seeds='=>'string[]', 'timeout='=>'float', 'read_timeout='=>'float', 'persistent='=>'bool', 'auth='=>'?string'],
+'RedisCluster::__construct' => ['void', 'name'=>'?string', 'seeds='=>'?string[]', 'timeout='=>'int|float', 'read_timeout='=>'int|float', 'persistent='=>'bool', 'auth='=>'mixed', 'context'=>'?array'],
 'RedisCluster::_masters' => ['array'],
 'RedisCluster::_prefix' => ['string', 'key'=>'mixed'],
 'RedisCluster::_redir' => [''],


### PR DESCRIPTION
Updates phpredis's RedisCluster::__construct for updates added in v5.3.7

Made the definition match the official stub provided by phpredis here:

https://github.com/phpredis/phpredis/blob/008ec534e36dad1390f5e1d75d1f259134ab4596/redis_cluster.stub.php#L50

See also: https://github.com/JetBrains/phpstorm-stubs/pull/1549