### PR TITLE
Fix a tricky global variable type pollution bug

### DIFF
--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -537,9 +537,8 @@ class Analysis
         ?Request $request,
         ?string $override_contents = null
     ): Context {
-        // Snapshot global variables before analyzing this file
-        // This allows us to restore globals if the file is later modified
-        GlobalScope::snapshotBeforeAnalyzingFile($file_path);
+        // Track which file is being analyzed for global variable contribution tracking
+        GlobalScope::startAnalyzingFile($file_path);
 
         // Set the file on the context
         $context = (new Context())->withFile($file_path);
@@ -570,11 +569,13 @@ class Analysis
                     $file_path
                 );
 
+                GlobalScope::finishAnalyzingFile();
                 return $context;
             }
             $node = Parser::parseCode($code_base, $context, $request, $file_path, $file_contents, false);
         } catch (ParseException | ParseError | CompileError) {
             // Issue::SyntaxError was already emitted.
+            GlobalScope::finishAnalyzingFile();
             return $context;
         }
 
@@ -596,6 +597,10 @@ class Analysis
         $context->warnAboutUnusedUseElements($code_base);
 
         ConfigPluginSet::instance()->afterAnalyzeFile($code_base, $context, $file_contents, $node);
+
+        // Mark the end of this file's analysis for global variable tracking
+        GlobalScope::finishAnalyzingFile();
+
         return $context;
     }
 

--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -29,6 +29,7 @@ use Phan\Language\Element\Method;
 use Phan\Language\FQSEN\FullyQualifiedClassName;
 use Phan\Language\FQSEN\FullyQualifiedFunctionName;
 use Phan\Language\FQSEN\FullyQualifiedMethodName;
+use Phan\Language\Scope\GlobalScope;
 use Phan\Library\FileCache;
 use Phan\Library\StringUtil;
 use Phan\Parse\ParseVisitor;
@@ -74,6 +75,12 @@ class Analysis
     {
         $original_file_path = $file_path;
         $code_base->setCurrentParsedFile($file_path);
+
+        // Register undo operation for global variables (will be restored when file changes)
+        // This is registered during parse phase when undo tracking is enabled
+        if (!$is_php_internal_stub) {
+            GlobalScope::registerUndoForFile($file_path);
+        }
         if ($is_php_internal_stub) {
             /** @see \Phan\Language\FileRef::isPHPInternal() */
             $file_path = 'internal';
@@ -530,6 +537,10 @@ class Analysis
         ?Request $request,
         ?string $override_contents = null
     ): Context {
+        // Snapshot global variables before analyzing this file
+        // This allows us to restore globals if the file is later modified
+        GlobalScope::snapshotBeforeAnalyzingFile($file_path);
+
         // Set the file on the context
         $context = (new Context())->withFile($file_path);
         // @phan-suppress-next-line PhanAccessMethodInternal

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -302,6 +302,15 @@ class CodeBase
     }
 
     /**
+     * Get the UndoTracker instance if undo tracking is enabled, null otherwise.
+     * Used by GlobalScope and other components that need to record undo operations.
+     */
+    public function getUndoTracker(): ?UndoTracker
+    {
+        return $this->undo_tracker;
+    }
+
+    /**
      * Enable hydration of elements. (populating class elements with information from their ancestors)
      *
      * This is called after the parse phase is finished.

--- a/src/Phan/Language/Scope/GlobalScope.php
+++ b/src/Phan/Language/Scope/GlobalScope.php
@@ -38,6 +38,14 @@ final class GlobalScope extends Scope
     private static $code_base = null;
 
     /**
+     * @var array<string,array<string,Variable>>
+     * Snapshots of global variables before each file's analysis phase.
+     * Maps file path -> snapshot of $global_variable_map before that file was analyzed.
+     * Used for incremental analysis to restore globals when a file changes.
+     */
+    private static $file_snapshots = [];
+
+    /**
      * @return bool
      * True if we're in a class scope
      */
@@ -134,22 +142,6 @@ final class GlobalScope extends Scope
             // with superglobals.
             // TODO: Add a warning for incompatible assignments in callers.
             return;
-        }
-
-        // Record undo operation for incremental analysis
-        $code_base = self::$code_base;
-        if ($code_base !== null) {
-            $undo_tracker = $code_base->getUndoTracker();
-            if ($undo_tracker) {
-                $old_variable = self::$global_variable_map[$variable_name] ?? null;
-                $undo_tracker->recordUndo(static function (CodeBase $_) use ($variable_name, $old_variable): void {
-                    if ($old_variable === null) {
-                        unset(self::$global_variable_map[$variable_name]);
-                    } else {
-                        self::$global_variable_map[$variable_name] = $old_variable;
-                    }
-                });
-            }
         }
 
         self::$global_variable_map[$variable->getName()] = $variable;
