### PR TITLE
Update download links for php zip files

### DIFF
--- a/src/Phan/Bootstrap.php
+++ b/src/Phan/Bootstrap.php
@@ -62,25 +62,29 @@ function phan_output_ast_installation_instructions(): void
     }
     if (DIRECTORY_SEPARATOR === '\\') {
         if (PHP_VERSION_ID >= 70300 && PHP_VERSION_ID < 80100 || !preg_match('/[a-zA-Z]/', PHP_VERSION)) {
-            // e.g. https://windows.php.net/downloads/pecl/releases/ast/1.0.16/php_ast-1.0.16-8.0-nts-vs16-x64.zip for php 8.0, 64-bit non thread safe
-            // e.g. https://windows.php.net/downloads/pecl/releases/ast/1.0.16/php_ast-1.0.16-7.4-ts-vc15-x86.zip for php 7.4, 32-bit thread safe
+            // e.g. https://downloads.php.net/~windows/pecl/releases/ast/1.1.1/php_ast-1.1.1-8.0-nts-vs16-x64.zip for php 8.0, 64-bit non thread safe
+            // e.g. https://downloads.php.net/~windows/pecl/releases/ast/1.1.1/php_ast-1.1.1-7.4-ts-vc15-x86.zip for php 7.4, 32-bit thread safe
+            // The older release https://pecl.php.net/package/ast/1.0.16/windows has releases for PHP 7.3 and 7.4
+            $version = PHP_VERSION_ID >= 80000 ? LATEST_KNOWN_PHP_AST_VERSION : '1.0.16';
             fprintf(
                 STDERR,
-                PHP_EOL . "Windows users can download php-ast from https://windows.php.net/downloads/pecl/releases/ast/%s/php_ast-%s-%s-%s-%s-%s.zip" . PHP_EOL,
-                LATEST_KNOWN_PHP_AST_VERSION,
-                LATEST_KNOWN_PHP_AST_VERSION,
+                PHP_EOL . "Windows users can download php-ast from https://downloads.php.net/~windows/pecl/releases/ast/%s/php_ast-%s-%s-%s-%s-%s.zip" . PHP_EOL,
+                $version,
+                $version,
                 PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION,
                 PHP_ZTS ? 'ts' : 'nts',
                 PHP_VERSION_ID >= 80000 ? 'vs16' : 'vc15',
                 PHP_INT_SIZE == 4 ? 'x86' : 'x64'
             );
-            fwrite(STDERR, "(if that link doesn't work, check https://windows.php.net/downloads/pecl/releases/ast/ )" . PHP_EOL);
+            fwrite(STDERR, "(if that link doesn't work, check https://downloads.php.net/~windows/pecl/releases/ast/ )" . PHP_EOL);
+            fwrite(STDERR, "php-ast 1.0.11 is the minimum php-ast version needed for ast version 85. https://pecl.php.net/package/ast/1.0.11/windows does not supply dlls for php 7.2 because php-ast 1.0.11 was published after security support for php 7.2 was dropped" . PHP_EOL);
+
             fwrite(STDERR, "To install php-ast, add php_ast.dll from the zip to $extension_dir," . PHP_EOL);
         } else {
             if (PHP_VERSION_ID < 70300) {
                 fwrite(STDERR, "php-ast 1.0.11 is the minimum php-ast version needed for ast version 85. https://pecl.php.net/package/ast/1.0.11/windows does not supply dlls for php 7.2 because php-ast 1.0.11 was published after security support for php 7.2 was dropped" . PHP_EOL);
             } else {
-                fprintf(STDERR, "Releases for php %s may not yet be available at https://windows.php.net/downloads/pecl/releases/ast/" . PHP_EOL, PHP_VERSION);
+                fprintf(STDERR, "Releases for php %s may not yet be available at https://downloads.php.net/~windows/pecl/releases/ast/" . PHP_EOL, PHP_VERSION);
             }
             fwrite(STDERR, "To build php-ast from source for Windows, see https://wiki.php.net/internals/windows/stepbystepbuild_sdk_2 and https://wiki.php.net/internals/windows/stepbystepbuild_sdk_2#building_pecl_extensions" . PHP_EOL);
         }


### PR DESCRIPTION
Newer zip files for newer php-ast releases aren't added to the older windows.php.net domain but are added to downloads.php.net