### PR TITLE
Fix bug #4849

### DIFF
--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -3136,21 +3136,60 @@ class UnionTypeVisitor extends AnalysisVisitor
 
                     $union_type = $this->getDependentReturnTypeOfCall($method, $node);
 
-                    // Map template types to concrete types
+                    // Map template types to concrete types and resolve static types
                     // TODO: When the template types are part of the method doc comment, don't look it up in the class union type
-                    if (isset($node->children['expr']) && $union_type->hasTemplateTypeRecursive()) {
-                        // Get the type of the object calling the method
-                        $expression_type = UnionTypeVisitor::unionTypeFromNode(
-                            $this->code_base,
-                            $this->context,
-                            $node->children['expr'],
-                            $this->should_catch_issue_exception
-                        );
+                    if (isset($node->children['expr'])) {
+                        $expression_type = null;
 
-                        // Map template types to concrete types
-                        $union_type = $union_type->withTemplateParameterTypeMap(
-                            $expression_type->getTemplateParameterTypeMap($this->code_base)
-                        );
+                        // Handle static return types by preserving intersection types and generics
+                        if (!$method->isStatic() && $union_type->hasTypeMatchingCallback(
+                            function (Type $type): bool {
+                                return $type->hasStaticOrSelfTypesRecursive($this->code_base);
+                            }
+                        )) {
+                            // Get the type of the object calling the method
+                            $expression_type = UnionTypeVisitor::unionTypeFromNode(
+                                $this->code_base,
+                                $this->context,
+                                $node->children['expr'],
+                                $this->should_catch_issue_exception
+                            );
+
+                            // A method call like `$foo->returnThis()` returns the same type as
+                            // `$foo`, filtered to only the subtypes of the class we're analyzing.
+                            // This preserves intersection types and generic type parameters,
+                            // but avoids introducing impossible cases when `$foo` was a union.
+                            $class_fqsen = $class->getFQSEN();
+                            $static_type_for_this_call = $expression_type->findTypeMatchingCallback(
+                                function (Type $type) use ($class_fqsen): bool {
+                                    // Check if this type is the class itself or a subclass
+                                    if ($type->asFQSEN() === $class_fqsen) {
+                                        return true;
+                                    }
+                                    return $type->isSubclassOf($class_fqsen->asType(), $this->code_base);
+                                }
+                            );
+                            if ($static_type_for_this_call) {
+                                // Remove the base class type if present (Method::getUnionType() may add it)
+                                $union_type = $union_type->withoutType($class_fqsen->asType())
+                                    ->withStaticResolvedTo($static_type_for_this_call);
+                            }
+                        }
+
+                        if ($union_type->hasTemplateTypeRecursive()) {
+                            if (!$expression_type) {
+                                $expression_type = UnionTypeVisitor::unionTypeFromNode(
+                                    $this->code_base,
+                                    $this->context,
+                                    $node->children['expr'],
+                                    $this->should_catch_issue_exception
+                                );
+                            }
+                            // Map template types to concrete types
+                            $union_type = $union_type->withTemplateParameterTypeMap(
+                                $expression_type->getTemplateParameterTypeMap($this->code_base)
+                            );
+                        }
                     }
 
                     // Resolve any references to `static` or `static[]`

--- a/src/Phan/Language/EmptyUnionType.php
+++ b/src/Phan/Language/EmptyUnionType.php
@@ -246,6 +246,16 @@ final class EmptyUnionType extends UnionType
     /**
      * @return UnionType
      * A new UnionType with any references to 'static' resolved
+     * to the given type.
+     */
+    public function withStaticResolvedTo(Type $static_type): UnionType
+    {
+        return $this;
+    }
+
+    /**
+     * @return UnionType
+     * A new UnionType with any references to 'static' resolved
      * in the given context.
      */
     public function withStaticResolvedInFunctionLike(

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -3491,6 +3491,32 @@ class Type implements Stringable
     }
 
     /**
+     * @return Type
+     * Either this or 'static' resolved to the given type.
+     */
+    public function withStaticResolvedTo(
+        Type $static_type
+    ): Type {
+        if ($this->template_parameter_type_list) {
+            return $this->withStaticResolvedToTemplate($static_type);
+        }
+        return $this;
+    }
+
+    private function withStaticResolvedToTemplate(
+        Type $static_type
+    ): Type {
+        $new_template_parameter_type_list = [];
+        foreach ($this->template_parameter_type_list as $t) {
+            $new_template_parameter_type_list[] = $t->withStaticResolvedTo($static_type);
+        }
+        if ($new_template_parameter_type_list === $this->template_parameter_type_list) {
+            return $this;
+        }
+        return self::fromType($this, $new_template_parameter_type_list);
+    }
+
+    /**
      * @return string
      * A string representation of this type in FQSEN form.
      */

--- a/src/Phan/Language/Type/ArrayShapeType.php
+++ b/src/Phan/Language/Type/ArrayShapeType.php
@@ -1048,6 +1048,23 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
         return self::fromFieldTypes($new_field_types, $this->is_nullable);
     }
 
