### PR TITLE
Do not infer real types from PHPDoc for iterator key/elements

### DIFF
--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -3960,15 +3960,16 @@ class UnionType implements Serializable, Stringable
                 $new_real_type_builder->clearTypeSet();
                 break;
             }
+            $key_union_real_type = $key_union_type->getRealUnionType();
             // TODO: Instead of coercing string to int here, update the real type when the array is assigned to,
             // if the string is a non-literal.
             //
             // Note that array shapes with 0 elements do not have types. (tests/files/src/0461_array_key_exists.php)
             if ($type instanceof ArrayType && $type->isPossiblyTruthy()) {
-                if ($key_union_type->isEmpty()) {
-                    $key_union_type = UnionType::fromFullyQualifiedPHPDocString('int|string');
+                if ($key_union_real_type->isEmpty()) {
+                    $key_union_real_type = UnionType::fromFullyQualifiedPHPDocString('int|string');
                 } else {
-                    foreach ($key_union_type->getTypeSet() as $key_type) {
+                    foreach ($key_union_real_type->getTypeSet() as $key_type) {
                         if ($key_type instanceof StringType && $key_type->isPossiblyNumeric()) {
                             // Numeric literals such as `'0'` cast to 0 when inserted as array keys.
                             $new_real_type_builder->addType(IntType::instance(false));
@@ -3977,7 +3978,7 @@ class UnionType implements Serializable, Stringable
                     }
                 }
             }
-            $new_real_type_builder->addUnionType($key_union_type);
+            $new_real_type_builder->addUnionType($key_union_real_type);
         }
         $type_set = $new_type_builder->getTypeSet();
         $real_type_set = $new_real_type_builder->getTypeSet();
@@ -4023,7 +4024,8 @@ class UnionType implements Serializable, Stringable
                 $real_builder->clearTypeSet();
                 break;
             }
-            $real_builder->addUnionType($element_type);
+            $element_real_type = $element_type->getRealUnionType();
+            $real_builder->addUnionType($element_real_type);
         }
 
         static $array_type_nonnull = null;

--- a/tests/files/expected/0986_iteratoraggregate_real.php.expected
+++ b/tests/files/expected/0986_iteratoraggregate_real.php.expected
@@ -1,0 +1,2 @@
+%s:24 PhanDebugAnnotation @phan-debug-var requested for variable $key - it has union type int
+%s:24 PhanDebugAnnotation @phan-debug-var requested for variable $value - it has union type string

--- a/tests/files/src/0986_iteratoraggregate_real.php
+++ b/tests/files/src/0986_iteratoraggregate_real.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace NS986;
+
+class MyAggregate implements \IteratorAggregate {
+    public $arr;
+
+    /** @param array<int,string> $modelArray */
+    public function __construct($modelArray = [])
+    {
+        $this->arr = $modelArray;
+    }
+
+    /**
+     * @return \Iterator<int,string>
+     */
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->arr);
+    }
+}
+
+$aggregate = new MyAggregate( [ 'not an integer' => [ 'array, not string' ] ] );
+foreach ($aggregate as $key => $value) {
+    // No real types should be inferred here.
+    '@phan-debug-var $key, $value';
+    echo "$key - $value\n";
+}


### PR DESCRIPTION
When building the real union type of iterator keys and elements, use the real types of keys/elements, not PHPDoc types.