@@ -265,5 +257,55 @@ final class GlobalScope extends Scope
     {
         self::$global_variable_map = [];
         self::$code_base = null;
+        self::$file_snapshots = [];
+    }
+
+    /**
+     * Snapshot the current global variables state before analyzing a file.
+     * This is called before the analysis phase for each file.
+     * The snapshot will be restored if the file is later modified or removed.
+     *
+     * @param string $file_path The file about to be analyzed
+     */
+    public static function snapshotBeforeAnalyzingFile(string $file_path): void
+    {
+        // Store a snapshot of the current global variable map
+        // We store references, not clones, for performance
+        self::$file_snapshots[$file_path] = self::$global_variable_map;
+    }
+
+    /**
+     * Restore global variables to the state before a file was analyzed.
+     * This is called by the undo mechanism when a file is modified or removed.
+     *
+     * @param string $file_path The file being undone
+     */
+    public static function undoAnalysisForFile(string $file_path): void
+    {
+        if (isset(self::$file_snapshots[$file_path])) {
+            // Restore the snapshot from before this file was analyzed
+            self::$global_variable_map = self::$file_snapshots[$file_path];
+            unset(self::$file_snapshots[$file_path]);
+        }
+    }
+
+    /**
+     * Register undo operation for a file during parse phase.
+     * This is called during the parse phase when undo tracking is enabled.
+     * The registered closure will restore globals when the file changes.
+     *
+     * @param string $file_path The file being parsed
+     */
+    public static function registerUndoForFile(string $file_path): void
+    {
+        $code_base = self::$code_base;
+        if ($code_base !== null) {
+            $undo_tracker = $code_base->getUndoTracker();
+            if ($undo_tracker) {
+                $undo_tracker->recordUndo(static function (CodeBase $_) use ($file_path): void {
+                    self::undoAnalysisForFile($file_path);
+                });
+            }
+        }
     }
 }

--- a/src/Phan/Language/Scope/GlobalScope.php
+++ b/src/Phan/Language/Scope/GlobalScope.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phan\Language\Scope;
 
 use AssertionError;
+use Phan\CodeBase;
 use Phan\Language\Element\Variable;
 use Phan\Language\FQSEN\FullyQualifiedClassName;
 use Phan\Language\FQSEN\FullyQualifiedPropertyName;
@@ -28,6 +29,13 @@ final class GlobalScope extends Scope
      * variables registered under $GLOBALS.
      */
     private static $global_variable_map = [];
+
+    /**
+     * @var ?CodeBase
+     * Reference to the CodeBase for recording undo operations.
+     * This is set during initialization to enable incremental analysis.
+     */
+    private static $code_base = null;
 
     /**
      * @return bool
@@ -127,6 +135,23 @@ final class GlobalScope extends Scope
             // TODO: Add a warning for incompatible assignments in callers.
             return;
         }
+
+        // Record undo operation for incremental analysis
+        $code_base = self::$code_base;
+        if ($code_base !== null) {
+            $undo_tracker = $code_base->getUndoTracker();
+            if ($undo_tracker) {
+                $old_variable = self::$global_variable_map[$variable_name] ?? null;
+                $undo_tracker->recordUndo(static function (CodeBase $_) use ($variable_name, $old_variable): void {
+                    if ($old_variable === null) {
+                        unset(self::$global_variable_map[$variable_name]);
+                    } else {
+                        self::$global_variable_map[$variable_name] = $old_variable;
+                    }
+                });
+            }
+        }
+
         self::$global_variable_map[$variable->getName()] = $variable;
     }
 
@@ -214,5 +239,31 @@ final class GlobalScope extends Scope
         string $template_type_identifier
     ): bool {
         return false;
+    }
+
+    /**
+     * Set the CodeBase reference for recording undo operations during incremental analysis.
+     * This should be called during Phan initialization.
+     */
+    public static function setCodeBase(CodeBase $code_base): void
+    {
+        self::$code_base = $code_base;
+    }
+
+    /**
+     * Clear the CodeBase reference. Used for cleanup and testing.
+     */
+    public static function clearCodeBase(): void
+    {
+        self::$code_base = null;
+    }
+
+    /**
+     * Reset all global variables. Used for testing and daemon mode cleanup.
+     */
+    public static function reset(): void
+    {
+        self::$global_variable_map = [];
+        self::$code_base = null;
     }
 }

