### PR TITLE
Invert alias => canonical relationship for dns_check_record and dns_get_mx

### DIFF
--- a/.phan/plugins/DeprecateAliasPlugin.php
+++ b/.phan/plugins/DeprecateAliasPlugin.php
@@ -294,10 +294,10 @@ class DeprecateAliasPlugin extends PluginV3 implements
         'bzclose' => 'fclose',
         'bzflush' => 'fflush',
         'bzwrite' => 'fwrite',
-        'checkdnsrr' => 'dns_check_record',
+        'dns_check_record' => 'checkdnsrr',
         'dir' => 'getdir',
         'ftp_quit' => 'ftp_close',
-        'getmxrr' => 'dns_get_mx',
+        'dns_get_mx' => 'getmxrr',
         // 'getrandmax' => 'mt_getrandmax',  // confusing because rand is not an alias of mt_rand
         'get_required_files' => 'get_included_files',
         'gmp_div' => 'gmp_div_q',


### PR DESCRIPTION
According to the PHP manual, the following functions are aliases of their respective "canonical" name:

| Canonical | Alias |
|---|---|
| [checkdnsrr](https://www.php.net/manual/en/function.checkdnsrr.php) | [dns_check_record()](https://www.php.net/manual/en/function.dns-check-record.php) |
| [getmxrr()](https://www.php.net/manual/en/function.getmxrr.php) | [dns_get_mx()](https://www.php.net/manual/en/function.dns-get-mx.php) |

However, the DeprecateAliasPlugin seems to have these inverted:

```none
PhanDeprecatedFunctionInternal Call to deprecated function \checkdnsrr() (Deprecated because: DeprecateAliasPlugin marked this as an alias of dns_check_record())
PhanDeprecatedFunctionInternal Call to deprecated function \getmxrr() (Deprecated because: DeprecateAliasPlugin marked this as an alias of dns_get_mx())
```

This PR flips the relationships, which fixes #4798.