### PR TITLE
UnionType: Fix edge case where substing generics would make up types

### DIFF
--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -1053,6 +1053,11 @@ class UnionType implements Serializable, Stringable
             }
         }
 
+        if ($has_template && !$concrete_type_list && $this->real_type_set) {
+            // Can't have an empty union type with a real type set
+            $concrete_type_list = UnionType::typeSetFromString('mixed');
+        }
+
         return $has_template ? UnionType::of($concrete_type_list, $this->real_type_set) : $this;
     }
 

--- a/tests/files/expected/0202_generic_class.php.expected
+++ b/tests/files/expected/0202_generic_class.php.expected
@@ -1,25 +1,27 @@
 %s:70 PhanTypeMismatchReturn Returning 42 of type 42 but failMismatch() is declared to return T0
 %s:74 PhanTypeMissingReturn Method \Tuple2::failVoid is declared to return T0 in phpdoc but has no return value
-%s:79 PhanTypeMismatchReturn Returning $this->e1 of type T1 but failAnotherGeneric() is declared to return T0
-%s:83 PhanTemplateTypeStaticMethod static method \Tuple2::failStatic does not declare template type in its own comment and may not use the template type of class instances
-%s:84 PhanTypeMismatchReturn Returning 42 of type 42 but failStatic() is declared to return T0
-%s:104 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_a->e1 of type 'string' but \check() takes int defined at %s:89
-%s:104 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_a->e0 of type 42 but \check() takes string defined at %s:89
-%s:105 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_a->getE1() of type 'string' but \check() takes int defined at %s:89
-%s:105 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_a->getE0() of type 42 but \check() takes string defined at %s:89
-%s:106 PhanTypeMismatchPropertyProbablyReal Assigning 42 of type 42 to property but \Tuple2->e1 is 'string' (no real type) (the inferred real assigned type has nothing in common with the declared phpdoc property type)
-%s:107 PhanTypeMismatchArgumentProbablyReal Argument 1 ($e1) is 42 of type 42 but \Tuple2::setE1() takes 'string' (no real type) defined at %s:46 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
-%s:108 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_a->e0 of type 42 but \check2() takes bool defined at %s:90
-%s:117 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_b->e0 of type T0 but \check() takes int defined at %s:89
-%s:117 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_b->e1 of type T1 but \check() takes string defined at %s:89
-%s:118 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_b->getE0() of type T0 but \check() takes int defined at %s:89
-%s:118 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_b->getE1() of type T1 but \check() takes string defined at %s:89
-%s:119 PhanTypeMismatchProperty Assigning 42 of type 42 to property but \Tuple2->e0 is T0
-%s:122 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_b2->e1 of type T1 but \check2() takes string defined at %s:90
-%s:125 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_b->e1 of type T1 but \check() takes int defined at %s:89
-%s:125 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_b->e0 of type T0 but \check() takes string defined at %s:89
-%s:126 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_b->getE1() of type T1 but \check() takes int defined at %s:89
-%s:126 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_b->getE0() of type T0 but \check() takes string defined at %s:89
-%s:127 PhanTypeMismatchProperty Assigning 42 of type 42 to property but \Tuple2->e1 is T1
-%s:129 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_b->e0 of type T0 but \check2() takes bool defined at %s:90
-%s:129 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_b->e1 of type T1 but \check2() takes string defined at %s:90
+%s:79 PhanTypeMismatchReturn Returning $this->e1 of type T1 but failWrongGenericGet() is declared to return T0
+%s:84 PhanTypeMismatchProperty Assigning $e0 of type T0 to property but \Tuple2->e1 is T1
+%s:88 PhanTemplateTypeStaticMethod static method \Tuple2::failStatic does not declare template type in its own comment and may not use the template type of class instances
+%s:89 PhanTypeMismatchReturn Returning 42 of type 42 but failStatic() is declared to return T0
+%s:93 PhanTemplateTypeStaticMethod static method \Tuple2::failStaticLeak does not declare template type in its own comment and may not use the template type of class instances
+%s:114 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_a->e1 of type 'string' but \check() takes int defined at %s:99
+%s:114 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_a->e0 of type 42 but \check() takes string defined at %s:99
+%s:115 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_a->getE1() of type 'string' but \check() takes int defined at %s:99
+%s:115 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_a->getE0() of type 42 but \check() takes string defined at %s:99
+%s:116 PhanTypeMismatchPropertyProbablyReal Assigning 42 of type 42 to property but \Tuple2->e1 is 'string' (no real type) (the inferred real assigned type has nothing in common with the declared phpdoc property type)
+%s:117 PhanTypeMismatchArgumentProbablyReal Argument 1 ($e1) is 42 of type 42 but \Tuple2::setE1() takes 'string' (no real type) defined at %s:46 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
+%s:118 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_a->e0 of type 42 but \check2() takes bool defined at %s:100
+%s:127 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_b->e0 of type T0 but \check() takes int defined at %s:99
+%s:127 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_b->e1 of type T1 but \check() takes string defined at %s:99
+%s:128 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_b->getE0() of type T0 but \check() takes int defined at %s:99
+%s:128 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_b->getE1() of type T1 but \check() takes string defined at %s:99
+%s:129 PhanTypeMismatchProperty Assigning 42 of type 42 to property but \Tuple2->e0 is T0
+%s:132 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_b2->e1 of type T1 but \check2() takes string defined at %s:100
+%s:135 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_b->e1 of type T1 but \check() takes int defined at %s:99
+%s:135 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_b->e0 of type T0 but \check() takes string defined at %s:99
+%s:136 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_b->getE1() of type T1 but \check() takes int defined at %s:99
+%s:136 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_b->getE0() of type T0 but \check() takes string defined at %s:99
+%s:137 PhanTypeMismatchProperty Assigning 42 of type 42 to property but \Tuple2->e1 is T1
+%s:139 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_b->e0 of type T0 but \check2() takes bool defined at %s:100
+%s:139 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_b->e1 of type T1 but \check2() takes string defined at %s:100

