### PR TITLE
Add 'static analysis' keyword to composer.json to trigger `--dev` prompt

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "phan/phan",
     "description": "A static analyzer for PHP",
-    "keywords": ["php", "static", "analyzer"],
+    "keywords": ["php", "static", "analyzer", "static analysis"],
     "type": "project",
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
Composer 2.4 and later can automatically suggest to use the `--dev` flag when someone runs `composer require phan/phan` without the `--dev` flag.

See [Get Composer to suggest dev packages to `require-dev`](https://php.watch/articles/composer-prompt-require-dev-dev-packages)