### PR TITLE
Warn when accessing non-int offsets of union types containing string

### DIFF
--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -2165,22 +2165,20 @@ class UnionTypeVisitor extends AnalysisVisitor
          *           but have unknown array shapes in $union_type
          */
         $has_generic_array = false;
-        $has_string = false;
+        $has_valid_string_access = false;
         $resulting_element_type = null;
         foreach ($union_type->getTypeSet() as $type) {
             if (!($type instanceof ArrayShapeType)) {
                 if ($type instanceof StringType) {
-                    $has_string = true;
                     if (\is_int($dim_value) || \filter_var($dim_value, \FILTER_VALIDATE_INT) !== false) {
                         // If we request a string offset from a string, that's not valid. Only accept integer dimensions as valid.
                         // in php, indices of strings can be negative
+                        $has_valid_string_access = true;
                         if ($resulting_element_type instanceof UnionType) {
                             $resulting_element_type = $resulting_element_type->withType(StringType::instance(false));
                         } else {
                             $resulting_element_type = StringType::instance(false)->asPHPDocUnionType();
                         }
-                    } else {
-                        // TODO: Warn about string indices of strings?
                     }
                 } elseif ($type->isArrayLike($code_base) || $type->isObject() || $type instanceof MixedType) {
                     if ($type instanceof ListType && (!\is_numeric($dim_value) || $dim_value < 0)) {
@@ -2213,15 +2211,15 @@ class UnionTypeVisitor extends AnalysisVisitor
             }
         }
         if ($resulting_element_type === null) {
-            if (!$has_string && !$has_generic_array) {
-                // This is exclusively array shape types.
+            if (!$has_valid_string_access && !$has_generic_array) {
+                // This is exclusively array shape and non-array types.
                 // Return false to indicate that the offset doesn't exist in any of those array shape types.
                 return false;
             }
             return null;
         }
-        if ($has_string || $has_generic_array) {
-            if ($has_string && $has_generic_array) {
+        if ($has_valid_string_access || $has_generic_array) {
+            if ($has_valid_string_access && $has_generic_array) {
                 return null;
             }
             if ($resulting_element_type->hasRealTypeSet()) {

--- a/tests/files/expected/0982_string_or_array_string_offset.php.expected
+++ b/tests/files/expected/0982_string_or_array_string_offset.php.expected
@@ -1,0 +1,4 @@
+%s:10 PhanTypeInvalidDimOffset Invalid offset "missing" of $x of array type array{a:int}|string
+%s:15 PhanTypeInvalidDimOffset Invalid offset 3 of $y of array type array{a:int}|int
+%s:16 PhanTypeInvalidDimOffset Invalid offset "missing" of $y of array type array{a:int}|int
+%s:28 PhanTypeInvalidDimOffset Invalid offset 3 of $y of array type array{a:int}|int

--- a/tests/files/src/0982_string_or_array_string_offset.php
+++ b/tests/files/src/0982_string_or_array_string_offset.php
@@ -1,0 +1,30 @@
+<?php
+
+// Regression test for https://github.com/phan/phan/issues/4709
+
+namespace NS982;
+
+/** @param string|array{a:int} $x */
+function arrayOrString( $x ) {
+    var_export($x[3]);
+    var_export($x['missing']);
+}
+
+/** @param int|array{a:int} $y */
+function arrayOrInt( $y ) {
+    var_export($y[3]);
+    var_export($y['missing']);
+}
+
+// The following would need stricter checks to emit issues
+/** @param string|array{a:int} $x */
+function arrayOrStringOffsetExists( $x ) {
+    var_export($x[3]);
+    var_export($x['a']);
+}
+
+/** @param int|array{a:int} $y */
+function arrayOrIntOffsetExists( $y ) {
+    var_export($y[3]);
+    var_export($y['a']);
+}


### PR DESCRIPTION
When resolving the array element type for a union type containing both `string` and array shape types, do not allow any type containing string. Instead, do that iff the offset being accessed is an integer. Else we just ignore the fact that one of the types was string, because it's no different than any other type for which we can't access string offsets.

Note, the warning will only be emitted if the string offset does not exist in any of the array shape types, but that is unrelated to the fact that the other type in the union is string: it would be the same for integers etc. To emit a warning there, phan would need a stricter mode (like the [strict_*_checking](https://github.com/phan/phan/wiki/Phan-Config-Settings#strict_object_checking) options) where it warns if even one of the types in the union is not array-like. This is essentially the same proposal I made in https://github.com/phan/phan/issues/4879#issuecomment-2973431399.

Closes #4709.