### PR TITLE
Fix bug #4802

### DIFF
--- a/src/Phan/Plugin/Internal/VariableTracker/VariableGraph.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableGraph.php
@@ -43,6 +43,16 @@ final class VariableGraph
     public $def_bitset = [];
 
     /**
+     * @var array<int,string> maps usage node ids to the variable name seen at that node
+     */
+    private $use_node_id_to_var_name = [];
+
+    /**
+     * @var array<string,associative-array<int,true>> maps variable names to node ids that modify them
+     */
+    private $modification_node_ids = [];
+
+    /**
      * @var array<string,int> maps variable names to whether
      *    they have ever occurred as a given self::IS_* category in the current scope
      */
@@ -97,11 +107,12 @@ final class VariableGraph
             // (it will be overridden later if there are flags to set)
             $this->variable_types[$name] = 0;
         }
+        $node_id = \spl_object_id($node);
+        $this->use_node_id_to_var_name[$node_id] = $name;
         // @phan-suppress-next-line PhanUndeclaredProperty added by ArgumentType analyzer
         if (isset($node->is_reference)) {
             $this->markAsReference($name);
         }
-        $node_id = \spl_object_id($node);
         $scope->recordUsageById($name, $node_id);
         $defs_for_variable = $scope->getDefinition($name);
         if (!$defs_for_variable) {
@@ -116,10 +127,15 @@ final class VariableGraph
 
     /**
      * Record that $name was modified in place
+     *
+     * @param Node|null $node the node responsible for the modification, if known
      */
-    public function recordVariableModification(string $name): void
+    public function recordVariableModification(string $name, ?Node $node = null): void
     {
         $this->const_expr_declarations[$name][-1] = 0;
+        if ($node instanceof Node) {
+            $this->modification_node_ids[$name][\spl_object_id($node)] = true;
+        }
     }
 
     /**
@@ -298,5 +314,21 @@ final class VariableGraph
             }
         }
         return $combined_use_def_map;
+    }
+
+    /**
+     * @return array<int,string>
+     */
+    public function getUseNodeIdToVariableNameMap(): array
+    {
+        return $this->use_node_id_to_var_name;
+    }
+
+    /**
+     * @return array<string,associative-array<int,true>>
+     */
+    public function getModificationNodeIdsByVariable(): array
+    {
+        return $this->modification_node_ids;
     }
 }

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
@@ -518,7 +518,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
                     self::$variable_graph->markAsUnset($expr);
                 }
                 self::$variable_graph->recordVariableUsage($name, $expr, $this->scope);
-                self::$variable_graph->recordVariableModification($name);
+                self::$variable_graph->recordVariableModification($name, $expr);
             }
         }
         return $this->analyzeWhenValidNode($this->scope, $expr);  // lower false positives by not treating this as a definition
@@ -548,7 +548,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
                         self::$variable_graph->markAsUnset($expr);
                         self::$variable_graph->recordVariableDefinition($name, $expr, $this->scope, null);
                     } else {
-                        self::$variable_graph->recordVariableModification($name);
+                        self::$variable_graph->recordVariableModification($name, $expr);
                     }
                 }
                 break;

--- a/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
+++ b/src/Phan/Plugin/Internal/VariableTrackerPlugin.php
@@ -147,6 +147,8 @@ final class VariableTrackerElementVisitor extends PluginAwarePostAnalysisVisitor
             return;
         }
         $combined_use_defs = $variable_graph->computeCombinedUseDefs();
+        $use_node_id_to_var_name = $variable_graph->getUseNodeIdToVariableNameMap();
+        $modification_nodes_by_variable = $variable_graph->getModificationNodeIdsByVariable();
         foreach ($loop_nodes as $loop_node) {
             // Check if any variables read by the loop condition were set within the statements.
             $cond = $loop_node->children['cond'];
@@ -173,10 +175,15 @@ final class VariableTrackerElementVisitor extends PluginAwarePostAnalysisVisitor
                     }
                     if ($id_set_of_stmts) {
                         foreach ($id_set_in_loop as $id => $_) {
-                            if (!isset($combined_use_defs[$id])) {
+                            $var_name = $use_node_id_to_var_name[$id] ?? null;
+                            if (isset($combined_use_defs[$id]) && \array_intersect_key($combined_use_defs[$id], $id_set_of_stmts)) {
+                                continue 2;
+                            }
+                            if ($var_name === null) {
                                 continue;
                             }
-                            if (\array_intersect_key($combined_use_defs[$id], $id_set_of_stmts)) {
+                            $modified_nodes = $modification_nodes_by_variable[$var_name] ?? null;
+                            if ($modified_nodes && \array_intersect_key($modified_nodes, $id_set_of_stmts)) {
                                 continue 2;
                             }
                         }

--- a/tests/files/src/4802_possibly_infinite_loop.php
+++ b/tests/files/src/4802_possibly_infinite_loop.php
@@ -1,0 +1,12 @@
+<?php
+/** @phan-file-suppress PhanUnreferencedFunction */
+function issue4802(array $pages, array $fallback): array {
+    if (!$pages) {
+        return $pages;
+    }
+    $albumCount = count($fallback);
+    while (count($pages) < $albumCount) {
+        $pages[] = '<!-- my-placeholder -->';
+    }
+    return $pages;
+}


### PR DESCRIPTION
- Extended `VariableGraph` to remember which variable each use-node corresponds to and where array/offset/property writes occur, so loop analysis can see that `count($var)` conditions reference values updated in the body
- Updated `VariableTrackerVisitor` to pass the AST node responsible for property/dimension assignments into the modification tracker, letting the graph tie the loop body back to the same symbol
- Taught `VariableTrackerPlugin::checkPossiblyInfiniteLoopNodes()` to skip the warning when either a definition or one of the new modification nodes for the condition variable appears inside the loop body

# Performance Impact
  - All the new tracking lives inside the dead-code/unused-variable pass (VariableTrackerPlugin), so normal Phan runs without that plugin are unaffected.
  - Two small hash maps were added per analyzed function: use_node_id_to_var_name (one entry per variable read) and modification_node_ids (one entry per write we
  already noticed). These are simple spl_object_id→string/int lookups; they’re populated while we’re already traversing the same nodes, so insertion cost is O(1) each.
  - When checking for PhanPossiblyInfiniteLoop, we do an extra array_intersect_key between the condition’s node-id set and the recorded modification set. That’s a hash-
  intersection bounded by the number of nodes inside the loop body, typically small for real-world loops.
  - Memory scales linearly with the number of variable reads/writes in a single function-like scope; for most code this should be negligible and comparable to other
  per-function bookkeeping we already perform.