### PR TITLE
Fix bug #4896

### DIFF
--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -1690,12 +1690,14 @@ class ContextNode
             }
         }
         if (!$is_static && Config::get_strict_object_checking() &&
-                !($node->flags & PhanAnnotationAdder::FLAG_IGNORE_UNDEF)) {
+                !($node->flags & PhanAnnotationAdder::FLAG_IGNORE_UNDEF) &&
+                $node->kind !== ast\AST_NULLSAFE_PROP) {
             self::checkPossiblyUndeclaredInstanceProperty($this->code_base, $this->context, $node, $property_name);
         }
         if ($properties) {
             if ($class_without_property && Config::get_strict_object_checking() &&
-                    !($node->flags & PhanAnnotationAdder::FLAG_IGNORE_UNDEF)) {
+                    !($node->flags & PhanAnnotationAdder::FLAG_IGNORE_UNDEF) &&
+                    $node->kind !== ast\AST_NULLSAFE_PROP) {
                 $this->emitIssue(
                     Issue::PossiblyUndeclaredPropertyOfClass,
                     $node->lineno,

--- a/tests/real_types_test/expected/011_nullsafe_property.php.expected
+++ b/tests/real_types_test/expected/011_nullsafe_property.php.expected
@@ -1,0 +1,17 @@
+src/011_nullsafe_property.php:4 PhanReadOnlyPublicProperty Possibly zero write references to public property \Address->street
+src/011_nullsafe_property.php:8 PhanReadOnlyPublicProperty Possibly zero write references to public property \Person->code
+src/011_nullsafe_property.php:9 PhanReadOnlyPublicProperty Possibly zero write references to public property \Person->address
+src/011_nullsafe_property.php:12 PhanUnreferencedClass Possibly zero references to class \Test
+src/011_nullsafe_property.php:13 PhanReadOnlyPublicProperty Possibly zero write references to public property \Test->person
+src/011_nullsafe_property.php:15 PhanUnreferencedPublicMethod Possibly zero references to public method \Test::testNullsafeOperator()
+src/011_nullsafe_property.php:17 PhanUnusedVariable Unused definition of variable $code
+src/011_nullsafe_property.php:20 PhanUnusedVariable Unused definition of variable $street
+src/011_nullsafe_property.php:23 PhanPossiblyUndeclaredProperty Reference to possibly undeclared property street of expression of type ?\Address (null does not declare that property)
+src/011_nullsafe_property.php:23 PhanUnusedVariable Unused definition of variable $mixed
+src/011_nullsafe_property.php:26 PhanUnreferencedPublicMethod Possibly zero references to public method \Test::testRegularAccess()
+src/011_nullsafe_property.php:28 PhanPossiblyUndeclaredProperty Reference to possibly undeclared property code of expression of type ?\Person (null does not declare that property)
+src/011_nullsafe_property.php:28 PhanUnusedVariable Unused definition of variable $code
+src/011_nullsafe_property.php:31 PhanPossiblyUndeclaredProperty Reference to possibly undeclared property address of expression of type ?\Person (null does not declare that property)
+src/011_nullsafe_property.php:31 PhanUnusedVariable Unused definition of variable $street
+src/011_nullsafe_property.php:34 PhanUnreferencedPublicMethod Possibly zero references to public method \Test::testNonNullable()
+src/011_nullsafe_property.php:37 PhanUnusedVariable Unused definition of variable $code

--- a/tests/real_types_test/src/011_nullsafe_property.php
+++ b/tests/real_types_test/src/011_nullsafe_property.php
@@ -1,0 +1,39 @@
+<?php
+
+class Address {
+    public string $street = '123 Main St';
+}
+
+class Person {
+    public int $code = 123;
+    public ?Address $address = null;
+}
+
+class Test {
+    public ?Person $person = null;
+
+    public function testNullsafeOperator(): void {
+        // Should NOT trigger PhanPossiblyUndeclaredProperty - using nullsafe operator
+        $code = $this->person?->code;
+
+        // Should NOT trigger - chained nullsafe operators
+        $street = $this->person?->address?->street;
+
+        // Mixed nullsafe and regular access
+        $mixed = $this->person?->address->street; // Should NOT trigger on address, but could on street
+    }
+
+    public function testRegularAccess(): void {
+        // SHOULD trigger PhanPossiblyUndeclaredProperty - regular property access on nullable
+        $code = $this->person->code;
+
+        // Should trigger on person property
+        $street = $this->person->address?->street;
+    }
+
+    public function testNonNullable(): void {
+        $person = new Person();
+        // Should NOT trigger - non-nullable
+        $code = $person->code;
+    }
+}


### PR DESCRIPTION
Phan was not distinguishing between regular property access (`->`) and nullsafe property access (`?->`) when checking for possibly undeclared properties with `strict_object_checking` enabled. The nullsafe operator is specifically designed to handle null gracefully, so warning about "null does not declare that property" is incorrect.

The fix adds a simple check to exclude `AST_NULLSAFE_PROP` nodes from the strict object checking that would otherwise emit false positive warnings.