### PR TITLE
Infer parameter default type more accurately

### DIFF
--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -902,13 +902,13 @@ trait FunctionTrait
         // see if the type of the default is cool with the
         // specified type.
         if ($parameter->hasDefaultValue()) {
-            $default_type = $parameter->getDefaultValueType();
-            $default_is_null = $default_type->isType(NullType::instance(false));
+            $default_literal_type = $parameter->getDefaultValueLiteralType();
+            $default_is_null = $default_literal_type->isType(NullType::instance(false));
             // If the default type isn't null and can't cast
             // to the parameter's declared type, emit an
             // issue.
             if (!$default_is_null) {
-                if (!$default_type->canCastToUnionType(
+                if (!$default_literal_type->canCastToUnionType(
                     $parameter->getUnionType(),
                     $code_base
                 )) {
@@ -919,7 +919,7 @@ trait FunctionTrait
                         $function->getFileRef()->getLineNumberStart(),
                         (string)$parameter->getUnionType(),
                         $parameter_name,
-                        (string)$default_type
+                        (string)$default_literal_type
                     );
                 }
             }
@@ -939,18 +939,27 @@ trait FunctionTrait
                 }
                 // The parameter constructor or above check for wasEmpty already took care of null default case
             } else {
-                $default_type = $default_type->withFlattenedArrayShapeOrLiteralTypeInstances()->withRealTypeSet($parameter->getNonVariadicUnionType()->getRealTypeSet());
+                $param_nonvariadic_type = $parameter->getNonVariadicUnionType();
                 if ($was_empty) {
+                    $default_type = $default_literal_type->withFlattenedArrayShapeOrLiteralTypeInstances()
+                        ->withRealTypeSet($param_nonvariadic_type->getRealTypeSet());
                     $parameter->addUnionType(self::inferNormalizedTypesOfDefault($default_type));
                     if (!Config::getValue('guess_unknown_parameter_type_using_default')) {
                         $parameter->addUnionType(MixedType::instance(false)->asPHPDocUnionType());
                     }
                 } else {
-                    // Don't add both `int` and `?int` to the same set.
-                    foreach ($default_type->getTypeSet() as $default_type_part) {
-                        if (!$parameter->getNonvariadicUnionType()->hasType($default_type_part->withIsNullable(true))) {
+                    $flattened_default_type = $default_literal_type->withFlattenedArrayShapeTypeInstances();
+                    foreach ($flattened_default_type->getTypeSet() as $default_type_part) {
+                        if (!$param_nonvariadic_type->hasType($default_type_part)) {
                             // if ($parameter->isCloneOfVariadic()) { throw new \Error("Impossible\n"); }
-                            $parameter->addType($default_type_part);
+                            $non_literal_default_type_part = $default_type_part->asNonLiteralType();
+                            if (
+                                !$param_nonvariadic_type->hasType($non_literal_default_type_part) &&
+                                // Don't add both `int` and `?int` to the same set.
+                                !$param_nonvariadic_type->hasType($non_literal_default_type_part->withIsNullable(true))
+                            ) {
+                                $parameter->addType($non_literal_default_type_part);
+                            }
                         }
                     }
                 }

--- a/src/Phan/Language/Element/Parameter.php
+++ b/src/Phan/Language/Element/Parameter.php
@@ -369,7 +369,7 @@ class Parameter extends Variable
     private static function maybeGetKnownDefaultValueForNode($node): ?UnionType
     {
         if (!($node instanceof Node)) {
-            return Type::nonLiteralFromObject($node)->asRealUnionType();
+            return Type::fromObject($node)->asRealUnionType();
         }
         // XXX: This could be made more precise and handle things like unary/binary ops.
         // However, this doesn't know about constants that haven't been parsed yet.

--- a/tests/files/expected/0005_compat.php.expected
+++ b/tests/files/expected/0005_compat.php.expected
@@ -1,5 +1,5 @@
 %s:16 PhanTypeMismatchDefault Default value for int $b can't be false
-%s:16 PhanTypeMismatchDefault Default value for string $c can't be int
+%s:16 PhanTypeMismatchDefault Default value for string $c can't be -1
 %s:21 PhanTypeMismatchDeclaredParamNullable Doc-block of $categories in fromCategories is phpdoc param type \A which is not a permitted replacement of the nullable param type ?\A declared in the signature ('?T' should be documented as 'T|null' or '?T')
 %s:26 PhanDeprecatedImplicitNullableParam Implicit nullable parameters (\A $categories = null) have been deprecated in PHP 8.4
 %s:%d PhanParamReqAfterOpt Required parameter (\A $context) follows optional (?\A $categories = null)

--- a/tests/files/expected/0005_compat.php.expected84
+++ b/tests/files/expected/0005_compat.php.expected84
@@ -1,5 +1,5 @@
 %s:16 PhanTypeMismatchDefault Default value for int $b can't be false
-%s:16 PhanTypeMismatchDefault Default value for string $c can't be int
+%s:16 PhanTypeMismatchDefault Default value for string $c can't be -1
 %s:21 PhanTypeMismatchDeclaredParamNullable Doc-block of $categories in fromCategories is phpdoc param type \A which is not a permitted replacement of the nullable param type ?\A declared in the signature ('?T' should be documented as 'T|null' or '?T')
 %s:26 PhanDeprecatedImplicitNullableParam Implicit nullable parameters (\A $categories = null) have been deprecated in PHP 8.4
 %s:%d PhanParamReqAfterOpt Required parameter (\A $context) follows optional (?\A $categories = null)

--- a/tests/files/expected/0255_default_types.php.expected
+++ b/tests/files/expected/0255_default_types.php.expected
@@ -1,1 +1,1 @@
-%s:4 PhanTypeMismatchArgument Argument 1 ($arg) is $a of type int but \NS255\f1() takes string defined at %s:3
+%s:4 PhanTypeMismatchArgument Argument 1 ($arg) is $a of type 1 but \NS255\f1() takes string defined at %s:3

--- a/tests/files/expected/0280_should_infer_nullable_from_default.php.expected
+++ b/tests/files/expected/0280_should_infer_nullable_from_default.php.expected
@@ -4,5 +4,5 @@
 %s:21 PhanDeprecatedImplicitNullableParam Implicit nullable parameters (int $arg = null) have been deprecated in PHP 8.4
 %s:23 PhanParamSignatureMismatch Declaration of function foo(int $arg = 20) should be compatible with function foo(?int $arg = null) defined in %s:10 (Expected int $arg = 20 to have the same type as ?int $arg = null or a supertype)
 %s:23 PhanParamSignatureRealMismatchParamType Declaration of function foo(int $arg = 20) should be compatible with function foo(?int $arg = null) (parameter #1 of real signature type 'int' cannot replace original parameter of real signature type '?int') defined in %s:10
-%s:27 PhanTypeMismatchDefault Default value for ?int $x can't be float
+%s:27 PhanTypeMismatchDefault Default value for ?int $x can't be 2.0
 %s:34 PhanTypeMismatchArgumentReal Argument 1 ($arg) is null of type null but \C280::foo() takes int defined at %s:23

--- a/tests/files/expected/0985_literal_param_default.php.expected
+++ b/tests/files/expected/0985_literal_param_default.php.expected
@@ -1,0 +1,4 @@
+%s:24 PhanTypeMismatchArgumentReal Argument 1 ($a) is [] of type array{} but \NS985\testNullableWithNonNullDefault() takes ?int defined at %s:22
+%s:27 PhanTypeMismatchArgumentReal Argument 1 ($a) is [] of type array{} but \NS985\testNullableWithNullDefault() takes ?int defined at %s:25
+%s:30 PhanTypeMismatchArgumentReal Argument 1 ($a) is [] of type array{} but \NS985\testNonNullableWithNonNullDefault() takes int defined at %s:28
+%s:33 PhanTypeMismatchArgumentReal Argument 1 ($a) is [] of type array{} but \NS985\testNonNullableWithNullDefault() takes ?int defined at %s:31

--- a/tests/files/src/0985_literal_param_default.php
+++ b/tests/files/src/0985_literal_param_default.php
@@ -1,0 +1,33 @@
+<?php
+
+// Regression test for https://github.com/phan/phan/issues/4398
+
+namespace NS985;
+
+class ParentClass {
+    /**
+     * @param 'AND'|'OR' $operator
+     */
+    public function test_func($operator='AND') {
+        return $this;
+    }
+}
+
+/**
+ * @method ChildClass test_func('AND'|'OR' $operator='AND')
+ */
+class ChildClass extends ParentClass {
+}
+
+function testNullableWithNonNullDefault( ?int $a = 42 ) {
+}
+testNullableWithNonNullDefault( [] );
+function testNullableWithNullDefault( ?int $a = null ) {
+}
+testNullableWithNullDefault( [] );
+function testNonNullableWithNonNullDefault( int $a = 42 ) {
+}
+testNonNullableWithNonNullDefault( [] );
+function testNonNullableWithNullDefault( int $a = null ) { // @phan-suppress-current-line PhanDeprecatedImplicitNullableParam
+}
+testNonNullableWithNullDefault( [] );

--- a/tests/php80_files/expected/037_key_types.php.expected
+++ b/tests/php80_files/expected/037_key_types.php.expected
@@ -2,6 +2,6 @@
 %s:11 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type array<string,int>(real=array)
 %s:11 PhanTypeMismatchArgument Argument 1 ($foo) is ['key'=>'value'] of type array{key:'value'} but \Test37::__construct() takes array<string,int> defined at %s:9
 %s:16 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for public int|string $arg = 1 of \Invalid37::__construct(int|string $arg = 1)
-%s:16 PhanTypeMismatchDefault Default value for string $arg can't be int
+%s:16 PhanTypeMismatchDefault Default value for string $arg can't be 1
 %s:16 PhanTypeMismatchPropertyDefaultReal Default value for string $arg can't be 1 of type int
 %s:16 PhanWriteOnlyPublicProperty Possibly zero read references to public property \Invalid37->arg

--- a/tests/rasmus_files/expected/0030_def_arg_type.php.expected
+++ b/tests/rasmus_files/expected/0030_def_arg_type.php.expected
@@ -1,2 +1,2 @@
 %s:4 PhanDeprecatedImplicitNullableParam Implicit nullable parameters (\A $arg3 = null) have been deprecated in PHP 8.4
-%s:4 PhanTypeMismatchDefault Default value for int $arg2 can't be float
+%s:4 PhanTypeMismatchDefault Default value for int $arg2 can't be 1.5


### PR DESCRIPTION
- Fix `Parameter::maybeGetKnownDefaultValueForNode` forcefully producing a non-literal type. The generalization will be done later, inside Parameter, if requested.
- Use the literal default value when checking validity of signatures.
- When the parameter has a non-empty union type, check if the parameter union type contains the default value _before_ converting it to a non-literal type.

Closes #4398