### PR TITLE
Add some docs and notes from learning my way around Phan

### DIFF
--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -92,6 +92,8 @@ use function trim;
  * A plain Type represents a class instance.
  * Separate subclasses exist for NativeType, ArrayType, ScalarType, TemplateType, etc.
  *
+ * All instances of Type are interned, and can be compared using `===`, since Type
+ * objects representing the same type will always be the same class instance.
  *
  * @phan-file-suppress PhanPartialTypeMismatchArgumentInternal
  * @phan-file-suppress PhanSuspiciousTruthyString

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -75,6 +75,11 @@ use function substr;
  * (This was the most efficient representation, since most union types have 0, 1, or 2 unique types in practice)
  * To add/remove a type to a UnionType, you replace it with a UnionType that had that type added.
  *
+ * Unlike Type, UnionType objects are not interned. Two UnionTypes representing the same type may
+ * not even compare equal with `==`, because the order of entries in the list of Types may be
+ * different. Code dealing with UnionType should not depend on the order. Types are always shown in
+ * canonical order when printing the objects, e.g. in __toString().
+ *
  * @see AnnotatedUnionType for the way Phan represents extra information about types
  * @see https://github.com/phan/phan/wiki/About-Union-Types
  *

--- a/tests/Phan/AbstractPhanFileTest.php
+++ b/tests/Phan/AbstractPhanFileTest.php
@@ -236,9 +236,8 @@ abstract class AbstractPhanFileTest extends CodeBaseAwareTest
 
         if ($_ENV['PHAN_DUMP_NEW_TEST_EXPECTATION'] ?? null) {
             if (!\preg_match($wanted_re_full, $output)) {
-                // This assumes linux/unix output, could be patched to support Windows if needed.
-                // Then run `for file in tests/**/*.expected*.new; do mv $file ${file/\.new/}; done`
-                // to copy all of the tests
+                // Run `for file in $(find tests -name *.expected*.new); do mv $file ${file/\.new/}; done`
+                // to overwrite test expectations with the generated outputs.
                 $suggested_re = \preg_replace('@\./tests/\S*\.php([78]\d*)?@', '%s', $output);
                 $suggested_re = \preg_replace('/closure_[^\(]*\(/', 'closure_%s(', $suggested_re);
                 \file_put_contents($expected_file_path . '.new', $suggested_re);

--- a/tests/run_all_tests
+++ b/tests/run_all_tests
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# PHAN_TEST_PARALLEL can be set to 1 in your .bashrc (or other shell configuration) if you want to test in parallel by default.
+# PHAN_TEST_PARALLEL can be set to 0 in your .bashrc (or other shell configuration) if you do not want to test in parallel by default.
 PHAN_TEST_PARALLEL=${PHAN_TEST_PARALLEL:-1}
 if [[ "$#" != 0 ]]; then
 	if [[ "$#" == 1 && "$@" == "--parallel" ]]; then


### PR DESCRIPTION
src/Phan/Language/Type.php
* It wasn't obvious to me that Type instances can be compared with `===` and why it works.

src/Phan/Language/UnionType.php
* It wasn't obvious to me that UnionType instances can not be compared easily, unlike Type.

tests/Phan/AbstractPhanFileTest.php
* That shell command didn't work for me, provide another one that should be more reliable.
* The expectation dumping mechanism does work on Windows, though. For whatever reason the path part after the "tests" uses slashes and not backslashes.

tests/run_all_tests
* Parallel execution is enabled by default, in fact.