### PR TITLE
Refactor type compatibility checks a bit

### DIFF
--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -3171,9 +3171,6 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             return;
         }
         $minimum_target_php_version_id = Config::get_closest_minimum_target_php_version_id();
-        if ($minimum_target_php_version_id >= 80200) {
-            return;
-        }
 
         if ($type->kind === ast\AST_TYPE_INTERSECTION) {
             if ($minimum_target_php_version_id < 80100) {
@@ -3234,7 +3231,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 );
             }
         } elseif ($inner_type->flags === ast\flags\TYPE_TRUE) {
-            if ($minimum_target_php_version_id < 82000) {
+            if ($minimum_target_php_version_id < 80200) {
                 $this->emitIssue(
                     Issue::CompatibleTrueType,
                     $inner_type->lineno,
@@ -3242,11 +3239,13 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 );
             }
         } elseif (!$is_union && \in_array($inner_type->flags, [ast\flags\TYPE_NULL, ast\flags\TYPE_FALSE], true)) {
-            $this->emitIssue(
-                Issue::CompatibleStandaloneType,
-                $inner_type->lineno,
-                ASTReverter::toShortTypeString($type)
-            );
+            if ($minimum_target_php_version_id < 80200) {
+                $this->emitIssue(
+                    Issue::CompatibleStandaloneType,
+                    $inner_type->lineno,
+                    ASTReverter::toShortTypeString( $type )
+                );
+            }
         }
     }
 


### PR DESCRIPTION
As a follow-up to https://github.com/phan/phan/pull/4903:
- Drop early return that was hard to spot, in favour of local version checks
- Fix version ID for PHP 8.2