### PR TITLE
ASTReverter: Support array elements that are references

### DIFF
--- a/src/Phan/AST/ASTReverter.php
+++ b/src/Phan/AST/ASTReverter.php
@@ -435,6 +435,9 @@ class ASTReverter
             },
             ast\AST_ARRAY_ELEM => static function (Node $node): string {
                 $value_representation = self::toShortString($node->children['value']);
+                if ($node->flags & ast\flags\ARRAY_ELEM_REF) {
+                    $value_representation = "&$value_representation";
+                }
                 $key_node = $node->children['key'];
                 if ($key_node !== null) {
                     return self::toShortString($key_node) . '=>' . $value_representation;

--- a/tests/Phan/AST/ASTReverterTest.php
+++ b/tests/Phan/AST/ASTReverterTest.php
@@ -54,6 +54,7 @@ final class ASTReverterTest extends BaseTest
             ['array(2,3=>4)', '[2,3=>4]'],
             ["['x'=>'var']"],
             ['[2]'],
+            ['[&$x]'],
         ];
     }
 }


### PR DESCRIPTION
I know that this is an "approximate [...] representation" and "does not work for all node kinds", but this seems important.