### PR TITLE
Handle intersection types in `@throws`

### DIFF
--- a/src/Phan/Analysis/ThrowsTypesAnalyzer.php
+++ b/src/Phan/Analysis/ThrowsTypesAnalyzer.php
@@ -43,7 +43,8 @@ class ThrowsTypesAnalyzer
         CodeBase $code_base,
         FunctionInterface $method
     ): void {
-        foreach ($method->getOwnThrowsUnionType()->getTypeSet() as $type) {
+        // TODO: There could be some special handling here for intersection types
+        foreach ($method->getOwnThrowsUnionType()->getUniqueFlattenedTypeSet() as $type) {
             // TODO: When analyzing the method body, only check the valid exceptions
             self::analyzeSingleThrowType($code_base, $method, $type);
         }

--- a/tests/files/expected/1005_throws_intersection.php.expected
+++ b/tests/files/expected/1005_throws_intersection.php.expected
@@ -1,0 +1,4 @@
+%s:13 PhanTypeInvalidThrowsIsInterface @throws annotation of test1 has suspicious interface type \ExceptionA for an @throws annotation, expected class (PHP allows interfaces to be caught, so this might be intentional)
+%s:13 PhanTypeInvalidThrowsIsInterface @throws annotation of test1 has suspicious interface type \ExceptionB for an @throws annotation, expected class (PHP allows interfaces to be caught, so this might be intentional)
+%s:29 PhanTypeInvalidThrowsNonThrowable @throws annotation of test3 has suspicious class type \NotAnException, which does not extend Error/Exception
+%s:29 PhanUndeclaredTypeThrowsType @throws type of test3 has undeclared type \NotDefinedException

--- a/tests/files/src/1005_throws_intersection.php
+++ b/tests/files/src/1005_throws_intersection.php
@@ -1,0 +1,31 @@
+<?php
+
+interface ExceptionA {}
+interface ExceptionB {}
+class MyException extends Exception implements ExceptionA, ExceptionB {}
+
+class NotAnException {}
+
+/**
+ * This emits issues about throwing interface types, maybe that shouldn't happen for intersections?
+ * @throws ExceptionA&ExceptionB
+ */
+function test1() {
+	throw new MyException();
+}
+
+/**
+ * The "Throwable" interface is a special case and does not emit issues.
+ * @throws MyException&Throwable
+ */
+function test2() {
+	throw new MyException();
+}
+
+/**
+ * This must still emit issues about using invalid types in "throws" when they're in an intersection type.
+ * @throws NotAnException&NotDefinedException
+ */
+function test3() {
+	throw new MyException();
+}


### PR DESCRIPTION
Use getUniqueFlattenedTypeSet() in order to check individual types in the intersection type (as if it was a union type).

Maybe we could do some smarter analysis, but intersection types in `@throws` seem unusual, and this is enough to prevent crashes.

Fixes #5071.