### PR TITLE
Feature707

### DIFF
--- a/src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php
@@ -11,6 +11,7 @@ use Phan\AST\UnionTypeVisitor;
 use Phan\CodeBase;
 use Phan\Language\Context;
 use Phan\Language\Element\Func;
+use Phan\Language\FQSEN\FullyQualifiedGlobalConstantName;
 use Phan\Language\Type;
 use Phan\Language\Type\ArrayShapeType;
 use Phan\Language\Type\CallableArrayType;
@@ -25,6 +26,8 @@ use Phan\Language\UnionType;
 use Phan\PluginV3;
 use Phan\PluginV3\ReturnTypeOverrideCapability;
 
+use Phan\Exception\FQSENException;
+use InvalidArgumentException;
 use function count;
 use function is_int;
 use function is_string;
@@ -51,6 +54,7 @@ final class DependentReturnTypeOverridePlugin extends PluginV3 implements
         $string_union_type = StringType::instance(false)->asPHPDocUnionType();
         $string_union_type_real = StringType::instance(false)->asRealUnionType();
         $string_union_type_with_null_in_real = UnionType::fromFullyQualifiedPHPDocAndRealString('string', '?string');
+        $mixed_union_type = UnionType::fromFullyQualifiedPHPDocString('mixed');
         $true_union_type = TrueType::instance(false)->asPHPDocUnionType();
         $string_or_true_union_type = $string_union_type->withUnionType($true_union_type);
         $string_or_false_real_type = UnionType::fromFullyQualifiedRealString('string|false');
@@ -258,6 +262,39 @@ final class DependentReturnTypeOverridePlugin extends PluginV3 implements
             }
             return $string_or_false_real_type;
         };
+
+        /**
+         * @param list<Node|int|float|string> $args
+         */
+        $constant_handler = static function (
+            CodeBase $code_base,
+            Context $context,
+            Func $unused_function,
+            array $args
+        ) use ($mixed_union_type): UnionType {
+            if (count($args) === 0) {
+                return $mixed_union_type;
+            }
+            $constant_name = (new ContextNode($code_base, $context, $args[0]))->getEquivalentPHPScalarValue();
+            if (!is_string($constant_name) || $constant_name === '') {
+                return $mixed_union_type;
+            }
+            try {
+                $fqsen = $constant_name[0] === '\\'
+                    ? FullyQualifiedGlobalConstantName::fromFullyQualifiedString($constant_name)
+                    : FullyQualifiedGlobalConstantName::fromStringInContext($constant_name, $context);
+            } catch (InvalidArgumentException | FQSENException) {
+                return $mixed_union_type;
+            }
+            if (!$code_base->hasGlobalConstantWithFQSEN($fqsen)) {
+                return $mixed_union_type;
+            }
+            $constant = $code_base->getGlobalConstantByFQSEN($fqsen);
+            if ($constant->isDynamicConstant()) {
+                return $mixed_union_type;
+            }
+            return $constant->getUnionType();
+        };
         /**
          * @param CodeBase $unused_code_base @phan-unused-param
          * @param Context $unused_context @phan-unused-param
@@ -421,6 +458,7 @@ final class DependentReturnTypeOverridePlugin extends PluginV3 implements
             'trim'                        => $one_or_two_string_handler,
             'ltrim'                       => $one_or_two_string_handler,
             'rtrim'                       => $one_or_two_string_handler,
+            'constant'                    => $constant_handler,
         ];
     }
 

--- a/tests/files/expected/0707_constant.php.expected
+++ b/tests/files/expected/0707_constant.php.expected
@@ -1,0 +1,1 @@
+%s:4 PhanTypeMismatchArgumentInternal%S Argument 1 ($string) is $cfg of type array{dsn:'mysql'} but \strlen() takes string

--- a/tests/files/src/0707_constant.php
+++ b/tests/files/src/0707_constant.php
@@ -1,0 +1,4 @@
+<?php
+const CONFIG = ['dsn' => 'mysql'];
+$cfg = constant('CONFIG');
+strlen($cfg);


### PR DESCRIPTION
Implement #707 

`DependentReturnTypeOverridePlugin::getReturnTypeOverridesStatic()` now reads return types for `constant('NAME')` from Phan’s constant table when the constant is defined via const (non‑dynamic)