### PR TITLE
Use `mixed` instead of empty union to substitute unspecified template types

### DIFF
--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -38,6 +38,7 @@ use Phan\Language\Scope\GlobalScope;
 use Phan\Language\Type;
 use Phan\Language\Type\IterableType;
 use Phan\Language\Type\LiteralStringType;
+use Phan\Language\Type\MixedType;
 use Phan\Language\Type\StaticType;
 use Phan\Language\Type\StringType;
 use Phan\Language\Type\TemplateType;
@@ -3858,7 +3859,7 @@ class Clazz extends AddressableElement
                         }
                         /** @param list<\ast\Node|mixed> $unused_arg_list */
                         $template_type_resolver = static function (array $unused_arg_list, Context $unused_context): UnionType {
-                            return UnionType::empty();
+                            return MixedType::instance(false)->asPHPDocUnionType();
                         };
                     }
                     $template_type_resolvers[] = $template_type_resolver;

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -1653,7 +1653,7 @@ trait FunctionTrait
                 );
                 /** @param list<\ast\Node|mixed> $unused_arg_list */
                 $parameter_extractor = static function (array $unused_arg_list, Context $unused_context): UnionType {
-                    return UnionType::empty();
+                    return MixedType::instance(false)->asPHPDocUnionType();
                 };
             }
             $parameter_extractor_map[$template_type->getName()] = $parameter_extractor;

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -2711,7 +2711,7 @@ class Type implements Stringable
      *
      * @param bool $omit_missing
      * If the type is missing some type parameters expected by the class,
-     * omit them in the result instead of returning empty union types.
+     * omit them in the result instead of returning the mixed type.
      *
      * @return array<string,UnionType>
      * A map from template type identifier to a concrete type
@@ -2739,7 +2739,7 @@ class Type implements Stringable
                 if (isset($template_parameter_type_list[$i])) {
                     $map[$identifier] = $template_parameter_type_list[$i];
                 } elseif (!$omit_missing) {
-                    $map[$identifier] = UnionType::empty();
+                    $map[$identifier] = MixedType::instance(false)->asPHPDocUnionType();
                 }
             }
 

--- a/tests/files/expected/0985_template_unspecified.php.expected
+++ b/tests/files/expected/0985_template_unspecified.php.expected
@@ -18,10 +18,10 @@
 %s:110 PhanDebugAnnotation @phan-debug-var requested for variable $aa - it has union type \stdClass
 %s:110 PhanDebugAnnotation @phan-debug-var requested for variable $bb - it has union type \stdClass
 %s:110 PhanDebugAnnotation @phan-debug-var requested for variable $cc - it has union type \stdClass
-%s:110 PhanDebugAnnotation @phan-debug-var requested for variable $dd - it has union type (empty union type)
+%s:110 PhanDebugAnnotation @phan-debug-var requested for variable $dd - it has union type mixed
 %s:110 PhanDebugAnnotation @phan-debug-var requested for variable $ee - it has union type \stdClass
 %s:110 PhanDebugAnnotation @phan-debug-var requested for variable $ff - it has union type \stdClass
-%s:110 PhanDebugAnnotation @phan-debug-var requested for variable $gg - it has union type (empty union type)
+%s:110 PhanDebugAnnotation @phan-debug-var requested for variable $gg - it has union type mixed
 %s:119 PhanDebugAnnotation @phan-debug-var requested for variable $aC - it has union type \Container<\Bar>(real=\Container<\Bar>)
 %s:119 PhanDebugAnnotation @phan-debug-var requested for variable $bC - it has union type \Container<\Bar>
 %s:119 PhanDebugAnnotation @phan-debug-var requested for variable $cC - it has union type \Container<\Bar>
@@ -46,7 +46,7 @@
 %s:146 PhanDebugAnnotation @phan-debug-var requested for variable $aa0 - it has union type null
 %s:146 PhanDebugAnnotation @phan-debug-var requested for variable $bb0 - it has union type null
 %s:146 PhanDebugAnnotation @phan-debug-var requested for variable $cc0 - it has union type never
-%s:146 PhanDebugAnnotation @phan-debug-var requested for variable $dd0 - it has union type (empty union type)
+%s:146 PhanDebugAnnotation @phan-debug-var requested for variable $dd0 - it has union type mixed
 %s:146 PhanDebugAnnotation @phan-debug-var requested for variable $ee0 - it has union type null
 %s:146 PhanDebugAnnotation @phan-debug-var requested for variable $ff0 - it has union type never
-%s:146 PhanDebugAnnotation @phan-debug-var requested for variable $gg0 - it has union type (empty union type)
+%s:146 PhanDebugAnnotation @phan-debug-var requested for variable $gg0 - it has union type mixed

--- a/tests/files/expected/0993_generic_option.php.expected
+++ b/tests/files/expected/0993_generic_option.php.expected
@@ -24,3 +24,9 @@
 %s:213 PhanTypeMismatchArgumentProbablyReal Argument 1 ($x) is new NoneNull() of type \NS993\NoneNull|\NS993\Option|\NS993\Option<null> but \NS993\test() takes \NS993\Option<\NS993\Foo> (no real type) defined at %s:204 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
 %s:214 PhanTypeMismatchArgumentProbablyReal Argument 1 ($x) is new Foo() of type \NS993\Foo but \NS993\test() takes \NS993\Option<\NS993\Foo> (no real type) defined at %s:204 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
 %s:215 PhanTypeMismatchArgumentProbablyReal Argument 1 ($x) is null of type null but \NS993\test() takes \NS993\Option<\NS993\Foo> (no real type) defined at %s:204 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
