### PR TITLE
Flag 'catch' variables declared as unused in PHP 8

### DIFF
--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -1708,6 +1708,14 @@ Unused definition of variable ${VARIABLE} as a caught exception
 
 e.g. [this issue](https://github.com/phan/phan/tree/v5/tests/plugin_test/expected/054_shadowed_exception.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/v5/tests/plugin_test/src/054_shadowed_exception.php#L6).
 
+## PhanUnusedVariableDeclarationCaughtException
+
+```
+Variable ${VARIABLE} for caught exception is declared as unused. Omit the variable instead.
+```
+
+e.g. [these issues](https://github.com/phan/phan/tree/v5/tests/php81_files/expected/032_noncapturing_catch.php.expected) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/v5/tests/php81_files/src/032_noncapturing_catch.php).
+
 ## PhanUnusedVariableGlobal
 
 ```

--- a/src/Phan/Analysis/PreOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PreOrderAnalysisVisitor.php
@@ -32,6 +32,7 @@ use Phan\Language\Type\ArrayShapeType;
 use Phan\Language\Type\NullType;
 use Phan\Language\Type\VoidType;
 use Phan\Library\StringUtil;
+use Phan\Plugin\Internal\VariableTrackerPlugin;
 
 /**
  * PreOrderAnalysisVisitor is where we do the pre-order part of the analysis
@@ -820,6 +821,19 @@ class PreOrderAnalysisVisitor extends ScopeVisitor
         ))->getVariableName();
 
         if ($variable_name !== '') {
+            if (
+                VariableTrackerPlugin::shouldExemptUnusedVariableWithName($variable_name) &&
+                Config::get_closest_minimum_target_php_version_id() >= 80000
+            ) {
+                // If the variable is declared as unused, suggest a non-capturing catch when possible. Other
+                // variables are handled in VariableTrackerElementVisitor, as we check whether they're used.
+                $this->emitIssue(
+                    Issue::UnusedVariableDeclarationCaughtException,
+                    $node->lineno,
+                    $variable_name
+                );
+            }
+
             $variable = Variable::fromNodeInContext(
                 $var_node,
                 $this->context,

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -495,6 +495,7 @@ class Issue
     public const UselessBinaryAddRight                 = 'PhanUselessBinaryAddRight';
     public const SuspiciousBinaryAddLists              = 'PhanSuspiciousBinaryAddLists';
     public const UnusedVariableCaughtException         = 'PhanUnusedVariableCaughtException';  // has higher false positive rates than UnusedVariable
+    public const UnusedVariableDeclarationCaughtException = 'PhanUnusedVariableDeclarationCaughtException';
     public const UnusedGotoLabel                       = 'PhanUnusedGotoLabel';
     public const UnusedVariableReference               = 'PhanUnusedVariableReference';
     public const UnusedVariableStatic                  = 'PhanUnusedVariableStatic';
@@ -4314,6 +4315,14 @@ class Issue
                 'Unused definition of variable ${VARIABLE} as a caught exception',
                 self::REMEDIATION_B,
                 6046
+            ),
+            new Issue(
+                self::UnusedVariableDeclarationCaughtException,
+                self::CATEGORY_NOOP,
+                self::SEVERITY_LOW,
+                'Variable ${VARIABLE} for caught exception is declared as unused. Omit the variable instead.',
+                self::REMEDIATION_B,
+                6098
             ),
             new Issue(
                 self::UnusedVariableReference,

--- a/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
+++ b/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
@@ -37,6 +37,14 @@ use function strlen;
 final class VariableTrackerPlugin extends PluginV3 implements
     PostAnalyzeNodeCapability
 {
+    /**
+     * Check whether a variable with the given name should be exempt from UnusedVariable warnings. Returns true
+     * for variables like $_, $unused*, and $raii*
+     */
+    public static function shouldExemptUnusedVariableWithName(string $variable_name): bool
+    {
+        return \preg_match('/^(_$|(unused|raii))/iD', $variable_name) > 0;
+    }
 
     /**
      * @return string the name of a visitor
@@ -396,8 +404,7 @@ final class VariableTrackerElementVisitor extends PluginAwarePostAnalysisVisitor
             if ($variable_name === 'this') {
                 continue;
             }
-            if (\preg_match('/^(_$|(unused|raii))/iD', $variable_name) > 0) {
-                // Skip over $_, $unused*, and $raii*
+            if (VariableTrackerPlugin::shouldExemptUnusedVariableWithName($variable_name)) {
                 continue;
             }
             if (Variable::isSuperglobalVariableWithName($variable_name)) {

--- a/tests/php81_files/expected/032_noncapturing_catch.php.expected
+++ b/tests/php81_files/expected/032_noncapturing_catch.php.expected
@@ -1,0 +1,2 @@
+%s:5 PhanUnusedVariableDeclarationCaughtException Variable $unused for caught exception is declared as unused. Omit the variable instead.
+%s:6 PhanUnusedVariableDeclarationCaughtException Variable $_ for caught exception is declared as unused. Omit the variable instead.

--- a/tests/php81_files/src/032_noncapturing_catch.php
+++ b/tests/php81_files/src/032_noncapturing_catch.php
@@ -1,0 +1,7 @@
+<?php
+
+try {
+    $GLOBALS['somefunc']();
+} catch ( RuntimeException | LogicException $unused ) {
+} catch ( Throwable $_ ) {
+}


### PR DESCRIPTION
If a variable in a `catch` clause has a name that declares it as unused (according to the definition in VariableTrackerPlugin), and if we're only supporting PHP 8, suggest dropping the variable altogether and using a non-capturing catch instead.

This is implemented in the normal PreOrder visitor instead of VariableTrackerPlugin because it's much more limited in scope and doesn't require actually tracking the variables, so it can be used even if you don't want to enable variable tracking. Also, the existing code in VariableTrackerElementVisitor seems a bit hard to refactor, as it skips these variables immediately, long before figuring out what kind of declaration (e.g., `catch` variable) we've got. Extract the variable name check to a static method, putting it in the plugin class so it can be used from elsewhere without autoloading issues when the plugin is disabled.

Add a test in php81_files; not in php80_files because those have the minimum target PHP version set to 7.2 for testing compatibility stuff.

Closes #4954