### PR TITLE
Fix all inferred iterable key/value types being marked as real

### DIFF
--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -2480,7 +2480,7 @@ class Type implements Stringable
             if ($method_type->hasTemplateTypeRecursive()) {
                 $method_type = $method_type->withTemplateParameterTypeMap(
                     $iterator_type->getTemplateParameterTypeMap($code_base)
-                )->withoutTemplateTypeRecursive();
+                );
             }
             $new_expanded_types = null;
             // TODO: Support getIterator returning a union type with more than one type.
@@ -2523,7 +2523,7 @@ class Type implements Stringable
             if ($result->hasTemplateTypeRecursive()) {
                 $result = $result->withTemplateParameterTypeMap(
                     $iterator_type->getTemplateParameterTypeMap($code_base)
-                )->withoutTemplateTypeRecursive();
+                );
             }
             return $result;
         }
@@ -2576,7 +2576,7 @@ class Type implements Stringable
             if ($method_type->hasTemplateTypeRecursive()) {
                 $method_type = $method_type->withTemplateParameterTypeMap(
                     $iterator_type->getTemplateParameterTypeMap($code_base)
-                )->withoutTemplateTypeRecursive();
+                );
             }
             $new_expanded_types = null;
             // TODO: Support getIterator returning a union type with more than one type.
@@ -2619,7 +2619,7 @@ class Type implements Stringable
             if ($result->hasTemplateTypeRecursive()) {
                 $result = $result->withTemplateParameterTypeMap(
                     $iterator_type->getTemplateParameterTypeMap($code_base)
-                )->withoutTemplateTypeRecursive();
+                );
             }
             return $result;
         }

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -2527,7 +2527,7 @@ class Type implements Stringable
             }
             return $result;
         }
-        return StringType::instance(false)->asPHPDocUnionType();
+        return StringType::instance(false)->asRealUnionType();
     }
 
     /**

--- a/src/Phan/Language/Type/ArrayType.php
+++ b/src/Phan/Language/Type/ArrayType.php
@@ -332,7 +332,7 @@ class ArrayType extends IterableType
      */
     public function iterableKeyUnionType(CodeBase $code_base): UnionType
     {
-        return UnionType::fromFullyQualifiedPHPDocString('int|string');
+        return UnionType::fromFullyQualifiedRealString('int|string');
     }
 
     /**

--- a/src/Phan/Language/Type/CallableArrayType.php
+++ b/src/Phan/Language/Type/CallableArrayType.php
@@ -45,7 +45,7 @@ class CallableArrayType extends ArrayType implements GenericArrayInterface
     public function iterableKeyUnionType(CodeBase $code_base): UnionType
     {
         // Reduce false positive partial type mismatch errors
-        return IntType::instance(false)->asPHPDocUnionType();
+        return IntType::instance(false)->asRealUnionType();
     }
 
     /**
@@ -81,7 +81,7 @@ class CallableArrayType extends ArrayType implements GenericArrayInterface
     }
 
     public function genericArrayElementUnionType(): UnionType {
-        return UnionType::fromFullyQualifiedPHPDocString('string|object');
+        return UnionType::fromFullyQualifiedRealString('string|object');
     }
 
     protected function isSubtypeOfNonNullableType(Type $type, CodeBase $code_base): bool

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -289,7 +289,7 @@ class GenericArrayType extends ArrayType implements GenericArrayInterface
      */
     public function iterableValueUnionType(?CodeBase $code_base = null): UnionType
     {
-        return $this->element_type->asPHPDocUnionType();
+        return $this->element_type->asRealUnionType();
     }
 
     /**
@@ -309,7 +309,7 @@ class GenericArrayType extends ArrayType implements GenericArrayInterface
      */
     public function genericArrayElementUnionType(): UnionType
     {
-        return $this->element_type->asPHPDocUnionType();
+        return $this->element_type->asRealUnionType();
     }
 
     public function __toString(): string
@@ -574,9 +574,9 @@ class GenericArrayType extends ArrayType implements GenericArrayInterface
         static $string_union_type = null;
         static $int_or_string_union_type = null;
         if ($int_union_type === null) {
-            $int_union_type = UnionType::fromFullyQualifiedPHPDocString('int');
-            $string_union_type = UnionType::fromFullyQualifiedPHPDocString('string');
-            $int_or_string_union_type = UnionType::fromFullyQualifiedPHPDocString('int|string');
+            $int_union_type = UnionType::fromFullyQualifiedRealString('int');
+            $string_union_type = UnionType::fromFullyQualifiedRealString('string');
+            $int_or_string_union_type = UnionType::fromFullyQualifiedRealString('int|string');
         }
         switch ($key_type) {
             case self::KEY_INT:

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -1088,6 +1088,7 @@ class UnionType implements Serializable, Stringable
     /**
      * @return UnionType
      * Removes template types from this union type, e.g. converts T|\stdClass to \stdClass.
+     * You probably don't want to use this method.
      * @suppress PhanUnreferencedPublicMethod
      */
     public function withoutTemplateTypeRecursive(): UnionType

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -3983,7 +3983,7 @@ class UnionType implements Serializable, Stringable
                     }
                 }
             }
