### PR TITLE
Update handling and documentation of target PHP versions

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -34,7 +34,7 @@ return [
     // and checks for undefined classes/methods/functions)
     //
     // Supported values: `'5.6'`, `'7.0'`, `'7.1'`, `'7.2'`, `'7.3'`, `'7.4'`,
-    // `'8.0'`, `'8.1'`, `null`.
+    // `'8.0'`, `'8.1'`, `'8.2'`, `'8.3'`, `'8.4'`, `null`.
     // If this is set to `null`,
     // then Phan assumes the PHP version which is closest to the minor version
     // of the php executable used to execute Phan.
@@ -45,7 +45,7 @@ return [
 
     // The PHP version that will be used for feature/syntax compatibility warnings.
     // Supported values: `'5.6'`, `'7.0'`, `'7.1'`, `'7.2'`, `'7.3'`, `'7.4'`,
-    // `'8.0'`, `'8.1'`, `null`.
+    // `'8.0'`, `'8.1'`, `'8.2'`, `'8.3'`, `'8.4'`, `null`.
     // If this is set to `null`, Phan will first attempt to infer the value from
     // the project's composer.json's `{"require": {"php": "version range"}}` if possible.
     // If that could not be determined, then Phan assumes `target_php_version`.

--- a/internal/CLI-HELP.md
+++ b/internal/CLI-HELP.md
@@ -103,13 +103,13 @@ Usage: ./phan [options] [files...]
  -b, --backward-compatibility-checks
   Check for potential PHP 5 -> PHP 7 BC issues
 
- --target-php-version {5.6,7.0,7.1,7.2,7.3,7.4,8.0,8.1,native}
+ --target-php-version {5.6,7.0,7.1,7.2,7.3,7.4,8.0,8.1,8.2,8.3,8.4,native}
   The PHP version that the codebase will be checked for compatibility against.
   For best results, the PHP binary used to run Phan should have the same PHP version.
   (Phan relies on Reflection for some param counts
    and checks for undefined classes/methods/functions)
 
- --minimum-target-php-version {5.6,7.0,7.1,7.2,7.3,7.4,8.0,8.1,native}
+ --minimum-target-php-version {5.6,7.0,7.1,7.2,7.3,7.4,8.0,8.1,8.2,8.3,8.4,native}
   The PHP version that will be used for feature/syntax compatibility warnings.
 
  -i, --ignore-undeclared

--- a/internal/Phan-Config-Settings.md
+++ b/internal/Phan-Config-Settings.md
@@ -724,7 +724,7 @@ If this is null, this will be inferred from `target_php_version`.
 The PHP version that will be used for feature/syntax compatibility warnings.
 
 Supported values: `'5.6'`, `'7.0'`, `'7.1'`, `'7.2'`, `'7.3'`, `'7.4'`,
-`'8.0'`, `'8.1'`, `'8.2'`, `'8.3'`, `null`.
+`'8.0'`, `'8.1'`, `'8.2'`, `'8.3'`, `'8.4'`, `null`.
 If this is set to `null`, Phan will first attempt to infer the value from
 the project's composer.json's `{"require": {"php": "version range"}}` if possible.
 If that could not be determined, then Phan assumes `target_php_version`.
@@ -756,7 +756,7 @@ For best results, the PHP binary used to run Phan should have the same PHP versi
 and checks for undefined classes/methods/functions)
 
 Supported values: `'5.6'`, `'7.0'`, `'7.1'`, `'7.2'`, `'7.3'`, `'7.4'`,
-`'8.0'`, `'8.1'`, `'8.2'`, `'8.3'`, `null`.
+`'8.0'`, `'8.1'`, `'8.2'`, `'8.3'`, `'8.4'`, `null`.
 If this is set to `null`,
 then Phan assumes the PHP version which is closest to the minor version
 of the php executable used to execute Phan.

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -690,9 +690,15 @@ class CLI
                     }
                     break;
                 case 'target-php-version':
+                    if (\strtolower($value) === 'native') {
+                        $value = null;
+                    }
                     Config::setValue('target_php_version', $value);
                     break;
                 case 'minimum-target-php-version':
+                    if (\strtolower($value) === 'native') {
+                        $value = null;
+                    }
                     Config::setValue('minimum_target_php_version', $value);
                     break;
                 case 'd':
