### PR TITLE
Avoid aggressive plugin caching in tests

### DIFF
--- a/src/Phan/Plugin/Internal/CallableParamPlugin.php
+++ b/src/Phan/Plugin/Internal/CallableParamPlugin.php
@@ -208,11 +208,7 @@ final class CallableParamPlugin extends PluginV3 implements
      */
     public function getAnalyzeFunctionCallClosures(CodeBase $code_base): array
     {
-        // Unit tests invoke this repeatedly. Cache it.
-        static $analyzers = null;
-        if ($analyzers === null) {
-            $analyzers = self::getAnalyzeFunctionCallClosuresStatic($code_base);
-        }
-        return $analyzers;
+        // Cannot cache this as it depends on the CodeBase.
+        return self::getAnalyzeFunctionCallClosuresStatic($code_base);
     }
 }

--- a/src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php
@@ -501,11 +501,7 @@ final class DependentReturnTypeOverridePlugin extends PluginV3 implements
      */
     public function getReturnTypeOverrides(CodeBase $code_base): array
     {
-        // Unit tests invoke this repeatedly. Cache it.
-        static $overrides = null;
-        if ($overrides === null) {
-            $overrides = self::getReturnTypeOverridesStatic($code_base);
-        }
-        return $overrides;
+        // Cannot cache this as it depends on the CodeBase.
+        return self::getReturnTypeOverridesStatic($code_base);
     }
 }

--- a/src/Phan/Plugin/Internal/ExtendedDependentReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ExtendedDependentReturnTypeOverridePlugin.php
@@ -165,11 +165,7 @@ final class ExtendedDependentReturnTypeOverridePlugin extends PluginV3 implement
      */
     public function getReturnTypeOverrides(CodeBase $code_base): array
     {
-        // Unit tests invoke this repeatedly. Cache it.
-        static $overrides = null;
-        if ($overrides === null) {
-            $overrides = self::getReturnTypeOverridesStatic($code_base);
-        }
-        return $overrides;
+        // Cannot cache this as it depends on the CodeBase.
+        return self::getReturnTypeOverridesStatic($code_base);
     }
 }

--- a/tests/files/expected/0859_closure_declaration_type_parsing.php.expected
+++ b/tests/files/expected/0859_closure_declaration_type_parsing.php.expected
@@ -1,4 +1,5 @@
 %s:9 PhanTypeMismatchArgumentReal Argument 1 ($c) is [1] of type array{0:1} but \test_closures() takes Closure():(string[]) (real type \Closure) defined at %s:7
 %s:9 PhanTypeMismatchArgument Argument 2 ($a) is [2] of type array{0:2} but \test_closures() takes (Closure():string)[] defined at %s:7
+%s:16 PhanTypeInvalidCallableArraySize In a place where phan was expecting a callable, saw an array of size 1, but callable arrays must be of size 2
 %s:16 PhanTypeMismatchArgumentReal Argument 1 ($c) is [1] of type array{0:1} but \test_callables() takes callable():(string[]) (real type callable) defined at %s:14
 %s:16 PhanTypeMismatchArgument Argument 2 ($a) is [2] of type array{0:2} but \test_callables() takes (callable():string)[] defined at %s:14

--- a/tests/php80_files/expected/041_intersection_type_phpdoc.php.expected
+++ b/tests/php80_files/expected/041_intersection_type_phpdoc.php.expected
@@ -1,7 +1,6 @@
 %s:8 PhanDebugAnnotation @phan-debug-var requested for variable $a - it has union type callable-object
 %s:8 PhanDebugAnnotation @phan-debug-var requested for variable $b - it has union type callable-array&non-empty-array<mixed,string>
 %s:8 PhanDebugAnnotation @phan-debug-var requested for variable $c - it has union type callable-string
-%s:16 PhanUnreferencedPublicMethod Possibly zero references to public method \A41::method()
 %s:22 PhanTypeMismatchArgumentProbablyReal Argument 1 ($a) is [A41::class,'method'] of type array{0:'A41',1:'method'} but \test41() takes callable-object (no real type) defined at %s:8 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
 %s:22 PhanTypeMismatchArgumentProbablyReal Argument 2 ($b) is 'A41::method' of type 'A41::method' but \test41() takes callable-array&non-empty-array<mixed,string> (no real type) defined at %s:8 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
 %s:22 PhanTypeMismatchArgumentProbablyReal Argument 3 ($c) is (function) of type Closure():void but \test41() takes callable-string (no real type) defined at %s:8 (the inferred real argument type has nothing in common with the parameter's phpdoc type)


### PR DESCRIPTION
Previously we were caching various plugin method handlers in unit tests, even when those handlers depend on the codebase. This is problematic because the codebase changes for every test, and so for example the list of declared classes/function-likes etc. also changes. This can lead to subtle issues that become especially apparent when running tests in isolation or using a different ordering. Welp, cache invalidation is hard.

So, disable caching for plugins dependent on the CodeBase. Locally, I did not observe any performance improvements: `__FakeAllPHPUnitTests` takes ~40.5 seconds (not parallelized) with or without this patch. And still, in general, I would rather have slower tests than mysterious failures.