### PR TITLE
Fix EmptyFQSENException crash with intersection types in asClassFQSENList

### DIFF
--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -2967,24 +2967,31 @@ class UnionType implements Serializable, Stringable
             if ($class_type->isNativeType()) {
                 continue;
             }
-            // Get the class FQSEN
-            $class_fqsen = FullyQualifiedClassName::fromType($class_type);
-
-            if ($class_type->isStaticType()) {
-                if (!$context->isInClassScope()) {
-                    throw new IssueException(
-                        Issue::fromType(Issue::ContextNotObject)(
-                            $context->getFile(),
-                            $context->getLineNumberStart(),
-                            [
-                                $class_type->getName()
-                            ]
-                        )
-                    );
+            // Handle intersection types by iterating over their parts
+            $type_parts = $class_type instanceof IntersectionType ? $class_type->getTypeParts() : [$class_type];
+            foreach ($type_parts as $part) {
+                if ($part->isNativeType()) {
+                    continue;
                 }
-                yield $class_fqsen;
-            } else {
-                yield $class_fqsen;
+                // Get the class FQSEN
+                $class_fqsen = FullyQualifiedClassName::fromType($part);
+
+                if ($part->isStaticType()) {
+                    if (!$context->isInClassScope()) {
+                        throw new IssueException(
+                            Issue::fromType(Issue::ContextNotObject)(
+                                $context->getFile(),
+                                $context->getLineNumberStart(),
+                                [
+                                    $part->getName()
+                                ]
+                            )
+                        );
+                    }
+                    yield $class_fqsen;
+                } else {
+                    yield $class_fqsen;
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes a crash that occurs when analyzing code with intersection types (e.g., `A&B`) when using `--analyze-twice` or with plugins that call `asClassFQSENList()`.

## Error

```
ERROR: Phan\Exception\EmptyFQSENException: The name cannot be empty for FQSEN '\'
  in src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php:187
```

## Root Cause

- `UnionType::asClassFQSENList()` called `FullyQualifiedClassName::fromType()` directly on `IntersectionType` instances
- `IntersectionType` stores `\` as its internal name (set in parent constructor at `IntersectionType.php:52`)
- This caused `fromFullyQualifiedString('\')` to throw `EmptyFQSENException` because the name is empty after stripping the leading backslash

## Solution

Updated `UnionType::asClassFQSENList()` to:
- Detect `IntersectionType` instances
- Iterate over their constituent parts via `getTypeParts()`
- Yield an FQSEN for each non-native type part

This follows the same pattern already used elsewhere in the codebase (lines 763, 769, 4618, 6389).

## Example Code That Triggered the Crash

```php
<?php

interface ModuleInterface {
    public static function declareInput($loader): void;
}

interface ValidatableInterface {
    public static function validate(): bool;
}

/**
 * @param ModuleInterface&ValidatableInterface $module
 */
function processModule($module): void {
    // Static method call on intersection type parameter
    $module::declareInput(null);
    $module::validate();
}
```

When running with `--analyze-twice` or with a plugin that analyzes static calls, this would crash.

## Testing

- ✅ All 2116 unit tests pass
- ✅ Phan self-analysis with `--analyze-twice` completes successfully
- ✅ No regressions in type analysis behavior
- ✅ Fix verified against original crash scenario