### PR TITLE
Improve handling of never-typed functions and methods

### DIFF
--- a/.phan/plugins/AlwaysReturnPlugin.php
+++ b/.phan/plugins/AlwaysReturnPlugin.php
@@ -87,7 +87,23 @@ final class AlwaysReturnPlugin extends PluginV3 implements
             }
             return;
         }
-        if (!BlockExitStatusChecker::willUnconditionallyThrowOrReturn($stmts_list)) {
+        $returnUnion = $method->getUnionType();
+        $unionTypes = $returnUnion->getTypeSet();
+        $isNeverReturn = count($unionTypes) === 1 && $unionTypes[0] instanceof NeverType;
+        $blockExitStatusChecker = new BlockExitStatusChecker($code_base, $method->getContext());
+        $exitStatus = $blockExitStatusChecker->__invoke($stmts_list);
+        if ($isNeverReturn && (($exitStatus & ~BlockExitStatusChecker::STATUS_NOT_RETURN_BITMASK) !== 0)) {
+            if (!$method->checkHasSuppressIssueAndIncrementCount('PhanPluginNeverReturnMethod')) {
+                self::emitIssue(
+                    $code_base,
+                    $method->getContext(),
+                    'PhanPluginNeverReturnMethod',
+                    "Method {METHOD} has a return type of {TYPE}, but may try to return a value",
+                    [(string)$method->getFQSEN(), (string)$method->getUnionType()]
+                );
+            }
+        }
+        if (!$isNeverReturn && !BlockExitStatusChecker::willUnconditionallyThrowOrReturn($stmts_list)) {
             if (!$method->checkHasSuppressIssueAndIncrementCount('PhanPluginAlwaysReturnMethod')) {
                 self::emitIssue(
                     $code_base,
@@ -136,7 +152,23 @@ final class AlwaysReturnPlugin extends PluginV3 implements
             }
             return;
         }
-        if (!BlockExitStatusChecker::willUnconditionallyThrowOrReturn($stmts_list)) {
+        $returnUnion = $function->getUnionType();
+        $unionTypes = $returnUnion->getTypeSet();
+        $isNeverReturn = count($unionTypes) === 1 && $unionTypes[0] instanceof NeverType;
+        $blockExitStatusChecker = new BlockExitStatusChecker($code_base, $function->getContext());
+        $exitStatus = $blockExitStatusChecker->__invoke($stmts_list);
+        if ($isNeverReturn && (($exitStatus & ~BlockExitStatusChecker::STATUS_NOT_RETURN_BITMASK) !== 0)) {
+            if (!$function->checkHasSuppressIssueAndIncrementCount('PhanPluginNeverReturnFunction')) {
+                self::emitIssue(
+                    $code_base,
+                    $function->getContext(),
+                    'PhanPluginNeverReturnFunction',
+                    "Function {FUNCTION} has a return type of {TYPE}, but may try to return a value",
+                    [(string)$function->getFQSEN(), (string)$function->getUnionType()]
+                );
+            }
+        }
+        if (!$isNeverReturn && !BlockExitStatusChecker::willUnconditionallyThrowOrReturn($stmts_list)) {
             if (!$function->checkHasSuppressIssueAndIncrementCount('PhanPluginAlwaysReturnFunction')) {
                 self::emitIssue(
                     $code_base,

--- a/.phan/plugins/README.md
+++ b/.phan/plugins/README.md
@@ -58,8 +58,10 @@ This is stricter than Phan's default checks (Phan accepts a function or method t
 
 - **PhanPluginInconsistentReturnMethod**: `Method {METHOD} has no return type and will inconsistently return or not return`
 - **PhanPluginAlwaysReturnMethod**: `Method {METHOD} has a return type of {TYPE}, but may fail to return a value`
+- **PhanPluginNeverReturnMethod**: `Method {METHOD} has a return type of never, but may try to return a value`
 - **PhanPluginInconsistentReturnFunction**: `Function {FUNCTION} has no return type and will inconsistently return or not return`
 - **PhanPluginAlwaysReturnFunction**: `Function {FUNCTION} has a return type of {TYPE}, but may fail to return a value`
+- **PhanPluginNeverReturnFunction**: `Function {FUNCTION} has a return type of {TYPE}, but may try to return a value`
 
 #### DuplicateArrayKeyPlugin.php
 

--- a/src/Phan/Analysis/BlockExitStatusChecker.php
+++ b/src/Phan/Analysis/BlockExitStatusChecker.php
@@ -8,6 +8,13 @@ use AssertionError;
 use ast;
 use ast\Node;
 use Phan\AST\Visitor\KindVisitorImplementation;
+use Phan\CodeBase;
+use Phan\Exception\FQSENException;
+use Phan\Language\Context;
+use Phan\Language\FQSEN\FullyQualifiedClassName;
+use Phan\Language\FQSEN\FullyQualifiedFunctionName;
+use Phan\Language\FQSEN\FullyQualifiedMethodName;
+use Phan\Language\Type\NeverType;
 
 use function count;
 
@@ -73,8 +80,18 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
         self::STATUS_PROCEED |
         self::STATUS_GOTO;
 
-    public function __construct()
-    {
+    /** @var ?CodeBase */
+    private $code_base;
+
+    /** @var ?Context */
+    private $context;
+
+    public function __construct(
+        ?CodeBase $code_base = null,
+        ?Context $context = null
+    ) {
+        $this->code_base = $code_base;
+        $this->context = $context;
     }
 
     /**
@@ -539,7 +556,7 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
         if ($status) {
             return $status;
         }
-        $status = self::computeStatusOfCall($node);
+        $status = $this->computeStatusOfCall($node);
         $node->flags = $status;
         return $status;
     }
@@ -551,8 +568,13 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
      */
     public function visitStaticCall(Node $node): int
     {
-        // TODO: The expression or arguments might unconditionally throw, though that is rare in practice.
-        return ($node->flags & self::STATUS_BITMASK) ?: self::STATUS_PROCEED;
+        $status = $node->flags & self::STATUS_BITMASK;
+        if ($status) {
+            return $status;
+        }
+        $status = $this->computeStatusOfStaticCall($node);
+        $node->flags = $status;
+        return $status;
     }
 
     /**
@@ -564,8 +586,13 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
      */
     public function visitMethodCall(Node $node): int
     {
-        // TODO: The expression or arguments might unconditionally throw, though that is rare in practice.
-        return ($node->flags & self::STATUS_BITMASK) ?: self::STATUS_PROCEED;
+        $status = $node->flags & self::STATUS_BITMASK;
+        if ($status) {
+            return $status;
+        }
+        $status = $this->computeStatusOfMethodCall($node);
+        $node->flags = $status;
+        return $status;
     }
 
     /**
@@ -580,7 +607,10 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
         return ($node->flags & self::STATUS_BITMASK) ?: self::STATUS_PROCEED;
     }
 
-    private static function computeStatusOfCall(Node $node): int
+    /**
+     * @suppress PhanImpossibleTypeComparison
+     */
+    private function computeStatusOfCall(Node $node): int
     {
         $expression = $node->children['expr'];
         if ($expression instanceof Node) {
@@ -618,8 +648,168 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
         if (\strcasecmp($function_name, 'trigger_error') === 0) {
             return self::computeTriggerErrorStatusCodeForConstant($node->children['args']->children[1] ?? null);
         }
+        if ($function_name !== false && $this->code_base !== null && $this->context !== null) {
+            try {
+                $function_fqsen = FullyQualifiedFunctionName::fromStringInContext(
+                    $function_name,
+                    $this->context
+                );
+            } catch (FQSENException $e) {
+                // @phan-suppress-previous-line PhanUnusedVariableCaughtException
+                // Cannot find, cannot infer
+                return self::STATUS_PROCEED;
+            }
+            if ($this->code_base->hasFunctionWithFQSEN($function_fqsen)) {
+                $function = $this->code_base->getFunctionByFQSEN($function_fqsen);
+                $returnUnion = $function->getUnionType();
+                $unionTypes = $returnUnion->getTypeSet();
+                $isNeverReturn = count($unionTypes) === 1 && $unionTypes[0] instanceof NeverType;
+                if ($isNeverReturn) {
+                    return self::STATUS_NOT_RETURN_BITMASK;
+                }
+            }
+        }
         // TODO: Could allow .phan/config.php or plugins to define additional behaviors, e.g. for methods.
         // E.g. if (!$var) {HttpFramework::generate_302_and_die(); }
+        return self::STATUS_PROCEED;
+    }
+
+    private function computeStatusOfStaticCall(Node $node): int
+    {
+        if ($this->code_base === null || $this->context === null) {
+            return self::STATUS_PROCEED;
+        }
+        if ($node->children['args']->kind === ast\AST_CALLABLE_CONVERT) {
+            // This is creating a closure, not calling it.
+            return self::STATUS_PROCEED;
+        }
+
+        $class = $node->children['class'];
+        if ($class instanceof Node) {
+            if ($class->kind !== ast\AST_NAME) {
+                return self::STATUS_PROCEED;  // best guess
+            }
+            $class_name = $class->children['name'];
+            if (!\is_string($class_name)) {
+                return self::STATUS_PROCEED;
+            }
+        } else {
+            if (!\is_string($class)) {
+                return self::STATUS_THROW;  // Probably impossible.
+            }
+            $class_name = $class;
+        }
+
+        $method = $node->children['method'];
+        if ($method instanceof Node) {
+            if ($method->kind !== ast\AST_NAME) {
+                return self::STATUS_PROCEED;  // best guess
+            }
+            $method_name = $method->children['name'];
+            if (!\is_string($method_name)) {
+                return self::STATUS_PROCEED;
+            }
+        } else {
+            if (!\is_string($method)) {
+                return self::STATUS_THROW;  // Probably impossible.
+            }
+            $method_name = $method;
+        }
+        // Look for the class and method
+        if ($class_name === 'self') {
+            $class_fqsen = $this->context->getClassFQSEN();
+        } else {
+            try {
+                $class_fqsen = FullyQualifiedClassName::fromStringInContext(
+                    $class_name,
+                    $this->context
+                );
+            } catch (FQSENException $e) {
+                // @phan-suppress-previous-line PhanUnusedVariableCaughtException
+                // Cannot find, cannot infer
+                return self::STATUS_PROCEED;
+            }
+        }
+        $method_fqsen = FullyQualifiedMethodName::make(
+            $class_fqsen,
+            $method_name
+        );
+
+        if ($this->code_base->hasMethodWithFQSEN($method_fqsen)) {
+            $method = $this->code_base->getMethodByFQSEN($method_fqsen);
+            $returnUnion = $method->getUnionType();
+            $unionTypes = $returnUnion->getTypeSet();
+            $isNeverReturn = count($unionTypes) === 1 && $unionTypes[0] instanceof NeverType;
+            if ($isNeverReturn) {
+                return self::STATUS_NOT_RETURN_BITMASK;
+            }
+        }
+        // TODO: Could allow .phan/config.php or plugins to define additional behaviors
+        return self::STATUS_PROCEED;
+    }
+
+    private function computeStatusOfMethodCall(Node $node): int
+    {
+        if ($this->code_base === null || $this->context === null) {
+            return self::STATUS_PROCEED;
+        }
+        if ($node->children['args']->kind === ast\AST_CALLABLE_CONVERT) {
+            // This is creating a closure, not calling it.
+            return self::STATUS_PROCEED;
+        }
+
+        $expr = $node->children['expr'];
+        if ($expr instanceof Node) {
+            if ($expr->kind !== ast\AST_VAR) {
+                return self::STATUS_PROCEED;  // best guess
+            }
+            $var_name = $expr->children['name'];
+            if (!\is_string($var_name)) {
+                return self::STATUS_PROCEED;
+            }
+        } else {
+            if (!\is_string($expr)) {
+                return self::STATUS_THROW;  // Probably impossible.
+            }
+            $var_name = $expr;
+        }
+
+        $method = $node->children['method'];
+        if ($method instanceof Node) {
+            if ($method->kind !== ast\AST_NAME) {
+                return self::STATUS_PROCEED;  // best guess
+            }
+            $method_name = $method->children['name'];
+            if (!\is_string($method_name)) {
+                return self::STATUS_PROCEED;
+            }
+        } else {
+            if (!\is_string($method)) {
+                return self::STATUS_THROW;  // Probably impossible.
+            }
+            $method_name = $method;
+        }
+        if ($var_name === 'this') {
+            $class_fqsen = $this->context->getClassFQSEN();
+        } else {
+            // TODO not yet handled
+            return self::STATUS_PROCEED;
+        }
+        $method_fqsen = FullyQualifiedMethodName::make(
+            $class_fqsen,
+            $method_name
+        );
+
+        if ($this->code_base->hasMethodWithFQSEN($method_fqsen)) {
+            $method = $this->code_base->getMethodByFQSEN($method_fqsen);
+            $returnUnion = $method->getUnionType();
+            $unionTypes = $returnUnion->getTypeSet();
+            $isNeverReturn = count($unionTypes) === 1 && $unionTypes[0] instanceof NeverType;
+            if ($isNeverReturn) {
+                return self::STATUS_NOT_RETURN_BITMASK;
+            }
+        }
+        // TODO: Could allow .phan/config.php or plugins to define additional behaviors
         return self::STATUS_PROCEED;
     }
 

--- a/tests/Phan/PHP81Test.php
+++ b/tests/Phan/PHP81Test.php
@@ -25,6 +25,7 @@ final class PHP81Test extends AbstractPhanFileTest
             'UnknownElementTypePlugin',
             'UnreachableCodePlugin',
             'UseReturnValuePlugin',
+            'AlwaysReturnPlugin',
         ],
         'plugin_config' => ['infer_pure_methods' => true],
     ];

--- a/tests/php81_files/expected/006_noreturn.php.expected
+++ b/tests/php81_files/expected/006_noreturn.php.expected
@@ -2,6 +2,7 @@
 %s:23 PhanUnreferencedClass Possibly zero references to class \Point\Of\BadJoke
 %s:24 PhanParamSignatureMismatch Declaration of function joke() : string should be compatible with function joke() : never defined in %s:12
 %s:24 PhanParamSignatureRealMismatchReturnType Declaration of function joke() : string should be compatible with function joke() : never (method where the return type in the real signature is 'string' cannot override method where the return type in the real signature is 'never') defined in %s:12
+%s:29 PhanPluginNeverReturnFunction Function \Point\Of\up has a return type of never, but may try to return a value
 %s:29 PhanUnreferencedFunction Possibly zero references to function \Point\Of\up()
 %s:31 PhanSyntaxReturnStatementInNever Syntax error: function up() has return type never, meaning it must not contain return statements (it should exit, throw, or run forever)
 %s:33 PhanSyntaxReturnStatementInNever Syntax error: function up() has return type never, meaning it must not contain return statements (it should exit, throw, or run forever)

--- a/tests/php81_files/expected/026_noreturn_function_indirect.php.expected
+++ b/tests/php81_files/expected/026_noreturn_function_indirect.php.expected
@@ -1,1 +1,0 @@
-%s:7 PhanPluginAlwaysReturnFunction Function \indirectExit has a return type of never, but may fail to return a value

--- a/tests/php81_files/expected/026_noreturn_function_indirect.php.expected
+++ b/tests/php81_files/expected/026_noreturn_function_indirect.php.expected
@@ -1,0 +1,1 @@
+%s:7 PhanPluginAlwaysReturnFunction Function \indirectExit has a return type of never, but may fail to return a value

--- a/tests/php81_files/expected/027_noreturn_method_static_indirect.php.expected
+++ b/tests/php81_files/expected/027_noreturn_method_static_indirect.php.expected
@@ -1,1 +1,0 @@
-%s:9 PhanPluginAlwaysReturnMethod Method \Test::indirectExit has a return type of never, but may fail to return a value

--- a/tests/php81_files/expected/027_noreturn_method_static_indirect.php.expected
+++ b/tests/php81_files/expected/027_noreturn_method_static_indirect.php.expected
@@ -1,0 +1,1 @@
+%s:9 PhanPluginAlwaysReturnMethod Method \Test::indirectExit has a return type of never, but may fail to return a value

--- a/tests/php81_files/expected/028_noreturn_method_instance_indirect.php.expected
+++ b/tests/php81_files/expected/028_noreturn_method_instance_indirect.php.expected
@@ -1,1 +1,0 @@
-%s:9 PhanPluginAlwaysReturnMethod Method \Test::indirectExit has a return type of never, but may fail to return a value

--- a/tests/php81_files/expected/028_noreturn_method_instance_indirect.php.expected
+++ b/tests/php81_files/expected/028_noreturn_method_instance_indirect.php.expected
@@ -1,0 +1,1 @@
+%s:9 PhanPluginAlwaysReturnMethod Method \Test::indirectExit has a return type of never, but may fail to return a value

--- a/tests/php81_files/expected/029_noreturn_function_inconsistent.php.expected
+++ b/tests/php81_files/expected/029_noreturn_function_inconsistent.php.expected
@@ -1,0 +1,2 @@
+%s:3 PhanPluginAlwaysReturnFunction Function \inconsistentExit has a return type of never, but may fail to return a value
+%s:3 PhanTypeMissingReturnReal Method \inconsistentExit is declared to return never in its real type signature but has no return value

--- a/tests/php81_files/expected/029_noreturn_function_inconsistent.php.expected
+++ b/tests/php81_files/expected/029_noreturn_function_inconsistent.php.expected
@@ -1,2 +1,2 @@
-%s:3 PhanPluginAlwaysReturnFunction Function \inconsistentExit has a return type of never, but may fail to return a value
+%s:3 PhanPluginNeverReturnFunction Function \inconsistentExit has a return type of never, but may try to return a value
 %s:3 PhanTypeMissingReturnReal Method \inconsistentExit is declared to return never in its real type signature but has no return value

--- a/tests/php81_files/expected/030_noreturn_method_static_inconsistent.php.expected
+++ b/tests/php81_files/expected/030_noreturn_method_static_inconsistent.php.expected
@@ -1,1 +1,1 @@
-%s:5 PhanPluginAlwaysReturnMethod Method \Test::inconsistentExit has a return type of never, but may fail to return a value
+%s:5 PhanPluginNeverReturnMethod Method \Test::inconsistentExit has a return type of never, but may try to return a value

--- a/tests/php81_files/expected/030_noreturn_method_static_inconsistent.php.expected
+++ b/tests/php81_files/expected/030_noreturn_method_static_inconsistent.php.expected
@@ -1,0 +1,1 @@
+%s:5 PhanPluginAlwaysReturnMethod Method \Test::inconsistentExit has a return type of never, but may fail to return a value

--- a/tests/php81_files/expected/031_noreturn_method_instance_inconsistent.php.expected
+++ b/tests/php81_files/expected/031_noreturn_method_instance_inconsistent.php.expected
@@ -1,1 +1,1 @@
-%s:5 PhanPluginAlwaysReturnMethod Method \Test::inconsistentExit has a return type of never, but may fail to return a value
+%s:5 PhanPluginNeverReturnMethod Method \Test::inconsistentExit has a return type of never, but may try to return a value

--- a/tests/php81_files/expected/031_noreturn_method_instance_inconsistent.php.expected
+++ b/tests/php81_files/expected/031_noreturn_method_instance_inconsistent.php.expected
@@ -1,0 +1,1 @@
+%s:5 PhanPluginAlwaysReturnMethod Method \Test::inconsistentExit has a return type of never, but may fail to return a value

--- a/tests/php81_files/src/016_first_class_callable.php
+++ b/tests/php81_files/src/016_first_class_callable.php
@@ -24,3 +24,5 @@ echo strlen(C16::staticMethod(...)(new stdClass()));
 // Test detection of unused results
 C16::staticMethod(...);
 (new C16())->instanceMethod(...);
+
+// @phan-file-suppress PhanPluginAlwaysReturnMethod

--- a/tests/php81_files/src/026_noreturn_function_indirect.php
+++ b/tests/php81_files/src/026_noreturn_function_indirect.php
@@ -1,0 +1,11 @@
+<?php
+
+function doExit(): never {
+    exit();
+}
+
+function indirectExit(): never {
+    doExit();
+}
+
+indirectExit();

--- a/tests/php81_files/src/027_noreturn_method_static_indirect.php
+++ b/tests/php81_files/src/027_noreturn_method_static_indirect.php
@@ -1,0 +1,14 @@
+<?php
+
+class Test {
+
+    public static function doExit(): never {
+        exit();
+    }
+
+    public static function indirectExit(): never {
+        self::doExit();
+    }
+}
+
+Test::indirectExit();

--- a/tests/php81_files/src/028_noreturn_method_instance_indirect.php
+++ b/tests/php81_files/src/028_noreturn_method_instance_indirect.php
@@ -1,0 +1,14 @@
+<?php
+
+class Test {
+
+    public function doExit(): never {
+        exit();
+    }
+
+    public function indirectExit(): never {
+        $this->doExit();
+    }
+}
+
+(new Test)->indirectExit();

--- a/tests/php81_files/src/029_noreturn_function_inconsistent.php
+++ b/tests/php81_files/src/029_noreturn_function_inconsistent.php
@@ -1,0 +1,9 @@
+<?php
+
+function inconsistentExit(string $val): never {
+    if ($val === "yes") {
+        exit();
+    }
+}
+
+inconsistentExit("yes");

--- a/tests/php81_files/src/030_noreturn_method_static_inconsistent.php
+++ b/tests/php81_files/src/030_noreturn_method_static_inconsistent.php
@@ -1,0 +1,12 @@
+<?php
+
+class Test {
+
+    public static function inconsistentExit(string $val): never {
+        if ($val === "yes") {
+            exit();
+        }
+    }
+}
+
+Test::inconsistentExit("yes");

--- a/tests/php81_files/src/031_noreturn_method_instance_inconsistent.php
+++ b/tests/php81_files/src/031_noreturn_method_instance_inconsistent.php
@@ -1,0 +1,12 @@
+<?php
+
+class Test {
+
+    public function inconsistentExit(string $val): never {
+        if ($val === "yes") {
+            exit();
+        }
+    }
+}
+
+(new Test)->inconsistentExit("yes");

--- a/tests/plugin_test/expected/199_never_type_and_plugins.php.expected
+++ b/tests/plugin_test/expected/199_never_type_and_plugins.php.expected
@@ -9,7 +9,7 @@ src/199_never_type_and_plugins.php:7 PhanDebugAnnotation @phan-debug-var request
 src/199_never_type_and_plugins.php:9 PhanTypeInvalidRightOperandOfAdd Invalid operator: right operand of + is never (expected array or number)
 src/199_never_type_and_plugins.php:9 PhanUseReturnValueOfNever Saw use of value of expression exit('fail') which likely uses the exit statement with a return type of 'never' - this will not return normally
 src/199_never_type_and_plugins.php:13 PhanCompatibleNeverType Return type 'never' means that a function will not return normally starting in PHP 8.1. In PHP 8.0, 'never' refers to a class/interface with the name 'never'
-src/199_never_type_and_plugins.php:13 PhanPluginAlwaysReturnFunction Function \up has a return type of never, but may fail to return a value
+src/199_never_type_and_plugins.php:13 PhanPluginNeverReturnFunction Function \up has a return type of never, but may try to return a value
 src/199_never_type_and_plugins.php:13 PhanTypeMissingReturnReal Method \up is declared to return never in its real type signature but has no return value
 src/199_never_type_and_plugins.php:14 PhanUnusedVariable Unused definition of variable $x
 src/199_never_type_and_plugins.php:14 PhanUseReturnValueOfNever Saw use of value of expression exit($message) which likely uses the exit statement with a return type of 'never' - this will not return normally


### PR DESCRIPTION
When a function or method is typed to not return anything, if the function might not return or throw, instead of complain that the function might "fail to return a value", complain that the function might "try to return a value", because the expectation is reversed. In cases where the function explicitly does return, `PhanSyntaxReturnStatementInNever` will complain.

The new error messages are from new issues `PhanPluginNeverReturnMethod` and `PhanPluginAlwaysReturnMethod`.

If a function or method calls another function or method, try to infer of that other method will always throw; global functions, static methods, and instance methods on `$this` should all be handled.

Fixes #4779