### PR TITLE
Improve handling of promoted properties also declared via doc comments

### DIFF
--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -517,6 +517,22 @@ class ParseVisitor extends ScopeVisitor
             true
         );
         if (!$property) {
+            // Might be added via PHP doc comments, in which case we still want
+            // to handle it
+            $property_fqsen = FullyQualifiedPropertyName::make(
+                $class->getFQSEN(),
+                $parameter->getName()
+            );
+            if ($this->code_base->hasPropertyWithFQSEN($property_fqsen)) {
+                $old_property = $this->code_base->getPropertyByFQSEN($property_fqsen);
+                if ($old_property->getDefiningFQSEN() === $property_fqsen
+                    && $old_property->isFromPHPDoc()
+                ) {
+                    $property = $old_property;
+                }
+            }
+        }
+        if (!$property) {
             return;
         }
         $property->setAttributeList($parameter->getAttributeList());

--- a/tests/php80_files/expected/051_doc_property_writes.php.expected
+++ b/tests/php80_files/expected/051_doc_property_writes.php.expected
@@ -1,0 +1,2 @@
+%s:7 PhanReadOnlyPHPDocProperty Possibly zero write references to PHPDoc @property \Demo51->writtenViaPropertyPromotion
+%s:14 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for public string $writtenViaPropertyPromotion of \Demo51::__construct(string $writtenViaPropertyPromotion, string $writtenManually)

--- a/tests/php80_files/expected/051_doc_property_writes.php.expected
+++ b/tests/php80_files/expected/051_doc_property_writes.php.expected
@@ -1,2 +1,2 @@
-%s:7 PhanReadOnlyPHPDocProperty Possibly zero write references to PHPDoc @property \Demo51->writtenViaPropertyPromotion
+%s:13 PhanAttributeWrongTarget Saw use of attribute \MyParamAttrib declared at %s:4 which supports being declared on \Attribute::TARGET_PARAMETER but it was declared on public string $writtenViaPropertyPromotion which requires an attribute declared to support \Attribute::TARGET_PROPERTY
 %s:14 PhanCompatibleConstructorPropertyPromotion Cannot use constructor property promotion before php 8.0 for public string $writtenViaPropertyPromotion of \Demo51::__construct(string $writtenViaPropertyPromotion, string $writtenManually)

--- a/tests/php80_files/src/051_doc_property_writes.php
+++ b/tests/php80_files/src/051_doc_property_writes.php
@@ -1,0 +1,22 @@
+<?php
+
+#[Attribute(Attribute::TARGET_PARAMETER)]
+class MyParamAttrib {}
+
+/**
+ * @property string $writtenViaPropertyPromotion
+ * @property string $writtenManually
+ */
+class Demo51 {
+
+	public function __construct(
+		#[MyParamAttrib]
+		public string $writtenViaPropertyPromotion,
+		string $writtenManually
+	) {
+		$this->writtenManually = $writtenManually;
+	}
+}
+
+$d = new Demo51("foo", "bar");
+var_dump($d->writtenViaPropertyPromotion, $d->writtenManually);


### PR DESCRIPTION
When a property is declared via PHP doc comments, `ParseVisitor::addProperty()` will return null, previously causing `ParseVisitor::addPromotedConstructorPropertyFromParam()` to skip the remainder of its handling. This led to
- false positives for `PhanReadOnlyPHPDocProperty`
- false negatives for `PhanAttributeWrongTarget`

Now, if the `addProperty()` call fails, `addPromotedConstructorPropertyFromParam()` will check for an existing property declared with doc comments and, if one exists, update it the same as it would update a property not declared with doc comments.

Fixes #5022