### PR TITLE
Fix bug #5036

### DIFF
--- a/src/Phan/Analysis/BlockExitStatusChecker.php
+++ b/src/Phan/Analysis/BlockExitStatusChecker.php
@@ -9,6 +9,7 @@ use ast;
 use ast\Node;
 use Phan\AST\Visitor\KindVisitorImplementation;
 use Phan\CodeBase;
+use Phan\Exception\CodeBaseException;
 use Phan\Exception\FQSENException;
 use Phan\Language\Context;
 use Phan\Language\FQSEN\FullyQualifiedClassName;
@@ -714,8 +715,24 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
             $method_name = $method;
         }
         // Look for the class and method
-        if ($class_name === 'self') {
-            $class_fqsen = $this->context->getClassFQSEN();
+        $class_fqsen = null;
+        $normalized_class_name = \is_string($class_name) ? \strtolower($class_name) : '';
+        if ($normalized_class_name === 'self' || $normalized_class_name === 'static') {
+            $class_fqsen = $this->context->getClassFQSENOrNull();
+            if ($class_fqsen === null) {
+                return self::STATUS_PROCEED;
+            }
+        } elseif ($normalized_class_name === 'parent') {
+            try {
+                $class = $this->context->getClassInScope($this->code_base);
+            } catch (CodeBaseException $e) {
+                // @phan-suppress-previous-line PhanUnusedVariableCaughtException
+                return self::STATUS_PROCEED;
+            }
+            if (!$class->hasParentType()) {
+                return self::STATUS_PROCEED;
+            }
+            $class_fqsen = $class->getParentClassFQSEN();
         } else {
             try {
                 $class_fqsen = FullyQualifiedClassName::fromStringInContext(
@@ -727,6 +744,9 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
                 // Cannot find, cannot infer
                 return self::STATUS_PROCEED;
             }
+        }
+        if ($class_fqsen === null) {
+            return self::STATUS_PROCEED;
         }
         $method_fqsen = FullyQualifiedMethodName::make(
             $class_fqsen,

--- a/src/Phan/Analysis/BlockExitStatusChecker.php
+++ b/src/Phan/Analysis/BlockExitStatusChecker.php
@@ -715,13 +715,9 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
             $method_name = $method;
         }
         // Look for the class and method
-        $class_fqsen = null;
-        $normalized_class_name = \is_string($class_name) ? \strtolower($class_name) : '';
+        $normalized_class_name = \strtolower($class_name);
         if ($normalized_class_name === 'self' || $normalized_class_name === 'static') {
             $class_fqsen = $this->context->getClassFQSENOrNull();
-            if ($class_fqsen === null) {
-                return self::STATUS_PROCEED;
-            }
         } elseif ($normalized_class_name === 'parent') {
             try {
                 $class = $this->context->getClassInScope($this->code_base);
@@ -745,7 +741,7 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
                 return self::STATUS_PROCEED;
             }
         }
-        if ($class_fqsen === null) {
+        if (!isset($class_fqsen) || $class_fqsen === null) {
             return self::STATUS_PROCEED;
         }
         $method_fqsen = FullyQualifiedMethodName::make(

--- a/src/Phan/Analysis/BlockExitStatusChecker.php
+++ b/src/Phan/Analysis/BlockExitStatusChecker.php
@@ -741,7 +741,7 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
                 return self::STATUS_PROCEED;
             }
         }
-        if (!isset($class_fqsen) || $class_fqsen === null) {
+        if (!isset($class_fqsen)) {
             return self::STATUS_PROCEED;
         }
         $method_fqsen = FullyQualifiedMethodName::make(

--- a/tests/plugin_test/src/224_noreturn_method_parent_static.php
+++ b/tests/plugin_test/src/224_noreturn_method_parent_static.php
@@ -1,0 +1,28 @@
+<?php
+
+class ParentNeverReturn
+{
+    protected static function terminate(): never
+    {
+        exit;
+    }
+}
+
+class ChildNeverReturn extends ParentNeverReturn
+{
+    public static function viaParent(): never
+    {
+        parent::terminate();
+    }
+
+    public static function viaStatic(): never
+    {
+        static::terminate();
+    }
+}
+
+if ((rand() % 2) > 0) {
+    ChildNeverReturn::viaParent();
+} else {
+    ChildNeverReturn::viaStatic();
+}


### PR DESCRIPTION
- Updated `computeStatusOfStaticCall()` to resolve `parent::` and `static::` targets via the current scope, ensuring calls to inherited never methods are treated as non-returning