### PR TITLE
Add more test cases for generic classes

### DIFF
--- a/tests/files/expected/0202_generic_class.php.expected
+++ b/tests/files/expected/0202_generic_class.php.expected
@@ -1,10 +1,25 @@
-%s:42 PhanTypeMismatchReturn Returning 42 of type 42 but failMismatch() is declared to return T0
-%s:46 PhanTypeMissingReturn Method \Tuple2::failVoid is declared to return T0 in phpdoc but has no return value
-%s:51 PhanTypeMismatchReturn Returning $this->e1 of type T1 but failAnotherGeneric() is declared to return T0
-%s:55 PhanTemplateTypeStaticMethod static method \Tuple2::failStatic does not declare template type in its own comment and may not use the template type of class instances
-%s:56 PhanTypeMismatchReturn Returning 42 of type 42 but failStatic() is declared to return T0
-%s:64 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_a->e0 of type 42 but \f() takes string defined at %s:61
-%s:64 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_a->e1 of type 'string' but \f() takes int defined at %s:61
-%s:65 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_a->getE0() of type 42 but \f() takes string defined at %s:61
-%s:65 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_a->getE1() of type 'string' but \f() takes int defined at %s:61
-%s:70 PhanTypeMismatchPropertyProbablyReal Assigning 42 of type 42 to property but \Tuple2->e1 is 'string' (no real type) (the inferred real assigned type has nothing in common with the declared phpdoc property type)
+%s:70 PhanTypeMismatchReturn Returning 42 of type 42 but failMismatch() is declared to return T0
+%s:74 PhanTypeMissingReturn Method \Tuple2::failVoid is declared to return T0 in phpdoc but has no return value
+%s:79 PhanTypeMismatchReturn Returning $this->e1 of type T1 but failAnotherGeneric() is declared to return T0
+%s:83 PhanTemplateTypeStaticMethod static method \Tuple2::failStatic does not declare template type in its own comment and may not use the template type of class instances
+%s:84 PhanTypeMismatchReturn Returning 42 of type 42 but failStatic() is declared to return T0
+%s:104 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_a->e1 of type 'string' but \check() takes int defined at %s:89
+%s:104 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_a->e0 of type 42 but \check() takes string defined at %s:89
+%s:105 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_a->getE1() of type 'string' but \check() takes int defined at %s:89
+%s:105 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_a->getE0() of type 42 but \check() takes string defined at %s:89
+%s:106 PhanTypeMismatchPropertyProbablyReal Assigning 42 of type 42 to property but \Tuple2->e1 is 'string' (no real type) (the inferred real assigned type has nothing in common with the declared phpdoc property type)
+%s:107 PhanTypeMismatchArgumentProbablyReal Argument 1 ($e1) is 42 of type 42 but \Tuple2::setE1() takes 'string' (no real type) defined at %s:46 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
+%s:108 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_a->e0 of type 42 but \check2() takes bool defined at %s:90
+%s:117 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_b->e0 of type T0 but \check() takes int defined at %s:89
+%s:117 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_b->e1 of type T1 but \check() takes string defined at %s:89
+%s:118 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_b->getE0() of type T0 but \check() takes int defined at %s:89
+%s:118 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_b->getE1() of type T1 but \check() takes string defined at %s:89
+%s:119 PhanTypeMismatchProperty Assigning 42 of type 42 to property but \Tuple2->e0 is T0
+%s:122 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_b2->e1 of type T1 but \check2() takes string defined at %s:90
+%s:125 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_b->e1 of type T1 but \check() takes int defined at %s:89
+%s:125 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_b->e0 of type T0 but \check() takes string defined at %s:89
+%s:126 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_b->getE1() of type T1 but \check() takes int defined at %s:89
+%s:126 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_b->getE0() of type T0 but \check() takes string defined at %s:89
+%s:127 PhanTypeMismatchProperty Assigning 42 of type 42 to property but \Tuple2->e1 is T1
+%s:129 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_b->e0 of type T0 but \check2() takes bool defined at %s:90
+%s:129 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_b->e1 of type T1 but \check2() takes string defined at %s:90

