### PR TITLE
Fix dockerized test runner and GH actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,5 +45,4 @@ jobs:
 
       # Runs a single command using the runners shell
       - name: Build and test in docker
-        run: sudo apt-get install -y sqlite3
         run: bash tests/run_all_tests_dockerized ${{ matrix.PHP_VERSION }} ${{ matrix.DOCKER_ARCHITECTURE }}

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -4,7 +4,7 @@ FROM php:$PHP_VERSION
 RUN pecl install ast-1.1.0 && docker-php-ext-enable ast
 RUN curl https://getcomposer.org/download/latest-2.x/composer.phar -o /usr/bin/composer.phar && chmod a+x /usr/bin/composer.phar
 WORKDIR /phan
-RUN apt-get update && apt-get install -y unzip parallel colordiff && apt-get clean
+RUN apt-get update && apt-get install -y unzip parallel colordiff sqlite3 && apt-get clean
 
 ADD composer.json composer.lock ./
 RUN composer.phar install && composer.phar clear-cache


### PR DESCRIPTION
Github CI is currently failing with:

> The workflow is not valid. .github/workflows/main.yml (Line: 49, Col: 9): 'run' is already defined

Also, because these tests run in a separate container, we need to install sqlite there.