### PR TITLE
Increase AST flag mask from 20 to 26 bits

### DIFF
--- a/src/Phan/AST/ASTHasher.php
+++ b/src/Phan/AST/ASTHasher.php
@@ -69,7 +69,7 @@ class ASTHasher
      */
     private static function computeHash(Node $node): string
     {
-        $str = 'N' . $node->kind . ':' . ($node->flags & 0xfffff);
+        $str = 'N' . $node->kind . ':' . ($node->flags & 0x3ffffff);
         foreach ($node->children as $key => $child) {
             // added in PhanAnnotationAdder
             if (\is_string($key) && \strncmp($key, 'phan', 4) === 0) {


### PR DESCRIPTION
## Summary

The AST hash computation was masking node flags to 20 bits (`0xfffff`), but AST flag constants can be up to 25 bits (maximum value `0x1000000`).

This increases the mask to 26 bits (`0x3ffffff`) to accommodate all valid AST flag values without truncation.

## Technical Details

- Old mask: `0xfffff` (20 bits, max value 1,048,575)
- New mask: `0x3ffffff` (26 bits, max value 67,108,863)
- Maximum AST flag constant: `0x1000000` (16,777,216, requires 25 bits)

## Test Plan

Verified maximum AST constant value:
```php
php -r "
\$defined = get_defined_constants(true);
\$max = 0;
foreach (\$defined['ast'] ?? [] as \$value) {
    if (is_int(\$value) && \$value > \$max) \$max = \$value;
}
echo 'Max: ' . \$max . ' (0x' . dechex(\$max) . ')' . PHP_EOL;
"
# Output: Max: 16777216 (0x1000000)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)