### PR TITLE
Added PHP 8.4 support to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ composer require phan/phan
 With Phan installed, you'll want to [create a `.phan/config.php` file](https://github.com/phan/phan/wiki/Getting-Started#creating-a-config-file) in
 your project to tell Phan how to analyze your source code. Once configured, you can run it via `./vendor/bin/phan`.
 
-Phan 5 depends on PHP 7.2+ with the [php-ast](https://github.com/nikic/php-ast) extension (1.1.1+ is preferred) and supports analyzing PHP version 7.0-8.2 syntax.
+Phan 5 depends on PHP 7.2+ with the [php-ast](https://github.com/nikic/php-ast) extension (1.1.1+ is preferred) and supports analyzing PHP version 7.0-8.4 syntax.
 Installation instructions for php-ast can be found [here](https://github.com/nikic/php-ast#installation).
 (Phan can be used without php-ast by using the CLI option `--allow-polyfill-parser`, but there are slight differences in the parsing of doc comments)
 
@@ -125,7 +125,7 @@ A simple `.phan/config.php` file might look something like the following.
 return [
 
     // Supported values: `'5.6'`, `'7.0'`, `'7.1'`, `'7.2'`, `'7.3'`, `'7.4'`,
-    // `'8.0'`, `'8.1'`, `'8.2'`, `'8.3'`, `null`.
+    // `'8.0'`, `'8.1'`, `'8.2'`, `'8.3'`, `'8.4'`, `null`.
     // If this is set to `null`,
     // then Phan assumes the PHP version which is closest to the minor version
     // of the php executable used to execute Phan.


### PR DESCRIPTION
I added support for PHP 8.4 to README.md.

Since Phan has supported PHP 8.4 syntax starting from version 5.4.6, I thought an update to the README was necessary.

This PR is for updating the documentation only. No code changes included.
Thank you!