### PR TITLE
Annotate array_chunk as returning list<array>

### DIFF
--- a/src/Phan/Language/Internal/FunctionSignatureMapReal.php
+++ b/src/Phan/Language/Internal/FunctionSignatureMapReal.php
@@ -25,7 +25,7 @@ return [
 'addcslashes' => 'string',
 'addslashes' => 'string',
 'array_change_key_case' => 'array',
-'array_chunk' => 'array',
+'array_chunk' => 'list<array>',
 'array_column' => 'array',
 'array_combine' => 'array',
 'array_count_values' => 'int[]',

--- a/src/Phan/Language/Internal/FunctionSignatureMapReal_php73.php
+++ b/src/Phan/Language/Internal/FunctionSignatureMapReal_php73.php
@@ -25,7 +25,7 @@ return [
 'addcslashes' => '?string',
 'addslashes' => '?string',
 'array_change_key_case' => '?array',
-'array_chunk' => '?array',
+'array_chunk' => '?list<array>',
 'array_column' => '?array|?false',
 'array_combine' => '?array|?false',
 'array_count_values' => '?int[]',


### PR DESCRIPTION
`array_chunk` is guaranteed to return a list of arrays (or null, before PHP 8), so update the annotated return type for better type inference. For a future change, it would be nice to actually infer the type of list elements, based on the first argument to `array_chunk` (#4807). This is just a first step.