### PR TITLE
Do not warn for trailing commas in PHP 8

### DIFF
--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -3152,7 +3152,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         }
         $params_node = $node->children['params'];
         // @phan-suppress-next-line PhanUndeclaredProperty
-        if (isset($params_node->polyfill_has_trailing_comma)) {
+        if (isset($params_node->polyfill_has_trailing_comma) && Config::get_closest_minimum_target_php_version_id() < 80000) {
             $this->emitIssue(
                 Issue::CompatibleTrailingCommaParameterList,
                 end($params_node->children)->lineno ?? $params_node->lineno,

--- a/tests/misc/fallback_test/.phan/config.php
+++ b/tests/misc/fallback_test/.phan/config.php
@@ -14,8 +14,6 @@ use \Phan\Issue;
  * in addition to testing backwards compatibility checks and dead code detection.
  */
 return [
-    'minimum_target_php_version' => '7.2',
-
     // If true, missing properties will be created when
     // they are first seen. If false, we'll report an
     // error message.

--- a/tests/misc/fallback_test/expected/014_try_statement10.php.expected80
+++ b/tests/misc/fallback_test/expected/014_try_statement10.php.expected80
@@ -1,2 +1,1 @@
-src/014_try_statement10.php:5 PhanCompatibleNonCapturingCatch Catching exceptions without a variable is not supported before PHP 8.0 in catch ()
 src/014_try_statement10.php:5 PhanSyntaxError syntax error, unexpected token ")" (at column 9)

--- a/tests/misc/fallback_test/expected/032_declare_directive.php.expected80
+++ b/tests/misc/fallback_test/expected/032_declare_directive.php.expected80
@@ -1,2 +1,2 @@
 src/032_declare_directive.php:2 PhanSyntaxError syntax error, unexpected token "class"
-src/032_declare_directive.php:5 PhanTypeMismatchArgumentInternalReal Argument 1 ($string) is new C89() of type \C89 but \strlen() takes string
+src/032_declare_directive.php:5 PhanTypeMismatchArgumentInternalReal Argument 1 ($string) is new C89() of type \C89|\Stringable but \strlen() takes string

--- a/tests/misc/fallback_test/expected/073_trailing_commas.php.expected73
+++ b/tests/misc/fallback_test/expected/073_trailing_commas.php.expected73
@@ -1,0 +1,2 @@
+src/073_trailing_commas.php:8 PhanCompatibleTrailingCommaParameterList Cannot use trailing commas in parameter or closure use lists before php 8.0 in declaration of (function). NOTE: THIS ISSUE CAN ONLY DETECTED BY THE POLYFILL.
+src/073_trailing_commas.php:10 PhanCompatibleTrailingCommaParameterList Cannot use trailing commas in parameter or closure use lists before php 8.0 in declaration of (function). NOTE: THIS ISSUE CAN ONLY DETECTED BY THE POLYFILL.

--- a/tests/misc/fallback_test/expected/079_dnf.php.expected80
+++ b/tests/misc/fallback_test/expected/079_dnf.php.expected80
@@ -1,4 +1,3 @@
-src/079_dnf.php:2 PhanCompatibleUnionType Cannot use union types (string|Countable) before php 8.0
 src/079_dnf.php:2 PhanSyntaxError syntax error, unexpected token "("
 src/079_dnf.php:2 PhanUnusedGlobalFunctionParameter Parameter $x is never used
 src/079_dnf.php:4 PhanTypeMismatchArgumentReal Argument 1 ($x) is null of type null but \foo79() takes \Countable|string defined at src/079_dnf.php:2

--- a/tests/misc/fallback_test/expected/079_dnf.php.expected82
+++ b/tests/misc/fallback_test/expected/079_dnf.php.expected82
@@ -1,4 +1,3 @@
-src/079_dnf.php:2 PhanCompatibleUnionType Cannot use union types (string|Countable) before php 8.0
 src/079_dnf.php:2 PhanSyntaxError syntax error, unexpected token ")"
 src/079_dnf.php:2 PhanUnusedGlobalFunctionParameter Parameter $x is never used
 src/079_dnf.php:4 PhanTypeMismatchArgumentReal Argument 1 ($x) is null of type null but \foo79() takes \Countable|string defined at src/079_dnf.php:2

--- a/tests/misc/fallback_test/test.sh
+++ b/tests/misc/fallback_test/test.sh
@@ -10,6 +10,18 @@ echo "PHP_VERSION_ID=$PHP_VERSION_ID";
 
 for path in $(echo expected/*.php.expected | LC_ALL=C sort); do
     original_path="$path"
+    if [[ "$PHP_VERSION_ID" -ge 70300 ]]; then
+        alternate_path=${original_path/.expected/.expected73}
+        if [ -f "$alternate_path" ]; then
+            path="$alternate_path"
+        fi
+    fi
+    if [[ "$PHP_VERSION_ID" -ge 70400 ]]; then
+        alternate_path=${original_path/.expected/.expected74}
+        if [ -f "$alternate_path" ]; then
+            path="$alternate_path"
+        fi
+    fi
     if [[ "$PHP_VERSION_ID" -ge 80000 ]]; then
         alternate_path=${original_path/.expected/.expected80}
         if [ -f "$alternate_path" ]; then


### PR DESCRIPTION
Add a missing PHP version check so that we do not warn for trailing commas in function calls in PHP 8+. Remove the hardcoded minimum PHP version from fallback tests, and vary the output as needed depending on the PHP version.