### PR TITLE
Bug4857

### DIFF
--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -309,6 +309,56 @@ class GenericArrayType extends ArrayType implements GenericArrayInterface
         return $this->element_type->asRealUnionType();
     }
 
+    /**
+     * @param array<int,Type> $target_type_set
+     */
+    public function canCastToAnyTypeInSet(array $target_type_set, CodeBase $code_base): bool
+    {
+        $element_union_types = null;
+        foreach ($target_type_set as $target_type) {
+            if ($target_type instanceof GenericArrayType) {
+                if ((($this->key_type ?: self::KEY_MIXED) & ($target_type->key_type ?: self::KEY_MIXED)) === 0) {
+                    continue;
+                }
+                $target_elements = $target_type->genericArrayElementUnionType();
+                $element_union_types = $element_union_types !== null ? $element_union_types->withUnionType($target_elements) : $target_elements;
+                continue;
+            }
+            if ($this->canCastToType($target_type, $code_base)) {
+                return true;
+            }
+        }
+        if ($element_union_types !== null) {
+            return $this->genericArrayElementUnionType()->canCastToUnionType($element_union_types, $code_base);
+        }
+        return false;
+    }
+
+    /**
+     * @param array<int,Type> $target_type_set
+     */
+    public function canCastToAnyTypeInSetWithoutConfig(array $target_type_set, CodeBase $code_base): bool
+    {
+        $element_union_types = null;
+        foreach ($target_type_set as $target_type) {
+            if ($target_type instanceof GenericArrayType) {
+                if ((($this->key_type ?: self::KEY_MIXED) & ($target_type->key_type ?: self::KEY_MIXED)) === 0) {
+                    continue;
+                }
+                $target_elements = $target_type->genericArrayElementUnionType();
+                $element_union_types = $element_union_types !== null ? $element_union_types->withUnionType($target_elements) : $target_elements;
+                continue;
+            }
+            if ($this->canCastToTypeWithoutConfig($target_type, $code_base)) {
+                return true;
+            }
+        }
+        if ($element_union_types !== null) {
+            return $this->genericArrayElementUnionType()->canCastToUnionTypeWithoutConfig($element_union_types, $code_base);
+        }
+        return false;
+    }
+
     public function __toString(): string
     {
         $string = $this->element_type->__toString();

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -321,7 +321,11 @@ class GenericArrayType extends ArrayType implements GenericArrayInterface
                     continue;
                 }
                 $target_elements = $target_type->genericArrayElementUnionType();
-                $element_union_types = $element_union_types !== null ? $element_union_types->withUnionType($target_elements) : $target_elements;
+                if ($element_union_types instanceof UnionType) {
+                    $element_union_types = $element_union_types->withUnionType($target_elements);
+                } else {
+                    $element_union_types = $target_elements;
+                }
                 continue;
             }
             if ($this->canCastToType($target_type, $code_base)) {
@@ -346,7 +350,11 @@ class GenericArrayType extends ArrayType implements GenericArrayInterface
                     continue;
                 }
                 $target_elements = $target_type->genericArrayElementUnionType();
