### PR TITLE
clean up

### DIFF
--- a/tests/php85_files/src/001_new_functions.php
+++ b/tests/php85_files/src/001_new_functions.php
@@ -11,15 +11,50 @@ $last = array_last($arr);
 $error_handler = get_error_handler();
 $exception_handler = get_exception_handler();
 
-// Closure::getCurrent()
-function test_closure_get_current(): ?\Closure {
+// Closure::getCurrent() - Returns the currently executing closure
+// Test 1: Called from within a closure - should return the closure itself
+$test_closure = function(): ?\Closure {
     return \Closure::getCurrent();
+};
+
+$result = $test_closure();
+if ($result !== null) {
+    echo 'Got current closure';
 }
 
-$current = test_closure_get_current();
-if ($current instanceof \Closure) {
-    echo 'closure';
+// Test 2: Called from regular function - throws Error
+function test_not_in_closure(): never {
+    try {
+        \Closure::getCurrent();
+        throw new \Exception('Should have thrown Error');
+    } catch (\Error $e) {
+        if (str_contains($e->getMessage(), 'not a closure')) {
+            echo 'Correctly throws Error when not in closure';
+        }
+        throw $e;
+    }
 }
+
+try {
+    test_not_in_closure();
+} catch (\Error $e) {
+    // Expected error
+}
+
+// Test 3: Nested closures - should return the innermost closure, not the outer
+$outer = function(): ?\Closure {
+    $inner = function(): ?\Closure {
+        return \Closure::getCurrent(); // Should return $inner, not $outer
+    };
+    $inner_result = $inner();
+    // Verify it's the inner closure, not the outer one
+    if ($inner_result !== null) {
+        echo 'Got innermost closure';
+    }
+    return $inner_result;
+};
+
+$nested_result = $outer();
 
 // locale_is_right_to_left()
 $is_rtl = locale_is_right_to_left('ar');


### PR DESCRIPTION
Fix the \Closure::getCurrent() part of the PHP 8.5 new_functions test