### PR TITLE
[PHP 8.5] Use `PHP_BUILD_DATE` constant

### DIFF
--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -3487,6 +3487,11 @@ class TolerantASTConverter
         if (\strpos(\PHP_VERSION, '-dev') === false) {
             return null;
         }
+
+        if (\defined('PHP_BUILD_DATE')) {
+            return \PHP_BUILD_DATE;
+        }
+
         \ob_start();
         \phpinfo(\INFO_GENERAL);
         $contents = (string)\ob_get_clean();


### PR DESCRIPTION
PHP 8.5 has a [new constant named `PHP_BUILD_DATE`](https://php.watch/versions/8.5/PHP_BUILD_DATE) that contains the same value as the `phpinfo` build date.

We currently use "Build date" field parsed from `phpinfo` output as a cache-key.

In PHP 8.5 and later, this value is directly avaiable, so there is no need to parse `phpinfo` output.