### PR TITLE
Throw exception for invalid issue format strings

### DIFF
--- a/.phan/plugins/AsymmetricVisibilityPlugin.php
+++ b/.phan/plugins/AsymmetricVisibilityPlugin.php
@@ -67,7 +67,7 @@ class AsymmetricVisibilityPlugin extends PluginV3 implements AnalyzePropertyCapa
                 $code_base,
                 $property->getContext(),
                 'PhanPluginAsymmetricVisibilityLessRestrictive',
-                "Visibility ({VISIBILITY}) of property {PROPERTY} must not be weaker than set visibility ({SET_VISIBILITY})",
+                "Visibility ({CODE}) of property {PROPERTY} must not be weaker than set visibility ({CODE})",
                 [
                     $property->getVisibilityName(),
                     $property->getRepresentationForIssue(),

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -15,6 +15,7 @@ use Phan\Language\Type;
 use Phan\Language\UnionType;
 use Phan\Library\ConversionSpec;
 use Phan\Plugin\ConfigPluginSet;
+use RuntimeException;
 use Stringable;
 
 /**
@@ -849,13 +850,12 @@ class Issue
             $key = $matches[1];
             $replacement_exists = \array_key_exists($key, self::UNCOLORED_FORMAT_STRING_FOR_TEMPLATE);
             if (!$replacement_exists) {
-                \error_log(\sprintf(
+                throw new RuntimeException(\sprintf(
                     "No coloring info for issue message (%s), key {%s}. Valid template types: %s",
                     $template,
                     $key,
                     \implode(', ', \array_keys(self::UNCOLORED_FORMAT_STRING_FOR_TEMPLATE))
                 ));
-                return '%s';
             }
             return self::UNCOLORED_FORMAT_STRING_FOR_TEMPLATE[$key];
         }, $template);


### PR DESCRIPTION
These indicate a programming error, so we should make sure the developer sees the warning, instead of burying it in a wall of output text.

Fix two non-existing types in AsymmetricVisibilityPlugin that I happened to see by chance while analyzing CI output.