### PR TITLE
Update PHPDocToRealTypesPlugin for PHP 8

### DIFF
--- a/.phan/plugins/PHPDocToRealTypesPlugin.php
+++ b/.phan/plugins/PHPDocToRealTypesPlugin.php
@@ -3,10 +3,12 @@
 declare(strict_types=1);
 
 use Phan\CodeBase;
+use Phan\Config;
 use Phan\IssueInstance;
 use Phan\Language\Element\Func;
 use Phan\Language\Element\FunctionInterface;
 use Phan\Language\Element\Method;
+use Phan\Language\Type;
 use Phan\Library\FileCacheEntry;
 use Phan\Phan;
 use Phan\Plugin\Internal\IssueFixingPlugin\FileEditSet;
@@ -33,9 +35,11 @@ class PHPDocToRealTypesPlugin extends PluginV3 implements
     private const CanUsePHP71Void = 'PhanPluginCanUsePHP71Void';
     private const CanUseReturnType = 'PhanPluginCanUseReturnType';
     private const CanUseNullableReturnType = 'PhanPluginCanUseNullableReturnType';
+    private const CanUseUnionReturnType = 'PhanPluginCanUseUnionReturnType';
 
     private const CanUseParamType = 'PhanPluginCanUseParamType';
     private const CanUseNullableParamType = 'PhanPluginCanUseNullableParamType';
+    private const CanUseUnionParamType = 'PhanPluginCanUseUnionParamType';
 
     /** @var array<string,Method> */
     private $deferred_analysis_methods = [];
@@ -52,8 +56,10 @@ class PHPDocToRealTypesPlugin extends PluginV3 implements
             self::CanUsePHP71Void => $return_closure,
             self::CanUseReturnType => $return_closure,
             self::CanUseNullableReturnType => $return_closure,
+            self::CanUseUnionReturnType => $return_closure,
             self::CanUseNullableParamType => $param_closure,
             self::CanUseParamType => $param_closure,
+            self::CanUseUnionParamType => $param_closure,
         ];
     }
 
@@ -108,19 +114,29 @@ class PHPDocToRealTypesPlugin extends PluginV3 implements
                 continue;
             }
             $union_type = $phpdoc_param->getNonVariadicUnionType()->asNormalizedTypes();
-            if ($union_type->typeCount() !== 1) {
+            if (
+                $union_type->isEmpty() ||
+                ($union_type->typeCount() > 1 && Config::get_closest_minimum_target_php_version_id() < 80000)
+            ) {
                 continue;
             }
-            $type = $union_type->getTypeSet()[0];
-            if (!$type->canUseInRealSignature()) {
+            if ($union_type->hasTypeMatchingCallback(static function (Type $type): bool {
+                return !$type->canUseInRealSignature();
+            })) {
                 continue;
+            }
+            if ($union_type->typeCount() > 1) {
+                $issue_type = self::CanUseUnionParamType;
+            } else {
+                $type = $union_type->getTypeSet()[0];
+                $issue_type = $type->isNullableLabeled() ? self::CanUseNullableParamType : self::CanUseParamType;
             }
             self::emitIssue(
                 $code_base,
                 $method->getContext(),
-                $type->isNullable() ? self::CanUseNullableParamType : self::CanUseParamType,
+                $issue_type,
                 'Can use {TYPE} as the type of parameter ${PARAMETER} of {METHOD}',
-                [$type->asSignatureType(), $parameter->getName(), $method->getName()]
+                [$union_type->asSignatureUnionType(), $parameter->getName(), $method->getName()]
             );
         }
     }
@@ -139,19 +155,30 @@ class PHPDocToRealTypesPlugin extends PluginV3 implements
             return;
         }
         $union_type = $union_type->asNormalizedTypes();
