### PR TITLE
Fix Bug 4789

### DIFF
--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1552,9 +1552,25 @@ class UnionTypeVisitor extends AnalysisVisitor
             $stdclass = Type::fromFullyQualifiedString('\stdClass');
         }
         $has_array = $expr_type->hasArray();
+        $array_shape_real_types = [];
         if ($has_array) {
             if ($expr_type->isExclusivelyArray()) {
+                foreach ($expr_type->getTypeSet() as $type) {
+                    if ($type instanceof ArrayShapeType) {
+                        $array_shape_real_types[] = $type;
+                    }
+                }
+                if ($array_shape_real_types) {
+                    return $stdclass->asRealUnionType()->withRealTypeSet(
+                        UnionType::of($array_shape_real_types)->getTypeSet()
+                    );
+                }
                 return $stdclass->asRealUnionType();
+            }
+            foreach ($expr_type->getTypeSet() as $type) {
+                if ($type instanceof ArrayShapeType) {
+                    $array_shape_real_types[] = $type;
+                }
             }
         }
         $expr_type = $expr_type->objectTypes();
@@ -1564,11 +1580,14 @@ class UnionTypeVisitor extends AnalysisVisitor
         $expr_type = $expr_type->nonNullableClone();
         if ($has_array) {
             $expr_type = $expr_type->withType($stdclass);
-            if ($expr_type->hasRealTypeSet()) {
-                return $expr_type->withRealTypeSet(\array_merge($expr_type->getRealTypeSet(), [$stdclass]));
-            } else {
-                return $expr_type->withRealType(ObjectType::instance(false));
+            $real_types = $expr_type->getRealTypeSet();
+            if (!$real_types) {
+                $real_types = [ObjectType::instance(false)];
             }
+            if ($array_shape_real_types) {
+                $real_types = UnionType::of(\array_merge($real_types, $array_shape_real_types))->getTypeSet();
+            }
+            return $expr_type->withRealTypeSet($real_types);
         }
         if (!$expr_type->hasRealTypeSet()) {
             return $expr_type->withRealType(ObjectType::instance(false));
@@ -2809,6 +2828,16 @@ class UnionTypeVisitor extends AnalysisVisitor
                 $node
             ))->getProperty($is_static);
 
+            $expression_type = null;
+            if ($expr_node instanceof Node) {
+                $expression_type = UnionTypeVisitor::unionTypeFromNode(
+                    $this->code_base,
+                    $this->context,
+                    $expr_node,
+                    $this->should_catch_issue_exception
+                );
+            }
+
             if ($property->isWriteOnly()) {
                 $this->emitIssue(
                     $property->isFromPHPDoc() ? Issue::AccessWriteOnlyMagicProperty : Issue::AccessWriteOnlyProperty,
@@ -2835,14 +2864,17 @@ class UnionTypeVisitor extends AnalysisVisitor
 
             // Map template types to concrete types
             if ($union_type->hasTemplateTypeRecursive()) {
-                // Get the type of the object to which the property belongs
-                $expression_type = UnionTypeVisitor::unionTypeFromNode(
-                    $this->code_base,
-                    $this->context,
-                    $expr_node,
-                    $this->should_catch_issue_exception
-                );
-
+                if (!$expression_type && $expr_node instanceof Node) {
+                    $expression_type = UnionTypeVisitor::unionTypeFromNode(
+                        $this->code_base,
+                        $this->context,
+                        $expr_node,
+                        $this->should_catch_issue_exception
+                    );
+                }
+                if (!$expression_type) {
+                    return $union_type;
+                }
                 $union_type = $union_type->withTemplateParameterTypeMap(
                     $expression_type->getTemplateParameterTypeMap($this->code_base)
                 );
@@ -2858,6 +2890,17 @@ class UnionTypeVisitor extends AnalysisVisitor
                         if ($declaring_union_type !== $union_type && !$declaring_union_type->hasTemplateTypeRecursive()) {
                             $union_type = $union_type->withUnionType($declaring_union_type);
                         }
+                    }
+                }
+            }
+
+            if ($expression_type) {
+                $shape_union_type = self::inferObjectShapePropertyUnionType($expression_type, $property->getName());
+                if (!$shape_union_type->isEmpty()) {
+                    if ($property->getClassFQSEN()->__toString() === '\\stdClass' && $property->getPHPDocUnionType()->isEmpty()) {
+                        $union_type = $shape_union_type;
+                    } else {
+                        $union_type = $union_type->withUnionType($shape_union_type);
                     }
                 }
             }
@@ -2917,6 +2960,22 @@ class UnionTypeVisitor extends AnalysisVisitor
         }
 
         return UnionType::empty();
+    }
+
+    private static function inferObjectShapePropertyUnionType(UnionType $expression_type, string $property_name): UnionType
+    {
+        $result = UnionType::empty();
+        foreach ($expression_type->getRealTypeSet() as $real_type) {
+            if (!$real_type instanceof ArrayShapeType) {
+                continue;
+            }
+            $field_types = $real_type->getFieldTypes();
+            if (!\array_key_exists($property_name, $field_types)) {
+                continue;
+            }
+            $result = $result->withUnionType($field_types[$property_name]);
+        }
+        return $result;
     }
 
     private function warnIfPossiblyUndefinedProperty(Node $node, string $prop_name, UnionType $union_type): void

