### PR TITLE
PHP 8.4.9 lineno fix

### DIFF
--- a/tests/files/expected/0005_compat.php.expected
+++ b/tests/files/expected/0005_compat.php.expected
@@ -2,6 +2,6 @@
 %s:16 PhanTypeMismatchDefault Default value for string $c can't be int
 %s:21 PhanTypeMismatchDeclaredParamNullable Doc-block of $categories in fromCategories is phpdoc param type \A which is not a permitted replacement of the nullable param type ?\A declared in the signature ('?T' should be documented as 'T|null' or '?T')
 %s:26 PhanDeprecatedImplicitNullableParam Implicit nullable parameters (\A $categories = null) have been deprecated in PHP 8.4
-%s:26 PhanParamReqAfterOpt Required parameter (\A $context) follows optional (?\A $categories = null)
+%s:%d PhanParamReqAfterOpt Required parameter (\A $context) follows optional (?\A $categories = null)
 %s:35 PhanDeprecatedImplicitNullableParam Implicit nullable parameters (\A $categories = null) have been deprecated in PHP 8.4
-%s:35 PhanParamReqAfterOpt Required parameter (\A $context) follows optional (\A|null $categories = null)
+%s:%d PhanParamReqAfterOpt Required parameter (\A $context) follows optional (\A|null $categories = null)

--- a/tests/files/expected/0005_compat.php.expected84
+++ b/tests/files/expected/0005_compat.php.expected84
@@ -2,6 +2,6 @@
 %s:16 PhanTypeMismatchDefault Default value for string $c can't be int
 %s:21 PhanTypeMismatchDeclaredParamNullable Doc-block of $categories in fromCategories is phpdoc param type \A which is not a permitted replacement of the nullable param type ?\A declared in the signature ('?T' should be documented as 'T|null' or '?T')
 %s:26 PhanDeprecatedImplicitNullableParam Implicit nullable parameters (\A $categories = null) have been deprecated in PHP 8.4
-%s:27 PhanParamReqAfterOpt Required parameter (\A $context) follows optional (?\A $categories = null)
+%s:%d PhanParamReqAfterOpt Required parameter (\A $context) follows optional (?\A $categories = null)
 %s:35 PhanDeprecatedImplicitNullableParam Implicit nullable parameters (\A $categories = null) have been deprecated in PHP 8.4
-%s:36 PhanParamReqAfterOpt Required parameter (\A $context) follows optional (\A|null $categories = null)
+%s:%d PhanParamReqAfterOpt Required parameter (\A $context) follows optional (\A|null $categories = null)

--- a/tests/files/expected/0964_phan_type_alias_inline_string.php.expected
+++ b/tests/files/expected/0964_phan_type_alias_inline_string.php.expected
@@ -2,6 +2,6 @@
 %s:15 PhanTypeMismatchArgument Argument 1 ($data) is ['key'=>'value'] of type array{key:'value'} but \test1() takes array<string,int> defined at %s:12
 %s:19 PhanTypeAliasUsedOutsideComment Saw a type alias ArrayIS used outside of a comment - this will refer to a class name instead of array<int,string>
 %s:19 PhanUndeclaredTypeReturnType Return type of test2() is undeclared type \ArrayIS (Did you mean array)
-%s:20 PhanUndeclaredTypeParameter Parameter $data has undeclared type \ArraySI (Did you mean array)
+%s:%d PhanUndeclaredTypeParameter Parameter $data has undeclared type \ArraySI (Did you mean array)
 %s:22 PhanTypeAliasUsedOutsideComment Saw a type alias ArrayIS used outside of a comment - this will refer to a class name instead of array<int,string>
 %s:22 PhanUndeclaredClassMethod Call to method __construct from undeclared class \ArrayIS

--- a/tests/files/expected/0964_phan_type_alias_inline_string.php.expected84
+++ b/tests/files/expected/0964_phan_type_alias_inline_string.php.expected84
@@ -2,6 +2,6 @@
 %s:15 PhanTypeMismatchArgument Argument 1 ($data) is ['key'=>'value'] of type array{key:'value'} but \test1() takes array<string,int> defined at %s:12
 %s:19 PhanTypeAliasUsedOutsideComment Saw a type alias ArrayIS used outside of a comment - this will refer to a class name instead of array<int,string>
 %s:19 PhanUndeclaredTypeReturnType Return type of test2() is undeclared type \ArrayIS (Did you mean array)
-%s:21 PhanUndeclaredTypeParameter Parameter $data has undeclared type \ArraySI (Did you mean array)
+%s:%d PhanUndeclaredTypeParameter Parameter $data has undeclared type \ArraySI (Did you mean array)
 %s:22 PhanTypeAliasUsedOutsideComment Saw a type alias ArrayIS used outside of a comment - this will refer to a class name instead of array<int,string>
 %s:22 PhanUndeclaredClassMethod Call to method __construct from undeclared class \ArrayIS


### PR DESCRIPTION
PHP 8.4,0-8.4.8 had a line number bug that was fixed in 8.4.9. Ignore the lineno for param-related errors in the 8.4 tests