### PR TITLE
Fix bug #4854

### DIFF
--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -50,6 +50,16 @@ class ConditionVisitor extends KindVisitorImplementation implements ConditionVis
     public const CONSTANT_EXISTS_PREFIX = "__phan\x00constant_exists_";
 
     /**
+     * @var int Maximum recursion depth for re-applying stored conditional expressions (issue #4854)
+     */
+    private const MAX_CONDITIONAL_EXPR_DEPTH = 3;
+
+    /**
+     * @var int Current depth when recursively processing stored conditional expressions (issue #4854)
+     */
+    private static $conditional_expr_depth = 0;
+
+    /**
      * @var Context
      * The context in which the node we're going to be looking
      * at exists.
@@ -562,7 +572,39 @@ class ConditionVisitor extends KindVisitorImplementation implements ConditionVis
     public function visitVar(Node $node): Context
     {
         $this->checkVariablesDefined($node);
-        return $this->removeFalseyFromVariable($node, $this->context, false);
+
+        // Fix for issue #4854: Check if this variable has a stored conditional expression
+        // BEFORE removeFalseyFromVariable, since that may clone the variable
+        $var_name = $node->children['name'];
+        $cond_expr = null;
+        if (\is_string($var_name) && self::$conditional_expr_depth < self::MAX_CONDITIONAL_EXPR_DEPTH) {
+            $variable = $this->context->getScope()->getVariableByNameOrNull($var_name);
+            if ($variable) {
+                // @phan-suppress-next-line PhanUndeclaredProperty - using AllowDynamicProperties
+                $cond_expr = $variable->phan_condition_expr ?? null;
+            }
+        }
+
+        $context = $this->removeFalseyFromVariable($node, $this->context, false);
+
+        // If this variable had a stored conditional expression (from an assignment like
+        // `$x = ($a instanceof Foo)`), re-apply that condition to properly narrow types
+        if ($cond_expr instanceof Node) {
+            // Recursively apply the stored conditional expression to narrow types
+            // This handles cases like: $hasCompare = ($a instanceof Foo); if ($hasCompare) { ... }
+            // Track depth to prevent infinite recursion
+            self::$conditional_expr_depth++;
+            try {
+                $context = (new ConditionVisitor(
+                    $this->code_base,
+                    $context
+                ))->__invoke($cond_expr);
+            } finally {
+                self::$conditional_expr_depth--;
+            }
+        }
+
+        return $context;
     }
 
     public function visitNullsafeProp(Node $node): Context

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -117,6 +117,61 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
     }
 
     /**
+     * Check if an expression has potential to narrow types when used in conditionals
+     * (e.g., instanceof, is_string(), etc.)
+     *
+     * @param Node $node The expression node to check
+     * @return bool True if the expression can narrow types
+     */
+    private static function exprHasTypeNarrowingPotential(Node $node): bool
+    {
+        switch ($node->kind) {
+            case ast\AST_INSTANCEOF:
+            case ast\AST_CALL:
+            case ast\AST_ISSET:
+            case ast\AST_EMPTY:
+                // These nodes can narrow types
+                return true;
+            case ast\AST_BINARY_OP:
+                // Binary operators like && and || may contain type-narrowing expressions
+                $left = $node->children['left'];
+                $right = $node->children['right'];
+                return ($left instanceof Node && self::exprHasTypeNarrowingPotential($left)) ||
+                       ($right instanceof Node && self::exprHasTypeNarrowingPotential($right));
+            case ast\AST_UNARY_OP:
+                // Unary ! operator may wrap a type-narrowing expression
+                $expr = $node->children['expr'];
+                return $expr instanceof Node && self::exprHasTypeNarrowingPotential($expr);
+            default:
+                return false;
+        }
+    }
+
+    /**
+     * Check if an expression references a specific variable (for detecting self-referential assignments)
+     *
+     * @param Node $node The expression node to check
+     * @param string $var_name The variable name to look for
+     * @return bool True if the expression references the variable
+     */
+    private static function exprReferencesVariable(Node $node, string $var_name): bool
+    {
+        if ($node->kind === ast\AST_VAR) {
+            $name = $node->children['name'];
+            return \is_string($name) && $name === $var_name;
+        }
+
+        // Recursively check children
+        foreach ($node->children as $child) {
+            if ($child instanceof Node && self::exprReferencesVariable($child, $var_name)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * @param Node $node
      * A node to parse
      *
@@ -185,6 +240,30 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             ))->getClosure();
 
             $method->addReference($this->context);
+        }
+
+        // Fix for issue #4854: Track conditional expressions assigned to boolean variables
+        // so that type narrowing can be re-applied when the variable is tested in conditionals
+        // Only store expressions that can actually narrow types (instanceof, is_string(), etc.)
+        // and avoid self-referential expressions like $x = $x || something (prevents infinite recursion)
+        if ($var_node->kind === ast\AST_VAR &&
+            $expr_node instanceof Node &&
+            self::exprHasTypeNarrowingPotential($expr_node) &&
+            $right_type->hasTypeMatchingCallback(static function (Type $type): bool {
+                return $type->getName() === 'bool' || $type->getName() === 'true' || $type->getName() === 'false';
+            })) {
+            // Get the variable name
+            $var_name = $var_node->children['name'];
+            if (\is_string($var_name) && !self::exprReferencesVariable($expr_node, $var_name)) {
+                // Get the variable from the context and attach the conditional expression to it
+                $variable = $context->getScope()->getVariableByNameOrNull($var_name);
+                if ($variable) {
+                    // Store the RHS expression node so ConditionVisitor can re-apply type narrowing
+                    // when this variable is tested in an if/while condition
+                    // @phan-suppress-next-line PhanUndeclaredProperty - using AllowDynamicProperties
+                    $variable->phan_condition_expr = $expr_node;
+                }
+            }
         }
 
         return $context;

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -256,6 +256,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             $var_name = $var_node->children['name'];
             if (\is_string($var_name) && !self::exprReferencesVariable($expr_node, $var_name)) {
                 // Get the variable from the context and attach the conditional expression to it
+                '@phan-var Context $context';  // Help fallback parser with type inference
                 $variable = $context->getScope()->getVariableByNameOrNull($var_name);
                 if ($variable) {
                     // Store the RHS expression node so ConditionVisitor can re-apply type narrowing

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -998,6 +998,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
         if ($expr_node instanceof Node) {
             if ($expr_node->kind === ast\AST_ARRAY) {
                 // e.g. foreach ([1, 2] as $value) has at least one
+                // @phan-suppress-next-line PhanPossiblyUndeclaredProperty - false positive exposed by issue #4854 fix, see visitVar()
                 $has_at_least_one_iteration = \count($expr_node->children) > 0;
             } else {
                 // e.g. look up global constants and class constants.

--- a/tests/files/expected/4854_instanceof_assignment.php.expected
+++ b/tests/files/expected/4854_instanceof_assignment.php.expected
@@ -1,0 +1,1 @@
+%s:55 PhanUndeclaredMethod Call to undeclared method \Foo::nah

--- a/tests/files/src/4854_instanceof_assignment.php
+++ b/tests/files/src/4854_instanceof_assignment.php
@@ -1,0 +1,67 @@
+<?php
+
+// Test for issue #4854: Type condition lost when intermediary variable is used
+
+abstract class IThing {}
+
+class Foo extends IThing {
+    public function compare($x): bool {
+        return true;
+    }
+}
+
+class Bar extends IThing {
+    public function compare($x): bool {
+        return false;
+    }
+}
+
+class Quux extends IThing {
+    public function nah($x): bool {
+        return true;
+    }
+}
+
+// This works fine - direct instanceof in condition
+function compare1(IThing $a, IThing $b): bool {
+    if ($a instanceof Foo || $a instanceof Bar) {
+        return $a->compare($b);  // No error - type is correctly narrowed
+    }
+    return false;
+}
+
+// This previously failed but should work with fix
+function compare2(IThing $a, IThing $b): bool {
+    $aHasCompare = ($a instanceof Foo || $a instanceof Bar);
+    if ($aHasCompare) {
+        return $a->compare($b);  // Should NOT error - type should be narrowed from boolean variable
+    }
+    return false;
+}
+
+// Test with more complex condition
+function compare3(IThing $a, IThing $b): bool {
+    $aIsValid = $a instanceof Foo || $a instanceof Bar || $a instanceof Quux;
+    if ($aIsValid) {
+        return $a->nah($b);  // Should NOT error - Quux has nah method
+    }
+    return false;
+}
+
+// Test that wrong method still errors
+function compare4(IThing $a, IThing $b): bool {
+    $aHasCompare = ($a instanceof Foo || $a instanceof Bar);
+    if ($aHasCompare) {
+        return $a->nah($b);  // SHOULD error - Foo/Bar don't have nah method
+    }
+    return false;
+}
+
+// Test with &&
+function compare5(IThing $a, IThing $b): bool {
+    $bothValid = ($a instanceof Foo && $b instanceof Bar);
+    if ($bothValid) {
+        return $a->compare($b);  // Should NOT error
+    }
+    return false;
+}


### PR DESCRIPTION
Fix losing type conditions when intermediary variables are used.
Watch out for self-referential assignments and add a recursion check just in case I missed something.
