### PR TITLE
Fix session_set_save_handler `gc` arg type

### DIFF
--- a/src/Phan/Language/Internal/FunctionSignatureMap.php
+++ b/src/Phan/Language/Internal/FunctionSignatureMap.php
@@ -12929,7 +12929,7 @@ return [
 'session_save_path' => ['string', 'path='=>'string'],
 'session_set_cookie_params' => ['bool', 'lifetime_or_options'=>'int', 'path='=>'string', 'domain='=>'?string', 'secure='=>'bool', 'httponly='=>'bool'],
 'session_set_cookie_params\'1' => ['bool', 'lifetime_or_options'=>'array{lifetime?:int,path?:string,domain?:?string,secure?:bool,httponly?:bool}'],
-'session_set_save_handler' => ['bool', 'open'=>'callable(string,string):bool', 'close'=>'callable():bool', 'read'=>'callable(string):string', 'write'=>'callable(string,string):bool', 'destroy'=>'callable(string):bool', 'gc'=>'callable(string):bool', 'create_sid='=>'callable():string', 'validate_sid='=>'callable(string):bool', 'update_timestamp='=>'callable(string):bool'],
+'session_set_save_handler' => ['bool', 'open'=>'callable(string,string):bool', 'close'=>'callable():bool', 'read'=>'callable(string):string', 'write'=>'callable(string,string):bool', 'destroy'=>'callable(string):bool', 'gc'=>'callable(int):bool', 'create_sid='=>'callable():string', 'validate_sid='=>'callable(string):bool', 'update_timestamp='=>'callable(string):bool'],
 'session_set_save_handler\'1' => ['bool', 'open'=>'SessionHandlerInterface', 'close='=>'bool'],
 'session_start' => ['bool', 'options='=>'array'],
 'session_status' => ['int'],


### PR DESCRIPTION
The type for the arg is a callable(int): bool and not callable(string): bool per the PHP documentation:
https://www.php.net/manual/en/function.session-set-save-handler.php

I looked up the history and think its type has always been an int based on this change that added the parameter to the function: https://github.com/php/php-src/commit/d8a9548cb24#diff-5f6a19fd4cbf115ff6db6f76c0ddf0a81bdca1d2fc33fd44900a079ce2acac2cR43