### PR TITLE
A possible fix for bug #4951

### DIFF
--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -1471,6 +1471,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/v6/tests/files/expected/0669
 Unused definition of variable ${VARIABLE} as the value of a foreach loop that included keys
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/v6/tests/files/expected/4951_array_key_literal.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/v6/tests/files/src/4951_array_key_literal.php#L34).
 
 ## PhanUseConstantNoEffect
 

--- a/src/Phan/Language/Type/ArrayShapeType.php
+++ b/src/Phan/Language/Type/ArrayShapeType.php
@@ -224,6 +224,18 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
         if (\count($this->field_types) === 0) {
             return UnionType::empty();
         }
+        $union_type_builder = new UnionTypeBuilder();
+        foreach ($this->field_types as $key => $_) {
+            if (\is_string($key)) {
+                $union_type_builder->addType(LiteralStringType::instanceForValue($key, false));
+                continue;
+            }
+            $union_type_builder->addType(LiteralIntType::instanceForValue($key, false));
+        }
+        $literal_key_types = $union_type_builder->getTypeSet();
+        if ($literal_key_types) {
+            return UnionType::of($literal_key_types);
+        }
         return GenericArrayType::unionTypeForKeyType($this->getKeyType());
     }
 

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -65,6 +65,7 @@ use function count;
 use function implode;
 use function in_array;
 use function is_int;
