### PR TITLE
Don't emit PhanUndeclaredConstant etc. when the constant may not be loaded yet

### DIFF
--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -2617,12 +2617,8 @@ class UnionTypeVisitor extends AnalysisVisitor
                 $this->context,
                 $node
             ))->getConst();
-        } catch (IssueException $exception) {
-            Issue::maybeEmitInstance(
-                $this->code_base,
-                $this->context,
-                $exception->getIssueInstance()
-            );
+        } catch (IssueException $_) {
+            // Ignore, we may not have loaded the constant yet
             return UnionType::empty();
         }
 

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -1318,7 +1318,6 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         } catch (IssueException $exception) {
             // We need to do this in order to check keys and (after the first 5) values in AST arrays.
             // Other parts of the AST may also not be covered.
-            // (This issue may be a duplicate)
             Issue::maybeEmitInstance(
                 $this->code_base,
                 $context,

--- a/tests/files/expected/0997_constant_loaded_late.php.expected
+++ b/tests/files/expected/0997_constant_loaded_late.php.expected
@@ -1,0 +1,3 @@
+%s:12 PhanUndeclaredConstant Reference to undeclared constant \SOME_CONSTANT2. This will cause a thrown Error in php 8.0+.
+%s:17 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type string
+%s:20 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type string

--- a/tests/files/src/0997_constant_loaded_late.php
+++ b/tests/files/src/0997_constant_loaded_late.php
@@ -1,0 +1,21 @@
+<?php
+
+class Foo {
+    /**
+     * @var string
+     */
+    public $var = SOME_CONSTANT;
+
+    /**
+     * @var string
+     */
+    public $var2 = SOME_CONSTANT2;
+}
+
+define('SOME_CONSTANT', 'const');
+
+$x = (new Foo())->var;
+'@phan-debug-var $x';
+
+$x = (new Foo())->var2;
+'@phan-debug-var $x';


### PR DESCRIPTION

Only emit during the analysis phase, not the parsing phase.

Fixes #4855