### PR TITLE
Normalize generic multi-type elements before expanding them

### DIFF
--- a/src/Phan/Language/Type/GenericMultiArrayType.php
+++ b/src/Phan/Language/Type/GenericMultiArrayType.php
@@ -125,6 +125,11 @@ final class GenericMultiArrayType extends ArrayType implements MultiType, Generi
      */
     public function asIndividualTypeInstances(): array
     {
+        $normalized_types = UnionType::normalizeMultiTypes($this->element_types);
+        // Normalize e.g. `A|null` to `?A`, because otherwise we'd expand this multi-type to
+        // `A[]|null[]` and Phan can't deduce later that it's the same type as `(?A)[]`. (#5049)
+        $normalized_types = UnionType::of($normalized_types)->asNormalizedTypes()->getTypeSet();
+
         return \array_map(function (Type $type): GenericArrayType {
             if ($this->always_has_elements) {
                 if ($this->is_list) {
@@ -141,7 +146,7 @@ final class GenericMultiArrayType extends ArrayType implements MultiType, Generi
                 }
                 return GenericArrayType::fromElementType($type, $this->is_nullable, $this->key_type);
             }
-        }, UnionType::normalizeMultiTypes($this->element_types));
+        }, $normalized_types);
     }
 
     /**

--- a/tests/Phan/Output/Printer/CSVPrinterTest.php
+++ b/tests/Phan/Output/Printer/CSVPrinterTest.php
@@ -27,7 +27,7 @@ final class CSVPrinterTest extends BaseTest
 
         $lines = \array_map(
             /**
-             * @return array<int,null>|array<int,string>
+             * @return array<int,?string>
              */
             static function(string $line): array {
                 return str_getcsv($line, ",", '"', "\\");
@@ -35,7 +35,7 @@ final class CSVPrinterTest extends BaseTest
             \explode("\n", $output->fetch())
         );
         // str_getcsv() returns [0 => null] if passed the empty string.
-        // @phan-suppress-next-line PhanPartialTypeMismatchArgumentInternal
+        // @phan-suppress-next-line PhanTypeMismatchArgumentInternal
         $fields = \array_combine($lines[0], $lines[1]);
         $this->assertSame("test.php", $fields["filename"]);
         $this->assertSame("0", $fields["line"]);

--- a/tests/files/expected/0386_multi_union_type.php.expected
+++ b/tests/files/expected/0386_multi_union_type.php.expected
@@ -1,1 +1,1 @@
-%s:8 PhanTypeMismatchReturn Returning [new stdClass()] of type array{0:\stdClass} but testPipeInTemplate386() is declared to return array<int,bool>|array<int,null>
+%s:8 PhanTypeMismatchReturn Returning [new stdClass()] of type array{0:\stdClass} but testPipeInTemplate386() is declared to return array<int,?bool>

--- a/tests/files/src/1002_multi_union_type_nullable.php
+++ b/tests/files/src/1002_multi_union_type_nullable.php
@@ -1,0 +1,16 @@
+<?php
+
+class DoTest {
+	/**
+	 * @var array<string,stdClass|null>
+	 */
+	private $prop = [];
+
+	function getObj(): ?stdClass {
+		return rand() ? (object)[] : null;
+	}
+
+	public function test( string $key ) {
+		$this->prop[$key] = $this->getObj();
+	}
+}


### PR DESCRIPTION
Phan only supports union types inside generic type parameters by expanding them to an union of simple generic types, that is, `(A|null)[]` becomes `A[]|null[]`. The temporary value that holds a union inside the type param is called a multi-type.

As a result, while `A|null` and `?A` are treated as the same type, `(A|null)[]` and `(?A)[]` were not. It seems difficult to fix this in the type system, it would require "deeper" normalization than we currently do. Instead, normalize before expanding the multi-types, so that `(A|null)[]` becomes `(?A)[]` instead of `A[]|null[]`. This avoids problems at least in this common case. Fixes #5049.