### PR TITLE
Make PHPDocRedundantPlugin handle magic methods

### DIFF
--- a/.phan/plugins/PHPDocRedundantPlugin.php
+++ b/.phan/plugins/PHPDocRedundantPlugin.php
@@ -45,7 +45,7 @@ class PHPDocRedundantPlugin extends PluginV3 implements
 
     public function analyzeMethod(CodeBase $code_base, Method $method): void
     {
-        if ($method->isMagic() || $method->isPHPInternal()) {
+        if ($method->isPHPInternal()) {
             return;
         }
         if ($method->getFQSEN() !== $method->getDefiningFQSEN()) {

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -5938,7 +5938,6 @@ class Issue
 
     /**
      * @param list<mixed> $template_parameters
-     * @return IssueInstance
      */
     public function __invoke(
         string $file,

--- a/src/Phan/Language/FileRef.php
+++ b/src/Phan/Language/FileRef.php
@@ -179,8 +179,6 @@ class FileRef implements \Serializable
 
     /**
      * Get a string representation of the context
-     *
-     * @return string
      */
     public function __toString(): string
     {

--- a/src/Phan/LanguageServer/Protocol/CompletionItem.php
+++ b/src/Phan/LanguageServer/Protocol/CompletionItem.php
@@ -68,15 +68,6 @@ class CompletionItem
      */
     public $insertText;
 
-    /**
-     * @param string|null     $label
-     * @param int|null        $kind
-     * @param string|null     $detail
-     * @param string|null     $documentation
-     * @param string|null     $sortText
-     * @param string|null     $filterText
-     * @param string|null     $insertText
-     */
     public function __construct(
         ?string $label = null,
         ?int $kind = null,

--- a/src/Phan/LanguageServer/Protocol/FileEvent.php
+++ b/src/Phan/LanguageServer/Protocol/FileEvent.php
@@ -27,10 +27,6 @@ class FileEvent
      */
     public $type;
 
-    /**
-     * @param string $uri
-     * @param int $type
-     */
     public function __construct(string $uri, int $type)
     {
         $this->uri = $uri;

--- a/src/Phan/LanguageServer/Protocol/InitializeResult.php
+++ b/src/Phan/LanguageServer/Protocol/InitializeResult.php
@@ -18,9 +18,6 @@ class InitializeResult
      */
     public $capabilities;
 
-    /**
-     * @param ?ServerCapabilities $capabilities
-     */
     public function __construct(?ServerCapabilities $capabilities = null)
     {
         $this->capabilities = $capabilities ?? new ServerCapabilities();

--- a/src/Phan/LanguageServer/Server/TextDocument.php
+++ b/src/Phan/LanguageServer/Server/TextDocument.php
@@ -46,10 +46,6 @@ class TextDocument
      */
     protected $file_mapping;
 
-    /**
-     * @param LanguageClient $client
-     * @param FileMapping $file_mapping
-     */
     public function __construct(
         LanguageClient $client,
         LanguageServer $server,

--- a/tests/fixer_test/expected/006_redundant_comment.php.expected
+++ b/tests/fixer_test/expected/006_redundant_comment.php.expected
@@ -1,3 +1,4 @@
 src_copy/006_redundant_comment.php:8 PhanPluginRedundantFunctionComment Redundant doc comment on function returns_int(). Either add a description or remove the comment: '/** @return int */'
 src_copy/006_redundant_comment.php:18 PhanPluginRedundantClosureComment Redundant doc comment on closure Closure(int $input) : int. Either add a description or remove the comment: "/**\n * @param int \$input\n * @return int\n */"
-src_copy/006_redundant_comment.php:27 PhanPluginRedundantMethodComment Redundant doc comment on method f(). Either add a description or remove the comment: "/**\n     *\n     */"
+src_copy/006_redundant_comment.php:29 PhanPluginRedundantMethodComment Redundant doc comment on method __construct(). Either add a description or remove the comment: "/**\n     * @param int \$a\n     * @param string \$b\n     * @param bool|null \$c\n     */"
+src_copy/006_redundant_comment.php:35 PhanPluginRedundantMethodComment Redundant doc comment on method f(). Either add a description or remove the comment: "/**\n     *\n     */"

--- a/tests/fixer_test/expected_src/006_redundant_comment.php
+++ b/tests/fixer_test/expected_src/006_redundant_comment.php
@@ -16,6 +16,9 @@ $doubles_input =
 var_export($doubles_input(21));
 
 class C {
+    public function __construct( int $a, string $b, ?bool $c ) {
+        echo $c ? $a : $b;
+    }
     public static function f($value) : void {
         var_export($value);
     }

--- a/tests/fixer_test/src/006_redundant_comment.php
+++ b/tests/fixer_test/src/006_redundant_comment.php
@@ -22,6 +22,14 @@ var_export($doubles_input(21));
 
 class C {
     /**
+     * @param int $a
+     * @param string $b
+     * @param bool|null $c
+     */
+    public function __construct( int $a, string $b, ?bool $c ) {
+        echo $c ? $a : $b;
+    }
+    /**
      *
      */
     public static function f($value) : void {


### PR DESCRIPTION
The plugin skips all magic methods ever since its creation (04213ee8092ed73e947d7adbd0af50e3086afda4), but this isn't documented either in the code, the commit message, or a README file. It seems to me that the restriction can be lifted. This would be especially useful for constructors, where long parameter lists (leading to potentially longer redundant doc comments) aren't uncommon.