### PR TITLE
Fix `static` type resolution in property assignments

### DIFF
--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -1116,7 +1116,10 @@ class AssignmentVisitor extends AnalysisVisitor
         // know what the array structure of the parameter is
         // outside of the scope of this assignment, so we add to
         // its union type rather than replace it.
-        $property_union_type = $property->getPHPDocUnionType()->withStaticResolvedInContext($this->context);
+        // TODO: If the property is inherited, this will resolve `static` in the context of the parent class, and
+        // thus yield a supertype of the intended type. However, we can't resolve `static` in the right context here,
+        // and the PHPDoc type isn't meant to be replaced with concrete types as in Property::inheritStaticUnionType().
+        $property_union_type = $property->getPHPDocUnionType()->withStaticResolvedInContext($property->getContext());
         $resolved_right_type = $this->right_type->withStaticResolvedInContext($this->context);
         if ($this->dim_depth > 0) {
             if ($resolved_right_type->canCastToExpandedUnionType(

--- a/tests/files/expected/0982_prop_static_resolution.php.expected
+++ b/tests/files/expected/0982_prop_static_resolution.php.expected
@@ -1,0 +1,6 @@
+%s:18 PhanDebugAnnotation @phan-debug-var requested for variable $base - it has union type \NS982\HasStaticProp
+%s:20 PhanDebugAnnotation @phan-debug-var requested for variable $child - it has union type \NS982\ChildWithStaticProp|\NS982\HasStaticProp
+%s:28 PhanDebugAnnotation @phan-debug-var requested for variable $baseProp - it has union type \NS982\HasStaticProp
+%s:32 PhanTypeMismatchPropertyProbablyReal Assigning $this of type \NS982\UnrelatedClass|static to property but \NS982\HasStaticProp->staticProp is \NS982\HasStaticProp (no real type) (the inferred real assigned type has nothing in common with the declared phpdoc property type)
+%s:35 PhanDebugAnnotation @phan-debug-var requested for variable $childProp - it has union type \NS982\ChildWithStaticProp|\NS982\HasStaticProp
+%s:39 PhanTypeMismatchPropertyProbablyReal Assigning $this of type \NS982\UnrelatedClass|static to property but \NS982\ChildWithStaticProp->staticProp is \NS982\HasStaticProp (no real type) (the inferred real assigned type has nothing in common with the declared phpdoc property type)

--- a/tests/files/src/0982_prop_static_resolution.php
+++ b/tests/files/src/0982_prop_static_resolution.php
@@ -1,0 +1,42 @@
+<?php
+
+// Regression test for https://github.com/phan/phan/issues/4883
+
+namespace NS982;
+
+class HasStaticProp {
+    /** @var static */
+    public $staticProp;
+}
+
+class ChildWithStaticProp extends HasStaticProp {
+    public function __construct() {
+        $this->staticProp = $this;
+    }
+}
+
+$base = (new HasStaticProp)->staticProp;
+'@phan-debug-var $base';
+$child = (new ChildWithStaticProp)->staticProp;
+'@phan-debug-var $child';
+
+
+class UnrelatedClass {
+    /** @suppress PhanUnusedVariable */
+    public function unrelatedMethod() {
+        $baseInstance = new HasStaticProp;
+        $baseProp = $baseInstance->staticProp;
+        '@phan-debug-var $baseProp';
+        $baseInstance->staticProp = new HasStaticProp;
+        $baseInstance->staticProp = new ChildWithStaticProp;
+        $baseInstance->staticProp = $this;
+
+        $childInstance = new ChildWithStaticProp;
+        $childProp = $childInstance->staticProp;
+        '@phan-debug-var $childProp';
+        $childInstance->staticProp = new ChildWithStaticProp;
+        $childInstance->staticProp = new HasStaticProp; // TODO: This should warn
+        $childInstance->staticProp = $this;
+    }
+}
+(new UnrelatedClass)->unrelatedMethod();


### PR DESCRIPTION
When analyzing an assignment, and the property's PHPDoc type is `static`, resolve it in the context of that property, not of whatever random class the assignment is in.

As noted in a TODO, this can actually give us a supertype when the property is inherited, but there doesn't seem to be a simple way of fixing it.

Closes #4883.