### PR TITLE
Fix serialize_precision for unit tests

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -20,6 +20,7 @@
         <env name="PHAN_DISABLE_COLOR_OUTPUT" value="" force="true" />
         <env name="PHAN_DISABLE_PROGRESS_BAR" value="1" force="true" />
         <env name="PHAN_COLOR_SCHEME" value="" force="true" />
+        <ini name="serialize_precision" value="-1"/>
     </php>
 
     <testsuites>


### PR DESCRIPTION
Without this change output in tests looks like
```
./tests/files/src/0263_alias_outside_phpdoc.php:7 PhanTypeMismatchArgumentReal Argument 5 ($e) is 3.140000000000000124344978758017532527446746826171875 of type 3.140000000000000124344978758017532527446746826171875 but \foo263() takes \double defined at ./tests/files/src/0263_alias_outside_phpdoc.php:4
```
instead of
```
./tests/files/src/0263_alias_outside_phpdoc.php:7 PhanTypeMismatchArgumentReal Argument 5 ($e) is 3.14 of type 3.14 but \foo263() takes \double defined at ./tests/files/src/0263_alias_outside_phpdoc.php:4
```