### PR TITLE
Distinguish anonymous classes on the same line

### DIFF
--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -2354,10 +2354,12 @@ class ContextNode
             throw new AssertionError('Node must be an anonymous class node');
         }
 
-        $class_name = 'anonymous_class_'
-            . \substr(\md5(
-                $this->context->getFile() . $this->context->getLineNumberStart()
-            ), 0, 8);
+        $hash_material =
+            $this->context->getFile() . '|' .
+            $this->node->lineno . '|' .
+            $this->node->children['__declId'];
+
+        $class_name = 'anonymous_class_' . \substr(\md5($hash_material), 0, 8);
 
         return $class_name;
     }

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -3369,7 +3369,7 @@ class UnionTypeVisitor extends AnalysisVisitor
             $anonymous_class_name =
                 (new ContextNode(
                     $this->code_base,
-                    $this->context,
+                    (clone $this->context)->withLineNumberStart($node->lineno),
                     $node
                 ))->getUnqualifiedNameForAnonymousClass();
 

--- a/tests/files/src/0992_distinguish_anon_class.php
+++ b/tests/files/src/0992_distinguish_anon_class.php
@@ -1,0 +1,12 @@
+<?php
+
+class Foo {
+    function test() { echo 'first'; }
+}
+class Foo2 extends Foo {
+    function test() { echo 'second'; }
+}
+
+$a = rand() % 2 ? new class() extends Foo {} : new class() extends Foo2 {};
+
+$a->test();

--- a/tests/misc/fallback_test/expected/020_issue.php.expected
+++ b/tests/misc/fallback_test/expected/020_issue.php.expected
@@ -1,2 +1,1 @@
-src/020_issue.php:2 PhanRedefineClass Class \anonymous_class_%s defined at src/020_issue.php:2 was previously defined as Class \anonymous_class_%s at src/020_issue.php:2
 src/020_issue.php:2 PhanSyntaxError syntax error, unexpected '{', expecting identifier (T_STRING) (at column 7)

--- a/tests/misc/fallback_test/expected/020_issue.php.expected80
+++ b/tests/misc/fallback_test/expected/020_issue.php.expected80
@@ -1,2 +1,1 @@
-src/020_issue.php:2 PhanRedefineClass Class \anonymous_class_%s defined at src/020_issue.php:2 was previously defined as Class \anonymous_class_%s at src/020_issue.php:2
 src/020_issue.php:2 PhanSyntaxError syntax error, unexpected token "{", expecting identifier (at column 7)


### PR DESCRIPTION
Similarly to closures, FullyQualifiedFunctionName::fromClosureInContext().

Fixes #4823.