### PR TITLE
Fix bug #4735

### DIFF
--- a/src/Phan/Language/Type/ArrayShapeType.php
+++ b/src/Phan/Language/Type/ArrayShapeType.php
@@ -701,25 +701,48 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
         if (\count($array_shape_types) === 1) {
             return $array_shape_types[0];
         }
-        $field_types = $array_shape_types[0]->field_types;
-        unset($array_shape_types[0]);
 
+        // Collect all possible field keys across all shapes
+        $all_keys = [];
         foreach ($array_shape_types as $type) {
-            foreach ($type->field_types as $key => $union_type) {
-                $old_union_type = $field_types[$key] ?? null;
-                if ($old_union_type === null) {
-                    // The new type is possibly undefined iff the current type is.
-                    $new_union_type = $union_type;
-                } else {
-                    $new_union_type = $old_union_type->withUnionType($union_type);
-                    if ($old_union_type->isPossiblyUndefined() && $union_type->isPossiblyUndefined()) {
-                        $new_union_type = $new_union_type->withIsPossiblyUndefined(true);
-                    }
-                    // Else we're good because the type returned by `withUnionType` is never possibly undefined.
-                }
-                $field_types[$key] = $new_union_type;
+            foreach ($type->field_types as $key => $_) {
+                $all_keys[$key] = true;
             }
         }
+
+        $field_types = [];
+        foreach ($all_keys as $key => $_) {
+            $field_union_types = [];
+            $all_possibly_undefined = true;
+
+            // Collect the union type for this field from each shape that has it
+            foreach ($array_shape_types as $type) {
+                if (isset($type->field_types[$key])) {
+                    $field_type = $type->field_types[$key];
+                    $field_union_types[] = $field_type;
+                    // If at least one shape has this field as required, it's not "all possibly undefined"
+                    if (!$field_type->isPossiblyUndefined()) {
+                        $all_possibly_undefined = false;
+                    }
+                }
+            }
+
+            // Merge all union types for this field
+            $merged = $field_union_types[0];
+            for ($i = 1; $i < \count($field_union_types); $i++) {
+                $merged = $merged->withUnionType($field_union_types[$i]);
+            }
+
+            // Per doc comment: "Elements are considered to be possibly undefined iff
+            // they are possibly undefined in all of the types."
+            // A field is optional in result only if it's marked as optional in ALL shapes where it appears
+            if ($all_possibly_undefined) {
+                $merged = $merged->withIsPossiblyUndefined(true);
+            }
+
+            $field_types[$key] = $merged;
+        }
+
         return self::fromFieldTypes($field_types, false);
     }
 