-        if ($union_type->typeCount() !== 1) {
+
+        if (
+            $union_type->isEmpty() ||
+            ($union_type->typeCount() > 1 && Config::get_closest_minimum_target_php_version_id() < 80000)
+        ) {
             return;
         }
-        $type = $union_type->getTypeSet()[0];
-        if (!$type->canUseInRealSignature()) {
+        if ($union_type->hasTypeMatchingCallback(static function (Type $type): bool {
+            return !$type->canUseInRealSignature();
+        })) {
             return;
+        }
+        if ($union_type->typeCount() > 1) {
+            $issue_type = self::CanUseUnionReturnType;
+        } else {
+            $type = $union_type->getTypeSet()[0];
+            $issue_type = $type->isNullableLabeled() ? self::CanUseNullableReturnType : self::CanUseReturnType;
         }
         self::emitIssue(
             $code_base,
             $method->getContext(),
-            $type->isNullable() ? self::CanUseNullableReturnType : self::CanUseReturnType,
+            $issue_type,
             'Can use {TYPE} as a return type of {METHOD}',
-            [$type->asSignatureType(), $method->getName()]
+            [$union_type->asSignatureUnionType(), $method->getName()]
         );
     }
 }

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -1246,6 +1246,10 @@ final class EmptyUnionType extends UnionType
         return $this;
     }
 
