### PR TITLE
Fix parameter type inheritance false positives

### DIFF
--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -916,11 +916,16 @@ class ParameterTypesAnalyzer
                 if ($parent_parameter_type->isEmpty()) {
                     continue;
                 }
+                // Check if the parameter type is exclusively from its default value, and not from the doc comment
+                // or a type declaration (default types are not added as real types).
+                $type_is_exclusively_from_default = !$comment_parameter &&
+                    $parameter->hasDefaultValue() &&
+                    !$parameter->getUnionType()->hasRealTypeSet();
                 // Allow @inheritDoc to be used to indicate that phpdoc parent parameter types
                 // should override inferred contravariant parameter types.
-                // Also inherit when there's no comment parameter (type may be from default value)
+                // Also inherit when the type is exclusively from the default value
                 if ($parameter_type->isEmpty() ||
-                        !$comment_parameter ||
+                        $type_is_exclusively_from_default ||
                         ($parent_parameter_type->isExclusivelyNarrowedFormOf($code_base, $parameter_type) &&
                         ($parameter_type->isExclusivelyArray() || \stripos((string) $method->getDocComment(), '@inheritDoc') !== false))) {
                     $parameter->setUnionType($parent_parameter_type->eraseRealTypeSetRecursively()->withRealTypeSet($parameter_type->getRealTypeSet()));

--- a/tests/files/expected/1069_covariant_return_type.php.expected
+++ b/tests/files/expected/1069_covariant_return_type.php.expected
@@ -1,1 +1,0 @@
-%s:29 PhanTypeMismatchArgumentSuperType Argument 1 ($o) is new BaseClass() of type \NS1069\BaseClass but \NS1069\BarFactory::build() takes \NS1069\SubClass defined at %s:24 (expected type to be the same or a subtype, but saw a supertype instead)


### PR DESCRIPTION
When choosing to inherit the parent types, also make sure that there is no type declaration, and that the type is entirely from the default value.

This fixes a regression introduced in 143bedd and discovered in bb7097b (because some tests weren't running).