--- a/src/Phan/Language/Type/ArrayType.php
+++ b/src/Phan/Language/Type/ArrayType.php
@@ -261,17 +261,41 @@ class ArrayType extends IterableType
     {
         $type_set = [];
         $left_array_shape_types = [];
+
+        // Check if ANY variant has this field
+        $any_variant_has_field = false;
         foreach ($left->getTypeSet() as $type) {
             if ($type instanceof ArrayShapeType) {
-                $left_array_shape_types[] = $type;
+                $field_types = $type->getFieldTypes();
+                if (isset($field_types[$field_dim_value])) {
+                    $any_variant_has_field = true;
+                    break;
+                }
+            }
+        }
+
+        foreach ($left->getTypeSet() as $type) {
+            if ($type instanceof ArrayShapeType) {
+                $field_types = $type->getFieldTypes();
+                // Only filter out variants if at least one variant has the field.
+                // If no variants have the field, keep all variants (it's just adding a new field).
+                if (!$any_variant_has_field || isset($field_types[$field_dim_value]) || \count($field_types) === 0) {
+                    $left_array_shape_types[] = $type;
+                }
+                // else: Some variants have the field but this one doesn't - eliminate it
             } else {
                 $type_set[] = $type;
             }
         }
-        $type_set[] = ArrayShapeType::combineWithPrecedence(
-            ArrayShapeType::fromFieldTypes([$field_dim_value => $field_type], false),
-            ArrayShapeType::union($left_array_shape_types)
-        );
+        if (\count($left_array_shape_types) > 0) {
+            $type_set[] = ArrayShapeType::combineWithPrecedence(
+                ArrayShapeType::fromFieldTypes([$field_dim_value => $field_type], false),
+                ArrayShapeType::union($left_array_shape_types)
+            );
+        } else {
+            // All array shape variants were filtered out - just create a shape with this field
+            $type_set[] = ArrayShapeType::fromFieldTypes([$field_dim_value => $field_type], false);
+        }
         $real_type_set = $left->hasRealTypeSet() ? self::computeRealTypeSetForArrayShapeTypeWithField($left, $field_dim_value, $field_type) : [];
         // TODO: Determine if the real type is an array
         return UnionType::of($type_set, $real_type_set);
@@ -287,24 +311,49 @@ class ArrayType extends IterableType
     private static function computeRealTypeSetForArrayShapeTypeWithField(UnionType $left, bool|float|int|string $field_dim_value, UnionType $field_type): array
     {
         $has_non_array_shape = false;
+        $filtered_array_shape_types = [];
+
+        // Check if ANY variant has this field
+        $any_variant_has_field = false;
+        foreach ($left->getRealTypeSet() as $type) {
+            if ($type instanceof ArrayShapeType) {
+                $field_types = $type->getFieldTypes();
+                if (isset($field_types[$field_dim_value])) {
+                    $any_variant_has_field = true;
+                    break;
+                }
+            }
+        }
+
         foreach ($left->getRealTypeSet() as $type) {
             if (!$type instanceof ArrayType || $type->isNullable()) {
                 return [];
             }
             if (!$type instanceof ArrayShapeType) {
                 $has_non_array_shape = true;
+            } else {
+                // Only filter out variants if at least one variant has the field.
+                // If no variants have the field, keep all variants (it's just adding a new field).
+                $field_types = $type->getFieldTypes();
+                if (!$any_variant_has_field || isset($field_types[$field_dim_value]) || \count($field_types) === 0) {
+                    $filtered_array_shape_types[] = $type;
+                }
             }
         }
         if ($has_non_array_shape) {
             return [ArrayType::instance(false)];
         }
-        return [
-            ArrayShapeType::combineWithPrecedence(
-                ArrayShapeType::fromFieldTypes([$field_dim_value => $field_type->asRealUnionType()], false),
-                // @phan-suppress-next-line PhanTypeMismatchArgument this was asserted to be list<ArrayShapeType>
-                ArrayShapeType::union($left->getRealTypeSet())
-            )
-        ];
+        if (\count($filtered_array_shape_types) > 0) {
+            return [
+                ArrayShapeType::combineWithPrecedence(
+                    ArrayShapeType::fromFieldTypes([$field_dim_value => $field_type->asRealUnionType()], false),
+                    ArrayShapeType::union($filtered_array_shape_types)
+                )
+            ];
+        } else {
+            // All array shape variants were filtered out - just create a shape with this field
+            return [ArrayShapeType::fromFieldTypes([$field_dim_value => $field_type->asRealUnionType()], false)];
+        }
     }
 
     protected function canCastToNonNullableType(Type $type, CodeBase $code_base): bool

--- a/tests/files/src/4735_array_shape_field_narrowing.php
+++ b/tests/files/src/4735_array_shape_field_narrowing.php
@@ -1,0 +1,144 @@
+<?php
+
+// Test case 1: Simple union with missing keys in different variants
+function test_missing_keys_in_variants(int $choice) {
+    if ($choice === 0) {
+        $data = ['first' => [], 'second' => []];
+    } elseif ($choice === 1) {
+        $data = ['first' => [1]];  // Missing 'second'
+    } else {
+        $data = ['second' => [42]];  // Missing 'first'
+    }
+
+    // Checking 'first' should eliminate variants without 'first'
+    if (isset($data['first']) && $data['first'] !== []) {
+        // In this branch, 'second' might be undefined because
+        // the variant array{first:list<1>} doesn't have 'second'
+        if (isset($data['second'])) {
+            var_dump($data['second']);
+        }
+    }
+
+    // After the condition, 'second' can still be undefined
+    // because we're back to the full union including array{first:list<1>}
+    if (isset($data['second'])) {
+        var_dump($data['second']);
+    }
+}
+
+// Test case 2: Union where all variants have both keys
+function test_all_variants_have_keys(bool $cond) {
+    if ($cond) {
+        $data = [
+            'first' => [],
+            'second' => []
+        ];
+    } else {
+        $data = [
+            'first' => [1],
+            'second' => [42]
+        ];
+    }
+
+    // Checking 'first' should not affect 'second' availability
+    if ($data['first'] !== []) {
+        // 'second' is always defined in both variants
+        var_dump($data['second']);  // Should NOT warn
+    }
+
+    // 'second' is still always defined
+    var_dump($data['second']);  // Should NOT warn
+}
+
+// Test case 3: Accessing field in isset() condition
+function test_isset_field_access(bool $cond) {
+    if ($cond) {
+        $data = ['first' => [], 'second' => []];
+    } else {
+        $data = ['second' => [42]];  // Missing 'first'
+    }
+
+    // After isset check, only variants with 'first' remain
+    if (isset($data['first'])) {
+        // In this branch, 'second' is always defined
+        var_dump($data['second']);  // Should NOT warn
+    }
+}
+
+// Test case 4: Multiple field accesses
+function test_multiple_field_accesses(int $choice) {
+    if ($choice === 0) {
+        $data = ['first' => 1, 'second' => 2, 'third' => 3];
+    } elseif ($choice === 1) {
+        $data = ['first' => 1, 'second' => 2];
+    } elseif ($choice === 2) {
+        $data = ['first' => 1, 'third' => 3];
+    } else {
+        $data = ['second' => 2, 'third' => 3];
+    }
+
+    // Accessing 'first' should eliminate variant without 'first'
+    if (isset($data['first'])) {
+        // Variants: array{first:1,second:2,third:3} | array{first:1,second:2} | array{first:1,third:3}
+        // 'second' is possibly undefined (missing in third variant)
+        if (isset($data['second'])) {
+            var_dump($data['second']);
+        }
+        // 'third' is possibly undefined (missing in second variant)
+        if (isset($data['third'])) {
+            var_dump($data['third']);
+        }
+    }
+}
+
+// Test case 5: Field comparison narrowing
+function test_field_comparison(bool $cond) {
+    if ($cond) {
+        $data = ['x' => 'string', 'y' => 42];
+    } else {
+        $data = ['x' => 123];  // Missing 'y'
+    }
+
+    // Accessing 'x' should eliminate variants without 'x' (none in this case)
+    if ($data['x'] !== 'string') {
+        // Both variants have 'x', but only first has 'y'
+        if (isset($data['y'])) {
+            var_dump($data['y']);
+        }
+    }
+}
+
+// Test case 6: Empty array shape
+function test_empty_array_shape() {
+    $arr = [];
+
+    // Accessing field on empty array creates the field
+    $arr['first'] = [1, 2, 3];
+
+    // 'first' is now defined
+    var_dump($arr['first']);  // Should NOT warn
+}
+
+// Test case 7: The original bug #4735 simplified
+function test_original_bug_simplified(bool $cond) {
+    // Create data with both 'first' and 'second' always present
+    $data = [
+        'first' => [],
+        'second' => []
+    ];
+
+    if ($cond) {
+        $data['first'][] = 1;
+    }
+    $data['second'][] = 42;
+
+    // This creates union: array{first:array{}|list<1>,second:list<42>}
+    // Both keys are present in all variants
+
+    if ($data['first'] !== []) {
+        // ...
+    }
+
+    // 'second' should still be defined
+    var_dump($data['second']);  // Should NOT warn
+}


### PR DESCRIPTION
When checking one array field (e.g., `$data['first'] !== []`), Phan incorrectly marked unrelated fields (e.g., 'second') as possibly undefined in array shape unions.

The method `ArrayType::combineArrayShapeTypesWithField()` was merging ALL array shape variants without filtering, including variants that don't have the accessed field. This caused fields to be marked as optional incorrectly.
Added smart filtering logic to `combineArrayShapeTypesWithField()`:
- Check if ANY variant has the accessed field
- If yes: filter out variants that don't have it (they're eliminated by field access)
- If no: keep all variants (it's just adding a new field)
Applied same filtering to real type sets in `computeRealTypeSetForArrayShapeTypeWithField()`

This was tricky to figure out until you see that you should only filter out variants when at least ONE variant has the field. If NO variants have the field, keep all variants and just add the field (existing behaviour for isset() on new fields).

@codex review