--- a/src/Phan/Language/Scope/GlobalScope.php
+++ b/src/Phan/Language/Scope/GlobalScope.php
@@ -38,12 +38,20 @@ final class GlobalScope extends Scope
     private static $code_base = null;
 
     /**
-     * @var array<string,array<string,Variable>>
-     * Snapshots of global variables before each file's analysis phase.
-     * Maps file path -> snapshot of $global_variable_map before that file was analyzed.
-     * Used for incremental analysis to restore globals when a file changes.
+     * @var array<string,array<string,array{action:string,old?:Variable}>>
+     * Tracks per-file contributions to global variables.
+     * Maps file path -> variable name -> contribution record.
+     * Each record contains 'action' (added|modified) and optionally 'old' (previous Variable).
+     * Used for incremental analysis to undo only a specific file's changes.
      */
-    private static $file_snapshots = [];
+    private static $file_contributions = [];
+
+    /**
+     * @var ?string
+     * The file currently being analyzed (set during analysis phase).
+     * Used to track which file contributes which global variables.
+     */
+    private static $current_analyzing_file = null;
 
     /**
      * @return bool
@@ -142,6 +150,24 @@ final class GlobalScope extends Scope
             // with superglobals.
             // TODO: Add a warning for incompatible assignments in callers.
             return;
+        }
+
+        // Track this file's contribution for incremental analysis
+        $current_file = self::$current_analyzing_file;
+        if ($current_file !== null) {
+            if (!isset(self::$global_variable_map[$variable_name])) {
+                // This file is adding a new global variable
+                self::$file_contributions[$current_file][$variable_name] = ['action' => 'added'];
+            } elseif (self::$global_variable_map[$variable_name] !== $variable) {
+                // This file is modifying an existing global variable
+                // Only record the first modification by this file
+                if (!isset(self::$file_contributions[$current_file][$variable_name])) {
+                    self::$file_contributions[$current_file][$variable_name] = [
+                        'action' => 'modified',
+                        'old' => self::$global_variable_map[$variable_name]
+                    ];
+                }
+            }
         }
 
         self::$global_variable_map[$variable->getName()] = $variable;
@@ -257,36 +283,58 @@ final class GlobalScope extends Scope
     {
         self::$global_variable_map = [];
         self::$code_base = null;
-        self::$file_snapshots = [];
+        self::$file_contributions = [];
+        self::$current_analyzing_file = null;
     }
 
     /**
-     * Snapshot the current global variables state before analyzing a file.
-     * This is called before the analysis phase for each file.
-     * The snapshot will be restored if the file is later modified or removed.
+     * Mark the start of analyzing a file.
+     * This tracks which file is responsible for adding/modifying global variables.
      *
      * @param string $file_path The file about to be analyzed
      */
