### PR TITLE
Avoid double-scanning -n files

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -41,9 +41,9 @@ New features (Analysis):
     across several lines without being misinterpreted.
 
 New features (CLI):
-- Add an `-n` flag that can be used to skip reading the Phan configuration and analyze only the files specified as arguments.
-  Example: `phan -n test1.php test2.php`
-  This is useful for quick testing without setting up a full Phan configuration.
+- `-n`/`--no-config-file` implicitly limits analysis to just the files provided
+  on the command line (e.g. `phan -n test1.php test2.php`) avoiding analysis of
+  the rest of the project when you only want quick ad-hoc checks.
 - Added support for incremental analysis, where only changed files and their dependents
   will be analyzed on subsequent runs. Significantly speeds up re-analysis.
   - Add the `--incremental` / `-i` option that enables incremental analysis.
@@ -4732,4 +4732,3 @@ The 0.8.x versions will be tracking syntax from PHP versions 7.0.x and is runnab
 Please use version 0.8.x if you're using a version of PHP < 7.1.
 For best results, run version 0.8.x with PHP 7.0 if you are analyzing a codebase which normally runs on php <= 7.0
 (If php 7.1 is used, Phan will think that some new classes, methods, and functions exist or have different parameter lists because it gets this info from `Reflection`)
-

--- a/src/Phan/CLI.php
+++ b/src/Phan/CLI.php
@@ -1028,6 +1028,12 @@ class CLI
 
         Phan::setPrinter($printer);
         Phan::setIssueCollector($collector);
+
+        $no_config_mode = array_key_exists('n', $opts) || array_key_exists('no-config-file', $opts);
+        if ($no_config_mode) {
+            $this->file_list_only = true;
+        }
+
         if (!$this->file_list_only) {
             // Merge in any remaining args on the CLI
             $this->file_list_in_config = \array_merge(
@@ -1040,10 +1046,7 @@ class CLI
         }
 
         // Handle positional file arguments (especially useful with -n flag)
-        if (array_key_exists('n', $opts)) {
-            // Mark it so we only analyze the specified files
-            $this->file_list_only = true;
-
+        if ($no_config_mode) {
             // Extract positional arguments from $argv
             // PHP's getopt doesn't provide a way to get remaining args, so we parse manually
             $positional_args = [];
@@ -1421,7 +1424,7 @@ class CLI
      */
     public function recomputeFileList(): void
     {
-        $this->file_list = $this->file_list_in_config;
+        $this->file_list = self::uniqueFileList($this->file_list_in_config);
 
         if (!$this->file_list_only) {
             // Merge in any files given in the config

--- a/tests/Phan/CLITest.php
+++ b/tests/Phan/CLITest.php
@@ -277,6 +277,46 @@ final class CLITest extends BaseTest
         );
     }
 
+    /**
+     * @suppress PhanAccessMethodInternal
+     * @throws ExitException
+     * @throws UsageException
+     */
+    public function testNoConfigPositionalArgs(): void
+    {
+        $extensions_to_disable = CLI::extensionsToDisable();
+        if (count($extensions_to_disable) > 0) {
+            $this->markTestIncomplete('PHP extension(s) has to be disabled in order for this test to run: ' . implode(', ', $extensions_to_disable));
+        }
+
+        $project_root = \dirname(__DIR__) . '/misc/config/';
+        $opts = ['n' => false, 'project-root-directory' => $project_root];
+        $argv = ['./phan', '-n', 'src/a.php', 'src/b.php'];
+        $cli = CLI::fromRawValues($opts, $argv);
+
+        $this->assertSame(['src/a.php', 'src/b.php'], $cli->getFileList());
+    }
+
+    /**
+     * @suppress PhanAccessMethodInternal
+     * @throws ExitException
+     * @throws UsageException
+     */
+    public function testNoConfigPositionalArgsDeduplicate(): void
+    {
+        $extensions_to_disable = CLI::extensionsToDisable();
+        if (count($extensions_to_disable) > 0) {
+            $this->markTestIncomplete('PHP extension(s) has to be disabled in order for this test to run: ' . implode(', ', $extensions_to_disable));
+        }
+
+        $project_root = \dirname(__DIR__) . '/misc/config/';
+        $opts = ['n' => false, 'project-root-directory' => $project_root];
+        $argv = ['./phan', '-n', 'src/a.php', 'src/a.php'];
+        $cli = CLI::fromRawValues($opts, $argv);
+
+        $this->assertSame(['src/a.php'], $cli->getFileList());
+    }
+
     public function testSameVersionAsNEWS(): void
     {
         $news = \file_get_contents(\dirname(__DIR__, 2) . '/NEWS.md');


### PR DESCRIPTION
Make `--file-list-only` implicit when using `phan -n file1 file2` to avoid double-scanning files.