### PR TITLE
Allow `@extends`/`@inherits` in PHPDoc on traits again

### DIFF
--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -233,6 +233,12 @@ class ParseVisitor extends ScopeVisitor
                 if ($class->isClass()) {
                     // TODO: Emit issue if this does not match `class ... extends`
                     $class->setParentType($inherited_type_option->get());
+                } elseif ($class->isTrait()) {
+                    // This seems to work only by accident; traits are not supposed to have parent classes.
+                    // However, users rely on it, and it's kind of neat to have. See discussion on #5002.
+                    // TODO: Emit issue if this does not match the `use` on the referenced class
+                    // TODO: Emit issue if there is a `use` on any other class (and not a subclass)
+                    $class->setParentType($inherited_type_option->get());
                 } else {
                     // TODO: Support generic interfaces
                     // TODO: Emit issue if this does not match `interface ... extends`

--- a/tests/files/expected/1003_trait_extends.php.expected
+++ b/tests/files/expected/1003_trait_extends.php.expected
@@ -1,0 +1,2 @@
+%s:8 PhanUndeclaredMethod Call to undeclared method \NS1003a\T::m (Did you mean expr->f())
+%s:8 PhanUndeclaredProperty Reference to undeclared property \NS1003a\T->p

--- a/tests/files/src/1003_trait_extends.php
+++ b/tests/files/src/1003_trait_extends.php
@@ -1,0 +1,82 @@
+<?php
+
+// Trait used correctly, but with no documentation, causes issues to be emitted.
+// The expected class elements must be documented.
+namespace NS1003a {
+	trait T {
+		function f(): void {
+			$this->m( $this->p );
+		}
+	}
+
+	class C {
+		use T;
+		private $p = 123;
+		private function m($v): void {
+			echo $v;
+		}
+	}
+
+	// This is incorrect, and should emit some issues, but it currently doesn't.
+	class D {
+		use T;
+	}
+
+	(new C)->f();
+	(new D)->f();
+}
+
+// Trait used correctly, with documentation for expected class.
+namespace NS1003b {
+	/** @extends C */
+	trait T {
+		function f(): void {
+			$this->m( $this->p );
+		}
+	}
+
+	class C {
+		use T;
+		private $p = 123;
+		private function m($v): void {
+			echo $v;
+		}
+	}
+
+	// This is incorrect, and should emit some issues, but it currently doesn't.
+	class D {
+		use T;
+	}
+
+	(new C)->f();
+	(new D)->f();
+}
+
+// Trait used correctly, with documentation for individual methods/props.
+namespace NS1003c {
+	/**
+	 * @method m($v):void
+	 * @property $p
+	 */
+	trait T {
+		function f(): void {
+			$this->m( $this->p );
+		}
+	}
+
+	class C {
+		use T;
+		private $p = 123;
+		private function m($v): void {
+			echo $v;
+		}
+	}
+
+	// This is incorrect, and should emit some issues, but it currently doesn't.
+	class D {
+		use T;
+	}
+
+	(new C)->f();
+	(new D)->f();
+}


### PR DESCRIPTION
`@extends`/`@inherits` can be used to document that the trait is only used on that class, and avoid issues about undeclared methods/properties/constants when they're defined in that class.

I'm not sure if this is supposed to work, but it does, see #5002. I unintentionally broke it in 1193d813f2. Add some tests so that it doesn't get accidentally broken again.