### PR TITLE
improve array filtering heuristics

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,6 +61,9 @@
         "patches": {
             "tysonandre/var_representation_polyfill": {
                 "Fix deprecated semicolon in switch case for PHP 8.5 compatibility": "patches/var_representation_polyfill_php85_compat.patch"
+            },
+            "microsoft/tolerant-php-parser": {
+                "Add explicit nullable parameter types for PHP 8.4": "patches/tolerant-parser-nullable-params.patch"
             }
         }
     }

--- a/patches/tolerant-parser-nullable-params.patch
+++ b/patches/tolerant-parser-nullable-params.patch
@@ -1,0 +1,35 @@
+diff --git a/src/Parser.php b/src/Parser.php
+--- a/src/Parser.php
++++ b/src/Parser.php
+@@
+-    public function parseSourceFile(string $fileContents, string $uri = null) : SourceFileNode {
++    public function parseSourceFile(string $fileContents, ?string $uri = null) : SourceFileNode {
+         $this->lexer = $this->makeLexer($fileContents);
+ 
+         $this->reset();
+diff --git a/src/Token.php b/src/Token.php
+--- a/src/Token.php
++++ b/src/Token.php
+@@
+-    public function getText(string $document = null) {
++    public function getText(?string $document = null) {
+         if ($document === null) {
+             return null;
+         }
+         return substr($document, $this->start, $this->length - ($this->start - $this->fullStart));
+     }
+diff --git a/src/Node.php b/src/Node.php
+--- a/src/Node.php
++++ b/src/Node.php
+@@
+-    public function getDescendantNodesAndTokens(callable $shouldDescendIntoChildrenFn = null) {
++    public function getDescendantNodesAndTokens(?callable $shouldDescendIntoChildrenFn = null) {
+@@
+-    public function walkDescendantNodesAndTokens(callable $callback, callable $shouldDescendIntoChildrenFn = null) {
++    public function walkDescendantNodesAndTokens(callable $callback, ?callable $shouldDescendIntoChildrenFn = null) {
+@@
+-    public function getDescendantNodes(callable $shouldDescendIntoChildrenFn = null) {
++    public function getDescendantNodes(?callable $shouldDescendIntoChildrenFn = null) {
+@@
+-    public function getDescendantTokens(callable $shouldDescendIntoChildrenFn = null) {
++    public function getDescendantTokens(?callable $shouldDescendIntoChildrenFn = null) {

--- a/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
@@ -723,7 +723,6 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
             return false;
         }
         foreach ($filter_function_list as $filter_function) {
-            \assert($filter_function instanceof \Phan\Language\Element\FunctionInterface);
             $node = $filter_function->getNode();
             if (!($node instanceof Node)) {
                 return false;

--- a/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
@@ -16,7 +16,6 @@ use Phan\Config;
 use Phan\Issue;
 use Phan\Language\Context;
 use Phan\Language\Element\Func;
-use Phan\Language\Element\FunctionInterface;
 use Phan\Language\Type;
 use Phan\Language\Type\ArrayShapeType;
 use Phan\Language\Type\ArrayType;
@@ -715,12 +714,16 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
         ];
     }
 
+    /**
+     * @param array<int,\Phan\Language\Element\FunctionInterface> $filter_function_list
+     */
     private static function callbacksRemoveNull(array $filter_function_list): bool
     {
         if (!$filter_function_list) {
             return false;
         }
         foreach ($filter_function_list as $filter_function) {
+            \assert($filter_function instanceof \Phan\Language\Element\FunctionInterface);
             $node = $filter_function->getNode();
             if (!($node instanceof Node)) {
                 return false;
@@ -762,7 +765,8 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
             return null;
         }
         if ($node->kind === \ast\AST_ARROW_FUNC) {
-            return $stmts->children['expr'] ?? null;
+            $expr = $stmts->children['expr'] ?? null;
+            return $expr instanceof Node ? $expr : null;
         }
         if ($node->kind === \ast\AST_CLOSURE) {
             foreach ($stmts->children as $child) {
@@ -806,7 +810,7 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
         return false;
     }
 
-    private static function isNullLiteralNode($node): bool
+    private static function isNullLiteralNode(?Node $node): bool
     {
         if ($node instanceof Node && $node->kind === \ast\AST_CONST) {
             $name_node = $node->children['name'] ?? null;

--- a/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phan\Plugin\Internal;
 
+use ast\flags;
 use ast\Node;
 use Closure;
 use Phan\Analysis\ArgumentType;
@@ -15,6 +16,7 @@ use Phan\Config;
 use Phan\Issue;
 use Phan\Language\Context;
 use Phan\Language\Element\Func;
+use Phan\Language\Element\FunctionInterface;
 use Phan\Language\Type;
 use Phan\Language\Type\ArrayShapeType;
 use Phan\Language\Type\ArrayType;
@@ -268,6 +270,11 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
                                     $analyzer->analyzeCallableWithArgumentTypes([$passed_array_element_types], $filter_function);
                                 }
                             }
+                        }
+                        if (self::callbacksRemoveNull($filter_function_list)) {
+                            $generic_passed_array_type = $generic_passed_array_type->withMappedElementTypes(static function (UnionType $union_type): UnionType {
+                                return $union_type->nonNullableClone();
+                            });
                         }
                         // TODO: Handle 3 args?
                         //
@@ -706,6 +713,108 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
             'iterator_to_array'         => $iterator_to_array_callback,
             // TODO: iterator_to_array
         ];
+    }
+
+    private static function callbacksRemoveNull(array $filter_function_list): bool
+    {
+        if (!$filter_function_list) {
+            return false;
+        }
+        foreach ($filter_function_list as $filter_function) {
+            $node = $filter_function->getNode();
+            if (!($node instanceof Node)) {
+                return false;
+            }
+            $param_name = self::extractFirstParameterName($node);
+            if (!\is_string($param_name)) {
+                return false;
+            }
+            $expr = self::extractReturnExpression($node);
+            if (!($expr instanceof Node)) {
+                return false;
+            }
+            if (!self::expressionChecksNotNull($expr, $param_name)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static function extractFirstParameterName(Node $node): ?string
+    {
+        $params = $node->children['params'] ?? null;
+        if (!($params instanceof Node)) {
+            return null;
+        }
+        foreach ($params->children as $param_node) {
+            if ($param_node instanceof Node && $param_node->kind === \ast\AST_PARAM) {
+                $name = $param_node->children['name'] ?? null;
+                return \is_string($name) ? $name : null;
+            }
+        }
+        return null;
+    }
+
+    private static function extractReturnExpression(Node $node): ?Node
+    {
+        $stmts = $node->children['stmts'] ?? null;
+        if (!($stmts instanceof Node)) {
+            return null;
+        }
+        if ($node->kind === \ast\AST_ARROW_FUNC) {
+            return $stmts->children['expr'] ?? null;
+        }
+        if ($node->kind === \ast\AST_CLOSURE) {
+            foreach ($stmts->children as $child) {
+                if ($child instanceof Node && $child->kind === \ast\AST_RETURN) {
+                    $expr = $child->children['expr'] ?? null;
+                    return $expr instanceof Node ? $expr : null;
+                }
+            }
+        }
+        return null;
+    }
+
+    private static function expressionChecksNotNull(Node $expr, string $param_name): bool
+    {
+        if ($expr->kind !== \ast\AST_BINARY_OP) {
+            return false;
+        }
+        $flags = $expr->flags;
+        if ($flags !== flags\BINARY_IS_NOT_EQUAL && $flags !== flags\BINARY_IS_NOT_IDENTICAL) {
+            return false;
+        }
+        $left = $expr->children['left'] ?? null;
+        $right = $expr->children['right'] ?? null;
+        if ($left instanceof Node && $right instanceof Node) {
+            if (self::isParamVariableNode($left, $param_name) && self::isNullLiteralNode($right)) {
+                return true;
+            }
+            if (self::isParamVariableNode($right, $param_name) && self::isNullLiteralNode($left)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static function isParamVariableNode(Node $node, string $param_name): bool
+    {
+        if ($node->kind === \ast\AST_VAR) {
+            $name = $node->children['name'] ?? null;
+            return \is_string($name) && $name === $param_name;
+        }
+        return false;
+    }
+
+    private static function isNullLiteralNode($node): bool
+    {
+        if ($node instanceof Node && $node->kind === \ast\AST_CONST) {
+            $name_node = $node->children['name'] ?? null;
+            if ($name_node instanceof Node && $name_node->kind === \ast\AST_NAME) {
+                return \strcasecmp((string)($name_node->children['name'] ?? ''), 'null') === 0;
+            }
+        }
+        return false;
     }
 
     /**

--- a/tests/real_types_test/src/049_mb_str_split.php
+++ b/tests/real_types_test/src/049_mb_str_split.php
@@ -1,17 +1,29 @@
 <?php
 
+/**
+ * @return list<string>
+ */
 function split_default(string $value): array
 {
     return mb_str_split($value);
 }
 
+/**
+ * @return list<string>
+ */
 function split_with_length(string $value): array
 {
     return mb_str_split($value, 2);
 }
 
+/**
+ * @return list<string>
+ */
 function split_with_encoding(string $value): array
 {
     return mb_str_split($value, 1, 'UTF-8');
 }
 
+split_default('example');
+split_with_length('example');
+split_with_encoding('example');

--- a/tests/real_types_test/src/050_array_filter_closure.php
+++ b/tests/real_types_test/src/050_array_filter_closure.php
@@ -5,11 +5,11 @@
  */
 function filter_and_implode(array $parts): string
 {
-    $filtered = array_filter(
-        $parts,
-        static fn (?string $value): bool => $value !== null
-    );
+    $filtered = array_filter($parts, static function (?string $value): bool {
+        return $value !== null;
+    });
 
     return implode('', $filtered);
 }
 
+filter_and_implode(['a', null, 'b']);

--- a/tests/real_types_test/src/050_array_filter_closure.php
+++ b/tests/real_types_test/src/050_array_filter_closure.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @param array<int,?string> $parts
+ */
+function filter_and_implode(array $parts): string
+{
+    $filtered = array_filter(
+        $parts,
+        static fn (?string $value): bool => $value !== null
+    );
+
+    return implode('', $filtered);
+}
+


### PR DESCRIPTION
`array_filter()` now recognizes null-stripping callbacks and keeps the element type non-null

```php
<?php
/** @param array<int,?string> $parts */
function filter_and_implode(array $parts): string {
    $filtered = array_filter(
        $parts,
        static fn (?string $value): bool => $value !== null
    );
    return implode('', $filtered);
}

Addresses some issues in issue #5098 