--- a/tests/files/expected/0544_phan_generic_class.php.expected
+++ b/tests/files/expected/0544_phan_generic_class.php.expected
@@ -1,10 +1,25 @@
-%s:42 PhanTypeMismatchReturn Returning 42 of type 42 but failMismatch() is declared to return T0
-%s:46 PhanTypeMissingReturn Method \PhanTuple2::failVoid is declared to return T0 in phpdoc but has no return value
-%s:51 PhanTypeMismatchReturn Returning $this->e1 of type T1 but failAnotherGeneric() is declared to return T0
-%s:55 PhanTemplateTypeStaticMethod static method \PhanTuple2::failStatic does not declare template type in its own comment and may not use the template type of class instances
-%s:56 PhanTypeMismatchReturn Returning 42 of type 42 but failStatic() is declared to return T0
-%s:64 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_a->e0 of type 42 but \f() takes string defined at %s:61
-%s:64 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_a->e1 of type 'string' but \f() takes int defined at %s:61
-%s:65 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_a->getE0() of type 42 but \f() takes string defined at %s:61
-%s:65 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_a->getE1() of type 'string' but \f() takes int defined at %s:61
-%s:70 PhanTypeMismatchPropertyProbablyReal Assigning 42 of type 42 to property but \PhanTuple2->e1 is 'string' (no real type) (the inferred real assigned type has nothing in common with the declared phpdoc property type)
+%s:70 PhanTypeMismatchReturn Returning 42 of type 42 but failMismatch() is declared to return T0
+%s:74 PhanTypeMissingReturn Method \PhanTuple2::failVoid is declared to return T0 in phpdoc but has no return value
+%s:79 PhanTypeMismatchReturn Returning $this->e1 of type T1 but failAnotherGeneric() is declared to return T0
+%s:83 PhanTemplateTypeStaticMethod static method \PhanTuple2::failStatic does not declare template type in its own comment and may not use the template type of class instances
+%s:84 PhanTypeMismatchReturn Returning 42 of type 42 but failStatic() is declared to return T0
+%s:104 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_a->e1 of type 'string' but \check() takes int defined at %s:89
+%s:104 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_a->e0 of type 42 but \check() takes string defined at %s:89
+%s:105 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_a->getE1() of type 'string' but \check() takes int defined at %s:89
+%s:105 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_a->getE0() of type 42 but \check() takes string defined at %s:89
+%s:106 PhanTypeMismatchPropertyProbablyReal Assigning 42 of type 42 to property but \PhanTuple2->e1 is 'string' (no real type) (the inferred real assigned type has nothing in common with the declared phpdoc property type)
+%s:107 PhanTypeMismatchArgumentProbablyReal Argument 1 ($e1) is 42 of type 42 but \PhanTuple2::setE1() takes 'string' (no real type) defined at %s:46 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
+%s:108 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_a->e0 of type 42 but \check2() takes bool defined at %s:90
+%s:117 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_b->e0 of type T0 but \check() takes int defined at %s:89
+%s:117 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_b->e1 of type T1 but \check() takes string defined at %s:89
+%s:118 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_b->getE0() of type T0 but \check() takes int defined at %s:89
+%s:118 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_b->getE1() of type T1 but \check() takes string defined at %s:89
+%s:119 PhanTypeMismatchProperty Assigning 42 of type 42 to property but \PhanTuple2->e0 is T0
+%s:122 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_b2->e1 of type T1 but \check2() takes string defined at %s:90
+%s:125 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_b->e1 of type T1 but \check() takes int defined at %s:89
+%s:125 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_b->e0 of type T0 but \check() takes string defined at %s:89
+%s:126 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_b->getE1() of type T1 but \check() takes int defined at %s:89
+%s:126 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_b->getE0() of type T0 but \check() takes string defined at %s:89
+%s:127 PhanTypeMismatchProperty Assigning 42 of type 42 to property but \PhanTuple2->e1 is T1
+%s:129 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_b->e0 of type T0 but \check2() takes bool defined at %s:90
+%s:129 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_b->e1 of type T1 but \check2() takes string defined at %s:90

