### PR TITLE
Support validating callable arrays where the object is of intersection type

### DIFF
--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -3866,7 +3866,7 @@ class UnionTypeVisitor extends AnalysisVisitor
      * @return list<FullyQualifiedMethodName>
      * A list of CallableTypes associated with the given node
      */
-    private function methodFQSENListFromObjectAndMethodName($class_or_expr, string $method_name): array
+    private function methodFQSENListFromObjectAndMethodName($class_or_expr, string $method_name, bool $log_error): array
     {
         $code_base = $this->code_base;
         $context = $this->context;
@@ -3878,12 +3878,14 @@ class UnionTypeVisitor extends AnalysisVisitor
         $object_types = $union_type->objectTypes();
         if ($object_types->isEmpty()) {
             if (!$union_type->canCastToUnionType(StringType::instance(false)->asPHPDocUnionType(), $code_base)) {
-                $this->emitIssue(
-                    Issue::TypeInvalidCallableObjectOfMethod,
-                    $context->getLineNumberStart(),
-                    (string)$union_type,
-                    $method_name
-                );
+                if ($log_error) {
+                    $this->emitIssue(
+                        Issue::TypeInvalidCallableObjectOfMethod,
+                        $context->getLineNumberStart(),
+                        (string)$union_type,
+                        $method_name
+                    );
+                }
             }
             return [];
         }
@@ -3897,23 +3899,27 @@ class UnionTypeVisitor extends AnalysisVisitor
             $class_fqsen = FullyQualifiedClassName::fromType($object_type);
             if ($object_type instanceof StaticOrSelfType) {
                 if (!$context->isInClassScope()) {
-                    $this->emitIssue(
-                        Issue::ContextNotObjectInCallable,
-                        $context->getLineNumberStart(),
-                        (string)$class_fqsen,
-                        "$class_fqsen::$method_name"
-                    );
+                    if ($log_error) {
+                        $this->emitIssue(
+                            Issue::ContextNotObjectInCallable,
+                            $context->getLineNumberStart(),
+                            (string)$class_fqsen,
+                            "$class_fqsen::$method_name"
+                        );
+                    }
                     continue;
                 }
                 $class_fqsen = $context->getClassFQSEN();
             }
             if (!$code_base->hasClassWithFQSEN($class_fqsen)) {
-                $this->emitIssue(
-                    Issue::UndeclaredClassInCallable,
-                    $context->getLineNumberStart(),
-                    (string)$class_fqsen,
-                    "$class_fqsen::$method_name"
-                );
+                if ($log_error) {
+                    $this->emitIssue(
+                        Issue::UndeclaredClassInCallable,
+                        $context->getLineNumberStart(),
+                        (string)$class_fqsen,
+                        "$class_fqsen::$method_name"
+                    );
+                }
                 continue;
             }
             $class = $code_base->getClassByFQSEN($class_fqsen);
@@ -3929,12 +3935,14 @@ class UnionTypeVisitor extends AnalysisVisitor
         }
         if (\count($result_types) === 0 && $class instanceof Clazz) {
             // TODO: Include suggestion for method name
-            $this->emitIssue(
-                Issue::UndeclaredMethodInCallable,
-                $context->getLineNumberStart(),
-                $method_name,
-                (string)$union_type
-            );
+            if ($log_error) {
+                $this->emitIssue(
+                    Issue::UndeclaredMethodInCallable,
+                    $context->getLineNumberStart(),
+                    $method_name,
+                    (string)$union_type
+                );
+            }
         }
         return $result_types;
     }
@@ -4094,7 +4102,7 @@ class UnionTypeVisitor extends AnalysisVisitor
                     if (!is_string($method_name)) {
                         return [];
                     }
-                    return $this->methodFQSENListFromObjectAndMethodName($class_or_expr, $method_name);
+                    return $this->methodFQSENListFromObjectAndMethodName($class_or_expr, $method_name, $log_error);
                 }
                 if (\in_array(\strtolower($class_fqsen->getName()), ['static', 'self', 'parent'], true)) {
                     $this->emitDeprecatedPartiallySupportedCallable($class_fqsen->getName(), $method_name);

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -3889,7 +3889,7 @@ class UnionTypeVisitor extends AnalysisVisitor
         }
         $result_types = [];
         $class = null;
