### PR TITLE
Support multiline @param/@var/@return blocks docblocks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,6 +35,10 @@ New features (Analysis):
 - Full support for "new without parentheses" syntax (e.g., `new MyClass()->method()`)
   - Type inference works correctly across method chains
   - Property and array access supported
+- Multiline doc comments for `@param`, `@var`, and `@return`
+  - Doc comment parsing now normalizes multi-line `@param`, `@var`, and `@return`
+    annotations before analysis, allowing nested array/generic syntax to be laid out
+    across several lines without being misinterpreted.
 
 New features (CLI):
 - Add an `-n` flag that can be used to skip reading the Phan configuration and analyze only the files specified as arguments.
@@ -4729,4 +4733,3 @@ Please use version 0.8.x if you're using a version of PHP < 7.1.
 For best results, run version 0.8.x with PHP 7.0 if you are analyzing a codebase which normally runs on php <= 7.0
 (If php 7.1 is used, Phan will think that some new classes, methods, and functions exist or have different parameter lists because it gets this info from `Reflection`)
 
-???

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ Phan is able to perform the following kinds of analysis:
 * Supports generic arrays such as `int[]`, `UserObject[]`, `array<int,UserObject>`, etc..
 * Supports array shapes such as `array{key:string,otherKey:?stdClass}`, etc. (internally and in PHPDoc tags)
   This also supports indicating that fields of an array shape are optional
-  via `array{requiredKey:string,optionalKey?:string}` (useful for `@param`)
+  via `array{requiredKey:string,optionalKey?:string}` (useful for `@param`).
+  Multi-line forms of `@param`, `@var`, and `@return` annotations are normalized before being parsed, so docblocks can format nested arrays/generics over several lines.
 * Supports phpdoc [type annotations](https://github.com/phan/phan/wiki/Annotating-Your-Source-Code).
 * Supports inheriting phpdoc type annotations.
 * Supports checking that phpdoc type annotations are a narrowed form (E.g. subclasses/subtypes) of the real type signatures

--- a/src/Phan/Language/Element/Comment/Builder.php
+++ b/src/Phan/Language/Element/Comment/Builder.php
@@ -99,7 +99,7 @@ final class Builder
         bool $did_add_template_types = false
     ) {
         $this->comment = $comment;
-        $this->lines = \explode("\n", $comment);
+        $this->lines = \explode("\n", self::reduceMultiline($comment));
         $this->comment_lines_count = \count($this->lines);
         $this->code_base = $code_base;
         $this->context = $context;
@@ -330,7 +330,7 @@ final class Builder
             // > A tag always starts on a new line with an at-sign (@) followed by the name of the tag.
             // > Between the start of the line and the tag’s name (including at-sign) there may be one or more spaces or tabs.
             $line = \trim($line);
-            $trimmed = \preg_replace('/^\/?[\*\s]+/', '', $line);
+            $trimmed = \preg_replace('/^\/?[*\s]+/', '', $line);
             if (($trimmed[0] ?? '') !== '@') {
                 continue;
             }
@@ -1600,5 +1600,54 @@ final class Builder
             );
         }
         $this->issues = [];
+    }
+
+    private static function reduceMultiline(string $comment): string
+    {
+        return \implode('@', \array_map(
+            static function (string $annotation): string {
+                if (\strpos($annotation, "\n") === false
+                    || !\preg_match('/^((?:param|var|return)\s[^$\n]+[\[(<{])\n/', $annotation, $match)
+                ) {
+                    return $annotation;
+                }
+
+                $buffer = $match[1];
+                $remaining = \substr($annotation, \strlen($match[0]));
+                $level = 1;
+
+                while ($remaining !== '') {
+                    if (!\preg_match('/^[^\[(<{\])>}]*([\[(<{\])>}])/', $remaining, $match)) {
+                        $buffer .= $remaining;
+                        break;
+                    }
+
+                    if (\in_array($match[1], ['{', '<', '[', '('], true)) {
+                        $level++;
+                        $buffer .= $level
+                            ? \ltrim(\preg_replace('/\n\s+\*\s+/', ' ', "\n" . $match[0]))
+                            : $match[0];
+                        $remaining = \substr($remaining, \strlen($match[0]));
+                        continue;
+                    }
+
+                    if ((--$level) < 0) {
+                        return $annotation;
+                    }
+
+                    $inner = \substr($match[0], 0, -1);
+                    $inner = \rtrim(\preg_replace('/\n\s+\*\s+/', ' ', "\n" . $inner), "\n ,");
+                    $buffer .= \ltrim($inner) . $match[1];
+                    $remaining = \substr($remaining, \strlen($match[0]));
+                }
+
+                if ($level !== 0) {
+                    return $annotation;
+                }
+
+                return $buffer;
+            },
+            \explode('@', \str_replace("\r", '', $comment))
+        ));
     }
 }

--- a/tests/files/expected/0605_array_shape_template.php.expected
+++ b/tests/files/expected/0605_array_shape_template.php.expected
@@ -1,2 +1,2 @@
-%s:13 PhanUndeclaredMethod Call to undeclared method \stdClass::method
-%s:24 PhanTypeMismatchArgumentInternal%SReal Argument 1 ($string) is swap_pair([rand(0, 5),new stdClass()]) of type array{0:\stdClass,1:int} (real type array) but \strlen() takes string
+%s:16 PhanUndeclaredMethod Call to undeclared method \stdClass::method
+%s:27 PhanTypeMismatchArgumentInternal%SReal Argument 1 ($string) is swap_pair([rand(0, 5),new stdClass()]) of type array{0:\stdClass,1:int} (real type array) but \strlen() takes string

--- a/tests/files/src/0605_array_shape_template.php
+++ b/tests/files/src/0605_array_shape_template.php
@@ -1,7 +1,10 @@
 <?php
 /**
  * @template TClassName
- * @param array{class:class-string<TClassName>,args:array<int,mixed>} $params
+ * @param array{
+ *     class: class-string<TClassName>,
+ *     args: array<int, mixed>,
+ * } $params
  * @return TClassName
  */
 function class_instance_factory(array $params) {


### PR DESCRIPTION
This implements PR #4833 and issue #1488 in the v6 branch. Thanks to @kylekatarnls for the work on this.

Support multiline param/var/return blocks docblocks. Only those 3 support multiline.

eg.
```php
<?php
/**
 * @template TClassName
 * @param array{
 *     class: class-string<TClassName>,
 *     args: array<int, mixed>,
 * } $params
 * @return TClassName
 */
function class_instance_factory(array $params) {
    $class = $params['class'];
    $args = $params['args'];
    return new $class(...$args);
}
```