### PR TITLE
Make ContextNode methods specify whether to catch IssueException

### DIFF
--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -2658,7 +2658,7 @@ class ContextNode
      *         If this could be resolved and we're certain of the value, this gets a raw PHP value for $node.
      *         Otherwise, this returns $node.
      */
-    public function getEquivalentPHPValueForNode($node, int $flags)
+    public function getEquivalentPHPValueForNode($node, int $flags, bool $should_catch_issue_exception = true)
     {
         if (!($node instanceof Node)) {
             return $node;
@@ -2700,7 +2700,9 @@ class ContextNode
                 $new_node = $constant->getNodeForValue();
                 if (is_object($new_node)) {
                     // Avoid infinite recursion, only resolve once
-                    $new_node = (new ContextNode($this->code_base, $constant->getContext(), $new_node))->getEquivalentPHPValueForNode($new_node, $flags & ~(self::RESOLVE_CONSTANTS | self::RESOLVE_ONLY_CONSTANT_VARS | self::RESOLVE_DONT_USE_VARS));
+                    $recursiveFlags = $flags & ~(self::RESOLVE_CONSTANTS | self::RESOLVE_ONLY_CONSTANT_VARS | self::RESOLVE_DONT_USE_VARS);
+                    $new_node = (new ContextNode($this->code_base, $constant->getContext(), $new_node))
+                        ->getEquivalentPHPValueForNode($new_node, $recursiveFlags, $should_catch_issue_exception);
                 }
                 return $new_node;
             case ast\AST_CLASS_CONST:
@@ -2716,7 +2718,8 @@ class ContextNode
                 $new_node = $constant->getNodeForValue();
                 if (is_object($new_node)) {
                     // Avoid infinite recursion, only resolve once
-                    $new_node = (new ContextNode($this->code_base, $constant->getContext(), $new_node))->getEquivalentPHPValueForNode($new_node, $flags & ~self::RESOLVE_CONSTANTS);
+                    $new_node = (new ContextNode($this->code_base, $constant->getContext(), $new_node))
+                        ->getEquivalentPHPValueForNode($new_node, $flags & ~self::RESOLVE_CONSTANTS, $should_catch_issue_exception);
                 }
                 return $new_node;
             case ast\AST_CLASS_NAME:
@@ -2773,7 +2776,8 @@ class ContextNode
         $node_type = UnionTypeVisitor::unionTypeFromNode(
             $this->code_base,
             $this->context,
-            $node
+            $node,
+            $should_catch_issue_exception
         );
         $value = $node_type->asValueOrNullOrSelf();
         if (\is_object($value)) {
@@ -2981,9 +2985,9 @@ class ContextNode
      *   If this could be resolved and we're certain of the value, this gets an equivalent definition.
      *   Otherwise, this returns $node.
      */
-    public function getEquivalentPHPValue(int $flags = self::RESOLVE_DEFAULT)
+    public function getEquivalentPHPValue(int $flags = self::RESOLVE_DEFAULT, bool $should_catch_issue_exception = true)
     {
-        return $this->getEquivalentPHPValueForNode($this->node, $flags);
+        return $this->getEquivalentPHPValueForNode($this->node, $flags, $should_catch_issue_exception);
     }
 
     /**
@@ -3016,8 +3020,12 @@ class ContextNode
      *
      * @suppress PhanPartialTypeMismatchReturn the flags prevent this from returning an array
      */
-    public function getEquivalentPHPScalarValue()
+    public function getEquivalentPHPScalarValue(bool $should_catch_issue_exception = true)
     {
-        return $this->getEquivalentPHPValueForNode($this->node, self::RESOLVE_SCALAR_DEFAULT);
+        return $this->getEquivalentPHPValueForNode(
+            $this->node,
+            self::RESOLVE_SCALAR_DEFAULT,
+            $should_catch_issue_exception
+        );
     }
 }

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -836,7 +836,7 @@ class UnionTypeVisitor extends AnalysisVisitor
                     return null;
                 }
             }
