### PR TITLE
Move code for complex callables from ContextNode to UnionTypeVisitor

### DIFF
--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -1084,54 +1084,7 @@ class ContextNode
             return [];
         }
         // The least common case: A dynamic function call such as $x(), (self::$x)(), etc.
-        return $this->getFunctionLikeFromDynamicExpression();
-    }
-
-    /**
-     * Yields a list of FunctionInterface objects for the 'expr' of an AST_CALL.
-     * Precondition: expr->kind !== ast\AST_NAME
-     *
-     * @return \Generator<void, FunctionInterface, void, void>
-     */
-    private function getFunctionLikeFromDynamicExpression(): \Generator
-    {
-        $code_base = $this->code_base;
-        $context = $this->context;
-        $expression = $this->node;
-        $union_type = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $expression)->withStaticResolvedInContext($context);
-        if ($union_type->isEmpty()) {
-            return;
-        }
-
-        $has_type = false;
-        foreach ($union_type->getTypeSet() as $type) {
-            $func = $type->asFunctionInterfaceOrNull($code_base, $context);
-            if ($func) {
-                yield $func;
-                $has_type = true;
-            }
-        }
-        if (!$has_type) {
-            if (!$union_type->hasPossiblyCallableType($code_base)) {
-                Issue::maybeEmit(
-                    $code_base,
-                    $context,
-                    Issue::TypeInvalidCallable,
-                    $expression->lineno ?? $context->getLineNumberStart(),
-                    $union_type
-                );
-                return;
-            }
-        }
-        if (Config::get_strict_method_checking() && $union_type->containsDefiniteNonCallableType($code_base)) {
-            Issue::maybeEmit(
-                $code_base,
-                $context,
-                Issue::TypePossiblyInvalidCallable,
-                $expression->lineno ?? $context->getLineNumberStart(),
-                $union_type
-            );
-        }
+        return UnionTypeVisitor::getFunctionLikesFromCallableNode($this->code_base, $this->context, $this->node, true);
     }
 
     /**

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -4248,26 +4248,61 @@ class UnionTypeVisitor extends AnalysisVisitor
             return [];
         }
 
-        // Get the types associated with the node
-        $union_type = self::unionTypeFromNode(
+        $functions = self::getFunctionLikesFromCallableNode(
             $this->code_base,
             $this->context,
             $node,
-            $this->should_catch_issue_exception
+            !$this->should_catch_issue_exception && $log_error
         );
+        $fqsens = [];
+        foreach( $functions as $func ) {
+            $fqsens[] = $func->getFQSEN();
+        }
+        return $fqsens;
+    }
 
-        $closure_types = [];
-        foreach ($union_type->getTypeSet() as $type) {
-            if ($type instanceof ClosureType && $type->hasKnownFQSEN()) {
-                // TODO: Support class instances with __invoke()
-                $fqsen = $type->asFQSEN();
-                if (!($fqsen instanceof FullyQualifiedFunctionLikeName)) {
-                    throw new AssertionError('Expected fqsen of closure to be a FullyQualifiedFunctionLikeName');
-                }
-                $closure_types[] = $fqsen;
+    /**
+     * @param Node|string|bool|int|float|null $node
+     * @param bool $log_error whether or not to log errors while searching
+     * @return iterable<FunctionInterface>
+     */
+    public static function getFunctionLikesFromCallableNode(CodeBase $code_base, Context $context, $node, bool $log_error): iterable {
+        $node_type = self::unionTypeFromNode($code_base, $context, $node, !$log_error)->withStaticResolvedInContext($context);
+
+        if ($node_type->isEmpty()) {
+            return;
+        }
+
+        $has_type = false;
+        foreach ($node_type->getTypeSet() as $type) {
+            $func = $type->asFunctionInterfaceOrNull($code_base, $context, $log_error);
+            if ($func) {
+                yield $func;
+                $has_type = true;
             }
         }
-        return $closure_types;
+
+        if ($log_error) {
+            if ( !$has_type && !$node_type->hasPossiblyCallableType( $code_base ) ) {
+                Issue::maybeEmit(
+                    $code_base,
+                    $context,
+                    Issue::TypeInvalidCallable,
+                    $node->lineno ?? $context->getLineNumberStart(),
+                    $node_type
+                );
+                return;
+            }
+            if ( Config::get_strict_method_checking() && $node_type->containsDefiniteNonCallableType( $code_base ) ) {
+                Issue::maybeEmit(
+                    $code_base,
+                    $context,
+                    Issue::TypePossiblyInvalidCallable,
+                    $node->lineno ?? $context->getLineNumberStart(),
+                    $node_type
+                );
+            }
+        }
     }
 
     /**

--- a/src/Phan/Language/Type/ArrayShapeType.php
+++ b/src/Phan/Language/Type/ArrayShapeType.php
@@ -901,26 +901,30 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
     public function asFunctionInterfaceOrNull(CodeBase $code_base, Context $context, bool $warn = true): ?FunctionInterface
     {
         if (\count($this->field_types) !== 2) {
-            Issue::maybeEmit(
-                $code_base,
-                $context,
-                Issue::TypeInvalidCallableArraySize,
-                $context->getLineNumberStart(),
-                \count($this->field_types)
-            );
+            if ($warn) {
+                Issue::maybeEmit(
+                    $code_base,
+                    $context,
+                    Issue::TypeInvalidCallableArraySize,
+                    $context->getLineNumberStart(),
+                    \count( $this->field_types )
+                );
+            }
             return null;
         }
         $i = 0;
         foreach ($this->field_types as $key => $_) {
             if ($key !== $i) {
                 // TODO: Be more consistent about emitting issues in Type->asFunctionInterfaceOrNull and its subclasses (e.g. if missing __invoke)
-                Issue::maybeEmit(
-                    $code_base,
-                    $context,
-                    Issue::TypeInvalidCallableArrayKey,
-                    $context->getLineNumberStart(),
-                    $i
-                );
+                if ($warn) {
+                    Issue::maybeEmit(
+                        $code_base,
+                        $context,
+                        Issue::TypeInvalidCallableArrayKey,
+                        $context->getLineNumberStart(),
+                        $i
+                    );
+                }
                 return null;
             }
             $i++;

--- a/src/Phan/Language/Type/LiteralStringType.php
+++ b/src/Phan/Language/Type/LiteralStringType.php
@@ -445,7 +445,7 @@ final class LiteralStringType extends StringType implements LiteralTypeInterface
     {
         // parse 'function_name' or 'class_name::method_name'
         // NOTE: In other subclasses of Type, calling this might recurse.
-        $function_like_fqsens = UnionTypeVisitor::functionLikeListFromNodeAndContext($code_base, $context, $this->value, true);
+        $function_like_fqsens = UnionTypeVisitor::functionLikeListFromNodeAndContext($code_base, $context, $this->value, $warn);
         return $function_like_fqsens[0] ?? null;
     }
 

--- a/tests/plugin_test/expected/104_array_map.php.expected
+++ b/tests/plugin_test/expected/104_array_map.php.expected
@@ -1,1 +1,3 @@
-src/104_array_map.php:3 PhanTypeMismatchArgumentInternal Argument 1 ($value) is $results[0] of type string but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array
+src/104_array_map.php:6 PhanTypeMismatchArgumentInternal Argument 1 ($value) is $results[0] of type string but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array
+src/104_array_map.php:15 PhanDebugAnnotation @phan-debug-var requested for variable $res1 - it has union type string[](real=?array)
+src/104_array_map.php:19 PhanDebugAnnotation @phan-debug-var requested for variable $res2 - it has union type string[](real=?array)

--- a/tests/plugin_test/src/104_array_map.php
+++ b/tests/plugin_test/src/104_array_map.php
@@ -1,3 +1,25 @@
 <?php
+
+namespace NS104;
+
 $results = array_map('strtolower', ['a', 'b']);
 echo count($results[0]);
+
+class TestIndirectCallable {
+    public function boolToString( bool $x ): string {
+        return $x ? 'true' : 'false';
+    }
+
+    /** @param bool[] $a */
+    public function testStringsToBools( array $a ): void {
+        $res1 = array_map( [ $this, 'boolToString' ], $a );
+        '@phan-debug-var $res1';
+
+        $cb = [ $this, 'boolToString' ];
+        $res2 = array_map( $cb, $a );
+        '@phan-debug-var $res2';
+
+        echo implode( ', ', $res1 + $res2 );
+    }
+}
+( new TestIndirectCallable() )->testStringsToBools( [ rand() > 0, rand() < 1 ] );


### PR DESCRIPTION
Reduce duplication by using the same code for both `ContextNode::functionFromNode` and `UnionTypeVisitor::functionLikeListFromNodeAndContext`. This notably fixes a few limitations of the latter, like not being able to infer callables if they were assigned to a temporary variable.

Make `asFunctionInterfaceOrNull` always respect the `$warn` parameter, so we don't emit unwanted issues.

Add a test to show the new behaviour using `array_map` as an example (although there are many more code paths leading here).