### PR TITLE
Improve type inference for destructuring of shaped array assignments

### DIFF
--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -2151,11 +2151,13 @@ class UnionTypeVisitor extends AnalysisVisitor
      */
     public static function resolveArrayShapeElementTypesForOffset(UnionType $union_type, $dim_value, bool $is_computing_real_type_set, CodeBase $code_base)
     {
-        // Get the possible element types from non-array shape arrays in the $union_type.
-        $resulting_element_type = UnionType::getTypeForGenericArrayDestructuringAccess($union_type, $code_base);
-
-        $has_generic_array = false; // True if there are non-array shape arrays in the $union_type
+        /**
+         * @var bool $has_non_array_shape_type this will be true if there are types that support array access
+         *           but have unknown array shapes in $union_type
+         */
+        $has_generic_array = false;
         $has_string = false;
+        $resulting_element_type = null;
         foreach ($union_type->getTypeSet() as $type) {
             if (!($type instanceof ArrayShapeType)) {
                 if ($type instanceof StringType) {
@@ -2163,7 +2165,11 @@ class UnionTypeVisitor extends AnalysisVisitor
                     if (\is_int($dim_value) || \filter_var($dim_value, \FILTER_VALIDATE_INT) !== false) {
                         // If we request a string offset from a string, that's not valid. Only accept integer dimensions as valid.
                         // in php, indices of strings can be negative
-                        $resulting_element_type = $resulting_element_type->withType(StringType::instance(false));
+                        if ($resulting_element_type instanceof UnionType) {
+                            $resulting_element_type = $resulting_element_type->withType(StringType::instance(false));
+                        } else {
+                            $resulting_element_type = StringType::instance(false)->asPHPDocUnionType();
+                        }
                     } else {
                         // TODO: Warn about string indices of strings?
                     }
@@ -2190,7 +2196,11 @@ class UnionTypeVisitor extends AnalysisVisitor
             if ($element_type !== null) {
                 // $element_type may be non-null but $element_type->isEmpty() may be true.
                 // So, we use null to indicate failure below
-                $resulting_element_type = $resulting_element_type->withUnionType($element_type);
+                if ($resulting_element_type instanceof UnionType) {
+                    $resulting_element_type = $resulting_element_type->withUnionType($element_type);
+                } else {
+                    $resulting_element_type = $element_type;
+                }
             }
         }
         if ($resulting_element_type === null) {

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -672,7 +672,7 @@ class AssignmentVisitor extends AnalysisVisitor
                     'array|ArrayAccess'
                 );
             }
-            $element_type = UnionType::getTypeForGenericArrayDestructuringAccess($array_access_types, $this->code_base);
+            $element_type = UnionType::getTypeForGenericArrayDestructuringAccess($right_type, $this->code_base);
         }
 
         $expect_string_keys_lineno = false;

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -1047,7 +1047,7 @@ final class EmptyUnionType extends UnionType
      * @return UnionType
      * The subset of types in this
      */
-    public function genericArrayElementTypes(bool $add_real_types, CodeBase $code_base): UnionType
+    public function genericArrayElementTypes(bool $add_real_types, CodeBase $code_base, bool $include_array_shape_types = true): UnionType
     {
         return $this; // empty
     }

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -4059,7 +4059,7 @@ class UnionType implements Serializable, Stringable
      * @param bool $add_real_types if true, this adds the real types that would be possible for `$x[$offset]`
      * @suppress PhanStaticClassAccessWithStaticVariable static variables are safely initialized
      */
-    public function genericArrayElementTypes(bool $add_real_types, CodeBase $code_base): UnionType
+    public function genericArrayElementTypes(bool $add_real_types, CodeBase $code_base, bool $include_array_shape_types = true): UnionType
     {
         // This is frequently called, and has been optimized
         $result = [];
@@ -4069,6 +4069,10 @@ class UnionType implements Serializable, Stringable
                 if ($type instanceof GenericArrayType) {
                     $result[] = $type->genericArrayElementType();
                 } else {
+                    // It's a shaped array (TODO: confirm)
+                    if (!$include_array_shape_types) {
+                        continue;
+                    }
                     foreach ($type->genericArrayElementUnionType()->getTypeSet() as $inner_type) {
                         $result[] = $inner_type;
                     }
@@ -4158,7 +4162,7 @@ class UnionType implements Serializable, Stringable
      * @param  CodeBase  $code_base
      */
     public static function getTypeForGenericArrayDestructuringAccess(UnionType $right_type, CodeBase $code_base): UnionType {
-        return $right_type->genericArrayElementTypes(false, $code_base)
+        return $right_type->genericArrayElementTypes(false, $code_base, false)
             ->withRealTypeSet(
                 self::computeRealElementTypesForDestructuringAccess($right_type->getRealTypeSet(), $code_base)
             );

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -4197,6 +4197,9 @@ class UnionType implements Serializable, Stringable
             if (!$type instanceof ArrayType) {
                 return [];
             }
+            if ($type instanceof ArrayShapeType) {
+                continue;
+            }
             $new_types = $type->genericArrayElementUnionType()->getTypeSet();
             if (!$new_types) {
                 return [];

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -4148,12 +4148,30 @@ class UnionType implements Serializable, Stringable
     }
 
     /**
+     * Returns the UnionType for of an element of the LHS in a destructuring assignment such as:
+     * `[$a, $b] = expr`
+     *
+     * This only handles the generic arrays that the RHS consists of. This will not handle
+     * the array shape types of the RHS.
+     *
+     * @param  UnionType $right_type
+     * @param  CodeBase  $code_base
+     * @return UnionType
+     */
+    public static function getTypeForGenericArrayDestructuringAccess(UnionType $right_type, CodeBase $code_base): UnionType {
+        return $right_type->genericArrayElementTypes(false, $code_base)
+            ->withRealTypeSet(
+                self::computeRealElementTypesForDestructuringAccess($right_type->getRealTypeSet(), $code_base)
+            );
+    }
+
+    /**
      * Returns the real types seen for an array destructuring expression such as `[$x] = expr`
      * @param non-empty-list<Type> $real_type_set the set of types of expr
      * @return list<Type> possibly empty, possibly with duplicates. These types are nullable to indicate that array accesses can fail.
      * @internal
      */
-    public static function computeRealElementTypesForDestructuringAccess(array $real_type_set, CodeBase $code_base): array
+    private static function computeRealElementTypesForDestructuringAccess(array $real_type_set, CodeBase $code_base): array
     {
         $result = [];
         foreach ($real_type_set as $type) {

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -4156,7 +4156,6 @@ class UnionType implements Serializable, Stringable
      *
      * @param  UnionType $right_type
      * @param  CodeBase  $code_base
-     * @return UnionType
      */
     public static function getTypeForGenericArrayDestructuringAccess(UnionType $right_type, CodeBase $code_base): UnionType {
         return $right_type->genericArrayElementTypes(false, $code_base)


### PR DESCRIPTION
Previously, when analyzing an assignment like `[$a, $b] = expr`, if `expr` had at least one shaped array in its UnionType, we would mostly ignore whatever generic arrays it had in its UnionType (e.g. `Foo[]`) when inferring the type of `$a` and `$b`. That is, if `expr` had a UnionType like `Foo[]|array{0:null,1:null}`, we would only infer that `$a` and `$b` can be `null`.

The goal of this changeset is to instead infer that `$a` and `$b` are `Foo|null`.