### PR TITLE
Properly handle variadic parameters in UnknownElementTypePlugin

### DIFF
--- a/.phan/plugins/UnknownElementTypePlugin.php
+++ b/.phan/plugins/UnknownElementTypePlugin.php
@@ -77,6 +77,7 @@ class UnknownElementTypePlugin extends PluginV3 implements
         $warning_closures = [];
         $inferred_types = [];
         foreach ($method->getParameterList() as $i => $parameter) {
+            $parameter = $parameter->asNonVariadic();
             if ($parameter->getUnionType()->isEmpty()) {
                 $warning_closures[$i] = static function () use ($code_base, $parameter, $method, $i, &$inferred_types): void {
                     $suggestion = self::suggestionFromUnionType($inferred_types[$i] ?? null);
@@ -282,6 +283,7 @@ class UnknownElementTypePlugin extends PluginV3 implements
         $warning_closures = [];
         $inferred_types = [];
         foreach ($function->getParameterList() as $i => $parameter) {
+            $parameter = $parameter->asNonVariadic();
             if ($parameter->getUnionType()->isEmpty()) {
                 if ($function->getFQSEN()->isClosure()) {
                     $issue = 'PhanPluginUnknownClosureParamType';

--- a/src/Phan/Language/Type/IntersectionType.php
+++ b/src/Phan/Language/Type/IntersectionType.php
@@ -722,7 +722,7 @@ final class IntersectionType extends Type
     }
 
     /**
-     * @suppress PhanPluginUnknownArrayMethodParamType
+     * @param mixed ...$args
      * @no-named-arguments
      */
     private function allTypePartsMatchMethodWithArgs(string $method_name, ...$args): bool

--- a/tests/php80_files/expected/029_named_variadic.php.expected
+++ b/tests/php80_files/expected/029_named_variadic.php.expected
@@ -1,3 +1,3 @@
-%s:2 PhanPluginUnknownArrayFunctionParamType Function named() has a parameter type of array for $args, but does not specify any key types or value types
+%s:2 PhanPluginUnknownFunctionParamType Function named() has no declared or inferred parameter type for $args
 %s:5 PhanCompatibleNamedArgument Cannot use named arguments before php 8.0 in argument (args: [2])
 %s:5 PhanSuspiciousNamedArgumentForVariadic Passing named argument to a variadic parameter $args of the same name in a call to \named(...$args). This will set the array offset "args" of the resulting variadic parameter, not the parameter itself (suppress this if this is deliberate).

--- a/tests/php80_files/expected/032_variadic_promoted_property.php.expected
+++ b/tests/php80_files/expected/032_variadic_promoted_property.php.expected
@@ -2,7 +2,7 @@
 %s:3 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for public ...$rest of \VariadicPromotedProperty::__construct(int $value, ...$rest)
 %s:3 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for public int $value of \VariadicPromotedProperty::__construct(int $value, ...$rest)
 %s:3 PhanInvalidNode Cannot declare variadic promoted property
-%s:3 PhanPluginUnknownArrayMethodParamType Method \VariadicPromotedProperty::__construct has a parameter type of array for $rest, but does not specify any key types or value types
+%s:3 PhanPluginUnknownMethodParamType Method \VariadicPromotedProperty::__construct has no declared or inferred parameter type for $rest
 %s:3 PhanWriteOnlyPublicProperty Possibly zero read references to public property \VariadicPromotedProperty->value
 %s:6 PhanEmptyPublicMethod Empty public method \VariadicPromotedProperty::other()
 %s:6 PhanInvalidNode Cannot use constructor property promotion modifier on parameter public int $foo of non-constructor \VariadicPromotedProperty::other(int $foo)

--- a/tests/php80_files/expected/050_unknown_type_variadic_mixed.php.expected
+++ b/tests/php80_files/expected/050_unknown_type_variadic_mixed.php.expected
@@ -1,0 +1,5 @@
+%s:19 PhanPluginUnknownArrayFunctionParamType Function testTruePositive1() has a parameter type of array for $foo, but does not specify any key types or value types
+%s:30 PhanPluginUnknownFunctionParamType Function testTruePositive2() has no declared or inferred parameter type for $foo
+%s:50 PhanPluginUnknownArrayMethodParamType Method \NS50\TestWithMethods::testTruePositive1 has a parameter type of array for $foo, but does not specify any key types or value types
+%s:61 PhanPluginUnknownMethodParamType Method \NS50\TestWithMethods::testTruePositive2 has no declared or inferred parameter type for $foo
+

--- a/tests/php80_files/src/050_unknown_type_variadic_mixed.php
+++ b/tests/php80_files/src/050_unknown_type_variadic_mixed.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace NS50;
+
+// Test unknown type detection for variadic parameters with `mixed` type.
+// @phan-file-suppress PhanUnreferencedFunction,PhanUnreferencedClass,PhanUnreferencedPublicMethod
+
+function testFunctionWithTypeDeclaration( mixed ...$foo ): void {
+    echo implode( ',', $foo );
+}
+
+/**
+ * @param mixed ...$foo
+ */
+function testFunctionWithDocComment( ...$foo ): void {
+    echo implode( ',', $foo );
+}
+
+function testTruePositive1( array ...$foo ): void {
+    echo implode( ',', $foo[0] );
+}
+
+/**
+ * @param string[] ...$foo
+ */
+function testTruePositive1__correct( array ...$foo ): void {
+    echo implode( ',', $foo[0] );
+}
+
+function testTruePositive2( ...$foo ): void {
+    echo implode( ',', $foo);
+}
+
+function testTruePositive2__correct( string ...$foo ): void {
+    echo implode( ',', $foo);
+}
+
+class TestWithMethods {
+    public function testWithTypeDeclaration( mixed ...$foo ): void {
+        echo implode( ',', $foo );
+    }
+
+    /**
+     * @param mixed ...$foo
+     */
+    public function testWithDocComment( ...$foo ): void {
+        echo implode( ',', $foo );
+    }
+
+    public function testTruePositive1( array ...$foo ): void {
+        echo implode( ',', $foo[0] );
+    }
+
+    /**
+     * @param string[] ...$foo
+     */
+    public function testTruePositive1__correct( array ...$foo ): void {
+        echo implode( ',', $foo[0] );
+    }
+
+    public function testTruePositive2( ...$foo ): void {
+        echo implode( ',', $foo);
+    }
+
+    public function testTruePositive2__correct( string ...$foo ): void {
+        echo implode( ',', $foo);
+    }
+}


### PR DESCRIPTION
Analyze the parameter as non variadic, so that we use the union type of its elements, rather than the overall array type.

Fixes #4927