-        foreach ($object_types->getTypeSet() as $object_type) {
+        foreach ($object_types->getUniqueFlattenedTypeSet() as $object_type) {
             // TODO: support templates here.
             if ($object_type instanceof ObjectType || $object_type instanceof TemplateType) {
                 continue;

--- a/tests/files/expected/0999_callable_from_intersection.php.expected
+++ b/tests/files/expected/0999_callable_from_intersection.php.expected
@@ -1,0 +1,15 @@
+%s:18 PhanUndeclaredMethodInCallable Call to undeclared method oops in callable. Possible object type(s) for that method are \A
+%s:19 PhanUndeclaredMethodInCallable Call to undeclared method oops in callable. Possible object type(s) for that method are \A
+%s:20 PhanUndeclaredMethodInCallable Call to undeclared method oops in callable. Possible object type(s) for that method are \A
+%s:23 PhanUndeclaredMethodInCallable Call to undeclared method func in callable. Possible object type(s) for that method are \B
+%s:24 PhanUndeclaredMethodInCallable Call to undeclared method func in callable. Possible object type(s) for that method are \B
+%s:25 PhanUndeclaredMethodInCallable Call to undeclared method func in callable. Possible object type(s) for that method are \B
+%s:27 PhanUndeclaredMethodInCallable Call to undeclared method oops in callable. Possible object type(s) for that method are \B
+%s:28 PhanUndeclaredMethodInCallable Call to undeclared method oops in callable. Possible object type(s) for that method are \B
+%s:29 PhanUndeclaredMethodInCallable Call to undeclared method oops in callable. Possible object type(s) for that method are \B
+%s:39 PhanUndeclaredMethodInCallable Call to undeclared method oops in callable. Possible object type(s) for that method are \A&\B
+%s:40 PhanUndeclaredMethodInCallable Call to undeclared method oops in callable. Possible object type(s) for that method are \A&\B
+%s:41 PhanUndeclaredMethodInCallable Call to undeclared method oops in callable. Possible object type(s) for that method are \A&\B
+%s:47 PhanUndeclaredMethodInCallable Call to undeclared method func in callable. Possible object type(s) for that method are \B&\C
+%s:48 PhanUndeclaredMethodInCallable Call to undeclared method func in callable. Possible object type(s) for that method are \B&\C
+%s:49 PhanUndeclaredMethodInCallable Call to undeclared method func in callable. Possible object type(s) for that method are \B&\C

--- a/tests/files/expected/0999_callable_from_intersection.php.expected
+++ b/tests/files/expected/0999_callable_from_intersection.php.expected
@@ -1,15 +1,10 @@
-%s:18 PhanUndeclaredMethodInCallable Call to undeclared method oops in callable. Possible object type(s) for that method are \A
 %s:19 PhanUndeclaredMethodInCallable Call to undeclared method oops in callable. Possible object type(s) for that method are \A
 %s:20 PhanUndeclaredMethodInCallable Call to undeclared method oops in callable. Possible object type(s) for that method are \A
-%s:23 PhanUndeclaredMethodInCallable Call to undeclared method func in callable. Possible object type(s) for that method are \B
 %s:24 PhanUndeclaredMethodInCallable Call to undeclared method func in callable. Possible object type(s) for that method are \B
 %s:25 PhanUndeclaredMethodInCallable Call to undeclared method func in callable. Possible object type(s) for that method are \B
-%s:27 PhanUndeclaredMethodInCallable Call to undeclared method oops in callable. Possible object type(s) for that method are \B
 %s:28 PhanUndeclaredMethodInCallable Call to undeclared method oops in callable. Possible object type(s) for that method are \B
 %s:29 PhanUndeclaredMethodInCallable Call to undeclared method oops in callable. Possible object type(s) for that method are \B
-%s:39 PhanUndeclaredMethodInCallable Call to undeclared method oops in callable. Possible object type(s) for that method are \A&\B
 %s:40 PhanUndeclaredMethodInCallable Call to undeclared method oops in callable. Possible object type(s) for that method are \A&\B
 %s:41 PhanUndeclaredMethodInCallable Call to undeclared method oops in callable. Possible object type(s) for that method are \A&\B
-%s:47 PhanUndeclaredMethodInCallable Call to undeclared method func in callable. Possible object type(s) for that method are \B&\C
 %s:48 PhanUndeclaredMethodInCallable Call to undeclared method func in callable. Possible object type(s) for that method are \B&\C
 %s:49 PhanUndeclaredMethodInCallable Call to undeclared method func in callable. Possible object type(s) for that method are \B&\C

--- a/tests/files/src/0999_callable_from_intersection.php
+++ b/tests/files/src/0999_callable_from_intersection.php
@@ -1,0 +1,54 @@
+<?php
+
+interface A {
+    function func();
+}
+interface B {}
+interface C {
+    function oops();
+}
+
+function assert_callable( callable $c ): void {}
+
+function foo1( A $var ): void {
+    is_callable( [ $var, 'func' ] ); // OK (redundant)
+    call_user_func( [ $var, 'func' ] ); // OK
+    assert_callable( [ $var, 'func' ] ); // OK
+
+    is_callable( [ $var, 'oops' ] ); // OK
+    call_user_func( [ $var, 'oops' ] ); // Error
+    assert_callable( [ $var, 'oops' ] ); // Error
+}
+function foo2( B $var ): void {
+    is_callable( [ $var, 'func' ] ); // OK
+    call_user_func( [ $var, 'func' ] ); // Error
+    assert_callable( [ $var, 'func' ] ); // Error
+
+    is_callable( [ $var, 'oops' ] ); // OK
+    call_user_func( [ $var, 'oops' ] ); // Error
+    assert_callable( [ $var, 'oops' ] ); // Error
+}
+/**
+ * @param A&B $var
+ */
+function foo3( $var ): void {
+    is_callable( [ $var, 'func' ] ); // OK (redundant)
+    call_user_func( [ $var, 'func' ] ); // OK
+    assert_callable( [ $var, 'func' ] ); // OK
+
+    is_callable( [ $var, 'oops' ] ); // OK
+    call_user_func( [ $var, 'oops' ] ); // Error
+    assert_callable( [ $var, 'oops' ] ); // Error
+}
+/**
+ * @param B&C $var
+ */
+function foo4( $var ): void {
+    is_callable( [ $var, 'func' ] ); // OK
+    call_user_func( [ $var, 'func' ] ); // Error
+    assert_callable( [ $var, 'func' ] ); // Error
+
+    is_callable( [ $var, 'oops' ] ); // OK (redundant)
+    call_user_func( [ $var, 'oops' ] ); // OK
+    assert_callable( [ $var, 'oops' ] ); // OK
+}


### PR DESCRIPTION
Use getUniqueFlattenedTypeSet() in methodFQSENListFromObjectAndMethodName(),
similarly to how it's already used in classListFromNode(), in order to
check individual types in the intersection.

Fixes #4851. 

Bonus: Do not report invalid callables when given an union type in more cases. 
Follow-up to https://github.com/phan/phan/commit/c0533f8f9373f384ee6af2655eed5a8a057db9d9. I missed the fact that this method can emit issues too.