--- a/tests/files/expected/0300_misc_types.php.expected
+++ b/tests/files/expected/0300_misc_types.php.expected
@@ -15,7 +15,7 @@
 %s:22 PhanUnusedVariableReference Unused definition of variable $refIntVar as a reference
 %s:23 PhanImpossibleCondition Impossible attempt to cast false of type false to truthy
 %s:23 PhanTypeMismatchArgument Argument 1 ($x) is `ls` of type ?string but \expect_int_300() takes int defined at %s:4
-%s:25 PhanTypeMismatchArgumentReal Argument 1 ($x) is (object)(['key'=>'val']) of type \stdClass but \expect_string_300() takes string defined at %s:3
+%s:25 PhanTypeMismatchArgumentReal Argument 1 ($x) is (object)(['key'=>'val']) of type \stdClass (real type array{key:'val'}) but \expect_string_300() takes string defined at %s:3
 %s:26 PhanImpossibleCondition Impossible attempt to cast null of type null to truthy
 %s:26 PhanTypeMismatchArgument Argument 1 ($x) is (null ? 'string' : 3) of type 3 but \expect_string_300() takes string defined at %s:3
 %s:27 PhanImpossibleCondition Impossible attempt to cast null of type null to truthy

--- a/tests/files/expected/0365_array_map_callable.php.expected
+++ b/tests/files/expected/0365_array_map_callable.php.expected
@@ -1,6 +1,7 @@
 %s:7 PhanTypeMismatchArgumentReal Argument 1 ($x) is [$str] of type 'x' (real type ?'x') but Closure(int $x) : int takes int defined at %s:7
 %s:7 PhanTypeMismatchReturn Returning array_map((function), [$str]) of type non-empty-array<int,int> but test365A() is declared to return string[]
 %s:13 PhanTypeMismatchReturn Returning array_map('strlen', [$str]) of type non-empty-array<int,int> but test365B() is declared to return string[]
+%s:18 PhanTypeMismatchReturnReal Returning (object)(['key'=>$x]) of type \stdClass (real type array{key:string}) but createObject() is declared to return \stdClass
 %s:32 PhanTypeMismatchReturn Returning array_map('C365::createObject', [$str]) of type non-empty-array<int,\stdClass> but test365C() is declared to return string[]
 %s:38 PhanUndeclaredClassInCallable Reference to undeclared class \Missing365 in callable \Missing365::createObject
 %s:44 PhanTypeMismatchArgumentReal Argument 1 ($x) is [$str] of type 'x' (real type ?'x') but \C365::createArray() takes int defined at %s:24

--- a/tests/files/expected/0371_callable_in_namespace.php.expected
+++ b/tests/files/expected/0371_callable_in_namespace.php.expected
@@ -2,6 +2,7 @@
 %s:26 PhanTypeMismatchArgumentReal Argument 1 ($x) is ['key'=>$obj] of type \stdClass (real type ?\stdClass) but \Foo\NS371\strlen371() takes string defined at %s:4
 %s:32 PhanTypeMismatchArgumentReal Argument 1 ($x) is [$obj] of type \stdClass (real type ?\stdClass) but \Foo\NS371\C371::strlen371() takes string defined at %s:8
 %s:38 PhanTypeMismatchReturn Returning array_map('Foo\\NS371\\C371::strlen371', [$str]) of type non-empty-array<int,int> but my_test371E() is declared to return string[]
+%s:48 PhanTypeMismatchReturnReal Returning (object)(['key'=>$x]) of type \stdClass (real type array{key:string}) but createObject() is declared to return \stdClass
 %s:62 PhanTypeMismatchReturn Returning array_map('Foo\\Bar\\C371::createObject', [$str]) of type non-empty-array<int,\stdClass> but test371C() is declared to return string[]
 %s:68 PhanTypeMismatchReturn Returning array_map([C371::class,'createObject'], [$str]) of type non-empty-array<int,\stdClass> but test371C2() is declared to return string[]
 %s:74 PhanUndeclaredClassInCallable Reference to undeclared class \Foo\Bar\Missing371 in callable \Foo\Bar\Missing371::createObject

--- a/tests/files/expected/0604_closure_combine.php.expected
+++ b/tests/files/expected/0604_closure_combine.php.expected
@@ -1,2 +1,3 @@
+%s:27 PhanTypeMismatchReturnReal Returning (object)(['value'=>$value]) of type \stdClass (real type array{value:string}) but Closure(string $value) : \stdClass is declared to return \stdClass
 %s:30 PhanTypeMismatchArgumentProbablyReal Argument 1 ($p0) is 'key' of type 'key' but Closure(string[]):\stdClass takes string[] (no real type) defined at %s:10 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
 %s:59 PhanTypeMismatchArgument Argument 1 ($p0) is [new stdClass()] of type array{0:\stdClass} but Closure(array<int,string>):string takes array<int,string> defined at %s:47

