### PR TITLE
Fix #4533

### DIFF
--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -5434,6 +5434,16 @@ class UnionType implements Serializable, Stringable
         if ($empty_array_shape_type && !$has_other_array_type) {
             $result[] = ArrayType::instance($empty_array_shape_type->isNullable());
         }
+        // Issue #4533: If we have both array{} and non-empty-array types, convert non-empty-array to array
+        // to avoid false positives in MoreSpecificElementTypePlugin.
+        // array{} | non-empty-array<K,V> is semantically equivalent to array<K,V>
+        if ($empty_array_shape_type && $has_other_array_type) {
+            foreach ($result as $i => $type) {
+                if ($type instanceof NonEmptyArrayInterface) {
+                    $result[$i] = $type->asPossiblyEmptyArrayType();
+                }
+            }
+        }
         return $result;
     }
 

--- a/tests/plugin_test/expected/315_more_specific_empty_array.php.expected
+++ b/tests/plugin_test/expected/315_more_specific_empty_array.php.expected
@@ -1,0 +1,5 @@
+src/315_more_specific_empty_array.php:6 PhanUnreferencedClass Possibly zero references to class \TestEmptyArrayReturn
+src/315_more_specific_empty_array.php:14 PhanUnreferencedPublicMethod Possibly zero references to public method \TestEmptyArrayReturn::getFiles()
+src/315_more_specific_empty_array.php:19 PhanPluginNonBoolBranch Non bool value of type 0|1|false evaluated in if clause
+src/315_more_specific_empty_array.php:32 PhanUnreferencedPublicMethod Possibly zero references to public method \TestEmptyArrayReturn::filterItems()
+src/315_more_specific_empty_array.php:46 PhanUnreferencedPublicMethod Possibly zero references to public method \TestEmptyArrayReturn::alwaysHasItems()

--- a/tests/plugin_test/src/315_more_specific_empty_array.php
+++ b/tests/plugin_test/src/315_more_specific_empty_array.php
@@ -1,0 +1,49 @@
+<?php
+
+// Test for issue #4533: MoreSpecificElementTypePlugin should not warn about
+// functions that can return empty arrays when the inferred type is array{}|non-empty-array
+
+class TestEmptyArrayReturn {
+    /**
+     * This function can return an empty array.
+     * @param string $path
+     * @param string $baseurl
+     * @param string $preg_match
+     * @return array<string,string>
+     */
+    public static function getFiles($path, $baseurl, $preg_match = '/.*/'): array {
+        $files = scandir($path, SCANDIR_SORT_ASCENDING);
+        $list = [];
+
+        foreach ($files as $file) {
+            if (preg_match($preg_match, $file) && is_file($path . DIRECTORY_SEPARATOR . $file)) {
+                $list[$file] = "$baseurl$file";
+            }
+        }
+        // At this point, $list has type array{}|non-empty-array<string,string>
+        // MoreSpecificElementTypePlugin should NOT warn about this
+        return $list;
+    }
+
+    /**
+     * Another example with a simpler pattern
+     * @return array<int,string>
+     */
+    public static function filterItems(array $items, callable $filter): array {
+        $result = [];
+        foreach ($items as $item) {
+            if ($filter($item)) {
+                $result[] = $item;
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * This should still warn because it never returns an empty array
+     * @return array<int,string>
+     */
+    public static function alwaysHasItems(): array {
+        return ['always', 'has', 'items'];
+    }
+}


### PR DESCRIPTION
`MoreSpecificElementTypePlugin` was incorrectly warning that functions can't return empty arrays when the inferred type was `array{}|non-empty-array<K,V>`. This happened because `withFlattenedArrayShapeOrLiteralTypeInstances()` was dropping the empty array shape (`array{}`), leaving only `non-empty-array<K,V>`.

When we have both an empty array shape (`array{}`) AND other array types (including `non-empty-array`), the fix converts all `non-empty-array<K,V>` types to `array<K,V>` using the `asPossiblyEmptyArrayType()` method. This is semantically correct since `array{} | non-empty-array<K,V>` is equivalent to `array<K,V>`.

@codex review