### PR TITLE
Fix bug #5053: Inherit @phan-mandatory-param from interface methods

### DIFF
--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -860,6 +860,7 @@ trait FunctionTrait
         }
         $real_type_set = $parameter->getNonVariadicUnionType()->getRealTypeSet();
         $parameter_name = $parameter->getName();
+        $is_mandatory_in_phpdoc = false;
         if ($comment->hasParameterWithNameOrOffset(
             $parameter_name,
             $parameter_offset
@@ -869,10 +870,28 @@ trait FunctionTrait
                 $parameter_offset
             );
             if ($comment_param->isMandatoryInPHPDoc()) {
-                $function->recordHasMandatoryPHPDocParamAtOffset($parameter_offset);
+                $is_mandatory_in_phpdoc = true;
             }
         } else {
             $comment_param = null;
+        }
+
+        // Check overridden methods (from parent classes/interfaces) for @phan-mandatory-param
+        if (!$is_mandatory_in_phpdoc && $function instanceof Method) {
+            foreach ($function->getOverriddenMethods($code_base) as $overridden_method) {
+                $overridden_comment = $overridden_method->getComment();
+                if ($overridden_comment && $overridden_comment->hasParameterWithNameOrOffset($parameter_name, $parameter_offset)) {
+                    $overridden_param = $overridden_comment->getParameterWithNameOrOffset($parameter_name, $parameter_offset);
+                    if ($overridden_param->isMandatoryInPHPDoc()) {
+                        $is_mandatory_in_phpdoc = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        if ($is_mandatory_in_phpdoc) {
+            $function->recordHasMandatoryPHPDocParamAtOffset($parameter_offset);
         }
         if ($parameter->getNonVariadicUnionType()->isEmpty()) {
             // If there is no type specified in PHP, check

--- a/tests/files/expected/5053_interface_mandatory_param.php.expected
+++ b/tests/files/expected/5053_interface_mandatory_param.php.expected
@@ -1,0 +1,4 @@
+%s:47 PhanParamTooFewInPHPDoc Call with 1 arg(s) to \Test::func(string $a, ?mixed $b = null) which has phpdoc indicating it requires 2 arg(s) ($b is mandatory) defined at %s:14
+%s:50 PhanParamTooFewInPHPDoc Call with 1 arg(s) to \Test2::func(string $a, ?mixed $b = null) which has phpdoc indicating it requires 2 arg(s) ($b is mandatory) defined at %s:23
+%s:53 PhanParamTooFewInPHPDoc Call with 1 arg(s) to \Test3::func(string $a, ?string $b = null) which has phpdoc indicating it requires 2 arg(s) ($b is mandatory) defined at %s:33
+%s:56 PhanParamTooFewInPHPDoc Call with 1 arg(s) to \Test4::func(string $a, ?string $b = null) which has phpdoc indicating it requires 2 arg(s) ($b is mandatory) defined at %s:42

--- a/tests/files/src/5053_interface_mandatory_param.php
+++ b/tests/files/src/5053_interface_mandatory_param.php
@@ -1,0 +1,62 @@
+<?php
+
+interface ITest {
+    /**
+     * @param string $a
+     * @param string|null $b @phan-mandatory-param
+     */
+    public function func($a, $b = null);
+}
+
+// Test case 1: Method implementation with no PHPDoc
+// Should inherit @phan-mandatory-param from interface
+class Test implements ITest {
+    public function func($a, $b = null) {}
+}
+
+// Test case 2: Method implementation with partial PHPDoc
+// Should inherit @phan-mandatory-param from interface
+class Test2 implements ITest {
+    /**
+     * @param string $a
+     */
+    public function func($a, $b = null) {}
+}
+
+// Test case 3: Method implementation with complete PHPDoc but no @phan-mandatory-param
+// Should inherit @phan-mandatory-param from interface
+class Test3 implements ITest {
+    /**
+     * @param string $a
+     * @param string|null $b
+     */
+    public function func($a, $b = null) {}
+}
+
+// Test case 4: Method with its own @phan-mandatory-param should still work
+class Test4 implements ITest {
+    /**
+     * @param string $a
+     * @param string|null $b @phan-mandatory-param
+     */
+    public function func($a, $b = null) {}
+}
+
+// All of these should emit PhanParamTooFewInPHPDoc
+$t = new Test();
+$t->func('hi');
+
+$t2 = new Test2();
+$t2->func('hi');
+
+$t3 = new Test3();
+$t3->func('hi');
+
+$t4 = new Test4();
+$t4->func('hi');
+
+// These should be fine (2 args provided)
+$t->func('hi', 'there');
+$t2->func('hi', 'there');
+$t3->func('hi', 'there');
+$t4->func('hi', 'there');


### PR DESCRIPTION
When a class implements an interface method without its own PHPDoc comment, or with a partial PHPDoc comment, the @phan-mandatory-param annotation from the interface method's comment should be inherited.

This fix modifies addParamToScopeOfFunctionOrMethod() to check overridden methods (from parent classes and interfaces) for @phan-mandatory-param annotations when the current method's comment doesn't have it.

This ensures that:
1. Methods without PHPDoc inherit the mandatory param annotation
2. Methods with partial PHPDoc (missing some @param tags) inherit it
3. Methods with complete PHPDoc but no @phan-mandatory-param inherit it
4. The annotation works correctly for both interfaces and abstract classes

Fixes #5053