### PR TITLE
Bug4599 - false positive PhanAccessReadOnlyProperty

### DIFF
--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -89,6 +89,12 @@ class AssignmentVisitor extends AnalysisVisitor
     private $suppress_dim_property_mismatch;
 
     /**
+     * @var bool true if this is a conditional check (isset/array_key_exists) rather than an actual assignment
+     * When true, skip read-only property checks since we're only inferring that a field exists, not modifying it.
+     */
+    private $is_conditional_check;
+
+    /**
      * @param CodeBase $code_base
      * The global code base we're operating within
      *
@@ -110,6 +116,10 @@ class AssignmentVisitor extends AnalysisVisitor
      *
      * @param ?UnionType $dim_type
      * The type of the dimension.
+     *
+     * @param bool $is_conditional_check
+     * True if this is being used for conditional type inference (isset/array_key_exists)
+     * rather than an actual assignment. Skips read-only property checks.
      */
     public function __construct(
         CodeBase $code_base,
@@ -118,7 +128,8 @@ class AssignmentVisitor extends AnalysisVisitor
         UnionType $right_type,
         int $dim_depth = 0,
         ?UnionType $dim_type = null,
-        bool $suppress_dim_property_mismatch = false
+        bool $suppress_dim_property_mismatch = false,
+        bool $is_conditional_check = false
     ) {
         parent::__construct($code_base, $context);
 
@@ -127,6 +138,7 @@ class AssignmentVisitor extends AnalysisVisitor
         $this->dim_type = $dim_type;  // null for `$x[] =` or when dim_depth is 0.
         $this->assignment_node = $assignment_node;
         $this->suppress_dim_property_mismatch = $suppress_dim_property_mismatch;
+        $this->is_conditional_check = $is_conditional_check;
     }
 
     /**
@@ -927,7 +939,8 @@ class AssignmentVisitor extends AnalysisVisitor
             $right_type,
             $this->dim_depth + 1,
             $dim_type,
-            $this->suppress_dim_property_mismatch
+            $this->suppress_dim_property_mismatch,
+            $this->is_conditional_check  // Propagate the flag for nested dimensions
         ))->__invoke($expr_node);
 
         return $context;
@@ -1161,7 +1174,9 @@ class AssignmentVisitor extends AnalysisVisitor
     {
         $code_base = $this->code_base;
         if ($property->isReadOnly()) {
-            if ($this->dim_depth === 0 || !self::shouldSkipReadOnlyDimAssignmentCheck($property)) {
+            // Skip read-only checks if this is a conditional check (isset/array_key_exists)
+            // We're only inferring that the field exists, not actually modifying it
+            if (!$this->is_conditional_check && ($this->dim_depth === 0 || !self::shouldSkipReadOnlyDimAssignmentCheck($property))) {
                 $this->analyzeAssignmentToReadOnlyProperty($property, $node);
             }
         }

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -404,7 +404,11 @@ class ConditionVisitor extends KindVisitorImplementation implements ConditionVis
                     // There is a difference between `if (is_string($x['field']))` and `$x['field'] = (some string)` for the way the `elseif` should be analyzed.
                     $context->withClonedScope(),
                     $ancestor_node,
-                    $old_type->nonNullableClone()
+                    $old_type->nonNullableClone(),
+                    0,
+                    null,
+                    false,
+                    true  // is_conditional_check: This is isset, not an assignment
                 ))->__invoke($ancestor_node);
             }
             return $context->withScopeVariable($variable);

--- a/src/Phan/Analysis/ConditionVisitorUtil.php
+++ b/src/Phan/Analysis/ConditionVisitorUtil.php
@@ -724,7 +724,8 @@ trait ConditionVisitorUtil
                 $new_field_type,
                 0,
                 null,
-                true
+                true,
+                true  // is_conditional_check: This is a type check, not an assignment
             ))->__invoke($node);
         } catch (IssueException $exception) {
             if (!$suppress_issues) {
@@ -1586,7 +1587,8 @@ trait ConditionVisitorUtil
             $new_field_type,
             0,
             null,
-            true
+            true,
+            true  // is_conditional_check: This is a type check (is_array, etc.), not an assignment
         ))->__invoke($node);
     }
 

--- a/tests/files/expected/4599_isset_readonly.php.expected
+++ b/tests/files/expected/4599_isset_readonly.php.expected
@@ -1,0 +1,3 @@
+%s:41 PhanAccessReadOnlyProperty Cannot modify read-only property \SideEffectFreeClass->values defined at %s:11
+%s:57 PhanAccessReadOnlyProperty Cannot modify read-only property \ClassWithReadonlyProperty->data defined at %s:47
+%s:77 PhanAccessReadOnlyProperty Cannot modify read-only property \ClassWithReadOnlyAnnotation->config defined at %s:65

--- a/tests/files/src/4599_isset_readonly.php
+++ b/tests/files/src/4599_isset_readonly.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * Test for issue #4599: False positive PhanAccessReadOnlyProperty with isset()
+ */
+
+/**
+ * @phan-side-effect-free
+ */
+class SideEffectFreeClass {
+    protected array $values = [];
+
+    // isset() should not trigger read-only warning
+    public function get($key) {
+        if (!isset($this->values[$key])) {
+            throw new InvalidArgumentException();
+        }
+        return $this->values[$key];
+    }
+
+    // array_key_exists() should not trigger read-only warning
+    public function has($key): bool {
+        return array_key_exists($key, $this->values);
+    }
+
+    // Nested dimensions: isset($this->values['a']['b'])
+    public function getNestedValue($key1, $key2) {
+        if (!isset($this->values[$key1][$key2])) {
+            throw new InvalidArgumentException();
+        }
+        return $this->values[$key1][$key2];
+    }
+
+    // Type checks like is_array() should not trigger warning
+    public function checkType($key): bool {
+        return is_array($this->values[$key]);
+    }
+
+    // Actual assignment SHOULD trigger warning
+    public function shouldWarn($key, $value): void {
+        $this->values[$key] = $value;
+    }
+}
+
+class ClassWithReadonlyProperty {
+    public function __construct(
+        public readonly array $data = []
+    ) {}
+
+    // isset() on readonly property should not trigger warning
+    public function has($key): bool {
+        return isset($this->data[$key]);
+    }
+
+    // Actual assignment SHOULD trigger warning
+    public function shouldWarn($key, $value): void {
+        $this->data[$key] = $value;
+    }
+}
+
+class ClassWithReadOnlyAnnotation {
+    /**
+     * @phan-read-only
+     */
+    protected array $config = [];
+
+    // isset() should not trigger warning
+    public function getConfig($key) {
+        if (!isset($this->config[$key])) {
+            return null;
+        }
+        return $this->config[$key];
+    }
+
+    // Actual assignment SHOULD trigger warning
+    public function setConfig($key, $value): void {
+        $this->config[$key] = $value;
+    }
+}


### PR DESCRIPTION
There was false positive `PhanAccessReadOnlyProperty` warning when using isset() on read-only properties in `@phan-side-effect-free` classes

`isset()` and `array_key_exists()` use `AssignmentVisitor` internally for type inference, which was incorrectly checking for read-only property modifications even though these are read-only operations.

Added a boolean flag `is_conditional_check` to `AssignmentVisitor` to distinguish between:
- Actual assignments (should check read-only properties)
- Conditional type inference like `isset()`, `array_key_exists()`, `is_array()` (should skip read-only checks)

@codex review