### PR TITLE
Variables are not detected as possibly undefined when they only exist in a try scope

### DIFF
--- a/src/Phan/Analysis/ContextMergeVisitor.php
+++ b/src/Phan/Analysis/ContextMergeVisitor.php
@@ -114,16 +114,26 @@ class ContextMergeVisitor extends KindVisitorImplementation
             // 2. As if try did not fail, using the latter to analyze statements after the finally{}.
             return true;
         }
+        $catch_nodes = $node->children['catches']->children ?? [];
+        if (!$catch_nodes) {
+            // If there are no catches, be conservative and assume the try might fail.
+            return true;
+        }
         // E.g. after analyzing the following code:
         //      try { $x = expr(); } catch (Exception $e) { echo "Caught"; return; } catch (OtherException $e) { continue; }
-        // Phan should infer that $x is guaranteed to be defined.
-        foreach ($node->children['catches']->children ?? [] as $catch_node) {
+        // Phan should infer that $x is guaranteed to be defined only if every catch unconditionally exits.
+        foreach ($catch_nodes as $catch_node) {
+            if (!($catch_node instanceof Node)) {
+                continue;
+            }
             // @phan-suppress-next-line PhanTypeMismatchArgumentNullable, PhanPossiblyUndeclaredProperty this is never null
-            if (BlockExitStatusChecker::willUnconditionallySkipRemainingStatements($catch_node->children['stmts'])) {
-                return false;
+            if (!BlockExitStatusChecker::willUnconditionallySkipRemainingStatements($catch_node->children['stmts'])) {
+                // At least one catch may fall through, so analyze as if the try might fail.
+                return true;
             }
         }
-        return true;
+        // All catches unconditionally exit, so we can analyze remaining statements as if the try succeeded.
+        return false;
     }
 
     /**
@@ -176,7 +186,7 @@ class ContextMergeVisitor extends KindVisitorImplementation
         // Merge types from catch blocks into the merged try scope
         // We use $raw_try_scope to check which variables were in the try block,
         // but we modify $merged_try_scope to preserve possibly undefined flags
-        foreach ($raw_try_scope->getVariableMap() as $variable_name => $_) {
+        foreach ($raw_try_scope->getVariableMap() as $variable_name => $raw_variable) {
             $variable_name = (string)$variable_name;  // e.g. ${42}
             $merged_variable = $merged_try_scope->getVariableByNameOrNull($variable_name);
             if (!$merged_variable) {
@@ -186,9 +196,30 @@ class ContextMergeVisitor extends KindVisitorImplementation
             // Merge types if try and catch have a variable in common
             $catch_variable = $catch_scope->getVariableByNameOrNull($variable_name);
             if ($catch_variable) {
-                $merged_variable->setUnionType($merged_variable->getUnionType()->withUnionType(
-                    $catch_variable->getUnionType()
-                ));
+                $merged_union_type = $merged_variable->getUnionType();
+                $catch_union_type = $catch_variable->getUnionType();
+                $raw_union_type = $raw_variable->getUnionType();
+                $was_definitely_undefined = $merged_union_type->isDefinitelyUndefined();
+                $was_possibly_undefined = !$was_definitely_undefined && $merged_union_type->isPossiblyUndefined();
+                $catch_defines_variable = !$catch_union_type->isPossiblyUndefined() && !$catch_union_type->isDefinitelyUndefined();
+
+                if ($catch_defines_variable) {
+                    $new_union_type = $raw_union_type->withUnionType($catch_union_type);
+                    if (!$raw_union_type->containsNullableOrUndefined() && !$catch_union_type->containsNullableOrUndefined()) {
+                        $new_union_type = $new_union_type->nonNullableClone();
+                    }
+                } else {
+                    $new_union_type = $merged_union_type->withUnionType($catch_union_type);
+                    if ($was_definitely_undefined && ($catch_union_type->isDefinitelyUndefined() || $catch_union_type->isPossiblyUndefined())) {
+                        $new_union_type = $new_union_type->withIsDefinitelyUndefined();
+                    } elseif ($was_possibly_undefined && ($catch_union_type->isPossiblyUndefined() || $catch_union_type->isDefinitelyUndefined())) {
+                        $new_union_type = $new_union_type->withIsPossiblyUndefined(true);
+                    }
+                    if (($was_definitely_undefined || $was_possibly_undefined) && !$raw_union_type->containsNullableOrUndefined() && !$catch_union_type->containsNullableOrUndefined()) {
+                        $new_union_type = $new_union_type->nonNullableClone();
+                    }
+                }
+                $merged_variable->setUnionType($new_union_type);
             }
         }
 

--- a/src/Phan/Analysis/ContextMergeVisitor.php
+++ b/src/Phan/Analysis/ContextMergeVisitor.php
@@ -151,24 +151,20 @@ class ContextMergeVisitor extends KindVisitorImplementation
         }
         // TODO: Check if try node unconditionally returns.
 
-        // Merge in the types for any variables found in a catch.
-        // if ($node->children['finally'] !== null) {
-            // If we have to analyze a finally statement later,
-            // then be conservative and assume the try statement may or may not have failed.
-            // E.g. the below example must have a inferred type of string|false
-            //      $x = new stdClass(); try {...; $x = (string)fn(); } catch(Exception $e) { $x = false; }
-            // $try_scope = $this->context->getScope();
-        // } else {
-            // If we don't have to worry about analyzing the finally statement, then assume that the entire try statement succeeded or the a catch statement succeeded.
-            // @phan-suppress-next-line PhanPossiblyNonClassMethodCall
-            $try_scope = \reset($this->child_context_list)->getScope();
-        // }
+        // Use the context scope that was already processed by mergeTryContext.
+        // This preserves the "possibly undefined" flags for variables defined only in the try block.
+        // $this->context was set by mergeTryContext and already has variables from the try block
+        // marked as possibly undefined (if applicable).
+        $merged_try_scope = clone($this->context->getScope());
+
+        // Get the raw try scope (without possibly undefined flags) for merging types
+        $raw_try_scope = \reset($this->child_context_list)->getScope();
 
         if (!$catch_scope_list) {
             // All of the catch statements will unconditionally rethrow or return.
             // So, after the try and catch blocks (finally is analyzed separately),
-            // the context is the same as if the try block finished successfully.
-            return $this->context->withScope($try_scope);
+            // the context is the same as the merged try context (which may have possibly undefined variables).
+            return $this->context;
         }
 
         if (\count($catch_scope_list) > 1) {
@@ -177,15 +173,20 @@ class ContextMergeVisitor extends KindVisitorImplementation
             $catch_scope = \reset($catch_scope_list);
         }
 
-        // TODO: Use getVariableMapExcludingScope
-        foreach ($try_scope->getVariableMap() as $variable_name => $variable) {
+        // Merge types from catch blocks into the merged try scope
+        // We use $raw_try_scope to check which variables were in the try block,
+        // but we modify $merged_try_scope to preserve possibly undefined flags
+        foreach ($raw_try_scope->getVariableMap() as $variable_name => $_) {
             $variable_name = (string)$variable_name;  // e.g. ${42}
+            $merged_variable = $merged_try_scope->getVariableByNameOrNull($variable_name);
+            if (!$merged_variable) {
+                // Variable was in raw try but not in merged scope (shouldn't happen, but be defensive)
+                continue;
+            }
             // Merge types if try and catch have a variable in common
-            $catch_variable = $catch_scope->getVariableByNameOrNull(
-                $variable_name
-            );
+            $catch_variable = $catch_scope->getVariableByNameOrNull($variable_name);
             if ($catch_variable) {
-                $variable->setUnionType($variable->getUnionType()->withUnionType(
+                $merged_variable->setUnionType($merged_variable->getUnionType()->withUnionType(
                     $catch_variable->getUnionType()
                 ));
             }
@@ -195,13 +196,13 @@ class ContextMergeVisitor extends KindVisitorImplementation
         // (unless the try statement unconditionally throws, returns, exits, infinitely loops, etc.)
         if ($try_statement_will_throw_or_return) {
             foreach ($catch_scope->getVariableMap() as $variable) {
-                // Add it to the try scope
-                $try_scope->addVariable($variable);
+                // Add it to the merged try scope
+                $merged_try_scope->addVariable($variable);
             }
         } else {
             foreach ($catch_scope->getVariableMap() as $variable_name => $variable) {
                 $variable_name = (string)$variable_name;
-                if (!$try_scope->hasVariableWithName($variable_name)) {
+                if (!$raw_try_scope->hasVariableWithName($variable_name)) {
                     $type = $variable->getUnionType();
                     if (!$type->containsNullableLabeled()) {
                         $type = $type->withType(NullType::instance(false));
@@ -211,15 +212,15 @@ class ContextMergeVisitor extends KindVisitorImplementation
                     // Combine all of the catch blocks into one context and merge with that instead?
                     $variable->setUnionType($type->withIsPossiblyUndefined(true));
 
-                    // Add it to the try scope
-                    $try_scope->addVariable($variable);
+                    // Add it to the merged try scope
+                    $merged_try_scope->addVariable($variable);
                 }
             }
         }
 
         // Set the new scope with only the variables and types
         // that are common to all branches
-        return $this->context->withScope($try_scope);
+        return $this->context->withScope($merged_try_scope);
     }
 
     /**

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -2222,8 +2222,8 @@ class CodeBase
         Context $context,
         bool $suggest_in_global_namespace
     ): array {
+        $suggestions = [];
         try {
-            $suggestions = [];
             $fqsen = $this->getClassIfConstructorAccessible($namespace, $name, $context);
             if ($fqsen && $this->hasClassWithFQSEN($fqsen)) {
                 $suggestions[] = $fqsen;

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
@@ -1095,9 +1095,20 @@ final class VariableTrackerVisitor extends AnalysisVisitor
         $try_scope = $this->analyze($try_scope, $try_node);
         '@phan-var VariableTrackingBranchScope $try_scope';
 
-        // TODO: Use BlockExitStatusChecker, like BlockAnalysisVisitor
-        // TODO: Optimize
-        $main_scope = $outer_scope->mergeWithSingleBranchScope($try_scope);
+        // Determine if the try block might fail (throw an exception before completing).
+        // If it might fail, variables defined in the try block should be treated as possibly undefined.
+        $try_might_fail = self::willTryBlockPossiblyFail($catches_node, $finally_node);
+
+        // Merge the try scope with the outer scope.
+        // If the try might fail, use mergeBranchScopeList with merge_parent_scope=true
+        // to treat variables defined in the try block as possibly undefined.
+        // Otherwise, use mergeWithSingleBranchScope to treat them as definitely defined.
+        if ($try_might_fail) {
+            $main_scope = $outer_scope->mergeBranchScopeList([$try_scope], true, []);
+        } else {
+            $main_scope = $outer_scope->mergeWithSingleBranchScope($try_scope);
+        }
+
         $catches_will_throw_or_return = BlockExitStatusChecker::willUnconditionallyThrowOrReturn($catches_node);
 
         $catch_node_list = $catches_node->children;
@@ -1122,6 +1133,47 @@ final class VariableTrackerVisitor extends AnalysisVisitor
             return $combined_scope;
         }
         return $main_scope;
+    }
+
+    /**
+     * Determines if the try block might fail (throw an exception before completing).
+     * This is used to determine if variables defined in the try block should be treated
+     * as possibly undefined after the try-catch block.
+     *
+     * Similar logic to ContextMergeVisitor::willRemainingStatementsBeAnalyzedAsIfTryMightFail()
+     *
+     * @param Node|null $catches_node the AST_CATCH_LIST node
+     * @param Node|null $finally_node the finally block node
+     */
+    private static function willTryBlockPossiblyFail(?Node $catches_node, $finally_node): bool
+    {
+        // If there's a finally block, we analyze it as if the try block might have failed
+        if ($finally_node !== null) {
+            return true;
+        }
+
+        // If there are no catch blocks, the try block could fail and propagate the exception
+        if (!$catches_node || \count($catches_node->children) === 0) {
+            return true;
+        }
+
+        // If ALL catch blocks unconditionally throw/return, then after the try-catch block,
+        // we know the try block succeeded (otherwise we'd have exited in a catch block).
+        // E.g.: try { $x = expr(); } catch (Exception $e) { return; }
+        // In this case, $x is guaranteed to be defined after the try-catch.
+        foreach ($catches_node->children as $catch_node) {
+            if (!($catch_node instanceof Node)) {
+                continue;
+            }
+            // @phan-suppress-next-line PhanTypeMismatchArgumentNullable, PhanPossiblyUndeclaredProperty
+            if (!BlockExitStatusChecker::willUnconditionallySkipRemainingStatements($catch_node->children['stmts'])) {
+                // At least one catch block can fall through, so the try might have failed
+                return true;
+            }
+        }
+
+        // All catch blocks unconditionally exit, so the try block must have succeeded
+        return false;
     }
 
     /**

--- a/tests/files/expected/0016_try_catch.php.expected
+++ b/tests/files/expected/0016_try_catch.php.expected
@@ -1,0 +1,1 @@
+%s:9 PhanPossiblyUndeclaredGlobalVariable Global variable $a is possibly undeclared

--- a/tests/files/expected/0116_try_merge.php.expected
+++ b/tests/files/expected/0116_try_merge.php.expected
@@ -2,3 +2,4 @@
 %s:17 PhanTypeMismatchArgument Argument 1 ($p) is $b of type 42|true but \f() takes string defined at %s:15
 %s:18 PhanPossiblyUndeclaredGlobalVariable Global variable $c is possibly undeclared
 %s:18 PhanTypeMismatchArgument Argument 1 ($p) is $c of type 21|null but \f() takes string defined at %s:15
+%s:19 PhanPossiblyUndeclaredGlobalVariable Global variable $d is possibly undeclared

--- a/tests/files/expected/4884_try_possibly_undefined.php.expected
+++ b/tests/files/expected/4884_try_possibly_undefined.php.expected
@@ -1,0 +1,5 @@
+%s:28 PhanPossiblyUndeclaredVariable Variable $val is possibly undeclared
+%s:61 PhanPossiblyUndeclaredVariable Variable $val4 is possibly undeclared
+%s:74 PhanPossiblyUndeclaredVariable Variable $val5 is possibly undeclared
+%s:87 PhanPossiblyUndeclaredVariable Variable $val6 is possibly undeclared
+%s:97 PhanPossiblyUndeclaredVariable Variable $val7 is possibly undeclared

--- a/tests/files/src/4884_try_possibly_undefined.php
+++ b/tests/files/src/4884_try_possibly_undefined.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * Test fixtures covering issue #4884.
+ *
+ * @phan-file-suppress PhanPluginNoCommentOnFunction
+ * @phan-file-suppress PhanPluginUnknownFunctionReturnType
+ * @phan-file-suppress PhanThrowTypeAbsent
+ * @phan-file-suppress PhanUnusedVariableCaughtException
+ * @phan-file-suppress PhanPluginRemoveDebugEcho
+ * @phan-file-suppress PhanPluginEmptyStatementTryFinally
+ */
+
 function mayThrow() {
     if (rand()) {
         throw new Exception;

--- a/tests/files/src/4884_try_possibly_undefined.php
+++ b/tests/files/src/4884_try_possibly_undefined.php
@@ -1,0 +1,87 @@
+<?php
+
+function mayThrow() {
+    if (rand()) {
+        throw new Exception;
+    }
+    return 42;
+}
+
+// Test case 1: Variable defined in try, used after try-catch
+// Should warn: variable is possibly undefined
+function test1() {
+    try {
+        $val = mayThrow();
+    } catch (Exception $e) {
+    }
+    echo $val;  // PhanPossiblyUndeclaredVariable
+}
+
+// Test case 2: Variable defined in try, all catches exit
+// Should NOT warn: variable is guaranteed to be defined
+function test2() {
+    try {
+        $val2 = mayThrow();
+    } catch (Exception $e) {
+        return;  // All catch blocks exit
+    }
+    echo $val2;  // No warning - $val2 is definitely defined
+}
+
+// Test case 3: Variable defined before try
+// Should NOT warn: variable is already defined
+function test3() {
+    $val3 = 0;
+    try {
+        $val3 = mayThrow();
+    } catch (Exception $e) {
+    }
+    echo $val3;  // No warning - $val3 was defined before try
+}
+
+// Test case 4: try with finally block
+// Should warn: variable is possibly undefined (finally doesn't guarantee try completed)
+function test4() {
+    try {
+        $val4 = mayThrow();
+    } catch (Exception $e) {
+    } finally {
+    }
+    echo $val4;  // PhanPossiblyUndeclaredVariable
+}
+
+// Test case 5: Inline conditional throw
+// Should warn: variable is possibly undefined
+function test5() {
+    try {
+        if (rand()) {
+            throw new Exception();
+        }
+        $val5 = 42;
+    } catch (Exception $e) {
+    }
+    echo $val5;  // PhanPossiblyUndeclaredVariable
+}
+
+// Test case 6: Multiple catch blocks, some exit
+// Should warn: at least one catch can fall through
+function test6() {
+    try {
+        $val6 = mayThrow();
+    } catch (RuntimeException $e) {
+        return;  // This one exits
+    } catch (Exception $e) {
+        // This one doesn't exit
+    }
+    echo $val6;  // PhanPossiblyUndeclaredVariable
+}
+
+// Test case 7: No catch blocks
+// Should warn: exception will propagate
+function test7() {
+    try {
+        $val7 = mayThrow();
+    } finally {
+    }
+    echo $val7;  // PhanPossiblyUndeclaredVariable
+}


### PR DESCRIPTION
Fix bug #4884

Aligned try/catch flow analysis with the new undefined-variable detection and refreshed the supporting fixtures.
  - Refined how we decide whether a try can leave variables undefined and merged catch scopes so that assignments in falling-through catches replace the old branch data
  instead of leaking nullable/array types
  - Pre-initialized suggestion collections outside the try so constructor lookup failures no longer trigger fresh possibly-undeclared warnings 