### PR TITLE
UseReturnValuePlugin: support `#[\NoDiscard]` attribute

### DIFF
--- a/src/Phan/Plugin/Internal/UseReturnValuePlugin/UseReturnValueVisitor.php
+++ b/src/Phan/Plugin/Internal/UseReturnValuePlugin/UseReturnValueVisitor.php
@@ -15,6 +15,7 @@ use Phan\Exception\CodeBaseException;
 use Phan\Language\Element\Func;
 use Phan\Language\Element\FunctionInterface;
 use Phan\Language\Element\Method;
+use Phan\Language\FQSEN\FullyQualifiedClassName;
 use Phan\Plugin\Internal\UseReturnValuePlugin;
 use Phan\PluginV3\PluginAwarePostAnalysisVisitor;
 
@@ -531,6 +532,34 @@ class UseReturnValueVisitor extends PluginAwarePostAnalysisVisitor
             $fqsen_key = \strtolower(\ltrim($fqsen, "\\"));
             $result = UseReturnValuePlugin::HARDCODED_FQSENS[$fqsen_key] ?? null;
             if (!$result) {
+                // Polyfill support for #[\NoDiscard]
+                $attribs = $method->getAttributeList();
+                if ($attribs) {
+                    // @phan-suppress-next-line PhanThrowTypeAbsentForCall
+                    $noDiscardFQSEN = FullyQualifiedClassName::make('', 'NoDiscard');
+                    foreach ($attribs as $attrib) {
+                        if ($attrib->getFQSEN() !== $noDiscardFQSEN) {
+                            continue;
+                        }
+                        if ($method->isPHPInternal()) {
+                            $code = UseReturnValuePlugin::UseReturnValueInternalKnown;
+                            $msg = 'Expected to use the return value of the internal function/method {FUNCTION}';
+                            $params = [$fqsen];
+                        } else {
+                            $code = UseReturnValuePlugin::UseReturnValueKnown;
+                            $msg = 'Expected to use the return value of the user-defined function/method {FUNCTION} defined at {FILE}:{LINE}';
+                            $params = [$method->getRepresentationForIssue(), $method->getContext()->getFile(), $method->getContext()->getLineNumberStart()];
+                        }
+                        $this->emitPluginIssue(
+                            $this->code_base,
+                            (clone $this->context)->withLineNumberStart($node->lineno),
+                           $code,
+                           $msg,
+                           $params
+                        );
+                        return true;
+                    }
+                }
                 return $result ?? true;
             }
             if ($result === UseReturnValuePlugin::SPECIAL_CASE) {

--- a/tests/php80_files/expected/053_NoDiscard_polyfill.php.expected
+++ b/tests/php80_files/expected/053_NoDiscard_polyfill.php.expected
@@ -1,0 +1,6 @@
+%s:18 PhanUndeclaredClassAttribute Reference to undeclared class \NoDiscard in an attribute
+%s:25 PhanUndeclaredClassAttribute Reference to undeclared class \NoDiscard in an attribute
+%s:31 PhanUndeclaredClassAttribute Reference to undeclared class \NoDiscard in an attribute
+%s:38 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \withoutSideEffects() defined at %s:%d
+%s:40 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \ClassWithoutSideEffects::instanceMethod() defined at %s:%d
+%s:41 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \ClassWithoutSideEffects::staticMethod() defined at %s:%d

--- a/tests/php80_files/expected/053_NoDiscard_polyfill.php.expected
+++ b/tests/php80_files/expected/053_NoDiscard_polyfill.php.expected
@@ -4,3 +4,6 @@
 %s:38 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \withoutSideEffects() defined at %s:%d
 %s:40 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \ClassWithoutSideEffects::instanceMethod() defined at %s:%d
 %s:41 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \ClassWithoutSideEffects::staticMethod() defined at %s:%d
+%s:43 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \withSideEffects() defined at %s:%d
+%s:45 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \ClassWithSideEffects::instanceMethod() defined at %s:%d
+%s:46 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \ClassWithSideEffects::staticMethod() defined at %s:%d

--- a/tests/php80_files/src/053_NoDiscard_polyfill.php
+++ b/tests/php80_files/src/053_NoDiscard_polyfill.php
@@ -1,0 +1,46 @@
+<?php
+// Polyfill the PHP 8.5 support for NoDiscard <https://wiki.php.net/rfc/marking_return_value_as_important>
+
+function withoutSideEffects(): int {
+	return 1;
+}
+
+class ClassWithoutSideEffects {
+	public function instanceMethod(): int {
+		return 2;
+	}
+
+	public static function staticMethod(): int {
+		return 3;
+	}
+}
+
+#[\NoDiscard]
+function withSideEffects(): int {
+	echo __FUNCTION__ . "\n";
+	return 1;
+}
+
+class ClassWithSideEffects {
+	#[\NoDiscard]
+	public function instanceMethod(): int {
+		echo __METHOD__ . "\n";
+		return 2;
+	}
+
+	#[\NoDiscard]
+	public static function staticMethod(): int {
+		echo __METHOD__ . "\n";
+		return 3;
+	}
+}
+
+withoutSideEffects();
+$o = new ClassWithoutSideEffects();
+$o->instanceMethod();
+ClassWithoutSideEffects::staticMethod();
+
+withSideEffects();
+$o = new ClassWithSideEffects();
+$o->instanceMethod();
+ClassWithSideEffects::staticMethod();


### PR DESCRIPTION
If the attribute is applied, the return value should be used. Even if the attribute class does not exist (PHP < 8.5) we can still add the support for requiring the return value to be used.