### PR TITLE
Preserve real types in UnionType::withoutType

### DIFF
--- a/src/Phan/AST/Parser.php
+++ b/src/Phan/AST/Parser.php
@@ -190,7 +190,7 @@ class Parser
         string $file_path,
         string $file_contents,
         bool $suppress_parse_errors,
-        Error $native_parse_error,
+        CompileError $native_parse_error,
         ?Request $request = null
     ): Node {
         if ($file_path !== 'internal') {

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -805,18 +805,10 @@ class UnionType implements Serializable, Stringable
      */
     public function withoutType(Type $type): UnionType
     {
-        // Copy the array $this->type_set
-        $type_set = $this->type_set;
-        foreach ($type_set as $key => $other_type) {
-            if ($type === $other_type) {
-                // Remove the only instance of $type from the copy.
-                // TODO: Make this work for removing from the real type set
-                unset($type_set[$key]);
-                return UnionType::ofUnique(\array_values($type_set), []);
-            }
-        }
-        // We did not find $type in type_set. The resulting union type is unchanged.
-        return $this->eraseRealTypeSetRecursively();
+        return UnionType::ofUnique(
+            \array_values(array_diff($this->type_set, [$type])),
+            \array_values(array_diff($this->real_type_set, [$type])),
+        );
     }
 
     /**

--- a/tests/files/expected/0684_unary_op_in_condition.php.expected
+++ b/tests/files/expected/0684_unary_op_in_condition.php.expected
@@ -1,2 +1,2 @@
-%s:35 PhanTypeMismatchArgumentInternal Argument 1 ($value) is $x of type bool but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array
-%s:60 PhanTypeMismatchArgumentInternal Argument 1 ($value) is $x of type bool but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array
+%s:35 PhanTypeMismatchArgumentInternalReal Argument 1 ($value) is $x of type bool but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array (real type \Countable|array)
+%s:60 PhanTypeMismatchArgumentInternalReal Argument 1 ($value) is $x of type bool but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array (real type \Countable|array)

--- a/tests/files/expected/5078_intersection_static_type.php.expected
+++ b/tests/files/expected/5078_intersection_static_type.php.expected
@@ -1,4 +1,4 @@
-%s:26 PhanDebugAnnotation @phan-debug-var requested for variable $a - it has union type \B
+%s:26 PhanDebugAnnotation @phan-debug-var requested for variable $a - it has union type \B(real=\B)
 %s:26 PhanDebugAnnotation @phan-debug-var requested for variable $b - it has union type \A&\X(real=\A&\X)
-%s:26 PhanDebugAnnotation @phan-debug-var requested for variable $c - it has union type \A&\X
-%s:26 PhanDebugAnnotation @phan-debug-var requested for variable $d - it has union type \A&\X
+%s:26 PhanDebugAnnotation @phan-debug-var requested for variable $c - it has union type \A&\X(real=\A&\X)
+%s:26 PhanDebugAnnotation @phan-debug-var requested for variable $d - it has union type \A&\X(real=\A&\X)

--- a/tests/files/expected/5079_generic_static_type.php.expected
+++ b/tests/files/expected/5079_generic_static_type.php.expected
@@ -1,6 +1,6 @@
 %s:28 PhanTypeMismatchArgument Argument 1 ($box) is $b of type \Box|\Box<int> but \acceptBoxString() takes \Box<string> defined at %s:23
 %s:32 PhanDebugAnnotation @phan-debug-var requested for variable $a - it has union type \Box<int>
 %s:32 PhanDebugAnnotation @phan-debug-var requested for variable $b - it has union type \Box<int>
-%s:32 PhanDebugAnnotation @phan-debug-var requested for variable $c - it has union type \Box<int>
-%s:32 PhanDebugAnnotation @phan-debug-var requested for variable $d - it has union type \Box<int>
-%s:32 PhanTypeMismatchArgument Argument 1 ($box) is $d of type \Box|\Box<int> but \acceptBoxString() takes \Box<string> defined at %s:23
+%s:32 PhanDebugAnnotation @phan-debug-var requested for variable $c - it has union type \Box<int>(real=\Box<int>)
+%s:32 PhanDebugAnnotation @phan-debug-var requested for variable $d - it has union type \Box<int>(real=\Box<int>)
+%s:32 PhanTypeMismatchArgumentProbablyReal Argument 1 ($box) is $d of type \Box|\Box<int> but \acceptBoxString() takes \Box<string> (no real type) defined at %s:23 (the inferred real argument type has nothing in common with the parameter's phpdoc type)


### PR DESCRIPTION
This makes real type inference more accurate when intersection types and generics are used, as a follow-up to 2d078c9.