### PR TITLE
Fix bug #4863

### DIFF
--- a/src/Phan/Analysis/ArgumentType.php
+++ b/src/Phan/Analysis/ArgumentType.php
@@ -31,8 +31,10 @@ use Phan\Language\Type;
 use Phan\Language\Type\ArrayShapeType;
 use Phan\Language\Type\ArrayType;
 use Phan\Language\Type\FalseType;
+use Phan\Language\Type\GenericArrayType;
 use Phan\Language\Type\IntType;
 use Phan\Language\Type\MixedType;
+use Phan\Language\Type\NonEmptyArrayInterface;
 use Phan\Language\Type\NullType;
 use Phan\Language\Type\TemplateType;
 use Phan\Language\UnionType;
@@ -1167,6 +1169,9 @@ final class ArgumentType
 
             // See if the argument can be cast to the parameter.
             if ($argument_type_resolved->canCastToUnionType($alternate_parameter_type, $code_base)) {
+                if (self::hasIncompatibleEmptyAndNonEmptyArray($code_base, $argument_type_resolved, $alternate_parameter_type)) {
+                    continue;
+                }
                 if ($alternate_parameter_type->hasRealTypeSet() && $argument_type->hasRealTypeSet()) {
                     $real_parameter_type = $alternate_parameter_type->getRealUnionType();
                     $real_argument_type = $argument_type->getRealUnionType();
@@ -1284,6 +1289,55 @@ final class ArgumentType
     private static function hasTemplateTypeFromFunctionRecursive(UnionType $union_type, FunctionInterface $function): bool {
         foreach ($union_type->getTypesRecursively() as $type) {
             if ($type instanceof TemplateType && $function->declaresTemplateTypeInComment($type)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static function hasIncompatibleEmptyAndNonEmptyArray(CodeBase $code_base, UnionType $argument_type, UnionType $parameter_type): bool
+    {
+        if ($parameter_type->typeCount() !== 1) {
+            return false;
+        }
+        $param_type = $parameter_type->getTypeSet()[0] ?? null;
+        if (!($param_type instanceof GenericArrayType)) {
+            return false;
+        }
+        $types = $argument_type->getTypeSet();
+        if (count($types) !== 2) {
+            return false;
+        }
+        $saw_empty_array = false;
+        $non_empty_array = null;
+        foreach ($types as $type) {
+            if ($type instanceof ArrayShapeType && !$type->getFieldTypes()) {
+                $saw_empty_array = true;
+                continue;
+            }
+            if ($type instanceof NonEmptyArrayInterface) {
+                if ($non_empty_array !== null) {
+                    return false;
+                }
+                $non_empty_array = $type;
+                continue;
+            }
+            return false;
+        }
+        if (!$saw_empty_array || !$non_empty_array) {
+            return false;
+        }
+        $possibly_empty = $non_empty_array->asPossiblyEmptyArrayType();
+        if (!($possibly_empty instanceof GenericArrayType)) {
+            return false;
+        }
+        if ($possibly_empty->getKeyType() !== $param_type->getKeyType()) {
+            return false;
+        }
+        $element_union = $possibly_empty->genericArrayElementUnionType();
+        $target_element_union = $param_type->genericArrayElementUnionType();
+        if (!$element_union->canCastToUnionType($target_element_union, $code_base)) {
+            if (!$target_element_union->canCastToUnionType($element_union, $code_base)) {
                 return true;
             }
         }

--- a/tests/files/expected/4863_array_value_types.php.expected
+++ b/tests/files/expected/4863_array_value_types.php.expected
@@ -1,0 +1,2 @@
+%s:15 PhanDebugAnnotation @phan-debug-var requested for variable $var - it has union type array{}|non-empty-associative-array<int,\stdClass>(real=array{}|non-empty-associative-array<int,\stdClass>)
+%s:19 PhanTypeMismatchArgument Argument 1 ($bar) is $var of type array{}|non-empty-associative-array<int,\stdClass> but \myFunc() takes array<int,string> defined at %s:6

--- a/tests/files/src/4863_array_value_types.php
+++ b/tests/files/src/4863_array_value_types.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @param array<int,string> $bar
+ */
+function myFunc(array $bar): void {
+    echo $bar[0];
+}
+
+/**
+ * @param int[] $ints
+ */
+function buildAndCall(array $ints): void {
+    $var = [];
+    foreach ($ints as $val) {
+        $var[$val] = new stdClass();
+    }
+    '@phan-debug-var $var';
+    myFunc($var);
+}
+
+buildAndCall([1, 2, 3]);


### PR DESCRIPTION
Phan now re-checks union arguments that mix an empty array with a known non-empty array. If the non-empty branch’s element type can’t match the parameter’s declared type, the call is rejected instead of silently passing.
```php
  <?php
  function myFunc(array<int,string> $bar): void {}

  $var = [];
  foreach ([1] as $i) {
      $var[$i] = new stdClass();  // non-empty associative array of stdClass
  }

  myFunc($var);  // Phan now reports PhanTypeMismatchArgument
```