### PR TITLE
Fix bug #5143

### DIFF
--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -5884,8 +5884,9 @@ class UnionType implements Serializable, Stringable
      */
     private static function applyNumericOperationToList(array $type_set, Closure $operation): array
     {
-        $added_fallbacks = false;
         $result = [];
+        $needs_int_fallback = false;
+        $needs_float_fallback = false;
         foreach ($type_set as $type) {
             if ($type->isNullable()) {
                 $result[] = LiteralIntType::instanceForValue(0, false);
@@ -5902,20 +5903,23 @@ class UnionType implements Serializable, Stringable
                     }
                     continue;
                 }
-                if ($added_fallbacks) {
+                if ($type instanceof IntType) {
+                    $needs_int_fallback = true;
                     continue;
                 }
-                if (!($type instanceof IntType)) {
-                    $result[] = FloatType::instance(false);
-                    if (!($type instanceof FloatType)) {
-                        $result[] = IntType::instance(false);
-                    }
-                    $added_fallbacks = true;
-                } else {
-                    $result[] = IntType::instance(false);
-                    // Keep added_fallbacks false in case this needs to add FloatType
+                if ($type instanceof FloatType) {
+                    $needs_float_fallback = true;
+                    continue;
                 }
+                $needs_float_fallback = true;
+                $needs_int_fallback = true;
             }
+        }
+        if ($needs_float_fallback) {
+            $result[] = FloatType::instance(false);
+        }
+        if ($needs_int_fallback) {
+            $result[] = IntType::instance(false);
         }
         if (!$result) {
             // @phan-suppress-next-line PhanTypeMismatchReturn

--- a/tests/files/expected/085_unary_numeric_union.php.expected
+++ b/tests/files/expected/085_unary_numeric_union.php.expected
@@ -1,0 +1,6 @@
+%s:5 PhanDebugAnnotation @phan-debug-var requested for variable $value - it has union type float|int(real=float|int)
+%s:7 PhanDebugAnnotation @phan-debug-var requested for variable $minus - it has union type float|int(real=float|int)
+%s:9 PhanDebugAnnotation @phan-debug-var requested for variable $plus - it has union type float|int(real=float|int)
+%s:13 PhanDebugAnnotation @phan-debug-var requested for variable $value - it has union type float|int(real=float|int)
+%s:15 PhanDebugAnnotation @phan-debug-var requested for variable $minus - it has union type float|int(real=float|int)
+%s:17 PhanDebugAnnotation @phan-debug-var requested for variable $plus - it has union type float|int(real=float|int)

--- a/tests/files/src/085_unary_numeric_union.php
+++ b/tests/files/src/085_unary_numeric_union.php
@@ -1,0 +1,19 @@
+<?php
+
+/* @phan-file-suppress PhanUnusedVariable */
+
+function unaryFloatInt(float|int $value): void {
+    '@phan-debug-var $value';
+    $minus = -$value;
+    '@phan-debug-var $minus';
+    $plus = +$value;
+    '@phan-debug-var $plus';
+}
+
+function unaryIntFloat(int|float $value): void {
+    '@phan-debug-var $value';
+    $minus = -$value;
+    '@phan-debug-var $minus';
+    $plus = +$value;
+    '@phan-debug-var $plus';
+}


### PR DESCRIPTION
- Reworked numeric fallback aggregation in `UnionType.php` so unary +/- now add int and float fallbacks independently of the union’s iteration order, eliminating the previous ordering bug