### PR TITLE
fix: add hash options argument to the 8.1 function signature delta map

### DIFF
--- a/src/Phan/Language/Internal/FunctionSignatureMap_php81_delta.php
+++ b/src/Phan/Language/Internal/FunctionSignatureMap_php81_delta.php
@@ -181,6 +181,10 @@ return [
       'old' => ['string|false', 'ftp'=>'resource'],
       'new' => ['string|false', 'ftp'=>'FTP\Connection'],
     ],
+    'hash' => [
+      'old' => ['string', 'algo'=>'string', 'data'=>'string', 'binary='=>'bool'],
+      'new' => ['string', 'algo'=>'string', 'data'=>'string', 'binary='=>'bool', 'options='=>'array'],
+    ],
     'imap_append' => [
       'old' => ['bool', 'imap'=>'resource', 'folder'=>'string', 'message'=>'string', 'options='=>'string', 'internal_date='=>'string'],
       'new' => ['bool', 'imap'=>'IMAP\Connection', 'folder'=>'string', 'message'=>'string', 'options='=>'string', 'internal_date='=>'string'],


### PR DESCRIPTION
According to the docs, the `options` argument was added to the `hash()` internal function in PHP 8.1, but is missing from the delta map, leading to false positives of `PhanParamTooManyInternal` when using the `options` argument.

This PR adds the new argument to the delta map for PHP 8.1.

I didn't see any tests specific to individual deltas. Let me know if I should add any.