### PR TITLE
better messaging on enum issues

### DIFF
--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -5117,7 +5117,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/v6/tests/files/expected/0799
 ## PhanSyntaxEnumCaseExpectedValue
 
 ```
-Syntax error: Expected enum case {CONST} to have a value of type {TYPE} but it has no value
+Syntax error: Case {CONST} of backed enum {CLASS} must have a value of type {TYPE}
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/v6/tests/files/expected/1145_enum_wrong_case_type.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/v6/tests/files/src/1145_enum_wrong_case_type.php#L5).
@@ -5125,7 +5125,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/v6/tests/files/expected/1145
 ## PhanSyntaxEnumCaseUnexpectedValue
 
 ```
-Syntax error: Expected enum case {CONST} not to have a value
+Syntax error: Case {CONST} of unit enum {CLASS} must not have a value
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/v6/tests/files/expected/1145_enum_wrong_case_type.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/v6/tests/files/src/1145_enum_wrong_case_type.php#L9).

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -997,9 +997,8 @@ class Issue
                 self::SyntaxEnumCaseExpectedValue,
                 self::CATEGORY_SYNTAX,
                 self::SEVERITY_CRITICAL,
-                // XXX can't improve on this until the minimum supported AST extension version is raised due to php-ast not providing the actual flags until AST version 85.
-                // TODO: Can improve now that we require version 120?
-                "Syntax error: Expected enum case {CONST} to have a value of type {TYPE} but it has no value",
+                // AST version 120+ exposes the enum backing type, so include the enum name in the diagnostic.
+                "Syntax error: Case {CONST} of backed enum {CLASS} must have a value of type {TYPE}",
                 self::REMEDIATION_A,
                 17016
             ),
@@ -1007,9 +1006,7 @@ class Issue
                 self::SyntaxEnumCaseUnexpectedValue,
                 self::CATEGORY_SYNTAX,
                 self::SEVERITY_CRITICAL,
-                // XXX can't improve on this until the minimum supported AST extension version is raised due to php-ast not providing the actual flags until AST version 85.
-                // TODO: Can improve now that we require version 120?
-                "Syntax error: Expected enum case {CONST} not to have a value",
+                "Syntax error: Case {CONST} of unit enum {CLASS} must not have a value",
                 self::REMEDIATION_A,
                 17020
             ),

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -1579,6 +1579,7 @@ class Clazz extends AddressableElement
                     Issue::SyntaxEnumCaseExpectedValue,
                     $enum_case->getContext()->getLineNumberStart(),
                     $name,
+                    $this->getRepresentationForIssue(),
                     $this->enum_type
                 );
             } else {
@@ -1587,7 +1588,8 @@ class Clazz extends AddressableElement
                     $enum_case->getContext(),
                     Issue::SyntaxEnumCaseUnexpectedValue,
                     $enum_case->getContext()->getLineNumberStart(),
-                    $name
+                    $name,
+                    $this->getRepresentationForIssue()
                 );
             }
         }

--- a/tests/files/expected/1130_enum.php.expected
+++ b/tests/files/expected/1130_enum.php.expected
@@ -12,4 +12,4 @@
 %s:23 PhanNoopNewNoSideEffects Unused result of new object creation expression in new HasDuplicate() (this is likely free of side effects - there is no known non-empty constructor or destructor)
 %s:23 PhanTypeInstantiateEnum Saw instantiation of enum \Enums\HasDuplicate
 %s:25 PhanClassContainsAbstractMethod non-abstract class \Enums\InvalidEnum contains abstract method \Enums\InvalidEnum::mustNotBeAbstract() declared at %s:29
-%s:27 PhanSyntaxEnumCaseUnexpectedValue Syntax error: Expected enum case Foo not to have a value
+%s:27 PhanSyntaxEnumCaseUnexpectedValue Syntax error: Case Foo of unit enum \Enums\InvalidEnum must not have a value

--- a/tests/files/expected/1137_enum_error_cases.php.expected
+++ b/tests/files/expected/1137_enum_error_cases.php.expected
@@ -11,5 +11,5 @@
 %s:24 PhanEnumCannotHaveProperties Enum \Mu is not allowed to declare instance or static properties but it contains property $publicProperty declared at %s:24
 %s:26 PhanInstanceMethodWithNoEnumCases Saw enum \Mu that declares no enum cases but contains instance method instanceMethod() declared at %s:26
 %s:39 PhanInvalidNode Cannot declare an enum case statement in a non-enum
-%s:43 PhanSyntaxEnumCaseUnexpectedValue Syntax error: Expected enum case HEARTS not to have a value
+%s:43 PhanSyntaxEnumCaseUnexpectedValue Syntax error: Case HEARTS of unit enum \Suit must not have a value
 %s:45 PhanTypeInstantiateEnum Saw instantiation of enum \Suit

--- a/tests/files/expected/1145_enum_wrong_case_type.php.expected
+++ b/tests/files/expected/1145_enum_wrong_case_type.php.expected
@@ -1,3 +1,3 @@
-%s:5 PhanSyntaxEnumCaseExpectedValue Syntax error: Expected enum case Hearts to have a value of type string but it has no value
-%s:9 PhanSyntaxEnumCaseUnexpectedValue Syntax error: Expected enum case ZERO not to have a value
+%s:5 PhanSyntaxEnumCaseExpectedValue Syntax error: Case Hearts of backed enum \NS1145\Suit must have a value of type string
+%s:9 PhanSyntaxEnumCaseUnexpectedValue Syntax error: Case ZERO of unit enum \NS1145\Nat1 must not have a value
 %s:13 PhanTypeUnexpectedEnumCaseType Saw enum case ZERO with a value of type 'zero' that did not match expected type int


### PR DESCRIPTION
Updated enum syntax issue templates to include the enum’s FQSEN and to distinguish backed vs unit enums when values are missing