@@ -1553,13 +1559,13 @@ $init_help
  -b, --backward-compatibility-checks
   Check for potential PHP 5 -> PHP 7 BC issues
 
- --target-php-version {5.6,7.0,7.1,7.2,7.3,7.4,8.0,8.1,native}
+ --target-php-version {5.6,7.0,7.1,7.2,7.3,7.4,8.0,8.1,8.2,8.3,8.4,native}
   The PHP version that the codebase will be checked for compatibility against.
   For best results, the PHP binary used to run Phan should have the same PHP version.
   (Phan relies on Reflection for some param counts
    and checks for undefined classes/methods/functions)
 
- --minimum-target-php-version {5.6,7.0,7.1,7.2,7.3,7.4,8.0,8.1,native}
+ --minimum-target-php-version {5.6,7.0,7.1,7.2,7.3,7.4,8.0,8.1,8.2,8.3,8.4,native}
   The PHP version that will be used for feature/syntax compatibility warnings.
 
  -i, --ignore-undeclared

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -135,7 +135,7 @@ class Config
         // and checks for undefined classes/methods/functions)
         //
         // Supported values: `'5.6'`, `'7.0'`, `'7.1'`, `'7.2'`, `'7.3'`, `'7.4'`,
-        // `'8.0'`, `'8.1'`, `'8.2'`, `'8.3'`, `null`.
+        // `'8.0'`, `'8.1'`, `'8.2'`, `'8.3'`, `'8.4'`, `null`.
         // If this is set to `null`,
         // then Phan assumes the PHP version which is closest to the minor version
         // of the php executable used to execute Phan.
@@ -147,7 +147,7 @@ class Config
         // The PHP version that will be used for feature/syntax compatibility warnings.
         //
         // Supported values: `'5.6'`, `'7.0'`, `'7.1'`, `'7.2'`, `'7.3'`, `'7.4'`,
-        // `'8.0'`, `'8.1'`, `'8.2'`, `'8.3'`, `null`.
+        // `'8.0'`, `'8.1'`, `'8.2'`, `'8.3'`, `'8.4'`, `null`.
         // If this is set to `null`, Phan will first attempt to infer the value from
         // the project's composer.json's `{"require": {"php": "version range"}}` if possible.
         // If that could not be determined, then Phan assumes `target_php_version`.
@@ -1282,9 +1282,6 @@ class Config
         }
         // @phan-suppress-next-line PhanSuspiciousTruthyString, PhanSuspiciousTruthyCondition
         $value = (string) ($value ?: PHP_VERSION);
-        if (\strtolower($value) === 'native') {
-            $value = PHP_VERSION;
-        }
 
         self::$closest_target_php_version_id = self::computeClosestTargetPHPVersionId($value);
 

--- a/tool/analyze_phpt
+++ b/tool/analyze_phpt
@@ -46,13 +46,13 @@ class AnalyzePhpt {
     Options:
       -h, --help: Print this help message to stdout.
       -p, --progress-bar: Show a progress bar.
-      --target-php-version {5.6,7.0,7.1,7.2,7.3,7.4,8.0,8.1,native}
+      --target-php-version {5.6,7.0,7.1,7.2,7.3,7.4,8.0,8.1,8.2,8.3,8.4,native}
        The PHP version that the codebase will be checked for compatibility against.
        For best results, the PHP binary used to run Phan should have the same PHP version.
        (Phan relies on Reflection for some param counts
         and checks for undefined classes/methods/functions)
 
-      --minimum-target-php-version {5.6,7.0,7.1,7.2,7.3,7.4,8.0,8.1,native}
+      --minimum-target-php-version {5.6,7.0,7.1,7.2,7.3,7.4,8.0,8.1,8.2,8.3,8.4,native}
        The PHP version that will be used for feature/syntax compatibility warnings.
       --add-parse-file: Add a path to a file to parse but not analyze.
       --color, --no-color: Add or remove colors from the outputted issues.


### PR DESCRIPTION
Document versions up to 8.4 everywhere needed.

Move handling of `native` to CLI, as the value is documented, and meant to be used, for CLI only. Make it work for `minimum_target_php_version` too (it was already documented).