### PR TITLE
Update DOMNode::insertBefore() in FunctionSignatureMap.php

### DIFF
--- a/src/Phan/Language/Internal/FunctionSignatureMap.php
+++ b/src/Phan/Language/Internal/FunctionSignatureMap.php
@@ -2297,7 +2297,7 @@ return [
 'DOMNode::getNodePath' => ['?string'],
 'DOMNode::hasAttributes' => ['bool'],
 'DOMNode::hasChildNodes' => ['bool'],
-'DOMNode::insertBefore' => ['DOMNode', 'node'=>'DOMNode', 'child='=>'DOMNode'],
+'DOMNode::insertBefore' => ['DOMNode', 'node'=>'DOMNode', 'child='=>'?DOMNode'],
 'DOMNode::isDefaultNamespace' => ['bool', 'namespace'=>'string'],
 'DOMNode::isSameNode' => ['bool', 'otherNode'=>'DOMNode'],
 'DOMNode::isSupported' => ['bool', 'feature'=>'string', 'version'=>'string'],


### PR DESCRIPTION
The second argument to DOMNode::insertBefore() can be null, as documented on https://www.php.net/manual/en/domnode.insertbefore.php (as well as https://developer.mozilla.org/en-US/docs/Web/API/Node/insertBefore etc).