--- a/tests/files/expected/0985_template_unspecified.php.expected
+++ b/tests/files/expected/0985_template_unspecified.php.expected
@@ -1,0 +1,37 @@
+%s:9 PhanDebugAnnotation @phan-debug-var requested for variable $this - it has union type static(real=static)
+%s:25 PhanDebugAnnotation @phan-debug-var requested for variable $that - it has union type static(real=static)
+%s:37 PhanDebugAnnotation @phan-debug-var requested for variable $that - it has union type static(real=static)
+%s:48 PhanDebugAnnotation @phan-debug-var requested for variable $that - it has union type static(real=static)
+%s:60 PhanDebugAnnotation @phan-debug-var requested for variable $cont - it has union type \Container<T>(real=\Container<T>)
+%s:60 PhanDebugAnnotation @phan-debug-var requested for variable $cont - it has union type \Container<T|null>(real=\Container<T|null>)
+%s:71 PhanDebugAnnotation @phan-debug-var requested for variable $cont - it has union type \Container<T>(real=\Container<T>)
+%s:81 PhanDebugAnnotation @phan-debug-var requested for variable $cont - it has union type \Container<mixed>(real=\Container<mixed>)
+%s:81 PhanDebugAnnotation @phan-debug-var requested for variable $cont - it has union type \Container<mixed|null>(real=\Container<mixed|null>)
+%s:92 PhanDebugAnnotation @phan-debug-var requested for variable $a - it has union type \Container<\stdClass>(real=\Container<\stdClass>)
+%s:92 PhanDebugAnnotation @phan-debug-var requested for variable $b - it has union type \Container<\stdClass>
+%s:92 PhanDebugAnnotation @phan-debug-var requested for variable $c - it has union type \Container<>
+%s:92 PhanDebugAnnotation @phan-debug-var requested for variable $d - it has union type \Container
+%s:92 PhanDebugAnnotation @phan-debug-var requested for variable $e - it has union type \Container<\stdClass>
+%s:92 PhanDebugAnnotation @phan-debug-var requested for variable $f - it has union type \Container<>
+%s:92 PhanDebugAnnotation @phan-debug-var requested for variable $g - it has union type \Container
+%s:101 PhanDebugAnnotation @phan-debug-var requested for variable $aa - it has union type \stdClass
+%s:101 PhanDebugAnnotation @phan-debug-var requested for variable $bb - it has union type \stdClass
+%s:101 PhanDebugAnnotation @phan-debug-var requested for variable $cc - it has union type (empty union type)
+%s:101 PhanDebugAnnotation @phan-debug-var requested for variable $dd - it has union type T
+%s:101 PhanDebugAnnotation @phan-debug-var requested for variable $ee - it has union type \stdClass
+%s:101 PhanDebugAnnotation @phan-debug-var requested for variable $ff - it has union type (empty union type)
+%s:101 PhanDebugAnnotation @phan-debug-var requested for variable $gg - it has union type T
+%s:110 PhanDebugAnnotation @phan-debug-var requested for variable $a0 - it has union type \Container<null>(real=\Container<null>)
+%s:110 PhanDebugAnnotation @phan-debug-var requested for variable $b0 - it has union type \Container<null>
+%s:110 PhanDebugAnnotation @phan-debug-var requested for variable $c0 - it has union type \Container<>
+%s:110 PhanDebugAnnotation @phan-debug-var requested for variable $d0 - it has union type \Container
+%s:110 PhanDebugAnnotation @phan-debug-var requested for variable $e0 - it has union type \Container<null>
+%s:110 PhanDebugAnnotation @phan-debug-var requested for variable $f0 - it has union type \Container<>
+%s:110 PhanDebugAnnotation @phan-debug-var requested for variable $g0 - it has union type \Container
+%s:119 PhanDebugAnnotation @phan-debug-var requested for variable $aa0 - it has union type null
+%s:119 PhanDebugAnnotation @phan-debug-var requested for variable $bb0 - it has union type null
+%s:119 PhanDebugAnnotation @phan-debug-var requested for variable $cc0 - it has union type (empty union type)
+%s:119 PhanDebugAnnotation @phan-debug-var requested for variable $dd0 - it has union type T
+%s:119 PhanDebugAnnotation @phan-debug-var requested for variable $ee0 - it has union type null
+%s:119 PhanDebugAnnotation @phan-debug-var requested for variable $ff0 - it has union type (empty union type)
+%s:119 PhanDebugAnnotation @phan-debug-var requested for variable $gg0 - it has union type T

--- a/tests/files/src/0202_generic_class.php
+++ b/tests/files/src/0202_generic_class.php
@@ -37,6 +37,34 @@ class Tuple2 {
         return $this->e1;
     }
 
