### PR TITLE
SelfType, StaticType: Print template types when debugging if provided

### DIFF
--- a/src/Phan/Language/Type/SelfType.php
+++ b/src/Phan/Language/Type/SelfType.php
@@ -95,15 +95,10 @@ final class SelfType extends StaticOrSelfType
         return true;
     }
 
-    public function __toString(): string
+    /** @override */
+    public function asFQSENString(): string
     {
-        $string = $this->name;
-
-        if ($this->is_nullable) {
-            $string = '?' . $string;
-        }
-
-        return $string;
+        return $this->name;
     }
 
     /**

--- a/src/Phan/Language/Type/StaticType.php
+++ b/src/Phan/Language/Type/StaticType.php
@@ -100,15 +100,10 @@ final class StaticType extends StaticOrSelfType
         return true;
     }
 
-    public function __toString(): string
+    /** @override */
+    public function asFQSENString(): string
     {
-        $string = $this->name;
-
-        if ($this->is_nullable) {
-            $string = '?' . $string;
-        }
-
-        return $string;
+        return $this->name;
     }
 
     /**


### PR DESCRIPTION
SelfType and StaticType may be templated types (see instanceWithTemplateTypeList()). When they are, we should allow the list of template types to be printed in @phan-debug-var and other debugging interfaces.