-            $result = (new ContextNode($code_base, $context, $node))->getEquivalentPHPValue();
+            $result = (new ContextNode($code_base, $context, $node))->getEquivalentPHPValue(ContextNode::RESOLVE_DEFAULT, false);
 
             if ($result instanceof Node) {
                 return null;
@@ -1347,7 +1347,11 @@ class UnionTypeVisitor extends AnalysisVisitor
                 if ($context_node === null) {
                     $context_node = new ContextNode($this->code_base, $this->context, null);
                 }
-                $key_node = $context_node->getEquivalentPHPValueForNode($key_node, ContextNode::RESOLVE_CONSTANTS);
+                $key_node = $context_node->getEquivalentPHPValueForNode(
+                    $key_node,
+                    ContextNode::RESOLVE_CONSTANTS,
+                    $this->should_catch_issue_exception
+                );
                 if (\is_object($key_node)) {
                     return null;
                 }
@@ -2041,7 +2045,12 @@ class UnionTypeVisitor extends AnalysisVisitor
     private function resolveArrayShapeElementTypes(Node $node, UnionType $union_type): ?UnionType
     {
         $dim_node = $node->children['dim'];
-        $dim_value = $dim_node instanceof Node ? (new ContextNode($this->code_base, $this->context, $dim_node))->getEquivalentPHPScalarValue() : $dim_node;
+        if ($dim_node instanceof Node) {
+            $dim_value = (new ContextNode($this->code_base, $this->context, $dim_node))
+                ->getEquivalentPHPScalarValue($this->should_catch_issue_exception);
+        } else {
+            $dim_value = $dim_node;
+        }
         // TODO: detect and warn about null
         $has_non_empty_array = false;
         $check_invalid_dim = !($node->flags & self::FLAG_IGNORE_NULLABLE);
@@ -4042,7 +4051,8 @@ class UnionTypeVisitor extends AnalysisVisitor
             if (!($method_name instanceof Node)) {
                 $method_name = UnionTypeVisitor::anyStringLiteralForNode($this->code_base, $this->context, $method_name);
             }
-            $method_name = (new ContextNode($code_base, $context, $method_name))->getEquivalentPHPScalarValue();
+            $method_name = (new ContextNode($code_base, $context, $method_name))
+                ->getEquivalentPHPScalarValue($this->should_catch_issue_exception);
             if (!is_string($method_name)) {
                 $method_name_type = UnionTypeVisitor::unionTypeFromNode($this->code_base, $this->context, $method_name, $this->should_catch_issue_exception);
                 if (!$method_name_type->canCastToUnionType(StringType::instance(false)->asPHPDocUnionType(), $code_base)) {
@@ -4176,7 +4186,8 @@ class UnionTypeVisitor extends AnalysisVisitor
     {
         $orig_node = $node;
         if ($node instanceof Node) {
-            $node = (new ContextNode($this->code_base, $this->context, $node))->getEquivalentPHPValue();
+            $node = (new ContextNode($this->code_base, $this->context, $node))
+                ->getEquivalentPHPValue(ContextNode::RESOLVE_DEFAULT, $this->should_catch_issue_exception);
         }
         if (is_string($node)) {
             if (strpos($node, '::') !== false) {

--- a/tests/files/src/0981_undeclared_variable_after_loop.php
+++ b/tests/files/src/0981_undeclared_variable_after_loop.php
@@ -1,0 +1,14 @@
+<?php
+
+// Regression test for https://github.com/phan/phan/issues/4617
+
+( static function() {
+    $emptyArr = [];
+    foreach ( [ 1, 2, 3 ] as $_ ) {
+        if ( rand() ) {
+            continue;
+        }
+        $idx = 'foo';
+        echo $emptyArr[$idx] ?? 'bar';
+    }
+} )();


### PR DESCRIPTION
This lets us respect the value of `$this->should_catch_issue_exception` when ContextNode is used from UnionTypeVisitor.

It's not entirely clear whether these resolve* methods are ever supposed to emit issues; it might make sense to just ditch this new parameter and just pass `false`. However, that would be a bigger change (and possibly breaking, e.g. for 3rd party plugins), so it isn't done here. Still, the parameter is only added to a minimal subset of methods, so we can more easily change this later.

Closes #4617
Related to #4885