### PR TITLE
parameter-analysis caching

### DIFF
--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -51,6 +51,13 @@ class ParameterTypesAnalyzer
         CodeBase $code_base,
         FunctionInterface $method
     ): void {
+        if ($code_base->getUndoTracker()) {
+            try {
+                self::analyzeParameterTypesInner($code_base, $method);
+            } catch (RecursionDepthException) {
+            }
+            return;
+        }
         try {
             $analysis_hash = self::computeAnalysisHash($code_base, $method);
             if ($method->hasParameterTypesBeenAnalyzed($analysis_hash)) {

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -51,8 +51,12 @@ class ParameterTypesAnalyzer
         CodeBase $code_base,
         FunctionInterface $method
     ): void {
-        $analysis_hash = self::computeAnalysisHash($code_base, $method);
-        if ($method->hasParameterTypesBeenAnalyzed($analysis_hash)) {
+        try {
+            $analysis_hash = self::computeAnalysisHash($code_base, $method);
+            if ($method->hasParameterTypesBeenAnalyzed($analysis_hash)) {
+                return;
+            }
+        } catch (RecursionDepthException) {
             return;
         }
         try {

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -50,10 +50,15 @@ class ParameterTypesAnalyzer
         CodeBase $code_base,
         FunctionInterface $method
     ): void {
+        if ($method->hasParameterTypesBeenAnalyzed()) {
+            return;
+        }
         try {
             self::analyzeParameterTypesInner($code_base, $method);
         } catch (RecursionDepthException) {
+            return;
         }
+        $method->markParameterTypesAnalyzed();
     }
 
     /**

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -14,6 +14,7 @@ use Phan\Exception\RecursionDepthException;
 use Phan\Issue;
 use Phan\IssueFixSuggester;
 use Phan\Language\Element\Clazz;
+use Phan\Language\Element\Comment;
 use Phan\Language\Element\Comment\Parameter as CommentParameter;
 use Phan\Language\Element\FunctionInterface;
 use Phan\Language\Element\Method;
@@ -50,7 +51,8 @@ class ParameterTypesAnalyzer
         CodeBase $code_base,
         FunctionInterface $method
     ): void {
-        if ($method->hasParameterTypesBeenAnalyzed()) {
+        $analysis_hash = self::computeAnalysisHash($code_base, $method);
+        if ($method->hasParameterTypesBeenAnalyzed($analysis_hash)) {
             return;
         }
         try {
@@ -58,7 +60,7 @@ class ParameterTypesAnalyzer
         } catch (RecursionDepthException) {
             return;
         }
-        $method->markParameterTypesAnalyzed();
+        $method->markParameterTypesAnalyzed($analysis_hash);
     }
 
     /**
@@ -258,6 +260,73 @@ class ParameterTypesAnalyzer
             $prev_name = $parameter_name;
             $prev_index = $parameter_index_in_comment;
         }
+    }
+
+    /**
+     * @return string hash representing the inputs relevant to parameter type analysis for $method.
+     */
+    private static function computeAnalysisHash(CodeBase $code_base, FunctionInterface $method): string
+    {
+        $parts = [];
+        $parts[] = 'self:' . self::hashParameterList($method->getParameterList());
+        $parts[] = 'doc:' . self::hashComment($method->getComment());
+
+        if ($method instanceof Method) {
+            $ancestor_parts = [];
+            foreach ($method->getOverriddenMethods($code_base) as $overridden_method) {
+                $ancestor_parts[] = $overridden_method->getFQSEN() . ':' .
+                    self::hashParameterList($overridden_method->getParameterList()) . ':' .
+                    self::hashComment($overridden_method->getComment());
+            }
+            if ($ancestor_parts) {
+                $parts[] = 'parents:' . \implode('|', $ancestor_parts);
+            }
+        }
+        return \md5(\implode(';', $parts));
+    }
+
+    /**
+     * @param list<Parameter> $parameters
+     */
+    private static function hashParameterList(array $parameters): string
+    {
+        if (!$parameters) {
+            return '[]';
+        }
+        $parts = [];
+        foreach ($parameters as $parameter) {
+            $parts[] = $parameter->getName() . ':' .
+                $parameter->getUnionType()->__toString() . ':' .
+                ($parameter->isOptional() ? '1' : '0') . ':' .
+                ($parameter->isVariadic() ? '1' : '0');
+        }
+        return \md5(\implode(',', $parts));
+    }
+
+    private static function hashComment(?Comment $comment): string
+    {
+        if (!$comment) {
+            return '';
+        }
+        $parts = [];
+        foreach ($comment->getParameterMap() as $name => $comment_param) {
+            $parts[] = 'map:' . $name . ':' . $comment_param->getUnionType()->__toString() . ':' .
+                ($comment_param->isVariadic() ? '1' : '0') . ':' .
+                ($comment_param->isMandatoryInPHPDoc() ? '1' : '0');
+        }
+        foreach ($comment->getParameterList() as $comment_param) {
+            $parts[] = 'list:' . $comment_param->getUnionType()->__toString();
+        }
+        foreach ($comment->getVariableList() as $comment_variable) {
+            $parts[] = 'var:' . $comment_variable->getName();
+        }
+        if ($comment->hasReturnUnionType()) {
+            $parts[] = 'return:' . $comment->getReturnType()->__toString();
+        }
+        if ($parts === []) {
+            return '';
+        }
+        return \md5(\implode('|', $parts));
     }
 
     /**

--- a/src/Phan/Language/Element/FunctionInterface.php
+++ b/src/Phan/Language/Element/FunctionInterface.php
@@ -185,6 +185,21 @@ interface FunctionInterface extends AddressableElementInterface
     public function setParameterList(array $parameter_list): void;
 
     /**
+     * Reset the cached state that indicates parameter types have already been analyzed.
+     */
+    public function resetParameterTypesAnalysis(): void;
+
+    /**
+     * Mark that parameter types have already been analyzed for this function-like.
+     */
+    public function markParameterTypesAnalyzed(): void;
+
+    /**
+     * True if parameter type analysis has already been performed for this function-like.
+     */
+    public function hasParameterTypesBeenAnalyzed(): bool;
+
+    /**
      * @internal - moves real parameter defaults to the inferred phpdoc parameters
      */
     public function inheritRealParameterDefaults(): void;

--- a/src/Phan/Language/Element/FunctionInterface.php
+++ b/src/Phan/Language/Element/FunctionInterface.php
@@ -190,14 +190,14 @@ interface FunctionInterface extends AddressableElementInterface
     public function resetParameterTypesAnalysis(): void;
 
     /**
-     * Mark that parameter types have already been analyzed for this function-like.
+     * Mark that parameter types have already been analyzed for this function-like using the given analysis hash.
      */
-    public function markParameterTypesAnalyzed(): void;
+    public function markParameterTypesAnalyzed(string $analysis_hash): void;
 
     /**
-     * True if parameter type analysis has already been performed for this function-like.
+     * True if parameter type analysis has already been performed for this function-like with the same analysis hash.
      */
-    public function hasParameterTypesBeenAnalyzed(): bool;
+    public function hasParameterTypesBeenAnalyzed(string $analysis_hash): bool;
 
     /**
      * @internal - moves real parameter defaults to the inferred phpdoc parameters

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -241,7 +241,8 @@ trait FunctionTrait
     /**
      * @var bool set to true once ParameterTypesAnalyzer has successfully run for this function-like.
      */
-    private $parameter_types_analyzed = false;
+    /** @var ?string hash of analysis inputs when parameter types were last analyzed */
+    private $parameter_types_analysis_hash = null;
 
     /**
      * @var FunctionLikeDeclarationType|null (Lazily generated representation of this as a closure type)
@@ -595,22 +596,22 @@ trait FunctionTrait
         if (\is_null($this->parameter_list_hash)) {
             $this->initParameterListInfo();
         }
-        $this->parameter_types_analyzed = false;
+        $this->parameter_types_analysis_hash = null;
     }
 
     public function resetParameterTypesAnalysis(): void
     {
-        $this->parameter_types_analyzed = false;
+        $this->parameter_types_analysis_hash = null;
     }
 
-    public function markParameterTypesAnalyzed(): void
+    public function markParameterTypesAnalyzed(string $analysis_hash): void
     {
-        $this->parameter_types_analyzed = true;
+        $this->parameter_types_analysis_hash = $analysis_hash;
     }
 
-    public function hasParameterTypesBeenAnalyzed(): bool
+    public function hasParameterTypesBeenAnalyzed(string $analysis_hash): bool
     {
-        return $this->parameter_types_analyzed;
+        return $this->parameter_types_analysis_hash === $analysis_hash;
     }
 
     /**
@@ -760,6 +761,8 @@ trait FunctionTrait
     public function appendParameter(Parameter $parameter): void
     {
         $this->parameter_list[] = $parameter;
+        $this->parameter_list_hash = null;
+        $this->parameter_types_analysis_hash = null;
     }
 
     /**
@@ -772,7 +775,7 @@ trait FunctionTrait
     {
         $this->parameter_list = [];
         $this->parameter_list_hash = null;
-        $this->parameter_types_analyzed = false;
+        $this->parameter_types_analysis_hash = null;
     }
 
     /**
@@ -1263,6 +1266,7 @@ trait FunctionTrait
     public function setComment(Comment $comment): void
     {
         $this->comment = $comment;
+        $this->parameter_types_analysis_hash = null;
     }
 
     public function getOwnThrowsUnionType(): UnionType

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -239,6 +239,11 @@ trait FunctionTrait
     private $function_call_analyzer_callback_set = [];
 
     /**
+     * @var bool set to true once ParameterTypesAnalyzer has successfully run for this function-like.
+     */
+    private $parameter_types_analyzed = false;
+
+    /**
      * @var FunctionLikeDeclarationType|null (Lazily generated representation of this as a closure type)
      */
     private $as_closure_declaration_type;
@@ -590,6 +595,22 @@ trait FunctionTrait
         if (\is_null($this->parameter_list_hash)) {
             $this->initParameterListInfo();
         }
+        $this->parameter_types_analyzed = false;
+    }
+
+    public function resetParameterTypesAnalysis(): void
+    {
+        $this->parameter_types_analyzed = false;
+    }
+
+    public function markParameterTypesAnalyzed(): void
+    {
+        $this->parameter_types_analyzed = true;
+    }
+
+    public function hasParameterTypesBeenAnalyzed(): bool
+    {
+        return $this->parameter_types_analyzed;
     }
 
     /**
@@ -751,6 +772,7 @@ trait FunctionTrait
     {
         $this->parameter_list = [];
         $this->parameter_list_hash = null;
+        $this->parameter_types_analyzed = false;
     }
 
     /**

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -132,6 +132,8 @@ class Method extends ClassElement implements FunctionInterface
     public function __clone()
     {
         $this->setInternalScope(clone($this->getInternalScope()));
+        $this->overridden_methods_cache = null;
+        $this->resetParameterTypesAnalysis();
     }
 
     /**

--- a/src/Phan/Language/Type/FunctionLikeDeclarationType.php
+++ b/src/Phan/Language/Type/FunctionLikeDeclarationType.php
@@ -80,10 +80,6 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
      */
     private $is_variadic;
 
-    /**
-     * @var bool set to true once ParameterTypesAnalyzer has run for this declaration type.
-     */
-    private $parameter_types_analyzed = false;
     // end computed properties
 
     /**
@@ -656,17 +652,17 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
 
     public function resetParameterTypesAnalysis(): void
     {
-        $this->parameter_types_analyzed = false;
+        // noop for declaration types
     }
 
-    public function markParameterTypesAnalyzed(): void
+    public function markParameterTypesAnalyzed(string $analysis_hash): void
     {
-        $this->parameter_types_analyzed = true;
+        // noop for declaration types
     }
 
-    public function hasParameterTypesBeenAnalyzed(): bool
+    public function hasParameterTypesBeenAnalyzed(string $analysis_hash): bool
     {
-        return $this->parameter_types_analyzed;
+        return false;
     }
 
     /**

--- a/src/Phan/Language/Type/FunctionLikeDeclarationType.php
+++ b/src/Phan/Language/Type/FunctionLikeDeclarationType.php
@@ -79,6 +79,11 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
      * @var bool
      */
     private $is_variadic;
+
+    /**
+     * @var bool set to true once ParameterTypesAnalyzer has run for this declaration type.
+     */
+    private $parameter_types_analyzed = false;
     // end computed properties
 
     /**
@@ -647,6 +652,21 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
     public function setParameterList(array $parameter_list): void
     {
         throw new \AssertionError('unexpected call to ' . __METHOD__);
+    }
+
+    public function resetParameterTypesAnalysis(): void
+    {
+        $this->parameter_types_analyzed = false;
+    }
+
+    public function markParameterTypesAnalyzed(): void
+    {
+        $this->parameter_types_analyzed = true;
+    }
+
+    public function hasParameterTypesBeenAnalyzed(): bool
+    {
+        return $this->parameter_types_analyzed;
     }
 
     /**


### PR DESCRIPTION
- ParameterTypesAnalyzer now short-circuits if analysis already ran and marks the method when done.
- FunctionInterface exposes helpers to mark/reset/query that state.
- FunctionTrait implements the flag and resets it when parameters change; Method::__clone() clears both the override cache and the analysis flag.