### PR TITLE
Fix bug #4707

### DIFF
--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -483,6 +483,14 @@ Array and string offset access syntax with curly braces is no longer supported. 
 
 e.g. [this issue](https://github.com/phan/phan/tree/v6/tests/misc/fallback_test/expected/062_test.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/v6/tests/misc/fallback_test/src/062_test.php#L2).
 
+## PhanCompatibleEnumPropertyInConstExpression
+
+```
+Fetching properties of enums in constant expressions (e.g. {CODE}) is only supported in PHP 8.2+.
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/v6/tests/files/expected/4707_enum_property_const_expr.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/v6/tests/files/src/4707_enum_property_const_expr.php#L11).
+
 ## PhanCompatibleImplodeOrder
 
 ```
@@ -584,6 +592,12 @@ The unset cast (in {CODE}) is a fatal error.
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/v6/tests/misc/fallback_test/expected/061_cast_crash.php.expected#L11) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/v6/tests/misc/fallback_test/src/061_cast_crash.php#L45).
+
+## PhanNonEnumPropertyInConstExpression
+
+```
+Only properties of enums can be fetched in constant expressions, {TYPE} given
+```
 
 # Context
 

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -605,6 +605,8 @@ class Issue
     public const CompatibleReadonlyClass                 = 'PhanCompatibleReadonlyClass';
     public const CompatibleTypedClassConstant            = 'PhanCompatibleTypedClassConstant';
     public const CompatibleOverrideAttribute             = 'PhanCompatibleOverrideAttribute';
+    public const CompatibleEnumPropertyInConstExpression = 'PhanCompatibleEnumPropertyInConstExpression';
+    public const NonEnumPropertyInConstExpression        = 'PhanNonEnumPropertyInConstExpression';
 
     // Issue::CATEGORY_GENERIC
     public const TemplateTypeConstant       = 'PhanTemplateTypeConstant';
@@ -5089,6 +5091,22 @@ class Issue
                 'Attribute #[Override] on {CLASS} is only supported in PHP {DETAILS}.',
                 self::REMEDIATION_B,
                 3055
+            ),
+            new Issue(
+                self::CompatibleEnumPropertyInConstExpression,
+                self::CATEGORY_COMPATIBLE,
+                self::SEVERITY_NORMAL,
+                'Fetching properties of enums in constant expressions (e.g. {CODE}) is only supported in PHP 8.2+.',
+                self::REMEDIATION_B,
+                3056
+            ),
+            new Issue(
+                self::NonEnumPropertyInConstExpression,
+                self::CATEGORY_COMPATIBLE,
+                self::SEVERITY_CRITICAL,
+                'Only properties of enums can be fetched in constant expressions, {TYPE} given',
+                self::REMEDIATION_B,
+                3057
             ),
             new Issue(
                 self::CompatibleAutoload,

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -2076,6 +2076,8 @@ class ParseVisitor extends ScopeVisitor
     {
         try {
             self::checkIsAllowedInConstExpr($node, $const_expr_context);
+            // After validating the basic structure, check for enum property access (PHP 8.2+)
+            $this->checkEnumPropertyAccessInConstExpr($node);
             return true;
         } catch (InvalidArgumentException $e) {
             $this->emitIssue(
@@ -2084,6 +2086,94 @@ class ParseVisitor extends ScopeVisitor
                 $e->getMessage()
             );
             return false;
+        }
+    }
+
+    /**
+     * Check for enum property access in constant expressions (PHP 8.2+ feature).
+     * Emits compatibility warning if targeting PHP < 8.2.
+     * Emits error if the left-hand side is not an enum.
+     *
+     * @param Node|string|float|int|bool|null $node
+     */
+    private function checkEnumPropertyAccessInConstExpr(Node|bool|float|int|null|string $node): void
+    {
+        if (!($node instanceof Node)) {
+            return;
+        }
+
+        // Check if this is an enum property access node
+        if ($node->kind === ast\AST_PROP || $node->kind === ast\AST_NULLSAFE_PROP) {
+            // Emit compatibility warning for PHP < 8.2
+            if (Config::get_closest_target_php_version_id() < 80200) {
+                $this->emitIssue(
+                    Issue::CompatibleEnumPropertyInConstExpression,
+                    $node->lineno,
+                    ASTReverter::toShortString($node)
+                );
+            }
+
+            // Check if the left-hand side is an enum
+            $expr_node = $node->children['expr'];
+            if ($expr_node instanceof Node) {
+                try {
+                    $expr_type = UnionTypeVisitor::unionTypeFromNode(
+                        $this->code_base,
+                        $this->context,
+                        $expr_node,
+                        false
+                    );
+
+                    // For nullsafe property access, null is allowed
+                    if ($node->kind === ast\AST_NULLSAFE_PROP) {
+                        $expr_type = $expr_type->nonNullableClone();
+                    }
+
+                    // Check if all types are enums
+                    $has_non_enum = false;
+                    foreach ($expr_type->getTypeSet() as $type) {
+                        // Skip checking for null in nullsafe access
+                        if ($type instanceof NullType) {
+                            continue;
+                        }
+
+                        // Check if this type corresponds to an enum class
+                        if ($type->isObjectWithKnownFQSEN()) {
+                            $fqsen = FullyQualifiedClassName::fromType($type);
+                            if ($this->code_base->hasClassWithFQSEN($fqsen)) {
+                                $class = $this->code_base->getClassByFQSEN($fqsen);
+                                if (!$class->isEnum()) {
+                                    $has_non_enum = true;
+                                    break;
+                                }
+                            } else {
+                                // Unknown class - might be enum, don't warn
+                                continue;
+                            }
+                        } else {
+                            // Not a class type (e.g., mixed, object, etc.)
+                            $has_non_enum = true;
+                            break;
+                        }
+                    }
+
+                    if ($has_non_enum) {
+                        $this->emitIssue(
+                            Issue::NonEnumPropertyInConstExpression,
+                            $node->lineno,
+                            $expr_type
+                        );
+                    }
+                } catch (IssueException) {
+                    // If we can't determine the type, don't emit a warning
+                    // The issue will be caught during analysis phase
+                }
+            }
+        }
+
+        // Recursively check child nodes
+        foreach ($node->children as $child_node) {
+            $this->checkEnumPropertyAccessInConstExpr($child_node);
         }
     }
 

--- a/tests/files/expected/4707_enum_property_const_expr.php.expected
+++ b/tests/files/expected/4707_enum_property_const_expr.php.expected
@@ -1,0 +1,6 @@
+%s:11 PhanCompatibleEnumPropertyInConstExpression Fetching properties of enums in constant expressions (e.g. Status::Pending->name) is only supported in PHP 8.2+.
+%s:15 PhanCompatibleEnumPropertyInConstExpression Fetching properties of enums in constant expressions (e.g. Status::Active->value) is only supported in PHP 8.2+.
+%s:15 PhanUnusedVariableStatic Unreferenced definition of variable $v as a static variable
+%s:23 PhanCompatibleEnumPropertyInConstExpression Fetching properties of enums in constant expressions (e.g. Status::Active->name) is only supported in PHP 8.2+.
+%s:28 PhanCompatibleEnumPropertyInConstExpression Fetching properties of enums in constant expressions (e.g. Status::Pending->name) is only supported in PHP 8.2+.
+%s:32 PhanCompatibleEnumPropertyInConstExpression Fetching properties of enums in constant expressions (e.g. Status::Pending?->name) is only supported in PHP 8.2+.

--- a/tests/files/expected/4768_enum_case_property.php.expected
+++ b/tests/files/expected/4768_enum_case_property.php.expected
@@ -1,0 +1,2 @@
+%s:9 PhanCompatibleEnumPropertyInConstExpression Fetching properties of enums in constant expressions (e.g. self::DECIMAL->value) is only supported in PHP 8.2+.
+%s:13 PhanCompatibleEnumPropertyInConstExpression Fetching properties of enums in constant expressions (e.g. self::DECIMAL->name) is only supported in PHP 8.2+.

--- a/tests/files/src/4707_enum_property_const_expr.php
+++ b/tests/files/src/4707_enum_property_const_expr.php
@@ -1,0 +1,32 @@
+<?php
+
+// Test enum property access in constant expressions (PHP 8.2+)
+
+enum Status: string {
+    case Pending = 'pending';
+    case Active = 'active';
+}
+
+// Valid: Enum property in const
+const C1 = Status::Pending->name;
+
+// Valid: Enum property in static variable
+function testStaticVar() {
+    static $v = Status::Active->value;
+}
+
+// Valid: Enum property in parameter default
+function testParamDefault($p = Status::Pending->value) {}
+
+// Valid: Enum property in class property
+class ValidClass {
+    public string $prop = Status::Active->name;
+}
+
+// Valid: Enum property in class constant
+class ValidClassConst {
+    const C = Status::Pending->name;
+}
+
+// Nullsafe property access - valid with enum
+const C2 = Status::Pending?->name;


### PR DESCRIPTION
Phan now detects enum property access in constant expressions and emits PhanCompatibleEnumPropertyInConstExpression warnings when targeting PHP < 8.2.