### PR TITLE
Fix bug #4461

### DIFF
--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -31,9 +31,11 @@ use Phan\Language\Context;
 use Phan\Language\Element\Clazz;
 use Phan\Language\Element\Comment\Builder;
 use Phan\Language\Element\Variable;
+use Phan\Language\FQSEN\FullyQualifiedClassConstantName;
 use Phan\Language\FQSEN\FullyQualifiedClassName;
 use Phan\Language\FQSEN\FullyQualifiedPropertyName;
 use Phan\Language\Scope\BranchScope;
+use Phan\Language\Scope\ClassConstantScope;
 use Phan\Language\Scope\GlobalScope;
 use Phan\Language\Scope\PropertyScope;
 use Phan\Language\Type;
@@ -3276,6 +3278,60 @@ class BlockAnalysisVisitor extends AnalysisVisitor
             // Step into each child node and get an
             // updated context for the node
             $context = $this->analyzeAndGetUpdatedContext($context, $node, $default);
+        }
+
+        return $this->postOrderAnalyze($context, $node);
+    }
+
+    /**
+     * Visit a class constant element (AST_CONST_ELEM) to set up proper scope
+     * for suppression annotations on the constant's PHPDoc.
+     *
+     * This is necessary to fix issue #4461 where @suppress annotations on class
+     * constants are ignored because the context doesn't have the constant's scope.
+     *
+     * @param Node $node
+     * A node to parse
+     *
+     * @return Context
+     * A new or an unchanged context resulting from
+     * parsing the node
+     */
+    public function visitConstElem(Node $node): Context
+    {
+        $context = $this->context;
+
+        // Only create a ClassConstantScope for class constants, not global constants
+        if ($context->isInClassScope()) {
+            $const_name = (string)$node->children['name'];
+            $class = $context->getClassInScope($this->code_base);
+
+            $context = $this->context->withScope(new ClassConstantScope(
+                $context->getScope(),
+                FullyQualifiedClassConstantName::make($class->getFQSEN(), $const_name)
+            ))->withLineNumberStart(
+                $node->lineno
+            );
+
+            // Don't bother calling PreOrderAnalysisVisitor, it does nothing
+
+            // Let any configured plugins do a pre-order
+            // analysis of the node.
+            ConfigPluginSet::instance()->preAnalyzeNode(
+                $this->code_base,
+                $context,
+                $node
+            );
+        }
+
+        // With a context that is inside of the node passed
+        // to this method, we analyze all children of the
+        // node.
+        $value = $node->children['value'] ?? null;
+        if ($value instanceof Node) {
+            // Step into each child node and get an
+            // updated context for the node
+            $context = $this->analyzeAndGetUpdatedContext($context, $node, $value);
         }
 
         return $this->postOrderAnalyze($context, $node);

--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -566,6 +566,27 @@ class Context extends FileRef
     }
 
     /**
+     * @return bool
+     * True if this context is currently within a class constant
+     * scope, else false.
+     * @suppress PhanUnreferencedPublicMethod
+     */
+    public function isInClassConstantScope(): bool
+    {
+        return $this->scope->isInClassConstantScope();
+    }
+
+    /**
+     * @return FullyQualifiedClassConstantName
+     * A fully-qualified structural element name describing
+     * the current class constant in scope.
+     */
+    public function getClassConstantFQSEN(): FullyQualifiedClassConstantName
+    {
+        return $this->scope->getClassConstantFQSEN();
+    }
+
+    /**
      * @param CodeBase $code_base
      * The global code base holding all state
      *
@@ -710,6 +731,36 @@ class Context extends FileRef
 
     /**
      * @param CodeBase $code_base
+     * The code base from which to retrieve a class constant in scope
+     *
+     * @return Element\ClassConstant
+     * Get the class constant in this scope, or fail real hard
+     *
+     * @throws CodeBaseException
+     * Thrown if we can't find the class constant in scope within the
+     * given codebase.
+     */
+    public function getClassConstantInScope(CodeBase $code_base): Element\ClassConstant
+    {
+        if (!$this->scope->isInClassConstantScope()) {
+            throw new AssertionError("Must be in class constant scope to get class constant");
+        }
+
+        $constant_fqsen = $this->scope->getClassConstantFQSEN();
+        if (!$code_base->hasClassConstantWithFQSEN($constant_fqsen)) {
+            throw new CodeBaseException(
+                $constant_fqsen,
+                "Cannot find class constant with FQSEN {$constant_fqsen} in context {$this}"
+            );
+        }
+
+        return $code_base->getClassConstantByFQSEN(
+            $constant_fqsen
+        );
+    }
+
+    /**
+     * @param CodeBase $code_base
      * The code base from which to retrieve the TypedElement
      *
      * @return TypedElement
@@ -726,6 +777,8 @@ class Context extends FileRef
             return $this->getFunctionLikeInScope($code_base);
         } elseif ($this->scope->isInPropertyScope()) {
             return $this->getPropertyInScope($code_base);
+        } elseif ($this->scope->isInClassConstantScope()) {
+            return $this->getClassConstantInScope($code_base);
         } elseif ($this->scope->isInClassScope()) {
             return $this->getClassInScope($code_base);
         }

--- a/src/Phan/Language/Scope.php
+++ b/src/Phan/Language/Scope.php
@@ -7,6 +7,7 @@ namespace Phan\Language;
 use AssertionError;
 use Phan\Config;
 use Phan\Language\Element\Variable;
+use Phan\Language\FQSEN\FullyQualifiedClassConstantName;
 use Phan\Language\FQSEN\FullyQualifiedClassName;
 use Phan\Language\FQSEN\FullyQualifiedFunctionName;
 use Phan\Language\FQSEN\FullyQualifiedMethodName;
@@ -37,6 +38,7 @@ abstract class Scope
     public const IN_INTERFACE_SCOPE     = 0x08;
     public const IN_CLASS_LIKE_SCOPE    = self::IN_CLASS_SCOPE | self::IN_TRAIT_SCOPE | self::IN_INTERFACE_SCOPE;
     public const IN_PROPERTY_SCOPE      = 0x10;
+    public const IN_CLASS_CONSTANT_SCOPE = 0x20;
 
     /**
      * @var Scope the parent scope, if this is not the global scope
@@ -204,6 +206,24 @@ abstract class Scope
     public function getPropertyFQSEN(): FullyQualifiedPropertyName
     {
         return $this->parent_scope->getPropertyFQSEN();
+    }
+
+    /**
+     * @return bool
+     * True if we're in a class constant scope
+     */
+    public function isInClassConstantScope(): bool
+    {
+        return (self::IN_CLASS_CONSTANT_SCOPE & $this->flags) !== 0;
+    }
+
+    /**
+     * @return FullyQualifiedClassConstantName
+     * Crawl the scope hierarchy to get a class constant FQSEN.
+     */
+    public function getClassConstantFQSEN(): FullyQualifiedClassConstantName
+    {
+        return $this->parent_scope->getClassConstantFQSEN();
     }
 
     /**

--- a/src/Phan/Language/Scope/ClassConstantScope.php
+++ b/src/Phan/Language/Scope/ClassConstantScope.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phan\Language\Scope;
+
+use Phan\Language\FQSEN\FullyQualifiedClassConstantName;
+use Phan\Language\FQSEN\FullyQualifiedClassName;
+use Phan\Language\Scope;
+
+/**
+ * Represents the Scope of the Context of a class's constant declaration.
+ */
+class ClassConstantScope extends ClosedScope
+{
+    public function __construct(
+        Scope $parent_scope,
+        FullyQualifiedClassConstantName $fqsen
+    ) {
+        $this->parent_scope = $parent_scope;
+        $this->fqsen = $fqsen;
+        $this->flags = $parent_scope->flags | Scope::IN_CLASS_CONSTANT_SCOPE;
+    }
+
+    /**
+     * @return bool
+     * True if we're in a class constant scope
+     * @override
+     */
+    public function isInClassConstantScope(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return bool
+     * True if we're in a class scope (True for class constants)
+     * @override
+     */
+    public function isInClassScope(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return FullyQualifiedClassConstantName
+     * Get the FullyQualifiedClassConstantName of the constant whose scope
+     * we're in.
+     * @override
+     */
+    public function getClassConstantFQSEN(): FullyQualifiedClassConstantName
+    {
+        if ($this->fqsen instanceof FullyQualifiedClassConstantName) {
+            return $this->fqsen;
+        }
+
+        throw new \AssertionError("FQSEN must be a FullyQualifiedClassConstantName");
+    }
+
+    /**
+     * @return FullyQualifiedClassName
+     * Crawl the scope hierarchy to get a class FQSEN.
+     */
+    public function getClassFQSEN(): FullyQualifiedClassName
+    {
+        return $this->parent_scope->getClassFQSEN();
+    }
+
+    /**
+     * @return ?FullyQualifiedClassName
+     * Crawl the scope hierarchy to get a class FQSEN.
+     * Return null if there is no class FQSEN.
+     */
+    public function getClassFQSENOrNull(): ?FullyQualifiedClassName
+    {
+        return $this->parent_scope->getClassFQSENOrNull();
+    }
+}

--- a/tests/files/expected/4461_class_constant_suppression.php.expected
+++ b/tests/files/expected/4461_class_constant_suppression.php.expected
@@ -1,0 +1,1 @@
+%s:18 PhanTypeInvalidArrayKeyLiteral Saw array key null with key value null but expected a value that could cast to int|string

--- a/tests/files/src/4461_class_constant_suppression.php
+++ b/tests/files/src/4461_class_constant_suppression.php
@@ -1,0 +1,30 @@
+<?php
+
+class TestClassConstantSuppression {
+    /**
+     * Suppression on class constant should work now
+     * @suppress PhanTypeInvalidArrayKeyLiteral
+     */
+    public const WITH_SUPPRESS = [null => 'value'];
+
+    /**
+     * Multiple suppressions on class constant
+     * @suppress PhanTypeInvalidArrayKeyLiteral
+     * @suppress PhanUnreferencedPublicClassConstant
+     */
+    public const WITH_MULTIPLE_SUPPRESS = [false => 'bool_key'];
+
+    // Without suppression - should warn
+    public const WITHOUT_SUPPRESS = [null => 'no_suppression'];
+
+    /**
+     * Suppression should also work for other issues
+     * @suppress PhanUnreferencedPublicClassConstant
+     */
+    public const UNUSED_CONSTANT = 'unused';
+}
+
+class TestInlineSuppression {
+    // @phan-suppress-next-line PhanTypeInvalidArrayKeyLiteral
+    public const INLINE_SUPPRESS = [null => 'value'];
+}


### PR DESCRIPTION
PHPDoc `@suppress` annotations on class constants were being ignored because the context didn't include the class constant element's scope when analyzing the constant's value. Fixed by adding class constant scope support following the same pattern used for properties.

@codex review