### PR TITLE
Fix #4807 - Infer return type of array_chunk more accurately

### DIFF
--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -1095,7 +1095,7 @@ trait FunctionTrait
      */
     public function analyzeWithNewParams(Context $context, CodeBase $code_base, array $parameter_list): Context
     {
-        $hash = $this->computeParameterListHash($parameter_list);
+        $hash = self::computeParameterListHash($parameter_list);
         $has_pass_by_reference_variable = null;
         // Nothing to do, except if PassByReferenceVariable was used
         if ($hash === $this->parameter_list_hash) {

--- a/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
@@ -726,6 +726,64 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
             }
             return $value_type->asListTypes();
         };
+        /**
+         * @param list<Node|int|float|string> $args
+         * Infer return type of array_chunk based on input array and $preserve_keys parameter
+         */
+        $array_chunk_callback = static function (CodeBase $code_base, Context $context, Func $function, array $args) use ($nullable_list_type_set): UnionType {
+            if (\count($args) < 1) {
+                return UnionType::fromFullyQualifiedPHPDocAndRealString('list<array>', '?list<array>');
+            }
+
+            // Get the element type from the input array
+            $input_array_type = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $args[0]);
+            $element_type = $input_array_type->genericArrayElementTypes(true, $code_base);
+
+            if ($element_type->isEmpty()) {
+                return UnionType::fromFullyQualifiedPHPDocAndRealString('list<array>', '?list<array>');
+            }
+
+            // Determine if $preserve_keys is true, false, or unknown
+            $preserve_keys = null;  // null means unknown
+            if (\count($args) >= 3) {
+                $preserve_keys_type = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $args[2]);
+                // Try to determine the boolean value statically
+                if ($preserve_keys_type->isExclusivelyBoolTypes()) {
+                    if ($preserve_keys_type->containsTruthy() && !$preserve_keys_type->containsFalsey()) {
+                        $preserve_keys = true;
+                    } elseif ($preserve_keys_type->containsFalsey() && !$preserve_keys_type->containsTruthy()) {
+                        $preserve_keys = false;
+                    }
+                }
+            } else {
+                // Default is false when omitted
+                $preserve_keys = false;
+            }
+
+            // Build the chunk type based on $preserve_keys
+            if ($preserve_keys === false) {
+                // list<list<V>>
+                $chunk_type = $element_type->asListTypes();
+            } elseif ($preserve_keys === true) {
+                // list<array<K,V>>
+                $key_type_enum = GenericArrayType::keyTypeFromUnionTypeKeys($input_array_type);
+                $chunk_type = $element_type->asGenericArrayTypes($key_type_enum);
+            } else {
+                // Unknown: list<list<V>|array<K,V>>
+                $list_chunk = $element_type->asListTypes();
+                $key_type_enum = GenericArrayType::keyTypeFromUnionTypeKeys($input_array_type);
+                $array_chunk = $element_type->asGenericArrayTypes($key_type_enum);
+                $chunk_type = $list_chunk->withUnionType($array_chunk);
+            }
+
+            // Wrap in a list and add real type
+            $result = $chunk_type->asListTypes();
+            if (!$result->hasRealTypeSet()) {
+                $result = $result->withRealTypeSet($nullable_list_type_set);
+            }
+
+            return $result;
+        };
         return [
             // Gets the element types of the first
             'array_pop'   => $get_element_type_of_first_arg_check_nonempty_null,
@@ -779,8 +837,8 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
             'array_uintersect_uassoc'   => $get_first_array_arg_assoc,
             'array_unique'              => $get_first_array_arg_assoc_same_size,
             'array_values'              => $array_values_callback,
+            'array_chunk'               => $array_chunk_callback,
             'iterator_to_array'         => $iterator_to_array_callback,
-            // TODO: iterator_to_array
         ];
     }
 