+%s:231 PhanDebugAnnotation @phan-debug-var requested for variable $option0 - it has union type \NS993\None|\NS993\Some<42>(real=\NS993\None|\NS993\Some<42>)
+%s:231 PhanDebugAnnotation @phan-debug-var requested for variable $option1 - it has union type \NS993\Option<mixed>
+%s:231 PhanDebugAnnotation @phan-debug-var requested for variable $option2 - it has union type \NS993\Option(real=\NS993\Option)
+%s:236 PhanDebugAnnotation @phan-debug-var requested for variable $val0 - it has union type 42|null
+%s:236 PhanDebugAnnotation @phan-debug-var requested for variable $val1 - it has union type mixed|null
+%s:236 PhanDebugAnnotation @phan-debug-var requested for variable $val2 - it has union type mixed|null

--- a/tests/files/expected/0996_generic_type_leak.php.expected
+++ b/tests/files/expected/0996_generic_type_leak.php.expected
@@ -1,15 +1,15 @@
 %s:6 PhanGenericConstructorTypes Missing template parameter for type T on constructor for generic class \X
-%s:11 PhanDebugAnnotation @phan-debug-var requested for variable $x0 - it has union type \X<>(real=\X<>)
-%s:11 PhanDebugAnnotation @phan-debug-var requested for variable $y0 - it has union type (empty union type)
+%s:11 PhanDebugAnnotation @phan-debug-var requested for variable $x0 - it has union type \X<mixed>(real=\X<mixed>)
+%s:11 PhanDebugAnnotation @phan-debug-var requested for variable $y0 - it has union type mixed
 %s:19 PhanDebugAnnotation @phan-debug-var requested for variable $x1 - it has union type \X(real=\X)
-%s:19 PhanDebugAnnotation @phan-debug-var requested for variable $y1 - it has union type (empty union type)
+%s:19 PhanDebugAnnotation @phan-debug-var requested for variable $y1 - it has union type mixed
 %s:28 PhanTemplateTypeNotDeclaredInFunctionParams Template type U not declared in parameters of function/method getX2() (or Phan can't extract template types for this use case)
-%s:32 PhanDebugAnnotation @phan-debug-var requested for variable $x2 - it has union type \X<>(real=\X)
-%s:32 PhanDebugAnnotation @phan-debug-var requested for variable $y2 - it has union type (empty union type)
-%s:41 PhanTypeMismatchReturn Returning new X() of type \X<> but getX3() is declared to return \X&\I
+%s:32 PhanDebugAnnotation @phan-debug-var requested for variable $x2 - it has union type \X<mixed>(real=\X)
+%s:32 PhanDebugAnnotation @phan-debug-var requested for variable $y2 - it has union type mixed
+%s:41 PhanTypeMismatchReturn Returning new X() of type \X<mixed> but getX3() is declared to return \X&\I
 %s:44 PhanDebugAnnotation @phan-debug-var requested for variable $x3 - it has union type \X&\I
-%s:44 PhanDebugAnnotation @phan-debug-var requested for variable $y3 - it has union type (empty union type)
+%s:44 PhanDebugAnnotation @phan-debug-var requested for variable $y3 - it has union type mixed
 %s:51 PhanCommentParamOnEmptyParamList Saw an @param annotation for $x, but the param list of function getX4() : \X|\X<U>; is empty
 %s:54 PhanTemplateTypeNotDeclaredInFunctionParams Template type U not declared in parameters of function/method getX4() (or Phan can't extract template types for this use case)
-%s:58 PhanDebugAnnotation @phan-debug-var requested for variable $x4 - it has union type \X<>(real=\X)
-%s:58 PhanDebugAnnotation @phan-debug-var requested for variable $y4 - it has union type (empty union type)
+%s:58 PhanDebugAnnotation @phan-debug-var requested for variable $x4 - it has union type \X<mixed>(real=\X)
+%s:58 PhanDebugAnnotation @phan-debug-var requested for variable $y4 - it has union type mixed

--- a/tests/files/src/0993_generic_option.php
+++ b/tests/files/src/0993_generic_option.php
@@ -213,3 +213,25 @@ test(new Some(null));
 test(new NoneNull);
 test(new Foo);
 test(null);
+
+
+// Test union types with unspecified type parameters (#5052)
+
+/** @return Option<mixed> */
+function maybeMixed1() {
+    return rand() ? new Some(42) : new None;
+}
+
+function maybeMixed2(): Option {
+    return rand() ? new Some(42) : new None;
+}
+
+$option0 = rand() ? new Some(42) : new None;
+$option1 = maybeMixed1();
+$option2 = maybeMixed2();
+'@phan-debug-var $option0, $option1, $option2';
+
+$val0 = $option0->getOrElse(null);
+$val1 = $option1->getOrElse(null);
+$val2 = $option2->getOrElse(null);
+'@phan-debug-var $val0, $val1, $val2';


### PR DESCRIPTION
They behave almost the same in type checks, but `mixed` works better in practice when the template type is used as a part of union type, e.g. `T|null`, which now becomes `mixed|null` (a bit weird but mostly correct) instead of just `null` (usually wrong). Add an example to the Option type test to demonstrate this. Fixes #5052.

This also reverts ea81e9bfa348d355b71b88415b44a5523a1ff882 and makes things consistent in the opposite direction.