### PR TITLE
Consistently disable the garbage collector in Bootstrap.php

### DIFF
--- a/src/Phan/Bootstrap.php
+++ b/src/Phan/Bootstrap.php
@@ -13,6 +13,11 @@ use Phan\CodeBase;
 use Phan\Config;
 use Phan\Library\StringUtil;
 
+// Phan does a ton of GC and this offers a major speed
+// improvement if your system can handle it (which it
+// should be able to)
+gc_disable();
+
 // Listen for all errors
 error_reporting(E_ALL);
 

--- a/src/phan.php
+++ b/src/phan.php
@@ -2,11 +2,6 @@
 
 declare(strict_types=1);
 
-// Phan does a ton of GC and this offers a major speed
-// improvement if your system can handle it (which it
-// should be able to)
-gc_disable();
-
 // Check the environment to make sure Phan can run successfully
 require_once(__DIR__ . '/requirements.php');
 

--- a/src/prep.php
+++ b/src/prep.php
@@ -2,11 +2,6 @@
 
 declare(strict_types=1);
 
-// Phan does a ton of GC and this offers a major speed
-// improvement if your system can handle it (which it
-// should be able to)
-gc_disable();
-
 // Check the environment to make sure Phan can run successfully
 // @phan-file-suppress PhanPluginRemoveDebugEcho
 require_once __DIR__ . '/requirements.php';


### PR DESCRIPTION
The garbage collector should always be off when running phan, to avoid major performance degradation. This was already the case when running phan "normally" (via phan.php), but not for other invocations using other entry points. The main example of this are tests, which would thus run with the GC enabled. By moving the `gc_disable` call to Bootstrap.php, we make sure that it is applied regardless of the entry point.

Locally, the performance gains aren't huge: using PHP 8.3, `vendor/bin/phpunit` went from 46s to 40s; and `run_all_tests_dockerized 8.3` from 40s to 34s (some tests are run in parallel). Still, there may be instances where the impact becomes more noticeable, as seen in the downstream bug report https://phabricator.wikimedia.org/T377044#10873882.