### PR TITLE
Increase max recursion depth in asExpandedTypes

### DIFF
--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -2816,7 +2816,7 @@ class Type implements Stringable
         // We're going to assume that if the type hierarchy
         // is taller than some value we probably messed up
         // and should bail out.
-        if ($recursion_depth >= 20) {
+        if ($recursion_depth >= 24) {
             throw new RecursionDepthException("Recursion has gotten out of hand: " . Frame::getExpandedTypesDetails());
         }
 

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -4438,7 +4438,7 @@ class UnionType implements Serializable, Stringable
         bool $preserving_template = false
     ): UnionType {
         // TODO: Preserve the original real types without expanding them?
-        if ($recursion_depth >= 12) {
+        if ($recursion_depth >= 24) {
             throw new RecursionDepthException("Recursion has gotten out of hand: " . Frame::getExpandedTypesDetails());
         }
 

--- a/tests/php72_files/src/0010_long_inheritance.php
+++ b/tests/php72_files/src/0010_long_inheritance.php
@@ -1,0 +1,34 @@
+<?php
+
+// Regression test for https://github.com/phan/phan/issues/5044 (needs PHP >= 7.2 due to parameter type contravariance in `doSomething`)
+
+/* @phan-file-suppress PhanUnreferencedClass */
+
+class ConcreteClass implements MyInterface {
+    public function doSomething( $module ) {
+        if ( !$module instanceof Class5 ) {
+            return;
+        }
+    }
+}
+
+interface MyInterface {
+    public function doSomething( Class1 $module );
+}
+
+interface Interface0 {}
+
+interface Interface1 extends Interface0 {}
+
+abstract class Class0 implements Interface1 {
+    public function getObject(): Interface1 {
+        return new static;
+    }
+}
+
+class Class1 extends Class0 {}
+class Class2 extends Class1 {}
+class Class3 extends Class2 {}
+class Class4 extends Class3 {}
+class Class5 extends Class4 {}
+


### PR DESCRIPTION
The way the `$recursion_depth` parameter works is that it's incremented by both `Type` and `UnionType`, so the depth is effectively increasing by 2 for each type. For example, in the attached test we'd have:

- 0: Type Class5
- 1: Union type (Class4)
- 2: Type Class4
- 3: Union type (Class3)
- 4: Type Class3

...and so on. So, a hierarchy 6 levels deep was enough to trigger the recursion limit of 12 in UnionType. 6 is a low limit though, and there's definitely a possibility of real code reaching that depth, as seen in the MediaWiki case. So, bump the limit to 24 to allow 12 levels, and update the limit in Type accordingly. Perhaps we could go higher than this, but let's start with this and see how it goes.

Closes #5044