-            $new_real_type_builder->addUnionType($key_union_type);
+            $new_real_type_builder->addUnionType($key_union_type->getRealUnionType());
         }
         $type_set = $new_type_builder->getTypeSet();
         $real_type_set = $new_real_type_builder->getTypeSet();
@@ -4029,7 +4029,7 @@ class UnionType implements Serializable, Stringable
                 $real_builder->clearTypeSet();
                 break;
             }
-            $real_builder->addUnionType($element_type);
+            $real_builder->addUnionType($element_type->getRealUnionType());
         }
 
         static $array_type_nonnull = null;

--- a/src/Phan/Library/Map.php
+++ b/src/Phan/Library/Map.php
@@ -101,6 +101,7 @@ class Map extends SplObjectStorage
     /**
      * @return Map<K,V>
      * A new map with each value cloned (keys remain uncloned)
+     * @suppress PhanTypePossiblyInvalidCloneNotObject phan does not support base types of template types yet.
      */
     public function deepCopyValues(): Map
     {

--- a/tests/files/expected/0962_iteratoraggregate_template.php.expected
+++ b/tests/files/expected/0962_iteratoraggregate_template.php.expected
@@ -1,6 +1,6 @@
 %s:49 PhanDebugAnnotation @phan-debug-var requested for variable $iterator - it has union type \Iterator<int,\UserModel>
 %s:49 PhanDebugAnnotation @phan-debug-var requested for variable $users - it has union type \Collection<\UserModel>(real=\Collection)
-%s:51 PhanDebugAnnotation @phan-debug-var requested for variable $key - it has union type int
-%s:51 PhanDebugAnnotation @phan-debug-var requested for variable $user - it has union type \UserModel
+%s:51 PhanDebugAnnotation @phan-debug-var requested for variable $key - it has union type int(real=int)
+%s:51 PhanDebugAnnotation @phan-debug-var requested for variable $user - it has union type \UserModel(real=T)
 %s:55 PhanDebugAnnotation @phan-debug-var requested for variable $key - it has union type int
 %s:55 PhanDebugAnnotation @phan-debug-var requested for variable $user - it has union type \UserModel

--- a/tests/files/expected/0962_iteratoraggregate_template.php.expected
+++ b/tests/files/expected/0962_iteratoraggregate_template.php.expected
@@ -1,6 +1,6 @@
 %s:49 PhanDebugAnnotation @phan-debug-var requested for variable $iterator - it has union type \Iterator<int,\UserModel>
 %s:49 PhanDebugAnnotation @phan-debug-var requested for variable $users - it has union type \Collection<\UserModel>(real=\Collection)
-%s:51 PhanDebugAnnotation @phan-debug-var requested for variable $key - it has union type int(real=int)
-%s:51 PhanDebugAnnotation @phan-debug-var requested for variable $user - it has union type \UserModel(real=T)
+%s:51 PhanDebugAnnotation @phan-debug-var requested for variable $key - it has union type int
+%s:51 PhanDebugAnnotation @phan-debug-var requested for variable $user - it has union type \UserModel
 %s:55 PhanDebugAnnotation @phan-debug-var requested for variable $key - it has union type int
 %s:55 PhanDebugAnnotation @phan-debug-var requested for variable $user - it has union type \UserModel

--- a/tests/files/expected/0986_iterator_real.php.expected
+++ b/tests/files/expected/0986_iterator_real.php.expected
@@ -1,0 +1,4 @@
+%s:49 PhanDebugAnnotation @phan-debug-var requested for variable $iKey - it has union type string(real=string)
+%s:49 PhanDebugAnnotation @phan-debug-var requested for variable $iVal - it has union type string(real=string)
+%s:56 PhanDebugAnnotation @phan-debug-var requested for variable $aKey - it has union type int(real=int)
+%s:56 PhanDebugAnnotation @phan-debug-var requested for variable $aVal - it has union type string(real=string)

--- a/tests/files/expected/0986_iterator_real.php.expected
+++ b/tests/files/expected/0986_iterator_real.php.expected
@@ -1,4 +1,4 @@
 %s:49 PhanDebugAnnotation @phan-debug-var requested for variable $iKey - it has union type string(real=string)
 %s:49 PhanDebugAnnotation @phan-debug-var requested for variable $iVal - it has union type string(real=string)
-%s:56 PhanDebugAnnotation @phan-debug-var requested for variable $aKey - it has union type int(real=int)
-%s:56 PhanDebugAnnotation @phan-debug-var requested for variable $aVal - it has union type string(real=string)
+%s:56 PhanDebugAnnotation @phan-debug-var requested for variable $aKey - it has union type int
+%s:56 PhanDebugAnnotation @phan-debug-var requested for variable $aVal - it has union type string

--- a/tests/files/expected/0986_iterator_unreal.php.expected
+++ b/tests/files/expected/0986_iterator_unreal.php.expected
@@ -1,0 +1,4 @@
+%s:49 PhanDebugAnnotation @phan-debug-var requested for variable $iKey - it has union type string(real=string)
+%s:49 PhanDebugAnnotation @phan-debug-var requested for variable $iVal - it has union type string(real=string)
+%s:56 PhanDebugAnnotation @phan-debug-var requested for variable $aKey - it has union type int(real=int)
+%s:56 PhanDebugAnnotation @phan-debug-var requested for variable $aVal - it has union type string(real=string)

--- a/tests/files/expected/0986_iterator_unreal.php.expected
+++ b/tests/files/expected/0986_iterator_unreal.php.expected
@@ -1,4 +1,4 @@
-%s:49 PhanDebugAnnotation @phan-debug-var requested for variable $iKey - it has union type string(real=string)
-%s:49 PhanDebugAnnotation @phan-debug-var requested for variable $iVal - it has union type string(real=string)
-%s:56 PhanDebugAnnotation @phan-debug-var requested for variable $aKey - it has union type int(real=int)
-%s:56 PhanDebugAnnotation @phan-debug-var requested for variable $aVal - it has union type string(real=string)
+%s:49 PhanDebugAnnotation @phan-debug-var requested for variable $iKey - it has union type string
+%s:49 PhanDebugAnnotation @phan-debug-var requested for variable $iVal - it has union type string
+%s:56 PhanDebugAnnotation @phan-debug-var requested for variable $aKey - it has union type int
+%s:56 PhanDebugAnnotation @phan-debug-var requested for variable $aVal - it has union type string

--- a/tests/files/src/0986_iterator_real.php
+++ b/tests/files/src/0986_iterator_real.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace NS986;
+
+use Iterator;
+
+class MyIterator implements Iterator {
+
+    public function current(): string {
+        return $GLOBALS['a'];
+    }
+
+    public function next() {
+    }
+
+
+    public function key(): string {
+        return $GLOBALS['c'];
+    }
+
+    public function valid() {
+        return (bool)rand();
+    }
+
+    public function rewind() {
+    }
+}
+
+class MyAggregate implements \IteratorAggregate {
+    public $arr;
+
+    /** @param array<int,string> $arr */
+    public function __construct(array $arr) {
+        $this->arr = $arr;
+    }
+
+    /**
+     * @return Iterator<int,string>
+     */
+    public function getIterator() {
+        return new \ArrayIterator($this->arr);
+    }
+}
+
+( static function () {
+    // Real types should be inferred for loop variables in the first loop only.
+
+    $iterator = new MyIterator();
+    foreach ( $iterator as $iKey => $iVal ) {
+        '@phan-debug-var $iKey, $iVal';
+        echo "$iKey - $iVal\n";
+    }
+
+    // @phan-suppress-next-line PhanTypeMismatchArgument
+    $aggregate = new MyAggregate( [ 'not an integer' => true ] );
+    foreach ($aggregate as $aKey => $aVal) {
+        '@phan-debug-var $aKey, $aVal';
+        echo "$aKey - $aVal\n";
+    }
+} )();

--- a/tests/files/src/0986_iterator_unreal.php
+++ b/tests/files/src/0986_iterator_unreal.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace NS986;
+
+use Iterator;
+
+class MyIterator implements Iterator {
+    /** @return string */
+    public function current() {
+        return $GLOBALS['a'];
+    }
+
+    public function next() {
+    }
+
+    /** @return string */
+    public function key() {
+        return $GLOBALS['c'];
+    }
+
+    public function valid() {
+        return (bool)rand();
+    }
+
+    public function rewind() {
+    }
+}
+
+class MyAggregate implements \IteratorAggregate {
+    public $arr;
+
+    /** @param array<int,string> $arr */
+    public function __construct(array $arr) {
+        $this->arr = $arr;
+    }
+
+    /**
+     * @return Iterator<int,string>
+     */
+    public function getIterator() {
+        return new \ArrayIterator($this->arr);
+    }
+}
+
+( static function () {
+    // No real types should be inferred for loop variables.
+
+    $iterator = new MyIterator();
+    foreach ( $iterator as $iKey => $iVal ) {
+        '@phan-debug-var $iKey, $iVal';
+        echo "$iKey - $iVal\n";
+    }
+
+    // @phan-suppress-next-line PhanTypeMismatchArgument
+    $aggregate = new MyAggregate( [ 'not an integer' => true ] );
+    foreach ($aggregate as $aKey => $aVal) {
+        '@phan-debug-var $aKey, $aVal';
+        echo "$aKey - $aVal\n";
+    }
+} )();


### PR DESCRIPTION
Fixes #4986.

* In UnionType::iterableKeyUnionType/iterableValueUnionType,
  when building the real type set, only take the real parts
  of the individual types.
* In Type::iterableKeyUnionType/iterableValueUnionType and subclasses,
  make sure we return a union type with a real part when the type
  is supposed to be real. I didn't think about this too hard, to be
  honest, I just kept changing PHPDoc types to real until all existing
  tests covering iterables were passing (there's a lot of them).
* Remove use of withoutTemplateTypeRecursive() in iterable-related code.
  It's not correct to drop these types, and doing so masks other bugs.