### PR TITLE
Bug5001

### DIFF
--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -1603,6 +1603,17 @@ class ContextNode
         $class_without_property = null;
         $property = null;
         $properties = [];
+        $expr_node = $node->children['expr'] ?? $node->children['class'] ?? null;
+        $expr_union_type = null;
+        if ($expr_node instanceof Node) {
+            $expr_union_type = UnionTypeVisitor::unionTypeFromNode(
+                $this->code_base,
+                $this->context,
+                $expr_node
+            );
+        }
+        $expr_is_this = !$is_static && $expr_node instanceof Node && $expr_node->kind === ast\AST_VAR && (($expr_node->children['name'] ?? null) === 'this');
+        $expr_has_static_type = $expr_union_type ? $expr_union_type->hasStaticType() : false;
         foreach ($class_list as $class) {
             $class_fqsen = $class->getFQSEN();
 
@@ -1632,7 +1643,9 @@ class ContextNode
                     );
                 }
 
-                $class_without_property = $class;
+                if (!($class->isInterface() && $expr_is_this && $expr_has_static_type)) {
+                    $class_without_property = $class;
+                }
                 continue;
             }
             if ($properties && $should_return_first_match) {
@@ -1696,17 +1709,28 @@ class ContextNode
         if ($properties) {
             if ($class_without_property && Config::get_strict_object_checking() &&
                     !($node->flags & PhanAnnotationAdder::FLAG_IGNORE_UNDEF)) {
-                $this->emitIssue(
-                    Issue::PossiblyUndeclaredPropertyOfClass,
-                    $node->lineno,
-                    $property_name,
-                    UnionTypeVisitor::unionTypeFromNode(
-                        $this->code_base,
-                        $this->context,
-                        $node->children['expr'] ?? $node->children['class']
-                    ),
-                    $class_without_property->getFQSEN()
-                );
+                    $union_type_for_issue = $expr_union_type;
+                    if ($union_type_for_issue === null) {
+                        $expr_or_class = $node->children['expr'] ?? $node->children['class'];
+                        if ($expr_or_class instanceof Node) {
+                            $union_type_for_issue = UnionTypeVisitor::unionTypeFromNode(
+                                $this->code_base,
+                                $this->context,
+                                $expr_or_class
+                            );
+                        } else {
+                            $union_type_for_issue = UnionType::empty();
+                        }
+                    }
+                    if (!($class_without_property && $class_without_property->isInterface() && $expr_is_this && $expr_has_static_type)) {
+                        $this->emitIssue(
+                            Issue::PossiblyUndeclaredPropertyOfClass,
+                            $node->lineno,
+                            $property_name,
+                            $union_type_for_issue,
+                            $class_without_property->getFQSEN()
+                        );
+                    }
             }
             return $properties;
         }

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -1707,30 +1707,30 @@ class ContextNode
             self::checkPossiblyUndeclaredInstanceProperty($this->code_base, $this->context, $node, $property_name);
         }
         if ($properties) {
-            if ($class_without_property && Config::get_strict_object_checking() &&
+            if ($class_without_property instanceof Clazz && Config::get_strict_object_checking() &&
                     !($node->flags & PhanAnnotationAdder::FLAG_IGNORE_UNDEF)) {
-                    $union_type_for_issue = $expr_union_type;
-                    if ($union_type_for_issue === null) {
-                        $expr_or_class = $node->children['expr'] ?? $node->children['class'];
-                        if ($expr_or_class instanceof Node) {
-                            $union_type_for_issue = UnionTypeVisitor::unionTypeFromNode(
-                                $this->code_base,
-                                $this->context,
-                                $expr_or_class
-                            );
-                        } else {
-                            $union_type_for_issue = UnionType::empty();
-                        }
-                    }
-                    if (!($class_without_property && $class_without_property->isInterface() && $expr_is_this && $expr_has_static_type)) {
-                        $this->emitIssue(
-                            Issue::PossiblyUndeclaredPropertyOfClass,
-                            $node->lineno,
-                            $property_name,
-                            $union_type_for_issue,
-                            $class_without_property->getFQSEN()
+                $union_type_for_issue = $expr_union_type;
+                if ($union_type_for_issue === null) {
+                    $expr_or_class = $node->children['expr'] ?? $node->children['class'];
+                    if ($expr_or_class instanceof Node) {
+                        $union_type_for_issue = UnionTypeVisitor::unionTypeFromNode(
+                            $this->code_base,
+                            $this->context,
+                            $expr_or_class
                         );
+                    } else {
+                        $union_type_for_issue = UnionType::empty();
                     }
+                }
+                if (!($class_without_property->isInterface() && $expr_is_this && $expr_has_static_type)) {
+                    $this->emitIssue(
+                        Issue::PossiblyUndeclaredPropertyOfClass,
+                        $node->lineno,
+                        $property_name,
+                        $union_type_for_issue,
+                        $class_without_property->getFQSEN()
+                    );
+                }
             }
             return $properties;
         }

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -1003,6 +1003,16 @@ class AssignmentVisitor extends AnalysisVisitor
         $property = null;
         $class_with_property = null;
         $class_without_property = null;
+        $expr_union_type = null;
+        $expr_has_static_type = false;
+        if ($expr_node instanceof Node) {
+            $expr_union_type = UnionTypeVisitor::unionTypeFromNode(
+                $this->code_base,
+                $this->context,
+                $expr_node
+            );
+            $expr_has_static_type = $expr_union_type->hasStaticType();
+        }
         foreach ($class_list as $clazz) {
             if ($clazz->isPropertyImmutableFromContext($this->code_base, $this->context, $property_name)) {
                 $this->emitTypeModifyImmutableObjectPropertyIssue($clazz, $property_name, $node);
@@ -1012,7 +1022,9 @@ class AssignmentVisitor extends AnalysisVisitor
             // a setter
             if (!$clazz->hasPropertyWithName($this->code_base, $property_name)) {
                 if (!$clazz->hasMethodWithName($this->code_base, '__set', true)) {
-                    $class_without_property = $clazz;
+                    if (!($clazz->isInterface() && $expr_node instanceof Node && $expr_node->kind === \ast\AST_VAR && $expr_node->children['name'] === 'this' && $expr_has_static_type)) {
+                        $class_without_property = $clazz;
+                    }
                     continue;
                 }
             }
@@ -1039,17 +1051,19 @@ class AssignmentVisitor extends AnalysisVisitor
 
         if ($property && $class_with_property) {
             if ($class_without_property && Config::get_strict_object_checking()) {
-                $this->emitIssue(
-                    Issue::PossiblyUndeclaredPropertyOfClass,
-                    $node->lineno,
-                    $property_name,
-                    UnionTypeVisitor::unionTypeFromNode(
-                        $this->code_base,
-                        $this->context,
-                        $node->children['expr'] ?? $node->children['class']
-                    ),
-                    $class_without_property->getFQSEN()
-                );
+                if (!($class_without_property->isInterface() && $expr_node instanceof Node && $expr_node->kind === \ast\AST_VAR && $expr_node->children['name'] === 'this' && $expr_has_static_type)) {
+                    $this->emitIssue(
+                        Issue::PossiblyUndeclaredPropertyOfClass,
+                        $node->lineno,
+                        $property_name,
+                        $expr_union_type ?? UnionTypeVisitor::unionTypeFromNode(
+                            $this->code_base,
+                            $this->context,
+                            $node->children['expr'] ?? $node->children['class']
+                        ),
+                        $class_without_property->getFQSEN()
+                    );
+                }
             }
             try {
                 return $this->analyzePropAssignment($class_with_property, $property, $node);

--- a/tests/files/src/5058_trait_interface_property.php
+++ b/tests/files/src/5058_trait_interface_property.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+interface Issue5001FooInterface
+{
+    public function doFoo(): void;
+}
+
+interface Issue5001BazInterface
+{
+    public function checkFoo(Issue5001FooInterface $foo): bool;
+    public function doBaz(Issue5001FooInterface $foo): void;
+}
+
+trait Issue5001Trait
+{
+    /** @var list<Issue5001BazInterface> */
+    private array $panels = [];
+
+    public function doFoo(Issue5001BazInterface $panel): void
+    {
+        if ($this instanceof Issue5001FooInterface && $panel->checkFoo($this)) {
+            throw new \InvalidArgumentException('Foo.');
+        }
+        $this->panels[] = $panel;
+    }
+}
+
+class Issue5001Dummy
+{
+    use Issue5001Trait;
+}
+
+(new Issue5001Dummy())->doFoo(new class implements Issue5001BazInterface {
+    public function checkFoo(Issue5001FooInterface $foo): bool
+    {
+        return false;
+    }
+
+    public function doBaz(Issue5001FooInterface $foo): void
+    {
+    }
+});


### PR DESCRIPTION
When a trait property is accessed after an instanceof check, we were flattening the `(static & Interface) | static` type and warning that the interface lacked the property even though the same `$this` instance (via static) provides it.
 - Updated `ContextNode::getPropertyListInternal()` to cache the expression’s union type, detect the $this access, and skip treating interface-only branches as missing the property in that case
 - Mirrored that logic for assignments so `$this->… = …` is handled consistently