### PR TITLE
Fix bug #4727

### DIFF
--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -1193,8 +1193,11 @@ class AssignmentVisitor extends AnalysisVisitor
 
         $resolved_right_type = $this->right_type->withStaticResolvedInContext($this->context);
         if ($this->dim_depth > 0) {
+            // Check compatibility without expanding property type to include parent classes.
+            // Expanding would incorrectly allow sibling types to be considered compatible.
+            // See https://github.com/phan/phan/issues/4727
             if ($resolved_right_type->canCastToUnionType(
-                $property_union_type->asExpandedTypesPreservingTemplate($code_base),
+                $property_union_type,
                 $code_base
             )) {
                 $this->addTypesToProperty($property, $node);
@@ -1214,7 +1217,7 @@ class AssignmentVisitor extends AnalysisVisitor
                                   ->withStaticResolvedInContext($this->context);
 
                 if (!$new_types->canCastToUnionType(
-                    $property_union_type->asExpandedTypesPreservingTemplate($code_base),
+                    $property_union_type,
                     $code_base
                 )) {
                     // echo "Emitting warning for $new_types\n";
@@ -1243,14 +1246,14 @@ class AssignmentVisitor extends AnalysisVisitor
         } else {
             // This is a regular assignment, not an assignment to an offset
             if (!$resolved_right_type->canCastToUnionType(
-                $property_union_type->asExpandedTypesPreservingTemplate($code_base),
+                $property_union_type,
                 $code_base
             )
                 && !($resolved_right_type->hasTypeInBoolFamily() && $property_union_type->hasTypeInBoolFamily())
                 && !$clazz->hasDynamicProperties($code_base)
                 && !$property->isDynamicProperty()
             ) {
-                if ($resolved_right_type->nonNullableClone()->canCastToUnionType($property_union_type->asExpandedTypesPreservingTemplate($code_base), $code_base) &&
+                if ($resolved_right_type->nonNullableClone()->canCastToUnionType($property_union_type, $code_base) &&
                         !$resolved_right_type->isType(NullType::instance(false))) {
                     if ($this->shouldSuppressIssue(Issue::TypeMismatchProperty, $node->lineno)) {
                         return $this->context;

--- a/tests/files/expected/4727_sibling_class_property_assignment.php.expected
+++ b/tests/files/expected/4727_sibling_class_property_assignment.php.expected
@@ -1,0 +1,3 @@
+%s:17 PhanTypeMismatchPropertyReal Assigning new A2() of type \A2 to property but \C->prop1 is \A1
+%s:18 PhanTypeMismatchPropertyProbablyReal Assigning new A2() of type \A2 to property but \C->prop2 is \A1 (no real type) (the inferred real assigned type has nothing in common with the declared phpdoc property type)
+%s:48 PhanTypeMismatchProperty Assigning $obj of type \anonymous_class_%s to property but \D->interfaceProp is \IA1

--- a/tests/files/src/4727_sibling_class_property_assignment.php
+++ b/tests/files/src/4727_sibling_class_property_assignment.php
@@ -1,0 +1,49 @@
+<?php
+
+class Base {}
+class A1 extends Base {}
+class A2 extends Base {}
+class SubA1 extends A1 {}
+
+class C {
+    public A1 $prop1;
+    /** @var A1 */
+    public $prop2;
+}
+
+// Test basic sibling assignment - should fail
+function test_sibling_assignment() {
+    $c = new C();
+    $c->prop1 = new A2();  // Should warn: PhanTypeMismatchPropertyReal
+    $c->prop2 = new A2();  // Should warn: PhanTypeMismatchPropertyProbablyReal
+}
+
+// Test valid subclass assignment - should pass
+function test_subclass_assignment() {
+    $c = new C();
+    $c->prop1 = new SubA1();  // OK: SubA1 is subclass of A1
+    $c->prop2 = new SubA1();  // OK: SubA1 is subclass of A1
+}
+
+// Test valid same-class assignment - should pass
+function test_same_class_assignment() {
+    $c = new C();
+    $c->prop1 = new A1();  // OK
+    $c->prop2 = new A1();  // OK
+}
+
+// Test with interfaces
+interface IBase {}
+interface IA1 extends IBase {}
+interface IA2 extends IBase {}
+
+class D {
+    /** @var IA1 */
+    public $interfaceProp;
+}
+
+function test_interface_sibling() {
+    $d = new D();
+    $obj = new class implements IA2 {};
+    $d->interfaceProp = $obj;  // Should warn: IA2 is not IA1
+}

--- a/tests/php82_files/expected/005_dnf_type_property.php.expected
+++ b/tests/php82_files/expected/005_dnf_type_property.php.expected
@@ -1,2 +1,3 @@
+%s:12 PhanTypeMismatchPropertyReal Assigning new C5() of type \C5 to property but \X5->value is (\Countable&\ArrayAccess)|\stdClass
 %s:14 PhanTypeMismatchPropertyReal Assigning null of type null to property but \X5->value is (\Countable&\ArrayAccess)|\stdClass
 %s:16 PhanTypeMismatchPropertyReal Assigning $v2 of type \X5 to property but \X5->value is (\Countable&\ArrayAccess)|\stdClass

--- a/tests/php82_files/src/005_dnf_type_property.php
+++ b/tests/php82_files/src/005_dnf_type_property.php
@@ -9,7 +9,7 @@ class C5 implements Countable {
 }
 $v = new X5();
 $v2 = new X5();
-$v->value = new C5(); // TODO: This should warn
+$v->value = new C5(); // Should warn: C5 only implements Countable, not ArrayAccess
 $v2->value = new ArrayObject();
 $v->value = null;
 $v->value = $v2->value;


### PR DESCRIPTION
The AssignmentVisitor had `asExpandedTypesPreservingTemplate()` calls to prevent parent type expansion that incorrectly allowed sibling types to be compatible.
A simple fix to a longstanding bug that I thought would be trickier and break more things.