### PR TITLE
Fix bug #4629

### DIFF
--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -2053,8 +2053,22 @@ class UnionTypeVisitor extends AnalysisVisitor
     {
         $dim_node = $node->children['dim'];
         if ($dim_node instanceof Node) {
-            $dim_value = (new ContextNode($this->code_base, $this->context, $dim_node))
-                ->getEquivalentPHPScalarValue($this->should_catch_issue_exception);
+            $catch_issues = $this->should_catch_issue_exception;
+            if ($dim_node->kind === ast\AST_CONST) {
+                $catch_issues = false;
+            }
+            try {
+                $dim_value = (new ContextNode($this->code_base, $this->context, $dim_node))
+                    ->getEquivalentPHPScalarValue($catch_issues);
+            } catch (IssueException $exception) {
+                if ($dim_node->kind === ast\AST_CONST) {
+                    return null;
+                }
+                throw $exception;
+            }
+            if ($dim_node->kind === ast\AST_CONST && $dim_value instanceof Node) {
+                return null;
+            }
         } else {
             $dim_value = $dim_node;
         }

--- a/tests/files/src/4629_define_global.php
+++ b/tests/files/src/4629_define_global.php
@@ -1,0 +1,10 @@
+<?php
+function issue4629_func() {
+    $arr = [0, 1];
+    return $arr[CONSTANT_NAME];
+}
+
+$m = 1;
+define('CONSTANT_NAME', $m);
+
+echo issue4629_func();


### PR DESCRIPTION
tweaked `UnionTypeVisitor::resolveArrayShapeElementTypes()` so array offsets backed by constants defined later via `define()` no longer try to resolve the constant immediately (we now skip the scalar conversion to avoid flagging `$m` before it exists) in a case like:
```php
<?php
function issue4629_func() {
    $arr = [0, 1];
    return $arr[CONSTANT_NAME];
}

$m = 1;
define('CONSTANT_NAME', $m);

echo issue4629_func();
```