### PR TITLE
Fix bug #4922

### DIFF
--- a/src/Phan/Language/Element/ConstantTrait.php
+++ b/src/Phan/Language/Element/ConstantTrait.php
@@ -17,7 +17,7 @@ trait ConstantTrait
 {
     use ElementFutureUnionType;
 
-    /** @var Node|string|float|int|resource the node (or built-in value) which defined the value of this constant. */
+    /** @var Node|string|float|int|bool|resource the node (or built-in value) which defined the value of this constant. */
     protected $defining_node;
 
     /**
@@ -34,7 +34,7 @@ trait ConstantTrait
     /**
      * Sets the node with the AST representing the value of this constant.
      *
-     * @param Node|string|float|int|resource $node Either a node or a constant to be used as the value of the constant.
+     * @param Node|string|float|int|bool|resource $node Either a node or a constant to be used as the value of the constant.
      * Can be resource for STDERR, etc.
      */
     public function setNodeForValue($node): void
@@ -45,7 +45,7 @@ trait ConstantTrait
     /**
      * Gets the node with the AST representing the value of this constant.
      *
-     * @return Node|string|float|int|resource
+     * @return Node|string|float|int|bool|resource
      */
     public function getNodeForValue()
     {

--- a/src/Phan/Language/Element/GlobalConstant.php
+++ b/src/Phan/Language/Element/GlobalConstant.php
@@ -10,6 +10,7 @@ use Phan\Exception\FQSENException;
 use Phan\Language\Context;
 use Phan\Language\FQSEN\FullyQualifiedGlobalConstantName;
 use Phan\Language\Type;
+use Phan\Language\Type\BoolType;
 use Phan\Language\UnionType;
 use Phan\Library\StringUtil;
 
@@ -20,6 +21,14 @@ use Phan\Library\StringUtil;
 class GlobalConstant extends AddressableElement implements ConstantInterface
 {
     use ConstantTrait;
+
+    /** @var array<string,true> names of internal boolean constants whose values vary between builds */
+    private const VOLATILE_BOOLEAN_CONSTANTS = [
+        'PHP_ZTS' => true,
+        'PHP_DEBUG' => true,
+        'ZEND_THREAD_SAFE' => true,
+        'ZEND_DEBUG_BUILD' => true,
+    ];
 
     /**
      * Sets whether this is a global constant that should be treated as if the real type is unknown.
@@ -104,10 +113,14 @@ class GlobalConstant extends AddressableElement implements ConstantInterface
             '\\' . $name
         );
         $type = Type::fromObject($value);
+        $real_type = $type->asNonLiteralType();
+        if (isset(self::VOLATILE_BOOLEAN_CONSTANTS[$name]) && is_bool($value)) {
+            $type = $real_type = BoolType::instance(false);
+        }
         $result = new self(
             new Context(),
             $name,
-            UnionType::of([$type], [$type->asNonLiteralType()]),
+            UnionType::of([$type], [$real_type]),
             0,
             $constant_fqsen
         );

--- a/tests/files/src/4922_bool_constant.php
+++ b/tests/files/src/4922_bool_constant.php
@@ -1,0 +1,10 @@
+<?php
+
+/**
+ * Return a descriptive label based on the thread-safety build flag.
+ */
+function zts_mode(): string {
+    return PHP_ZTS ? 'ts' : 'nts';
+}
+
+$result = PHP_DEBUG ? 'debug' : 'nodebug';


### PR DESCRIPTION
- Treat volatile build flags (`PHP_ZTS`, `PHP_DEBUG`, `ZEND_THREAD_SAFE`, `ZEND_DEBUG_BUILD`) as plain bool when reflecting global constants so they no longer resolve to literal false and trip `PhanImpossibleCondition`
- Allowed constant value storage to include booleans so the cached value remains consistent