### PR TITLE
Enable php extensions in CI that are enabled in many prod envs

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -6,6 +6,31 @@ RUN curl https://getcomposer.org/download/latest-2.x/composer.phar -o /usr/bin/c
 WORKDIR /phan
 RUN apt-get update && apt-get install -y unzip parallel colordiff sqlite3 && apt-get clean
 
+# intl
+RUN apt-get install -y zlib1g-dev libicu-dev g++ \
+    && docker-php-ext-configure intl \
+    && docker-php-ext-install intl
+
+# ldap
+RUN apt-get install -y libldap2-dev \
+    && docker-php-ext-configure ldap \
+    && docker-php-ext-install ldap
+
+# zip
+RUN apt-get install -y libzip-dev  zip \
+    # docker-php-ext-configure zip --with-libzip is required only for < 7.3
+    && if [[ $PHP_VERSION == 7.2* ]] ; then \
+       docker-php-ext-configure zip --with-libzip; \
+    fi && docker-php-ext-install zip
+
+# pgsql
+RUN apt-get install -y libpq-dev \
+    && docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
+    && docker-php-ext-install pgsql
+
+# sockets
+RUN docker-php-ext-install sockets
+
 ADD composer.json composer.lock ./
 RUN composer.phar install && composer.phar clear-cache
 


### PR DESCRIPTION
In order to make CI env closer to most production envs, the following PHP extensions are enabled: intl, ldap, zip, pgsql and sockets
