### PR TITLE
Fix version number in CompatibleIntersectionType message

### DIFF
--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -556,7 +556,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/v5/tests/files/expected/0511
 ## PhanCompatibleIntersectionType
 
 ```
-Cannot use intersection types ({TYPE}) before php 8.0
+Cannot use intersection types ({TYPE}) before php 8.1
 ```
 
 ## PhanCompatibleIterableTypePHP70

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -5257,7 +5257,7 @@ class Issue
                 self::CompatibleIntersectionType,
                 self::CATEGORY_COMPATIBLE,
                 self::SEVERITY_CRITICAL,
-                "Cannot use intersection types ({TYPE}) before php 8.0",
+                "Cannot use intersection types ({TYPE}) before php 8.1",
                 self::REMEDIATION_B,
                 3045
             ),


### PR DESCRIPTION
Intersection types were introduced in PHP 8.1.
https://www.php.net/manual/en/migration81.new-features.php

The code emitting this issue is correct, the mistake was only in the message.