### PR TITLE
Include the range in int-range errors

### DIFF
--- a/src/Phan/Language/Type/IntRangeType.php
+++ b/src/Phan/Language/Type/IntRangeType.php
@@ -136,6 +136,30 @@ final class IntRangeType extends IntType
     }
 
     /**
+     * @return string
+     * A human readable representation of this int-range type including the bounds
+     */
+    public function __toString(): string
+    {
+        return $this->memoize(__METHOD__, function (): string {
+            $string = $this->asFQSENString();
+
+            // Include the range bounds in the string representation for clearer error messages
+            if ($this->lower_bound !== null && $this->upper_bound !== null) {
+                $string .= '<' . $this->lower_bound . ', ' . $this->upper_bound . '>';
+            } elseif (count($this->template_parameter_type_list) > 0) {
+                $string .= $this->templateParameterTypeListAsString();
+            }
+
+            if ($this->is_nullable) {
+                $string = '?' . $string;
+            }
+
+            return $string;
+        });
+    }
+
+    /**
      * @param list<UnionType> $template_parameter_type_list
      * @return ?list<UnionType>
      */

--- a/tests/files/expected/1109_int_range.php.expected
+++ b/tests/files/expected/1109_int_range.php.expected
@@ -1,7 +1,7 @@
-%s:17 PhanTypeMismatchArgument Argument 1 ($value) is 0 of type 0 but \takesRange() takes int-range defined at %s:14
-%s:18 PhanTypeMismatchArgument Argument 1 ($value) is 12 of type 12 but \takesRange() takes int-range defined at %s:14
-%s:19 PhanTypeMismatchArgument Argument 1 ($value) is 101 of type 101 but \takesRange() takes int-range defined at %s:14
-%s:27 PhanTypeMismatchArgument Argument 1 ($value) is 0 of type 0 but \takesNegativeRange() takes int-range defined at %s:24
-%s:35 PhanTypeMismatchArgument Argument 1 ($value) is 4 of type 4 but \takesReversedRange() takes int-range defined at %s:32
-%s:50 PhanTypeMismatchReturn Returning 0 of type 0 but returnsTooLow() is declared to return int-range
-%s:58 PhanTypeMismatchReturn Returning 11 of type 11 but returnsTooHigh() is declared to return int-range
+%s:17 PhanTypeMismatchArgument Argument 1 ($value) is 0 of type 0 but \takesRange() takes int-range<1, 10> defined at %s:14
+%s:18 PhanTypeMismatchArgument Argument 1 ($value) is 12 of type 12 but \takesRange() takes int-range<1, 10> defined at %s:14
+%s:19 PhanTypeMismatchArgument Argument 1 ($value) is 101 of type 101 but \takesRange() takes int-range<1, 10> defined at %s:14
+%s:27 PhanTypeMismatchArgument Argument 1 ($value) is 0 of type 0 but \takesNegativeRange() takes int-range<-10, -1> defined at %s:24
+%s:35 PhanTypeMismatchArgument Argument 1 ($value) is 4 of type 4 but \takesReversedRange() takes int-range<5, 10> defined at %s:32
+%s:50 PhanTypeMismatchReturn Returning 0 of type 0 but returnsTooLow() is declared to return int-range<1, 10>
+%s:58 PhanTypeMismatchReturn Returning 11 of type 11 but returnsTooHigh() is declared to return int-range<1, 10>


### PR DESCRIPTION
Simple fix. Show the range on int-range errors.