+use function preg_match;
 use function substr;
 
 /**
@@ -4003,11 +4004,21 @@ class UnionType implements Serializable, Stringable
                     $key_union_type = UnionType::fromFullyQualifiedPHPDocString('int|string');
                 } else {
                     foreach ($key_union_type->getTypeSet() as $key_type) {
-                        if ($key_type instanceof StringType && $key_type->isPossiblyNumeric()) {
-                            // Numeric literals such as `'0'` cast to 0 when inserted as array keys.
-                            $new_real_type_builder->addType(IntType::instance(false));
-                            break;
+                        if (!($key_type instanceof StringType)) {
+                            continue;
                         }
+                        if ($key_type instanceof LiteralStringType) {
+                            $value = $key_type->getValue();
+                            if (!preg_match('/^[-+]?[0-9]+$/D', $value)) {
+                                // Strings with decimals or other characters remain strings as array keys.
+                                continue;
+                            }
+                        } elseif (!$key_type->isPossiblyNumeric()) {
+                            continue;
+                        }
+                        // Numeric literals such as `'0'` cast to 0 when inserted as array keys.
+                        $new_real_type_builder->addType(IntType::instance(false));
+                        break;
                     }
                 }
             }

--- a/tests/files/expected/0396_array_key_type_foreach.php.expected
+++ b/tests/files/expected/0396_array_key_type_foreach.php.expected
@@ -1,4 +1,4 @@
-%s:6 PhanTypeMismatchArgumentInternal Argument 1 ($string) is $key of type int but \strlen() takes string
-%s:9 PhanTypeMismatchArgumentInternal Argument 1 ($num1) is $key2 of type string but \intdiv() takes int
+%s:6 PhanTypeMismatchArgumentInternal Argument 1 ($string) is $key of type 0|1 but \strlen() takes string
+%s:9 PhanTypeMismatchArgumentInternal Argument 1 ($num1) is $key2 of type 'key'|'other' but \intdiv() takes int
 %s:12 PhanTypeMismatchArgumentInternal Argument 1 ($string) is $key3 of type int but \strlen() takes string
 %s:18 PhanTypeMismatchArgumentInternal%SReal Argument 1 ($object) is $key of type int|string but \get_class() takes object

--- a/tests/files/expected/0615_nested_array_foreach.php.expected
+++ b/tests/files/expected/0615_nested_array_foreach.php.expected
@@ -1,2 +1,2 @@
-%s:26 PhanTypeMismatchArgumentInternal%SReal Argument 1 ($value) is $key of type int but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array%S
+%s:26 PhanTypeMismatchArgumentInternal Argument 1 ($value) is $key of type 0 but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array
 %s:28 PhanTypeSuspiciousEcho Suspicious argument $_2 of type \stdClass for an echo/print statement

--- a/tests/files/expected/0622_foreach_complex.php.expected
+++ b/tests/files/expected/0622_foreach_complex.php.expected
@@ -1,2 +1,2 @@
-%s:15 PhanTypeMismatchArgumentInternal%SReal Argument 1 ($string) is $x of type array{field:string,field2:'value'} but \strlen() takes string
+%s:15 PhanTypeMismatchArgumentInternal%SReal Argument 1 ($string) is $x of type array{field:'key',field2:'value'} but \strlen() takes string
 %s:16 PhanTypeMismatchArgumentInternal%SReal Argument 1 ($string) is $o of type \stdClass but \strlen() takes string

--- a/tests/files/expected/0770_array_real_key.php.expected
+++ b/tests/files/expected/0770_array_real_key.php.expected
@@ -1,5 +1,5 @@
 %s:12 PhanTypeMismatchArgumentInternal Argument 1 ($string) is $i of type int but \strlen() takes string
-%s:17 PhanTypeMismatchArgumentInternal Argument 1 ($num1) is $i of type string but \intdiv() takes int
-%s:21 PhanTypeMismatchArgumentReal Argument 1 ($s) is $i of type int but \accepts_string() takes string defined at %s:3
+%s:17 PhanTypeMismatchArgumentInternal Argument 1 ($num1) is $i of type 'x' but \intdiv() takes int
+%s:21 PhanTypeMismatchArgument Argument 1 ($s) is $i of type 0|1 but \accepts_string() takes string defined at %s:3
 %s:29 PhanTypeMismatchArgumentInternal Argument 1 ($num1) is $i of type string but \intdiv() takes int
 %s:30 PhanTypeMismatchArgumentInternal%SReal Argument 1 ($string) is $value of type array{0:'value'} but \strlen() takes string

--- a/tests/files/expected/0808_array_key_exists_misuse.php.expected
+++ b/tests/files/expected/0808_array_key_exists_misuse.php.expected
@@ -1,3 +1,3 @@
 %s:15 PhanImpossibleTypeComparison Impossible attempt to check if null of type null is identical to keys of $others of type int|string
 %s:15 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($key) is null of type null but \array_key_exists() takes int|string
-%s:21 PhanImpossibleTypeComparison Impossible attempt to check if $i of type int is identical to keys of DEFAULT_SETTINGS of type string
+%s:21 PhanImpossibleTypeComparison Impossible attempt to check if $i of type int is identical to keys of DEFAULT_SETTINGS of type 'blocking'|'timeout'

--- a/tests/real_types_test/expected/004_array_real_key.php.expected
+++ b/tests/real_types_test/expected/004_array_real_key.php.expected
@@ -1,7 +1,7 @@
 src/004_array_real_key.php:8 PhanDebugAnnotation @phan-debug-var requested for variable $values - it has union type int|list<mixed>(real=array|int|null)
 src/004_array_real_key.php:10 PhanTypeMismatchArgumentInternal Argument 1 ($string) is $i of type int but \strlen() takes string
-src/004_array_real_key.php:15 PhanTypeMismatchArgumentInternal Argument 1 ($num1) is $i of type string but \intdiv() takes int
-src/004_array_real_key.php:19 PhanTypeMismatchArgumentReal Argument 1 ($s) is $i of type int but \accepts_string() takes string defined at src/004_array_real_key.php:3
+src/004_array_real_key.php:15 PhanTypeMismatchArgumentInternal Argument 1 ($num1) is $i of type 'x' but \intdiv() takes int
+src/004_array_real_key.php:19 PhanTypeMismatchArgument Argument 1 ($s) is $i of type 0|1 but \accepts_string() takes string defined at src/004_array_real_key.php:3
 src/004_array_real_key.php:23 PhanPluginUnknownArrayFunctionReturnType Function \create_array() has a return type of array, but does not specify key or value types
 src/004_array_real_key.php:23 PhanUnreferencedFunction Possibly zero references to function \create_array()
 src/004_array_real_key.php:27 PhanTypeMismatchArgumentInternal Argument 1 ($num1) is $i of type string but \intdiv() takes int


### PR DESCRIPTION
Not completely sure about this one. I followed @Daimona's suggestion of returning a union of LiteralStringType/LiteralIntType keys where array-shape offsets are known, so foreach keys keep concrete values and dynamic static calls get credited as references. It seems like everything works and the messaging is actually more informative because you see the literal values now. Please test it.