### PR TITLE
Make ArrayShapeType::union preserve the possibly_undefined flag

### DIFF
--- a/src/Phan/Language/Type/ArrayShapeType.php
+++ b/src/Phan/Language/Type/ArrayShapeType.php
@@ -749,9 +749,12 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
     }
 
     /**
-     * Computes the non-nullable union of two or more array shape types.
+     * Computes the union of two or more array shape types. Elements are considered to be possibly undefined iff
+     * they are possibly undefined in all of the types.
      *
-     * E.g. array{0: string} + array{0:int,1:int} === array{0:int|string,1:int}
+     * E.g.
+     * array{0: string} + array{0:int,1:int} === array{0:int|string,1:int}
+     * array{0?: string,1:int,2?:bool} + array{0:int,1?:int,2?:float} === array{0:int|string,1:int,2?:bool|float}
      * @param list<ArrayShapeType> $array_shape_types
      */
     public static function union(array $array_shape_types): ArrayShapeType
@@ -769,10 +772,16 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
             foreach ($type->field_types as $key => $union_type) {
                 $old_union_type = $field_types[$key] ?? null;
                 if ($old_union_type === null) {
-                    $field_types[$key] = $union_type;
-                    continue;
+                    // The new type is possibly undefined iff the current type is.
+                    $new_union_type = $union_type;
+                } else {
+                    $new_union_type = $old_union_type->withUnionType($union_type);
+                    if ($old_union_type->isPossiblyUndefined() && $union_type->isPossiblyUndefined()) {
+                        $new_union_type = $new_union_type->withIsPossiblyUndefined(true);
+                    }
+                    // Else we're good because the type returned by `withUnionType` is never possibly undefined.
                 }
-                $field_types[$key] = $old_union_type->withUnionType($union_type);
+                $field_types[$key] = $new_union_type;
             }
         }
         return self::fromFieldTypes($field_types, false);

--- a/src/Phan/Language/Type/ArrayType.php
+++ b/src/Phan/Language/Type/ArrayType.php
@@ -260,7 +260,6 @@ class ArrayType extends IterableType
         }
         $type_set[] = ArrayShapeType::combineWithPrecedence(
             ArrayShapeType::fromFieldTypes([$field_dim_value => $field_type], false),
-            // TODO: Add possibly_undefined annotations in union
             ArrayShapeType::union($left_array_shape_types)
         );
         $real_type_set = $left->hasRealTypeSet() ? self::computeRealTypeSetForArrayShapeTypeWithField($left, $field_dim_value, $field_type) : [];

--- a/tests/files/expected/0979_conditional_negated_property.php.expected
+++ b/tests/files/expected/0979_conditional_negated_property.php.expected
@@ -1,0 +1,2 @@
+%s:18 PhanDebugAnnotation @phan-debug-var requested for variable $propBefore - it has union type null|string
+%s:25 PhanDebugAnnotation @phan-debug-var requested for variable $propAfter - it has union type null|string

--- a/tests/files/src/0979_conditional_negated_property.php
+++ b/tests/files/src/0979_conditional_negated_property.php
@@ -1,0 +1,31 @@
+<?php
+
+// Regression test for https://github.com/phan/phan/issues/4916
+
+namespace NS979;
+
+class TestCoalesce {
+    /** @var string|null */
+    private $prop;
+    private $otherProp;
+
+    /** @suppress PhanUnusedVariable */
+    public function test() {
+        if ( rand() && !$this->prop ) {
+            $this->prop = 'foo';
+        }
+
+        $propBefore = $this->prop;
+        '@phan-debug-var $propBefore';
+
+        if ( !$this->otherProp ) {
+            return;
+        }
+
+        $propAfter = $this->prop;
+        '@phan-debug-var $propAfter';
+
+        // No issue here
+        echo $this->prop ?? 'bar';
+    }
+}


### PR DESCRIPTION
When computing the union of array shape types, flag individual keys as possibly undefined if (and only if) they are possibly undefined in all of the types. It might make sense to do that if _any_ element is possibly undefined, but that would maybe be a bigger change, and I haven't audited the callers to see if it would make sense (I should however note that the test suite would still pass).

This change addresses an old TODO, and it fixes a subtle bug where properties of `$this` would lose their possibly-undefined status when merging contexts that contain overrides for other properties of `$this`.

Closes #4916