--- a/tests/files/expected/0204_generic_inheritance.php.expected
+++ b/tests/files/expected/0204_generic_inheritance.php.expected
@@ -1,8 +1,8 @@
 %s:28 PhanTypeMismatchArgumentProbablyReal Argument 1 ($p) is 'string' of type 'string' but \C2::__construct() takes int (no real type) defined at %s:23 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
 %s:28 PhanTypeMismatchArgument Argument 1 ($p) is new C2('string')->p of type int but \f() takes bool defined at %s:3
 %s:36 PhanTypeMismatchArgument Argument 1 ($p) is new C3(false)->p of type T1 but \f() takes bool defined at %s:3
-%s:49 PhanTypeMismatchArgument Argument 1 ($p) is new C4('string')->p of type 'string' but \f() takes bool defined at %s:3
-%s:50 PhanTypeMismatchArgument Argument 1 ($p) is new C4(42)->p of type 42 but \f() takes bool defined at %s:3
-%s:55 PhanUndeclaredExtendedClass Class extends undeclared class \NotFound
-%s:58 PhanUndeclaredClass Reference to undeclared class \NotFound
-%s:67 PhanUndeclaredTypeParameter Parameter $p has undeclared type \NotFound
+%s:55 PhanTypeMismatchArgument Argument 1 ($p) is new C4(42)->p of type 42 but \f() takes bool defined at %s:3
+%s:57 PhanTypeMismatchArgument Argument 1 ($p) is new C4(42)->get() of type 42 but \f() takes bool defined at %s:3
+%s:62 PhanUndeclaredExtendedClass Class extends undeclared class \NotFound
+%s:65 PhanUndeclaredClass Reference to undeclared class \NotFound
+%s:74 PhanUndeclaredTypeParameter Parameter $p has undeclared type \NotFound

