### PR TITLE
Support multiline annotations @var, @param, and @return

### DIFF
--- a/tests/files/expected/0605_array_shape_template.php.expected
+++ b/tests/files/expected/0605_array_shape_template.php.expected
@@ -1,2 +1,2 @@
-%s:13 PhanUndeclaredMethod Call to undeclared method \stdClass::method
-%s:24 PhanTypeMismatchArgumentInternal%SReal Argument 1 ($string) is swap_pair([rand(0, 5),new stdClass()]) of type array{0:\stdClass,1:int} (real type array) but \strlen() takes string
+%s:16 PhanUndeclaredMethod Call to undeclared method \stdClass::method
+%s:27 PhanTypeMismatchArgumentInternal%SReal Argument 1 ($string) is swap_pair([rand(0, 5),new stdClass()]) of type array{0:\stdClass,1:int} (real type array) but \strlen() takes string

--- a/tests/files/src/0605_array_shape_template.php
+++ b/tests/files/src/0605_array_shape_template.php
@@ -1,7 +1,10 @@
 <?php
 /**
  * @template TClassName
- * @param array{class:class-string<TClassName>,args:array<int,mixed>} $params
+ * @param array{
+ *     class: class-string<TClassName>,
+ *     args: array<int, mixed>,
+ * } $params
  * @return TClassName
  */
 function class_instance_factory(array $params) {


### PR DESCRIPTION
Fix #1488

First commit adding the test shows the failure:
https://github.com/kylekatarnls/phan/actions/runs/7432676341

Second commit fix it by reducing multiline annotation to 1 line:
https://github.com/kylekatarnls/phan/actions/runs/7432799130