### PR TITLE
PR #4871 for v6 - Enums as class constants

### DIFF
--- a/src/Phan/Analysis/ClassConstantTypesAnalyzer.php
+++ b/src/Phan/Analysis/ClassConstantTypesAnalyzer.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Phan\Analysis;
 
 use Phan\CodeBase;
+use Phan\Config;
 use Phan\Exception\IssueException;
 use Phan\Issue;
 use Phan\IssueFixSuggester;
 use Phan\Language\Element\Clazz;
 use Phan\Language\FQSEN\FullyQualifiedClassName;
+use Phan\Language\Type;
 use Phan\Language\Type\TemplateType;
 use Phan\Language\UnionType;
 
@@ -55,9 +57,11 @@ class ClassConstantTypesAnalyzer
                 }
                 // Look at each type in the parameter's Union Type
                 foreach ($union_type->withFlattenedArrayShapeOrLiteralTypeInstances()->getTypeSet() as $outer_type) {
-                    $has_object = $outer_type->isObject();
+                    $has_object = $outer_type->isObject() && !self::isAllowedClassConstantObjectType($code_base, $outer_type);
                     foreach ($outer_type->getReferencedClasses() as $type) {
-                        $has_object = true;
+                        if (!self::isAllowedClassConstantObjectType($code_base, $type)) {
+                            $has_object = true;
+                        }
                         // If it's a reference to self, its OK
                         if ($type->isSelfType()) {
                             continue;
@@ -104,5 +108,20 @@ class ClassConstantTypesAnalyzer
                 }
             }
         }
+    }
+
+    private static function isAllowedClassConstantObjectType(CodeBase $code_base, Type $type): bool
+    {
+        if (Config::get_closest_minimum_target_php_version_id() < 80100) {
+            return false;
+        }
+        if (!$type->isObject()) {
+            return false;
+        }
+        $class_fqsen = FullyQualifiedClassName::fromType($type);
+        if (!$code_base->hasClassWithFQSEN($class_fqsen)) {
+            return false;
+        }
+        return $code_base->getClassByFQSEN($class_fqsen)->isEnum();
     }
 }

--- a/tests/php82_files/expected/009_enum_class_constant.php.expected
+++ b/tests/php82_files/expected/009_enum_class_constant.php.expected
@@ -1,0 +1,2 @@
+%s:17 PhanCommentObjectInClassConstantType Impossible phpdoc declaration that a class constant \InvalidDocs09::NOT_VALID has a type \stdClass containing objects. This type is ignored during analysis.
+%s:20 PhanCommentObjectInClassConstantType Impossible phpdoc declaration that a class constant \InvalidDocs09::ALSO_NOT_VALID has a type \stdClass containing objects. This type is ignored during analysis.

--- a/tests/php82_files/src/009_enum_class_constant.php
+++ b/tests/php82_files/src/009_enum_class_constant.php
@@ -1,0 +1,28 @@
+<?php
+
+enum EnumCase09 {
+    case Single;
+}
+
+class ValidDocs09 {
+    /** @var EnumCase09 */
+    public const VALID = EnumCase09::Single;
+
+    /** @var array<int|string, array<int, string|EnumCase09>> */
+    public const ALSO_VALID = [[EnumCase09::Single]];
+}
+
+class InvalidDocs09 {
+    /** @var EnumCase09|stdClass */
+    public const NOT_VALID = EnumCase09::Single;
+
+    /** @var stdClass|EnumCase09 */
+    public const ALSO_NOT_VALID = EnumCase09::Single;
+}
+
+var_dump(
+    ValidDocs09::VALID->name,
+    ValidDocs09::ALSO_VALID[0][0]->name,
+    InvalidDocs09::NOT_VALID->name,
+    InvalidDocs09::ALSO_NOT_VALID->name
+);


### PR DESCRIPTION
Fix for issue #4870 from PR #4871 by @jdwx 

- treat enum types as allowable class-constant objects