### PR TITLE
AssignmentVisitor: Fix checks for setting properties with template types

### DIFF
--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -2871,7 +2871,7 @@ class UnionTypeVisitor extends AnalysisVisitor
 
             // Map template types to concrete types
             if ($union_type->hasTemplateTypeRecursive()) {
-                // Get the type of the object calling the property
+                // Get the type of the object to which the property belongs
                 $expression_type = UnionTypeVisitor::unionTypeFromNode(
                     $this->code_base,
                     $this->context,

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -1118,6 +1118,21 @@ class AssignmentVisitor extends AnalysisVisitor
         // thus yield a supertype of the intended type. However, we can't resolve `static` in the right context here,
         // and the PHPDoc type isn't meant to be replaced with concrete types as in Property::inheritStaticUnionType().
         $property_union_type = $property->getPHPDocUnionType()->withStaticResolvedInContext($property->getContext());
+
+        // Map template types to concrete types
+        if ($property_union_type->hasTemplateTypeRecursive()) {
+            // Get the type of the object to which the property belongs
+            $expression_type = UnionTypeVisitor::unionTypeFromNode(
+                $this->code_base,
+                $this->context,
+                $node->children['expr'] ?? null
+            );
+
+            $property_union_type = $property_union_type->withTemplateParameterTypeMap(
+                $expression_type->getTemplateParameterTypeMap($this->code_base)
+            );
+        }
+
         $resolved_right_type = $this->right_type->withStaticResolvedInContext($this->context);
         if ($this->dim_depth > 0) {
             if ($resolved_right_type->canCastToExpandedUnionType(

--- a/tests/files/expected/0202_generic_class.php.expected
+++ b/tests/files/expected/0202_generic_class.php.expected
@@ -7,3 +7,5 @@
 %s:64 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_a->e1 of type 'string' but \f() takes int defined at %s:61
 %s:65 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_a->getE0() of type 42 but \f() takes string defined at %s:61
 %s:65 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_a->getE1() of type 'string' but \f() takes int defined at %s:61
+%s:66 PhanTypeMismatchProperty Assigning 42 of type 42 to property but \Tuple2->e0 is T0
+%s:70 PhanTypeMismatchProperty Assigning 42 of type 42 to property but \Tuple2->e1 is T1

--- a/tests/files/expected/0202_generic_class.php.expected
+++ b/tests/files/expected/0202_generic_class.php.expected
@@ -7,5 +7,4 @@
 %s:64 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_a->e1 of type 'string' but \f() takes int defined at %s:61
 %s:65 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_a->getE0() of type 42 but \f() takes string defined at %s:61
 %s:65 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_a->getE1() of type 'string' but \f() takes int defined at %s:61
-%s:66 PhanTypeMismatchProperty Assigning 42 of type 42 to property but \Tuple2->e0 is T0
-%s:70 PhanTypeMismatchProperty Assigning 42 of type 42 to property but \Tuple2->e1 is T1
+%s:70 PhanTypeMismatchPropertyProbablyReal Assigning 42 of type 42 to property but \Tuple2->e1 is 'string' (no real type) (the inferred real assigned type has nothing in common with the declared phpdoc property type)

--- a/tests/files/expected/0544_phan_generic_class.php.expected
+++ b/tests/files/expected/0544_phan_generic_class.php.expected
@@ -7,5 +7,4 @@
 %s:64 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_a->e1 of type 'string' but \f() takes int defined at %s:61
 %s:65 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_a->getE0() of type 42 but \f() takes string defined at %s:61
 %s:65 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_a->getE1() of type 'string' but \f() takes int defined at %s:61
-%s:66 PhanTypeMismatchProperty Assigning 42 of type 42 to property but \PhanTuple2->e0 is T0
-%s:70 PhanTypeMismatchProperty Assigning 42 of type 42 to property but \PhanTuple2->e1 is T1
+%s:70 PhanTypeMismatchPropertyProbablyReal Assigning 42 of type 42 to property but \PhanTuple2->e1 is 'string' (no real type) (the inferred real assigned type has nothing in common with the declared phpdoc property type)

--- a/tests/files/expected/0544_phan_generic_class.php.expected
+++ b/tests/files/expected/0544_phan_generic_class.php.expected
@@ -7,3 +7,5 @@
 %s:64 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_a->e1 of type 'string' but \f() takes int defined at %s:61
 %s:65 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_a->getE0() of type 42 but \f() takes string defined at %s:61
 %s:65 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_a->getE1() of type 'string' but \f() takes int defined at %s:61
+%s:66 PhanTypeMismatchProperty Assigning 42 of type 42 to property but \PhanTuple2->e0 is T0
+%s:70 PhanTypeMismatchProperty Assigning 42 of type 42 to property but \PhanTuple2->e1 is T1

--- a/tests/files/src/0202_generic_class.php
+++ b/tests/files/src/0202_generic_class.php
@@ -63,6 +63,8 @@ $tuple_a = new Tuple2(42, 'string');
 
 f($tuple_a->e0, $tuple_a->e1);
 f($tuple_a->getE0(), $tuple_a->getE1());
+$tuple_a->e0 = 42;
 
 f($tuple_a->e1, $tuple_a->e0);
 f($tuple_a->getE1(), $tuple_a->getE0());
+$tuple_a->e1 = 42;

--- a/tests/files/src/0544_phan_generic_class.php
+++ b/tests/files/src/0544_phan_generic_class.php
@@ -63,6 +63,8 @@ $tuple_a = new PhanTuple2(42, 'string');
 
 f($tuple_a->e0, $tuple_a->e1);
 f($tuple_a->getE0(), $tuple_a->getE1());
+$tuple_a->e0 = 42;
 
 f($tuple_a->e1, $tuple_a->e0);
 f($tuple_a->getE1(), $tuple_a->getE0());
+$tuple_a->e1 = 42;


### PR DESCRIPTION
The analysis when setting templated public properties was incorrect.

Follow the example of the checks for getting properties in UnionTypeVisitor.