--- a/tests/files/expected/4807_array_chunk.php.expected
+++ b/tests/files/expected/4807_array_chunk.php.expected
@@ -1,0 +1,22 @@
+%s:6 PhanDebugAnnotation @phan-debug-var requested for variable $result - it has union type list<list<1>>|list<list<2>>|list<list<3>>|list<list<4>>|list<list<5>>(real=list<list<?1>>|list<list<?2>>|list<list<?3>>|list<list<?4>>|list<list<?5>>)
+%s:15 PhanDebugAnnotation @phan-debug-var requested for variable $result - it has union type list<array<string,1>>|list<array<string,2>>|list<array<string,3>>(real=list<array<string,?1>>|list<array<string,?2>>|list<array<string,?3>>)
+%s:24 PhanDebugAnnotation @phan-debug-var requested for variable $result - it has union type list<list<1>>|list<list<2>>|list<list<3>>(real=list<list<?1>>|list<list<?2>>|list<list<?3>>)
+%s:33 PhanDebugAnnotation @phan-debug-var requested for variable $result - it has union type list<array<string,1>>|list<array<string,2>>|list<array<string,3>>|list<list<1>>|list<list<2>>|list<list<3>>(real=list<array<string,?1>>|list<array<string,?2>>|list<array<string,?3>>|list<list<?1>>|list<list<?2>>|list<list<?3>>)
+%s:42 PhanDebugAnnotation @phan-debug-var requested for variable $result - it has union type list<list<'bar'>>|list<list<'baz'>>|list<list<'foo'>>(real=list<list<?'bar'>>|list<list<?'baz'>>|list<list<?'foo'>>)
+%s:51 PhanDebugAnnotation @phan-debug-var requested for variable $result - it has union type list<list<'foo'>>|list<list<1>>|list<list<true>>(real=list<list<?'foo'>>|list<list<?1>>|list<list<?true>>)
+%s:60 PhanDebugAnnotation @phan-debug-var requested for variable $result - it has union type list<list<\stdClass>>(real=list<list<?\stdClass>>)
+%s:70 PhanDebugAnnotation @phan-debug-var requested for variable $result - it has union type list<array<string,10>>|list<array<string,20>>(real=list<array<string,?10>>|list<array<string,?20>>)
+%s:80 PhanDebugAnnotation @phan-debug-var requested for variable $result - it has union type list<list<1>>|list<list<2>>|list<list<3>>|list<list<4>>(real=list<list<?1>>|list<list<?2>>|list<list<?3>>|list<list<?4>>)
+%s:92 PhanDebugAnnotation @phan-debug-var requested for variable $result - it has union type list<list<array{name:'Alice'|'Bob',age:25|30}>>(real=list<list<?array{name:'Alice'|'Bob',age:25|30}>>)
+%s:104 PhanDebugAnnotation @phan-debug-var requested for variable $result - it has union type list<array<string,array{name:'Alice'|'Bob',age:25|30}>>(real=list<array<string,?array{name:'Alice'|'Bob',age:25|30}>>)
+%s:114 PhanTypeMismatchReturn Returning array_chunk($input, 2) of type list<list<1>>|list<list<2>>|list<list<3>> but test_wrong_return_type() is declared to return list<int>
+%s:120 PhanDebugAnnotation @phan-debug-var requested for variable $result - it has union type list<array<int,'a'>>|list<array<int,'b'>>|list<array<int,'c'>>(real=list<array<int,?'a'>>|list<array<int,?'b'>>|list<array<int,?'c'>>)
+%s:130 PhanDebugAnnotation @phan-debug-var requested for variable $first_chunk - it has union type list<1>|list<2>|list<3>|list<4>|list<5>(real=?list<?1>|?list<?2>|?list<?3>|?list<?4>|?list<?5>)
+%s:133 PhanDebugAnnotation @phan-debug-var requested for variable $first_element - it has union type 1|2|3|4|5(real=?1|?2|?3|?4|?5)
+%s:143 PhanDebugAnnotation @phan-debug-var requested for variable $chunk - it has union type array<string,1>|array<string,2>|array<string,3>(real=array<string,?1>|array<string,?2>|array<string,?3>)
+%s:146 PhanDebugAnnotation @phan-debug-var requested for variable $key - it has union type string(real=int|string)
+%s:146 PhanDebugAnnotation @phan-debug-var requested for variable $value - it has union type 1|2|3(real=?1|?2|?3)
+%s:157 PhanDeprecatedFunctionInternal Call to deprecated function \rand() (Deprecated because: Deprecated in PHP 8.3. Use random_int() or Random\Randomizer::getInt().)
+%s:158 PhanDebugAnnotation @phan-debug-var requested for variable $result - it has union type list<list<'a'>>|list<list<'b'>>|list<list<1>>|list<list<2>>(real=list<list<?'a'>>|list<list<?'b'>>|list<list<?1>>|list<list<?2>>)
+%s:168 PhanTypeMismatchReturn Returning array_chunk($input, 2) of type list<list<1>>|list<list<2>> but test_expect_preserved_but_default() is declared to return list<array<string,int>>
+%s:175 PhanTypeMismatchReturn Returning array_chunk($input, 2, true) of type list<array<string,1>>|list<array<string,2>> but test_expect_list_but_preserved() is declared to return list<list<int>>

