### PR TITLE
Fix a class const and enum regression

### DIFF
--- a/src/Phan/Analysis/ClassConstantTypesAnalyzer.php
+++ b/src/Phan/Analysis/ClassConstantTypesAnalyzer.php
@@ -144,8 +144,11 @@ class ClassConstantTypesAnalyzer
                 continue;
             }
 
-            // Check if constant has a real type (PHP 8.3+ typed constant)
             if (!$union_type->hasRealTypeSet()) {
+                continue;
+            }
+
+            if (!$constant->hasDeclaredType()) {
                 continue;
             }
 
@@ -235,23 +238,12 @@ class ClassConstantTypesAnalyzer
                 continue;
             }
 
-            $constant_union_type = $constant->getUnionType();
-            if (!$constant_union_type->hasRealTypeSet()) {
-                // Untyped constant - no covariance checking needed
+            if (!$constant->hasDeclaredType()) {
                 continue;
             }
 
-            // Check if this constant has an explicitly declared type (PHP 8.3+)
-            // vs just an inferred real type from its value
-            // For typed constants: PHPDoc type (from value) differs from real type (from declaration)
-            // For untyped constants: only real type exists, PHPDoc type is empty or same as real
-            $phpdoc_type = $constant_union_type->eraseRealTypeSet();
-            $real_type = $constant_union_type->getRealUnionType();
-            $has_declared_type = !$phpdoc_type->isEmpty() && !$phpdoc_type->isEqualTo($real_type);
-
-            if (!$has_declared_type) {
-                // This constant's real type is just inferred from its value (pre-8.3 style)
-                // No inheritance checking needed
+            $constant_union_type = $constant->getUnionType();
+            if (!$constant_union_type->hasRealTypeSet()) {
                 continue;
             }
 
@@ -279,20 +271,13 @@ class ClassConstantTypesAnalyzer
                     continue;
                 }
 
-                $inherited_union_type = $inherited_constant->getUnionType();
-                if (!$inherited_union_type->hasRealTypeSet()) {
-                    // Parent has no declared type - child can add a type
+                if (!$inherited_constant->hasDeclaredType()) {
                     continue;
                 }
 
-                // Check if parent has an explicitly declared type (PHP 8.3+)
-                $inherited_phpdoc_type = $inherited_union_type->eraseRealTypeSet();
-                $inherited_real_type_temp = $inherited_union_type->getRealUnionType();
-                $inherited_has_declared_type = !$inherited_phpdoc_type->isEmpty() &&
-                                              !$inherited_phpdoc_type->isEqualTo($inherited_real_type_temp);
-
-                if (!$inherited_has_declared_type) {
-                    // Parent's real type is just inferred from value - child can add explicit type
+                $inherited_union_type = $inherited_constant->getUnionType();
+                if (!$inherited_union_type->hasRealTypeSet()) {
+                    // Parent has no declared type - child can add a type
                     continue;
                 }
 

--- a/src/Phan/Language/Element/ClassConstant.php
+++ b/src/Phan/Language/Element/ClassConstant.php
@@ -111,7 +111,7 @@ class ClassConstant extends ClassElement implements ConstantInterface
         if ($constant->isPublic()) {
             $constant->setDefiningFQSEN($defining_fqsen);
         }
-        $constant->setHasDeclaredType($this->hasDeclaredType());
+        $constant->setHasDeclaredType($this->has_declared_type);
         return $constant;
     }
 
@@ -178,7 +178,7 @@ class ClassConstant extends ClassElement implements ConstantInterface
         $string .= 'const ';
 
         // Add type declaration only for constants that explicitly declare one (PHP 8.3+)
-        if ($this->hasDeclaredType()) {
+        if ($this->has_declared_type) {
             $string .= $this->getUnionType()->getRealUnionType()->__toString() . ' ';
         }
 
@@ -233,7 +233,7 @@ class ClassConstant extends ClassElement implements ConstantInterface
         $string .= 'const ';
 
         // Add type declaration only for constants that explicitly declare one (PHP 8.3+)
-        if ($this->hasDeclaredType()) {
+        if ($this->has_declared_type) {
             $string .= $this->getUnionType()->getRealUnionType()->__toString() . ' ';
         }
 

--- a/src/Phan/Language/Element/ClassConstant.php
+++ b/src/Phan/Language/Element/ClassConstant.php
@@ -23,6 +23,9 @@ class ClassConstant extends ClassElement implements ConstantInterface
     /** @var ?Comment the phpdoc comment associated with this declaration, if any exists. */
     private $comment;
 
+    /** @var bool true if this constant declared an explicit type in its signature */
+    private $has_declared_type = false;
+
     /**
      * @param Context $context
      * The context in which the structural element lives
@@ -65,6 +68,22 @@ class ClassConstant extends ClassElement implements ConstantInterface
     }
 
     /**
+     * Record whether this constant declared a type in its signature.
+     */
+    public function setHasDeclaredType(bool $has_declared_type): void
+    {
+        $this->has_declared_type = $has_declared_type;
+    }
+
+    /**
+     * True if this constant declared a type in its signature.
+     */
+    public function hasDeclaredType(): bool
+    {
+        return $this->has_declared_type;
+    }
+
+    /**
      * Create an alias from a trait use, which is treated as though it was defined in $clazz
      * E.g. if you import a trait's class constant as private/protected, it becomes private/protected **to the class which used the trait**
      *
@@ -92,6 +111,7 @@ class ClassConstant extends ClassElement implements ConstantInterface
         if ($constant->isPublic()) {
             $constant->setDefiningFQSEN($defining_fqsen);
         }
+        $constant->setHasDeclaredType($this->hasDeclaredType());
         return $constant;
     }
 
@@ -157,10 +177,9 @@ class ClassConstant extends ClassElement implements ConstantInterface
 
         $string .= 'const ';
 
-        // Add type declaration for typed constants (PHP 8.3+)
-        $union_type = $this->getUnionType();
-        if ($union_type->hasRealTypeSet()) {
-            $string .= $union_type->getRealUnionType()->__toString() . ' ';
+        // Add type declaration only for constants that explicitly declare one (PHP 8.3+)
+        if ($this->hasDeclaredType()) {
+            $string .= $this->getUnionType()->getRealUnionType()->__toString() . ' ';
         }
 
         $string .= $this->name . ' = ';
@@ -213,10 +232,9 @@ class ClassConstant extends ClassElement implements ConstantInterface
         // Also, PHP modules probably won't have private/protected constants.
         $string .= 'const ';
 
-        // Add type declaration for typed constants (PHP 8.3+)
-        $union_type = $this->getUnionType();
-        if ($union_type->hasRealTypeSet()) {
-            $string .= $union_type->getRealUnionType()->__toString() . ' ';
+        // Add type declaration only for constants that explicitly declare one (PHP 8.3+)
+        if ($this->hasDeclaredType()) {
+            $string .= $this->getUnionType()->getRealUnionType()->__toString() . ' ';
         }
 
         $string .= $this->name . ' = ';

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -50,6 +50,7 @@ use Phan\Memoize;
 use Phan\Plugin\ConfigPluginSet;
 use Phan\Suggestion;
 use ReflectionClass;
+use ReflectionClassConstant;
 use ReflectionProperty;
 use RuntimeException;
 
@@ -458,14 +459,29 @@ class Clazz extends AddressableElement
                 $name
             );
 
+            $value_type = Type::fromObject($value);
+
             $constant = new ClassConstant(
                 $context,
                 $name,
-                Type::fromObject($value)->asRealUnionType(),  // TODO: These can vary based on OS/build flags
+                $value_type->asRealUnionType(),  // TODO: These can vary based on OS/build flags
                 0,
                 $constant_fqsen
             );
             $constant->setNodeForValue($value);
+
+            $reflection_constant = method_exists($class, 'getReflectionConstant')
+                ? $class->getReflectionConstant($name)
+                : null;
+            if ($reflection_constant instanceof ReflectionClassConstant && method_exists($reflection_constant, 'hasType') && $reflection_constant->hasType()) {
+                $declared_type = UnionType::fromReflectionType($reflection_constant->getType())->asNormalizedTypes();
+                $constant->setUnionType(
+                    $value_type->asPHPDocUnionType()->withRealTypeSet($declared_type->getTypeSet())
+                );
+                $constant->setHasDeclaredType(true);
+            } else {
+                $constant->setHasDeclaredType(false);
+            }
 
             $clazz->addConstant($code_base, $constant);
         }

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -473,7 +473,9 @@ class Clazz extends AddressableElement
             $reflection_constant = method_exists($class, 'getReflectionConstant')
                 ? $class->getReflectionConstant($name)
                 : null;
+            // @phan-suppress-next-line PhanUndeclaredMethod reflection APIs added in PHP 8.3+
             if ($reflection_constant instanceof ReflectionClassConstant && method_exists($reflection_constant, 'hasType') && $reflection_constant->hasType()) {
+                // @phan-suppress-next-line PhanUndeclaredMethod reflection APIs added in PHP 8.3+
                 $declared_type = UnionType::fromReflectionType($reflection_constant->getType())->asNormalizedTypes();
                 $constant->setUnionType(
                     $value_type->asPHPDocUnionType()->withRealTypeSet($declared_type->getTypeSet())

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -1122,6 +1122,7 @@ class ParseVisitor extends ScopeVisitor
                 $flags,
                 $fqsen
             );
+            $constant->setHasDeclaredType(!$real_union_type->isEmpty());
 
             $constant->setDocComment($doc_comment);
             $constant->setAttributeList($attributes);
@@ -1259,6 +1260,7 @@ class ParseVisitor extends ScopeVisitor
         }
         $constant->setUnionType($class->getFQSEN()->asType()->asRealUnionType());
         $constant->setNodeForValue($value_node);
+        $constant->setHasDeclaredType(true);
 
         $class->addEnumCase($this->code_base, $constant);
 

--- a/tests/files/expected/0860_useless_binary_add_right.php.expected
+++ b/tests/files/expected/0860_useless_binary_add_right.php.expected
@@ -1,5 +1,4 @@
 %s:3 PhanUselessBinaryAddRight Addition of array{0:2} + array{0:3} ([2] + [3]) is probably unnecessary. Array fields from the left hand side will be used instead of each of the fields from the right hand side
-%s:7 PhanUselessBinaryAddRight Addition of array{0:2} + array{0:3} ([2] + [3]) is probably unnecessary. Array fields from the left hand side will be used instead of each of the fields from the right hand side
 %s:9 PhanUselessBinaryAddRight Addition of array{0:2} + array{0:3} ([2] + [3]) is probably unnecessary. Array fields from the left hand side will be used instead of each of the fields from the right hand side
 %s:17 PhanUselessBinaryAddRight Addition of array{0:2} + array{0:3} ([2] + [3]) is probably unnecessary. Array fields from the left hand side will be used instead of each of the fields from the right hand side
 %s:18 PhanUselessBinaryAddRight Addition of array{0:2} + array{0:3} ([2] + [3]) is probably unnecessary. Array fields from the left hand side will be used instead of each of the fields from the right hand side

--- a/tests/files/expected/1130_enum.php.expected
+++ b/tests/files/expected/1130_enum.php.expected
@@ -6,7 +6,6 @@
 %s:14 PhanAccessExtendsFinalClass Attempting to extend from final class \Enums\X defined at %s:5
 %s:19 PhanReusedEnumCaseValue Enum case IS_ALSO_ZERO has the same value('0') as a previous declared enum case IS_ZERO defined at %s:18
 %s:20 PhanReusedEnumCaseValue Enum case IS_ALSO_EMPTY has the same value('') as a previous declared enum case IS_EMPTY defined at %s:17
-%s:20 PhanTypeMismatchDeclaredConstant Constant \Enums\HasDuplicate::IS_ALSO_EMPTY is declared with type \Enums\HasDuplicate but has value ('' . '') of type ''
 %s:21 PhanInvalidConstantExpression Constant expression contains invalid operations ($var)
 %s:21 PhanTypeMismatchDeclaredConstant Constant \Enums\HasDuplicate::Invalid is declared with type \Enums\HasDuplicate but has value $var of type null=
 %s:21 PhanUndeclaredGlobalVariable Global variable $var is undeclared


### PR DESCRIPTION
Fixed a regression caused by PR  5128 which added full PHP 8.3 class constant support. 

- Added `ClassConstant::hasDeclaredType` plumbing and copied it through aliases so rendered hover snippets only show declared types when a signature actually exists
- Emit the new flag while parsing class constants and enum cases, ensuring analyzer/markup consumers understand which constants are truly typed
- Hydrated reflection constants now preserve declared types for internal classes and mark those as typed, keeping hover output and validation in sync
- The typed-constant analyzer now trusts the explicit flag when deciding whether to validate definitions or inheritance, preventing false positives on legacy
  constants while still checking real typed ones
 - Updated file-test expectations to reflect the restored behaviour (no extra warning on the suppressed array case and the enum expectation no longer assumes an
  additional constant-type mismatch)