### PR TITLE
UnionTypeVisitor: Fix typo in regexp escaping

### DIFF
--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -3468,7 +3468,7 @@ class UnionTypeVisitor extends AnalysisVisitor
         foreach ($node_type->getTypeSet() as $sub_type) {
             if ($sub_type instanceof LiteralStringType) {
                 $value = $sub_type->getValue();
-                if (!\preg_match('/\\\\?[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff\\\]*/', $value)) {
+                if (!\preg_match('/\\\\?[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff\\\\]*/', $value)) {
                     $is_valid = false;
                     continue;
                 }


### PR DESCRIPTION
We should have four backslashes to generate two backslashes in the regexp string in order to match a literal backslash.

Three worked because the PHP string escaping syntax is tolerant, but I noticed because it broke syntax highlighting in my editor.