### PR TITLE
Infer key/element types more accurately for callable-array

### DIFF
--- a/src/Phan/Language/Type/CallableArrayType.php
+++ b/src/Phan/Language/Type/CallableArrayType.php
@@ -15,7 +15,7 @@ use Phan\Language\UnionType;
  * NOTE: A CallableArrayType is not technically a list type because [1 => $methodName, 0 => $classOrObject] is also callable.
  * @phan-pure
  */
-class CallableArrayType extends ArrayType
+class CallableArrayType extends ArrayType implements GenericArrayInterface
 {
     use NativeTypeTrait;
 
@@ -54,7 +54,7 @@ class CallableArrayType extends ArrayType
      */
     public function iterableValueUnionType(CodeBase $code_base): UnionType
     {
-        return UnionType::fromFullyQualifiedPHPDocString('string|object');
+        return $this->genericArrayElementUnionType();
     }
 
     public function canCastToDeclaredType(CodeBase $code_base, Context $context, Type $other): bool
@@ -70,5 +70,17 @@ class CallableArrayType extends ArrayType
         return $other instanceof CallableType
             || $other instanceof CallableDeclarationType
             || parent::canCastToDeclaredType($code_base, $context, $other);
+    }
+
+    public function isDefinitelyNonEmptyArray(): bool {
+        return true;
+    }
+
+    public function getKeyType(): int {
+        return GenericArrayType::KEY_INT;
+    }
+
+    public function genericArrayElementUnionType(): UnionType {
+        return UnionType::fromFullyQualifiedPHPDocString('string|object');
     }
 }

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -545,13 +545,13 @@ class GenericArrayType extends ArrayType implements GenericArrayInterface
     {
         $key_types = self::KEY_EMPTY;
         foreach ($union_type->getTypeSet() as $type) {
-            if ($type instanceof GenericArrayType) {
-                // e.g. ListType, GenericArrayType
-                $key_types |= $type->key_type;
-            } elseif ($type instanceof ArrayShapeType) {
+            if ($type instanceof ArrayShapeType) {
                 if ($type->isNotEmptyArrayShape()) {
                     $key_types |= $type->getKeyType();
                 }
+            } elseif ($type instanceof GenericArrayInterface) {
+                // e.g. ListType, GenericArrayType
+                $key_types |= $type->getKeyType();
             }
             // Treating ArrayType as mixed or excluding ArrayType would both cause false positives. Ignore ArrayType.
             // TODO: Support IterableType for non-arrays?

--- a/tests/files/expected/0984_callable_array.php.expected
+++ b/tests/files/expected/0984_callable_array.php.expected
@@ -1,0 +1,6 @@
+%s:9 PhanDebugAnnotation @phan-debug-var requested for variable $first - it has union type object|string
+%s:11 PhanDebugAnnotation @phan-debug-var requested for variable $second - it has union type object|string
+%s:14 PhanDebugAnnotation @phan-debug-var requested for variable $reset - it has union type object|string%S
+%s:16 PhanDebugAnnotation @phan-debug-var requested for variable $key - it has union type int|null(real=int|null|string)
+%s:19 PhanDebugAnnotation @phan-debug-var requested for variable $k - it has union type int
+%s:19 PhanDebugAnnotation @phan-debug-var requested for variable $v - it has union type object|string

--- a/tests/files/src/0984_callable_array.php
+++ b/tests/files/src/0984_callable_array.php
@@ -1,0 +1,23 @@
+<?php
+
+/* @phan-file-suppress PhanUnusedVariable */
+
+namespace NS984;
+
+/** @param callable-array $callable */
+function takesCallable( $callable ) {
+    $first = $callable[0];
+    '@phan-debug-var $first';
+    $second = $callable[1];
+    '@phan-debug-var $second';
+
+    $reset = reset( $callable );
+    '@phan-debug-var $reset';
+    $key = key( $callable );
+    '@phan-debug-var $key';
+
+    foreach( $callable as $k => $v ) {
+        '@phan-debug-var $k, $v';
+        var_dump( $k, $v );
+    }
+}


### PR DESCRIPTION
Make CallableArrayType implement GenericArrayInterface, so that we can more accurately infer the key and element types, as well as the fact that it's never empty. In `GenericArrayType::keyTypeFromUnionTypeKeys`, check for GenericArrayInterface directly, which will also catch CallableArray (and GenericMultiArrayType).