### PR TITLE
Fix #4741

### DIFF
--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -2215,6 +2215,14 @@ e.g. [this issue](https://github.com/phan/phan/tree/v6/tests/files/expected/1096
 
 This category of issue comes up when more than one thing of whatever type have the same name and namespace.
 
+## PhanDuplicateStaticVariable
+
+```
+Duplicate declaration of static variable ${VARIABLE} in {FUNCTIONLIKE} - previously declared at {FILE}:{LINE}
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/v6/tests/files/expected/4741_duplicate_static_variable.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/v6/tests/files/src/4741_duplicate_static_variable.php#L8).
+
 ## PhanIncompatibleCompositionConstant
 
 This issue is emitted when a class uses traits that define the same constant with incompatible visibility or values, or when a class redefines a trait constant incompatibly. PHP 8.2+ allows constants in traits, and the definitions must be compatible.

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -753,6 +753,31 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             false
         );
 
+        // Check for duplicate static variable declarations (PHP 8.3+ fatal error)
+        if ($this->context->isInFunctionLikeScope()) {
+            $var_name = $variable->getName();
+            $scope = $this->context->getScope();
+
+            // Check if this static variable was already declared in this function
+            if ($scope->hasVariableWithName($var_name)) {
+                $existing_var = $scope->getVariableByName($var_name);
+
+                // Only warn if the existing variable is also a static variable
+                // (the IS_CONSTANT_DEFINITION flag is set on static variables)
+                if ($existing_var->getPhanFlagsHasState(\Phan\Language\Element\Flags::IS_CONSTANT_DEFINITION)) {
+                    $method = $this->context->getFunctionLikeInScope($this->code_base);
+                    $this->emitIssue(
+                        Issue::DuplicateStaticVariable,
+                        $node->lineno,
+                        $var_name,
+                        $method->getRepresentationForIssue(),
+                        $existing_var->getFileRef()->getFile(),
+                        $existing_var->getFileRef()->getLineNumberStart()
+                    );
+                }
+            }
+        }
+
         // If the element has a default, set its type
         // on the variable
         if (isset($node->children['default'])) {

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -528,6 +528,7 @@ class Issue
     public const RedefineFunctionInternal  = 'PhanRedefineFunctionInternal';
     public const RedefineClassConstant     = 'PhanRedefineClassConstant';
     public const RedefineProperty          = 'PhanRedefineProperty';
+    public const DuplicateStaticVariable   = 'PhanDuplicateStaticVariable';
     public const IncompatibleCompositionProp = 'PhanIncompatibleCompositionProp';
     public const IncompatibleCompositionMethod = 'PhanIncompatibleCompositionMethod';
     public const IncompatibleCompositionConstant = 'PhanIncompatibleCompositionConstant';
@@ -4739,6 +4740,14 @@ class Issue
                 'Property ${PROPERTY} defined at {FILE}:{LINE} was previously defined at {FILE}:{LINE}',
                 self::REMEDIATION_B,
                 8011
+            ),
+            new Issue(
+                self::DuplicateStaticVariable,
+                self::CATEGORY_REDEFINE,
+                self::SEVERITY_CRITICAL,
+                'Duplicate declaration of static variable ${VARIABLE} in {FUNCTIONLIKE} - previously declared at {FILE}:{LINE}',
+                self::REMEDIATION_B,
+                8015
             ),
             new Issue(
                 self::ReusedEnumCaseValue,

--- a/tests/files/expected/4741_duplicate_static_variable.php.expected
+++ b/tests/files/expected/4741_duplicate_static_variable.php.expected
@@ -1,0 +1,4 @@
+%s:8 PhanDuplicateStaticVariable Duplicate declaration of static variable $x in \testDuplicateSimple() - previously declared at %s:7
+%s:13 PhanDuplicateStaticVariable Duplicate declaration of static variable $a in \testDuplicateMultiple() - previously declared at %s:12
+%s:21 PhanDuplicateStaticVariable Duplicate declaration of static variable $y in \testDuplicateNested() - previously declared at %s:18
+%s:40 PhanDuplicateStaticVariable Duplicate declaration of static variable $prop in \TestClass::testMethod() - previously declared at %s:39

--- a/tests/files/src/4741_duplicate_static_variable.php
+++ b/tests/files/src/4741_duplicate_static_variable.php
@@ -1,0 +1,48 @@
+<?php
+
+// Test duplicate static variable declarations (issue #4741)
+// PHP 8.3+ makes this a fatal error
+
+function testDuplicateSimple() {
+    static $x = 1;
+    static $x = 2; // Should warn: duplicate static variable
+}
+
+function testDuplicateMultiple() {
+    static $a = 1, $b = 2;
+    static $a = 3; // Should warn: duplicate static variable $a
+    var_dump($a, $b);
+}
+
+function testDuplicateNested() {
+    static $y = 1;
+    $condition = (bool)rand(0, 1);
+    if ($condition) {
+        static $y = 2; // Should warn: duplicate static variable (same function scope)
+    }
+    var_dump($y);
+}
+
+function testNoDuplicate() {
+    static $z = 1;
+    var_dump($z);
+}
+
+function testDifferentNames() {
+    static $m = 1;
+    static $n = 2;
+    var_dump($m, $n);
+}
+
+class TestClass {
+    public function testMethod() {
+        static $prop = 1;
+        static $prop = 2; // Should warn: duplicate static variable
+    }
+}
+
+testDuplicateSimple();
+testDuplicateMultiple();
+testDuplicateNested();
+testNoDuplicate();
+testDifferentNames();


### PR DESCRIPTION
Warn about duplicate static variable declarations.
New issue type: `PhanDuplicateStaticVariable`
Added check in `visitStatic()` in the `PostOrderAnalysisVisitor`
PHP 8.2 and earlier: This was allowed but confusing (last declaration wins)
PHP 8.3+: This is a fatal error at runtime
Phan now warns about this for all PHP versions, because it really should never have been allowed in PHP in the first place