### PR TITLE
AssignmentVisitor: Fix analysis when assigning to properties with template types

### DIFF
--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -1128,9 +1128,10 @@ class AssignmentVisitor extends AnalysisVisitor
                 $node->children['expr'] ?? null
             );
 
-            $property_union_type = $property_union_type->withTemplateParameterTypeMap(
+            $property = $property->cloneWithTemplateParameterTypeMap(
                 $expression_type->getTemplateParameterTypeMap($this->code_base)
             );
+            $property_union_type = $property->getPHPDocUnionType()->withStaticResolvedInContext($property->getContext());
         }
 
         $resolved_right_type = $this->right_type->withStaticResolvedInContext($this->context);

--- a/tests/files/src/0996_generic_type_leak.php
+++ b/tests/files/src/0996_generic_type_leak.php
@@ -16,7 +16,7 @@ function getX1(): X {
     return new X;
 }
 $x1 = getX1();
-$y1 = $x1->u; // whatever the type of this is, it must not be "T"
+$y1 = $x1->u; $x1->u[] = 123;
 '@phan-debug-var $x1, $y1';
 
 


### PR DESCRIPTION
We resolved the template type in $property_union_type, but not in $property itself, and $property was later passed to sub-methods that do further analysis.