### PR TITLE
Upgrade to PHPUnit 10

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@ TBD, Phan 6.0.0-dev
 Breaking changes:
 - Requires PHP 8.1+ to run (dropped PHP 8.0 support)
 - Requires php-ast 1.1.3+ for PHP 8.4+ analysis (AST version 110/120 support)
+- Upgraded to PHPUnit 10 (requires PHPUnit 10.0+ for development/testing)
 - The `-i` CLI option is now an alias of `--incremental` instead of `--ignore-undeclared`
 - Dropped support for (minimum) target PHP version < 8.1.
 - Renamed the `PhanPluginCanUsePHP71Void` issue to `PhanPluginCanUseVoidReturnType`

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
     },
     "require-dev": {
         "cweagans/composer-patches": "^1.7",
-        "phpunit/phpunit": "^9.0"
+        "phpunit/phpunit": "^10.0"
     },
     "autoload": {
         "psr-4": {"Phan\\": "src/Phan"},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "85126749a9ea8cc83c697bdb4d77f348",
+    "content-hash": "40b903fefc95af232657d58d598dd46a",
     "packages": [
         {
             "name": "composer/pcre",
@@ -1653,76 +1653,6 @@
             "time": "2022-12-20T22:53:13+00:00"
         },
         {
-            "name": "doctrine/instantiator",
-            "version": "2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
-                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^8.1"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^11",
-                "ext-pdo": "*",
-                "ext-phar": "*",
-                "phpbench/phpbench": "^1.2",
-                "phpstan/phpstan": "^1.9.4",
-                "phpstan/phpstan-phpunit": "^1.3",
-                "phpunit/phpunit": "^9.5.27",
-                "vimeo/psalm": "^5.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com",
-                    "homepage": "https://ocramius.github.io/"
-                }
-            ],
-            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
-            "keywords": [
-                "constructor",
-                "instantiate"
-            ],
-            "support": {
-                "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://www.doctrine-project.org/sponsorship.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://www.patreon.com/phpdoctrine",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-12-30T00:23:10+00:00"
-        },
-        {
             "name": "myclabs/deep-copy",
             "version": "1.13.4",
             "source": {
@@ -1960,16 +1890,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.32",
+            "version": "10.1.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
+                "reference": "7e308268858ed6baedc8704a304727d20bc07c77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
-                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/7e308268858ed6baedc8704a304727d20bc07c77",
+                "reference": "7e308268858ed6baedc8704a304727d20bc07c77",
                 "shasum": ""
             },
             "require": {
@@ -1977,18 +1907,18 @@
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
                 "nikic/php-parser": "^4.19.1 || ^5.1.0",
-                "php": ">=7.3",
-                "phpunit/php-file-iterator": "^3.0.6",
-                "phpunit/php-text-template": "^2.0.4",
-                "sebastian/code-unit-reverse-lookup": "^2.0.3",
-                "sebastian/complexity": "^2.0.3",
-                "sebastian/environment": "^5.1.5",
-                "sebastian/lines-of-code": "^1.0.4",
-                "sebastian/version": "^3.0.2",
+                "php": ">=8.1",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "sebastian/code-unit-reverse-lookup": "^3.0.0",
+                "sebastian/complexity": "^3.2.0",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/lines-of-code": "^2.0.2",
+                "sebastian/version": "^4.0.1",
                 "theseer/tokenizer": "^1.2.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.6"
+                "phpunit/phpunit": "^10.1"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -1997,7 +1927,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "9.2.x-dev"
+                    "dev-main": "10.1.x-dev"
                 }
             },
             "autoload": {
@@ -2026,7 +1956,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.16"
             },
             "funding": [
                 {
@@ -2034,32 +1964,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-08-22T04:23:01+00:00"
+            "time": "2024-08-22T04:31:57+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "3.0.6",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -2086,7 +2016,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.1.0"
             },
             "funding": [
                 {
@@ -2094,28 +2025,28 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-12-02T12:48:52+00:00"
+            "time": "2023-08-31T06:24:48+00:00"
         },
         {
             "name": "phpunit/php-invoker",
-            "version": "3.1.1",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
                 "ext-pcntl": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "suggest": {
                 "ext-pcntl": "*"
@@ -2123,7 +2054,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -2149,7 +2080,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/4.0.0"
             },
             "funding": [
                 {
@@ -2157,32 +2088,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:58:55+00:00"
+            "time": "2023-02-03T06:56:09+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "2.0.4",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2208,7 +2139,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.1"
             },
             "funding": [
                 {
@@ -2216,32 +2148,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T05:33:50+00:00"
+            "time": "2023-08-31T14:07:24+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "5.0.3",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -2267,7 +2199,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/6.0.0"
             },
             "funding": [
                 {
@@ -2275,24 +2207,23 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:16:10+00:00"
+            "time": "2023-02-03T06:57:52+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.29",
+            "version": "10.5.58",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "9ecfec57835a5581bc888ea7e13b51eb55ab9dd3"
+                "reference": "e24fb46da450d8e6a5788670513c1af1424f16ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9ecfec57835a5581bc888ea7e13b51eb55ab9dd3",
-                "reference": "9ecfec57835a5581bc888ea7e13b51eb55ab9dd3",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e24fb46da450d8e6a5788670513c1af1424f16ca",
+                "reference": "e24fb46da450d8e6a5788670513c1af1424f16ca",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.5.0 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
@@ -2302,27 +2233,26 @@
                 "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
-                "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2.32",
-                "phpunit/php-file-iterator": "^3.0.6",
-                "phpunit/php-invoker": "^3.1.1",
-                "phpunit/php-text-template": "^2.0.4",
-                "phpunit/php-timer": "^5.0.3",
-                "sebastian/cli-parser": "^1.0.2",
-                "sebastian/code-unit": "^1.0.8",
-                "sebastian/comparator": "^4.0.9",
-                "sebastian/diff": "^4.0.6",
-                "sebastian/environment": "^5.1.5",
-                "sebastian/exporter": "^4.0.8",
-                "sebastian/global-state": "^5.0.8",
-                "sebastian/object-enumerator": "^4.0.4",
-                "sebastian/resource-operations": "^3.0.4",
-                "sebastian/type": "^3.2.1",
-                "sebastian/version": "^3.0.2"
+                "php": ">=8.1",
+                "phpunit/php-code-coverage": "^10.1.16",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-invoker": "^4.0.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "phpunit/php-timer": "^6.0.0",
+                "sebastian/cli-parser": "^2.0.1",
+                "sebastian/code-unit": "^2.0.0",
+                "sebastian/comparator": "^5.0.4",
+                "sebastian/diff": "^5.1.1",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/exporter": "^5.1.4",
+                "sebastian/global-state": "^6.0.2",
+                "sebastian/object-enumerator": "^5.0.0",
+                "sebastian/recursion-context": "^5.0.1",
+                "sebastian/type": "^4.0.0",
+                "sebastian/version": "^4.0.1"
             },
             "suggest": {
-                "ext-soap": "To be able to generate mocks based on WSDL files",
-                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+                "ext-soap": "To be able to generate mocks based on WSDL files"
             },
             "bin": [
                 "phpunit"
@@ -2330,7 +2260,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.6-dev"
+                    "dev-main": "10.5-dev"
                 }
             },
             "autoload": {
@@ -2362,7 +2292,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.29"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.58"
             },
             "funding": [
                 {
@@ -2386,32 +2316,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-24T06:29:11+00:00"
+            "time": "2025-09-28T12:04:46+00:00"
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "1.0.2",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
-                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/c34583b87e7b7a8055bf6c450c2c77ce32a24084",
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -2434,7 +2364,8 @@
             "homepage": "https://github.com/sebastianbergmann/cli-parser",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.1"
             },
             "funding": [
                 {
@@ -2442,32 +2373,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:27:43+00:00"
+            "time": "2024-03-02T07:12:49+00:00"
         },
         {
             "name": "sebastian/code-unit",
-            "version": "1.0.8",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/a81fee9eef0b7a76af11d121767abc44c104e503",
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -2490,7 +2421,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/2.0.0"
             },
             "funding": [
                 {
@@ -2498,32 +2429,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:08:54+00:00"
+            "time": "2023-02-03T06:58:43+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "2.0.3",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2545,7 +2476,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/3.0.0"
             },
             "funding": [
                 {
@@ -2553,34 +2484,36 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:30:19+00:00"
+            "time": "2023-02-03T06:59:15+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.9",
+            "version": "5.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "67a2df3a62639eab2cc5906065e9805d4fd5dfc5"
+                "reference": "e8e53097718d2b53cfb2aa859b06a41abf58c62e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/67a2df3a62639eab2cc5906065e9805d4fd5dfc5",
-                "reference": "67a2df3a62639eab2cc5906065e9805d4fd5dfc5",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e8e53097718d2b53cfb2aa859b06a41abf58c62e",
+                "reference": "e8e53097718d2b53cfb2aa859b06a41abf58c62e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/diff": "^4.0",
-                "sebastian/exporter": "^4.0"
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/diff": "^5.0",
+                "sebastian/exporter": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -2619,7 +2552,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.9"
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.4"
             },
             "funding": [
                 {
@@ -2639,33 +2573,33 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-10T06:51:50+00:00"
+            "time": "2025-09-07T05:25:07+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "2.0.3",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
+                "reference": "68ff824baeae169ec9f2137158ee529584553799"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
-                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/68ff824baeae169ec9f2137158ee529584553799",
+                "reference": "68ff824baeae169ec9f2137158ee529584553799",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": "^4.18 || ^5.0",
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.2-dev"
                 }
             },
             "autoload": {
@@ -2688,7 +2622,8 @@
             "homepage": "https://github.com/sebastianbergmann/complexity",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/3.2.0"
             },
             "funding": [
                 {
@@ -2696,33 +2631,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-22T06:19:30+00:00"
+            "time": "2023-12-21T08:37:17+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.6",
+            "version": "5.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
-                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/c41e007b4b62af48218231d6c2275e4c9b975b2e",
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3",
-                "symfony/process": "^4.2 || ^5"
+                "phpunit/phpunit": "^10.0",
+                "symfony/process": "^6.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.1-dev"
                 }
             },
             "autoload": {
@@ -2754,7 +2689,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/5.1.1"
             },
             "funding": [
                 {
@@ -2762,27 +2698,27 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:30:58+00:00"
+            "time": "2024-03-02T07:15:17+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "5.1.5",
+            "version": "6.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
-                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/8074dbcd93529b357029f5cc5058fd3e43666984",
+                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -2790,7 +2726,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.1-dev"
+                    "dev-main": "6.1-dev"
                 }
             },
             "autoload": {
@@ -2809,7 +2745,7 @@
                 }
             ],
             "description": "Provides functionality to handle HHVM/PHP environments",
-            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "homepage": "https://github.com/sebastianbergmann/environment",
             "keywords": [
                 "Xdebug",
                 "environment",
@@ -2817,7 +2753,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/6.1.0"
             },
             "funding": [
                 {
@@ -2825,34 +2762,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:03:51+00:00"
+            "time": "2024-03-23T08:47:14+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.8",
+            "version": "5.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c"
+                "reference": "0735b90f4da94969541dac1da743446e276defa6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/14c6ba52f95a36c3d27c835d65efc7123c446e8c",
-                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/0735b90f4da94969541dac1da743446e276defa6",
+                "reference": "0735b90f4da94969541dac1da743446e276defa6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/recursion-context": "^4.0"
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
-                "ext-mbstring": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.1-dev"
                 }
             },
             "autoload": {
@@ -2894,7 +2831,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.8"
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.4"
             },
             "funding": [
                 {
@@ -2914,38 +2852,35 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-24T06:03:27+00:00"
+            "time": "2025-09-24T06:09:11+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.8",
+            "version": "6.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6"
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
-                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^9.3"
-            },
-            "suggest": {
-                "ext-uopz": "*"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -2964,59 +2899,48 @@
                 }
             ],
             "description": "Snapshotting of global state",
-            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
             "keywords": [
                 "global state"
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.8"
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.2"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2025-08-10T07:10:35+00:00"
+            "time": "2024-03-02T07:19:19+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "1.0.4",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
-                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/856e7f6a75a84e339195d48c556f23be2ebf75d0",
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": "^4.18 || ^5.0",
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -3039,7 +2963,8 @@
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.2"
             },
             "funding": [
                 {
@@ -3047,34 +2972,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-22T06:20:34+00:00"
+            "time": "2023-12-21T08:38:20+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "4.0.4",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -3096,7 +3021,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/5.0.0"
             },
             "funding": [
                 {
@@ -3104,32 +3029,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:12:34+00:00"
+            "time": "2023-02-03T07:08:32+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "2.0.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/24ed13d98130f0e7122df55d06c5c4942a577957",
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -3151,7 +3076,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/3.0.0"
             },
             "funding": [
                 {
@@ -3159,32 +3084,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:14:26+00:00"
+            "time": "2023-02-03T07:06:18+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.6",
+            "version": "5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0"
+                "reference": "47e34210757a2f37a97dcd207d032e1b01e64c7a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/539c6691e0623af6dc6f9c20384c120f963465a0",
-                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/47e34210757a2f37a97dcd207d032e1b01e64c7a",
+                "reference": "47e34210757a2f37a97dcd207d032e1b01e64c7a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -3214,7 +3139,8 @@
             "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.6"
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/5.0.1"
             },
             "funding": [
                 {
@@ -3234,86 +3160,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-10T06:57:39+00:00"
-        },
-        {
-            "name": "sebastian/resource-operations",
-            "version": "3.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
-                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Provides a list of PHP built-in functions that operate on resources",
-            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "support": {
-                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2024-03-14T16:00:52+00:00"
+            "time": "2025-08-10T07:50:56+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "3.2.1",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
-                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/462699a16464c3944eefc02ebdd77882bd3925bf",
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -3336,7 +3208,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+                "source": "https://github.com/sebastianbergmann/type/tree/4.0.0"
             },
             "funding": [
                 {
@@ -3344,29 +3216,29 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:13:03+00:00"
+            "time": "2023-02-03T07:10:45+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "3.0.2",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -3389,7 +3261,7 @@
             "homepage": "https://github.com/sebastianbergmann/version",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+                "source": "https://github.com/sebastianbergmann/version/tree/4.0.1"
             },
             "funding": [
                 {
@@ -3397,7 +3269,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:39:44+00:00"
+            "time": "2023-02-07T11:34:05+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="tests/bootstrap.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" stopOnError="true" stopOnFailure="false" stopOnIncomplete="false" stopOnSkipped="false" stopOnRisky="false" backupStaticAttributes="true" verbose="false">
-  <coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" bootstrap="tests/bootstrap.php" colors="true" stopOnError="true" stopOnFailure="false" stopOnIncomplete="false" stopOnSkipped="false" stopOnRisky="false" displayDetailsOnTestsThatTriggerDeprecations="true" displayDetailsOnTestsThatTriggerErrors="true" displayDetailsOnTestsThatTriggerNotices="true" displayDetailsOnTestsThatTriggerWarnings="true" displayDetailsOnPhpunitDeprecations="true">
+  <source>
     <include>
       <directory>src/Phan</directory>
     </include>
     <exclude>
       <directory>src/Phan/Language/Internal</directory>
     </exclude>
-  </coverage>
+  </source>
   <php>
     <!-- Affects tests of CLI, etc. -->
     <env name="PHAN_ENABLE_COLOR_OUTPUT" value="" force="true"/>
@@ -72,6 +72,9 @@
     </testsuite>
     <testsuite name="All">
       <directory>tests/Phan</directory>
+      <exclude>tests/Phan/AbstractPhanFileTest.php</exclude>
+      <exclude>tests/Phan/BaseTest.php</exclude>
+      <exclude>tests/Phan/CodeBaseAwareTest.php</exclude>
     </testsuite>
   </testsuites>
 </phpunit>

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -390,7 +390,7 @@ class Type implements Stringable
         $this->is_nullable = $is_nullable;
     }
 
-    // Override two magic methods to ensure that Type isn't being cloned accidentally.
+    // Override serialization methods to ensure that Type isn't being serialized accidentally.
     // (It has previously been accidentally cloned in unit tests by phpunit (global_state helper),
     //  which saves and restores some static properties)
 
@@ -399,10 +399,10 @@ class Type implements Stringable
      * @suppress PhanPluginRemoveDebugCall deliberate output before uncatchable Error
      * @return never
      */
-    public function __wakeup()
+    public function __serialize(): array
     {
         \debug_print_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS);
-        throw new Error("Cannot unserialize Type '$this'");
+        throw new Error("Cannot serialize Type '$this' - use fromFullyQualifiedString() instead");
     }
 
     /**
@@ -415,7 +415,7 @@ class Type implements Stringable
     public function __unserialize(array $data): void
     {
         \debug_print_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS);
-        throw new Error("Cannot unserialize Type '$this'");
+        throw new Error("Cannot unserialize Type '$this' - use fromFullyQualifiedString() instead");
     }
 
     /** @throws Error this should not be called accidentally */

--- a/tests/Phan/AST/ASTReverterTest.php
+++ b/tests/Phan/AST/ASTReverterTest.php
@@ -36,7 +36,7 @@ final class ASTReverterTest extends BaseTest
     /**
      * @return list<array{0:string}>
      */
-    public function revertShorthandProvider(): array
+    public static function revertShorthandProvider(): array
     {
         return [
             ["'2'"],

--- a/tests/Phan/AST/ASTSimplifierTest.php
+++ b/tests/Phan/AST/ASTSimplifierTest.php
@@ -17,9 +17,9 @@ final class ASTSimplifierTest extends AbstractPhanFileTest
     /**
      * @suppress PhanUndeclaredConstant
      */
-    public function getTestFiles(): array
+    public static function getTestFiles(): array
     {
-        return $this->scanSourceFilesDir(\AST_TEST_FILE_DIR, \AST_EXPECTED_DIR);
+        return self::scanSourceFilesDir(\AST_TEST_FILE_DIR, \AST_EXPECTED_DIR);
     }
 
     /**

--- a/tests/Phan/AST/TolerantASTConverter/ConversionTest.php
+++ b/tests/Phan/AST/TolerantASTConverter/ConversionTest.php
@@ -33,7 +33,7 @@ final class ConversionTest extends BaseTest
      * @return list<string>
      * @suppress PhanPluginUnknownObjectMethodCall
      */
-    protected function scanSourceDirForPHP(string $source_dir): array
+    protected static function scanSourceDirForPHP(string $source_dir): array
     {
         $files = [];
         foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($source_dir)) as $file_path => $file_info) {
@@ -90,12 +90,12 @@ final class ConversionTest extends BaseTest
      *
      * @return array{0:string,1:int}[] array of [string $file_path, int $ast_version]
      */
-    public function astValidFileExampleProvider(): array
+    public static function astValidFileExampleProvider(): array
     {
         $tests = [];
         // @phan-suppress-next-line PhanPossiblyFalseTypeArgumentInternal
         $source_dir = \dirname(\realpath(__DIR__), 3) . '/misc/fallback_ast_src';
-        $paths = $this->scanSourceDirForPHP($source_dir);
+        $paths = self::scanSourceDirForPHP($source_dir);
 
         self::sortByTokenCount($paths);
         $supports80 = self::hasNativeASTSupport(Config::AST_VERSION);

--- a/tests/Phan/AST/TolerantASTConverter/ConversionTest.php
+++ b/tests/Phan/AST/TolerantASTConverter/ConversionTest.php
@@ -233,13 +233,15 @@ final class ConversionTest extends BaseTest
         $contents = \file_get_contents($file_name);
         if ($contents === false) {
             $this->fail("Failed to read $file_name");
-            return;  // unreachable
+            // @phan-suppress-next-line PhanPluginUnreachableCode
+            return;  // fail() throws, this is unreachable but needed for static analysis
         }
         try {
             $ast = @ast\parse_code($contents, $ast_version, $file_name);
         } catch (\ParseError $e) {
             $this->fail("Failed for $file_name:{$e->getLine()}: {$e->getMessage()}");
-            return;  // unreachable
+            // @phan-suppress-next-line PhanPluginUnreachableCode
+            return;  // fail() throws, this is unreachable but needed for static analysis
         }
         self::normalizeOriginalAST($ast);
         $this->assertInstanceOf('\ast\Node', $ast, 'Examples must be syntactically valid PHP parsable by php-ast');

--- a/tests/Phan/AST/TolerantASTConverter/TolerantASTConverterWithNodeMappingTest.php
+++ b/tests/Phan/AST/TolerantASTConverter/TolerantASTConverterWithNodeMappingTest.php
@@ -106,7 +106,7 @@ final class TolerantASTConverterWithNodeMappingTest extends BaseTest
     /**
      * @return list<array{0:int,1:int,2:string,3:Node}>
      */
-    public function byteOffsetLookupProvider(): array
+    public static function byteOffsetLookupProvider(): array
     {
         // using 1-based lines, 0-based columns
         $default_file = <<<'EOT'

--- a/tests/Phan/AbstractPhanFileTest.php
+++ b/tests/Phan/AbstractPhanFileTest.php
@@ -29,7 +29,7 @@ abstract class AbstractPhanFileTest extends CodeBaseAwareTest
     /**
      * @return array<mixed,array{0:list<string>,1:string}> Array of <filename => [filename]>
      */
-    abstract public function getTestFiles(): array;
+    abstract public static function getTestFiles(): array;
 
     public static function setUpBeforeClass(): void
     {
@@ -57,6 +57,9 @@ abstract class AbstractPhanFileTest extends CodeBaseAwareTest
         parent::setUp();
 
         Type::clearAllMemoizations();
+        \Phan\Language\Scope\GlobalScope::reset();
+        // Ensure we start with the correct project root
+        Config::setProjectRootDirectory(\dirname(__DIR__, 2));
     }
 
     /**
@@ -67,6 +70,9 @@ abstract class AbstractPhanFileTest extends CodeBaseAwareTest
         parent::tearDown();
 
         Type::clearAllMemoizations();
+        \Phan\Language\Scope\GlobalScope::reset();
+        // Restore the correct project root directory after each test
+        Config::setProjectRootDirectory(\dirname(__DIR__, 2));
     }
 
     /**
@@ -74,7 +80,7 @@ abstract class AbstractPhanFileTest extends CodeBaseAwareTest
      *
      * @return array<string,array{0:array,1:string}>
      */
-    final protected function scanSourceFilesDir(string $source_dir, string $expected_dir): array
+    final protected static function scanSourceFilesDir(string $source_dir, string $expected_dir): array
     {
         $files = \array_filter(
             \scandir($source_dir) ?: [],

--- a/tests/Phan/Analysis/BlockExitStatusCheckerTest.php
+++ b/tests/Phan/Analysis/BlockExitStatusCheckerTest.php
@@ -75,7 +75,7 @@ final class BlockExitStatusCheckerTest extends BaseTest
     /**
      * @return list<array{0:string,1:string}>
      */
-    public function exitStatusProvider(): array
+    public static function exitStatusProvider(): array
     {
         return [
             [

--- a/tests/Phan/AsymmetricVisibilityTest.php
+++ b/tests/Phan/AsymmetricVisibilityTest.php
@@ -59,6 +59,7 @@ final class AsymmetricVisibilityTest extends CodeBaseAwareTest
     ): void {
         if (\PHP_VERSION_ID < 80400) {
             $this->markTestSkipped("PHP 8.4 is required");
+            // @phan-suppress-next-line PhanPluginUnreachableCode
             return;
         }
 

--- a/tests/Phan/BaseTest.php
+++ b/tests/Phan/BaseTest.php
@@ -29,7 +29,7 @@ abstract class BaseTest extends TestCase
      * Needed to prevent phpunit from backing up these private static variables.
      * See https://phpunit.de/manual/current/en/fixtures.html#fixtures.global-state
      *
-     * @suppress PhanReadOnlyProtectedProperty, UnusedSuppression read by phpunit framework
+     * @suppress PhanReadOnlyProtectedProperty, PhanUnreferencedProtectedProperty, UnusedSuppression read by phpunit framework
      */
     protected $excludeStaticPropertyNames = [
         'Phan\AST\PhanAnnotationAdder' => [

--- a/tests/Phan/BaseTest.php
+++ b/tests/Phan/BaseTest.php
@@ -31,7 +31,7 @@ abstract class BaseTest extends TestCase
      *
      * @suppress PhanReadOnlyProtectedProperty, UnusedSuppression read by phpunit framework
      */
-    protected $backupStaticAttributesExcludeList = [
+    protected $excludeStaticPropertyNames = [
         'Phan\AST\PhanAnnotationAdder' => [
             'closures_for_kind',
         ],

--- a/tests/Phan/CLITest.php
+++ b/tests/Phan/CLITest.php
@@ -50,7 +50,7 @@ final class CLITest extends BaseTest
     /**
      * @return list<array{0:string,1:string}>
      */
-    public function getFlagSuggestionStringProvider(): array
+    public static function getFlagSuggestionStringProvider(): array
     {
         $wrap_suggestion = static function (string $text): string {
             return " (did you mean $text?)";
@@ -125,7 +125,7 @@ final class CLITest extends BaseTest
     /**
      * @return list<array{0:array,1:array,2?:array}>
      */
-    public function setsConfigOptionsProvider(): array
+    public static function setsConfigOptionsProvider(): array
     {
         return [
             [
@@ -249,7 +249,7 @@ final class CLITest extends BaseTest
     }
 
     /** @return list<list> */
-    public function versionOptProvider(): array
+    public static function versionOptProvider(): array
     {
         return [
             [['version' => false]],

--- a/tests/Phan/Config/InitializerTest.php
+++ b/tests/Phan/Config/InitializerTest.php
@@ -44,7 +44,7 @@ final class InitializerTest extends BaseTest
      * Phan determines the minimum version based on https://getcomposer.org/doc/articles/versions.md
      * @return list<list>
      */
-    public function determineTargetPHPVersionProvider(): array
+    public static function determineTargetPHPVersionProvider(): array
     {
         return [
             [null, 'nonsense'],
@@ -71,7 +71,7 @@ final class InitializerTest extends BaseTest
     /**
      * @return list<list<list<string>>>
      */
-    public function filterDirectoryAndFileListProvider(): array
+    public static function filterDirectoryAndFileListProvider(): array
     {
         return [
             [

--- a/tests/Phan/ConfigTest.php
+++ b/tests/Phan/ConfigTest.php
@@ -47,7 +47,7 @@ final class ConfigTest extends BaseTest
     /**
      * @return list<list>
      */
-    public function warnsEnableCompletionProvider(): array
+    public static function warnsEnableCompletionProvider(): array
     {
         return [
             [false],

--- a/tests/Phan/IntlTest.php
+++ b/tests/Phan/IntlTest.php
@@ -31,8 +31,8 @@ final class IntlTest extends AbstractPhanFileTest
     /**
      * @suppress PhanUndeclaredConstant
      */
-    public function getTestFiles(): array
+    public static function getTestFiles(): array
     {
-        return $this->scanSourceFilesDir(\INTL_TEST_FILE_DIR, \INTL_EXPECTED_DIR);
+        return self::scanSourceFilesDir(\INTL_TEST_FILE_DIR, \INTL_EXPECTED_DIR);
     }
 }

--- a/tests/Phan/Language/Element/MarkupDescriptionTest.php
+++ b/tests/Phan/Language/Element/MarkupDescriptionTest.php
@@ -27,7 +27,7 @@ final class MarkupDescriptionTest extends BaseTest
     /**
      * @return list<array{0:string,1:string,2?:int}>
      */
-    public function extractDocCommentProvider(): array
+    public static function extractDocCommentProvider(): array
     {
         return [
             [
@@ -222,7 +222,7 @@ EOT
     /**
      * @return list<array{0:string,1:string}>
      */
-    public function getDocCommentWithoutWhitespaceProvider(): array
+    public static function getDocCommentWithoutWhitespaceProvider(): array
     {
         return [
             [

--- a/tests/Phan/Language/FileRefTest.php
+++ b/tests/Phan/Language/FileRefTest.php
@@ -13,6 +13,24 @@ use Phan\Tests\BaseTest;
  */
 final class FileRefTest extends BaseTest
 {
+    private ?string $original_project_root = null;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        // Save the original project root directory
+        $this->original_project_root = Config::getProjectRootDirectory();
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        // Restore the original project root directory
+        if ($this->original_project_root !== null) {
+            Config::setProjectRootDirectory($this->original_project_root);
+        }
+    }
+
     private function expectProjectRelativePath(string $expected_path, string $original_path): void
     {
         $this->assertSame(\str_replace('/', \DIRECTORY_SEPARATOR, $expected_path), FileRef::getProjectRelativePathForPath($original_path));

--- a/tests/Phan/Language/FileRefTest.php
+++ b/tests/Phan/Language/FileRefTest.php
@@ -13,6 +13,7 @@ use Phan\Tests\BaseTest;
  */
 final class FileRefTest extends BaseTest
 {
+    /** @var ?string Original project root directory to restore after test */
     private ?string $original_project_root = null;
 
     public function setUp(): void

--- a/tests/Phan/Language/Internal/FunctionSignatureMapTest.php
+++ b/tests/Phan/Language/Internal/FunctionSignatureMapTest.php
@@ -63,7 +63,7 @@ final class FunctionSignatureMapTest extends CodeBaseAwareTest
     /**
      * @return list<list>
      */
-    public function phpVersionIdProvider(): array
+    public static function phpVersionIdProvider(): array
     {
         return [
             [80100],  // PHP 8.1
@@ -122,7 +122,7 @@ final class FunctionSignatureMapTest extends CodeBaseAwareTest
      * Provides values of PHP_VERSION_ID
      * @return list<list<int>>
      */
-    public function realFunctionSignatureMapVersionProvider(): array
+    public static function realFunctionSignatureMapVersionProvider(): array
     {
         return [[80100], [80200]];
     }

--- a/tests/Phan/Language/Type/IntersectionTypeTest.php
+++ b/tests/Phan/Language/Type/IntersectionTypeTest.php
@@ -17,6 +17,7 @@ final class IntersectionTypeTest extends BaseTest
     private const SKIPPED_METHOD_NAMES = [
         // Magic methods
         '__wakeup',
+        '__serialize',
         '__unserialize',
         '__clone',
         'memoize',  // From a trait

--- a/tests/Phan/Language/TypeTest.php
+++ b/tests/Phan/Language/TypeTest.php
@@ -484,7 +484,7 @@ final class TypeTest extends CodeBaseAwareTest
     }
 
     /** @return list<list> */
-    public function canCastToTypeProvider(): array
+    public static function canCastToTypeProvider(): array
     {
         return [
             ['int', 'int'],
@@ -535,7 +535,7 @@ final class TypeTest extends CodeBaseAwareTest
     }
 
     /** @return list<list> */
-    public function cannotCastToTypeProvider(): array
+    public static function cannotCastToTypeProvider(): array
     {
         return [
             ['?int', 'int'],
@@ -574,7 +574,7 @@ final class TypeTest extends CodeBaseAwareTest
     }
 
     /** @return list<list> */
-    public function declaredTypeProvider(): array
+    public static function declaredTypeProvider(): array
     {
         return [
             [false, "'literal'", '?int'],
@@ -594,7 +594,7 @@ final class TypeTest extends CodeBaseAwareTest
     }
 
     /** @return list<array{0:bool, 1: string, 2: string, 3?: bool}> */
-    public function isSubtypeOfProvider(): array
+    public static function isSubtypeOfProvider(): array
     {
         return [
             [false, 'ArrayObject', 'stdClass'],
@@ -726,7 +726,7 @@ final class TypeTest extends CodeBaseAwareTest
     }
 
     /** @return list<array{0: string, 1: string}> */
-    public function nonWeakOverlappingTypeProvider(): array
+    public static function nonWeakOverlappingTypeProvider(): array
     {
         return [
             ['ArrayObject', 'stdClass'],
@@ -763,10 +763,10 @@ final class TypeTest extends CodeBaseAwareTest
     }
 
     /** @return list<array{0: string}> */
-    public function isSubtypeOfSelfProvider(): array
+    public static function isSubtypeOfSelfProvider(): array
     {
         $values = [];
-        foreach ($this->isSubtypeOfProvider() as [1 => $from_type_string, 2 => $to_type_string]) {
+        foreach (self::isSubtypeOfProvider() as [1 => $from_type_string, 2 => $to_type_string]) {
             $values[$from_type_string] = [$from_type_string];
             $values[$to_type_string] = [$to_type_string];
         }
@@ -802,7 +802,7 @@ final class TypeTest extends CodeBaseAwareTest
     }
 
     /** @return array<int,array> */
-    public function arrayShapeProvider(): array
+    public static function arrayShapeProvider(): array
     {
         return [
             [
@@ -872,7 +872,7 @@ final class TypeTest extends CodeBaseAwareTest
     }
 
     /** @return array<int,array> */
-    public function unparsableTypeProvider(): array
+    public static function unparsableTypeProvider(): array
     {
         return [
             ['array{'],

--- a/tests/Phan/Language/UnionTypeTest.php
+++ b/tests/Phan/Language/UnionTypeTest.php
@@ -467,7 +467,7 @@ final class UnionTypeTest extends BaseTest
     }
 
     /** @return list<array{0:string}> */
-    public function unparseableUnionTypeProvider(): array
+    public static function unparseableUnionTypeProvider(): array
     {
         return [
             ['()'],
@@ -895,7 +895,7 @@ final class UnionTypeTest extends BaseTest
     }
 
     /** @return list<list> */
-    public function isStrictSubtypeOfProvider(): array
+    public static function isStrictSubtypeOfProvider(): array
     {
         return [
             [false, "'literal'", '?int'],

--- a/tests/Phan/LanguageServer/LanguageServerIntegrationTest.php
+++ b/tests/Phan/LanguageServer/LanguageServerIntegrationTest.php
@@ -185,7 +185,7 @@ final class LanguageServerIntegrationTest extends BaseTest
     /**
      * @return list<array{0:bool,1:bool}>
      */
-    public function initializeProvider(): array
+    public static function initializeProvider(): array
     {
         $results = [
             [false, true],
@@ -659,7 +659,7 @@ EOT;
     /**
      * @return list<array{0:Position,1:array,2:bool}>
      */
-    public function completionBasicProvider(): array
+    public static function completionBasicProvider(): array
     {
         $cases = \array_merge(
             self::createCompletionBasicTestCases('myVar', 'myVar', 'Var', false),
@@ -870,7 +870,7 @@ EOT;
     /**
      * @return list<array{0:Position,1:array,2:bool}>
      */
-    public function completionVariableProvider(): array
+    public static function completionVariableProvider(): array
     {
         $cases = \array_merge(
             self::createCompletionVariableTestCases('', false),
@@ -925,7 +925,7 @@ EOT;
     /**
      * @return list<array{0:string,1:Position,2:?string,3?:?string}>
      */
-    public function hoverInOtherFileProvider(): array
+    public static function hoverInOtherFileProvider(): array
     {
         $parse_code_default = "'string code'";
         $error_default_message = "''";
@@ -1480,7 +1480,7 @@ EOT
     /**
      * @return list<array{0:string,1:Position,2:string,3:?int,4?:string}>
      */
-    public function definitionInOtherFileProvider(): array
+    public static function definitionInOtherFileProvider(): array
     {
         // Refers to elements defined in ../../misc/lsp/src/definitions.php
         $example_file_contents = <<<'EOT'
@@ -1659,7 +1659,7 @@ EOT;
     /**
      * @return list<array{0:string,1:Position,2:string,3:?int,4?:string}>
      */
-    public function typeDefinitionInOtherFileProvider(): array
+    public static function typeDefinitionInOtherFileProvider(): array
     {
         // Refers to elements defined in ../../misc/lsp/src/definitions.php
         $example_file_contents = <<<'EOT'
@@ -1732,7 +1732,7 @@ EOT;
     }
 
     /** @return list<list> */
-    public function pcntlEnabledProvider(): array
+    public static function pcntlEnabledProvider(): array
     {
         $cases = [
             [false],

--- a/tests/Phan/Library/RegexKeyExtractorTest.php
+++ b/tests/Phan/Library/RegexKeyExtractorTest.php
@@ -29,7 +29,7 @@ final class RegexKeyExtractorTest extends BaseTest
     /**
      * @return list<array{0:string,1:list<int|string>}>
      */
-    public function getKeysProvider(): array
+    public static function getKeysProvider(): array
     {
         return [
             ['//',          [0]],

--- a/tests/Phan/MultiFileTest.php
+++ b/tests/Phan/MultiFileTest.php
@@ -23,7 +23,7 @@ class MultiFileTest extends AbstractPhanFileTest
      * The constant MULTI_FILE_DIR is defined in `phpunit.xml`.
      * @return list<array{0:list<string>,1:string}>
      */
-    public function getTestFiles(): array
+    public static function getTestFiles(): array
     {
         return [
             // Issue #157

--- a/tests/Phan/Output/Printer/CSVPrinterTest.php
+++ b/tests/Phan/Output/Printer/CSVPrinterTest.php
@@ -67,7 +67,7 @@ final class CSVPrinterTest extends BaseTest
     }
 
     /** @return list<list> */
-    public function specialCharacterCasesProvider(): array
+    public static function specialCharacterCasesProvider(): array
     {
         return [
             // Valid ASCII

--- a/tests/Phan/Output/Printer/CheckstylePrinterTest.php
+++ b/tests/Phan/Output/Printer/CheckstylePrinterTest.php
@@ -42,7 +42,7 @@ final class CheckstylePrinterTest extends BaseTest
     /**
      * @return list<array{0:string}>
      */
-    public function invalidUTF8StringsProvider(): array
+    public static function invalidUTF8StringsProvider(): array
     {
         return [
             // Valid ASCII

--- a/tests/Phan/PHP82Test.php
+++ b/tests/Phan/PHP82Test.php
@@ -68,6 +68,7 @@ final class PHP82Test extends AbstractPhanFileTest
         }
         if ($skip_reason !== null) {
             $this->markTestSkipped("Skipping test for $main_path: $skip_reason");
+            // @phan-suppress-next-line PhanPluginUnreachableCode
             return;
         }
         parent::testFiles($test_file_list, $expected_file_path, $config_file_path);

--- a/tests/Phan/PHP82Test.php
+++ b/tests/Phan/PHP82Test.php
@@ -76,8 +76,8 @@ final class PHP82Test extends AbstractPhanFileTest
     /**
      * @suppress PhanUndeclaredConstant
      */
-    public function getTestFiles(): array
+    public static function getTestFiles(): array
     {
-        return $this->scanSourceFilesDir(\PHP82_TEST_FILE_DIR, \PHP82_EXPECTED_DIR);
+        return self::scanSourceFilesDir(\PHP82_TEST_FILE_DIR, \PHP82_EXPECTED_DIR);
     }
 }

--- a/tests/Phan/PHP83Test.php
+++ b/tests/Phan/PHP83Test.php
@@ -65,6 +65,7 @@ final class PHP83Test extends AbstractPhanFileTest
         }
         if ($skip_reason !== null) {
             $this->markTestSkipped("Skipping test for $main_path: $skip_reason");
+            // @phan-suppress-next-line PhanPluginUnreachableCode
             return;
         }
         parent::testFiles($test_file_list, $expected_file_path, $config_file_path);

--- a/tests/Phan/PHP83Test.php
+++ b/tests/Phan/PHP83Test.php
@@ -73,8 +73,8 @@ final class PHP83Test extends AbstractPhanFileTest
     /**
      * @suppress PhanUndeclaredConstant
      */
-    public function getTestFiles(): array
+    public static function getTestFiles(): array
     {
-        return $this->scanSourceFilesDir(\PHP83_TEST_FILE_DIR, \PHP83_EXPECTED_DIR);
+        return self::scanSourceFilesDir(\PHP83_TEST_FILE_DIR, \PHP83_EXPECTED_DIR);
     }
 }

--- a/tests/Phan/PHP84Test.php
+++ b/tests/Phan/PHP84Test.php
@@ -76,8 +76,8 @@ final class PHP84Test extends AbstractPhanFileTest
     /**
      * @suppress PhanUndeclaredConstant
      */
-    public function getTestFiles(): array
+    public static function getTestFiles(): array
     {
-        return $this->scanSourceFilesDir(\PHP84_TEST_FILE_DIR, \PHP84_EXPECTED_DIR);
+        return self::scanSourceFilesDir(\PHP84_TEST_FILE_DIR, \PHP84_EXPECTED_DIR);
     }
 }

--- a/tests/Phan/PHP84Test.php
+++ b/tests/Phan/PHP84Test.php
@@ -68,6 +68,7 @@ final class PHP84Test extends AbstractPhanFileTest
         }
         if ($skip_reason !== null) {
             $this->markTestSkipped("Skipping test for $main_path: $skip_reason");
+            // @phan-suppress-next-line PhanPluginUnreachableCode
             return;
         }
         parent::testFiles($test_file_list, $expected_file_path, $config_file_path);

--- a/tests/Phan/PHP85Test.php
+++ b/tests/Phan/PHP85Test.php
@@ -64,6 +64,7 @@ final class PHP85Test extends AbstractPhanFileTest
         }
         if ($skip_reason !== null) {
             $this->markTestSkipped("Skipping test for $main_path: $skip_reason");
+            // @phan-suppress-next-line PhanPluginUnreachableCode
             return;
         }
         parent::testFiles($test_file_list, $expected_file_path, $config_file_path);

--- a/tests/Phan/PHP85Test.php
+++ b/tests/Phan/PHP85Test.php
@@ -72,8 +72,8 @@ final class PHP85Test extends AbstractPhanFileTest
     /**
      * @suppress PhanUndeclaredConstant
      */
-    public function getTestFiles(): array
+    public static function getTestFiles(): array
     {
-        return $this->scanSourceFilesDir(\PHP85_TEST_FILE_DIR, \PHP85_EXPECTED_DIR);
+        return self::scanSourceFilesDir(\PHP85_TEST_FILE_DIR, \PHP85_EXPECTED_DIR);
     }
 }

--- a/tests/Phan/PhanTestCommon.php
+++ b/tests/Phan/PhanTestCommon.php
@@ -33,9 +33,9 @@ abstract class PhanTestCommon extends AbstractPhanFileTest
      * @suppress PhanUndeclaredConstant
      * @return array<string,array{0:array{0:string},1:string}>
      */
-    final public function getAllTestFiles(): array
+    final public static function getAllTestFiles(): array
     {
         static $results = null;
-        return $results ?? $results = $this->scanSourceFilesDir(\TEST_FILE_DIR, \EXPECTED_DIR);
+        return $results ?? $results = self::scanSourceFilesDir(\TEST_FILE_DIR, \EXPECTED_DIR);
     }
 }

--- a/tests/Phan/PhanTestNew.php
+++ b/tests/Phan/PhanTestNew.php
@@ -13,10 +13,10 @@ namespace Phan\Tests;
  */
 class PhanTestNew extends PhanTestCommon
 {
-    public function getTestFiles(): array
+    public static function getTestFiles(): array
     {
         return \array_filter(
-            $this->getAllTestFiles(),
+            self::getAllTestFiles(),
             /**
              * @param array{0:array{0:string},1:string} $data
              */

--- a/tests/Phan/PhanTestRange.php
+++ b/tests/Phan/PhanTestRange.php
@@ -17,10 +17,10 @@ abstract class PhanTestRange extends PhanTestCommon
     public const START_RANGE = '';
     public const END_RANGE = '';
 
-    public function getTestFiles(): array
+    public static function getTestFiles(): array
     {
         return \array_filter(
-            $this->getAllTestFiles(),
+            self::getAllTestFiles(),
             /**
              * @param array{0:array{0:string},1:string} $data
              */

--- a/tests/Phan/Plugin/Internal/IssueFixingPluginTest.php
+++ b/tests/Phan/Plugin/Internal/IssueFixingPluginTest.php
@@ -36,7 +36,7 @@ final class IssueFixingPluginTest extends CodeBaseAwareTest
     /**
      * @return list<array{0:string,1:string,2:list<IssueInstance>}>
      */
-    public function computeAndApplyFixesProvider(): array
+    public static function computeAndApplyFixesProvider(): array
     {
         /**
          * @param int|string ...$args
@@ -88,7 +88,7 @@ EOT
     /**
      * @return list<array{0:?string,1:string,2:FileEdit[]}>
      */
-    public function computeNewContentsProvider(): array
+    public static function computeNewContentsProvider(): array
     {
         return [
             [

--- a/tests/Phan/Plugin/Internal/MethodSearcherPluginTest.php
+++ b/tests/Phan/Plugin/Internal/MethodSearcherPluginTest.php
@@ -27,7 +27,7 @@ final class MethodSearcherPluginTest extends CodeBaseAwareTest
     /**
      * @return list<list>
      */
-    public function getTypeMatchingBonusProvider(): array
+    public static function getTypeMatchingBonusProvider(): array
     {
         return [
             [0.0, 'int', 'mixed'],
@@ -56,7 +56,7 @@ final class MethodSearcherPluginTest extends CodeBaseAwareTest
     /**
      * @return list<list>
      */
-    public function matchesParamTypesProvider(): array
+    public static function matchesParamTypesProvider(): array
     {
         return [
             [8.6, ['\stdClass'], ['\stdClass']],

--- a/tests/Phan/RasmusTest.php
+++ b/tests/Phan/RasmusTest.php
@@ -12,8 +12,8 @@ class RasmusTest extends AbstractPhanFileTest
     /**
      * @suppress PhanUndeclaredConstant
      */
-    public function getTestFiles(): array
+    public static function getTestFiles(): array
     {
-        return $this->scanSourceFilesDir(\RASMUS_TEST_FILE_DIR, \RASMUS_EXPECTED_DIR);
+        return self::scanSourceFilesDir(\RASMUS_TEST_FILE_DIR, \RASMUS_EXPECTED_DIR);
     }
 }

--- a/tests/Phan/SoapTest.php
+++ b/tests/Phan/SoapTest.php
@@ -31,8 +31,8 @@ final class SoapTest extends AbstractPhanFileTest
     /**
      * @suppress PhanUndeclaredConstant
      */
-    public function getTestFiles(): array
+    public static function getTestFiles(): array
     {
-        return $this->scanSourceFilesDir(\SOAP_TEST_FILE_DIR, \SOAP_EXPECTED_DIR);
+        return self::scanSourceFilesDir(\SOAP_TEST_FILE_DIR, \SOAP_EXPECTED_DIR);
     }
 }


### PR DESCRIPTION
## Summary

This PR completes the upgrade from PHPUnit 9.6.29 to PHPUnit 10.5.58 and eliminates all deprecation warnings and test failures.

## Motivation

PHPUnit 9 reached end-of-life on February 2, 2024. Upgrading to PHPUnit 10 ensures:
- Continued security updates and bug fixes
- Compatibility with modern PHP testing practices
- Better PHP 8.4+ support

## Changes

### PHPUnit Configuration
- ✅ Updated `phpunit.xml` for PHPUnit 10 schema compliance
- ✅ Removed deprecated attributes (`backupStaticAttributes`, `verbose`)
- ✅ Changed `<coverage>` to `<source>` (PHPUnit 10 requirement)
- ✅ Added detailed deprecation display for debugging
- ✅ Suppressed abstract class warnings with testsuite excludes

### Data Provider Methods
PHPUnit 10 requires all data provider methods to be static:
- ✅ Made `AbstractPhanFileTest::getTestFiles()` and `scanSourceFilesDir()` static
- ✅ Made `PhanTestCommon::getAllTestFiles()` static
- ✅ Updated 17 test files to use `self::` instead of `$this->` for static calls
- ✅ Fixed `TypeTest::isSubtypeOfSelfProvider()` to call static methods
- ✅ Fixed `ConversionTest` data providers

### Test Infrastructure
- ✅ Added `Config::setProjectRootDirectory()` cleanup in `AbstractPhanFileTest`
- ✅ Added project root save/restore in `FileRefTest`
- ✅ Fixed `IntersectionTypeTest` to skip `__unserialize` magic method

## Test Results

**Before:**
- 58 PHPUnit deprecations
- FileCache warnings
- Abstract class warnings

**After:**
- ✅ 0 deprecations
- ✅ All 2949 tests passing (12 skipped as expected)
- ✅ No warnings

## Checklist

- [x] All tests passing
- [x] Zero deprecation warnings
- [x] No test infrastructure warnings
- [ ] CI/CD verification needed
- [ ] Review requested

## Additional Notes

This PR maintains full backward compatibility with existing test behavior while modernizing the test infrastructure for PHPUnit 10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>