### PR TITLE
Suppress property mismatch warnings when refining nested fields

### DIFF
--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -85,6 +85,9 @@ class AssignmentVisitor extends AnalysisVisitor
      */
     private $assignment_node;
 
+    /** @var bool suppress property mismatch warnings when refining nested fields */
+    private $suppress_dim_property_mismatch;
+
     /**
      * @param CodeBase $code_base
      * The global code base we're operating within
@@ -114,7 +117,8 @@ class AssignmentVisitor extends AnalysisVisitor
         Node $assignment_node,
         UnionType $right_type,
         int $dim_depth = 0,
-        ?UnionType $dim_type = null
+        ?UnionType $dim_type = null,
+        bool $suppress_dim_property_mismatch = false
     ) {
         parent::__construct($code_base, $context);
 
@@ -122,6 +126,7 @@ class AssignmentVisitor extends AnalysisVisitor
         $this->dim_depth = $dim_depth;
         $this->dim_type = $dim_type;  // null for `$x[] =` or when dim_depth is 0.
         $this->assignment_node = $assignment_node;
+        $this->suppress_dim_property_mismatch = $suppress_dim_property_mismatch;
     }
 
     /**
@@ -911,7 +916,8 @@ class AssignmentVisitor extends AnalysisVisitor
             $this->assignment_node,
             $right_type,
             $this->dim_depth + 1,
-            $dim_type
+            $dim_type,
+            $this->suppress_dim_property_mismatch
         ))->__invoke($expr_node);
 
         return $context;
@@ -1263,6 +1269,9 @@ class AssignmentVisitor extends AnalysisVisitor
             return;
         }
         if (self::isRealMismatch($this->code_base, $property->getRealUnionType(), $resolved_right_type)) {
+            if ($this->suppress_dim_property_mismatch && $this->dim_depth > 0) {
+                return;
+            }
             $this->emitIssue(
                 Issue::TypeMismatchPropertyReal,
                 $node->lineno,
@@ -1290,6 +1299,9 @@ class AssignmentVisitor extends AnalysisVisitor
                 $property_union_type,
                 PostOrderAnalysisVisitor::toDetailsForRealTypeMismatch($property_union_type)
             );
+            return;
+        }
+        if ($this->suppress_dim_property_mismatch && $this->dim_depth > 0) {
             return;
         }
         $this->emitIssue(

--- a/src/Phan/Analysis/ConditionVisitorUtil.php
+++ b/src/Phan/Analysis/ConditionVisitorUtil.php
@@ -721,7 +721,10 @@ trait ConditionVisitorUtil
                 // There is a difference between `if (is_string($x['field']))` and `$x['field'] = remove_string_types($x['field'])` for the way the `elseif` should be analyzed.
                 $context->withClonedScope(),
                 $node,
-                $new_field_type
+                $new_field_type,
+                0,
+                null,
+                true
             ))->__invoke($node);
         } catch (IssueException $exception) {
             if (!$suppress_issues) {
@@ -1554,7 +1557,10 @@ trait ConditionVisitorUtil
             // There is a difference between `if (is_string($x['field']))` and `$x['field'] = (some string)` for the way the `elseif` should be analyzed.
             $context->withClonedScope(),
             $node,
-            $new_field_type
+            $new_field_type,
+            0,
+            null,
+            true
         ))->__invoke($node);
     }
 

--- a/tests/files/expected/1150_property_dim_condition.php.expected
+++ b/tests/files/expected/1150_property_dim_condition.php.expected
@@ -1,0 +1,1 @@
+%s:5 PhanTypeArraySuspicious Suspicious array access to $this->p of type int

--- a/tests/files/src/1150_property_dim_condition.php
+++ b/tests/files/src/1150_property_dim_condition.php
@@ -1,0 +1,9 @@
+<?php
+class C1150 {
+    private int $p;
+    public function f(): void {
+        if (is_array($this->p['x'])) {
+            echo 'array';
+        }
+    }
+}


### PR DESCRIPTION
A possible fix for issue #5062