### PR TITLE
early exit on empty maps

### DIFF
--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -1088,6 +1088,10 @@ class Method extends ClassElement implements FunctionInterface
         // Clone the parameter list, so that modifying the parameters won't modify the others.
         $method->cloneParameterList();
 
+        if (!$template_type_map) {
+            return $method;
+        }
+
         // Map the method's return type
         if ($method->getUnionType()->hasTemplateTypeRecursive()) {
             $method->setUnionType(

--- a/src/Phan/Language/Element/Property.php
+++ b/src/Phan/Language/Element/Property.php
@@ -645,6 +645,10 @@ class Property extends ClassElement
     {
         $property = clone($this);
 
+        if (!$template_type_map) {
+            return $property;
+        }
+
         if (
             !$property->hasUnresolvedFutureUnionType()
             && $property->getUnionType()->hasTemplateTypeRecursive()

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -4168,6 +4168,9 @@ class Type implements Stringable
     public function withTemplateParameterTypeMap(
         array $template_parameter_type_map
     ): UnionType {
+        if (!$template_parameter_type_map) {
+            return $this->asPHPDocUnionType();
+        }
         if (!$this->template_parameter_type_list) {
             return $this->asPHPDocUnionType();
         }

--- a/src/Phan/Language/Type/ArrayShapeType.php
+++ b/src/Phan/Language/Type/ArrayShapeType.php
@@ -860,6 +860,9 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
     public function withTemplateParameterTypeMap(
         array $template_parameter_type_map
     ): UnionType {
+        if (!$template_parameter_type_map) {
+            return $this->asPHPDocUnionType();
+        }
         $field_types = $this->field_types;
         foreach ($field_types as $i => $type) {
             $new_type = $type->withTemplateParameterTypeMap($template_parameter_type_map);

--- a/src/Phan/Language/Type/ClosureDeclarationParameter.php
+++ b/src/Phan/Language/Type/ClosureDeclarationParameter.php
@@ -142,6 +142,9 @@ final class ClosureDeclarationParameter
      */
     public function withTemplateParameterTypeMap(array $template_parameter_type_map): ClosureDeclarationParameter
     {
+        if (!$template_parameter_type_map) {
+            return $this;
+        }
         $new_type = $this->type->withTemplateParameterTypeMap($template_parameter_type_map);
         if ($new_type === $this->type) {
             return $this;

--- a/src/Phan/Language/Type/FunctionLikeDeclarationType.php
+++ b/src/Phan/Language/Type/FunctionLikeDeclarationType.php
@@ -1092,6 +1092,9 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
     public function withTemplateParameterTypeMap(
         array $template_parameter_type_map
     ): UnionType {
+        if (!$template_parameter_type_map) {
+            return $this->asPHPDocUnionType();
+        }
         $new_params = \array_map(static function (ClosureDeclarationParameter $param) use ($template_parameter_type_map): ClosureDeclarationParameter {
             return $param->withTemplateParameterTypeMap($template_parameter_type_map);
         }, $this->params);

--- a/src/Phan/Language/Type/GenericArrayTemplateKeyType.php
+++ b/src/Phan/Language/Type/GenericArrayTemplateKeyType.php
@@ -45,6 +45,9 @@ class GenericArrayTemplateKeyType extends GenericArrayType
     public function withTemplateParameterTypeMap(
         array $template_parameter_type_map
     ): UnionType {
+        if (!$template_parameter_type_map) {
+            return $this->asPHPDocUnionType();
+        }
         $element_type = $this->genericArrayElementUnionType();
         $new_element_type = $element_type->withTemplateParameterTypeMap($template_parameter_type_map);
         $new_key_type = $this->template_key_type->withTemplateParameterTypeMap($template_parameter_type_map);

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -678,6 +678,9 @@ class GenericArrayType extends ArrayType implements GenericArrayInterface
     public function withTemplateParameterTypeMap(
         array $template_parameter_type_map
     ): UnionType {
+        if (!$template_parameter_type_map) {
+            return $this->asPHPDocUnionType();
+        }
         $element_type = $this->genericArrayElementUnionType();
         $new_element_type = $element_type->withTemplateParameterTypeMap($template_parameter_type_map);
         if ($element_type === $new_element_type) {

--- a/src/Phan/Language/Type/GenericIterableType.php
+++ b/src/Phan/Language/Type/GenericIterableType.php
@@ -158,6 +158,9 @@ final class GenericIterableType extends IterableType
     public function withTemplateParameterTypeMap(
         array $template_parameter_type_map
     ): UnionType {
+        if (!$template_parameter_type_map) {
+            return $this->asPHPDocUnionType();
+        }
         $new_key_type = $this->key_union_type->withTemplateParameterTypeMap($template_parameter_type_map);
         $new_element_type = $this->element_union_type->withTemplateParameterTypeMap($template_parameter_type_map);
         if ($new_element_type === $this->element_union_type &&

--- a/src/Phan/Language/Type/IntersectionType.php
+++ b/src/Phan/Language/Type/IntersectionType.php
@@ -554,6 +554,9 @@ final class IntersectionType extends Type
     public function withTemplateParameterTypeMap(
         array $template_parameter_type_map
     ): UnionType {
+        if (!$template_parameter_type_map) {
+            return $this->asPHPDocUnionType();
+        }
         return $this->mapTypeParts(static function (Type $part) use ($template_parameter_type_map): Type {
             $mapped = $part->withTemplateParameterTypeMap($template_parameter_type_map);
             return $mapped->typeCount() === 1 ? $mapped->getTypeSet()[0] : $part;

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -1163,6 +1163,9 @@ class UnionType implements Serializable, Stringable
     public function withTemplateParameterTypeMap(
         array $template_parameter_type_map
     ): UnionType {
+        if (!$template_parameter_type_map) {
+            return $this;
+        }
         $has_template = false;
         $concrete_type_list = [];
         foreach ($this->type_set as $type) {


### PR DESCRIPTION
Exit early or don't call `withTemplateParameterTypeMap()` at all when the map is empty