-                $element_union_types = $element_union_types !== null ? $element_union_types->withUnionType($target_elements) : $target_elements;
+                if ($element_union_types instanceof UnionType) {
+                    $element_union_types = $element_union_types->withUnionType($target_elements);
+                } else {
+                    $element_union_types = $target_elements;
+                }
                 continue;
             }
             if ($this->canCastToTypeWithoutConfig($target_type, $code_base)) {

--- a/src/Phan/LanguageServer/LanguageServer.php
+++ b/src/Phan/LanguageServer/LanguageServer.php
@@ -806,8 +806,8 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
         $most_recent_node_info_request = $this->most_recent_node_info_request;
         if ($most_recent_node_info_request) {
             if ($most_recent_node_info_request instanceof GoToDefinitionRequest) {
-                // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
-                $most_recent_node_info_request->recordDefinitionLocationList($response_data['definitions'] ?? null);
+                $definitions = $response_data['definitions'] ?? [];
+                $most_recent_node_info_request->recordDefinitionLocationList($definitions);
                 if ($most_recent_node_info_request->isHoverRequest()) {
                     $normalized_hover = $most_recent_node_info_request->setHoverResponse($response_data['hover_response'] ?? null);
                     // \fwrite(\STDERR, "Creating cached_hover_response\n");

--- a/tests/files/expected/0794_associative_array_casting_rules.php.expected
+++ b/tests/files/expected/0794_associative_array_casting_rules.php.expected
@@ -1,9 +1,3 @@
 %s:19 PhanUndeclaredFunction Call to undeclared function \test_assoc()
-%s:22 PhanTypeMismatchArgument Argument 1 ($list) is $b of type associative-array<mixed,\stdClass> but \NS794\accepts_list() takes list<mixed> defined at %s:9
-%s:23 PhanTypeMismatchArgument Argument 1 ($list) is $a of type associative-array<int,string> but \NS794\accepts_list() takes list<mixed> defined at %s:9
-%s:24 PhanTypeMismatchArgumentInternal Argument 2 ($args) is $b of type associative-array<mixed,\stdClass> but \call_user_func_array() takes list<mixed>
-%s:25 PhanTypeMismatchArgumentInternal Argument 2 ($args) is $a of type associative-array<int,string> but \call_user_func_array() takes list<mixed>
 %s:27 PhanParamTooFewInternalUnpack Call with 0 or more arg(s) to \var_dump($value, ...$values) which requires 1 arg(s). This may throw an ArgumentCountError if there are too few args at runtime.
-%s:37 PhanTypeMismatchArgument Argument 1 ($a) is $a of type list<string> but \NS794\test_cannot_pass_associative_to_list() takes associative-array<int,string> defined at %s:17
-%s:37 PhanTypeMismatchArgument Argument 2 ($b) is $b of type list<\stdClass> but \NS794\test_cannot_pass_associative_to_list() takes associative-array<mixed,\stdClass> defined at %s:17
 %s:38 PhanTypeMismatchArgument Argument 1 ($a) is $b of type list<\stdClass> but \NS794\test_cannot_pass_associative_to_list() takes associative-array<int,string> defined at %s:17

--- a/tests/files/expected/0796_possibly_empty_associative_array.php.expected
+++ b/tests/files/expected/0796_possibly_empty_associative_array.php.expected
@@ -1,2 +1,1 @@
 %s:8 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type associative-array<int,\stdClass>(real=associative-array<int,\stdClass>)
-%s:11 PhanTypeMismatchReturn Returning $x of type non-empty-associative-array<int,\stdClass> but test_associative_array_possibly_empty() is declared to return ?list<\stdClass>

--- a/tests/files/src/4857_non_empty_list.php
+++ b/tests/files/src/4857_non_empty_list.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @param array<string,int|string> $row
+ */
+function take_row($row): void {
+    var_dump($row);
+}
+
+/**
+ * @param list<array<string,int|string>> $rows
+ */
+function take_rows($rows): void {
+    var_dump($rows);
+}
+
+$row = ['a' => 1, 'b' => '2'];
+take_row($row);
+
+$rows = [];
+foreach ([1, 2, 3] as $_) {
+    $rows[] = $row;
+}
+take_rows($rows);

--- a/tests/plugin_test/expected/159_array_unshift_convert_to_list.php.expected
+++ b/tests/plugin_test/expected/159_array_unshift_convert_to_list.php.expected
@@ -1,2 +1,1 @@
-src/159_array_unshift_convert_to_list.php:9 PhanTypeMismatchReturn Returning $values of type non-empty-list<string> but test_unshift_converts_assoc_int_to_list() is declared to return associative-array<int,string>
 src/159_array_unshift_convert_to_list.php:18 PhanPartialTypeMismatchReturn Returning $values of type non-empty-array<string,string>|non-empty-list<string> but test_unshift_doesnt_convert_assoc_string() is declared to return list<string> (non-empty-array<string,string> is incompatible)


### PR DESCRIPTION
- merge element union types across compatible generic-array targets when checking `canCastToAnyTypeInSet*`, so a `non-empty-list<array{…}>` can satisfy `list<array<string,int|string>>` without degrading other casts
- When the language server forwards definition results it now substitutes an empty list rather than null, matching the callee’s contract