### PR TITLE
CallableParamPlugin: Do not report invalid callables for functions taking callable|foo unions

### DIFF
--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -3744,31 +3744,34 @@ class UnionTypeVisitor extends AnalysisVisitor
      * @param CodeBase $code_base
      * @param Context $context
      * @param int|string|float|Node $node the node to fetch CallableType instances for.
-     * @param bool $log_error whether or not to log errors while searching @phan-unused-param
+     * @param bool $log_error whether or not to log errors while searching
      * @return list<FunctionInterface>
-     * TODO: use log_error
      */
     public static function functionLikeListFromNodeAndContext(CodeBase $code_base, Context $context, $node, bool $log_error): array
     {
         try {
-            $function_fqsens = (new UnionTypeVisitor($code_base, $context, true))->functionLikeFQSENListFromNode($node);
+            $function_fqsens = (new UnionTypeVisitor($code_base, $context, true))->functionLikeFQSENListFromNode($node, $log_error);
         } catch (FQSENException $e) {
-            Issue::maybeEmit(
-                $code_base,
-                $context,
-                $e instanceof EmptyFQSENException ? Issue::EmptyFQSENInCallable : Issue::InvalidFQSENInCallable,
-                $context->getLineNumberStart(),
-                $e->getFQSEN()
-            );
+            if ($log_error) {
+                Issue::maybeEmit(
+                    $code_base,
+                    $context,
+                    $e instanceof EmptyFQSENException ? Issue::EmptyFQSENInCallable : Issue::InvalidFQSENInCallable,
+                    $context->getLineNumberStart(),
+                    $e->getFQSEN()
+                );
+            }
             return [];
         } catch (\InvalidArgumentException $_) {
-            Issue::maybeEmit(
-                $code_base,
-                $context,
-                Issue::InvalidFQSENInCallable,
-                $context->getLineNumberStart(),
-                '(unknown)'
-            );
+            if ($log_error) {
+                Issue::maybeEmit(
+                    $code_base,
+                    $context,
+                    Issue::InvalidFQSENInCallable,
+                    $context->getLineNumberStart(),
+                    '(unknown)'
+                );
+            }
             return [];
         }
         $functions = [];
@@ -3797,9 +3800,10 @@ class UnionTypeVisitor extends AnalysisVisitor
      * Fetch known classes for a place where a class name was provided as a string or string expression.
      * Warn if this is an invalid class name.
      * @param \ast\Node|string|int|float $node
+     * @param bool $log_error whether or not to log errors while searching
      * @return list<Clazz>
      */
-    public static function classListFromClassNameNode(CodeBase $code_base, Context $context, $node): array
+    public static function classListFromClassNameNode(CodeBase $code_base, Context $context, $node, bool $log_error = true): array
     {
         $results = [];
         $strings = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $node)->asStringScalarValues();
@@ -3807,33 +3811,39 @@ class UnionTypeVisitor extends AnalysisVisitor
             try {
                 $fqsen = FullyQualifiedClassName::fromFullyQualifiedString($string);
             } catch (FQSENException $e) {
-                Issue::maybeEmit(
-                    $code_base,
-                    $context,
-                    $e instanceof EmptyFQSENException ? Issue::EmptyFQSENInClasslike : Issue::InvalidFQSENInClasslike,
-                    $context->getLineNumberStart(),
-                    $e->getFQSEN()
-                );
+                if ($log_error) {
+                    Issue::maybeEmit(
+                        $code_base,
+                        $context,
+                        $e instanceof EmptyFQSENException ? Issue::EmptyFQSENInClasslike : Issue::InvalidFQSENInClasslike,
+                        $context->getLineNumberStart(),
+                        $e->getFQSEN()
+                    );
+                }
                 continue;
             } catch (\InvalidArgumentException $_) {
-                Issue::maybeEmit(
-                    $code_base,
-                    $context,
-                    Issue::InvalidFQSENInClasslike,
-                    $context->getLineNumberStart(),
-                    '(unknown)'
-                );
+                if ($log_error) {
+                    Issue::maybeEmit(
+                        $code_base,
+                        $context,
+                        Issue::InvalidFQSENInClasslike,
+                        $context->getLineNumberStart(),
+                        '(unknown)'
+                    );
+                }
                 continue;
             }
             if (!$code_base->hasClassWithFQSEN($fqsen)) {
                 // TODO: Different issue type?
-                Issue::maybeEmit(
-                    $code_base,
-                    $context,
-                    Issue::UndeclaredClassReference,
-                    $context->getLineNumberStart(),
-                    (string)$fqsen
-                );
+                if ($log_error) {
+                    Issue::maybeEmit(
+                        $code_base,
+                        $context,
+                        Issue::UndeclaredClassReference,
+                        $context->getLineNumberStart(),
+                        (string)$fqsen
+                    );
+                }
                 continue;
             }
             $results[] = $code_base->getClassByFQSEN($fqsen);
@@ -3850,7 +3860,7 @@ class UnionTypeVisitor extends AnalysisVisitor
      */
     public static function functionLikeFQSENListFromNodeAndContext(CodeBase $code_base, Context $context, $node): array
     {
-        return (new UnionTypeVisitor($code_base, $context, true))->functionLikeFQSENListFromNode($node);
+        return (new UnionTypeVisitor($code_base, $context, true))->functionLikeFQSENListFromNode($node, true);
     }
 
     /**
@@ -4039,7 +4049,7 @@ class UnionTypeVisitor extends AnalysisVisitor
      * @return list<FullyQualifiedMethodName>
      * A list of `FullyQualifiedMethodName`s associated with the given node
      */
-    private function methodFQSENListFromParts($class_or_expr, $method_name, bool $from_array): array
+    private function methodFQSENListFromParts($class_or_expr, $method_name, bool $from_array, bool $log_error): array
     {
         $code_base = $this->code_base;
         $context = $this->context;
@@ -4052,7 +4062,7 @@ class UnionTypeVisitor extends AnalysisVisitor
                 ->getEquivalentPHPScalarValue($this->should_catch_issue_exception);
             if (!is_string($method_name)) {
                 $method_name_type = UnionTypeVisitor::unionTypeFromNode($this->code_base, $this->context, $method_name, $this->should_catch_issue_exception);
-                if (!$method_name_type->canCastToUnionType(StringType::instance(false)->asPHPDocUnionType(), $code_base)) {
+                if ($log_error && !$method_name_type->canCastToUnionType(StringType::instance(false)->asPHPDocUnionType(), $code_base)) {
                     Issue::maybeEmit(
                         $code_base,
                         $context,
@@ -4100,20 +4110,24 @@ class UnionTypeVisitor extends AnalysisVisitor
                 }
             }
         } catch (FQSENException $e) {
-            $this->emitIssue(
-                $e instanceof EmptyFQSENException ? Issue::EmptyFQSENInClasslike : Issue::InvalidFQSENInClasslike,
-                $context->getLineNumberStart(),
-                $e->getFQSEN()
-            );
+            if ($log_error) {
+                $this->emitIssue(
+                    $e instanceof EmptyFQSENException ? Issue::EmptyFQSENInClasslike : Issue::InvalidFQSENInClasslike,
+                    $context->getLineNumberStart(),
+                    $e->getFQSEN()
+                );
+            }
             return [];
         }
         if (!$code_base->hasClassWithFQSEN($class_fqsen)) {
-            $this->emitIssue(
-                Issue::UndeclaredClassInCallable,
-                $context->getLineNumberStart(),
-                (string)$class_fqsen,
-                "$class_fqsen::" . (is_string($method_name) ? $method_name : '(unknown)')
-            );
+            if ($log_error) {
+                $this->emitIssue(
+                    Issue::UndeclaredClassInCallable,
+                    $context->getLineNumberStart(),
+                    (string)$class_fqsen,
+                    "$class_fqsen::" . (is_string($method_name) ? $method_name : '(unknown)')
+                );
+            };
             return [];
         }
         if (!is_string($method_name)) {
@@ -4121,15 +4135,17 @@ class UnionTypeVisitor extends AnalysisVisitor
         }
         $class = $code_base->getClassByFQSEN($class_fqsen);
         if (!$class->hasMethodWithName($code_base, $method_name, true)) {
-            $this->emitIssue(
-                Issue::UndeclaredStaticMethodInCallable,
-                $context->getLineNumberStart(),
-                "$class_fqsen::$method_name"
-            );
+            if ($log_error) {
+                $this->emitIssue(
+                    Issue::UndeclaredStaticMethodInCallable,
+                    $context->getLineNumberStart(),
+                    "$class_fqsen::$method_name"
+                );
+            };
             return [];
         }
         $method = $class->getMethodByName($code_base, $method_name);
-        if (!$method->isStatic()) {
+        if ($log_error && !$method->isStatic()) {
             $this->emitIssue(
                 Issue::StaticCallToNonStatic,
                 $context->getLineNumberStart(),
@@ -4145,7 +4161,7 @@ class UnionTypeVisitor extends AnalysisVisitor
      * @see ContextNode::getFunction() for a similar function
      * @return list<FullyQualifiedFunctionName>
      */
-    private function functionFQSENListFromFunctionName(string $function_name): array
+    private function functionFQSENListFromFunctionName(string $function_name, bool $log_error): array
     {
         // TODO: Catch invalid code such as call_user_func('\\\\x\\\\y')
         try {
@@ -4159,11 +4175,13 @@ class UnionTypeVisitor extends AnalysisVisitor
             return [];
         }
         if (!$this->code_base->hasFunctionWithFQSEN($function_fqsen)) {
-            $this->emitIssue(
-                Issue::UndeclaredFunctionInCallable,
-                $this->context->getLineNumberStart(),
-                $function_name
-            );
+            if ($log_error) {
+                $this->emitIssue(
+                    Issue::UndeclaredFunctionInCallable,
+                    $this->context->getLineNumberStart(),
+                    $function_name
+                );
+            }
             return [];
         }
         return [$function_fqsen];
@@ -4171,6 +4189,7 @@ class UnionTypeVisitor extends AnalysisVisitor
 
     /**
      * @param string|Node $node
+     * @param bool $log_error whether or not to log errors while searching
      *
      * @return list<FullyQualifiedFunctionLikeName>
      * A list of `FullyQualifiedFunctionLikeName`s associated with the given node
@@ -4179,7 +4198,7 @@ class UnionTypeVisitor extends AnalysisVisitor
      * An exception is thrown if we can't find a class for
      * the given type
      */
-    private function functionLikeFQSENListFromNode($node): array
+    private function functionLikeFQSENListFromNode($node, bool $log_error): array
     {
         $orig_node = $node;
         if ($node instanceof Node) {
@@ -4189,32 +4208,36 @@ class UnionTypeVisitor extends AnalysisVisitor
         if (is_string($node)) {
             if (strpos($node, '::') !== false) {
                 [$class_name, $method_name] = \explode('::', $node, 2);
-                return $this->methodFQSENListFromParts($class_name, $method_name, false);
+                return $this->methodFQSENListFromParts($class_name, $method_name, false, $log_error);
             }
-            return $this->functionFQSENListFromFunctionName($node);
+            return $this->functionFQSENListFromFunctionName($node, $log_error);
         }
         if (\is_array($node)) {
             if (\count($node) !== 2) {
-                $this->emitIssue(
-                    Issue::TypeInvalidCallableArraySize,
-                    $orig_node->lineno ?? $this->context->getLineNumberStart(),
-                    \count($node)
-                );
+                if ($log_error) {
+                    $this->emitIssue(
+                        Issue::TypeInvalidCallableArraySize,
+                        $orig_node->lineno ?? $this->context->getLineNumberStart(),
+                        \count($node)
+                    );
+                }
                 return [];
             }
             $i = 0;
             foreach ($node as $key => $_) {
                 if ($key !== $i) {
-                    $this->emitIssue(
-                        Issue::TypeInvalidCallableArrayKey,
-                        $orig_node->lineno ?? $this->context->getLineNumberStart(),
-                        $i
-                    );
+                    if ($log_error) {
+                        $this->emitIssue(
+                            Issue::TypeInvalidCallableArrayKey,
+                            $orig_node->lineno ?? $this->context->getLineNumberStart(),
+                            $i
+                        );
+                    }
                     return [];
                 }
                 $i++;
             }
-            return $this->methodFQSENListFromParts($node[0], $node[1], true);
+            return $this->methodFQSENListFromParts($node[0], $node[1], true, $log_error);
         }
         if (!($node instanceof Node)) {
             // TODO: Warn?

--- a/src/Phan/Plugin/Internal/CallableParamPlugin.php
+++ b/src/Phan/Plugin/Internal/CallableParamPlugin.php
@@ -51,11 +51,12 @@ final class CallableParamPlugin extends PluginV3 implements
         /**
          * @param list<Node|int|float|string> $args
          */
-        $closure = static function (CodeBase $code_base, Context $context, FunctionInterface $unused_function, array $args, ?Node $_) use ($params): void {
+        $closure = static function (CodeBase $code_base, Context $context, FunctionInterface $function, array $args, ?Node $_) use ($params): void {
             // TODO: Implement support for variadic callable arguments.
             foreach ($params as $i => $flags) {
                 $arg = $args[$i] ?? null;
-                if ($arg === null) {
+                $param = $function->getParameterForCaller($i);
+                if ($arg === null || $param === null) {
                     continue;
                 }
 
@@ -63,9 +64,7 @@ final class CallableParamPlugin extends PluginV3 implements
 
                 if ($flags & self::PARAM_HAS_CALLABLE) {
                     // Fetch possible functions for the provided callable argument.
-                    // As an intentional side effect, this warns about invalid callables.
-                    // TODO: Check if the signature allows non-array callables? Not sure of desired semantics.
-                    $function_like_list = UnionTypeVisitor::functionLikeListFromNodeAndContext($code_base, $context, $arg, true);
+                    $function_like_list = UnionTypeVisitor::functionLikeListFromNodeAndContext($code_base, $context, $arg, false);
                     if ($function_like_list) {
                         $references[] = $function_like_list;
                     }
@@ -73,8 +72,7 @@ final class CallableParamPlugin extends PluginV3 implements
 
                 if ($flags & self::PARAM_HAS_CLASSSTRING) {
                     // Fetch possible classes.
-                    // As an intentional side effect, this warns about invalid/undefined class names.
-                    $class_list = UnionTypeVisitor::classListFromClassNameNode($code_base, $context, $arg);
+                    $class_list = UnionTypeVisitor::classListFromClassNameNode($code_base, $context, $arg, false);
                     if ($class_list) {
                         $references[] = $class_list;
                     }
@@ -84,6 +82,32 @@ final class CallableParamPlugin extends PluginV3 implements
                     foreach ($references as $reference_list) {
                         foreach ($reference_list as $addressable) {
                             $addressable->addReference($context);
+                        }
+                    }
+                }
+
+                if (!$references) {
+                    // It's not a valid callable and/or class-string, but before we emit issues,
+                    // first check if we're dealing with a union type where some other types are valid.
+                    $other_param_types = $param->getUnionType()->eraseRealTypeSet()->makeFromFilter(static function (Type $type) use ($flags): bool {
+                        if ($type instanceof CallableInterface && ($flags & self::PARAM_HAS_CALLABLE)) {
+                            return false;
+                        }
+                        if ($type instanceof ClassStringType && ($flags & self::PARAM_HAS_CLASSSTRING)) {
+                            return false;
+                        }
+                        return true;
+                    });
+                    $valid_as_other_types = !$other_param_types->isEmpty() &&
+                        UnionTypeVisitor::unionTypeFromNode($code_base, $context, $arg)
+                            ->canCastToUnionType($other_param_types, $code_base);
+                    if (!$valid_as_other_types) {
+                        // Do it again, emitting issues this time.
+                        if ($flags & self::PARAM_HAS_CALLABLE) {
+                            UnionTypeVisitor::functionLikeListFromNodeAndContext($code_base, $context, $arg, true);
+                        }
+                        if ($flags & self::PARAM_HAS_CLASSSTRING) {
+                            UnionTypeVisitor::classListFromClassNameNode($code_base, $context, $arg, true);
                         }
                     }
                 }
@@ -168,10 +192,6 @@ final class CallableParamPlugin extends PluginV3 implements
         // See https://github.com/phan/phan/issues/1204 for note on function_exists() (not supported right now)
         $result['\\ReflectionFunction::__construct'] = self::generateClosure([0 => self::PARAM_HAS_CALLABLE]);
         $result['\\ReflectionClass::__construct'] = self::generateClosure([0 => self::PARAM_HAS_CLASSSTRING]);
-
-        // When a codebase calls function_exists(string|callable) to **check** if a function exists,
-        // don't emit PhanUndeclaredFunctionInCallable as a side effect.
-        unset($result['\\function_exists']);
 
         // Don't do redundant work extracting function definitions for commonly invoked functions.
         // TODO: Get actual statistics on how frequently used these are

--- a/src/Phan/Plugin/Internal/CallableParamPlugin.php
+++ b/src/Phan/Plugin/Internal/CallableParamPlugin.php
@@ -33,14 +33,16 @@ final class CallableParamPlugin extends PluginV3 implements
     HandleLazyLoadInternalFunctionCapability
 {
 
+    public const PARAM_HAS_CALLABLE = (1 << 0);
+    public const PARAM_HAS_CLASSSTRING = (1 << 1);
+
     /**
-     * @param list<int> $callable_params
-     * @param list<int> $class_params
+     * @param array<int,int> $params
      * @phan-return Closure(CodeBase,Context,FunctionInterface,array,?Node):void
      */
-    private static function generateClosure(array $callable_params, array $class_params): Closure
+    private static function generateClosure(array $params): Closure
     {
-        $key = \json_encode([$callable_params, $class_params]);
+        $key = \json_encode($params);
         static $cache = [];
         $closure = $cache[$key] ?? null;
         if ($closure !== null) {
@@ -49,46 +51,40 @@ final class CallableParamPlugin extends PluginV3 implements
         /**
          * @param list<Node|int|float|string> $args
          */
-        $closure = static function (CodeBase $code_base, Context $context, FunctionInterface $unused_function, array $args, ?Node $_) use ($callable_params, $class_params): void {
+        $closure = static function (CodeBase $code_base, Context $context, FunctionInterface $unused_function, array $args, ?Node $_) use ($params): void {
             // TODO: Implement support for variadic callable arguments.
-            foreach ($callable_params as $i) {
+            foreach ($params as $i => $flags) {
                 $arg = $args[$i] ?? null;
                 if ($arg === null) {
                     continue;
                 }
 
-                // Fetch possible functions for the provided callable argument.
-                // As an intentional side effect, this warns about invalid callables.
-                // TODO: Check if the signature allows non-array callables? Not sure of desired semantics.
-                $function_like_list = UnionTypeVisitor::functionLikeListFromNodeAndContext($code_base, $context, $arg, true);
-                if (count($function_like_list) === 0) {
-                    // Nothing to do
-                    continue;
-                }
+                $references = [];
 
-                if (Config::get_track_references()) {
-                    foreach ($function_like_list as $function) {
-                        $function->addReference($context);
+                if ($flags & self::PARAM_HAS_CALLABLE) {
+                    // Fetch possible functions for the provided callable argument.
+                    // As an intentional side effect, this warns about invalid callables.
+                    // TODO: Check if the signature allows non-array callables? Not sure of desired semantics.
+                    $function_like_list = UnionTypeVisitor::functionLikeListFromNodeAndContext($code_base, $context, $arg, true);
+                    if ($function_like_list) {
+                        $references[] = $function_like_list;
                     }
                 }
-                // self::analyzeFunctionAndNormalArgumentList($code_base, $context, $function_like_list, $arguments);
-            }
-            foreach ($class_params as $i) {
-                $arg = $args[$i] ?? null;
-                if ($arg === null) {
-                    continue;
+
+                if ($flags & self::PARAM_HAS_CLASSSTRING) {
+                    // Fetch possible classes.
+                    // As an intentional side effect, this warns about invalid/undefined class names.
+                    $class_list = UnionTypeVisitor::classListFromClassNameNode($code_base, $context, $arg);
+                    if ($class_list) {
+                        $references[] = $class_list;
+                    }
                 }
 
-                // Fetch possible classes. As an intentional side effect, this warns about invalid/undefined class names.
-                $class_list = UnionTypeVisitor::classListFromClassNameNode($code_base, $context, $arg);
-                if (count($class_list) === 0) {
-                    // Nothing to do
-                    continue;
-                }
-
-                if (Config::get_track_references()) {
-                    foreach ($class_list as $class) {
-                        $class->addReference($context);
+                if ($references && Config::get_track_references()) {
+                    foreach ($references as $reference_list) {
+                        foreach ($reference_list as $addressable) {
+                            $addressable->addReference($context);
+                        }
                     }
                 }
             }
@@ -103,30 +99,31 @@ final class CallableParamPlugin extends PluginV3 implements
      */
     private static function generateClosureForFunctionInterface(FunctionInterface $function): ?Closure
     {
-        $callable_params = [];
-        $class_params = [];
+        $params = [];
         foreach ($function->getParameterList() as $i => $param) {
+            $params[$i] = 0;
             // If there's a type such as Closure|string|int, don't automatically assume that any string or array passed in is meant to be a callable.
             // Explicitly require at least one type to be `callable`
             if ($param->getUnionType()->hasTypeMatchingCallback(static function (Type $type): bool {
                 // TODO: More specific closure for CallableDeclarationType
                 return $type instanceof CallableInterface;
             })) {
-                $callable_params[] = $i;
+                $params[$i] |= self::PARAM_HAS_CALLABLE;
             }
             if ($param->getUnionType()->hasTypeMatchingCallback(static function (Type $type): bool {
                 return $type instanceof ClassStringType;
             })) {
-                $class_params[] = $i;
+                $params[$i] |= self::PARAM_HAS_CLASSSTRING;
             }
         }
 
-        if (count($callable_params) === 0 && count($class_params) === 0) {
+        $params = array_filter($params);
+        if (count($params) === 0) {
             return null;
         }
         // Generate a de-duplicated closure.
         // fqsen can be global_function or ClassName::method
-        return self::generateClosure($callable_params, $class_params);
+        return self::generateClosure($params);
     }
 
     /**
@@ -169,8 +166,8 @@ final class CallableParamPlugin extends PluginV3 implements
 
         // new ReflectionFunction('my_func') is a usage of my_func()
         // See https://github.com/phan/phan/issues/1204 for note on function_exists() (not supported right now)
-        $result['\\ReflectionFunction::__construct'] = self::generateClosure([0], []);
-        $result['\\ReflectionClass::__construct'] = self::generateClosure([], [0]);
+        $result['\\ReflectionFunction::__construct'] = self::generateClosure([0 => self::PARAM_HAS_CALLABLE]);
+        $result['\\ReflectionClass::__construct'] = self::generateClosure([0 => self::PARAM_HAS_CLASSSTRING]);
 
         // When a codebase calls function_exists(string|callable) to **check** if a function exists,
         // don't emit PhanUndeclaredFunctionInCallable as a side effect.

--- a/tests/plugin_test/expected/211_callable_union.php.expected
+++ b/tests/plugin_test/expected/211_callable_union.php.expected
@@ -1,14 +1,5 @@
-src/211_callable_union.php:17 PhanTypeInvalidCallableArraySize In a place where phan was expecting a callable, saw an array of size 0, but callable arrays must be of size 2
-src/211_callable_union.php:18 PhanTypeInvalidCallableArraySize In a place where phan was expecting a callable, saw an array of size 3, but callable arrays must be of size 2
 src/211_callable_union.php:19 PhanUndeclaredFunctionInCallable Call to undeclared function puppies in callable
 src/211_callable_union.php:34 PhanTypeInvalidCallableArraySize In a place where phan was expecting a callable, saw an array of size 0, but callable arrays must be of size 2
 src/211_callable_union.php:35 PhanTypeInvalidCallableArraySize In a place where phan was expecting a callable, saw an array of size 3, but callable arrays must be of size 2
-src/211_callable_union.php:36 PhanUndeclaredFunctionInCallable Call to undeclared function puppies in callable
-src/211_callable_union.php:49 PhanUndeclaredFunctionInCallable Call to undeclared function stdClass in callable
-src/211_callable_union.php:50 PhanUndeclaredClassReference Reference to undeclared class \strval
 src/211_callable_union.php:51 PhanUndeclaredClassReference Reference to undeclared class \puppies
 src/211_callable_union.php:51 PhanUndeclaredFunctionInCallable Call to undeclared function puppies in callable
-src/211_callable_union.php:65 PhanUndeclaredFunctionInCallable Call to undeclared function stdClass in callable
-src/211_callable_union.php:66 PhanUndeclaredClassReference Reference to undeclared class \strval
-src/211_callable_union.php:67 PhanUndeclaredClassReference Reference to undeclared class \puppies
-src/211_callable_union.php:67 PhanUndeclaredFunctionInCallable Call to undeclared function puppies in callable

--- a/tests/plugin_test/expected/211_callable_union.php.expected
+++ b/tests/plugin_test/expected/211_callable_union.php.expected
@@ -1,0 +1,14 @@
+src/211_callable_union.php:17 PhanTypeInvalidCallableArraySize In a place where phan was expecting a callable, saw an array of size 0, but callable arrays must be of size 2
+src/211_callable_union.php:18 PhanTypeInvalidCallableArraySize In a place where phan was expecting a callable, saw an array of size 3, but callable arrays must be of size 2
+src/211_callable_union.php:19 PhanUndeclaredFunctionInCallable Call to undeclared function puppies in callable
+src/211_callable_union.php:34 PhanTypeInvalidCallableArraySize In a place where phan was expecting a callable, saw an array of size 0, but callable arrays must be of size 2
+src/211_callable_union.php:35 PhanTypeInvalidCallableArraySize In a place where phan was expecting a callable, saw an array of size 3, but callable arrays must be of size 2
+src/211_callable_union.php:36 PhanUndeclaredFunctionInCallable Call to undeclared function puppies in callable
+src/211_callable_union.php:49 PhanUndeclaredFunctionInCallable Call to undeclared function stdClass in callable
+src/211_callable_union.php:50 PhanUndeclaredClassReference Reference to undeclared class \strval
+src/211_callable_union.php:51 PhanUndeclaredClassReference Reference to undeclared class \puppies
+src/211_callable_union.php:51 PhanUndeclaredFunctionInCallable Call to undeclared function puppies in callable
+src/211_callable_union.php:65 PhanUndeclaredFunctionInCallable Call to undeclared function stdClass in callable
+src/211_callable_union.php:66 PhanUndeclaredClassReference Reference to undeclared class \strval
+src/211_callable_union.php:67 PhanUndeclaredClassReference Reference to undeclared class \puppies
+src/211_callable_union.php:67 PhanUndeclaredFunctionInCallable Call to undeclared function puppies in callable

--- a/tests/plugin_test/src/211_callable_union.php
+++ b/tests/plugin_test/src/211_callable_union.php
@@ -1,0 +1,67 @@
+<?php
+// @phan-file-suppress PhanTypeMismatchArgumentProbablyReal (suppress redundant errors that aren't from CallableParamPlugin)
+
+/**
+ * @param callable|array $x
+ */
+function test211_array($x) {
+    if (is_callable($x)) {
+        return $x();
+    } else {
+        return count($x);
+    }
+}
+
+test211_array('strval');
+test211_array(['Closure', 'fromCallable']);
+test211_array([]);
+test211_array([1, 2, 3]);
+test211_array('puppies'); // only this one is an error
+
+/**
+ * @param callable|string $x
+ */
+function test211_string($x) {
+    if (is_callable($x)) {
+        return $x();
+    } else {
+        return strlen($x);
+    }
+}
+
+test211_string('strval');
+test211_string(['Closure', 'fromCallable']);
+test211_string([]); // these two are errors
+test211_string([1, 2, 3]); // these two are errors
+test211_string('puppies');
+
+/**
+ * @param callable|class-string $x
+ */
+function test211_classstring($x) {
+    if (is_callable($x)) {
+        return $x();
+    } else {
+        return new $x();
+    }
+}
+
+test211_classstring('stdClass');
+test211_classstring('strval');
+test211_classstring('puppies'); // only this one is an error
+
+/**
+ * @param callable|class-string|string $x
+ */
+function test211_classstring_other($x) {
+    if (is_callable($x)) {
+        return $x();
+    } elseif (class_exists($x)) {
+        return new $x();
+    }
+    return null;
+}
+
+test211_classstring_other('stdClass');
+test211_classstring_other('strval');
+test211_classstring_other('puppies'); // not an error any more


### PR DESCRIPTION
And likewise for class-strings for functions taking class-string|foo.

Fixes #1648.

Most of the complexity here is needed for union types that include both class-string and callable, because we need to avoid emitting issues about a value being incorrect for one type when it's correct for the other, but still emit issues when a value is incorrect for both types.
