### PR TITLE
Emit issue for missing @extends or @inherit on a subclass of a generic class

### DIFF
--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -4860,6 +4860,14 @@ e.g. [this issue](https://github.com/phan/phan/tree/v5/tests/files/expected/0203
 Global variable {VARIABLE} may not be assigned an instance of a generic class
 ```
 
+## PhanGenericMissingParameters
+
+```
+Class {CLASS} must substitute all {COUNT} template parameters when inheriting {CLASS} (found {COUNT}) defined at {FILE}:{LINE} (use @extends or @inherit)
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/v5/tests/files/expected/0987_generic_missing_extends.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/v5/tests/files/src/0987_generic_missing_extends.php#L10).
+
 ## PhanTemplateTypeConstant
 
 This is emitted when a class constant's PHPDoc contains a type declared in a class's phpdoc template annotations.

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -636,6 +636,7 @@ class Issue
     public const GenericConstructorTypes    = 'PhanGenericConstructorTypes';
     public const TemplateTypeNotUsedInFunctionReturn = 'PhanTemplateTypeNotUsedInFunctionReturn';
     public const TemplateTypeNotDeclaredInFunctionParams = 'PhanTemplateTypeNotDeclaredInFunctionParams';
+    public const GenericMissingParameters = 'PhanGenericMissingParameters';
 
     // Issue::CATEGORY_COMMENT
     public const DebugAnnotation                  = 'PhanDebugAnnotation';
@@ -5481,6 +5482,14 @@ class Issue
                 "Template type {TYPE} not declared in parameters of function/method {FUNCTIONLIKE} (or Phan can't extract template types for this use case)",
                 self::REMEDIATION_B,
                 14006
+            ),
+            new Issue(
+                self::GenericMissingParameters,
+                self::CATEGORY_GENERIC,
+                self::SEVERITY_NORMAL,
+                "Class {CLASS} must substitute all {COUNT} template parameters when inheriting {CLASS} (found {COUNT}) defined at {FILE}:{LINE} (use @extends or @inherit)",
+                self::REMEDIATION_B,
+                14007
             ),
 
             // Issue::CATEGORY_INTERNAL

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -2820,6 +2820,21 @@ class Clazz extends AddressableElement
         if ($parent->isFinal()) {
             $this->emitExtendsFinalClassWarning($code_base, $parent);
         }
+        if ($parent->isGeneric() ) {
+            // Should have @extends/@inherits substituting all type parameters, otherwise they will
+            // be substituted with the empty union type, which is almost never what you want.
+            $parent_type = $this->getParentTypeOption();
+            if (
+                !$parent_type->isDefined() ||
+                count($parent_type->get()->getTemplateParameterTypeList()) < count($parent->getTemplateTypeMap())
+            ) {
+                $this->emitGenericMissingParametersWarning(
+                    $code_base, $parent,
+                    count($parent->getTemplateTypeMap()),
+                    count($parent_type->get()->getTemplateParameterTypeList())
+                );
+            }
+        }
 
         // Tell the parent to import its own parents first
 
@@ -2892,6 +2907,29 @@ class Clazz extends AddressableElement
                     $ancestor->getFileRef()->getLineNumberStart()
                 );
             }
+        }
+    }
+
+    private function emitGenericMissingParametersWarning(
+        CodeBase $code_base,
+        Clazz $ancestor,
+        int $expected_count,
+        int $actual_count
+    ): void {
+        $context = $this->getContext();
+        if (!$this->checkHasSuppressIssueAndIncrementCount(Issue::GenericMissingParameters)) {
+            Issue::maybeEmit(
+                $code_base,
+                $context,
+                Issue::GenericMissingParameters,
+                $this->parent_type_lineno ?: $context->getLineNumberStart(),
+                (string)$this->fqsen,
+                $expected_count,
+                (string)$ancestor->getFQSEN(),
+                $actual_count,
+                $ancestor->getFileRef()->getFile(),
+                $ancestor->getFileRef()->getLineNumberStart()
+            );
         }
     }
 

--- a/tests/files/expected/0204_generic_inheritance.php.expected
+++ b/tests/files/expected/0204_generic_inheritance.php.expected
@@ -1,5 +1,6 @@
 %s:28 PhanTypeMismatchArgumentProbablyReal Argument 1 ($p) is 'string' of type 'string' but \C2::__construct() takes int (no real type) defined at %s:23 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
 %s:28 PhanTypeMismatchArgument Argument 1 ($p) is new C2('string')->p of type int but \f() takes bool defined at %s:3
+%s:30 PhanGenericMissingParameters Class \C3 must substitute all 1 template parameters when inheriting \C1 (found 0) defined at %s:8 (use @extends or @inherit)
 %s:36 PhanTypeMismatchArgument Argument 1 ($p) is new C3(false)->p of type T1 but \f() takes bool defined at %s:3
 %s:49 PhanTypeMismatchArgument Argument 1 ($p) is new C4('string')->p of type 'string' but \f() takes bool defined at %s:3
 %s:50 PhanTypeMismatchArgument Argument 1 ($p) is new C4(42)->p of type 42 but \f() takes bool defined at %s:3

--- a/tests/files/expected/0987_generic_missing_extends.php.expected
+++ b/tests/files/expected/0987_generic_missing_extends.php.expected
@@ -1,0 +1,3 @@
+%s:10 PhanGenericMissingParameters Class \Err1 must substitute all 2 template parameters when inheriting \Generic (found 0) defined at %s:7 (use @extends or @inherit)
+%s:15 PhanGenericMissingParameters Class \Err2 must substitute all 2 template parameters when inheriting \Generic (found 0) defined at %s:7 (use @extends or @inherit)
+%s:20 PhanGenericMissingParameters Class \Err3 must substitute all 2 template parameters when inheriting \Generic (found 1) defined at %s:7 (use @extends or @inherit)

--- a/tests/files/src/0987_generic_missing_extends.php
+++ b/tests/files/src/0987_generic_missing_extends.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @template T0
+ * @template T1
+ */
+class Generic {
+}
+
+class Err1 extends Generic {}
+
+/**
+ * @extends Generic
+ */
+class Err2 extends Generic {}
+
+/**
+ * @extends Generic<int>
+ */
+class Err3 extends Generic {}
+
+/**
+ * @extends Generic<int,int>
+ */
+class OK1 extends Generic {}
+
+/**
+ * @template X0
+ * @template X1
+ * @extends Generic<X0,X1>
+ */
+class OK2 extends Generic {}


### PR DESCRIPTION
Without it, missing parameters' template types will leak into the subclass, which is almost never what you want.