### PR TITLE
Cast PHP constants to boolean

### DIFF
--- a/src/Phan/Bootstrap.php
+++ b/src/Phan/Bootstrap.php
@@ -72,7 +72,7 @@ function phan_output_ast_installation_instructions(): void
                 $version,
                 $version,
                 PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION,
-                PHP_ZTS ? 'ts' : 'nts',
+                (bool) PHP_ZTS ? 'ts' : 'nts',
                 PHP_VERSION_ID >= 80000 ? 'vs16' : 'vc15',
                 PHP_INT_SIZE == 4 ? 'x86' : 'x64'
             );

--- a/src/Phan/Phan.php
+++ b/src/Phan/Phan.php
@@ -800,7 +800,7 @@ class Phan implements IgnoredFilesFilterInterface
         }
         $warned = false;
         // Unless debugging Phan itself, these two configurations are unnecessarily adding slowness.
-        if (PHP_DEBUG) {
+        if ((bool) PHP_DEBUG) {
             CLI::printHelpSection("WARNING: Phan is around twice as slow when php is compiled with --enable-debug (That option is only needed when debugging Phan itself).\n", false, true);
             $warned = true;
         }


### PR DESCRIPTION
Both [PHP_ZTS](https://www.php.net/manual/en/reserved.constants.php#constant.php-zts) and [PHP_DEBUG](https://www.php.net/manual/en/reserved.constants.php#constant.php-debug) are booleans.