--- a/tests/files/expected/0544_phan_generic_class.php.expected
+++ b/tests/files/expected/0544_phan_generic_class.php.expected
@@ -1,25 +1,2 @@
-%s:70 PhanTypeMismatchReturn Returning 42 of type 42 but failMismatch() is declared to return T0
-%s:74 PhanTypeMissingReturn Method \PhanTuple2::failVoid is declared to return T0 in phpdoc but has no return value
-%s:79 PhanTypeMismatchReturn Returning $this->e1 of type T1 but failAnotherGeneric() is declared to return T0
-%s:83 PhanTemplateTypeStaticMethod static method \PhanTuple2::failStatic does not declare template type in its own comment and may not use the template type of class instances
-%s:84 PhanTypeMismatchReturn Returning 42 of type 42 but failStatic() is declared to return T0
-%s:104 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_a->e1 of type 'string' but \check() takes int defined at %s:89
-%s:104 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_a->e0 of type 42 but \check() takes string defined at %s:89
-%s:105 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_a->getE1() of type 'string' but \check() takes int defined at %s:89
-%s:105 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_a->getE0() of type 42 but \check() takes string defined at %s:89
-%s:106 PhanTypeMismatchPropertyProbablyReal Assigning 42 of type 42 to property but \PhanTuple2->e1 is 'string' (no real type) (the inferred real assigned type has nothing in common with the declared phpdoc property type)
-%s:107 PhanTypeMismatchArgumentProbablyReal Argument 1 ($e1) is 42 of type 42 but \PhanTuple2::setE1() takes 'string' (no real type) defined at %s:46 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
-%s:108 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_a->e0 of type 42 but \check2() takes bool defined at %s:90
-%s:117 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_b->e0 of type T0 but \check() takes int defined at %s:89
-%s:117 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_b->e1 of type T1 but \check() takes string defined at %s:89
-%s:118 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_b->getE0() of type T0 but \check() takes int defined at %s:89
-%s:118 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_b->getE1() of type T1 but \check() takes string defined at %s:89
-%s:119 PhanTypeMismatchProperty Assigning 42 of type 42 to property but \PhanTuple2->e0 is T0
-%s:122 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_b2->e1 of type T1 but \check2() takes string defined at %s:90
-%s:125 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_b->e1 of type T1 but \check() takes int defined at %s:89
-%s:125 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_b->e0 of type T0 but \check() takes string defined at %s:89
-%s:126 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_b->getE1() of type T1 but \check() takes int defined at %s:89
-%s:126 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_b->getE0() of type T0 but \check() takes string defined at %s:89
-%s:127 PhanTypeMismatchProperty Assigning 42 of type 42 to property but \PhanTuple2->e1 is T1
-%s:129 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_b->e0 of type T0 but \check2() takes bool defined at %s:90
-%s:129 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_b->e1 of type T1 but \check2() takes string defined at %s:90
+%s:41 PhanTypeMismatchArgument Argument 1 ($p0) is $tuple_a->e1 of type 'string' but \check() takes int defined at %s:32
+%s:41 PhanTypeMismatchArgument Argument 2 ($p1) is $tuple_a->e0 of type 42 but \check() takes string defined at %s:32

--- a/tests/files/expected/0985_template_unspecified.php.expected
+++ b/tests/files/expected/0985_template_unspecified.php.expected
@@ -1,37 +1,52 @@
 %s:9 PhanDebugAnnotation @phan-debug-var requested for variable $this - it has union type static(real=static)