--- a/tests/files/expected/4807_array_chunk.php.expected
+++ b/tests/files/expected/4807_array_chunk.php.expected
@@ -13,10 +13,9 @@
 %s:120 PhanDebugAnnotation @phan-debug-var requested for variable $result - it has union type list<array<int,'a'>>|list<array<int,'b'>>|list<array<int,'c'>>(real=list<array<int,?'a'>>|list<array<int,?'b'>>|list<array<int,?'c'>>)
 %s:130 PhanDebugAnnotation @phan-debug-var requested for variable $first_chunk - it has union type list<1>|list<2>|list<3>|list<4>|list<5>(real=?list<?1>|?list<?2>|?list<?3>|?list<?4>|?list<?5>)
 %s:133 PhanDebugAnnotation @phan-debug-var requested for variable $first_element - it has union type 1|2|3|4|5(real=?1|?2|?3|?4|?5)
-%s:143 PhanDebugAnnotation @phan-debug-var requested for variable $chunk - it has union type array<string,1>|array<string,2>|array<string,3>(real=array<string,?1>|array<string,?2>|array<string,?3>)
-%s:146 PhanDebugAnnotation @phan-debug-var requested for variable $key - it has union type string(real=int|string)
-%s:146 PhanDebugAnnotation @phan-debug-var requested for variable $value - it has union type 1|2|3(real=?1|?2|?3)
-%s:157 PhanDeprecatedFunctionInternal Call to deprecated function \rand() (Deprecated because: Deprecated in PHP 8.3. Use random_int() or Random\Randomizer::getInt().)
-%s:158 PhanDebugAnnotation @phan-debug-var requested for variable $result - it has union type list<list<'a'>>|list<list<'b'>>|list<list<1>>|list<list<2>>(real=list<list<?'a'>>|list<list<?'b'>>|list<list<?1>>|list<list<?2>>)
-%s:168 PhanTypeMismatchReturn Returning array_chunk($input, 2) of type list<list<1>>|list<list<2>> but test_expect_preserved_but_default() is declared to return list<array<string,int>>
-%s:175 PhanTypeMismatchReturn Returning array_chunk($input, 2, true) of type list<array<string,1>>|list<array<string,2>> but test_expect_list_but_preserved() is declared to return list<list<int>>
+%s:144 PhanDebugAnnotation @phan-debug-var requested for variable $chunk - it has union type array<string,1>|array<string,2>|array<string,3>(real=array<string,?1>|array<string,?2>|array<string,?3>)
+%s:148 PhanDebugAnnotation @phan-debug-var requested for variable $key - it has union type string(real=int|string)
+%s:148 PhanDebugAnnotation @phan-debug-var requested for variable $value - it has union type 1|2|3(real=?1|?2|?3)
+%s:160 PhanDebugAnnotation @phan-debug-var requested for variable $result - it has union type list<list<'a'>>|list<list<'b'>>|list<list<1>>|list<list<2>>(real=list<list<?'a'>>|list<list<?'b'>>|list<list<?1>>|list<list<?2>>)
+%s:170 PhanTypeMismatchReturn Returning array_chunk($input, 2) of type list<list<1>>|list<list<2>> but test_expect_preserved_but_default() is declared to return list<array<string,int>>
+%s:177 PhanTypeMismatchReturn Returning array_chunk($input, 2, true) of type list<array<string,1>>|list<array<string,2>> but test_expect_list_but_preserved() is declared to return list<list<int>>

