### PR TITLE
Respect log_error for invalid maybe-callable FQSENs

### DIFF
--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -4171,11 +4171,13 @@ class UnionTypeVisitor extends AnalysisVisitor
         try {
             $function_fqsen = FullyQualifiedFunctionName::fromFullyQualifiedString($function_name);
         } catch (FQSENException $e) {
-            $this->emitIssue(
-                $e instanceof EmptyFQSENException ? Issue::EmptyFQSENInCallable : Issue::InvalidFQSENInCallable,
-                $this->context->getLineNumberStart(),
-                $function_name
-            );
+            if ($log_error) {
+                $this->emitIssue(
+                    $e instanceof EmptyFQSENException ? Issue::EmptyFQSENInCallable : Issue::InvalidFQSENInCallable,
+                    $this->context->getLineNumberStart(),
+                    $function_name
+                );
+            }
             return [];
         }
         if (!$this->code_base->hasFunctionWithFQSEN($function_fqsen)) {

--- a/tests/plugin_test/expected/211_callable_union.php.expected
+++ b/tests/plugin_test/expected/211_callable_union.php.expected
@@ -1,5 +1,7 @@
 src/211_callable_union.php:19 PhanUndeclaredFunctionInCallable Call to undeclared function puppies in callable
 src/211_callable_union.php:34 PhanTypeInvalidCallableArraySize In a place where phan was expecting a callable, saw an array of size 0, but callable arrays must be of size 2
 src/211_callable_union.php:35 PhanTypeInvalidCallableArraySize In a place where phan was expecting a callable, saw an array of size 3, but callable arrays must be of size 2
-src/211_callable_union.php:51 PhanUndeclaredClassReference Reference to undeclared class \puppies
-src/211_callable_union.php:51 PhanUndeclaredFunctionInCallable Call to undeclared function puppies in callable
+src/211_callable_union.php:52 PhanUndeclaredClassReference Reference to undeclared class \puppies
+src/211_callable_union.php:52 PhanUndeclaredFunctionInCallable Call to undeclared function puppies in callable
+src/211_callable_union.php:53 PhanInvalidFQSENInCallable Possible call to a function 'not--even**a\valid//FQSEN' with an invalid FQSEN.
+src/211_callable_union.php:53 PhanInvalidFQSENInClasslike Possible use of a classlike 'not--even**a\valid//FQSEN' with an invalid FQSEN.

--- a/tests/plugin_test/src/211_callable_union.php
+++ b/tests/plugin_test/src/211_callable_union.php
@@ -34,6 +34,7 @@ test211_string(['Closure', 'fromCallable']);
 test211_string([]); // these two are errors
 test211_string([1, 2, 3]); // these two are errors
 test211_string('puppies');
+test211_string('not--even**a\\valid//FQSEN');
 
 /**
  * @param callable|class-string $x
@@ -48,7 +49,8 @@ function test211_classstring($x) {
 
 test211_classstring('stdClass');
 test211_classstring('strval');
-test211_classstring('puppies'); // only this one is an error
+test211_classstring('puppies'); // this one is an error
+test211_classstring('not--even**a\\valid//FQSEN'); // this one too
 
 /**
  * @param callable|class-string|string $x
@@ -65,3 +67,4 @@ function test211_classstring_other($x) {
 test211_classstring_other('stdClass');
 test211_classstring_other('strval');
 test211_classstring_other('puppies'); // not an error any more
+test211_classstring_other('not--even**a\\valid//FQSEN'); // not an error


### PR DESCRIPTION
When trying to find a callable from a node that may not actually be callable, do not emit issues for invalid FQSENs if `$log_error` is false.

Follow-up to #4975.