### PR TITLE
UseReturnValuePlugin: finish special-casing similar_text

### DIFF
--- a/src/Phan/Plugin/Internal/UseReturnValuePlugin.php
+++ b/src/Phan/Plugin/Internal/UseReturnValuePlugin.php
@@ -904,7 +904,7 @@ class UseReturnValuePlugin extends PluginV3 implements PostAnalyzeNodeCapability
     'reflectionmethod::invokeargs' => false,  // may be a void
     'rename' => false,  // some code is optimistic
     'reset' => false,  // move array cursor
-    'similar_text' => SELF::SPECIAL_CASE, // takes value by ref
+    'similar_text' => self::SPECIAL_CASE, // takes value by ref
     'session_id' => false,  // Triggers regeneration
     'strtok' => false,  // advances a cursor if called with 1 argument - Any argument position can be ignored.
     'trait_exists' => self::SPECIAL_CASE,  // triggers class autoloader to load the trait

--- a/src/Phan/Plugin/Internal/UseReturnValuePlugin/UseReturnValueVisitor.php
+++ b/src/Phan/Plugin/Internal/UseReturnValuePlugin/UseReturnValueVisitor.php
@@ -483,6 +483,7 @@ class UseReturnValueVisitor extends PluginAwarePostAnalysisVisitor
                 return !self::isSecondArgumentEqualToConst($node, 'false');
             case 'preg_match':
             case 'preg_match_all':
+            case 'similar_text':
                 return \count($node->children['args']->children) >= 3;
         }
         return true;

--- a/tests/plugin_test/expected/140_use_return_value_misc.php.expected
+++ b/tests/plugin_test/expected/140_use_return_value_misc.php.expected
@@ -10,3 +10,4 @@ src/140_use_return_value_misc.php:29 PhanPluginUseReturnValueInternalKnown Expec
 src/140_use_return_value_misc.php:32 PhanTypeMismatchArgumentInternal Argument 2 ($return) is 0 of type 0 but \var_export() takes bool
 src/140_use_return_value_misc.php:33 PhanPluginUseReturnValueInternalKnown Expected to use the return value of the internal function/method \var_export
 src/140_use_return_value_misc.php:33 PhanTypeMismatchArgumentInternal Argument 2 ($return) is 1 of type 1 but \var_export() takes bool
+src/140_use_return_value_misc.php:36 PhanPluginUseReturnValueInternalKnown Expected to use the return value of the internal function/method \similar_text

--- a/tests/plugin_test/src/140_use_return_value_misc.php
+++ b/tests/plugin_test/src/140_use_return_value_misc.php
@@ -31,3 +31,8 @@ preg_match_all('/x/', 'executable');
 preg_match_all('/x/', 'executable', $matches);
 var_export($matches, 0);
 var_export($matches, 1);
+
+// Should warn
+similar_text( 'foo', 'bar' );
+// Should not warn
+similar_text( 'foo', 'bar', $percent );


### PR DESCRIPTION
Follow-up to #4979: require using the return value iff the third argument (`&$percent`) is not passed, like for preg_match(_all). Add a test.