### PR TITLE
Fix failed tests caused by https://github.com/nikic/php-ast/issues/247

### DIFF
--- a/tests/misc/fallback_ast_src/php80_or_newer/030_attributes.php
+++ b/tests/misc/fallback_ast_src/php80_or_newer/030_attributes.php
@@ -26,8 +26,7 @@ echo X::test();
 $cb = #[MyAttribute()]
     fn(
         #[namespace\MyAttribute(MISSING_CONSTANT)]
-        int $x
-    ) => $x * 2 + 1;
+        int $x) => $x * 2 + 1;
 $cb2 = #[MyAttribute(),]
     fn() => 2;
 $cb(1);

--- a/tests/misc/fallback_ast_src/php80_or_newer/031_attributes_invalid.php
+++ b/tests/misc/fallback_ast_src/php80_or_newer/031_attributes_invalid.php
@@ -2,8 +2,7 @@
 #[MissingAttribute]
 function test31(
     #[MissingAttribute2, MissingAttribute3()]
-    int $argument
-) {
+    int $argument) {
     var_export($argument);
 }
 


### PR DESCRIPTION
In php8.4 there is a bug with getting line number where the argument is defined using `php-ast`: https://github.com/nikic/php-ast/issues/247.

This PR adjusts existing tests to not be affected by that issue. And maybe this PR should be reverted once https://github.com/nikic/php-ast/issues/247 is resolved.