### PR TITLE
Fix issue #5054

### DIFF
--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -2540,6 +2540,10 @@ class Type implements Stringable
                     $iterator_type->getTemplateParameterTypeMap($code_base)
                 );
             }
+            $template_key_type = $iterator_type->keyTypeOfTraversable();
+            if ($template_key_type instanceof UnionType && !$template_key_type->isEmpty()) {
+                return $template_key_type->asRealUnionType();
+            }
             return $result;
         }
         return StringType::instance(false)->asRealUnionType();
@@ -2635,6 +2639,10 @@ class Type implements Stringable
                 $result = $result->withTemplateParameterTypeMap(
                     $iterator_type->getTemplateParameterTypeMap($code_base)
                 );
+            }
+            $template_value_type = $iterator_type->valueTypeOfTraversable();
+            if ($template_value_type instanceof UnionType && !$template_value_type->isEmpty()) {
+                return $template_value_type->asRealUnionType();
             }
             return $result;
         }

--- a/tests/files/expected/5054_array_iterator_template.php.expected
+++ b/tests/files/expected/5054_array_iterator_template.php.expected
@@ -1,0 +1,3 @@
+%s:13 PhanDebugAnnotation @phan-debug-var requested for variable $iterator - it has union type \ArrayIterator<string,string>(real=\ArrayIterator)
+%s:15 PhanDebugAnnotation @phan-debug-var requested for variable $key - it has union type string(real=int|null|string)
+%s:15 PhanDebugAnnotation @phan-debug-var requested for variable $value - it has union type string(real=mixed)

--- a/tests/files/expected/5054_array_iterator_template.php.expected
+++ b/tests/files/expected/5054_array_iterator_template.php.expected
@@ -1,3 +1,3 @@
-%s:13 PhanDebugAnnotation @phan-debug-var requested for variable $iterator - it has union type \ArrayIterator<string,string>(real=\ArrayIterator)
-%s:15 PhanDebugAnnotation @phan-debug-var requested for variable $key - it has union type string(real=int|null|string)
-%s:15 PhanDebugAnnotation @phan-debug-var requested for variable $value - it has union type string(real=mixed)
+%s:10 PhanDebugAnnotation @phan-debug-var requested for variable $iterator - it has union type \ArrayIterator<string,string>(real=\ArrayIterator)
+%s:12 PhanDebugAnnotation @phan-debug-var requested for variable $key - it has union type string(real=int|null|string)
+%s:12 PhanDebugAnnotation @phan-debug-var requested for variable $value - it has union type string(real=mixed)

--- a/tests/files/src/5054_array_iterator_template.php
+++ b/tests/files/src/5054_array_iterator_template.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+/**
+ * @return ArrayIterator<string,string>
+ */
+function generateIterator(): ArrayIterator
+{
+    return new ArrayIterator(['k1' => 'a', 'k2' => 'b']);
+}
+
+$iterator = generateIterator();
+'@phan-debug-var $iterator';
+foreach ($iterator as $key => $value) {
+    '@phan-debug-var $key, $value';
+}


### PR DESCRIPTION
- Honored explicit iterator generics when inferring `foreach` keys/values by falling back to template arguments before returning `Iterator::key()/Iterator::current()` results, so `ArrayIterator<string,string>` now yields string element types instead of mixed.
- Added a regression test that exercises `ArrayIterator<string,string>` in a `foreach` loop