-%s:25 PhanDebugAnnotation @phan-debug-var requested for variable $that - it has union type static(real=static)
-%s:37 PhanDebugAnnotation @phan-debug-var requested for variable $that - it has union type static(real=static)
-%s:48 PhanDebugAnnotation @phan-debug-var requested for variable $that - it has union type static(real=static)
-%s:60 PhanDebugAnnotation @phan-debug-var requested for variable $cont - it has union type \Container<T>(real=\Container<T>)
-%s:60 PhanDebugAnnotation @phan-debug-var requested for variable $cont - it has union type \Container<T|null>(real=\Container<T|null>)
-%s:71 PhanDebugAnnotation @phan-debug-var requested for variable $cont - it has union type \Container<T>(real=\Container<T>)
-%s:81 PhanDebugAnnotation @phan-debug-var requested for variable $cont - it has union type \Container<mixed>(real=\Container<mixed>)
-%s:81 PhanDebugAnnotation @phan-debug-var requested for variable $cont - it has union type \Container<mixed|null>(real=\Container<mixed|null>)
-%s:92 PhanDebugAnnotation @phan-debug-var requested for variable $a - it has union type \Container<\stdClass>(real=\Container<\stdClass>)
-%s:92 PhanDebugAnnotation @phan-debug-var requested for variable $b - it has union type \Container<\stdClass>
-%s:92 PhanDebugAnnotation @phan-debug-var requested for variable $c - it has union type \Container<>
-%s:92 PhanDebugAnnotation @phan-debug-var requested for variable $d - it has union type \Container
-%s:92 PhanDebugAnnotation @phan-debug-var requested for variable $e - it has union type \Container<\stdClass>
-%s:92 PhanDebugAnnotation @phan-debug-var requested for variable $f - it has union type \Container<>
-%s:92 PhanDebugAnnotation @phan-debug-var requested for variable $g - it has union type \Container
-%s:101 PhanDebugAnnotation @phan-debug-var requested for variable $aa - it has union type \stdClass
-%s:101 PhanDebugAnnotation @phan-debug-var requested for variable $bb - it has union type \stdClass
-%s:101 PhanDebugAnnotation @phan-debug-var requested for variable $cc - it has union type (empty union type)
-%s:101 PhanDebugAnnotation @phan-debug-var requested for variable $dd - it has union type T
-%s:101 PhanDebugAnnotation @phan-debug-var requested for variable $ee - it has union type \stdClass
-%s:101 PhanDebugAnnotation @phan-debug-var requested for variable $ff - it has union type (empty union type)
-%s:101 PhanDebugAnnotation @phan-debug-var requested for variable $gg - it has union type T
-%s:110 PhanDebugAnnotation @phan-debug-var requested for variable $a0 - it has union type \Container<null>(real=\Container<null>)
-%s:110 PhanDebugAnnotation @phan-debug-var requested for variable $b0 - it has union type \Container<null>
-%s:110 PhanDebugAnnotation @phan-debug-var requested for variable $c0 - it has union type \Container<>
-%s:110 PhanDebugAnnotation @phan-debug-var requested for variable $d0 - it has union type \Container
-%s:110 PhanDebugAnnotation @phan-debug-var requested for variable $e0 - it has union type \Container<null>
-%s:110 PhanDebugAnnotation @phan-debug-var requested for variable $f0 - it has union type \Container<>
-%s:110 PhanDebugAnnotation @phan-debug-var requested for variable $g0 - it has union type \Container
-%s:119 PhanDebugAnnotation @phan-debug-var requested for variable $aa0 - it has union type null
-%s:119 PhanDebugAnnotation @phan-debug-var requested for variable $bb0 - it has union type null
-%s:119 PhanDebugAnnotation @phan-debug-var requested for variable $cc0 - it has union type (empty union type)
-%s:119 PhanDebugAnnotation @phan-debug-var requested for variable $dd0 - it has union type T
-%s:119 PhanDebugAnnotation @phan-debug-var requested for variable $ee0 - it has union type null
-%s:119 PhanDebugAnnotation @phan-debug-var requested for variable $ff0 - it has union type (empty union type)
-%s:119 PhanDebugAnnotation @phan-debug-var requested for variable $gg0 - it has union type T
+%s:18 PhanTypeMismatchDeclaredReturn Doc-block of getValueFoo contains declared return type T which is incompatible with the return type \Foo declared in the signature
+%s:30 PhanDebugAnnotation @phan-debug-var requested for variable $that - it has union type static(real=static)
+%s:42 PhanDebugAnnotation @phan-debug-var requested for variable $that - it has union type static(real=static)
+%s:53 PhanDebugAnnotation @phan-debug-var requested for variable $that - it has union type static(real=static)
+%s:65 PhanDebugAnnotation @phan-debug-var requested for variable $cont - it has union type \Container<T>(real=\Container<T>)
+%s:65 PhanDebugAnnotation @phan-debug-var requested for variable $cont - it has union type \Container<T|null>(real=\Container<T|null>)
+%s:76 PhanDebugAnnotation @phan-debug-var requested for variable $cont - it has union type \Container<T>(real=\Container<T>)
+%s:86 PhanDebugAnnotation @phan-debug-var requested for variable $cont - it has union type \Container<mixed>(real=\Container<mixed>)
+%s:86 PhanDebugAnnotation @phan-debug-var requested for variable $cont - it has union type \Container<mixed|null>(real=\Container<mixed|null>)
+%s:101 PhanDebugAnnotation @phan-debug-var requested for variable $a - it has union type \Container<\stdClass>(real=\Container<\stdClass>)
+%s:101 PhanDebugAnnotation @phan-debug-var requested for variable $b - it has union type \Container<\stdClass>
+%s:101 PhanDebugAnnotation @phan-debug-var requested for variable $c - it has union type \Container<>
+%s:101 PhanDebugAnnotation @phan-debug-var requested for variable $d - it has union type \Container
+%s:101 PhanDebugAnnotation @phan-debug-var requested for variable $e - it has union type \Container<\stdClass>
+%s:101 PhanDebugAnnotation @phan-debug-var requested for variable $f - it has union type \Container<>
+%s:101 PhanDebugAnnotation @phan-debug-var requested for variable $g - it has union type \Container
+%s:110 PhanDebugAnnotation @phan-debug-var requested for variable $aa - it has union type \stdClass
+%s:110 PhanDebugAnnotation @phan-debug-var requested for variable $bb - it has union type \stdClass
+%s:110 PhanDebugAnnotation @phan-debug-var requested for variable $cc - it has union type (empty union type)
+%s:110 PhanDebugAnnotation @phan-debug-var requested for variable $dd - it has union type T
+%s:110 PhanDebugAnnotation @phan-debug-var requested for variable $ee - it has union type \stdClass
+%s:110 PhanDebugAnnotation @phan-debug-var requested for variable $ff - it has union type (empty union type)
+%s:110 PhanDebugAnnotation @phan-debug-var requested for variable $gg - it has union type T
+%s:119 PhanDebugAnnotation @phan-debug-var requested for variable $aC - it has union type \Container<\Bar>(real=\Container<\Bar>)
+%s:119 PhanDebugAnnotation @phan-debug-var requested for variable $bC - it has union type \Container<\Bar>
+%s:119 PhanDebugAnnotation @phan-debug-var requested for variable $cC - it has union type \Container<>
+%s:119 PhanDebugAnnotation @phan-debug-var requested for variable $dC - it has union type \Container
+%s:119 PhanDebugAnnotation @phan-debug-var requested for variable $eC - it has union type \Container<\Bar>
+%s:119 PhanDebugAnnotation @phan-debug-var requested for variable $fC - it has union type \Container<>
+%s:119 PhanDebugAnnotation @phan-debug-var requested for variable $gC - it has union type \Container
+%s:128 PhanDebugAnnotation @phan-debug-var requested for variable $aaC - it has union type \Bar(real=\Foo)
+%s:128 PhanDebugAnnotation @phan-debug-var requested for variable $bbC - it has union type \Bar(real=\Foo)
+%s:128 PhanDebugAnnotation @phan-debug-var requested for variable $ccC - it has union type \Foo(real=\Foo)
+%s:128 PhanDebugAnnotation @phan-debug-var requested for variable $ddC - it has union type T(real=\Foo)
+%s:128 PhanDebugAnnotation @phan-debug-var requested for variable $eeC - it has union type \Bar(real=\Foo)
+%s:128 PhanDebugAnnotation @phan-debug-var requested for variable $ffC - it has union type \Foo(real=\Foo)
+%s:128 PhanDebugAnnotation @phan-debug-var requested for variable $ggC - it has union type T(real=\Foo)
+%s:137 PhanDebugAnnotation @phan-debug-var requested for variable $a0 - it has union type \Container<null>(real=\Container<null>)
+%s:137 PhanDebugAnnotation @phan-debug-var requested for variable $b0 - it has union type \Container<null>
+%s:137 PhanDebugAnnotation @phan-debug-var requested for variable $c0 - it has union type \Container<>
+%s:137 PhanDebugAnnotation @phan-debug-var requested for variable $d0 - it has union type \Container
+%s:137 PhanDebugAnnotation @phan-debug-var requested for variable $e0 - it has union type \Container<null>
+%s:137 PhanDebugAnnotation @phan-debug-var requested for variable $f0 - it has union type \Container<>
+%s:137 PhanDebugAnnotation @phan-debug-var requested for variable $g0 - it has union type \Container
+%s:146 PhanDebugAnnotation @phan-debug-var requested for variable $aa0 - it has union type null
+%s:146 PhanDebugAnnotation @phan-debug-var requested for variable $bb0 - it has union type null
+%s:146 PhanDebugAnnotation @phan-debug-var requested for variable $cc0 - it has union type (empty union type)
+%s:146 PhanDebugAnnotation @phan-debug-var requested for variable $dd0 - it has union type T
+%s:146 PhanDebugAnnotation @phan-debug-var requested for variable $ee0 - it has union type null
+%s:146 PhanDebugAnnotation @phan-debug-var requested for variable $ff0 - it has union type (empty union type)
+%s:146 PhanDebugAnnotation @phan-debug-var requested for variable $gg0 - it has union type T

