### PR TITLE
Avoid incrementing non-numeric strings

### DIFF
--- a/src/Phan/Language/Type/LiteralStringType.php
+++ b/src/Phan/Language/Type/LiteralStringType.php
@@ -429,7 +429,9 @@ final class LiteralStringType extends StringType implements LiteralTypeInterface
     public function getTypeAfterIncOrDec(): UnionType
     {
         $v = $this->value;
-        ++$v;
+        if (is_numeric($v)) {
+            ++$v;
+        }
         return Type::nonLiteralFromObject($v)->asPHPDocUnionType();
     }
 

--- a/tests/php83_files/src/003_increment_non_alphanumeric.php
+++ b/tests/php83_files/src/003_increment_non_alphanumeric.php
@@ -1,0 +1,9 @@
+<?php
+
+// Regression test for https://github.com/phan/phan/issues/4860
+
+( static function () {
+    $var = '';
+    $var++;
+    echo $var;
+} )();


### PR DESCRIPTION
Triggers a deprecation warning in PHP 8.3+, which makes phan crash.

Fixes #4860.