### PR TITLE
Update php-ast instructions for the 1.1.3 requirement

### DIFF
--- a/src/Phan/Bootstrap.php
+++ b/src/Phan/Bootstrap.php
@@ -65,34 +65,23 @@ function phan_output_ast_installation_instructions(): void
         $extension_dir .= ' (extension directory does not exist and may need to be changed)';
     }
     if (DIRECTORY_SEPARATOR === '\\') {
-        if (PHP_VERSION_ID >= 80100 || !preg_match('/[a-zA-Z]/', PHP_VERSION)) {
-            // e.g. https://downloads.php.net/~windows/pecl/releases/ast/1.1.1/php_ast-1.1.1-8.0-nts-vs16-x64.zip for php 8.0, 64-bit non thread safe
-            // e.g. https://downloads.php.net/~windows/pecl/releases/ast/1.1.1/php_ast-1.1.1-7.4-ts-vc15-x86.zip for php 7.4, 32-bit thread safe
-            // The older release https://pecl.php.net/package/ast/1.0.16/windows has releases for PHP 7.3 and 7.4
-            $version = LATEST_KNOWN_PHP_AST_VERSION;
-            fprintf(
-                STDERR,
-                PHP_EOL . "Windows users can download php-ast from https://downloads.php.net/~windows/pecl/releases/ast/%s/php_ast-%s-%s-%s-%s-%s.zip" . PHP_EOL,
-                $version,
-                $version,
-                PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION,
-                // @phan-suppress-next-line PhanImpossibleCondition, PHP_ZTS is a boolean, but phan assumes it is always false
-                PHP_ZTS ? 'ts' : 'nts',
-                'vs16',
-                PHP_INT_SIZE == 4 ? 'x86' : 'x64'
-            );
-            fwrite(STDERR, "(if that link doesn't work, check https://downloads.php.net/~windows/pecl/releases/ast/ )" . PHP_EOL);
-            fwrite(STDERR, "php-ast 1.0.14 is the minimum php-ast version needed for PHP 8.1+." . PHP_EOL);
-
-            fwrite(STDERR, "To install php-ast, add php_ast.dll from the zip to $extension_dir," . PHP_EOL);
-        } else {
-            if (PHP_VERSION_ID < 70300) {
-                fwrite(STDERR, "php-ast 1.0.14 is the minimum php-ast version needed for PHP 8.1+." . PHP_EOL);
-            } else {
-                fprintf(STDERR, "Releases for php %s may not yet be available at https://downloads.php.net/~windows/pecl/releases/ast/" . PHP_EOL, PHP_VERSION);
-            }
-            fwrite(STDERR, "To build php-ast from source for Windows, see https://wiki.php.net/internals/windows/stepbystepbuild_sdk_2 and https://wiki.php.net/internals/windows/stepbystepbuild_sdk_2#building_pecl_extensions" . PHP_EOL);
-        }
+        // e.g. https://downloads.php.net/~windows/pecl/releases/ast/1.1.1/php_ast-1.1.1-8.0-nts-vs16-x64.zip for php 8.0, 64-bit non thread safe
+        // e.g. https://downloads.php.net/~windows/pecl/releases/ast/1.1.1/php_ast-1.1.1-7.4-ts-vc15-x86.zip for php 7.4, 32-bit thread safe
+        // The older release https://pecl.php.net/package/ast/1.0.16/windows has releases for PHP 7.3 and 7.4
+        $version = LATEST_KNOWN_PHP_AST_VERSION;
+        fprintf(
+            STDERR,
+            PHP_EOL . "Windows users can download php-ast from https://downloads.php.net/~windows/pecl/releases/ast/%s/php_ast-%s-%s-%s-%s-%s.zip" . PHP_EOL,
+            $version,
+            $version,
+            PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION,
+            // @phan-suppress-next-line PhanImpossibleCondition, PHP_ZTS is a boolean, but phan assumes it is always false
+            PHP_ZTS ? 'ts' : 'nts',
+            'vs16',
+            PHP_INT_SIZE == 4 ? 'x86' : 'x64'
+        );
+        fwrite(STDERR, "(if that link doesn't work, check https://downloads.php.net/~windows/pecl/releases/ast/ )" . PHP_EOL);
+        fwrite(STDERR, "To install php-ast, add php_ast.dll from the zip to $extension_dir," . PHP_EOL);
         fwrite(STDERR, "Then, enable php-ast by adding the following lines to your php.ini file at '$ini_path'" . PHP_EOL . PHP_EOL);
         if (!is_dir((string)$configured_extension_dir) && is_dir($new_extension_dir)) {
             fwrite(STDERR, "extension_dir=$new_extension_dir" . PHP_EOL);

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -895,7 +895,6 @@ class CLI
                         break;
                     }
                     $ast_version = (new ReflectionExtension('ast'))->getVersion();
-                    // In order to parse with AST version 85, 1.0.11+ is required
                     if (\version_compare($ast_version, Config::MINIMUM_AST_EXTENSION_VERSION) < 0) {
                         Config::setValue('use_polyfill_parser', true);
                         break;
@@ -3043,14 +3042,15 @@ EOB
     private static function exitIfAstVersionIsInvalid(): void
     {
         $ast_version = (string)\phpversion('ast');
-        if (\version_compare($ast_version, '1.0.0') <= 0) {
-            if ($ast_version === '') {
-                // Seen in php 7.3 with file_cache when ast is initially enabled but later disabled, due to the result of extension_loaded being assumed to be a constant by opcache.
-                CLI::printErrorToStderr("ERROR: extension_loaded('ast') is true, but phpversion('ast') is the empty string. You probably need to clear opcache (opcache.file_cache='" . \ini_get('opcache.file_cache') . "')" . PHP_EOL);
-            }
+        if ($ast_version === '') {
+            // Seen in php 7.3 with file_cache when ast is initially enabled but later disabled, due to the result of extension_loaded being assumed to be a constant by opcache.
+            CLI::printErrorToStderr("ERROR: extension_loaded('ast') is true, but phpversion('ast') is the empty string. You probably need to clear opcache (opcache.file_cache='" . \ini_get('opcache.file_cache') . "')" . PHP_EOL);
+        }
+
+        if (\version_compare($ast_version, Config::MINIMUM_AST_EXTENSION_VERSION) < 0) {
             // NOTE: We haven't loaded the autoloader yet, so these issue messages can't be colorized.
             CLI::printErrorToStderr(sprintf(
-                "Phan 6.x requires php-ast %s+ because it depends on AST version 85. php-ast '%s' is installed." . PHP_EOL,
+                "Phan 6.x requires php-ast %s+ because it depends on AST version 120. php-ast '%s' is installed." . PHP_EOL,
                 Config::MINIMUM_AST_EXTENSION_VERSION,
                 $ast_version
             ));
@@ -3058,14 +3058,6 @@ EOB
             \phan_output_ast_installation_instructions();
             \fwrite(STDERR, "Exiting without analyzing files." . PHP_EOL);
             exit(1);
-        }
-        if (\version_compare($ast_version, '1.0.11') < 0) {
-            CLI::printWarningToStderr(sprintf("php-ast %s is being used with Phan 6. php-ast 1.0.11 or newer is recommended for compatibility with plugins and support for AST version 85.\n", $ast_version));
-            // Reuse PHAN_SUPPRESS_AST_DEPRECATION for this purpose as well.
-            if (!getenv('PHAN_SUPPRESS_AST_DEPRECATION')) {
-                \phan_output_ast_installation_instructions();
-                fwrite(STDERR, "(Set PHAN_SUPPRESS_AST_DEPRECATION=1 to suppress this message)" . PHP_EOL);
-            }
         }
     }
 

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -53,7 +53,7 @@ class Config
     /**
      * The minimum AST extension version in the oldest php version supported by Phan.
      */
-    public const MINIMUM_AST_EXTENSION_VERSION = namespace\AST_VERSION === 85 ? '1.0.11' : '1.0.7';
+    public const MINIMUM_AST_EXTENSION_VERSION = '1.1.3';
 
     /**
      * The version of the Phan plugin system.

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -1016,6 +1016,7 @@ class Issue
                 self::CATEGORY_SYNTAX,
                 self::SEVERITY_CRITICAL,
                 // XXX can't improve on this until the minimum supported AST extension version is raised due to php-ast not providing the actual flags until AST version 85.
+                // TODO: Can improve now that we require version 120?
                 "Syntax error: Expected enum case {CONST} to have a value of type {TYPE} but it has no value",
                 self::REMEDIATION_A,
                 17016
@@ -1025,6 +1026,7 @@ class Issue
                 self::CATEGORY_SYNTAX,
                 self::SEVERITY_CRITICAL,
                 // XXX can't improve on this until the minimum supported AST extension version is raised due to php-ast not providing the actual flags until AST version 85.
+                // TODO: Can improve now that we require version 120?
                 "Syntax error: Expected enum case {CONST} not to have a value",
                 self::REMEDIATION_A,
                 17020


### PR DESCRIPTION
Phan 6 requires php-ast 1.1.3, but the error messages we output when an older version is installed still used previous version numbers. Update them and remove some outdated bits.