### PR TITLE
Fix bug #5024

### DIFF
--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
@@ -144,6 +144,10 @@ final class VariableTrackerVisitor extends AnalysisVisitor
      */
     public function visitCall(Node $node): VariableTrackingScope
     {
+        $args = $node->children['args'] ?? null;
+        if ($args instanceof Node) {
+            $this->markArgumentsModifiedByReference($args);
+        }
         if (isset($node->dynamic_var_uses)) {
             $this->handleDynamicVarUses($node, $node->dynamic_var_uses);
         }
@@ -700,6 +704,53 @@ final class VariableTrackerVisitor extends AnalysisVisitor
     public static function markVariableAsModifiedByReference(Node $node): void
     {
         $node->modified_by_reference = true;
+    }
+
+    private function markArgumentsModifiedByReference(Node $args): void
+    {
+        foreach ($args->children as $argument) {
+            if (!($argument instanceof Node)) {
+                continue;
+            }
+            if ($argument->kind === ast\AST_NAMED_ARG) {
+                $argument = $argument->children['expr'];
+                if (!($argument instanceof Node)) {
+                    continue;
+                }
+            }
+            // @phan-suppress-next-line PhanUndeclaredProperty set by ArgumentType analyzer
+            if (!isset($argument->is_reference)) {
+                continue;
+            }
+            $this->markArgumentExpressionModifiedByReference($argument);
+        }
+    }
+
+    private function markArgumentExpressionModifiedByReference(Node $argument): void
+    {
+        switch ($argument->kind) {
+            case ast\AST_VAR:
+                self::markVariableAsModifiedByReference($argument);
+                return;
+            case ast\AST_DIM:
+            case ast\AST_PROP:
+                $expr = $argument->children['expr'] ?? null;
+                if ($expr instanceof Node) {
+                    $this->markArgumentExpressionModifiedByReference($expr);
+                }
+                return;
+            case ast\AST_STATIC_PROP:
+                // Static properties such as self::$prop don't correspond to local variables, nothing to mark.
+                return;
+            case ast\AST_REF:
+                $expr = $argument->children['var'] ?? null;
+                if ($expr instanceof Node) {
+                    $this->markArgumentExpressionModifiedByReference($expr);
+                }
+                return;
+            default:
+                return;
+        }
     }
 
     /**

--- a/tests/files/expected/0872_noop_closure.php.expected
+++ b/tests/files/expected/0872_noop_closure.php.expected
@@ -1,2 +1,1 @@
-%s:3 PhanPossiblyInfiniteLoop The loop condition $count does not seem to change within the loop and nothing seems to exit the loop
 %s:4 PhanParamNameIndicatingUnusedInClosure Saw a parameter named $_. If this was used to indicate that a parameter is unused to Phan, consider using @unused-param after a param comment or suppressing unused parameter warnings instead. PHP 8.0 introduces support for named parameters, so changing names to suppress unused parameter warnings is no longer recommended.

--- a/tests/files/src/0872_noop_closure.php
+++ b/tests/files/src/0872_noop_closure.php
@@ -4,6 +4,6 @@ function test_str_replace($value)  {
         $value = preg_replace_callback('/ab/', function ($_) {
             return '';
         }, $value, -1, $count);
-    } while ($count);  // TODO: Figure out reason for PhanPossiblyInfiniteLoop
+    } while ($count);
     return $value;
 }

--- a/tests/plugin_test/expected/225_infinite_loop_preg_replace.php.expected
+++ b/tests/plugin_test/expected/225_infinite_loop_preg_replace.php.expected
@@ -1,0 +1,2 @@
+src/225_infinite_loop_preg_replace.php:3 PhanPluginUseReturnValueNoopVoid The function/method \demo_loop() is declared to return void and it has no side effects
+src/225_infinite_loop_preg_replace.php:3 PhanUnreferencedFunction Possibly zero references to function \demo_loop()

--- a/tests/plugin_test/src/225_infinite_loop_preg_replace.php
+++ b/tests/plugin_test/src/225_infinite_loop_preg_replace.php
@@ -1,0 +1,8 @@
+<?php
+
+function demo_loop(string $input): void
+{
+    do {
+        $input = preg_replace('/ph/', '(f)', $input, -1, $count);
+    } while ($count > 0);
+}


### PR DESCRIPTION
- Guarded the new pass-by-reference tracking so it only descends into nodes that actually expose an `expr`, skipping static-property nodes and preventing crashes on patterns like `self::$prop`