### PR TITLE
Don't hydrate classes until all aliases are resolved

### DIFF
--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -930,7 +930,9 @@ class CodeBase
             return;
         }
         // The original class exists. Attempt to create aliases of the original class.
-        $class = $this->getClassByFQSEN($original_fqsen);
+        // Don't hydrate yet, though, because the referenced class could itself
+        // inherit from an alias, and not all of the aliases are loaded yet.
+        $class = $this->getClassByFQSENWithoutHydrating($original_fqsen);
         foreach ($alias_set as $alias_record) {
             if (!($alias_record instanceof ClassAliasRecord)) {
                 throw new AssertionError("Expected instances of ClassAliasRecord in alias_set");
@@ -939,7 +941,7 @@ class CodeBase
             // Don't do anything if there is a real class, or if an earlier class_alias created an alias.
             if ($this->hasClassWithFQSEN($alias_fqsen)) {
                 // Emit a different issue type to make filtering out false positives easier.
-                $clazz = $this->getClassByFQSEN($alias_fqsen);
+                $clazz = $this->getClassByFQSENWithoutHydrating($alias_fqsen);
                 Issue::maybeEmit(
                     $this,
                     $alias_record->context,


### PR DESCRIPTION
When analysing using `enable_class_alias_support`, it is possible to
have two aliases which refer to each other:
```
class_alias(A::class, 'OldA');
class B extends OldA { ... }
class C extends B { ... }
class_alias(C::class, 'OldC');
```
If phan processes the OldC => C alias first, it would hydrate C and
then B in the process.  But when hydrating B, the OldA => A alias isn't
loaded yet, so any properties or methods defined in A won't be loaded
into B or C.

The solution is simply to defer hydrating classes until after all of
the aliases have been processed.  This ensures that when C and B are
eventually hydrated, the 'OldA => A' alias is known.

This was https://phabricator.wikimedia.org/T389698 in the MediaWiki
issue tracker.
