### PR TITLE
Fix bug #5162

### DIFF
--- a/src/Phan/Language/Element/ClassConstant.php
+++ b/src/Phan/Language/Element/ClassConstant.php
@@ -112,6 +112,11 @@ class ClassConstant extends ClassElement implements ConstantInterface
             $constant->setDefiningFQSEN($defining_fqsen);
         }
         $constant->setHasDeclaredType($this->has_declared_type);
+
+        // Copy the defining node so that compatibility checks can recognize
+        // that this constant came from the trait (same value/node)
+        $constant->setNodeForValue($this->getNodeForValue());
+
         return $constant;
     }
 

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -3838,7 +3838,7 @@ class Clazz extends AddressableElement
                 // Check if this constant is defined in this class (not inherited from parent)
                 $defining_fqsen = $class_constant->getDefiningFQSEN();
                 if ($defining_fqsen->getFullyQualifiedClassName()->__toString() === $this->fqsen->__toString()) {
-                    // Class defines this constant - check compatibility with trait
+                    // Class has this constant - check if it was explicitly redefined or just inherited from trait
                     $source = $sources[0];
                     // @phan-suppress-next-line PhanSuspiciousTruthyCondition
                     if (!$source) {
@@ -3848,6 +3848,9 @@ class Clazz extends AddressableElement
                     if (!$trait_constant instanceof ClassConstant) {
                         continue;
                     }
+                    // If the class constant is compatible with the trait constant, it's likely just inherited
+                    // from the trait (not explicitly redefined). Only emit an error if they're incompatible,
+                    // which indicates the class tried to redefine it with a different visibility or value.
                     if (!self::areConstantsCompatible($class_constant, $trait_constant)) {
                         Issue::maybeEmit(
                             $code_base,

--- a/tests/files/expected/5162_trait_constant_false_positive.php.expected
+++ b/tests/files/expected/5162_trait_constant_false_positive.php.expected
@@ -1,0 +1,9 @@
+%s:5 PhanCompatibleTraitConstant Trait \T1 declares constant PRIV which is only allowed in 8.2+
+%s:6 PhanCompatibleTraitConstant Trait \T1 declares constant PROT which is only allowed in 8.2+
+%s:7 PhanCompatibleTraitConstant Trait \T1 declares constant PUB which is only allowed in 8.2+
+%s:18 PhanIncompatibleCompositionConstant \C2 and \T1 define the same constant (PRIV) in the composition of \C2. However, the definition differs and is considered incompatible. Class was composed in %s on line 18
+%s:33 PhanCompatibleTraitConstant Trait \T2 declares constant CONST_A which is only allowed in 8.2+
+%s:37 PhanCompatibleTraitConstant Trait \T3 declares constant CONST_B which is only allowed in 8.2+
+%s:47 PhanCompatibleTraitConstant Trait \T4 declares constant CONFLICT which is only allowed in 8.2+
+%s:51 PhanCompatibleTraitConstant Trait \T5 declares constant CONFLICT which is only allowed in 8.2+
+%s:54 PhanIncompatibleCompositionConstant \T4 and \T5 define the same constant (CONFLICT) in the composition of \C5. However, the definition differs and is considered incompatible. Class was composed in %s on line 54

--- a/tests/files/src/5162_trait_constant_false_positive.php
+++ b/tests/files/src/5162_trait_constant_false_positive.php
@@ -1,0 +1,56 @@
+<?php
+// Test for issue #5162 - false positive PhanIncompatibleCompositionConstant
+
+trait T1 {
+    private const PRIV = 'private';
+    protected const PROT = 'protected';
+    public const PUB = 'public';
+}
+
+// This class should NOT trigger PhanIncompatibleCompositionConstant
+// It's just using trait constants, not redefining them
+class C1 {
+    use T1;
+}
+
+// This class SHOULD trigger PhanIncompatibleCompositionConstant
+// It's redefining a trait constant with incompatible visibility
+class C2 {
+    use T1;
+
+    public const PRIV = 'public_redefinition';  // Error: incompatible with private
+}
+
+// This class should be OK - redefining with compatible visibility and value
+class C3 {
+    use T1;
+
+    public const PUB = 'public';  // OK: same visibility and value
+}
+
+// Test with multiple traits
+trait T2 {
+    private const CONST_A = 'a';
+}
+
+trait T3 {
+    private const CONST_B = 'b';
+}
+
+// Should be OK - each constant comes from a different trait
+class C4 {
+    use T2, T3;
+}
+
+// Should error - both traits define the same constant
+trait T4 {
+    private const CONFLICT = 'value1';
+}
+
+trait T5 {
+    private const CONFLICT = 'value2';
+}
+
+class C5 {
+    use T4, T5;  // Error: incompatible constants from two traits
+}


### PR DESCRIPTION
Classes using trait constants no longer get PhanIncompatibleCompositionConstant warnings