### PR TITLE
UnionType: Rewrite usesTemplateType() using getTypesRecursively()

### DIFF
--- a/src/Phan/Language/Type/GenericArrayTemplateKeyType.php
+++ b/src/Phan/Language/Type/GenericArrayTemplateKeyType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phan\Language\Type;
 
 use Closure;
+use Generator;
 use Phan\CodeBase;
 use Phan\Language\Context;
 use Phan\Language\Type;
@@ -63,9 +64,28 @@ class GenericArrayTemplateKeyType extends GenericArrayType
         });
     }
 
+    public function __toString(): string
+    {
+        $string = 'array<' . $this->template_key_type->__toString() . ','
+            . $this->element_type->__toString() . '>';
+
+        if ($this->is_nullable) {
+            $string = '?' . $string;
+        }
+
+        return $string;
+    }
+
     public function hasTemplateTypeRecursive(): bool
     {
         return true;
+    }
+
+    public function getTypesRecursively(): Generator
+    {
+        yield $this;
+        yield from $this->template_key_type->getTypesRecursively();
+        yield from $this->element_type->getTypesRecursively();
     }
 
     /**

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -944,6 +944,8 @@ class GenericArrayType extends ArrayType implements GenericArrayInterface
     public function getTypesRecursively(): Generator
     {
         yield $this;
+        // This is not really needed for the current uses of this method, but it's right in theory
+        yield from self::unionTypeForKeyType($this->key_type)->getTypesRecursively();
         yield from $this->element_type->getTypesRecursively();
     }
 

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -6326,10 +6326,12 @@ class UnionType implements Serializable, Stringable
      */
     public function usesTemplateType(TemplateType $template_type): bool
     {
-        $new_union_type = $this->withTemplateParameterTypeMap([
-            $template_type->getName() => UnionType::fromFullyQualifiedPHPDocString('mixed'),
-        ]);
-        return !$this->isEqualTo($new_union_type);
+        foreach ($this->getTypesRecursively() as $type) {
+            if ($type === $template_type) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
Implementing it using withTemplateParameterTypeMap() feels like a hack. getTypesRecursively() didn't exist when it was originaly written.

Fix some bugs with templated types like `array<K,V>` in the process.