### PR TITLE
Drop outdated comments from test case

### DIFF
--- a/tests/files/src/0991_template_instanceof.php
+++ b/tests/files/src/0991_template_instanceof.php
@@ -37,7 +37,7 @@ class X {
 			// $foo is T&B
 			$this->a = $foo; // OK
 			$this->b[] = $foo; // OK
-			$this->c = $foo; // Error (not detected, seems like a bug)
+			$this->c = $foo; // Error
 			$this->d[] = $foo; // Error
 			$this->a($foo); // OK
 			$this->c($foo); // Error
@@ -45,7 +45,7 @@ class X {
 			// $foo is T
 			$this->a = $foo; // OK
 			$this->b[] = $foo; // OK
-			$this->c = $foo; // Error (not detected, seems like a bug)
+			$this->c = $foo; // Error
 			$this->d[] = $foo; // Error
 			$this->a($foo); // OK
 			$this->c($foo); // Error

--- a/tests/files/src/0993_generic_option.php
+++ b/tests/files/src/0993_generic_option.php
@@ -171,8 +171,8 @@ $test->optionNull = null;
 // OK:
 $test->someFoo = new Some(new Foo);
 // Error:
-$test->someFoo = maybeFoo(); // Error (not detected, maybe a bug, maybe we allow it because of common parent type?)
-$test->someFoo = new None; // Error (not detected, maybe a bug, maybe we allow it because of common parent type?)
+$test->someFoo = maybeFoo(); // Error
+$test->someFoo = new None; // Error
 $test->someFoo = new Some(null);
 $test->someFoo = new NoneNull;
 $test->someFoo = new Foo;


### PR DESCRIPTION
The issues mentioned here are now correctly detected thanks to d19b5d0, with the expected output having been updated in bb7097b4d0.