+    /** @param T0 $e0 */
+    public function setE0($e0) {
+        $this->e0 = $e0;
+    }
+
+    /** @param T1 $e1 */
+    public function setE1($e1) {
+        $this->e1 = $e1;
+    }
+
+    /**
+     * @template X0
+     * @param X0 $e0
+     * @return static<X0, T1>
+     */
+    public function withE0($e0) {
+        return new static($e0, $this->e1);
+    }
+
+    /**
+     * @template X1
+     * @param X1 $e1
+     * @return static<T0, X1>
+     */
+    public function withE1($e1) {
+        return new static($this->e0, $e1);
+    }
+
     /** @return T0 */
     public function failMismatch() {
         return 42;
@@ -58,13 +86,44 @@ class Tuple2 {
 
 }
 
-function f(string $p0, int $p1) {}
+function check(int $p0, string $p1) {}
+function check2(bool $p0, string $p1) {}
+
+
 $tuple_a = new Tuple2(42, 'string');
 
-f($tuple_a->e0, $tuple_a->e1);
-f($tuple_a->getE0(), $tuple_a->getE1());
+// Valid code
+check($tuple_a->e0, $tuple_a->e1);
+check($tuple_a->getE0(), $tuple_a->getE1());
 $tuple_a->e0 = 42;
+$tuple_a->setE0(42);
+$tuple_a2 = $tuple_a->withE0(false);
+check2($tuple_a2->e0, $tuple_a2->e1);
 
-f($tuple_a->e1, $tuple_a->e0);
-f($tuple_a->getE1(), $tuple_a->getE0());
+// Invalid code
+check($tuple_a->e1, $tuple_a->e0);
+check($tuple_a->getE1(), $tuple_a->getE0());
 $tuple_a->e1 = 42;
+$tuple_a->setE1(42);
+check2($tuple_a->e0, $tuple_a->e1);
+
+
+function getUnparameterizedTuple(): Tuple2 {
+    return new Tuple2(42, 'string');
+}
+$tuple_b = getUnparameterizedTuple();
+
+// Valid code (currently emits issues, #4982)
+check($tuple_b->e0, $tuple_b->e1);
+check($tuple_b->getE0(), $tuple_b->getE1());
+$tuple_b->e0 = 42;
+$tuple_b->setE0(42);
+$tuple_b2 = $tuple_b->withE0(false);
+check2($tuple_b2->e0, $tuple_b2->e1);
+
+// Invalid but unverifiable, since the type parameters are not known, should not emit issues
+check($tuple_b->e1, $tuple_b->e0);
+check($tuple_b->getE1(), $tuple_b->getE0());
+$tuple_b->e1 = 42;
+$tuple_b->setE1(42);
+check2($tuple_b->e0, $tuple_b->e1);

--- a/tests/files/src/0544_phan_generic_class.php
+++ b/tests/files/src/0544_phan_generic_class.php
@@ -37,6 +37,34 @@ class PhanTuple2 {
         return $this->e1;
     }
 
+    /** @param T0 $e0 */
+    public function setE0($e0) {
+        $this->e0 = $e0;
+    }
+
+    /** @param T1 $e1 */
+    public function setE1($e1) {
+        $this->e1 = $e1;
+    }
+
+    /**
+     * @phan-template X0
+     * @param X0 $e0
+     * @return static<X0, T1>
+     */
+    public function withE0($e0) {
+        return new static($e0, $this->e1);
+    }
+
+    /**
+     * @phan-template X1
+     * @param X1 $e1
+     * @return static<T0, X1>
+     */
+    public function withE1($e1) {
+        return new static($this->e0, $e1);
+    }
+
     /** @return T0 */
     public function failMismatch() {
         return 42;
@@ -58,13 +86,44 @@ class PhanTuple2 {
 
 }
 
-function f(string $p0, int $p1) {}
+function check(int $p0, string $p1) {}
+function check2(bool $p0, string $p1) {}
+
+
 $tuple_a = new PhanTuple2(42, 'string');
 
-f($tuple_a->e0, $tuple_a->e1);
-f($tuple_a->getE0(), $tuple_a->getE1());
+// Valid code
+check($tuple_a->e0, $tuple_a->e1);
+check($tuple_a->getE0(), $tuple_a->getE1());
 $tuple_a->e0 = 42;
+$tuple_a->setE0(42);
+$tuple_a2 = $tuple_a->withE0(false);
+check2($tuple_a2->e0, $tuple_a2->e1);
 
-f($tuple_a->e1, $tuple_a->e0);
-f($tuple_a->getE1(), $tuple_a->getE0());
+// Invalid code
+check($tuple_a->e1, $tuple_a->e0);
+check($tuple_a->getE1(), $tuple_a->getE0());
 $tuple_a->e1 = 42;
+$tuple_a->setE1(42);
+check2($tuple_a->e0, $tuple_a->e1);
+
+
+function getUnparameterizedTuple(): PhanTuple2 {
+    return new PhanTuple2(42, 'string');
+}
+$tuple_b = getUnparameterizedTuple();
+
+// Valid code (currently emits issues, #4982)
+check($tuple_b->e0, $tuple_b->e1);
+check($tuple_b->getE0(), $tuple_b->getE1());
+$tuple_b->e0 = 42;
+$tuple_b->setE0(42);
+$tuple_b2 = $tuple_b->withE0(false);
+check2($tuple_b2->e0, $tuple_b2->e1);
+
+// Invalid but unverifiable, since the type parameters are not known, should not emit issues
+check($tuple_b->e1, $tuple_b->e0);
+check($tuple_b->getE1(), $tuple_b->getE0());
+$tuple_b->e1 = 42;
+$tuple_b->setE1(42);
+check2($tuple_b->e0, $tuple_b->e1);

--- a/tests/files/src/0985_template_unspecified.php
+++ b/tests/files/src/0985_template_unspecified.php
@@ -1,0 +1,120 @@
+<?php
+/** @template T */
+class Container {
+    /** @var T */
+    private $t;
+
+    /** @param T $t */
+    function __construct($t = null) {
+        $this->t = $t;
+        '@phan-debug-var $this';
+    }
+
+    /** @return T */
+    function getValue() {
+        return $this->t;
+    }
+
+    /**
+     * Returns a Container<T> (or Container<null> when called with 0 arguments).
+     * @template T
+     * @param T $value
+     * @return static<T>
+     */
+    static function newTyped($value = null) {
+        $that = new static($value);
+        '@phan-debug-var $that';
+        return $that;
+    }
+
+    /**
+     * Returns a Container<> (parameter is the empty union type). This may be a bug, but it's interesting.
+     * @template T
+     * @param T ...$values
+     * @return static<T>
+     */
+    static function newWithEmptyUnion(...$values) {
+        $that = new static($values[0] ?? null);
+        '@phan-debug-var $that';
+        return $that;
+    }
+
+    /**
+     * Returns an unparameterized Container type.
+     * @param mixed $value
+     * @return static
+     */
+    static function newUnparameterized($value = null) {
+        $that = new static($value);
+        '@phan-debug-var $that';
+        return $that;
+    }
+}
+
+/**
+ * @template T
+ * @param T $value
+ * @return Container<T>
+ */
+function newContainerTyped($value = null) {
+    $cont = new Container($value);
+    '@phan-debug-var $cont';
+    return $cont;
+}
+
+/**
+ * @template T
+ * @param T ...$values
+ * @return Container<T>
+ */
+function newContainerWithEmptyUnion(...$values) {
+    $cont = new Container($values[0] ?? null);
+    '@phan-debug-var $cont';
+    return $cont;
+}
+
+/**
+ * @param mixed $value
+ * @return Container
+ */
+function newContainerUnparameterized($value = null) {
+    $cont = new Container($value);
+    '@phan-debug-var $cont';
+    return $cont;
+}
+
+$a = new Container(new stdClass);
+$b = Container::newTyped(new stdClass);
+$c = Container::newWithEmptyUnion(new stdClass);
+$d = Container::newUnparameterized(new stdClass);
+$e = newContainerTyped(new stdClass);
+$f = newContainerWithEmptyUnion(new stdClass);
+$g = newContainerUnparameterized(new stdClass);
+'@phan-debug-var $a, $b, $c, $d, $e, $f, $g';
+
+$aa = $a->getValue();
+$bb = $b->getValue();
+$cc = $c->getValue();
+$dd = $d->getValue();
+$ee = $e->getValue();
+$ff = $f->getValue();
+$gg = $g->getValue();
+'@phan-debug-var $aa, $bb, $cc, $dd, $ee, $ff, $gg';
+
+$a0 = new Container();
+$b0 = Container::newTyped();
+$c0 = Container::newWithEmptyUnion();
+$d0 = Container::newUnparameterized();
+$e0 = newContainerTyped();
+$f0 = newContainerWithEmptyUnion();
+$g0 = newContainerUnparameterized();
+'@phan-debug-var $a0, $b0, $c0, $d0, $e0, $f0, $g0';
+
+$aa0 = $a0->getValue();
+$bb0 = $b0->getValue();
+$cc0 = $c0->getValue();
+$dd0 = $d0->getValue();
+$ee0 = $e0->getValue();
+$ff0 = $f0->getValue();
+$gg0 = $g0->getValue();
+'@phan-debug-var $aa0, $bb0, $cc0, $dd0, $ee0, $ff0, $gg0';


### PR DESCRIPTION
* Test a setter method
* Test a method that uses both class template params and method template params
* Test everything once again when the generic class is left unparameterized in a function return type (this emits lots of issues incorrectly, see #4982)

Also add a separate file that shows more details of what happens to templated types when left unparameterized, so that we can see how #4982 affects them.