### PR TITLE
Fix #4713

### DIFF
--- a/src/Phan/Analysis/NegatedConditionVisitor.php
+++ b/src/Phan/Analysis/NegatedConditionVisitor.php
@@ -757,8 +757,29 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
         if (($var_node->kind ?? null) !== ast\AST_VAR) {
             return $this->checkComplexIsset($var_node);
         }
-        // if (!isset($x)) means that $x is definitely null
-        return $this->updateVariableWithNewType($var_node, $this->context, NullType::instance(false)->asRealUnionType(), true, false);
+        // if (!isset($x)) means that $x is either null or undefined.
+        // However, if $x is definitely defined (e.g., function parameter), it can only be null.
+        // See https://github.com/phan/phan/issues/4713
+        $var_name = $var_node->children['name'];
+        $null_type = NullType::instance(false)->asRealUnionType();
+
+        if (\is_string($var_name)) {
+            $variable = $this->context->getScope()->getVariableByNameOrNull($var_name);
+            // Mark as possibly undefined if:
+            // 1. Variable doesn't exist in scope yet, OR
+            // 2. Variable exists but is already possibly undefined
+            if (!$variable || $variable->getUnionType()->isPossiblyUndefined()) {
+                $null_type = $null_type->withIsPossiblyUndefined(true);
+            }
+        }
+
+        return $this->updateVariableWithNewType(
+            $var_node,
+            $this->context,
+            $null_type,
+            true,
+            false
+        );
     }
 
     /**

--- a/tests/files/expected/0348_global_isset.php.expected
+++ b/tests/files/expected/0348_global_isset.php.expected
@@ -1,1 +1,2 @@
+%s:6 PhanPossiblyUndeclaredGlobalVariable Global variable $global348 is possibly undeclared
 %s:12 PhanUndeclaredGlobalVariable Global variable $globalC348 is undeclared

--- a/tests/plugin_test/expected/254_redundant_assignment_isset.php.expected
+++ b/tests/plugin_test/expected/254_redundant_assignment_isset.php.expected
@@ -1,0 +1,10 @@
+src/254_redundant_assignment_isset.php:3 PhanUnreferencedClass Possibly zero references to class \PossiblyUnsetConsideredNull
+src/254_redundant_assignment_isset.php:7 PhanUnreferencedPublicMethod Possibly zero references to public method \PossiblyUnsetConsideredNull::testUnset()
+src/254_redundant_assignment_isset.php:18 PhanUnreferencedPublicMethod Possibly zero references to public method \PossiblyUnsetConsideredNull::testUnsetNoNullSetter()
+src/254_redundant_assignment_isset.php:23 PhanPossiblyUndeclaredVariable Variable $var is possibly undeclared
+src/254_redundant_assignment_isset.php:26 PhanUnreferencedPublicMethod Possibly zero references to public method \PossiblyUnsetConsideredNull::testActuallyRedundant()
+src/254_redundant_assignment_isset.php:26 PhanUnusedPublicNoOverrideMethodParameter Parameter $key is never used
+src/254_redundant_assignment_isset.php:29 PhanPluginConstantVariableNull Variable $var is probably constant with a value of null
+src/254_redundant_assignment_isset.php:30 PhanPluginRedundantAssignment Assigning null to variable $var which already has that value
+src/254_redundant_assignment_isset.php:35 PhanUnreferencedPublicMethod Possibly zero references to public method \PossiblyUnsetConsideredNull::testIssetAfterAssignment()
+src/254_redundant_assignment_isset.php:46 PhanUnreferencedPublicMethod Possibly zero references to public method \PossiblyUnsetConsideredNull::testMultipleConditions()

--- a/tests/plugin_test/src/254_redundant_assignment_isset.php
+++ b/tests/plugin_test/src/254_redundant_assignment_isset.php
@@ -1,0 +1,62 @@
+<?php
+
+class PossiblyUnsetConsideredNull
+{
+    const LIST = ['a' => '1', 'b' => '2'];
+
+    static public function testUnset($key)
+    {
+        if (array_key_exists($key, self::LIST)) {
+            $var = "SET " . self::LIST[$key];
+        }
+        if (!isset($var)) {
+            $var = null;  // Should NOT warn - $var might be undefined
+        }
+        return $var;
+    }
+
+    static public function testUnsetNoNullSetter($key)
+    {
+        if (array_key_exists($key, self::LIST)) {
+            $var = "SET " . self::LIST[$key];
+        }
+        return $var;  // Should warn - $var is possibly undeclared
+    }
+
+    static public function testActuallyRedundant($key)
+    {
+        $var = null;
+        if (!isset($var)) {
+            $var = null;  // Should warn - $var is already null
+        }
+        return $var;
+    }
+
+    static public function testIssetAfterAssignment($key)
+    {
+        if (array_key_exists($key, self::LIST)) {
+            $var = null;  // Set to null
+        }
+        if (!isset($var)) {
+            $var = null;  // Should NOT warn - $var might be undefined (not set)
+        }
+        return $var;
+    }
+
+    static public function testMultipleConditions($key, $key2)
+    {
+        if (array_key_exists($key, self::LIST)) {
+            $var = "SET";
+        }
+        if (array_key_exists($key2, self::LIST)) {
+            $var2 = "SET2";
+        }
+        if (!isset($var)) {
+            $var = null;  // Should NOT warn - $var might be undefined
+        }
+        if (!isset($var2)) {
+            $var2 = null;  // Should NOT warn - $var2 might be undefined
+        }
+        return [$var, $var2];
+    }
+}


### PR DESCRIPTION
When Phan processed `!isset($var)`, it was setting the variable type to just `null`, losing the "possibly undefined" flag. The `RedundantAssignmentPlugin` checks this flag, so it incorrectly thought the assignment was redundant.   

- Modified NegatedConditionVisitor::visitIsset() to mark the variable as "possibly undefined" when !isset() is true
- Only applies to variables that are either:
    - Not yet in scope, OR
    - Already possibly undefined
- Function parameters and other definitely-defined variables remain just null (not possibly undefined)

