### PR TITLE
Added missing case for SelfType instantiation

### DIFF
--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -561,6 +561,9 @@ class Type implements Stringable
                     case 'non-zero-int':
                         $value = new NonZeroIntType($is_nullable);
                         break;
+                    case 'self':
+                        $value = new SelfType($is_nullable);
+                        break;
                 }
             }
             if (!$value) {


### PR DESCRIPTION
It looked like SelfType just needed to be in the list of custom handled instantiators in `make`, as it overrides its constructor in an identical way to other classes (like `CallableObjectType`) in this list.

Fixes #5057 