### PR TITLE
Bug4858

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -131,6 +131,7 @@ Type Inference & Analysis:
 - Fixed reference assignment literal type erasure: Variables involved in reference assignments now correctly erase literal types to prevent false positives ([#5197](https://github.com/phan/phan/pull/5197))
 
 PHPDoc & Attributes:
+- Fixed @deprecated detection for callable parameters: Emit PhanDeprecatedFunction when deprecated functions are passed as callable string arguments ([#4858](https://github.com/phan/phan/issues/4858))
 - Fixed @phan-suppress on class constants: Suppression annotations are no longer ignored ([#5188](https://github.com/phan/phan/pull/5188))
 - Fixed @phan-mandatory-param inheritance: Inherit annotation from interface methods ([#5116](https://github.com/phan/phan/pull/5116))
 - Fixed @phan-pure inheritance: Exclude `__call` and `__callStatic` from automatic inheritance ([#5124](https://github.com/phan/phan/pull/5124))

--- a/src/Phan/Plugin/Internal/CallableParamPlugin.php
+++ b/src/Phan/Plugin/Internal/CallableParamPlugin.php
@@ -9,6 +9,7 @@ use Closure;
 use Phan\AST\UnionTypeVisitor;
 use Phan\CodeBase;
 use Phan\Config;
+use Phan\Issue;
 use Phan\Language\Context;
 use Phan\Language\Element\Func;
 use Phan\Language\Element\FunctionInterface;
@@ -76,6 +77,39 @@ final class CallableParamPlugin extends PluginV3 implements
                     $class_list = UnionTypeVisitor::classListFromClassNameNode($code_base, $context, $arg, false);
                     if ($class_list) {
                         $references[] = $class_list;
+                    }
+                }
+
+                // Check if callable is deprecated (issue #4858)
+                if ($references) {
+                    foreach ($references as $reference_list) {
+                        foreach ($reference_list as $addressable) {
+                            if ($addressable instanceof FunctionInterface && $addressable->isDeprecated()) {
+                                $lineno = $arg instanceof Node ? $arg->lineno : $context->getLineNumberStart();
+
+                                if ($addressable->isPHPInternal()) {
+                                    Issue::maybeEmit(
+                                        $code_base,
+                                        $context,
+                                        Issue::DeprecatedFunctionInternal,
+                                        $lineno,
+                                        $addressable->getRepresentationForIssue(),
+                                        $addressable->getDeprecationReason()
+                                    );
+                                } else {
+                                    Issue::maybeEmit(
+                                        $code_base,
+                                        $context,
+                                        Issue::DeprecatedFunction,
+                                        $lineno,
+                                        $addressable->getRepresentationForIssue(),
+                                        $addressable->getFileRef()->getFile(),
+                                        $addressable->getFileRef()->getLineNumberStart(),
+                                        $addressable->getDeprecationReason()
+                                    );
+                                }
+                            }
+                        }
                     }
                 }
 

--- a/src/Phan/Plugin/Internal/ExtendedDependentReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ExtendedDependentReturnTypeOverridePlugin.php
@@ -140,7 +140,7 @@ final class ExtendedDependentReturnTypeOverridePlugin extends PluginV3 implement
             'json_encode'  => $wrap('json_encode', 1, 3),
             'substr'       => $wrap('substr', 1, 3),
             'strlen'       => $wrap('strlen', 1, 3),
-            'join'         => $wrap('join', 1),
+            'join'         => $wrap('join', 1), // @phan-suppress-current-line PhanDeprecatedFunctionInternal - TODO: Replace with 'implode'
             'ltrim'        => $wrap('ltrim', 1, 2),
             'preg_quote'   => $wrap('preg_quote', 1, 2),
             'rtrim'        => $wrap('rtrim', 1, 2),

--- a/src/Phan/Plugin/Internal/ExtendedDependentReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ExtendedDependentReturnTypeOverridePlugin.php
@@ -140,7 +140,7 @@ final class ExtendedDependentReturnTypeOverridePlugin extends PluginV3 implement
             'json_encode'  => $wrap('json_encode', 1, 3),
             'substr'       => $wrap('substr', 1, 3),
             'strlen'       => $wrap('strlen', 1, 3),
-            'join'         => $wrap('join', 1), // @phan-suppress-current-line PhanDeprecatedFunctionInternal - TODO: Replace with 'implode'
+            'join'         => $wrap('join', 1), // @phan-suppress-current-line PhanDeprecatedFunctionInternal
             'ltrim'        => $wrap('ltrim', 1, 2),
             'preg_quote'   => $wrap('preg_quote', 1, 2),
             'rtrim'        => $wrap('rtrim', 1, 2),

--- a/tests/files/expected/4858_deprecated_callable.php.expected
+++ b/tests/files/expected/4858_deprecated_callable.php.expected
@@ -1,0 +1,5 @@
+%s:23 PhanDeprecatedFunction Call to deprecated function \deprecated_func() defined at %s:6
+%s:24 PhanDeprecatedFunction Call to deprecated function \deprecated_func() defined at %s:6
+%s:25 PhanDeprecatedFunction Call to deprecated function \deprecated_func() defined at %s:6
+%s:26 PhanDeprecatedFunction Call to deprecated function \deprecated_func() defined at %s:6
+%s:27 PhanDeprecatedFunction Call to deprecated function \deprecated_func() defined at %s:6

--- a/tests/files/src/4858_deprecated_callable.php
+++ b/tests/files/src/4858_deprecated_callable.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @deprecated
+ */
+function deprecated_func() {
+}
+
+/**
+ * @param callable $cb
+ */
+function user_callback($cb) {
+    $cb();
+}
+
+/**
+ * @param callable $fn
+ */
+function another_callback($fn) {
+}
+
+// Should detect deprecated function usage
+deprecated_func();                           // Line 23: Direct call
+call_user_func('deprecated_func');          // Line 24: call_user_func
+user_callback('deprecated_func');           // Line 25: User callback
+another_callback('deprecated_func');        // Line 26: Another callback
+array_filter([1, 2, 3], 'deprecated_func'); // Line 27: array_filter


### PR DESCRIPTION
Phan wasn't detecting deprecated functions when passed as string arguments to callable parameters.
Modified `CallableParamPlugin.php` to check if resolved callable functions are deprecated and emit appropriate warnings.

@codex review