### PR TITLE
Ignore tests depending on enabled PHP extensions

### DIFF
--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -2829,9 +2829,8 @@ EOB
      */
     public function restartWithoutProblematicExtensions(): void
     {
-        $extensions_to_disable = [];
-        if (self::shouldRestartToExclude('xdebug')) {
-            $extensions_to_disable[] = 'xdebug';
+        $extensions_to_disable = self::extensionsToDisable();
+        if (in_array('xdebug', $extensions_to_disable)) {
             // Restart if Xdebug is loaded, unless the environment variable PHAN_ALLOW_XDEBUG is set.
             if (!getenv('PHAN_DISABLE_XDEBUG_WARN')) {
                 fwrite(STDERR, <<<EOT
@@ -2844,11 +2843,10 @@ EOT
                 );
             }
         }
-        if (self::shouldRestartToExclude('uopz')) {
+        if (in_array('uopz', $extensions_to_disable)) {
             // NOTE: uopz seems to cause instability when used and switched from enabled to disabled.
             //
             // TODO create and link to stubs if https://github.com/krakjoe/uopz/issues/123 is completed.
-            $extensions_to_disable[] = 'uopz';
             fwrite(
                 STDERR,
                 <<<EOT
@@ -2859,9 +2857,8 @@ EOT
 EOT
             );
         }
-        if (self::shouldRestartToExclude('grpc') && self::willUseMultipleProcesses()) {
+        if (in_array('grpc', $extensions_to_disable)) {
             // This still hangs when phan runs with --processes 2, even in 1.22.0
-            $extensions_to_disable[] = 'grpc';
             fwrite(
                 STDERR,
                 "[info] grpc can cause php to hang when Phan is run with options that require forking." . PHP_EOL .
@@ -2881,6 +2878,24 @@ EOT
             // Automatically restart if problematic extensions are loaded
             $ini_handler->check();
         }
+    }
+
+    public static function extensionsToDisable(): array
+    {
+        $extensions_to_disable = [];
+        if (self::shouldRestartToExclude('xdebug')) {
+            $extensions_to_disable[] = 'xdebug';
+        }
+
+        if (self::shouldRestartToExclude('uopz')) {
+            $extensions_to_disable[] = 'uopz';
+        }
+
+        if (self::shouldRestartToExclude('grpc') && self::willUseMultipleProcesses()) {
+            $extensions_to_disable[] = 'grpc';
+        }
+
+        return $extensions_to_disable;
     }
 
     private static function shouldRestartToExclude(string $extension): bool

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -2830,7 +2830,7 @@ EOB
     public function restartWithoutProblematicExtensions(): void
     {
         $extensions_to_disable = self::extensionsToDisable();
-        if (in_array('xdebug', $extensions_to_disable)) {
+        if (in_array('xdebug', $extensions_to_disable, true)) {
             // Restart if Xdebug is loaded, unless the environment variable PHAN_ALLOW_XDEBUG is set.
             if (!getenv('PHAN_DISABLE_XDEBUG_WARN')) {
                 fwrite(STDERR, <<<EOT
@@ -2843,7 +2843,7 @@ EOT
                 );
             }
         }
-        if (in_array('uopz', $extensions_to_disable)) {
+        if (in_array('uopz', $extensions_to_disable, true)) {
             // NOTE: uopz seems to cause instability when used and switched from enabled to disabled.
             //
             // TODO create and link to stubs if https://github.com/krakjoe/uopz/issues/123 is completed.
@@ -2857,7 +2857,7 @@ EOT
 EOT
             );
         }
-        if (in_array('grpc', $extensions_to_disable)) {
+        if (in_array('grpc', $extensions_to_disable, true)) {
             // This still hangs when phan runs with --processes 2, even in 1.22.0
             fwrite(
                 STDERR,
@@ -2880,6 +2880,9 @@ EOT
         }
     }
 
+    /**
+     * @return string[] List of PHP extensions to disable
+     */
     public static function extensionsToDisable(): array
     {
         $extensions_to_disable = [];

--- a/tests/Phan/CLITest.php
+++ b/tests/Phan/CLITest.php
@@ -80,6 +80,11 @@ final class CLITest extends BaseTest
      */
     public function testSetsConfigOptions(array $expected_changed_options, array $opts, array $extra = []): void
     {
+        $extensions_to_disable = CLI::extensionsToDisable();
+        if (count($extensions_to_disable) > 0) {
+            $this->markTestIncomplete('PHP extension(s) has to be disabled in order for this test to run: ' . implode(', ', $extensions_to_disable));
+        }
+
         $opts += ['project-root-directory' => \dirname(__DIR__) . '/misc/config/'];
         $expected_changed_options += [
             '__directory_regex' => '@^(\./)*(src)([/\\\\]|$)@',

--- a/tests/Phan/ForkPoolTest.php
+++ b/tests/Phan/ForkPoolTest.php
@@ -20,6 +20,8 @@ final class ForkPoolTest extends BaseTest
      */
     public function testBasicForkJoin(): void
     {
+        $this->isIgnored();
+
         $data = [
             [1, 2, 3, 4],
             [5, 6, 7, 8],
@@ -67,6 +69,8 @@ final class ForkPoolTest extends BaseTest
      */
     public function testStartupFunction(): void
     {
+        $this->isIgnored();
+
         $did_startup = false;
         $pool = new ForkPool(
             [[1], [2], [3], [4]],
@@ -91,5 +95,12 @@ final class ForkPoolTest extends BaseTest
             [true, true, true, true],
             $pool->wait()
         );
+    }
+
+    private function isIgnored(): void
+    {
+        if (\extension_loaded('grpc')) {
+            $this->markTestIncomplete('Ignoring becasue grpc PHP extension is enabled');
+        }
     }
 }


### PR DESCRIPTION
Make it possible to run tests without disabling PHP extensions in questions (`xdebug`, `uopz` and `grpc`).