--- a/tests/files/expected/0985_template_unspecified.php.expected
+++ b/tests/files/expected/0985_template_unspecified.php.expected
@@ -31,10 +31,10 @@
 %s:119 PhanDebugAnnotation @phan-debug-var requested for variable $gC - it has union type \Container
 %s:128 PhanDebugAnnotation @phan-debug-var requested for variable $aaC - it has union type \Bar(real=\Foo)
 %s:128 PhanDebugAnnotation @phan-debug-var requested for variable $bbC - it has union type \Bar(real=\Foo)
-%s:128 PhanDebugAnnotation @phan-debug-var requested for variable $ccC - it has union type \Foo(real=\Foo)
+%s:128 PhanDebugAnnotation @phan-debug-var requested for variable $ccC - it has union type mixed(real=\Foo)
 %s:128 PhanDebugAnnotation @phan-debug-var requested for variable $ddC - it has union type T(real=\Foo)
 %s:128 PhanDebugAnnotation @phan-debug-var requested for variable $eeC - it has union type \Bar(real=\Foo)
-%s:128 PhanDebugAnnotation @phan-debug-var requested for variable $ffC - it has union type \Foo(real=\Foo)
+%s:128 PhanDebugAnnotation @phan-debug-var requested for variable $ffC - it has union type mixed(real=\Foo)
 %s:128 PhanDebugAnnotation @phan-debug-var requested for variable $ggC - it has union type T(real=\Foo)
 %s:137 PhanDebugAnnotation @phan-debug-var requested for variable $a0 - it has union type \Container<null>(real=\Container<null>)
 %s:137 PhanDebugAnnotation @phan-debug-var requested for variable $b0 - it has union type \Container<null>

