### PR TITLE
Consider ClosureType as callable in CallableParamPlugin

### DIFF
--- a/src/Phan/Plugin/Internal/CallableParamPlugin.php
+++ b/src/Phan/Plugin/Internal/CallableParamPlugin.php
@@ -15,6 +15,7 @@ use Phan\Language\Element\FunctionInterface;
 use Phan\Language\Type;
 use Phan\Language\Type\CallableInterface;
 use Phan\Language\Type\ClassStringType;
+use Phan\Language\Type\ClosureType;
 use Phan\Plugin\ConfigPluginSet;
 use Phan\PluginV3;
 use Phan\PluginV3\AnalyzeFunctionCallCapability;
@@ -130,7 +131,8 @@ final class CallableParamPlugin extends PluginV3 implements
             // Explicitly require at least one type to be `callable`
             if ($param->getUnionType()->hasTypeMatchingCallback(static function (Type $type): bool {
                 // TODO: More specific closure for CallableDeclarationType
-                return $type instanceof CallableInterface;
+                // TODO: Use `Type::isCallable`? It might be slower though.
+                return $type instanceof CallableInterface || $type instanceof ClosureType;
             })) {
                 $params[$i] |= self::PARAM_HAS_CALLABLE;
             }

--- a/tests/php80_files/expected/052_unreferenced_closure_arrow.php.expected
+++ b/tests/php80_files/expected/052_unreferenced_closure_arrow.php.expected
@@ -1,0 +1,1 @@
+%s:9 PhanCompatibleArrowFunction Cannot use arrow functions before php 7.4 in (fn)

--- a/tests/php80_files/src/052_unreferenced_closure_arrow.php
+++ b/tests/php80_files/src/052_unreferenced_closure_arrow.php
@@ -1,0 +1,9 @@
+<?php
+
+// Regression test for https://github.com/phan/phan/issues/5040
+
+function takesClosure(Closure $clos) {
+    echo $clos();
+}
+
+takesClosure( static fn (): int => 42 ); // Should not be reported as unreferenced


### PR DESCRIPTION
As noted in the interface documentation, `CallableInterface` does not include Closure types. So, add an explicit check for ClosureType to treat them as callable and, for example, properly update their reference counts.

In principle it might make sense to use `Type::isCallable`, but that's more expensive than the `instanceof`, and this is probably fine most of the times.

Fixes #5040