### PR TITLE
Fix #4782

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@ Miscellaneous:
 - Fix ldap function signatures
 
 Bug fixes:
+- Fix interfaces can extend BackedEnum and UnitEnum (#4782)
 - Fix ini_set() signature to take any scalar since PHP 8.1 (#4806)
 - Fix RedisCluster setOption/getOption signatures (#4790)
 - Fix ldap function signatures

--- a/src/Phan/Analysis/ClassInheritanceAnalyzer.php
+++ b/src/Phan/Analysis/ClassInheritanceAnalyzer.php
@@ -186,7 +186,7 @@ class ClassInheritanceAnalyzer
                 );
             }
         }
-        if ($target_class->isInterface() && !$source_class->isEnum()) {
+        if ($target_class->isInterface() && !$source_class->isEnum() && !$source_class->isInterface()) {
             if (\in_array(\strtolower($target_class->getFQSEN()->__toString()), ['\unitenum', '\backedenum'], true)) {
                 Issue::maybeEmit(
                     $code_base,


### PR DESCRIPTION
Interfaces can extend `BackedEnum` and `UnitEnum`