--- a/tests/files/src/0202_generic_class.php
+++ b/tests/files/src/0202_generic_class.php
@@ -75,13 +75,23 @@ class Tuple2 {
     }
 
     /** @return T0 */
-    public function failAnotherGeneric() {
+    public function failWrongGenericGet() {
         return $this->e1;
+    }
+
+    /** @param T0 $e0 */
+    public function failWrongGenericSet($e0) {
+        return $this->e1 = $e0;
     }
 
     /** @return T0 */
     public static function failStatic() {
         return 42;
+    }
+
+    /** @return T0 */
+    public static function failStaticLeak() {
+        return getUnparameterizedTuple()->e0;
     }
 
 }

--- a/tests/files/src/0204_generic_inheritance.php
+++ b/tests/files/src/0204_generic_inheritance.php
@@ -44,10 +44,17 @@ class C4 extends C1 {
     public function __construct($p) {
         parent::__construct($p);
     }
+
+    /** @return T2 $p */
+    public function get() {
+        return $this->p;
+    }
 }
 
-f((new C4('string'))->p);
+f((new C4(false))->p);
 f((new C4(42))->p);
+f((new C4(false))->get());
+f((new C4(42))->get());
 
 /**
  * @inherits NotFound<string>

--- a/tests/files/src/0544_phan_generic_class.php
+++ b/tests/files/src/0544_phan_generic_class.php
@@ -27,103 +27,15 @@ class PhanTuple2 {
         $this->e1 = $e1;
     }
 
-    /** @return T0 */
-    public function getE0() {
-        return $this->e0;
-    }
-
-    /** @return T1 */
-    public function getE1() {
-        return $this->e1;
-    }
-
-    /** @param T0 $e0 */
-    public function setE0($e0) {
-        $this->e0 = $e0;
-    }
-
-    /** @param T1 $e1 */
-    public function setE1($e1) {
-        $this->e1 = $e1;
-    }
-
-    /**
-     * @phan-template X0
-     * @param X0 $e0
-     * @return static<X0, T1>
-     */
-    public function withE0($e0) {
-        return new static($e0, $this->e1);
-    }
-
-    /**
-     * @phan-template X1
-     * @param X1 $e1
-     * @return static<T0, X1>
-     */
-    public function withE1($e1) {
-        return new static($this->e0, $e1);
-    }
-
-    /** @return T0 */
-    public function failMismatch() {
-        return 42;
-    }
-
-    /** @return T0 */
-    public function failVoid() {
-    }
-
-    /** @return T0 */
-    public function failAnotherGeneric() {
-        return $this->e1;
-    }
-
-    /** @return T0 */
-    public static function failStatic() {
-        return 42;
-    }
-
 }
 
 function check(int $p0, string $p1) {}
 function check2(bool $p0, string $p1) {}
 
