### PR TITLE
Support tolerant's support for attributes on consts

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -327,12 +327,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phan/phan-tolerant.git",
-                "reference": "642a8930ad08fe6de1f083ca2c22f10c471367c9"
+                "reference": "329ef9577642c52e1f1495f3f00c199e898d873d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phan/phan-tolerant/zipball/642a8930ad08fe6de1f083ca2c22f10c471367c9",
-                "reference": "642a8930ad08fe6de1f083ca2c22f10c471367c9",
+                "url": "https://api.github.com/repos/phan/phan-tolerant/zipball/329ef9577642c52e1f1495f3f00c199e898d873d",
+                "reference": "329ef9577642c52e1f1495f3f00c199e898d873d",
                 "shasum": ""
             },
             "require": {
@@ -372,7 +372,7 @@
                 "source": "https://github.com/phan/phan-tolerant/tree/main",
                 "issues": "https://github.com/phan/phan-tolerant/issues"
             },
-            "time": "2025-10-22T12:24:48+00:00"
+            "time": "2025-10-22T14:25:01+00:00"
         },
         {
             "name": "netresearch/jsonmapper",

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -3170,8 +3170,13 @@ class TolerantASTConverter
             }
             $const_elems[] = static::phpParserConstelemToAstConstelem($prop, $i === 0 ? $doc_comment : null);
         }
+        $children = $const_elems;
+        $attributes = static::phpParserAttributeGroupsToAstAttributeList($n->attributes);
+        if ($attributes) {
+            $children[] = $attributes;
+        }
 
-        return new ast\Node(ast\AST_CONST_DECL, 0, $const_elems, $const_elems[0]->lineno ?? $start_line);
+        return new ast\Node(ast\AST_CONST_DECL, 0, $children, $const_elems[0]->lineno ?? $start_line);
     }
 
     private static function phpParserDeclareListToAstDeclares(PhpParser\Node\Statement\DeclareStatement $declareStatement, int $start_line, ?string $first_doc_comment): ast\Node

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -1582,6 +1582,10 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             if (!$child_node instanceof Node) {
                 throw new AssertionError('expected const element to be a Node');
             }
+            if ($child_node->kind === ast\AST_ATTRIBUTE_LIST) {
+                // Skip appended attribute groups (PHP 8.5+)
+                continue;
+            }
             $name = $child_node->children['name'];
             if (!\is_string($name)) {
                 throw new AssertionError('expected const name to be a string');

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -1404,6 +1404,10 @@ class ParseVisitor extends ScopeVisitor
             if (!$child_node instanceof Node) {
                 throw new AssertionError("Expected global constant element to be a Node");
             }
+            if ($child_node->kind === ast\AST_ATTRIBUTE_LIST) {
+                // Skip attribute lists appended to AST_CONST_DECL
+                continue;
+            }
 
             $value_node = $child_node->children['value'];
             if ($value_node instanceof Node && !$this->checkNodeIsConstExprOrWarn($value_node, self::CONSTANT_EXPRESSION_IN_CONSTANT)) {

--- a/tests/misc/fallback_ast_src/php85_or_newer/attributes_class_const.php
+++ b/tests/misc/fallback_ast_src/php85_or_newer/attributes_class_const.php
@@ -1,0 +1,9 @@
+<?php
+
+class AttributeConstExample {
+    #[Deprecated]
+    public const SIMPLE = 1;
+
+    #[Internal]
+    protected const MULTI = 2;
+}

--- a/tests/misc/fallback_ast_src/php85_or_newer/attributes_global_const.php
+++ b/tests/misc/fallback_ast_src/php85_or_newer/attributes_global_const.php
@@ -1,0 +1,8 @@
+<?php
+
+#[Deprecated]
+const GLOBAL_CONST = 1;
+
+#[Internal]
+#[SensitiveParameter]
+const GLOBAL_MULTI = 2;


### PR DESCRIPTION
Tolerant supports PHP  8.5 attributes on consts now.