### PR TITLE
Fix bug #4753

### DIFF
--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -3167,11 +3167,16 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
 
         $method = $this->context->getFunctionLikeInScope($this->code_base);
         if (($node->flags & (ast\flags\MODIFIER_FINAL | ast\flags\MODIFIER_PRIVATE)) === (ast\flags\MODIFIER_FINAL | ast\flags\MODIFIER_PRIVATE)) {
-            $this->emitIssue(
-                Issue::PrivateFinalMethod,
-                $node->lineno,
-                $method->getRepresentationForIssue()
-            );
+            // PHP 8.0+ only warns about private final methods when the method is NOT a constructor.
+            // See https://www.php.net/manual/en/migration80.incompatible.php
+            // See https://github.com/phan/phan/issues/4753
+            if (!($method instanceof Method) || !$method->isNewConstructor()) {
+                $this->emitIssue(
+                    Issue::PrivateFinalMethod,
+                    $node->lineno,
+                    $method->getRepresentationForIssue()
+                );
+            }
         }
 
         $return_type = $method->getUnionType();

--- a/tests/files/expected/4753_private_final_constructor.php.expected
+++ b/tests/files/expected/4753_private_final_constructor.php.expected
@@ -1,0 +1,2 @@
+%s:16 PhanPrivateFinalMethod PHP warns about private method \Bar::notConstructor() being final
+%s:30 PhanPrivateFinalConstant Private constant is not allowed to be final

--- a/tests/files/src/4753_private_final_constructor.php
+++ b/tests/files/src/4753_private_final_constructor.php
@@ -1,0 +1,31 @@
+<?php
+
+// Should NOT warn - constructors are exempt from private final warning in PHP 8.0+
+class Foo {
+	final private function __construct() {}
+}
+
+// Should NOT warn - abstract class with private final constructor
+abstract class Action {
+	/** Don't allow direct instantiations of this class, use newFromContext instead. */
+	final private function __construct() {}
+}
+
+// Should warn - regular private final method (not a constructor)
+class Bar {
+	final private function notConstructor() {}
+}
+
+// Should NOT warn - constructors in various contexts
+class Baz {
+	final private function __construct() {}
+
+	public static function create(): self {
+		return new self();
+	}
+}
+
+// Should warn - private final constant is still not allowed
+class WithConstant {
+	private final const X = 123;
+}


### PR DESCRIPTION
`PhanPrivateFinalMethod` incorrectly warned on constructors, even though PHP 8.0+ specifically exempts constructors from the "private final method" warning.
Added a trivial constructor method check