--- a/tests/files/src/4807_array_chunk.php
+++ b/tests/files/src/4807_array_chunk.php
@@ -140,9 +140,11 @@ function test_chunk_element_access() {
 function test_iterate_chunks() {
     $input = ['a' => 1, 'b' => 2, 'c' => 3];
     $chunks = array_chunk($input, 2, true);
+    // @phan-suppress-next-line PhanSideEffectFreeForeachBody
     foreach ($chunks as $chunk) {
         '@phan-debug-var $chunk';
         // Should be array<string,int>
+        // @phan-suppress-next-line PhanSideEffectFreeForeachBody, PhanUnusedVariableValueOfForeachWithKey, PhanUnusedVariable
         foreach ($chunk as $key => $value) {
             '@phan-debug-var $key';
             '@phan-debug-var $value';
@@ -154,7 +156,7 @@ function test_iterate_chunks() {
 // Test with union type input
 function test_union_input() {
     /** @var array<int>|array<string> $input */
-    $input = rand() ? [1, 2] : ['a', 'b'];
+    $input = random_int(0, 1) ? [1, 2] : ['a', 'b'];
     $result = array_chunk($input, 2);
     '@phan-debug-var $result';
     // Should be list<list<int|string>>

--- a/tests/files/src/4807_array_chunk.php
+++ b/tests/files/src/4807_array_chunk.php
@@ -1,0 +1,176 @@
+<?php declare(strict_types=1);
+
+// Test basic array_chunk with default preserve_keys (false)
+function test_default_behavior() {
+    $input = [1, 2, 3, 4, 5];
+    $result = array_chunk($input, 2);
+    '@phan-debug-var $result';
+    // Should be list<list<int>>
+    return $result;
+}
+
+// Test array_chunk with preserve_keys = true
+function test_preserve_keys_true() {
+    $input = ['a' => 1, 'b' => 2, 'c' => 3];
+    $result = array_chunk($input, 2, true);
+    '@phan-debug-var $result';
+    // Should be list<array<string,int>>
+    return $result;
+}
+
+// Test array_chunk with preserve_keys = false explicitly
+function test_preserve_keys_false() {
+    $input = ['a' => 1, 'b' => 2, 'c' => 3];
+    $result = array_chunk($input, 2, false);
+    '@phan-debug-var $result';
+    // Should be list<list<int>>
+    return $result;
+}
+
+// Test array_chunk with dynamic preserve_keys (unknown at analysis time)
+function test_dynamic_preserve_keys(bool $preserve) {
+    $input = ['a' => 1, 'b' => 2, 'c' => 3];
+    $result = array_chunk($input, 2, $preserve);
+    '@phan-debug-var $result';
+    // Should be list<list<int>|array<string,int>>
+    return $result;
+}
+
+// Test with string array
+function test_string_array() {
+    $input = ['foo', 'bar', 'baz'];
+    $result = array_chunk($input, 2);
+    '@phan-debug-var $result';
+    // Should be list<list<string>>
+    return $result;
+}
+
+// Test with mixed type array
+function test_mixed_array() {
+    $input = [1, 'foo', true];
+    $result = array_chunk($input, 2);
+    '@phan-debug-var $result';
+    // Should be list<list<int|string|true>>
+    return $result;
+}
+
+// Test with array of objects
+function test_object_array() {
+    $input = [new stdClass(), new stdClass()];
+    $result = array_chunk($input, 1);
+    '@phan-debug-var $result';
+    // Should be list<list<stdClass>>
+    return $result;
+}
+
+// Test with associative array preserve_keys=true
+function test_associative_preserve_keys() {
+    /** @var array<string, int> $input */
+    $input = ['x' => 10, 'y' => 20];
+    $result = array_chunk($input, 1, true);
+    '@phan-debug-var $result';
+    // Should be list<array<string,int>>
+    return $result;
+}
+
+// Test with list type
+function test_list_type() {
+    /** @var list<int> $input */
+    $input = [1, 2, 3, 4];
+    $result = array_chunk($input, 2);
+    '@phan-debug-var $result';
+    // Should be list<list<int>>
+    return $result;
+}
+
+// Test with array shape
+function test_array_shape() {
+    $input = [
+        ['name' => 'Alice', 'age' => 30],
+        ['name' => 'Bob', 'age' => 25]
+    ];
+    $result = array_chunk($input, 1);
+    '@phan-debug-var $result';
+    // Should be list<list<array{name:string,age:int}>>
+    return $result;
+}
+
+// Test with array shape and preserve_keys=true
+function test_array_shape_preserve() {
+    $input = [
+        'user1' => ['name' => 'Alice', 'age' => 30],
+        'user2' => ['name' => 'Bob', 'age' => 25]
+    ];
+    $result = array_chunk($input, 1, true);
+    '@phan-debug-var $result';
+    // Should be list<array<string,array{name:string,age:int}>>
+    return $result;
+}
+
+// Test return type mismatch - expecting wrong type
+/** @return list<int> */
+function test_wrong_return_type() {
+    $input = [1, 2, 3];
+    return array_chunk($input, 2); // Should emit PhanTypeMismatchReturn
+}
+
+// Test with numeric keys preserved
+function test_numeric_keys_preserved() {
+    $input = [10 => 'a', 20 => 'b', 30 => 'c'];
+    $result = array_chunk($input, 2, true);
+    '@phan-debug-var $result';
+    // Should be list<array<int,string>>
+    return $result;
+}
+
+// Test accessing chunked array elements
+function test_chunk_element_access() {
+    $input = [1, 2, 3, 4, 5];
+    $chunks = array_chunk($input, 2);
+    $first_chunk = $chunks[0];
+    '@phan-debug-var $first_chunk';
+    // Should be list<int>
+    $first_element = $first_chunk[0];
+    '@phan-debug-var $first_element';
+    // Should be int
+    return $first_element;
+}
+
+// Test iterating over chunks
+function test_iterate_chunks() {
+    $input = ['a' => 1, 'b' => 2, 'c' => 3];
+    $chunks = array_chunk($input, 2, true);
+    foreach ($chunks as $chunk) {
+        '@phan-debug-var $chunk';
+        // Should be array<string,int>
+        foreach ($chunk as $key => $value) {
+            '@phan-debug-var $key';
+            '@phan-debug-var $value';
+            // key should be string, value should be int
+        }
+    }
+}
+
+// Test with union type input
+function test_union_input() {
+    /** @var array<int>|array<string> $input */
+    $input = rand() ? [1, 2] : ['a', 'b'];
+    $result = array_chunk($input, 2);
+    '@phan-debug-var $result';
+    // Should be list<list<int|string>>
+    return $result;
+}
+
+// Test type mismatch when expecting preserve_keys behavior
+/** @return list<array<string,int>> */
+function test_expect_preserved_but_default() {
+    $input = ['a' => 1, 'b' => 2];
+    return array_chunk($input, 2); // Should emit PhanTypeMismatchReturn (default doesn't preserve keys)
+}
+
+// Test type mismatch when expecting list but got associative
+/** @return list<list<int>> */
+function test_expect_list_but_preserved() {
+    $input = ['a' => 1, 'b' => 2];
+    return array_chunk($input, 2, true); // Should emit PhanTypeMismatchReturn (preserve_keys=true)
+}


### PR DESCRIPTION
try to fix #4807 

Added an `array_chunk` callback to `ArrayReturnTypeOverridePlugin.php`  that provides type inference:
- Default behavior (preserve_keys=false): Returns `list<list<V>>` where V is the element type
- With preserve_keys=true: Returns `list<array<K,V>>` preserving original keys
- Dynamic/unknown preserve_keys: Returns `list<list<V>|array<K,V>>` (union of both)

  