### PR TITLE
Fix #4589

### DIFF
--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
@@ -1110,13 +1110,14 @@ final class VariableTrackerVisitor extends AnalysisVisitor
         }
 
         $catches_will_throw_or_return = BlockExitStatusChecker::willUnconditionallyThrowOrReturn($catches_node);
+        $try_always_exits = BlockExitStatusChecker::willUnconditionallyThrowOrReturn($try_node);
 
         $catch_node_list = $catches_node->children;
         if (\count($catch_node_list) > 0) {
             $catches_scope = new VariableTrackingBranchScope($main_scope);
             $catches_scope = $this->analyze($catches_scope, $catches_node);
             if (!$catches_will_throw_or_return) {
-                if (BlockExitStatusChecker::willUnconditionallyThrowOrReturn($try_node)) {
+                if ($try_always_exits && $finally_node === null) {
                     // @phan-suppress-next-line PhanTypeMismatchArgument
                     $main_scope = $main_scope->mergeBranchScopeList([$catches_scope], false, []);
                 } else {

--- a/tests/files/src/4589_try_catch_finally.php
+++ b/tests/files/src/4589_try_catch_finally.php
@@ -1,0 +1,13 @@
+<?php
+function test_issue_4589(string $path) {
+    $threw = null;
+    try {
+        return require $path;
+    } catch (\Throwable $e) {
+        $threw = $e;
+    } finally {
+        if ($threw) {
+            echo "exception handled\n";
+        }
+    }
+}


### PR DESCRIPTION
- Adjusted `VariableTrackerVisitor::visitTry()` so catch merges keep the pre-try definitions whenever a finally block is present, ensuring variables seeded before the try remain visible to the finally branch even if the try body always returns