### PR TITLE
Bug4980

### DIFF
--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -4830,6 +4830,14 @@ Comment declares @param ${PARAMETER} multiple times
 
 e.g. [this issue](https://github.com/phan/phan/tree/v6/tests/files/expected/0611_comment_duplicated_param.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/v6/tests/files/src/0611_comment_duplicated_param.php#L7).
 
+## PhanCommentGenericArrayTooManyTypes
+
+```
+PHPDoc type {TYPE} has {COUNT} template parameters; array-like types support at most {DETAILS}
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/v6/tests/files/expected/4980_array_generic_too_many.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/v6/tests/files/src/4980_array_generic_too_many.php#L4).
+
 ## PhanCommentObjectInClassConstantType
 
 ```

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -647,6 +647,7 @@ class Issue
     public const CommentDuplicateMagicProperty    = 'PhanCommentDuplicateMagicProperty';
     public const CommentObjectInClassConstantType = 'PhanCommentObjectInClassConstantType';
     public const CommentUnsupportedUnionType      = 'PhanCommentUnsupportedUnionType';
+    public const CommentGenericArrayTooManyTypes  = 'PhanCommentGenericArrayTooManyTypes';
     public const CommentUnextractableTypeAlias    = 'PhanCommentUnextractableTypeAlias';
     public const TypeAliasUsedOutsideComment      = 'PhanTypeAliasUsedOutsideComment';
     public const TypeAliasInternalTypeConflict    = 'PhanTypeAliasInternalTypeConflict';
@@ -5515,6 +5516,14 @@ class Issue
                 'Comment declares @property* ${PROPERTY} multiple times',
                 self::REMEDIATION_A,
                 16017
+            ),
+            new Issue(
+                self::CommentGenericArrayTooManyTypes,
+                self::CATEGORY_COMMENT,
+                self::SEVERITY_LOW,
+                'PHPDoc type {TYPE} has {COUNT} template parameters; array-like types support at most {DETAILS}',
+                self::REMEDIATION_A,
+                16031
             ),
             // TODO: Support declaring both instance and static methods of the same name
             new Issue(

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -1216,6 +1216,21 @@ class Type implements Stringable
         return ArrayType::instance($is_nullable);
     }
 
+    private static function getMaxTemplateParameterCountForDocType(string $lower_type_name): ?int
+    {
+        switch ($lower_type_name) {
+            case 'array':
+            case 'associative-array':
+            case 'non-empty-array':
+            case 'non-empty-associative-array':
+                return 2;
+            case 'list':
+            case 'non-empty-list':
+                return 1;
+        }
+        return null;
+    }
+
     /**
      * @param list<UnionType> $template_parameter_type_list
      * @param bool $is_nullable
@@ -1442,6 +1457,25 @@ class Type implements Stringable
         $template_parameter_type_name_list = $tuple->_2;
         $is_nullable = $tuple->_3;
         $shape_components = $tuple->_4;
+
+        if ($source === self::FROM_PHPDOC && $code_base && $template_parameter_type_name_list) {
+            $max_template_parameters = self::getMaxTemplateParameterCountForDocType(strtolower($type_name));
+            if ($max_template_parameters !== null) {
+                $actual_template_parameter_count = count($template_parameter_type_name_list);
+                if ($actual_template_parameter_count > $max_template_parameters) {
+                    $rendered_doc_type = ($is_nullable ? '?' : '') . $type_name . '<' . implode(', ', $template_parameter_type_name_list) . '>';
+                    Issue::maybeEmit(
+                        $code_base,
+                        $context,
+                        Issue::CommentGenericArrayTooManyTypes,
+                        $context->getLineNumberStart(),
+                        $rendered_doc_type,
+                        $actual_template_parameter_count,
+                        (string)$max_template_parameters
+                    );
+                }
+            }
+        }
 
 
         if (\preg_match('/^(' . self::noncapturing_literal_regex . ')$/D', $type_name)) {

--- a/tests/files/expected/4980_array_generic_too_many.php.expected
+++ b/tests/files/expected/4980_array_generic_too_many.php.expected
@@ -1,0 +1,1 @@
+%s:9 PhanCommentGenericArrayTooManyTypes PHPDoc type array<int, string, string> has 3 template parameters; array-like types support at most 2

--- a/tests/files/src/4980_array_generic_too_many.php
+++ b/tests/files/src/4980_array_generic_too_many.php
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * Example function exercising invalid array generics.
+ * @param array<int,string,string> $param
+ * @suppress PhanPluginUnknownArrayFunctionParamType
+ * @suppress PhanPluginUnknownArrayFunctionReturnType
+ */
+function takes_array_with_too_many_generics($param): array {
+    return $param;
+}


### PR DESCRIPTION
- Added the new issue type constant and entry: `PhanCommentGenericArrayTooManyTypes`
- During PHPDoc parsing we warn when array-like generics exceed their supported arity, letting Type::fromStringInContext emit the new issue while still normalizing the type fallback