### PR TITLE
Fix bug #5123

### DIFF
--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -366,8 +366,12 @@ class ParameterTypesAnalyzer
             return;
         }
         // Inherit (at)phan-pure annotations by default.
+        // EXCEPT for __call and __callStatic, which define completely new behavior when overridden.
         if ($overridden_method->isPure()) {
-            $method->setIsPure();
+            $method_name_lower = \strtolower($method->getName());
+            if ($method_name_lower !== '__call' && $method_name_lower !== '__callstatic') {
+                $method->setIsPure();
+            }
         }
 
         // Get the class that the overridden method lives on

--- a/tests/plugin_test/expected/251_magic_call_pure_override.php.expected
+++ b/tests/plugin_test/expected/251_magic_call_pure_override.php.expected
@@ -1,0 +1,17 @@
+src/251_magic_call_pure_override.php:9 PhanUnusedPublicMethodParameter Parameter $args is never used
+src/251_magic_call_pure_override.php:9 PhanUnusedPublicMethodParameter Parameter $name is never used
+src/251_magic_call_pure_override.php:16 PhanUnusedPublicMethodParameter Parameter $args is never used
+src/251_magic_call_pure_override.php:26 PhanUnusedPublicMethodParameter Parameter $args is never used
+src/251_magic_call_pure_override.php:26 PhanUnusedPublicMethodParameter Parameter $name is never used
+src/251_magic_call_pure_override.php:31 PhanUnreferencedFunction Possibly zero references to function \testChildWithSideEffects()
+src/251_magic_call_pure_override.php:36 PhanUnreferencedFunction Possibly zero references to function \testChildKeepsPure()
+src/251_magic_call_pure_override.php:38 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \ChildKeepsPure::__call() defined at src/251_magic_call_pure_override.php:26
+src/251_magic_call_pure_override.php:41 PhanUnreferencedFunction Possibly zero references to function \testParent()
+src/251_magic_call_pure_override.php:43 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \ParentWithPureCall::__call() defined at src/251_magic_call_pure_override.php:9
+src/251_magic_call_pure_override.php:51 PhanUnusedPublicMethodParameter Parameter $args is never used
+src/251_magic_call_pure_override.php:51 PhanUnusedPublicMethodParameter Parameter $name is never used
+src/251_magic_call_pure_override.php:56 PhanUnreferencedClass Possibly zero references to class \ChildOverridesCallStaticWithSideEffects
+src/251_magic_call_pure_override.php:57 PhanUnusedPublicMethodParameter Parameter $args is never used
+src/251_magic_call_pure_override.php:63 PhanUnreferencedFunction Possibly zero references to function \testCallStaticChild()
+src/251_magic_call_pure_override.php:67 PhanUnreferencedFunction Possibly zero references to function \testCallStaticParent()
+src/251_magic_call_pure_override.php:68 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \ParentWithPureCallStatic::__callStatic() defined at src/251_magic_call_pure_override.php:51

--- a/tests/plugin_test/src/251_magic_call_pure_override.php
+++ b/tests/plugin_test/src/251_magic_call_pure_override.php
@@ -1,0 +1,69 @@
+<?php
+
+// Test for issue #5123: Child class overriding __call should not inherit @phan-pure from parent
+
+class ParentWithPureCall {
+    /**
+     * @phan-pure
+     */
+    public function __call(string $name, array $args): int {
+        return 42;
+    }
+}
+
+class ChildOverridesWithSideEffects extends ParentWithPureCall {
+    // No @phan-pure annotation - has side effects
+    public function __call(string $name, array $args): int {
+        file_put_contents('/tmp/log.txt', "Called: $name\n", FILE_APPEND);
+        return 100;
+    }
+}
+
+class ChildKeepsPure extends ParentWithPureCall {
+    /**
+     * @phan-pure
+     */
+    public function __call(string $name, array $args): int {
+        return 999;
+    }
+}
+
+function testChildWithSideEffects() {
+    $child = new ChildOverridesWithSideEffects();
+    $child->someMethod();  // Should NOT warn - child's __call has side effects
+}
+
+function testChildKeepsPure() {
+    $child = new ChildKeepsPure();
+    $child->someMethod();  // SHOULD warn - child explicitly marked as @phan-pure
+}
+
+function testParent() {
+    $parent = new ParentWithPureCall();
+    $parent->someMethod();  // SHOULD warn - parent is @phan-pure
+}
+
+// Test __callStatic as well
+class ParentWithPureCallStatic {
+    /**
+     * @phan-pure
+     */
+    public static function __callStatic(string $name, array $args): int {
+        return 42;
+    }
+}
+
+class ChildOverridesCallStaticWithSideEffects extends ParentWithPureCallStatic {
+    public static function __callStatic(string $name, array $args): int {
+        file_put_contents('/tmp/log.txt', "Called: $name\n", FILE_APPEND);
+        return 100;
+    }
+}
+
+function testCallStaticChild() {
+    ChildOverridesCallStaticWithSideEffects::someMethod();  // Should NOT warn
+}
+
+function testCallStaticParent() {
+    ParentWithPureCallStatic::someMethod();  // SHOULD warn
+}


### PR DESCRIPTION
Fix false positives on incorrectly inherited the `@phan-pure` flag by excluding `__call` and `__callStatic` from automatic `@phan-pure` inheritance