### PR TITLE
Emit issues for duplicate `@template` annotations

### DIFF
--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -4900,6 +4900,14 @@ constant {CONST} may not have a template type
 
 e.g. [this issue](https://github.com/phan/phan/tree/v5/tests/plugin_test/expected/189_class_constant_badtype.php.expected#L4) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/v5/tests/plugin_test/src/189_class_constant_badtype.php#L9).
 
+## PhanTemplateTypeDuplicate
+
+```
+Template type {TYPE} is already declared in this comment
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/v5/tests/files/expected/1006_generic_type_duplicate.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/v5/tests/files/src/1006_generic_type_duplicate.php#L29).
+
 ## PhanTemplateTypeNotDeclaredInFunctionParams
 
 ```
@@ -4915,6 +4923,14 @@ Template type {TYPE} not used in return value of function/method {FUNCTIONLIKE}
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/v5/tests/files/expected/0577_unknown_tags.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/v5/tests/files/src/0577_unknown_tags.php#L20).
+
+## PhanTemplateTypeShadowsClass
+
+```
+Template type {TYPE} is already declared in the containing class
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/v5/tests/files/expected/1006_generic_type_duplicate.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/v5/tests/files/src/1006_generic_type_duplicate.php#L20).
 
 ## PhanTemplateTypeStaticMethod
 

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -641,6 +641,8 @@ class Issue
     public const TemplateTypeNotUsedInFunctionReturn = 'PhanTemplateTypeNotUsedInFunctionReturn';
     public const TemplateTypeNotDeclaredInFunctionParams = 'PhanTemplateTypeNotDeclaredInFunctionParams';
     public const GenericMissingParameters = 'PhanGenericMissingParameters';
+    public const TemplateTypeDuplicate = 'PhanTemplateTypeDuplicate';
+    public const TemplateTypeShadowsClass = 'PhanTemplateTypeShadowsClass';
 
     // Issue::CATEGORY_COMMENT
     public const DebugAnnotation                  = 'PhanDebugAnnotation';
@@ -5517,6 +5519,22 @@ class Issue
                 "Class {CLASS} must substitute all {COUNT} template parameters when inheriting {CLASS} (found {COUNT}) defined at {FILE}:{LINE} (use @extends or @inherit)",
                 self::REMEDIATION_B,
                 14007
+            ),
+            new Issue(
+                self::TemplateTypeDuplicate,
+                self::CATEGORY_GENERIC,
+                self::SEVERITY_NORMAL,
+                "Template type {TYPE} is already declared in this comment",
+                self::REMEDIATION_B,
+                14008
+            ),
+            new Issue(
+                self::TemplateTypeShadowsClass,
+                self::CATEGORY_GENERIC,
+                self::SEVERITY_NORMAL,
+                "Template type {TYPE} is already declared in the containing class",
+                self::REMEDIATION_B,
+                14009
             ),
 
             // Issue::CATEGORY_INTERNAL

--- a/src/Phan/Language/Element/Comment/Builder.php
+++ b/src/Phan/Language/Element/Comment/Builder.php
@@ -664,6 +664,13 @@ final class Builder
             if ($this->checkCompatible("@$tag_name", Comment::HAS_TEMPLATE_ANNOTATION, $i)) {
                 $template_type = $this->templateTypeFromCommentLine($line);
                 if ($template_type) {
+                    if (isset($this->template_type_list[$template_type->getName()])) {
+                        $this->emitIssue(
+                            Issue::TemplateTypeDuplicate,
+                            $this->guessActualLineLocation($i),
+                            (string)$template_type
+                        );
+                    }
                     $this->template_type_list[$template_type->getName()] = $template_type;
                 }
             }

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -11,6 +11,7 @@ use Phan\Analysis\Analyzable;
 use Phan\AST\UnionTypeVisitor;
 use Phan\CodeBase;
 use Phan\Config;
+use Phan\Issue;
 use Phan\Language\Context;
 use Phan\Language\ElementContext;
 use Phan\Language\FileRef;
@@ -570,6 +571,15 @@ class Method extends ClassElement implements FunctionInterface
             );
         }
         foreach ($comment->getTemplateTypeList() as $template_type) {
+            if (!$method->isStatic() && $method->getInternalScope()->hasTemplateType($template_type->getName())) {
+                Issue::maybeEmit(
+                    $code_base,
+                    $element_context,
+                    Issue::TemplateTypeShadowsClass,
+                    $element_context->getLineNumberStart(),
+                    (string)$template_type
+                );
+            }
             $method->getInternalScope()->addTemplateType($template_type);
         }
 

--- a/tests/files/expected/1006_generic_type_duplicate.php.expected
+++ b/tests/files/expected/1006_generic_type_duplicate.php.expected
@@ -1,0 +1,3 @@
+%s:20 PhanTemplateTypeShadowsClass Template type T is already declared in the containing class
+%s:36 PhanTemplateTypeDuplicate Template type T is already declared in this comment
+%s:49 PhanTemplateTypeDuplicate Template type U is already declared in this comment

--- a/tests/files/src/1006_generic_type_duplicate.php
+++ b/tests/files/src/1006_generic_type_duplicate.php
@@ -1,0 +1,56 @@
+<?
+
+/**
+ * @template T
+ */
+class A {
+	/** @var T */
+	private $t;
+
+	/** @param T $t */
+	function __construct($t) {
+		$this->t = $t;
+	}
+
+	/**
+	 * @template T
+	 * @param T $t
+	 * @return T
+	 */
+	function test($t) {
+		return $t;
+	}
+
+	/**
+	 * @template T
+	 * @param T $t
+	 * @return T
+	 */
+	static function test2($t) {
+		return $t;
+	}
+}
+
+/**
+ * @template T
+ * @template T
+ */
+class B {
+	/** @var T */
+	private $t;
+
+	/** @param T $t */
+	function __construct($t) {
+		$this->t = $t;
+	}
+
+	/**
+	 * @template U
+	 * @template U
+	 * @param U $t
+	 * @return U
+	 */
+	function test($t) {
+		return $t;
+	}
+}


### PR DESCRIPTION
PhanTemplateTypeDuplicate: When the same `@template` type appears more than once in one comment

PhanTemplateTypeShadowsClass: When the same `@template` type appears in a class comment and a (non-static) method comment