+    public function asSignatureUnionType(): UnionType {
+        return $this;
+    }
+
     public function hasTopLevelArrayShapeTypeInstances(): bool
     {
         return false;

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -4222,7 +4222,7 @@ class Type implements Stringable
 
     /**
      * Returns true if this type or a parent type can be used in a signature.
-     * Returns false for template types, resources, object, etc.
+     * Returns false for template types, resources, etc.
      */
     public function canUseInRealSignature(): bool
     {

--- a/src/Phan/Language/Type/FalseType.php
+++ b/src/Phan/Language/Type/FalseType.php
@@ -122,7 +122,9 @@ final class FalseType extends ScalarType implements LiteralTypeInterface
      */
     public function asSignatureType(): Type
     {
-        return BoolType::instance($this->is_nullable);
+        return Config::get_closest_minimum_target_php_version_id() >= 80200
+            ? $this
+            : BoolType::instance($this->is_nullable);
     }
 
     /** @return false */

--- a/src/Phan/Language/Type/MixedType.php
+++ b/src/Phan/Language/Type/MixedType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phan\Language\Type;
 
 use Phan\CodeBase;
+use Phan\Config;
 use Phan\Language\Context;
 use Phan\Language\Type;
 use Phan\Language\UnionType;
@@ -181,7 +182,7 @@ class MixedType extends NativeType
 
     public function canUseInRealSignature(): bool
     {
-        return false;
+        return Config::get_closest_minimum_target_php_version_id() >= 80000;
     }
 
     public function isPossiblyFalsey(): bool

--- a/src/Phan/Language/Type/NeverType.php
+++ b/src/Phan/Language/Type/NeverType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phan\Language\Type;
 
 use Phan\CodeBase;
+use Phan\Config;
 use Phan\Language\Context;
 use Phan\Language\Type;
 use Phan\Language\UnionType;
@@ -219,7 +220,7 @@ final class NeverType extends NativeType
     // TODO: Emit an issue if used for a parameter/property type.
     public function canUseInRealSignature(): bool
     {
-        return true;
+        return Config::get_closest_minimum_target_php_version_id() >= 80100;
     }
 
     public function asScalarType(): ?Type

--- a/src/Phan/Language/Type/NonEmptyMixedType.php
+++ b/src/Phan/Language/Type/NonEmptyMixedType.php
@@ -115,6 +115,10 @@ final class NonEmptyMixedType extends MixedType
         return $this->is_nullable ? $this->withIsNullable(false) : $this;
     }
 
+    public function asSignatureType(): Type {
+        return MixedType::instance(false);
+    }
+
     /** @override */
     public function isNullable(): bool
     {

--- a/src/Phan/Language/Type/NonNullMixedType.php
+++ b/src/Phan/Language/Type/NonNullMixedType.php
@@ -98,6 +98,10 @@ final class NonNullMixedType extends MixedType
         return NonEmptyMixedType::instance(false);
     }
 
+    public function asSignatureType(): Type {
+        return MixedType::instance(false);
+    }
+
     /** @override */
     public function isNullable(): bool
     {

--- a/src/Phan/Language/Type/NullType.php
+++ b/src/Phan/Language/Type/NullType.php
@@ -230,7 +230,7 @@ final class NullType extends ScalarType implements LiteralTypeInterface
 
     public function canUseInRealSignature(): bool
     {
-        return false;
+        return Config::get_closest_minimum_target_php_version_id() >= 80200;
     }
 
     public function asScalarType(): ?Type

--- a/src/Phan/Language/Type/ObjectType.php
+++ b/src/Phan/Language/Type/ObjectType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phan\Language\Type;
 
 use Phan\CodeBase;
+use Phan\Config;
 use Phan\Language\Context;
 use Phan\Language\Type;
 
@@ -83,8 +84,7 @@ class ObjectType extends NativeType
 
     public function canUseInRealSignature(): bool
     {
-        // Callers should check this separately if they want to support php 7.2
-        return false;
+        return Config::get_closest_minimum_target_php_version_id() >= 70200;
     }
 
     /** For ObjectType/CallableObjectType  */

--- a/src/Phan/Language/Type/TrueType.php
+++ b/src/Phan/Language/Type/TrueType.php
@@ -111,7 +111,9 @@ final class TrueType extends ScalarType implements LiteralTypeInterface
      */
     public function asSignatureType(): Type
     {
-        return BoolType::instance($this->is_nullable);
+        return Config::get_closest_minimum_target_php_version_id() >= 80200
+            ? $this
+            : BoolType::instance($this->is_nullable);
     }
 
     /** @return true */

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -5033,6 +5033,21 @@ class UnionType implements Serializable, Stringable
     }
 
     /**
+     * Returns the corresponding union type that would be used in a signature
+     */
+    public function asSignatureUnionType(): self
+    {
+        $nonreal_type = $this->eraseRealTypeSet();
+        if ($nonreal_type->containsNullableLabeled() && $nonreal_type->typeCount() > 1) {
+            // Use X|Y|null instead of ?X|?Y
+            $nonreal_type = $nonreal_type->nonNullableClone()->withType(NullType::instance(false));
+        }
+        return $nonreal_type->asMappedUnionType(static function (Type $type): Type {
+            return $type->asSignatureType();
+        });
+    }
+
+    /**
      * @param UnionType[] $union_types
      * @return UnionType union of these UnionTypes
      * @suppress PhanPartialTypeMismatchArgument false positive seen when no real types are known. count() would throw in php 8.0+ for non-countables.

--- a/src/Phan/Library/Set.php
+++ b/src/Phan/Library/Set.php
@@ -211,10 +211,9 @@ class Set extends \SplObjectStorage
         return $this->map(
             /**
              * @param T $element
-             * @return object
              * @suppress PhanTypePossiblyInvalidCloneNotObject phan does not support base types of template types yet.
              */
-            static function ($element) {
+            static function ($element): object {
                 return clone($element);
             }
         );

--- a/tests/fixer_test/.phan/config.php
+++ b/tests/fixer_test/.phan/config.php
@@ -14,8 +14,6 @@ use \Phan\Issue;
  * in addition to testing backwards compatibility checks and dead code detection.
  */
 return [
-    'target_php_version' => '7.1',
-
     // If true, missing properties will be created when
     // they are first seen. If false, we'll report an
     // error message.

--- a/tests/fixer_test/expected/009_implicit_nullable.php.expected
+++ b/tests/fixer_test/expected/009_implicit_nullable.php.expected
@@ -1,8 +1,8 @@
 src_copy/009_implicit_nullable.php:6 PhanDeprecatedImplicitNullableParam Implicit nullable parameters (array $y = null) have been deprecated in PHP 8.4
 src_copy/009_implicit_nullable.php:6 PhanDeprecatedImplicitNullableParam Implicit nullable parameters (int $x = null) have been deprecated in PHP 8.4
-src_copy/009_implicit_nullable.php:6 PhanPluginCanUseNullableParamType Can use ?int as the type of parameter $z of test
-src_copy/009_implicit_nullable.php:6 PhanPluginCanUsePHP71Void Can use php 7.1's void as a return type of test
-src_copy/009_implicit_nullable.php:6 PhanUnreferencedFunction Possibly zero references to function \test()
+src_copy/009_implicit_nullable.php:6 PhanPluginCanUseNullableParamType Can use ?int as the type of parameter $z of testImplicitNullable
+src_copy/009_implicit_nullable.php:6 PhanPluginCanUsePHP71Void Can use php 7.1's void as a return type of testImplicitNullable
+src_copy/009_implicit_nullable.php:6 PhanUnreferencedFunction Possibly zero references to function \testImplicitNullable()
 src_copy/009_implicit_nullable.php:6 PhanUnusedGlobalFunctionParameter Parameter $x is never used
 src_copy/009_implicit_nullable.php:6 PhanUnusedGlobalFunctionParameter Parameter $y is never used
 src_copy/009_implicit_nullable.php:6 PhanUnusedGlobalFunctionParameter Parameter $z is never used

--- a/tests/fixer_test/expected/010_union_types.php.expected80
+++ b/tests/fixer_test/expected/010_union_types.php.expected80
@@ -1,0 +1,4 @@
+src_copy/010_union_types.php:8 PhanPluginCanUseUnionParamType Can use \SplObjectStorage|\stdClass|null as the type of parameter $c of testUnionTypes
+src_copy/010_union_types.php:8 PhanPluginCanUseUnionParamType Can use array|string as the type of parameter $a of testUnionTypes
+src_copy/010_union_types.php:8 PhanPluginCanUseUnionParamType Can use bool|float|int|string as the type of parameter $b of testUnionTypes
+src_copy/010_union_types.php:8 PhanPluginCanUseUnionReturnType Can use int|string as a return type of testUnionTypes

--- a/tests/fixer_test/expected/011_mixed.php.expected80
+++ b/tests/fixer_test/expected/011_mixed.php.expected80
@@ -1,0 +1,4 @@
+src_copy/011_mixed.php:8 PhanPluginCanUseNullableParamType Can use ?mixed as the type of parameter $b of testMixed
+src_copy/011_mixed.php:8 PhanPluginCanUseParamType Can use mixed as the type of parameter $a of testMixed
+src_copy/011_mixed.php:8 PhanPluginCanUseUnionParamType Can use mixed|object as the type of parameter $c of testMixed
+src_copy/011_mixed.php:8 PhanPluginCanUseUnionReturnType Can use bool|mixed as a return type of testMixed

--- a/tests/fixer_test/expected/011_mixed.php.expected82
+++ b/tests/fixer_test/expected/011_mixed.php.expected82
@@ -1,0 +1,4 @@
+src_copy/011_mixed.php:8 PhanPluginCanUseNullableParamType Can use ?mixed as the type of parameter $b of testMixed
+src_copy/011_mixed.php:8 PhanPluginCanUseParamType Can use mixed as the type of parameter $a of testMixed
+src_copy/011_mixed.php:8 PhanPluginCanUseUnionParamType Can use mixed|object as the type of parameter $c of testMixed
+src_copy/011_mixed.php:8 PhanPluginCanUseUnionReturnType Can use false|mixed as a return type of testMixed

--- a/tests/fixer_test/expected/012_never.php.expected81
+++ b/tests/fixer_test/expected/012_never.php.expected81
@@ -1,0 +1,1 @@
+src_copy/012_never.php:5 PhanPluginCanUseReturnType Can use never as a return type of testNever

--- a/tests/fixer_test/expected/013_false_true_null.php.expected
+++ b/tests/fixer_test/expected/013_false_true_null.php.expected
@@ -1,0 +1,6 @@
+src_copy/013_false_true_null.php:8 PhanPluginCanUseNullableReturnType Can use ?bool as a return type of testFalseTrueNullAlone
+src_copy/013_false_true_null.php:8 PhanPluginCanUseParamType Can use bool as the type of parameter $a of testFalseTrueNullAlone
+src_copy/013_false_true_null.php:8 PhanPluginCanUseParamType Can use bool as the type of parameter $b of testFalseTrueNullAlone
+src_copy/013_false_true_null.php:20 PhanPluginCanUseNullableParamType Can use ?float as the type of parameter $c of testFalseTrueNullUnion
+src_copy/013_false_true_null.php:20 PhanPluginCanUseNullableReturnType Can use ?bool as a return type of testFalseTrueNullUnion
+src_copy/013_false_true_null.php:20 PhanPluginCanUseParamType Can use bool as the type of parameter $bool of testFalseTrueNullUnion

--- a/tests/fixer_test/expected/013_false_true_null.php.expected80
+++ b/tests/fixer_test/expected/013_false_true_null.php.expected80
@@ -1,0 +1,8 @@
+src_copy/013_false_true_null.php:8 PhanPluginCanUseNullableReturnType Can use ?bool as a return type of testFalseTrueNullAlone
+src_copy/013_false_true_null.php:8 PhanPluginCanUseParamType Can use bool as the type of parameter $a of testFalseTrueNullAlone
+src_copy/013_false_true_null.php:8 PhanPluginCanUseParamType Can use bool as the type of parameter $b of testFalseTrueNullAlone
+src_copy/013_false_true_null.php:20 PhanPluginCanUseNullableParamType Can use ?float as the type of parameter $c of testFalseTrueNullUnion
+src_copy/013_false_true_null.php:20 PhanPluginCanUseNullableReturnType Can use ?bool as a return type of testFalseTrueNullUnion
+src_copy/013_false_true_null.php:20 PhanPluginCanUseParamType Can use bool as the type of parameter $bool of testFalseTrueNullUnion
+src_copy/013_false_true_null.php:20 PhanPluginCanUseUnionParamType Can use bool|int as the type of parameter $b of testFalseTrueNullUnion
+src_copy/013_false_true_null.php:20 PhanPluginCanUseUnionParamType Can use bool|string as the type of parameter $a of testFalseTrueNullUnion

--- a/tests/fixer_test/expected/013_false_true_null.php.expected82
+++ b/tests/fixer_test/expected/013_false_true_null.php.expected82
@@ -1,0 +1,9 @@
+src_copy/013_false_true_null.php:8 PhanPluginCanUseNullableParamType Can use null as the type of parameter $c of testFalseTrueNullAlone
+src_copy/013_false_true_null.php:8 PhanPluginCanUseNullableReturnType Can use ?bool as a return type of testFalseTrueNullAlone
+src_copy/013_false_true_null.php:8 PhanPluginCanUseParamType Can use false as the type of parameter $a of testFalseTrueNullAlone
+src_copy/013_false_true_null.php:8 PhanPluginCanUseParamType Can use true as the type of parameter $b of testFalseTrueNullAlone
+src_copy/013_false_true_null.php:20 PhanPluginCanUseNullableParamType Can use ?float as the type of parameter $c of testFalseTrueNullUnion
+src_copy/013_false_true_null.php:20 PhanPluginCanUseNullableReturnType Can use ?bool as a return type of testFalseTrueNullUnion
+src_copy/013_false_true_null.php:20 PhanPluginCanUseParamType Can use bool as the type of parameter $bool of testFalseTrueNullUnion
+src_copy/013_false_true_null.php:20 PhanPluginCanUseUnionParamType Can use false|string as the type of parameter $a of testFalseTrueNullUnion
+src_copy/013_false_true_null.php:20 PhanPluginCanUseUnionParamType Can use int|true as the type of parameter $b of testFalseTrueNullUnion

--- a/tests/fixer_test/expected/014_object.php.expected
+++ b/tests/fixer_test/expected/014_object.php.expected
@@ -1,0 +1,2 @@
+src_copy/014_object.php:6 PhanPluginCanUseParamType Can use object as the type of parameter $o of testObject
+src_copy/014_object.php:6 PhanPluginCanUseReturnType Can use object as a return type of testObject

--- a/tests/fixer_test/expected_src/009_implicit_nullable.php
+++ b/tests/fixer_test/expected_src/009_implicit_nullable.php
@@ -3,5 +3,5 @@
  * @param ?array $y
  * @param ?int $z
  */
-function test(?int $x = null, ?array $y = null, ?int $z = null) : void {
+function testImplicitNullable(?int $x = null, ?array $y = null, ?int $z = null) : void {
 }

--- a/tests/fixer_test/expected_src/010_union_types.php
+++ b/tests/fixer_test/expected_src/010_union_types.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * @param string|array $a
+ * @param string|int|float|bool $b
+ * @param ?stdClass|SplObjectStorage $c
+ * @return int|string
+ */
+function testUnionTypes($a, $b, $c) {
+    return $a !== '' && $b !== true && $c !== false ? 42 : 'ans';
+}
+return testUnionTypes('a', 1, null);

--- a/tests/fixer_test/expected_src/010_union_types.php80.php
+++ b/tests/fixer_test/expected_src/010_union_types.php80.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * @param string|array $a
+ * @param string|int|float|bool $b
+ * @param ?stdClass|SplObjectStorage $c
+ * @return int|string
+ */
+function testUnionTypes(array|string $a, bool|float|int|string $b, \SplObjectStorage|\stdClass|null $c) : int|string {
+    return $a !== '' && $b !== true && $c !== false ? 42 : 'ans';
+}
+return testUnionTypes('a', 1, null);

--- a/tests/fixer_test/expected_src/011_mixed.php
+++ b/tests/fixer_test/expected_src/011_mixed.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * @param mixed $a
+ * @param ?mixed $b
+ * @param mixed|object $c
+ * @return false|mixed
+ */
+function testMixed($a, $b, $c) {
+    return $a !== 'foo' && $b !== null && $c !== '' ? $GLOBALS['unknown'] : false;
+}
+return testMixed(1, 2, 3);

--- a/tests/fixer_test/expected_src/011_mixed.php80.php
+++ b/tests/fixer_test/expected_src/011_mixed.php80.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * @param mixed $a
+ * @param ?mixed $b
+ * @param mixed|object $c
+ * @return false|mixed
+ */
+function testMixed(mixed $a, ?mixed $b, mixed|object $c) : bool|mixed {
+    return $a !== 'foo' && $b !== null && $c !== '' ? $GLOBALS['unknown'] : false;
+}
+return testMixed(1, 2, 3);

--- a/tests/fixer_test/expected_src/011_mixed.php82.php
+++ b/tests/fixer_test/expected_src/011_mixed.php82.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * @param mixed $a
+ * @param ?mixed $b
+ * @param mixed|object $c
+ * @return false|mixed
+ */
+function testMixed(mixed $a, ?mixed $b, mixed|object $c) : false|mixed {
+    return $a !== 'foo' && $b !== null && $c !== '' ? $GLOBALS['unknown'] : false;
+}
+return testMixed(1, 2, 3);

--- a/tests/fixer_test/expected_src/012_never.php
+++ b/tests/fixer_test/expected_src/012_never.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * @return never
+ */
+function testNever() {
+    die;
+}
+testNever();

--- a/tests/fixer_test/expected_src/012_never.php81.php
+++ b/tests/fixer_test/expected_src/012_never.php81.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * @return never
+ */
+function testNever() : never {
+    die;
+}
+testNever();

--- a/tests/fixer_test/expected_src/013_false_true_null.php
+++ b/tests/fixer_test/expected_src/013_false_true_null.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @param false $a
+ * @param true $b
+ * @param null $c
+ * @return false|true|null
+ */
+function testFalseTrueNullAlone(bool $a, bool $b, $c) : ?bool {
+    return [ $a, $b, $c ][ rand( 0, 2 ) ];
+}
+echo testFalseTrueNullAlone(false, true, null) ? 'a' : 'b';
+
+/**
+ * @param false|string $a
+ * @param true|int $b
+ * @param null|float $c
+ * @param true|false $bool
+ * @return false|true|null
+ */
+function testFalseTrueNullUnion($a, $b, ?float $c, bool $bool) : ?bool {
+    return $a !== false && $b !== true && $c !== null ? $bool : null;
+}
+echo testFalseTrueNullUnion(false, true, null, true) ? 'a' : 'b';

--- a/tests/fixer_test/expected_src/013_false_true_null.php80.php
+++ b/tests/fixer_test/expected_src/013_false_true_null.php80.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @param false $a
+ * @param true $b
+ * @param null $c
+ * @return false|true|null
+ */
+function testFalseTrueNullAlone(bool $a, bool $b, $c) : ?bool {
+    return [ $a, $b, $c ][ rand( 0, 2 ) ];
+}
+echo testFalseTrueNullAlone(false, true, null) ? 'a' : 'b';
+
+/**
+ * @param false|string $a
+ * @param true|int $b
+ * @param null|float $c
+ * @param true|false $bool
+ * @return false|true|null
+ */
+function testFalseTrueNullUnion(bool|string $a, bool|int $b, ?float $c, bool $bool) : ?bool {
+    return $a !== false && $b !== true && $c !== null ? $bool : null;
+}
+echo testFalseTrueNullUnion(false, true, null, true) ? 'a' : 'b';

--- a/tests/fixer_test/expected_src/013_false_true_null.php82.php
+++ b/tests/fixer_test/expected_src/013_false_true_null.php82.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @param false $a
+ * @param true $b
+ * @param null $c
+ * @return false|true|null
+ */
+function testFalseTrueNullAlone(false $a, true $b, null $c) : ?bool {
+    return [ $a, $b, $c ][ rand( 0, 2 ) ];
+}
+echo testFalseTrueNullAlone(false, true, null) ? 'a' : 'b';
+
+/**
+ * @param false|string $a
+ * @param true|int $b
+ * @param null|float $c
+ * @param true|false $bool
+ * @return false|true|null
+ */
+function testFalseTrueNullUnion(false|string $a, int|true $b, ?float $c, bool $bool) : ?bool {
+    return $a !== false && $b !== true && $c !== null ? $bool : null;
+}
+echo testFalseTrueNullUnion(false, true, null, true) ? 'a' : 'b';

--- a/tests/fixer_test/expected_src/014_object.php
+++ b/tests/fixer_test/expected_src/014_object.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * @param object $o
+ * @return object
+ */
+function testObject(object $o) : object {
+    return $o;
+}
+return testObject(new stdClass());

--- a/tests/fixer_test/src/009_implicit_nullable.php
+++ b/tests/fixer_test/src/009_implicit_nullable.php
@@ -3,5 +3,5 @@
  * @param ?array $y
  * @param ?int $z
  */
-function test(int $x = null, array $y = null, $z = null) {
+function testImplicitNullable(int $x = null, array $y = null, $z = null) {
 }

--- a/tests/fixer_test/src/010_union_types.php
+++ b/tests/fixer_test/src/010_union_types.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * @param string|array $a
+ * @param string|int|float|bool $b
+ * @param ?stdClass|SplObjectStorage $c
+ * @return int|string
+ */
+function testUnionTypes($a, $b, $c) {
+    return $a !== '' && $b !== true && $c !== false ? 42 : 'ans';
+}
+return testUnionTypes('a', 1, null);

--- a/tests/fixer_test/src/011_mixed.php
+++ b/tests/fixer_test/src/011_mixed.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * @param mixed $a
+ * @param ?mixed $b
+ * @param mixed|object $c
+ * @return false|mixed
+ */
+function testMixed($a, $b, $c) {
+    return $a !== 'foo' && $b !== null && $c !== '' ? $GLOBALS['unknown'] : false;
+}
+return testMixed(1, 2, 3);

--- a/tests/fixer_test/src/012_never.php
+++ b/tests/fixer_test/src/012_never.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * @return never
+ */
+function testNever() {
+    die;
+}
+testNever();

--- a/tests/fixer_test/src/013_false_true_null.php
+++ b/tests/fixer_test/src/013_false_true_null.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @param false $a
+ * @param true $b
+ * @param null $c
+ * @return false|true|null
+ */
+function testFalseTrueNullAlone($a, $b, $c) {
+    return [ $a, $b, $c ][ rand( 0, 2 ) ];
+}
+echo testFalseTrueNullAlone(false, true, null) ? 'a' : 'b';
+
+/**
+ * @param false|string $a
+ * @param true|int $b
+ * @param null|float $c
+ * @param true|false $bool
+ * @return false|true|null
+ */
+function testFalseTrueNullUnion($a, $b, $c, $bool) {
+    return $a !== false && $b !== true && $c !== null ? $bool : null;
+}
+echo testFalseTrueNullUnion(false, true, null, true) ? 'a' : 'b';

--- a/tests/fixer_test/src/014_object.php
+++ b/tests/fixer_test/src/014_object.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * @param object $o
+ * @return object
+ */
+function testObject($o) {
+    return $o;
+}
+return testObject(new stdClass());

--- a/tests/fixer_test/test.sh
+++ b/tests/fixer_test/test.sh
@@ -7,7 +7,45 @@ if [ ! -d expected -o ! -d expected_src ]; then
 	exit 1
 fi
 echo "Generating test cases"
-for path in $(echo expected/*.php.expected | LC_ALL=C sort); do cat $path; done > $EXPECTED_PATH
+
+PHP_VERSION_ID=$(php -r "echo PHP_VERSION_ID;")
+echo "PHP_VERSION_ID=$PHP_VERSION_ID";
+
+for path in $(echo expected/*.php.expected | LC_ALL=C sort); do
+    original_path="$path"
+    if [[ "$PHP_VERSION_ID" -ge 80000 ]]; then
+        alternate_path=${original_path/.expected/.expected80}
+        if [ -f "$alternate_path" ]; then
+            path="$alternate_path"
+        fi
+    fi
+    if [[ "$PHP_VERSION_ID" -ge 80100 ]]; then
+        alternate_path=${original_path/.expected/.expected81}
+        if [ -f "$alternate_path" ]; then
+            path="$alternate_path"
+        fi
+    fi
+    if [[ "$PHP_VERSION_ID" -ge 80200 ]]; then
+        alternate_path=${original_path/.expected/.expected82}
+        if [ -f "$alternate_path" ]; then
+            path="$alternate_path"
+        fi
+    fi
+    if [[ "$PHP_VERSION_ID" -ge 80300 ]]; then
+        alternate_path=${original_path/.expected/.expected83}
+        if [ -f "$alternate_path" ]; then
+            path="$alternate_path"
+        fi
+    fi
+    if [[ "$PHP_VERSION_ID" -ge 80400 ]]; then
+        alternate_path=${original_path/.expected/.expected84}
+        if [ -f "$alternate_path" ]; then
+            path="$alternate_path"
+        fi
+    fi
+    cat $path;
+done > $EXPECTED_PATH
+
 if [[ $? != 0 ]]; then
 	echo "Failed to concatenate test cases" 1>&2
 	exit 1
@@ -45,8 +83,43 @@ fi
 FOUND_EXPECTED=0
 UNEXPECTED_FIX=0
 for expected_src_file in expected_src/*.php; do
+    if [[ $expected_src_file =~ .php[0-9]+.php ]]; then
+        # Alternate file, checked when processing the canonical version.
+        continue
+    fi
+    original_path="$expected_src_file"
 	FOUND_EXPECTED=1
-	actual_src_file=${expected_src_file/expected_src/src_copy}
+	if [[ "$PHP_VERSION_ID" -ge 80000 ]]; then
+        alternate_expected_path=${original_path/.php/.php80.php}
+        if [ -f "$alternate_expected_path" ]; then
+            expected_src_file="$alternate_expected_path"
+        fi
+    fi
+    if [[ "$PHP_VERSION_ID" -ge 80100 ]]; then
+        alternate_expected_path=${original_path/.php/.php81.php}
+        if [ -f "$alternate_expected_path" ]; then
+            expected_src_file="$alternate_expected_path"
+        fi
+    fi
+    if [[ "$PHP_VERSION_ID" -ge 80200 ]]; then
+        alternate_expected_path=${original_path/.php/.php82.php}
+        if [ -f "$alternate_expected_path" ]; then
+            expected_src_file="$alternate_expected_path"
+        fi
+    fi
+    if [[ "$PHP_VERSION_ID" -ge 80300 ]]; then
+        alternate_expected_path=${original_path/.php/.php83.php}
+        if [ -f "$alternate_expected_path" ]; then
+            expected_src_file="$alternate_expected_path"
+        fi
+    fi
+    if [[ "$PHP_VERSION_ID" -ge 80400 ]]; then
+        alternate_expected_path=${original_path/.php/.php84.php}
+        if [ -f "$alternate_expected_path" ]; then
+            expected_src_file="$alternate_expected_path"
+        fi
+    fi
+	actual_src_file=${original_path/expected_src/src_copy}
 	# diff returns a non-zero exit code if files differ or are missing
 	if ! $DIFF -C 3 "$actual_src_file" "$expected_src_file"; then
 		echo "phan --automatic-fix did not generate the expected fix for $actual_src_file and $expected_src_file"


### PR DESCRIPTION
- Drop hardcoded checks on the size of the type set, and allow union types when targeting PHP 8.0+. This uses separate issue types for consistency. Add a supporting method, `UnionType::asSignatureUnionType`, to get a type representation suitable for function signatures.
- Allow using `mixed` in signatures when targeting PHP 8.0+
- Allow using `never` in signatures when targeting PHP 8.1+
- Allow `false`, `true`, and `null` as standalone types when targeting PHP 8.2+. For `false` and `true`, keep using BooleanType in previous PHP versions. Note that `asNormalizedTypes` already replaces `false|true` with `bool`, thus producing valid PHP code.
- Allow `object` in signatures when targeting PHP 7.2+. Asking callers to check this separately doesn't scale. Also, `PHPDocToRealTypesPlugin` has always been the only caller.
- Add tests for all of the above. The `PHP_VERSION_ID` trickery is copied from `fallback_test`. For expected_src files we use a slightly changed version that allows us to keep `.php` as the file extension.