### PR TITLE
Support dynamic class constant fetch

### DIFF
--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -3455,6 +3455,14 @@ Invalid @phan-closure-scope: expected a class name, got {TYPE}
 
 e.g. [this issue](https://github.com/phan/phan/tree/v5/tests/files/expected/0537_closure_scope.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/v5/tests/files/src/0537_closure_scope.php#L8).
 
+## PhanTypeInvalidConstantName
+
+```
+Saw a class constant fetch with a name of type {TYPE} but expected the name to be a string
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/v5/tests/php83_files/expected/004_fetch_class_constant_dynamically_syntax.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/v5/tests/php83_files/src/004_fetch_class_constant_dynamically_syntax.php#L9).
+
 ## PhanTypeInvalidDimOffset
 
 ```

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -2203,7 +2203,6 @@ class ContextNode
         }
 
         $constant_name = $node->children['const'];
-        $const_type = UnionTypeVisitor::unionTypeFromNode($this->code_base, $this->context, $node->children['const']);
 
         if (PHP_VERSION_ID < 80300) {
             // Only string is allowed in PHP 8.2 and earlier
@@ -2212,7 +2211,7 @@ class ContextNode
                     Issue::fromType(Issue::InvalidNode)(
                         $this->context->getFile(),
                         $node->lineno,
-                        [$const_type]
+                        ['Non-literal constant names are not valid in PHP < 8.3']
                     )
                 );
             }
