### PR TITLE
Fix bug #4827

### DIFF
--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -49,7 +49,6 @@ use Phan\Language\Type\ArrayType;
 use Phan\Language\Type\MixedType;
 use Phan\Language\Type\NeverType;
 use Phan\Language\Type\NullType;
-use Phan\Language\Type\StringType;
 use Phan\Language\UnionType;
 use Phan\Library\FileCache;
 use Phan\Library\IncrementalAnalysis\DependencyTracker;
@@ -467,12 +466,11 @@ class ParseVisitor extends ScopeVisitor
                 }
             }
         } elseif ('__tostring' === $method_name_lower) {
-            if (!$this->context->isStrictTypes()) {
-                $class->addAdditionalType(StringType::instance(false));
-            }
             // In PHP 8 and later having a __toString method automatically adds the Stringable interface, #4476
-            // @phan-suppress-next-line PhanThrowTypeAbsentForCall should not happen, built in type
-            $class->addAdditionalType(Type::fromFullyQualifiedString('\Stringable'));
+            if (Config::get_closest_minimum_target_php_version_id() >= 80000) {
+                // @phan-suppress-next-line PhanThrowTypeAbsentForCall should not happen, built in type
+                $class->addAdditionalType(Type::fromFullyQualifiedString('\Stringable'));
+            }
         }
 
 

--- a/tests/Phan/MultiFileTest.php
+++ b/tests/Phan/MultiFileTest.php
@@ -116,6 +116,14 @@ class MultiFileTest extends AbstractPhanFileTest
                 ],
                 MULTI_EXPECTED_DIR . DIRECTORY_SEPARATOR . '3706.php' . AbstractPhanFileTest::EXPECTED_SUFFIX,
             ],
+            // #4827
+            [
+                [
+                    MULTI_FILE_DIR . DIRECTORY_SEPARATOR . '4827_a.php',
+                    MULTI_FILE_DIR . DIRECTORY_SEPARATOR . '4827_b.php',
+                ],
+                MULTI_EXPECTED_DIR . DIRECTORY_SEPARATOR . '4827.php' . AbstractPhanFileTest::EXPECTED_SUFFIX,
+            ],
             // Manually add additional file sets and expected
             // output here.
 

--- a/tests/files/expected/0065_tostring.php.expected
+++ b/tests/files/expected/0065_tostring.php.expected
@@ -1,1 +1,3 @@
-%s:16 PhanTypeMismatchArgumentReal Argument 2 ($arg) is new Stringular() of type \Stringable|\Stringular|string but \test() takes int defined at %s:10
+%s:15 PhanTypeMismatchArgumentReal Argument 1 ($test) is new Stringular() of type \Stringable|\Stringular but \test() takes string defined at %s:10
+%s:16 PhanTypeMismatchArgumentReal Argument 1 ($test) is new Stringular() of type \Stringable|\Stringular but \test() takes string defined at %s:10
+%s:16 PhanTypeMismatchArgumentReal Argument 2 ($arg) is new Stringular() of type \Stringable|\Stringular but \test() takes int defined at %s:10

--- a/tests/multi_files/expected/4827.php.expected
+++ b/tests/multi_files/expected/4827.php.expected
@@ -1,0 +1,5 @@
+%s:6 PhanTypeMismatchArgumentReal Argument 1 ($value) is new HasToString() of type \HasToString|\Stringable but \takesString() takes string defined at %s:9
+%s:7 PhanTypeMismatchArgumentReal Argument 1 ($value) is new HasToString() of type \HasToString|\Stringable but \takesString() takes string defined at %s:9
+%s:7 PhanTypeMismatchArgumentReal Argument 2 ($arg) is new HasToString() of type \HasToString|\Stringable but \takesString() takes int defined at %s:9
+%s:10 PhanNoopNew Unused result of new object creation expression in new \Exception(new HasToString()) (this may be called for the side effects of the non-empty constructor or destructor)
+%s:10 PhanTypeMismatchArgumentInternalReal Argument 1 ($message) is new HasToString() of type \HasToString|\Stringable but \Exception::__construct() takes string

--- a/tests/multi_files/src/4827_a.php
+++ b/tests/multi_files/src/4827_a.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/4827_b.php';
+
+takesString(new HasToString());
+takesString(new HasToString(), new HasToString());
+
+function takesString(string $value, int $arg = 0): void {}
+new \Exception(new HasToString());

--- a/tests/multi_files/src/4827_b.php
+++ b/tests/multi_files/src/4827_b.php
@@ -1,0 +1,9 @@
+<?php
+
+class HasToString
+{
+    public function __toString(): string
+    {
+        return 'value';
+    }
+}


### PR DESCRIPTION
- Dropped the unconditional StringType fallback from `ParseVisitor::visitMethod()` so having `__toString()` no longer gives the class a global string type; the `Stringable` interface is still added
- This makes strict-callers treat `HasToString` as an object again, while the existing non‑strict checks (`hasClassWithToStringMethod()`) continue to suppress false positives where coercion is allowed