### PR TITLE
Fix array syntax with curly braces unit tests for php 8.4

### DIFF
--- a/tests/Phan/AST/TolerantASTConverter/ErrorTolerantConversionTest.php
+++ b/tests/Phan/AST/TolerantASTConverter/ErrorTolerantConversionTest.php
@@ -346,7 +346,7 @@ EOT;
         $this->runTestFallbackFromParser($incomplete_contents, $valid_contents);
     }
 
-    public function testIncompleteMethodCallBeforeIfWithPlaceholders(): void
+    public function testIncompleteMethodCallBeforeIfWithPlaceholdersPre840(): void
     {
         $incomplete_contents = <<<'EOT'
 <?php
@@ -369,10 +369,41 @@ $obj->
 if (true);
 echo "example";
 EOT;
+
+        if (\PHP_VERSION_ID >= 80400) {
+            $this->markTestIncomplete('Since PHP 8.4, array syntax with curly braces are not valid anymore');
+        }
         $this->runTestFallbackFromParser($incomplete_contents, $valid_contents, true);
     }
 
-    public function testIncompleteMethodCallBeforeIfWithoutPlaceholders(): void
+    public function testIncompleteMethodCallBeforeIfWithPlaceholders(): void
+    {
+        $incomplete_contents = <<<'EOT'
+<?php
+$obj->
+if (true) [
+    $y
+]
+$obj->
+if (true) {
+    echo "example";
+}
+EOT;
+        $valid_contents = <<<'EOT'
+<?php
+$obj->
+if (true)[
+    $y
+];
+$obj->
+if (true);
+echo "example";
+EOT;
+
+        $this->runTestFallbackFromParser($incomplete_contents, $valid_contents, true);
+    }
+
+    public function testIncompleteMethodCallBeforeIfWithoutPlaceholdersPre840(): void
     {
         $incomplete_contents = <<<'EOT'
 <?php
@@ -395,6 +426,36 @@ $obj->
 if (true);
 echo "example";
 EOT;
+        if (\PHP_VERSION_ID >= 80400) {
+            $this->markTestIncomplete('Since PHP 8.4, array syntax with curly braces are not valid anymore');
+        }
+        $this->runTestFallbackFromParser($incomplete_contents, $valid_contents, false);
+    }
+
+    public function testIncompleteMethodCallBeforeIfWithoutPlaceholders(): void
+    {
+        $incomplete_contents = <<<'EOT'
+<?php
+$obj->
+if (true) [
+    foo();
+]
+$obj->
+if (true) {
+    echo "example";
+}
+EOT;
+        $valid_contents = <<<'EOT'
+<?php
+$obj->
+if (true) [
+    foo()
+];
+$obj->
+if (true);
+echo "example";
+EOT;
+
         $this->runTestFallbackFromParser($incomplete_contents, $valid_contents, false);
     }
 


### PR DESCRIPTION
The following code [works differently](https://php-errors.readthedocs.io/en/latest/messages/syntax-error%2C-unexpected-token-%22%7B%22.html) post/pre 8.4:
```php
<?php
$obj->
if (true){
    foo()
};
```

Before 8.4, the code is parsed and fatal error is returned:
```
Fatal error: Array and string offset access syntax with curly braces is no longer supported
```

After 8.4 parse error is triggered:
```
Parse error: syntax error, unexpected token "{"
```

