### PR TITLE
Implement feature #4541 - literal type exclusion in `!in_array()` checks

### DIFF
--- a/src/Phan/Analysis/NegatedConditionVisitor.php
+++ b/src/Phan/Analysis/NegatedConditionVisitor.php
@@ -298,6 +298,10 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
             // @phan-suppress-next-line PhanPartialTypeMismatchArgument
             return $this->analyzeArrayKeyExistsNegation($args);
         }
+        if ($function_name === 'in_array') {
+            // @phan-suppress-next-line PhanPartialTypeMismatchArgument
+            return $this->analyzeInArrayNegation($args);
+        }
         static $map;
         if ($map === null) {
             $map = self::createNegationCallbackMap();
@@ -421,6 +425,98 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
             true,
             false
         );
+    }
+
+    /**
+     * Analyze !in_array($var, ['literal1', 'literal2'], true) to exclude literal values from $var's type.
+     * Only processes literal arrays with strict comparison for performance and correctness.
+     *
+     * @param list<Node|string|int|float> $args
+     */
+    private function analyzeInArrayNegation(array $args): Context
+    {
+        $context = $this->context;
+
+        // Require strict comparison (third argument must be true)
+        if (\count($args) < 3) {
+            return $context;
+        }
+        $is_strict = UnionTypeVisitor::checkCondUnconditionalTruthiness($args[2]) === true;
+        if (!$is_strict) {
+            return $context;
+        }
+
+        $var_node = $args[0];
+        if (!($var_node instanceof Node)) {
+            return $context;
+        }
+
+        $array_node = $args[1];
+        if (!($array_node instanceof Node) || $array_node->kind !== ast\AST_ARRAY) {
+            // Not a literal array, skip
+            return $context;
+        }
+
+        // Extract literal scalar values from the array
+        $literal_types = self::extractLiteralTypesFromArray($array_node);
+        if ($literal_types === null || $literal_types->isEmpty()) {
+            return $context;
+        }
+
+        // Update the variable to exclude these literal types
+        return $this->updateVariableWithConditionalFilter(
+            $var_node,
+            $context,
+            static function (UnionType $_): bool {
+                return true;
+            },
+            static function (UnionType $type) use ($literal_types): UnionType {
+                // Subtract each literal type from the variable's type
+                foreach ($literal_types->getTypeSet() as $literal_type) {
+                    $type = $type->withoutType($literal_type);
+                }
+                return $type;
+            },
+            true,
+            false
+        );
+    }
+
+    /**
+     * Extract literal scalar types from a literal array node.
+     * Returns null if the array is too complex or contains non-literals.
+     * Limits to 50 elements for performance.
+     */
+    private static function extractLiteralTypesFromArray(Node $array_node): ?UnionType
+    {
+        $children = $array_node->children;
+        if (\count($children) > 50) {
+            // Safety limit to prevent performance issues
+            return null;
+        }
+
+        $type_builder = new UnionTypeBuilder();
+
+        foreach ($children as $elem) {
+            if (!($elem instanceof Node) || $elem->kind !== ast\AST_ARRAY_ELEM) {
+                continue;
+            }
+
+            $value = $elem->children['value'];
+
+            // Only extract literal scalar values
+            if ($value instanceof Node) {
+                // Skip computed values, only process literals
+                continue;
+            }
+
+            if (\is_string($value) || \is_int($value) || \is_float($value) || \is_bool($value) || $value === null) {
+                $type_builder->addType(Type::fromObject($value));
+            }
+        }
+
+        $union_type = $type_builder->getPHPDocUnionType();
+        return $union_type->isEmpty() ? null : $union_type;
     }
 
     // TODO: empty, isset

--- a/tests/files/expected/4541_in_array_literal_exclusion.php.expected
+++ b/tests/files/expected/4541_in_array_literal_exclusion.php.expected
@@ -1,0 +1,1 @@
+%s:62 PhanTypeMismatchArgument Argument 1 ($param) is $status of type 'active'|'inactive' but \NS4541\expects_alpha_or_beta() takes 'alpha'|'beta' defined at %s:11

--- a/tests/files/src/4541_in_array_literal_exclusion.php
+++ b/tests/files/src/4541_in_array_literal_exclusion.php
@@ -1,0 +1,85 @@
+<?php
+
+// Test narrowing literal types after !in_array with strict comparison
+// This implements the feature requested in https://github.com/phan/phan/issues/4541
+
+namespace NS4541;
+
+/**
+ * @param 'alpha'|'beta' $param
+ */
+function expects_alpha_or_beta(string $param): void {
+    echo $param;
+}
+
+/**
+ * @param 1|2 $num
+ */
+function expects_one_or_two(int $num): void {
+    echo $num;
+}
+
+// Test string literal exclusion
+function test_string_literal_exclusion(string $x): void {
+    if ($x === 'alpha' || $x === 'beta' || $x === 'gamma') {
+        if (!in_array($x, ['gamma'], true)) {
+            // After excluding 'gamma', $x should be 'alpha'|'beta'
+            expects_alpha_or_beta($x);  // Should not warn
+        }
+    }
+}
+
+// Test int literal exclusion
+function test_int_literal_exclusion(int $value): void {
+    if ($value === 1 || $value === 2 || $value === 3) {
+        if (!in_array($value, [3], true)) {
+            // After excluding 3, $value should be 1|2
+            expects_one_or_two($value);  // Should not warn
+        }
+    }
+}
+
+// Test multiple exclusions
+function test_multiple_exclusions(string $status): void {
+    if ($status === 'new' || $status === 'active' || $status === 'inactive' || $status === 'deleted') {
+        if (!in_array($status, ['deleted', 'inactive'], true)) {
+            // After excluding 'deleted' and 'inactive', $status should be 'new'|'active'
+            // This demonstrates the feature working with multiple values to exclude
+            if ($status === 'deleted') {
+                // Type mismatch - $status is 'new'|'active', not 'deleted'
+                echo "bad";
+            }
+        }
+    }
+}
+
+// Test that non-strict comparison is NOT narrowed (for safety)
+function test_non_strict_not_narrowed(string $status): void {
+    if ($status === 'active' || $status === 'inactive') {
+        if (!in_array($status, ['active'], false)) {
+            // Should NOT narrow because strict=false is unsafe
+            // Both values still possible due to type coercion
+            expects_alpha_or_beta($status);  // Should warn - still could be 'active' or 'inactive'
+        }
+    }
+}
+
+// Test that non-literal arrays are NOT processed
+function test_non_literal_array(string $x, array $values): void {
+    if ($x === 'alpha' || $x === 'beta') {
+        if (!in_array($x, $values, true)) {
+            // Should NOT narrow - $values is not a literal array
+            expects_alpha_or_beta($x);  // Should not warn - $x is still 'alpha'|'beta' (not narrowed)
+        }
+    }
+}
+
+// Test with mixed type
+function test_mixed_type($value): void {
+    if ($value === 'alpha' || $value === 'beta' || $value === 'gamma') {
+        if (!in_array($value, ['gamma'], true)) {
+            // Works with mixed type too
+            expects_alpha_or_beta($value);  // Should not warn
+        }
+    }
+}


### PR DESCRIPTION
literal type exclusion in `!in_array()` checks
- Only triggers on literal arrays (not dynamic variables)
- 50-element maximum limit