### PR TITLE
Use explicit csv escape

### DIFF
--- a/src/Phan/Output/Printer/CSVPrinter.php
+++ b/src/Phan/Output/Printer/CSVPrinter.php
@@ -32,7 +32,7 @@ final class CSVPrinter implements BufferedPrinterInterface
             Issue::getNameForCategory($instance->getIssue()->getCategory()),
             $instance->getIssue()->getType(),
             $instance->getMessageAndMaybeSuggestion(),
-        ]);
+        ], ",", '"', "\\");
     }
 
     /** flush printer buffer */
@@ -66,6 +66,6 @@ final class CSVPrinter implements BufferedPrinterInterface
         \fputcsv($this->stream, [
             "filename", "line", "severity_ord", "severity_name",
             "category", "check_name", "message"
-        ]);
+        ], ",", '"', "\\");
     }
 }

--- a/tests/Phan/Output/Printer/CSVPrinterTest.php
+++ b/tests/Phan/Output/Printer/CSVPrinterTest.php
@@ -25,7 +25,7 @@ final class CSVPrinterTest extends BaseTest
         $printer->print(new IssueInstance(Issue::fromType(Issue::SyntaxError), 'test.php', 0, ["foo"]));
         $printer->flush();
 
-        $lines = \array_map(function($line) {
+        $lines = \array_map(static function($line) {
             return str_getcsv($line, ",", '"', "\\");
         }, \explode("\n", $output->fetch()));
         // str_getcsv() returns [0 => null] if passed the empty string.

--- a/tests/Phan/Output/Printer/CSVPrinterTest.php
+++ b/tests/Phan/Output/Printer/CSVPrinterTest.php
@@ -25,7 +25,9 @@ final class CSVPrinterTest extends BaseTest
         $printer->print(new IssueInstance(Issue::fromType(Issue::SyntaxError), 'test.php', 0, ["foo"]));
         $printer->flush();
 
-        $lines = \array_map("str_getcsv", \explode("\n", $output->fetch()));
+        $lines = \array_map(function($line) {
+            return str_getcsv($line, ",", '"', "\\");
+        }, \explode("\n", $output->fetch()));
         // str_getcsv() returns [0 => null] if passed the empty string.
         // @phan-suppress-next-line PhanPartialTypeMismatchArgumentInternal
         $fields = \array_combine($lines[0], $lines[1]);

--- a/tests/Phan/Output/Printer/CSVPrinterTest.php
+++ b/tests/Phan/Output/Printer/CSVPrinterTest.php
@@ -27,7 +27,7 @@ final class CSVPrinterTest extends BaseTest
 
         $lines = \array_map(
             /**
-             * @return string[]
+             * @return array<int,null>|array<int,string>
              */
             static function(string $line): array {
                 return str_getcsv($line, ",", '"', "\\");

--- a/tests/Phan/Output/Printer/CSVPrinterTest.php
+++ b/tests/Phan/Output/Printer/CSVPrinterTest.php
@@ -25,7 +25,7 @@ final class CSVPrinterTest extends BaseTest
         $printer->print(new IssueInstance(Issue::fromType(Issue::SyntaxError), 'test.php', 0, ["foo"]));
         $printer->flush();
 
-        $lines = \array_map(static function($line) {
+        $lines = \array_map(static function(string $line): array {
             return str_getcsv($line, ",", '"', "\\");
         }, \explode("\n", $output->fetch()));
         // str_getcsv() returns [0 => null] if passed the empty string.

--- a/tests/Phan/Output/Printer/CSVPrinterTest.php
+++ b/tests/Phan/Output/Printer/CSVPrinterTest.php
@@ -25,9 +25,15 @@ final class CSVPrinterTest extends BaseTest
         $printer->print(new IssueInstance(Issue::fromType(Issue::SyntaxError), 'test.php', 0, ["foo"]));
         $printer->flush();
 
-        $lines = \array_map(static function(string $line): array {
-            return str_getcsv($line, ",", '"', "\\");
-        }, \explode("\n", $output->fetch()));
+        $lines = \array_map(
+            /**
+             * @return string[]
+             */
+            static function(string $line): array {
+                return str_getcsv($line, ",", '"', "\\");
+            },
+            \explode("\n", $output->fetch())
+        );
         // str_getcsv() returns [0 => null] if passed the empty string.
         // @phan-suppress-next-line PhanPartialTypeMismatchArgumentInternal
         $fields = \array_combine($lines[0], $lines[1]);


### PR DESCRIPTION
Since 8.4 [$escape parameter must be provided](https://php.watch/versions/8.4/csv-functions-escape-parameter) for CSV functions. Avoided named parameters to make it compatible with old versions.