### PR TITLE
Fix #4853

### DIFF
--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -1662,6 +1662,9 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         // Get the method/function/closure we're in
         $method = $context->getFunctionLikeInScope($code_base);
 
+        $override_return_types = Config::getValue('override_return_types');
+        $allow_overriding_vague_return_types = Config::getValue('allow_overriding_vague_return_types');
+
         // Mark the method as returning something (even if void)
         $expr = $node->children['expr'];
         if (null !== $expr) {
@@ -1732,10 +1735,16 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             // match the method's declared return value. One reason for this approach is because
             // phpdoc return values may be incorrect or out of date, and phan errors about the
             // incorrect phpdoc  return values may be suppressed.
-            if ($method->isReturnTypeModifiable() && (!$is_mismatch || Config::getValue('override_return_types'))) {
+            if ($method->isReturnTypeModifiable() && (!$is_mismatch || $override_return_types)) {
                 // Add the new type to the set of values returned by the
                 // method
-                $method->setUnionType($method->getUnionType()->withUnionType($expression_type));
+                $union_type = $method->getUnionType();
+                if ($allow_overriding_vague_return_types && $union_type->hasMixedTypeStrict()) {
+                    $union_type = $union_type->makeFromFilter(static function (Type $type): bool {
+                        return \get_class($type) !== MixedType::class;
+                    });
+                }
+                $method->setUnionType($union_type->withUnionType($expression_type));
             }
         }
 

--- a/tests/infer_missing_types_test/expected/008_mixed_return.php.expected
+++ b/tests/infer_missing_types_test/expected/008_mixed_return.php.expected
@@ -1,0 +1,2 @@
+src/008_mixed_return.php:6 PhanPluginMoreSpecificActualReturnType Phan inferred that \returns_nullable_issue4853() documented to have return type mixed returns the more specific type null(real=null)
+src/008_mixed_return.php:10 PhanTypeSuspiciousEcho Suspicious argument returns_nullable_issue4853() of type null for an echo/print statement

--- a/tests/infer_missing_types_test/src/008_mixed_return.php
+++ b/tests/infer_missing_types_test/src/008_mixed_return.php
@@ -1,0 +1,10 @@
+<?php
+// Regression test for https://github.com/phan/phan/issues/4853
+/**
+ * @return mixed
+ */
+function returns_nullable_issue4853() {
+    return null;
+}
+
+echo returns_nullable_issue4853();


### PR DESCRIPTION
Tightened return-type overriding so that when `allow_overriding_vague_return_types` is enabled we strip docblock mixed before merging inferred types, allowing null returns to surface to callers