-
 $tuple_a = new PhanTuple2(42, 'string');
 
 // Valid code
 check($tuple_a->e0, $tuple_a->e1);
-check($tuple_a->getE0(), $tuple_a->getE1());
-$tuple_a->e0 = 42;
-$tuple_a->setE0(42);
-$tuple_a2 = $tuple_a->withE0(false);
-check2($tuple_a2->e0, $tuple_a2->e1);
 
 // Invalid code
 check($tuple_a->e1, $tuple_a->e0);
-check($tuple_a->getE1(), $tuple_a->getE0());
-$tuple_a->e1 = 42;
-$tuple_a->setE1(42);
-check2($tuple_a->e0, $tuple_a->e1);
-
-
-function getUnparameterizedTuple(): PhanTuple2 {
-    return new PhanTuple2(42, 'string');
-}
-$tuple_b = getUnparameterizedTuple();
-
-// Valid code (currently emits issues, #4982)
-check($tuple_b->e0, $tuple_b->e1);
-check($tuple_b->getE0(), $tuple_b->getE1());
-$tuple_b->e0 = 42;
-$tuple_b->setE0(42);
-$tuple_b2 = $tuple_b->withE0(false);
-check2($tuple_b2->e0, $tuple_b2->e1);
-
-// Invalid but unverifiable, since the type parameters are not known, should not emit issues
-check($tuple_b->e1, $tuple_b->e0);
-check($tuple_b->getE1(), $tuple_b->getE0());
-$tuple_b->e1 = 42;
-$tuple_b->setE1(42);
-check2($tuple_b->e0, $tuple_b->e1);

--- a/tests/files/src/0985_template_unspecified.php
+++ b/tests/files/src/0985_template_unspecified.php
@@ -15,6 +15,11 @@ class Container {
         return $this->t;
     }
 
+    /** @return T */
+    function getValueFoo(): Foo {
+        return $this->t;
+    }
+
     /**
      * Returns a Container<T> (or Container<null> when called with 0 arguments).
      * @template T
@@ -83,6 +88,10 @@ function newContainerUnparameterized($value = null) {
     return $cont;
 }
 
+// Classes for test case below
+class Foo {}
+class Bar extends Foo {}
+
 $a = new Container(new stdClass);
 $b = Container::newTyped(new stdClass);
 $c = Container::newWithEmptyUnion(new stdClass);
@@ -100,6 +109,24 @@ $ee = $e->getValue();
 $ff = $f->getValue();
 $gg = $g->getValue();
 '@phan-debug-var $aa, $bb, $cc, $dd, $ee, $ff, $gg';
+
+$aC = new Container(new Bar);
+$bC = Container::newTyped(new Bar);
+$cC = Container::newWithEmptyUnion(new Bar);
+$dC = Container::newUnparameterized(new Bar);
+$eC = newContainerTyped(new Bar);
+$fC = newContainerWithEmptyUnion(new Bar);
+$gC = newContainerUnparameterized(new Bar);
+'@phan-debug-var $aC, $bC, $cC, $dC, $eC, $fC, $gC';
+
+$aaC = $aC->getValueFoo();
+$bbC = $bC->getValueFoo();
+$ccC = $cC->getValueFoo();
+$ddC = $dC->getValueFoo();
+$eeC = $eC->getValueFoo();
+$ffC = $fC->getValueFoo();
+$ggC = $gC->getValueFoo();
+'@phan-debug-var $aaC, $bbC, $ccC, $ddC, $eeC, $ffC, $ggC';
 
 $a0 = new Container();
 $b0 = Container::newTyped();


### PR DESCRIPTION
If withTemplateParameterTypeMap() was called with a type like
`T(real=\Foo)` (e.g. a generic method returns the T type parameter,
but also has a real return type indicating superclass),
and the type to substitute for T was an empty union type,
this would return `\Foo(real=\Foo)` instead of `mixed(real=\Foo)`.

See similar code in iterableKeyUnionType().

Add test case for this and some extras.