### PR TITLE
Implement UncoveredEnumCasesInMatchPlugin

### DIFF
--- a/.phan/plugins/UncoveredEnumCasesInMatchPlugin.php
+++ b/.phan/plugins/UncoveredEnumCasesInMatchPlugin.php
@@ -1,0 +1,289 @@
+<?php
+
+declare(strict_types=1);
+
+use ast\Node;
+use Phan\AST\UnionTypeVisitor;
+use Phan\Language\Element\Clazz;
+use Phan\Language\Element\EnumCase;
+use Phan\Language\FQSEN\FullyQualifiedClassName;
+use Phan\PluginV3;
+use Phan\PluginV3\PluginAwarePostAnalysisVisitor;
+use Phan\PluginV3\PostAnalyzeNodeCapability;
+
+/**
+ * This plugin checks for match statements that do not cover all cases of an enum.
+ *
+ * When a match statement's condition is an enum type and all match arm conditions
+ * are enum cases from that enum, this plugin warns when:
+ * - Not all enum cases are covered
+ * - There is no default arm
+ *
+ * This is especially useful because uncovered enum cases in match expressions
+ * will throw UnhandledMatchError at runtime.
+ *
+ * A plugin file must:
+ * - Contain a class that inherits from \Phan\PluginV3
+ * - End by returning an instance of that class
+ *
+ * It is assumed without being checked that plugins aren't
+ * mangling state within the passed code base or context.
+ *
+ * Note: When adding new plugins,
+ * add them to the corresponding section of README.md
+ */
+final class UncoveredEnumCasesInMatchPlugin extends PluginV3 implements PostAnalyzeNodeCapability
+{
+    /**
+     * @return string - The name of the visitor that will be called
+     */
+    public static function getPostAnalyzeNodeVisitorClassName(): string
+    {
+        return UncoveredEnumCasesInMatchVisitor::class;
+    }
+}
+
+/**
+ * This visitor analyzes match expressions to detect uncovered enum cases.
+ *
+ * When __invoke on this class is called with a node, a method
+ * will be dispatched based on the `kind` of the given node.
+ */
+final class UncoveredEnumCasesInMatchVisitor extends PluginAwarePostAnalysisVisitor
+{
+    /**
+     * Visit a match expression and check for uncovered enum cases
+     *
+     * @param Node $node a node of kind AST_MATCH
+     */
+    public function visitMatch(Node $node): void
+    {
+        $cond_node = $node->children['cond'];
+        $stmts_node = $node->children['stmts'];
+
+        if (!($stmts_node instanceof Node)) {
+            return;
+        }
+
+        // Get the union type of the match condition
+        $cond_type = UnionTypeVisitor::unionTypeFromNode(
+            $this->code_base,
+            $this->context,
+            $cond_node
+        );
+
+        // Get all enum classes from the condition's union type
+        $enum_classes = $this->getEnumClassesFromUnionType($cond_type);
+
+        if (empty($enum_classes)) {
+            // No enum types in the condition
+            return;
+        }
+
+        // Check if there's a default arm and collect covered cases
+        $has_default = false;
+        $covered_cases = [];
+        $all_arms_are_enum_cases = true;
+        $has_any_arm = false;
+
+        foreach ($stmts_node->children as $arm_node) {
+            if (!($arm_node instanceof Node)) {
+                continue;
+            }
+
+            $cond_list = $arm_node->children['cond'] ?? null;
+            if ($cond_list === null) {
+                // This is a default arm
+                $has_default = true;
+                $has_any_arm = true;
+                continue;
+            }
+
+            if (!($cond_list instanceof Node)) {
+                continue;
+            }
+
+            $has_any_arm = true;
+
+            // Collect all enum cases covered by this arm
+            foreach ($cond_list->children as $arm_cond) {
+                $enum_case = $this->getEnumCaseFromExpression($arm_cond);
+                if ($enum_case !== null) {
+                    $covered_cases[$enum_case] = true;
+                } else {
+                    // This arm condition is not an enum case
+                    $all_arms_are_enum_cases = false;
+                }
+            }
+        }
+
+        // Don't check empty match expressions
+        if (!$has_any_arm) {
+            return;
+        }
+
+        // If there's a default, all cases are effectively covered
+        if ($has_default) {
+            return;
+        }
+
+        // Only warn if all match arms are enum cases from the enum classes in the condition
+        if (!$all_arms_are_enum_cases) {
+            return;
+        }
+
+        // Get all required enum cases from all enum classes
+        $all_required_cases = [];
+        foreach ($enum_classes as $enum_class) {
+            $enum_cases = $this->getEnumCases($enum_class);
+            foreach ($enum_cases as $case_name) {
+                $fqsen = $enum_class->getFQSEN()->__toString() . '::' . $case_name;
+                $all_required_cases[$fqsen] = $case_name;
+            }
+        }
+
+        // Find uncovered cases
+        $uncovered_cases = array_diff_key($all_required_cases, $covered_cases);
+
+        if (!empty($uncovered_cases)) {
+            $uncovered_list = implode(', ', array_values($uncovered_cases));
+            $enum_names = implode('|', array_map(
+                static fn(Clazz $class): string => $class->getFQSEN()->__toString(),
+                $enum_classes
+            ));
+
+            $this->emitPluginIssue(
+                $this->code_base,
+                (clone $this->context)->withLineNumberStart($node->lineno),
+                'PhanPluginUncoveredEnumCasesInMatch',
+                'Match expression with {STRING_LITERAL} condition does not cover all cases - missing: {STRING_LITERAL}. Either add the missing cases or add a default arm to handle them.',
+                [$enum_names, $uncovered_list],
+                \Phan\Issue::SEVERITY_NORMAL,
+                \Phan\Issue::REMEDIATION_A,
+                15090
+            );
+        }
+    }
+
+    /**
+     * Extract enum classes from a union type
+     *
+     * @return list<Clazz>
+     */
+    private function getEnumClassesFromUnionType(\Phan\Language\UnionType $union_type): array
+    {
+        $enum_classes = [];
+
+        foreach ($union_type->getTypeSet() as $type) {
+            if (!$type->isObjectWithKnownFQSEN()) {
+                continue;
+            }
+
+            $fqsen = $type->asFQSEN();
+            if (!($fqsen instanceof FullyQualifiedClassName)) {
+                continue;
+            }
+
+            if (!$this->code_base->hasClassWithFQSEN($fqsen)) {
+                continue;
+            }
+
+            $class = $this->code_base->getClassByFQSEN($fqsen);
+            if ($class->isEnum()) {
+                $enum_classes[] = $class;
+            }
+        }
+
+        return $enum_classes;
+    }
+
+    /**
+     * Get the FQSEN string of an enum case from an expression node
+     *
+     * @return ?string the FQSEN of the enum case, or null if not an enum case
+     */
+    private function getEnumCaseFromExpression(mixed $expr): ?string
+    {
+        if (!($expr instanceof Node)) {
+            return null;
+        }
+
+        // Check for AST_CLASS_CONST (e.g., Suit::Hearts)
+        if ($expr->kind !== \ast\AST_CLASS_CONST) {
+            return null;
+        }
+
+        $class_node = $expr->children['class'];
+        $const_name = $expr->children['const'];
+
+        if (!is_string($const_name)) {
+            return null;
+        }
+
+        // Try to resolve the class
+        $type = UnionTypeVisitor::unionTypeFromNode(
+            $this->code_base,
+            $this->context,
+            $class_node
+        );
+
+        foreach ($type->getTypeSet() as $class_type) {
+            if (!$class_type->isObjectWithKnownFQSEN()) {
+                continue;
+            }
+
+            $class_fqsen = $class_type->asFQSEN();
+            if (!($class_fqsen instanceof FullyQualifiedClassName)) {
+                continue;
+            }
+
+            if (!$this->code_base->hasClassWithFQSEN($class_fqsen)) {
+                continue;
+            }
+
+            $class = $this->code_base->getClassByFQSEN($class_fqsen);
+            if (!$class->isEnum()) {
+                continue;
+            }
+
+            // Check if this constant is an enum case
+            $const_fqsen = \Phan\Language\FQSEN\FullyQualifiedClassConstantName::make(
+                $class_fqsen,
+                $const_name
+            );
+
+            if (!$this->code_base->hasClassConstantWithFQSEN($const_fqsen)) {
+                continue;
+            }
+
+            $constant = $this->code_base->getClassConstantByFQSEN($const_fqsen);
+            if ($constant instanceof EnumCase) {
+                return $const_fqsen->__toString();
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Get all enum case names from an enum class
+     *
+     * @return list<string> array of case names
+     */
+    private function getEnumCases(Clazz $enum_class): array
+    {
+        $cases = [];
+
+        foreach ($enum_class->getConstantMap($this->code_base) as $constant) {
+            if ($constant instanceof EnumCase) {
+                $cases[] = $constant->getName();
+            }
+        }
+
+        return $cases;
+    }
+}
+
+// Every plugin needs to return an instance of itself at the
+// end of the file in which it's defined.
+return new UncoveredEnumCasesInMatchPlugin();

--- a/tests/plugin_test/.phan/config.php
+++ b/tests/plugin_test/.phan/config.php
@@ -154,5 +154,6 @@ return [
         'PHPDocInWrongCommentPlugin',
         'StaticVariableMisusePlugin',
         'AddNeverReturnTypePlugin',
+        'UncoveredEnumCasesInMatchPlugin',
     ],
 ];

--- a/tests/plugin_test/expected/252_uncovered_enum_cases_in_match.php.expected
+++ b/tests/plugin_test/expected/252_uncovered_enum_cases_in_match.php.expected
@@ -1,5 +1,24 @@
-%s:27 PhanPluginUncoveredEnumCasesInMatch Match expression with \Suit condition does not cover all cases - missing: Diamonds, Clubs. Either add the missing cases or add a default arm to handle them.
-%s:57 PhanPluginUncoveredEnumCasesInMatch Match expression with \Suit|\Game condition does not cover all cases - missing: Poker, Solitaire, Blackjack. Either add the missing cases or add a default arm to handle them.
-%s:83 PhanPluginUncoveredEnumCasesInMatch Match expression with \Suit condition does not cover all cases - missing: Clubs. Either add the missing cases or add a default arm to handle them.
-%s:103 PhanPluginUncoveredEnumCasesInMatch Match expression with \Color condition does not cover all cases - missing: Green. Either add the missing cases or add a default arm to handle them.
-%s:122 PhanPluginUncoveredEnumCasesInMatch Match expression with \Suit condition does not cover all cases - missing: Diamonds. Either add the missing cases or add a default arm to handle them.
+src/252_uncovered_enum_cases_in_match.php:25 PhanUnreferencedFunction Possibly zero references to function \testMatchEnum1()
+src/252_uncovered_enum_cases_in_match.php:27 PhanPluginUncoveredEnumCasesInMatch Match expression with \Suit condition does not cover all cases - missing: Diamonds, Clubs. Either add the missing cases or add a default arm to handle them.
+src/252_uncovered_enum_cases_in_match.php:34 PhanUnreferencedFunction Possibly zero references to function \testMatchEnum2()
+src/252_uncovered_enum_cases_in_match.php:45 PhanUnreferencedFunction Possibly zero references to function \testMatchEnum3()
+src/252_uncovered_enum_cases_in_match.php:55 PhanUnreferencedFunction Possibly zero references to function \testMatchEnum4()
+src/252_uncovered_enum_cases_in_match.php:57 PhanPluginUncoveredEnumCasesInMatch Match expression with \Suit|\Game condition does not cover all cases - missing: Poker, Solitaire, Blackjack. Either add the missing cases or add a default arm to handle them.
+src/252_uncovered_enum_cases_in_match.php:66 PhanUnreferencedFunction Possibly zero references to function \testMatchEnum5()
+src/252_uncovered_enum_cases_in_match.php:81 PhanUnreferencedFunction Possibly zero references to function \testMatchEnum6()
+src/252_uncovered_enum_cases_in_match.php:83 PhanPluginUncoveredEnumCasesInMatch Match expression with \Suit condition does not cover all cases - missing: Clubs. Either add the missing cases or add a default arm to handle them.
+src/252_uncovered_enum_cases_in_match.php:91 PhanUnreferencedFunction Possibly zero references to function \testMatchEnum7()
+src/252_uncovered_enum_cases_in_match.php:101 PhanUnreferencedFunction Possibly zero references to function \testMatchEnum8()
+src/252_uncovered_enum_cases_in_match.php:103 PhanPluginUncoveredEnumCasesInMatch Match expression with \Color condition does not cover all cases - missing: Green. Either add the missing cases or add a default arm to handle them.
+src/252_uncovered_enum_cases_in_match.php:110 PhanUnreferencedFunction Possibly zero references to function \testMatchEnum9()
+src/252_uncovered_enum_cases_in_match.php:120 PhanUnreferencedFunction Possibly zero references to function \testMatchEnum10()
+src/252_uncovered_enum_cases_in_match.php:122 PhanPluginUncoveredEnumCasesInMatch Match expression with \Suit condition does not cover all cases - missing: Diamonds. Either add the missing cases or add a default arm to handle them.
+src/252_uncovered_enum_cases_in_match.php:129 PhanUnreferencedFunction Possibly zero references to function \testMatchEnum11()
+src/252_uncovered_enum_cases_in_match.php:138 PhanPluginUseReturnValueNoopVoid The function/method \testMatchEnum12() is declared to return never and it has no side effects
+src/252_uncovered_enum_cases_in_match.php:138 PhanUnreferencedFunction Possibly zero references to function \testMatchEnum12()
+src/252_uncovered_enum_cases_in_match.php:140 PhanNoopMatchArms This match expression only has the default arm in match ($suit) {}
+src/252_uncovered_enum_cases_in_match.php:140 PhanNoopMatchExpression The result of this match expression is not used and the arms have no side effects (except for possibly throwing UnhandledMatchError) in match ($suit) {}
+src/252_uncovered_enum_cases_in_match.php:145 PhanUnreferencedFunction Possibly zero references to function \testMatchEnum13()
+src/252_uncovered_enum_cases_in_match.php:147 PhanNoopMatchArms This match expression only has the default arm in match ($suit) { default => 'Any suit' }
+src/252_uncovered_enum_cases_in_match.php:153 PhanUnreferencedFunction Possibly zero references to function \testMatchEnum14()
+src/252_uncovered_enum_cases_in_match.php:162 PhanUnreferencedFunction Possibly zero references to function \testMatchEnum15()

--- a/tests/plugin_test/expected/252_uncovered_enum_cases_in_match.php.expected
+++ b/tests/plugin_test/expected/252_uncovered_enum_cases_in_match.php.expected
@@ -1,0 +1,5 @@
+%s:27 PhanPluginUncoveredEnumCasesInMatch Match expression with \Suit condition does not cover all cases - missing: Diamonds, Clubs. Either add the missing cases or add a default arm to handle them.
+%s:57 PhanPluginUncoveredEnumCasesInMatch Match expression with \Suit|\Game condition does not cover all cases - missing: Poker, Solitaire, Blackjack. Either add the missing cases or add a default arm to handle them.
+%s:83 PhanPluginUncoveredEnumCasesInMatch Match expression with \Suit condition does not cover all cases - missing: Clubs. Either add the missing cases or add a default arm to handle them.
+%s:103 PhanPluginUncoveredEnumCasesInMatch Match expression with \Color condition does not cover all cases - missing: Green. Either add the missing cases or add a default arm to handle them.
+%s:122 PhanPluginUncoveredEnumCasesInMatch Match expression with \Suit condition does not cover all cases - missing: Diamonds. Either add the missing cases or add a default arm to handle them.

--- a/tests/plugin_test/src/252_uncovered_enum_cases_in_match.php
+++ b/tests/plugin_test/src/252_uncovered_enum_cases_in_match.php
@@ -1,0 +1,169 @@
+<?php
+
+// Test cases for UncoveredEnumCasesInMatchPlugin
+
+enum Suit {
+    case Hearts;
+    case Spades;
+    case Diamonds;
+    case Clubs;
+}
+
+enum Game {
+    case Poker;
+    case Solitaire;
+    case Blackjack;
+}
+
+enum Color: string {
+    case Red = 'red';
+    case Blue = 'blue';
+    case Green = 'green';
+}
+
+// Test 1: Missing enum cases - should warn
+function test1(Suit $suit): string
+{
+    return match ($suit) {
+        Suit::Spades => 'The swords of a soldier',
+        Suit::Hearts => 'The shape of my heart',
+    };
+}
+
+// Test 2: All cases covered - should NOT warn
+function test2(Suit $suit): string
+{
+    return match ($suit) {
+        Suit::Spades => 'The swords of a soldier',
+        Suit::Hearts => 'The shape of my heart',
+        Suit::Diamonds => 'Money for this art',
+        Suit::Clubs => 'Weapons of war',
+    };
+}
+
+// Test 3: Has default - should NOT warn
+function test3(Suit $suit): string
+{
+    return match ($suit) {
+        Suit::Spades => 'The swords of a soldier',
+        Suit::Hearts => 'The shape of my heart',
+        default => 'Generic card suit',
+    };
+}
+
+// Test 4: Union type with multiple enums, missing cases - should warn
+function test4(Suit|Game $var): string
+{
+    return match ($var) {
+        Suit::Spades => 'The swords of a soldier',
+        Suit::Hearts => 'The shape of my heart',
+        Suit::Diamonds => 'Money for this art',
+        Suit::Clubs => 'Weapons of war',
+    };
+}
+
+// Test 5: Union type with multiple enums, all covered - should NOT warn
+function test5(Suit|Game $var): string
+{
+    return match ($var) {
+        Suit::Spades => 'The swords of a soldier',
+        Suit::Hearts => 'The shape of my heart',
+        Suit::Diamonds => 'Money for this art',
+        Suit::Clubs => 'Weapons of war',
+        Game::Solitaire => 'Single player card game',
+        Game::Poker => 'Card game played against other players',
+        Game::Blackjack => 'Card game played against the house',
+    };
+}
+
+// Test 6: Union with non-enum types - should NOT warn
+// (because not all arms are enum cases)
+function test6(Suit|string|int|array $suit): string
+{
+    return match ($suit) {
+        Suit::Spades => 'The swords of a soldier',
+        Suit::Hearts => 'The shape of my heart',
+        Suit::Diamonds => 'Money for this art',
+    };
+}
+
+// Test 7: Mixed enum cases and other conditions - should NOT warn
+function test7(Suit $suit): string
+{
+    return match ($suit) {
+        Suit::Spades => 'The swords of a soldier',
+        Suit::Hearts => 'The shape of my heart',
+        default => 'Other',
+    };
+}
+
+// Test 8: Backed enum missing cases - should warn
+function test8(Color $color): string
+{
+    return match ($color) {
+        Color::Red => 'Stop',
+        Color::Blue => 'Go',
+    };
+}
+
+// Test 9: All backed enum cases covered - should NOT warn
+function test9(Color $color): string
+{
+    return match ($color) {
+        Color::Red => 'Stop',
+        Color::Blue => 'Go',
+        Color::Green => 'Caution',
+    };
+}
+
+// Test 10: Multiple conditions in single arm, missing cases - should warn
+function test10(Suit $suit): string
+{
+    return match ($suit) {
+        Suit::Spades, Suit::Clubs => 'Black',
+        Suit::Hearts => 'Red',
+    };
+}
+
+// Test 11: Multiple conditions in single arm, all covered - should NOT warn
+function test11(Suit $suit): string
+{
+    return match ($suit) {
+        Suit::Spades, Suit::Clubs => 'Black',
+        Suit::Hearts, Suit::Diamonds => 'Red',
+    };
+}
+
+// Test 12: Empty match (edge case) - should NOT warn
+function test12(Suit $suit): never
+{
+    match ($suit) {
+    };
+}
+
+// Test 13: Match with only default - should NOT warn
+function test13(Suit $suit): string
+{
+    return match ($suit) {
+        default => 'Any suit',
+    };
+}
+
+// Test 14: Non-enum match - should NOT warn
+function test14(int $x): string
+{
+    return match ($x) {
+        1 => 'one',
+        2 => 'two',
+    };
+}
+
+// Test 15: Mixed types but some arms are not enum cases - should NOT warn
+function test15(Suit|int $var): string
+{
+    return match ($var) {
+        Suit::Hearts => 'heart',
+        1 => 'one',
+        2 => 'two',
+    };
+}

--- a/tests/plugin_test/src/252_uncovered_enum_cases_in_match.php
+++ b/tests/plugin_test/src/252_uncovered_enum_cases_in_match.php
@@ -22,7 +22,7 @@ enum Color: string {
 }
 
 // Test 1: Missing enum cases - should warn
-function test1(Suit $suit): string
+function testMatchEnum1(Suit $suit): string
 {
     return match ($suit) {
         Suit::Spades => 'The swords of a soldier',
@@ -31,7 +31,7 @@ function test1(Suit $suit): string
 }
 
 // Test 2: All cases covered - should NOT warn
-function test2(Suit $suit): string
+function testMatchEnum2(Suit $suit): string
 {
     return match ($suit) {
         Suit::Spades => 'The swords of a soldier',
@@ -42,7 +42,7 @@ function test2(Suit $suit): string
 }
 
 // Test 3: Has default - should NOT warn
-function test3(Suit $suit): string
+function testMatchEnum3(Suit $suit): string
 {
     return match ($suit) {
         Suit::Spades => 'The swords of a soldier',
@@ -52,7 +52,7 @@ function test3(Suit $suit): string
 }
 
 // Test 4: Union type with multiple enums, missing cases - should warn
-function test4(Suit|Game $var): string
+function testMatchEnum4(Suit|Game $var): string
 {
     return match ($var) {
         Suit::Spades => 'The swords of a soldier',
@@ -63,7 +63,7 @@ function test4(Suit|Game $var): string
 }
 
 // Test 5: Union type with multiple enums, all covered - should NOT warn
-function test5(Suit|Game $var): string
+function testMatchEnum5(Suit|Game $var): string
 {
     return match ($var) {
         Suit::Spades => 'The swords of a soldier',
@@ -78,7 +78,7 @@ function test5(Suit|Game $var): string
 
 // Test 6: Union with non-enum types - should NOT warn
 // (because not all arms are enum cases)
-function test6(Suit|string|int|array $suit): string
+function testMatchEnum6(Suit|string|int|array $suit): string
 {
     return match ($suit) {
         Suit::Spades => 'The swords of a soldier',
@@ -88,7 +88,7 @@ function test6(Suit|string|int|array $suit): string
 }
 
 // Test 7: Mixed enum cases and other conditions - should NOT warn
-function test7(Suit $suit): string
+function testMatchEnum7(Suit $suit): string
 {
     return match ($suit) {
         Suit::Spades => 'The swords of a soldier',
@@ -98,7 +98,7 @@ function test7(Suit $suit): string
 }
 
 // Test 8: Backed enum missing cases - should warn
-function test8(Color $color): string
+function testMatchEnum8(Color $color): string
 {
     return match ($color) {
         Color::Red => 'Stop',
@@ -107,7 +107,7 @@ function test8(Color $color): string
 }
 
 // Test 9: All backed enum cases covered - should NOT warn
-function test9(Color $color): string
+function testMatchEnum9(Color $color): string
 {
     return match ($color) {
         Color::Red => 'Stop',
@@ -117,7 +117,7 @@ function test9(Color $color): string
 }
 
 // Test 10: Multiple conditions in single arm, missing cases - should warn
-function test10(Suit $suit): string
+function testMatchEnum10(Suit $suit): string
 {
     return match ($suit) {
         Suit::Spades, Suit::Clubs => 'Black',
@@ -126,7 +126,7 @@ function test10(Suit $suit): string
 }
 
 // Test 11: Multiple conditions in single arm, all covered - should NOT warn
-function test11(Suit $suit): string
+function testMatchEnum11(Suit $suit): string
 {
     return match ($suit) {
         Suit::Spades, Suit::Clubs => 'Black',
@@ -135,14 +135,14 @@ function test11(Suit $suit): string
 }
 
 // Test 12: Empty match (edge case) - should NOT warn
-function test12(Suit $suit): never
+function testMatchEnum12(Suit $suit): never
 {
     match ($suit) {
     };
 }
 
 // Test 13: Match with only default - should NOT warn
-function test13(Suit $suit): string
+function testMatchEnum13(Suit $suit): string
 {
     return match ($suit) {
         default => 'Any suit',
@@ -150,7 +150,7 @@ function test13(Suit $suit): string
 }
 
 // Test 14: Non-enum match - should NOT warn
-function test14(int $x): string
+function testMatchEnum14(int $x): string
 {
     return match ($x) {
         1 => 'one',
@@ -159,7 +159,7 @@ function test14(int $x): string
 }
 
 // Test 15: Mixed types but some arms are not enum cases - should NOT warn
-function test15(Suit|int $var): string
+function testMatchEnum15(Suit|int $var): string
 {
     return match ($var) {
         Suit::Hearts => 'heart',


### PR DESCRIPTION
This implements #4803

  - Detects when match expressions with enum conditions don't cover all enum cases
  - Only warns when all match arms are enum cases (no mixed conditions)
  - Warns when not all enum cases are covered AND there's no default arm
  - Handles union types with multiple enums (requires all cases from all enums)