### PR TITLE
Fix bug #4787

### DIFF
--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -32,6 +32,7 @@ use Phan\Language\FQSEN\FullyQualifiedPropertyName;
 use Phan\Language\NamespaceMapEntry;
 use Phan\Language\Type;
 use Phan\Language\UnionType;
+use Phan\Language\Type\StringType;
 use Phan\Library\Map;
 use Phan\Library\Set;
 use Phan\Library\StringSuggester;
@@ -238,9 +239,27 @@ class CodeBase
         $this->addGlobalConstantsByNames($internal_constant_name_list);
         // These are keywords that Phan expects to always exist - make sure to add them even if they weren't provided.
         $this->addGlobalConstantsByNames(['true', 'false', 'null']);
+        $this->ensureSidConstantExists();
         // We initialize the FQSENs early on so that they show up
         // in the proper casing.
         $this->addInternalFunctionsByNames($internal_function_name_list);
+    }
+
+    private function ensureSidConstantExists(): void
+    {
+        $sid_fqsen = FullyQualifiedGlobalConstantName::fromFullyQualifiedString('\\SID');
+        if ($this->hasGlobalConstantWithFQSEN($sid_fqsen)) {
+            return;
+        }
+        $sid_constant = new GlobalConstant(
+            new Context(),
+            'SID',
+            StringType::instance(false)->asPHPDocUnionType(),
+            0,
+            $sid_fqsen
+        );
+        $sid_constant->setIsDynamicConstant(true);
+        $this->addGlobalConstant($sid_constant);
     }
 
     /**

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -247,7 +247,11 @@ class CodeBase
 
     private function ensureSidConstantExists(): void
     {
-        $sid_fqsen = FullyQualifiedGlobalConstantName::fromFullyQualifiedString('\\SID');
+        try {
+            $sid_fqsen = FullyQualifiedGlobalConstantName::fromFullyQualifiedString('\\SID');
+        } catch (FQSENException) {
+            return;
+        }
         if ($this->hasGlobalConstantWithFQSEN($sid_fqsen)) {
             return;
         }

--- a/tests/files/src/4787_sid_constant.php
+++ b/tests/files/src/4787_sid_constant.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @phan-file-suppress PhanPluginNoCommentOnFile
+ * @phan-file-suppress PhanPluginNoCommentOnFunction
+ * @phan-file-suppress PhanPluginRemoveDebugEcho
+ */
+function useSidConstant(): void
+{
+    if (SID !== '') {
+        echo SID;
+    }
+}


### PR DESCRIPTION
Add some special-case handling for the SID constant. SID is special because it is the only internal constant that is dynamically defined and not defined during MINIT.