+    public function withStaticResolvedTo(Type $static_type): Type
+    {
+        $did_change = false;
+        $new_field_types = $this->field_types;
+        foreach ($new_field_types as $i => $field_type) {
+            $new_field_type = $field_type->withStaticResolvedTo($static_type);
+            if ($new_field_type !== $field_type) {
+                $did_change = true;
+                $new_field_types[$i] = $new_field_type;
+            }
+        }
+        if (!$did_change) {
+            return $this;
+        }
+        return self::fromFieldTypes($new_field_types, $this->is_nullable);
+    }
+
     /**
      * Returns a type where all referenced union types (e.g. in generic arrays) have real type sets removed.
      */

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -690,6 +690,22 @@ class GenericArrayType extends ArrayType implements GenericArrayInterface
     }
 
     /**
+     * Given a type such as array<int,static>, return array<int,$static_type>
+     */
+    public function withStaticResolvedTo(Type $static_type): Type
+    {
+        $resolved_element_type = $this->element_type->withStaticResolvedTo($static_type);
+        if ($this->element_type === $resolved_element_type) {
+            return $this;
+        }
+        return static::fromElementType(
+            $resolved_element_type,
+            $this->is_nullable,
+            $this->key_type
+        );
+    }
+
+    /**
      * Returns a type where all referenced union types (e.g. in generic arrays) have real type sets removed.
      * @phan-real-return static
      */

--- a/src/Phan/Language/Type/IntersectionType.php
+++ b/src/Phan/Language/Type/IntersectionType.php
@@ -623,6 +623,23 @@ final class IntersectionType extends Type
     }
 
     /**
+     * @return Type
+     * Either this or 'static' resolved to the given type.
+     */
+    public function withStaticResolvedTo(
+        Type $static_type
+    ): Type {
+        $type_parts = $this->type_parts;
+        foreach ($type_parts as $i => $type) {
+            $type_parts[$i] = $type->withStaticResolvedTo($static_type);
+        }
+        if ($type_parts === $this->type_parts) {
+            return $this;
+        }
+        return new self($type_parts);
+    }
+
+    /**
      * @return ?UnionType returns the iterable value's union type if this is a subtype of iterable, null otherwise.
      * @override
      */