@@ -2222,10 +2221,11 @@ class ContextNode
                 $constant_name = UnionTypeVisitor::anyStringLiteralForNode($this->code_base, $this->context, $constant_name);
             }
             if (!is_string($constant_name)) {
+                $const_type = UnionTypeVisitor::unionTypeFromNode($this->code_base, $this->context, $node->children['const']);
                 if (!$const_type->canCastToUnionType(StringType::instance(false)->asPHPDocUnionType(), $this->code_base)) {
                     // If we know the name node can't be a string, throw an IssueException
                     throw new IssueException(
-                        Issue::fromType(Issue::InvalidNode)(
+                        Issue::fromType(Issue::TypeInvalidConstantName)(
                             $this->context->getFile(),
                             $node->lineno,
                             [$const_type]

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -2203,8 +2203,21 @@ class ContextNode
         }
 
         $constant_name = $node->children['const'];
+        if (\PHP_VERSION_ID >= 80300) {
+            if ($constant_name instanceof Node) {
+                $constant_name = UnionTypeVisitor::anyStringLiteralForNode($this->code_base, $this->context, $constant_name);
+            }
+        }
         if (!is_string($constant_name)) {
-            throw new AssertionError('$constant_name must be a string');
+            $this->emitIssue(
+                Issue::InvalidNode,
+                $node->lineno,
+                "Class constant name must be a string or a variable (PHP 8.3+), got " . (is_object($constant_name) ? get_class($constant_name) : gettype($constant_name))
+            );
+            throw new NodeException(
+                $node,
+                "Class constant name must be a string or a variable (PHP 8.3+)"
+            );
         }
         if (!\strcasecmp($constant_name, 'class')) {
             $constant_name = 'class';

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -2203,21 +2203,41 @@ class ContextNode
         }
 
         $constant_name = $node->children['const'];
-        if (\PHP_VERSION_ID >= 80300) {
+        $const_type = UnionTypeVisitor::unionTypeFromNode($this->code_base, $this->context, $node->children['const']);
+
+        if (PHP_VERSION_ID < 80300) {
+            // Only string is allowed in PHP 8.2 and earlier
+            if (!is_string($constant_name)) {
+                throw new IssueException(
+                    Issue::fromType(Issue::InvalidNode)(
+                        $this->context->getFile(),
+                        $node->lineno,
+                        [$const_type]
+                    )
+                );
+            }
+        } else {
+            // String and string type variables are allowed in PHP 8.3 and later
             if ($constant_name instanceof Node) {
                 $constant_name = UnionTypeVisitor::anyStringLiteralForNode($this->code_base, $this->context, $constant_name);
             }
-        }
-        if (!is_string($constant_name)) {
-            $this->emitIssue(
-                Issue::InvalidNode,
-                $node->lineno,
-                "Class constant name must be a string or a variable (PHP 8.3+), got " . (is_object($constant_name) ? get_class($constant_name) : gettype($constant_name))
-            );
-            throw new NodeException(
-                $node,
-                "Class constant name must be a string or a variable (PHP 8.3+)"
-            );
+            if (!is_string($constant_name)) {
+                if (!$const_type->canCastToUnionType(StringType::instance(false)->asPHPDocUnionType(), $this->code_base)) {
+                    // If we know the name node can't be a string, throw an IssueException
+                    throw new IssueException(
+                        Issue::fromType(Issue::InvalidNode)(
+                            $this->context->getFile(),
+                            $node->lineno,
+                            [$const_type]
+                        )
+                    );
+                }
+                // Unable to infer type
+                throw new NodeException(
+                    $node,
+                    'Cannot infer type of const name'
+                );
+            }
         }
         if (!\strcasecmp($constant_name, 'class')) {
             $constant_name = 'class';

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -244,6 +244,7 @@ class Issue
     public const TypeComparisonToInvalidClassType = 'PhanTypeComparisonToInvalidClassType';
     public const TypeInvalidPropertyName = 'PhanTypeInvalidPropertyName';
     public const TypeInvalidStaticPropertyName = 'PhanTypeInvalidStaticPropertyName';
+    public const TypeInvalidConstantName = 'PhanTypeInvalidConstantName';
     public const TypeErrorInInternalCall = 'PhanTypeErrorInInternalCall';
     public const TypeErrorInOperation = 'PhanTypeErrorInOperation';
     public const TypeMismatchPropertyDefault        = 'PhanTypeMismatchPropertyDefault';
@@ -2636,6 +2637,14 @@ class Issue
                 "Saw a dynamic usage of a static property with a name of type {TYPE} but expected the name to be a string",
                 self::REMEDIATION_B,
                 10103
+            ),
+            new Issue(
+                self::TypeInvalidConstantName,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_CRITICAL,
+                "Saw a class constant fetch with a name of type {TYPE} but expected the name to be a string",
+                self::REMEDIATION_B,
+                10188
             ),
             new Issue(
                 self::TypeErrorInInternalCall,

--- a/tests/php83_files/expected/004_fetch_class_constant_dynamically_syntax.php.expected
+++ b/tests/php83_files/expected/004_fetch_class_constant_dynamically_syntax.php.expected
@@ -1,0 +1,4 @@
+%s:13 PhanInvalidNode Class constant name must be a string or a variable (PHP 8.3+), got NULL
+%s:14 PhanInvalidNode Class constant name must be a string or a variable (PHP 8.3+), got NULL
+%s:17 PhanInvalidNode Class constant name must be a string or a variable (PHP 8.3+), got NULL
+%s:18 PhanInvalidNode Class constant name must be a string or a variable (PHP 8.3+), got NULL

--- a/tests/php83_files/expected/004_fetch_class_constant_dynamically_syntax.php.expected
+++ b/tests/php83_files/expected/004_fetch_class_constant_dynamically_syntax.php.expected
@@ -1,6 +1,6 @@
-%s:9 PhanInvalidNode array{}
-%s:10 PhanInvalidNode null
-%s:14 PhanInvalidNode 123
-%s:22 PhanInvalidNode array{}
-%s:23 PhanInvalidNode null
-%s:27 PhanInvalidNode 123
+%s:9 PhanTypeInvalidConstantName Saw a class constant fetch with a name of type array{} but expected the name to be a string
+%s:10 PhanTypeInvalidConstantName Saw a class constant fetch with a name of type null but expected the name to be a string
+%s:14 PhanTypeInvalidConstantName Saw a class constant fetch with a name of type 123 but expected the name to be a string
+%s:22 PhanTypeInvalidConstantName Saw a class constant fetch with a name of type array{} but expected the name to be a string
+%s:23 PhanTypeInvalidConstantName Saw a class constant fetch with a name of type null but expected the name to be a string
+%s:27 PhanTypeInvalidConstantName Saw a class constant fetch with a name of type 123 but expected the name to be a string

--- a/tests/php83_files/expected/004_fetch_class_constant_dynamically_syntax.php.expected
+++ b/tests/php83_files/expected/004_fetch_class_constant_dynamically_syntax.php.expected
@@ -1,4 +1,6 @@
-%s:13 PhanInvalidNode Class constant name must be a string or a variable (PHP 8.3+), got NULL
-%s:14 PhanInvalidNode Class constant name must be a string or a variable (PHP 8.3+), got NULL
-%s:17 PhanInvalidNode Class constant name must be a string or a variable (PHP 8.3+), got NULL
-%s:18 PhanInvalidNode Class constant name must be a string or a variable (PHP 8.3+), got NULL
+%s:9 PhanInvalidNode array{}
+%s:10 PhanInvalidNode null
+%s:14 PhanInvalidNode 123
+%s:22 PhanInvalidNode array{}
+%s:23 PhanInvalidNode null
+%s:27 PhanInvalidNode 123

--- a/tests/php83_files/src/004_fetch_class_constant_dynamically_syntax.php
+++ b/tests/php83_files/src/004_fetch_class_constant_dynamically_syntax.php
@@ -1,7 +1,7 @@
 <?php
 // support https://wiki.php.net/rfc/dynamic_class_constant_fetch
 class C5 {
-    const string MY_CONST = 'bar';
+    const MY_CONST = 'bar';
 }
 $constName = 'MY_CONST';
 echo C5::MY_CONST;

--- a/tests/php83_files/src/004_fetch_class_constant_dynamically_syntax.php
+++ b/tests/php83_files/src/004_fetch_class_constant_dynamically_syntax.php
@@ -3,16 +3,25 @@
 class C5 {
     const string MY_CONST = 'bar';
 }
-enum E5: string {
-    case MY_ENUM = 'bar';
-}
 $constName = 'MY_CONST';
-$enumName = 'MY_ENUM';
 echo C5::MY_CONST;
 echo C5::{$constName};
 echo C5::{[]};
 echo C5::{null};
+$constName = 'MY_CONST_' . rand();
+echo C5::{$constName};
+$constName = 123;
+echo C5::{$constName};
+
+enum E5: string {
+    case MY_ENUM = 'bar';
+}
+$enumName = 'MY_ENUM';
 echo E5::MY_ENUM->value;
 echo E5::{$enumName}->value;
 echo E5::{[]}->value;
 echo E5::{null}->value;
+$enumName = 'MY_ENUM_' . rand();
+echo E5::{$enumName}->value;
+$enumName = 123;
+echo E5::{$enumName}->value;

--- a/tests/php83_files/src/004_fetch_class_constant_dynamically_syntax.php
+++ b/tests/php83_files/src/004_fetch_class_constant_dynamically_syntax.php
@@ -1,0 +1,18 @@
+<?php
+// support https://wiki.php.net/rfc/dynamic_class_constant_fetch
+class C5 {
+    const string MY_CONST = 'bar';
+}
+enum E5: string {
+    case MY_ENUM = 'bar';
+}
+$constName = 'MY_CONST';
+$enumName = 'MY_ENUM';
+echo C5::MY_CONST;
+echo C5::{$constName};
+echo C5::{[]};
+echo C5::{null};
+echo E5::MY_ENUM->value;
+echo E5::{$enumName}->value;
+echo E5::{[]}->value;
+echo E5::{null}->value;


### PR DESCRIPTION
Hi there!

This PR fixes issue #4961 .
I fixed an error that occurred when analyzing source code containing the dynamic class constant retrieval feature introduced in PHP 8.3.
Please review it.

Thank you!