### PR TITLE
Remove misleading TODO comment

### DIFF
--- a/src/Phan/Language/Element/Comment/Builder.php
+++ b/src/Phan/Language/Element/Comment/Builder.php
@@ -1335,8 +1335,6 @@ final class Builder
             $comment_params = [];
             // Special check if param list has 0 params.
             if ($arg_list !== '') {
-                // TODO: Would need to use a different approach if templates were ever supported
-                //       e.g. The magic method parsing doesn't support commas?
                 $params_strings = self::extractMethodParts($arg_list);
                 foreach ($params_strings as $i => $param_string) {
                     $param = $this->magicParamFromMagicMethodParamString($param_string, $i, $comment_line_offset);

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -3695,8 +3695,6 @@ class Type implements Stringable
         if ($arg_list === '') {
             return [];
         }
-        // TODO: Would need to use a different approach if templates were ever supported
-        //       e.g. The magic method parsing doesn't support commas?
         return \array_map('trim', self::extractNameList($arg_list));
     }
 


### PR DESCRIPTION
Templates are in fact supported in this code, since 2528da9814 and 3871952b12.