### PR TITLE
Fix issues with parsing '@extends'/'@inherits' in PHPDoc

### DIFF
--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -230,8 +230,16 @@ class ParseVisitor extends ScopeVisitor
             // set that on the class
             $inherited_type_option = $comment->getInheritedTypeOption();
             if ($inherited_type_option->isDefined()) {
-                $class->setParentType($inherited_type_option->get());
+                if ($class->isClass()) {
+                    // TODO: Emit issue if this does not match `class ... extends`
+                    $class->setParentType($inherited_type_option->get());
+                } else {
+                    // TODO: Support generic interfaces
+                    // TODO: Emit issue if this does not match `interface ... extends`
+                    // TODO: Support more than one @extends
+                }
             }
+
             $class->setMixinTypes($comment->getMixinTypes());
 
             // Add any implemented interfaces

--- a/tests/files/src/0994_extends_phpdoc.php
+++ b/tests/files/src/0994_extends_phpdoc.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace NS994a {
+    interface IA {}
+    interface IB {}
+    interface IC extends IA {}
+    interface ID extends IA, IB {}
+
+    class A {}
+    class B {}
+    class C extends A {}
+}
+
+namespace NS994b {
+    interface IA {}
+    /**
+     * @extends IA
+     */
+    interface IB {}
+    /**
+     * @extends IA
+     */
+    interface IC extends IA {}
+    /**
+     * @extends IA
+     * @extends IB
+     */
+    interface ID extends IA, IB {}
+
+    class A {}
+    /**
+     * @extends A
+     */
+    class B {}
+    /**
+     * @extends A
+     */
+    class C extends A {}
+}


### PR DESCRIPTION
* On interfaces, `@extends` should do nothing, as we don't support generic interfaces and we don't support specifying more than one `@extends`. Only parse the PHP `interface ... extends` syntax.
* On classes, adding `@extends` in addition to `class ... extends` should not cause the parent type to be added twice when it has generic type parameters, once with parameters and once without. This was causing some type checks that should fail to pass.

Fixes #5002.