--- a/tests/files/expected/1114_intersection_type_phpdoc_invalid.php.expected
+++ b/tests/files/expected/1114_intersection_type_phpdoc_invalid.php.expected
@@ -6,4 +6,5 @@
 %s:13 PhanDebugAnnotation @phan-debug-var requested for variable $other - it has union type int&null
 %s:13 PhanTypeMismatchArgument Argument 1 ($p0) is $other of type (int&null)|int|null but Closure(int&string):\stdClass&\ArrayObject takes int&string defined at %s:9
 %s:17 PhanTypeMismatchArgumentSuperType Argument 1 ($value) is (function) of type Closure(int):\stdClass but \test42() takes Closure(int&string):\stdClass&\ArrayObject defined at %s:9 (expected type to be the same or a subtype, but saw a supertype instead)
+%s:18 PhanTypeMismatchReturnReal Returning (object)(['x'=>$x]) of type \stdClass (real type array{x:int}) but Closure(int $x) : \stdClass is declared to return \stdClass
 %s:20 PhanTypeMismatchArgumentProbablyReal Argument 2 ($other) is null of type null but \test42() takes int&null (no real type) defined at %s:9 (the inferred real argument type has nothing in common with the parameter's phpdoc type)

--- a/tests/files/expected/4789_stdclass_shape.php.expected
+++ b/tests/files/expected/4789_stdclass_shape.php.expected
@@ -1,0 +1,2 @@
+%s:16 PhanDebugAnnotation @phan-debug-var requested for variable $var - it has union type 'string'
+%s:16 PhanUnusedVariable Unused definition of variable $var

--- a/tests/files/src/4789_stdclass_shape.php
+++ b/tests/files/src/4789_stdclass_shape.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @phan-file-suppress PhanPluginNoCommentOnFunction
+ * @phan-file-suppress PhanPluginNoCommentOnFile
+ */
+function assignInt(): void
+{
+    $data = (object) [];
+    $data->status = 3;
+}
+
+function assignString(): void
+{
+    $data = (object) ['status' => 'string'];
+    $var = $data->status;
+    '@phan-debug-var $var';
+}

--- a/tests/plugin_test/expected/049_redundant_null_coalescing.php.expected
+++ b/tests/plugin_test/expected/049_redundant_null_coalescing.php.expected
@@ -3,3 +3,4 @@ src/049_redundant_null_coalescing.php:4 PhanPluginDuplicateConditionalNullCoales
 src/049_redundant_null_coalescing.php:5 PhanPluginDuplicateConditionalNullCoalescing "isset(X) ? X : Y" can usually be simplified to "X ?? Y" in PHP 7. The duplicated expression X was $x->prop
 src/049_redundant_null_coalescing.php:6 PhanPluginDuplicateExpressionBinaryOp Both sides of the binary operator == are the same: $x->prop
 src/049_redundant_null_coalescing.php:9 PhanPluginDuplicateConditionalTernaryDuplication "X ? X : Y" can usually be simplified to "X ?: Y". The duplicated expression X was $x->prop
+src/049_redundant_null_coalescing.php:14 PhanTypeMismatchArgumentReal Argument 1 ($x) is (object)(['prop'=>'value']) of type \stdClass (real type array{prop:'value'}) but \example49() takes ?\stdClass defined at src/049_redundant_null_coalescing.php:3

--- a/tests/plugin_test/expected/071_other_callable_methods.php.expected
+++ b/tests/plugin_test/expected/071_other_callable_methods.php.expected
@@ -1,3 +1,4 @@
+src/071_other_callable_methods.php:5 PhanTypeMismatchReturnReal Returning (object)(['arg'=>$arg]) of type \stdClass (real type array{arg:mixed}) but __invoke() is declared to return \stdClass
 src/071_other_callable_methods.php:22 PhanTypeMismatchArgumentInternal Argument 1 ($string) is template_return_test(['InvokableTemplateTest','createArrayObject']) of type \ArrayAccess|\ArrayObject|\Countable|\IteratorAggregate|\Serializable|\Traversable|iterable but \strlen() takes string
 src/071_other_callable_methods.php:23 PhanUndeclaredStaticMethodInCallable Reference to undeclared static method \InvokableTemplateTest::missingMethod in callable
 src/071_other_callable_methods.php:24 PhanTypeMismatchArgumentInternal Argument 1 ($string) is template_return_test([$o,'createArrayObject']) of type \ArrayAccess|\ArrayObject|\Countable|\IteratorAggregate|\Serializable|\Traversable|iterable but \strlen() takes string


### PR DESCRIPTION
 - Refined `UnionTypeVisitor::typeAfterCastToObject()` so that when an array shape is cast to `stdClass`, the resulting object keeps the shape’s real-type metadata instead of collapsing to a generic `stdClass`.
 - Added `UnionTypeVisitor::inferObjectShapePropertyUnionType()` to pull the field types out of shape literals, letting subsequent property lookups on the same `stdClass` instance reuse the precise shape-derived unions rather than falling back to global defaults.