### PR TITLE
PhanCompatibleTrueType always triggers, even when minimum PHP version is greater than PHP8.2

### DIFF
--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -3234,11 +3234,13 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 );
             }
         } elseif ($inner_type->flags === ast\flags\TYPE_TRUE) {
-            $this->emitIssue(
-                Issue::CompatibleTrueType,
-                $inner_type->lineno,
-                'true'
-            );
+            if ($minimum_target_php_version_id < 82000) {
+                $this->emitIssue(
+                    Issue::CompatibleTrueType,
+                    $inner_type->lineno,
+                    'true'
+                );
+            }
         } elseif (!$is_union && \in_array($inner_type->flags, [ast\flags\TYPE_NULL, ast\flags\TYPE_FALSE], true)) {
             $this->emitIssue(
                 Issue::CompatibleStandaloneType,

--- a/src/Phan/Config/Initializer.php
+++ b/src/Phan/Config/Initializer.php
@@ -445,8 +445,10 @@ EOT;
             $version_guess = '7.4';
         } elseif ($version_constraint->matches(self::parseConstraintsForRange('<8.1-dev'))) {
             $version_guess = '8.0';
-        } elseif ($version_constraint->matches(self::parseConstraintsForRange('>=8.1-dev'))) {
+        } elseif ($version_constraint->matches(self::parseConstraintsForRange('<8.2-dev'))) {
             $version_guess = '8.1';
+        } elseif ($version_constraint->matches(self::parseConstraintsForRange('>=8.2-dev'))) {
+            $version_guess = '8.2';
         } else {
             return [null, ['TODO: Choose a target_php_version for this project, or leave as null and remove this comment']];
         }


### PR DESCRIPTION
When using the `true` return type introduced in PHP8.2, phan will always return the `PhanCompatibleTrueType Cannot use true as a type before php 8.2.` warning (regardless of target or minimum PHP version in `phan` config or `composer.json`). This can be resolved by suppressing this issue type, however this isn't possible if you have a single phan configuration file shared across multiple projects (where some projects might run PHP8.1 or lower).

This PR introduces two changes:
1. Updates the check with the same `if` used in the `CompatibleStaticType` to see if the minimum target PHP version is greater than or equal PHP8.2
2 .Extends the PHP versions detected in `determineTargetPHPVersion` to stop at PHP8.2 instead of PHP8.1, so if you have `>=8.2` (or `>= 8.3` / `>= 8.4`) set in `composer.json`, the minimum version is picked up without needing to set `minimum_target_php_version`. (if you would like me to extend the change to detect a minimum version of PHP8.3 or PHP8.4 just let me know).

No tests are provided for change 1, as the existing test currently only tests for PHP7 versions. Currently no tests are provided for change 2, as I don't know how to set up the test infrastructure to pass configuration options. If you would like me to write tests for either change (and can point me towards an example test for change 2) then I am happy to update the PR.