### PR TITLE
Fix bug #4768

### DIFF
--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -2139,6 +2139,8 @@ class ParseVisitor extends ScopeVisitor
         ast\AST_DIM => true,
         ast\AST_MAGIC_CONST => true,
         ast\AST_NAME => true,
+        ast\AST_NULLSAFE_PROP => true,
+        ast\AST_PROP => true,
         ast\AST_UNARY_OP => true,
         ast\AST_UNPACK => true,
     ];
@@ -2157,6 +2159,8 @@ class ParseVisitor extends ScopeVisitor
         ast\AST_DIM => true,
         ast\AST_MAGIC_CONST => true,
         ast\AST_NAME => true,
+        ast\AST_NULLSAFE_PROP => true,
+        ast\AST_PROP => true,
         ast\AST_UNARY_OP => true,
         ast\AST_UNPACK => true,
 
@@ -2254,6 +2258,8 @@ class ParseVisitor extends ScopeVisitor
         ast\AST_DIM => true,
         ast\AST_MAGIC_CONST => true,
         ast\AST_NAME => true,
+        ast\AST_NULLSAFE_PROP => true,
+        ast\AST_PROP => true,
         ast\AST_UNARY_OP => true,
 
         // In addition to expressions where the real type can be statically inferred (assuming types of child nodes were correctly inferred)

--- a/tests/files/src/4768_enum_case_property.php
+++ b/tests/files/src/4768_enum_case_property.php
@@ -1,0 +1,15 @@
+<?php
+class DecimalEntryFieldValue {}
+
+enum Issue4768String: string
+{
+    case DECIMAL = 'decimal';
+
+    public const MAP = [
+        self::DECIMAL->value => DecimalEntryFieldValue::class,
+    ];
+
+    public const NAMES = [
+        self::DECIMAL->name,
+    ];
+}


### PR DESCRIPTION
Extended ParseVisitor to treat `ast\AST_PROP` and `ast\AST_NULLSAFE_PROP` nodes as valid constant-expression forms, so enum case property fetches like `self::DECIMAL->value` no longer trigger `PhanInvalidConstantExpression` in code like:
```php
<?php
class DecimalEntryFieldValue {}

enum Issue4768String: string
{
    case DECIMAL = 'decimal';

    public const MAP = [
        self::DECIMAL->value => DecimalEntryFieldValue::class,
    ];

    public const NAMES = [
        self::DECIMAL->name,
    ];
}
```