### PR TITLE
support tolerant support for PHP 8.5 clone with modifiers

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -327,12 +327,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phan/phan-tolerant.git",
-                "reference": "cfd05c2ba34986904907affe70c9af745664e9d8"
+                "reference": "642a8930ad08fe6de1f083ca2c22f10c471367c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phan/phan-tolerant/zipball/cfd05c2ba34986904907affe70c9af745664e9d8",
-                "reference": "cfd05c2ba34986904907affe70c9af745664e9d8",
+                "url": "https://api.github.com/repos/phan/phan-tolerant/zipball/642a8930ad08fe6de1f083ca2c22f10c471367c9",
+                "reference": "642a8930ad08fe6de1f083ca2c22f10c471367c9",
                 "shasum": ""
             },
             "require": {
@@ -372,7 +372,7 @@
                 "source": "https://github.com/phan/phan-tolerant/tree/main",
                 "issues": "https://github.com/phan/phan-tolerant/issues"
             },
-            "time": "2025-10-22T11:28:42+00:00"
+            "time": "2025-10-22T12:24:48+00:00"
         },
         {
             "name": "netresearch/jsonmapper",

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -845,8 +845,9 @@ class TolerantASTConverter
                     $args = [];
                     $expr_node = static::phpParserNodeToAstNode($n->expression);
                     $args[] = $expr_node;
-                    if ($n->modifications !== null) {
-                        $args[] = static::phpParserNodeToAstNode($n->modifications);
+                    $modifications = $n->modifications;
+                    if ($modifications instanceof PhpParser\Node) {
+                        $args[] = static::phpParserNodeToAstNode($modifications);
                     }
                     $args_line = isset($args[0]) && $args[0] instanceof ast\Node ? $args[0]->lineno : $start_line;
                     return new ast\Node(

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -842,12 +842,19 @@ class TolerantASTConverter
             'Microsoft\PhpParser\Node\Expression\CloneExpression' => static function (PhpParser\Node\Expression\CloneExpression $n, int $start_line): ast\Node {
                 // AST version 120 represents clone as AST_CALL instead of AST_CLONE
                 if (self::$ast_version_parsing >= 120) {
+                    $args = [];
+                    $expr_node = static::phpParserNodeToAstNode($n->expression);
+                    $args[] = $expr_node;
+                    if ($n->modifications !== null) {
+                        $args[] = static::phpParserNodeToAstNode($n->modifications);
+                    }
+                    $args_line = isset($args[0]) && $args[0] instanceof ast\Node ? $args[0]->lineno : $start_line;
                     return new ast\Node(
                         ast\AST_CALL,
                         0,
                         [
                             'expr' => new ast\Node(ast\AST_NAME, flags\NAME_FQ, ['name' => 'clone'], $start_line),
-                            'args' => new ast\Node(ast\AST_ARG_LIST, 0, [static::phpParserNodeToAstNode($n->expression)], $start_line),
+                            'args' => new ast\Node(ast\AST_ARG_LIST, 0, $args, $args_line),
                         ],
                         $start_line
                     );

--- a/tests/Phan/AST/TolerantASTConverter/ConversionTest.php
+++ b/tests/Phan/AST/TolerantASTConverter/ConversionTest.php
@@ -113,6 +113,9 @@ final class ConversionTest extends TestBase
             if (\PHP_VERSION_ID < 80400 && \str_contains($normalized_path, '/php84_or_newer/')) {
                 continue;
             }
+            if (\PHP_VERSION_ID < 80500 && \str_contains($normalized_path, '/php85_or_newer/')) {
+                continue;
+            }
             if (\PHP_VERSION_ID >= 80400) {
                 foreach ([
                     '/misc/fallback_ast_src/exit.php',

--- a/tests/misc/fallback_ast_src/php84_or_newer/new_without_parenthesis.php
+++ b/tests/misc/fallback_ast_src/php84_or_newer/new_without_parenthesis.php
@@ -1,0 +1,4 @@
+<?php
+
+new stdClass;
+new \stdClass;

--- a/tests/misc/fallback_ast_src/php85_or_newer/clone_with.php
+++ b/tests/misc/fallback_ast_src/php85_or_newer/clone_with.php
@@ -1,0 +1,9 @@
+<?php
+
+class ClonableExample {
+    public int $prop = 0;
+}
+
+$object = new ClonableExample();
+
+clone($object, ['prop' => 42]);


### PR DESCRIPTION
Updated `src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php` to emit an `ast\AST_CALL` with both the cloned expression and optional modification array, matching php-ast’s output for PHP 8.5’s `clone($obj, [...])` syntax as per RFC https://wiki.php.net/rfc/clone_with_v2