-    public static function snapshotBeforeAnalyzingFile(string $file_path): void
+    public static function startAnalyzingFile(string $file_path): void
     {
-        // Store a snapshot of the current global variable map
-        // We store references, not clones, for performance
-        self::$file_snapshots[$file_path] = self::$global_variable_map;
+        self::$current_analyzing_file = $file_path;
+        // Initialize contribution tracking for this file
+        if (!isset(self::$file_contributions[$file_path])) {
+            self::$file_contributions[$file_path] = [];
+        }
     }
 
     /**
-     * Restore global variables to the state before a file was analyzed.
-     * This is called by the undo mechanism when a file is modified or removed.
+     * Mark the end of analyzing a file.
+     */
+    public static function finishAnalyzingFile(): void
+    {
+        self::$current_analyzing_file = null;
+    }
+
+    /**
+     * Undo the global variable changes made by a specific file.
+     * This removes variables added by the file and restores variables modified by the file.
+     * Variables from other files are left untouched.
      *
      * @param string $file_path The file being undone
      */
     public static function undoAnalysisForFile(string $file_path): void
     {
-        if (isset(self::$file_snapshots[$file_path])) {
-            // Restore the snapshot from before this file was analyzed
-            self::$global_variable_map = self::$file_snapshots[$file_path];
-            unset(self::$file_snapshots[$file_path]);
+        if (!isset(self::$file_contributions[$file_path])) {
+            return;
         }
+
+        // Undo this file's contributions in reverse order
+        foreach (self::$file_contributions[$file_path] as $variable_name => $contribution) {
+            if ($contribution['action'] === 'added') {
+                // This file added this variable - remove it
+                unset(self::$global_variable_map[$variable_name]);
+            } elseif ($contribution['action'] === 'modified' && isset($contribution['old'])) {
+                // This file modified this variable - restore the old value
+                self::$global_variable_map[$variable_name] = $contribution['old'];
+            }
+        }
+
+        unset(self::$file_contributions[$file_path]);
     }
 
     /**

--- a/src/phan.php
+++ b/src/phan.php
@@ -9,6 +9,7 @@ require_once(__DIR__ . '/Phan/Bootstrap.php');
 
 use Phan\CLI;
 use Phan\Config;
+use Phan\Language\Scope\GlobalScope;
 use Phan\Phan;
 
 // Create our CLI interface and load arguments
@@ -19,6 +20,9 @@ $cli = CLI::fromArgv();
 //
 // Phan filters out user-defined functions/classes/constants.
 $code_base = require(__DIR__ . '/codebase.php');
+
+// Initialize GlobalScope with CodeBase reference for incremental analysis undo tracking
+GlobalScope::setCodeBase($code_base);
 
 // Analyze the file list provided via the CLI
 $is_issue_found =

--- a/tests/Phan/MultiFileTest.php
+++ b/tests/Phan/MultiFileTest.php
@@ -124,6 +124,14 @@ class MultiFileTest extends AbstractPhanFileTest
                 ],
                 MULTI_EXPECTED_DIR . DIRECTORY_SEPARATOR . '4827.php' . AbstractPhanFileTest::EXPECTED_SUFFIX,
             ],
+            // #6001 - Global variable type pollution in incremental analysis
+            [
+                [
+                    MULTI_FILE_DIR . DIRECTORY_SEPARATOR . '6001_a.php',
+                    MULTI_FILE_DIR . DIRECTORY_SEPARATOR . '6001_b.php',
+                ],
+                MULTI_EXPECTED_DIR . DIRECTORY_SEPARATOR . '6001.php' . AbstractPhanFileTest::EXPECTED_SUFFIX,
+            ],
             // Manually add additional file sets and expected
             // output here.
 

--- a/tests/multi_files/src/6001_a.php
+++ b/tests/multi_files/src/6001_a.php
@@ -1,0 +1,4 @@
+<?php
+$file = fopen('php://memory', 'r');
+while (($line = fgets($file)) !== false) {
+}

--- a/tests/multi_files/src/6001_b.php
+++ b/tests/multi_files/src/6001_b.php
@@ -1,0 +1,2 @@
+<?php
+$file = 'this is not a stream';


### PR DESCRIPTION
Global variable types were being polluted during incremental re-analysis in daemon mode. When file B modified a global variable after file A, the undo operations didn't restore the variable's state, causing file A to see incorrect types on re-analysis.
Modified `GlobalScope` to record undo operations before modifying `$global_variable_map`, using a snapshot-based approach that stores only references to old Variable objects (not deep clones).
