### PR TITLE
fixing protobuf mergeFromJsonString stub

### DIFF
--- a/src/Phan/Language/Internal/FunctionSignatureMap.php
+++ b/src/Phan/Language/Internal/FunctionSignatureMap.php
@@ -4322,7 +4322,7 @@ return [
 'Google\Protobuf\Internal\Message::discardUnknownFields' => [''],
 'Google\Protobuf\Internal\Message::hasOneof' => ['', 'field'=>''],
 'Google\Protobuf\Internal\Message::mergeFrom' => ['', 'data'=>''],
-'Google\Protobuf\Internal\Message::mergeFromJsonString' => ['', 'data'=>'', 'ignore_unknown='=>'bool'],
+'Google\Protobuf\Internal\Message::mergeFromJsonString' => ['', 'data'=>'', 'ignore_json_unknown='=>'bool'],
 'Google\Protobuf\Internal\Message::mergeFromString' => ['', 'data'=>''],
 'Google\Protobuf\Internal\Message::readOneof' => ['', 'field'=>''],
 'Google\Protobuf\Internal\Message::readWrapperValue' => ['', 'field'=>''],

--- a/src/Phan/Language/Internal/FunctionSignatureMap.php
+++ b/src/Phan/Language/Internal/FunctionSignatureMap.php
@@ -4322,7 +4322,7 @@ return [
 'Google\Protobuf\Internal\Message::discardUnknownFields' => [''],
 'Google\Protobuf\Internal\Message::hasOneof' => ['', 'field'=>''],
 'Google\Protobuf\Internal\Message::mergeFrom' => ['', 'data'=>''],
-'Google\Protobuf\Internal\Message::mergeFromJsonString' => ['', 'data'=>''],
+'Google\Protobuf\Internal\Message::mergeFromJsonString' => ['', 'data'=>'', 'ignore_unknown='=>'bool'],
 'Google\Protobuf\Internal\Message::mergeFromString' => ['', 'data'=>''],
 'Google\Protobuf\Internal\Message::readOneof' => ['', 'field'=>''],
 'Google\Protobuf\Internal\Message::readWrapperValue' => ['', 'field'=>''],


### PR DESCRIPTION
since protobuf v3.13 (https://github.com/protocolbuffers/protobuf/pull/7695 about 4 years ago) Google\Protobuf\Internal\Message::mergeFromJsonString has an optional second boolean parameter.