### PR TITLE
VariableTrackerVisitor: flag more functions as non-deterministic

### DIFF
--- a/src/Phan/Plugin/Internal/UseReturnValuePlugin.php
+++ b/src/Phan/Plugin/Internal/UseReturnValuePlugin.php
@@ -625,7 +625,7 @@ class UseReturnValuePlugin extends PluginV3 implements PostAnalyzeNodeCapability
     'octdec' => true,
     'opendir' => true,
     'openssl_encrypt' => true,
-    'openssl_error_string' => true,
+    'openssl_error_string' => self::MUST_USE_WITH_SIDE_EFFECTS,
     'openssl_random_pseudo_bytes' => true,
     'openssl_x509_verify' => true,
     'ord' => true,

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
@@ -1171,11 +1171,14 @@ final class VariableTrackerVisitor extends AnalysisVisitor
         'rand' => true,
         'array_rand' => true,
         'mt_rand' => true,
+        'openssl_error_string' => true,
         'openssl_random_pseudo_bytes' => true,
         'random_bytes' => true,
         'random_int' => true,
         'next' => true,
         'prev' => true,
+        'ob_get_level' => true,
+        'error_get_last' => true,
     ];
 
     private static function isNonDeterministicCall(Node $node): bool


### PR DESCRIPTION
The return value of `error_get_last`, `ob_get_level`, and `openssl_error_string` depends on internal state. On top of that, `openssl_error_string` has side effects because it also dequeues errors.