### PR TITLE
Skip tolerant parser tests with exit call

### DIFF
--- a/tests/Phan/AST/TolerantASTConverter/ConversionTest.php
+++ b/tests/Phan/AST/TolerantASTConverter/ConversionTest.php
@@ -219,6 +219,17 @@ final class ConversionTest extends BaseTest
         if (\PHP_VERSION_ID >= 80000 && \basename($file_name) === 'use_simple.php') {
             $this->markTestIncomplete('php-ast cannot parse php8.0 syntax when running in php7.4 or older');
         }
+        if (\PHP_VERSION_ID >= 80400) {
+            $tests_to_skip = [
+                'misc/fallback_ast_src/exit.php',
+                'misc/fallback_ast_src/php-src_tests/bug60634_error_3.php',
+            ];
+            foreach ($tests_to_skip as $test_to_skip) {
+                if (str_ends_with($file_name, $test_to_skip)) {
+                    $this->markTestIncomplete('exit was changed to function since php8.4, and microsoft/tolerant-php-parser (fallback) cannot parse it correctly yet');
+                }
+            }
+        }
         $contents = \file_get_contents($file_name);
         if ($contents === false) {
             $this->fail("Failed to read $file_name");


### PR DESCRIPTION
Since 8.4.0 [exit is a proper function](https://www.php.net/manual/en/function.exit.php#refsect1-function.exit-changelog). While [microsoft/tolerant-php-parser](https://github.com/microsoft/tolerant-php-parser) still parses it into statement.  It cases failure for tests that are comparing results of `php-ast` (primary parser) with `microsoft/tolerant-php-parser` (fallback parser) and include `exit` function call:
- https://github.com/phan/phan/blob/v5/tests/misc/fallback_ast_src/exit.php#L3
- https://github.com/phan/phan/blob/v5/tests/misc/fallback_ast_src/php-src_tests/bug60634_error_3.php#L11

There are no simple ways to update https://github.com/microsoft/tolerant-php-parser, so this PR skips the failed tests. And it can be reverted once `microsoft/tolerant-php-parser` is fixed.