### PR TITLE
Require php-ast 1.1.2 with PHP 8.4

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@ Phan NEWS
 
 ??? ?? 202?, Phan 5.4.6 (dev)
 -----------------------
+Miscellaneous:
+- Require php-ast 1.1.2 or newer in PHP 8.4+ if php-ast is installed.
 
 Aug 13 2024, Phan 5.4.5
 -----------------------

--- a/src/Phan/Bootstrap.php
+++ b/src/Phan/Bootstrap.php
@@ -44,7 +44,7 @@ if (PHP_VERSION_ID < 70200) {
     exit(1);
 }
 
-const LATEST_KNOWN_PHP_AST_VERSION = '1.1.1';
+const LATEST_KNOWN_PHP_AST_VERSION = '1.1.2';
 
 /**
  * Dump instructions on how to install php-ast
@@ -150,7 +150,9 @@ if (extension_loaded('ast')) {
         exit(1);
     };
 
-    if (PHP_VERSION_ID >= 80300 && version_compare($ast_version, '1.1.1') < 0) {
+    if (PHP_VERSION_ID >= 80400 && version_compare($ast_version, '1.1.2') < 0) {
+        $phan_output_ast_too_old_and_exit('1.1.2', '8.4');
+    } elseif (PHP_VERSION_ID >= 80300 && version_compare($ast_version, '1.1.1') < 0) {
         $phan_output_ast_too_old_and_exit('1.1.1', '8.3');
     } elseif (PHP_VERSION_ID >= 80200 && version_compare($ast_version, '1.1.0') < 0) {
         $phan_output_ast_too_old_and_exit('1.1.0', '8.2');
@@ -179,9 +181,9 @@ if (extension_loaded('ast')) {
         exit(1);
     }
     // @phan-suppress-next-line PhanRedundantCondition, PhanImpossibleCondition, PhanSuspiciousValueComparison
-    if (PHP_VERSION_ID < 80400 && PHP_VERSION_ID % 100 === 0 && PHP_EXTRA_VERSION !== '') {
+    if (PHP_VERSION_ID < 80500 && PHP_VERSION_ID % 100 === 0 && PHP_EXTRA_VERSION !== '') {
         // Warn for 8.3.0RC1, 8.0.0RC1, 7.4.0alpha1, 7.3.0-dev, etc.
-        // But don't warn for 8.4.0 since there's no way yet to upgrade to a stable release.
+        // But don't warn for upcoming versions without a stable release.
         fwrite(STDERR, "WARNING: Phan may not work properly in versions prior to the first stable release of a php minor version. The currently used PHP version is " . PHP_VERSION . PHP_EOL);
     }
     unset($ast_version);

--- a/src/Phan/Language/Internal/ConstantDocumentationMap.php
+++ b/src/Phan/Language/Internal/ConstantDocumentationMap.php
@@ -157,6 +157,8 @@ return [
 'ast\AST_PROP_DECL' => 'A single group of property declarations inside a class. (numerically indexed children)',
 'ast\AST_PROP_ELEM' => 'A class property declaration. (children: name, default, docComment)',
 'ast\AST_PROP_GROUP' => 'A class property group declaration with optional type information for the group (in PHP 7.4+). Used in AST version 70+ (children: type, props, __declId)',
+'ast\AST_PROPERTY_HOOK' => 'A class property hook declaration. (children: name, docComment, params, stmts, attributes)',
+'ast\AST_PROPERTY_HOOK_SHORT_BODY' => 'A class property hook declaration using the shorthand format. (children: expr)',
 'ast\AST_REF' => 'only used for `&$v` in `foreach ($a as &$v)` (children: var)',
 'ast\AST_RETURN' => 'A `return;` or `return expr` statement. (children: expr)',
 'ast\AST_SHELL_EXEC' => 'A `\`some_shell_command\`` expression. (children: expr)',

--- a/tests/Phan/Language/Internal/ConstantDocumentationMapTest.php
+++ b/tests/Phan/Language/Internal/ConstantDocumentationMapTest.php
@@ -33,6 +33,6 @@ final class ConstantDocumentationMapTest extends BaseTest
                 }
             }
         }
-        $this->assertSame('', $failures, 'This test was written for php-ast 1.0.6 and php <=7.4. If you are using a newer php-ast version, this test failure is expected for `ast:`');
+        $this->assertSame('', $failures, 'This test was written for php-ast 1.1.2. If you are using a newer php-ast version, this test failure is expected for `ast:`');
     }
 }

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -1,7 +1,7 @@
 ARG PHP_IMAGE
 ARG PHP_VERSION
 FROM php:$PHP_VERSION
-RUN pecl install ast-1.1.1 && docker-php-ext-enable ast
+RUN pecl install ast-1.1.2 && docker-php-ext-enable ast
 RUN curl https://getcomposer.org/download/latest-2.x/composer.phar -o /usr/bin/composer.phar && chmod a+x /usr/bin/composer.phar
 WORKDIR /phan
 RUN apt-get update && apt-get install -y unzip parallel colordiff sqlite3 && apt-get clean


### PR DESCRIPTION
When running in PHP 8.4, php-ast >= 1.1.2 is required due to https://github.com/nikic/php-ast/commit/1fc2c3a12ac5f87fa45b1c6d8248e3bef2d20f68. So, update the minimum required version accordingly, and the docker image for tests as well. Note that the test suite is still failing in PHP 8.4 (#4894).

Also warn when using PHP 8.4 release candidates now that a stable release exists.