--- a/src/Phan/Language/Type/StaticType.php
+++ b/src/Phan/Language/Type/StaticType.php
@@ -132,6 +132,25 @@ final class StaticType extends StaticOrSelfType
     }
 
     /**
+     * @return Type
+     * 'static' resolved to the given type, preserving template parameters and nullability.
+     */
+    public function withStaticResolvedTo(
+        Type $type
+    ): Type {
+        if ($this->template_parameter_type_list) {
+            return $type->make(
+                $type->namespace,
+                $type->name,
+                $this->template_parameter_type_list,
+                $type->is_nullable,
+                Type::FROM_TYPE
+            );
+        }
+        return $type->withIsNullable($this->is_nullable);
+    }
+
+    /**
      * @return StaticType
      */
     public function withIsNullable(bool $is_nullable): Type

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -1157,6 +1157,18 @@ class UnionType implements Serializable, Stringable
     /**
      * @return UnionType
      * A new UnionType with any references to 'static' resolved
+     * to the given type.
+     */
+    public function withStaticResolvedTo(Type $static_type): UnionType
+    {
+        return $this->asMappedUnionType(static function (Type $type) use ($static_type): Type {
+            return $type->withStaticResolvedTo($static_type);
+        });
+    }
+
+    /**
+     * @return UnionType
+     * A new UnionType with any references to 'static' resolved
      * in the given function or method's context.
      */
     public function withStaticResolvedInFunctionLike(

--- a/tests/files/expected/5078_intersection_static_type.php.expected
+++ b/tests/files/expected/5078_intersection_static_type.php.expected
@@ -1,0 +1,4 @@
+%s:26 PhanDebugAnnotation @phan-debug-var requested for variable $a - it has union type \B
+%s:26 PhanDebugAnnotation @phan-debug-var requested for variable $b - it has union type \A&\X(real=\A&\X)
+%s:26 PhanDebugAnnotation @phan-debug-var requested for variable $c - it has union type \A&\X
+%s:26 PhanDebugAnnotation @phan-debug-var requested for variable $d - it has union type \A&\X

--- a/tests/files/expected/5079_generic_static_type.php.expected
+++ b/tests/files/expected/5079_generic_static_type.php.expected
@@ -1,0 +1,6 @@
+%s:28 PhanTypeMismatchArgument Argument 1 ($box) is $b of type \Box|\Box<int> but \acceptBoxString() takes \Box<string> defined at %s:23
+%s:32 PhanDebugAnnotation @phan-debug-var requested for variable $a - it has union type \Box<int>
+%s:32 PhanDebugAnnotation @phan-debug-var requested for variable $b - it has union type \Box<int>
+%s:32 PhanDebugAnnotation @phan-debug-var requested for variable $c - it has union type \Box<int>
+%s:32 PhanDebugAnnotation @phan-debug-var requested for variable $d - it has union type \Box<int>
+%s:32 PhanTypeMismatchArgument Argument 1 ($box) is $d of type \Box|\Box<int> but \acceptBoxString() takes \Box<string> defined at %s:23

--- a/tests/files/src/5078_intersection_static_type.php
+++ b/tests/files/src/5078_intersection_static_type.php
@@ -1,0 +1,27 @@
+<?php
+
+class A {
+	function doA(): static {
+		return $this;
+	}
+}
+
+interface X {
+	function doX(): static;
+}
+
+class B extends A implements X {
+	function doX(): static {
+		return $this;
+	}
+}
+
+function newB(): A&X {
+	return new B;
+}
+
+$a = (new B)->doA()->doX();
+$b = newB();
+$c = newB()->doA();
+$d = newB()->doA()->doX();
+'@phan-debug-var $a, $b, $c, $d';

--- a/tests/files/src/5079_generic_static_type.php
+++ b/tests/files/src/5079_generic_static_type.php
@@ -1,0 +1,33 @@
+<?php
+
+/** @template T */
+class Box {
+	/** @param T $t */
+	function __construct(
+		public $t
+	) {}
+
+	function getBox(): static {
+		return $this;
+	}
+}
+
+/** @return Box<int> */
+function newBoxInt() {
+	return new Box(1);
+}
+
+/** @param Box<int> $box */
+function acceptBoxInt($box) { return $box; }
+/** @param Box<string> $box */
+function acceptBoxString($box) { return $box; }
+
+$a = newBoxInt();
+var_dump(acceptBoxInt($a));
+$b = newBoxInt();
+var_dump(acceptBoxString($b));
+$c = newBoxInt()->getBox();
+var_dump(acceptBoxInt($c));
+$d = newBoxInt()->getBox();
+var_dump(acceptBoxString($d));
+'@phan-debug-var $a, $b, $c, $d';


### PR DESCRIPTION
static return type lost information about intersection types and generic type parameters. This is mostly @MatmaRex's work adapted for the v6 branch.

- Added `withStaticResolvedTo(Type $static_type)` method across the type system to preserve intersection types and generics when resolving static return types
- Updated `UnionTypeVisitor::visitMethodCall()` to use the new resolution approach that preserves type information

So, specifically:
- Intersection types: `newB()->a()->b()` correctly resolves to `A&X` (no longer fails with "undeclared method")
- Generic types: `newBoxInt()->getBox()` correctly preserves `Box<int>` type
