### PR TITLE
Use forked tolerant-php-parser under the phan namespace

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,8 +55,8 @@ jobs:
       - name: Install root dependencies
         run: composer install --no-interaction --no-progress
       - name: Install phan-tolerant dependencies
-        working-directory: vendor/microsoft/tolerant-php-parser
+        working-directory: vendor/phan/tolerant-php-parser
         run: composer install --no-interaction --no-progress
       - name: Run phan-tolerant PHPUnit suite (invariants + api)
-        working-directory: vendor/microsoft/tolerant-php-parser
+        working-directory: vendor/phan/tolerant-php-parser
         run: php -d zend.assertions=1 -d assert.exception=1 vendor/bin/phpunit --testsuite invariants,api

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,21 +42,3 @@ jobs:
       - name: Build and test in docker
         run: bash tests/run_all_tests_dockerized ${{ matrix.PHP_VERSION }} ${{ matrix.DOCKER_ARCHITECTURE }}
 
-  tolerant-tests:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.4'
-          tools: composer
-          coverage: none
-      - name: Install root dependencies
-        run: composer install --no-interaction --no-progress
-      - name: Install phan-tolerant dependencies
-        working-directory: vendor/phan/tolerant-php-parser
-        run: composer install --no-interaction --no-progress
-      - name: Run phan-tolerant PHPUnit suite (invariants + api)
-        working-directory: vendor/phan/tolerant-php-parser
-        run: php -d zend.assertions=1 -d assert.exception=1 vendor/bin/phpunit --testsuite invariants,api

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -458,7 +458,7 @@ return [
         'vendor/composer/semver/src',
         'vendor/composer/xdebug-handler/src',
         'vendor/felixfbecker/advanced-json-rpc/lib',
-        'vendor/microsoft/tolerant-php-parser/src',
+        'vendor/phan/tolerant-php-parser/src',
         'vendor/netresearch/jsonmapper/src',
         'vendor/phpdocumentor/reflection-docblock/src',
         'vendor/phpdocumentor/reflection-common/src',

--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,22 @@
             "cweagans/composer-patches": true
         }
     },
+    "conflict": {
+        "microsoft/tolerant-php-parser": "*"
+    },
     "repositories": [
         {
-            "type": "vcs",
-            "url": "https://github.com/phan/phan-tolerant.git"
+            "type": "package",
+            "package": {
+                "name": "phan/tolerant-php-parser",
+                "type": "library",
+                "version": "dev-main",
+                "source": {
+                    "url": "https://github.com/phan/phan-tolerant.git",
+                    "type": "git",
+                    "reference": "main"
+                }
+            }
         }
     ],
     "require": {
@@ -39,12 +51,12 @@
         "composer/xdebug-handler": "^2.0|^3.0",
         "felixfbecker/advanced-json-rpc": "^3.0.4",
         "netresearch/jsonmapper": "^1.6.0|^2.0|^3.0|^4.0|^5.0",
+        "phan/tolerant-php-parser": "dev-main",
         "sabre/event": "^5.1.3",
         "symfony/console": "^6.0",
         "symfony/string": "^6.0",
         "symfony/polyfill-mbstring": "^1.11.0",
-        "tysonandre/var_representation_polyfill": "^0.0.2|^0.1.0",
-        "microsoft/tolerant-php-parser": "dev-main"
+        "tysonandre/var_representation_polyfill": "^0.0.2|^0.1.0"
     },
     "suggest": {
         "ext-ast": "Needed for parsing ASTs (unless --use-fallback-parser is used). 1.1.3+ is needed.",
@@ -60,7 +72,8 @@
     },
     "autoload": {
         "psr-4": {
-            "Phan\\": "src/Phan"
+            "Phan\\": "src/Phan",
+            "Microsoft\\PhpParser\\": "vendor/phan/tolerant-php-parser/src"
         },
         "files": ["src/Phan/bootstrap/polyfills.php"]
     },

--- a/composer.json
+++ b/composer.json
@@ -39,8 +39,8 @@
         "phan/tolerant-php-parser": "dev-main",
         "sabre/event": "^5.1.3",
         "symfony/console": "^6.0",
-        "symfony/string": "^6.0",
         "symfony/polyfill-mbstring": "^1.11.0",
+        "symfony/string": "^6.0",
         "tysonandre/var_representation_polyfill": "^0.0.2|^0.1.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -27,21 +27,6 @@
     "conflict": {
         "microsoft/tolerant-php-parser": "*"
     },
-    "repositories": [
-        {
-            "type": "package",
-            "package": {
-                "name": "phan/tolerant-php-parser",
-                "type": "library",
-                "version": "dev-main",
-                "source": {
-                    "url": "https://github.com/phan/phan-tolerant.git",
-                    "type": "git",
-                    "reference": "main"
-                }
-            }
-        }
-    ],
     "require": {
         "php": "^8.1.0",
         "ext-filter": "*",
@@ -72,8 +57,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Phan\\": "src/Phan",
-            "Microsoft\\PhpParser\\": "vendor/phan/tolerant-php-parser/src"
+            "Phan\\": "src/Phan"
         },
         "files": ["src/Phan/bootstrap/polyfills.php"]
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ee7c0f9941d4cd466b5320be8f99d890",
+    "content-hash": "0a2abbd1fef100abb009409ce68c3f32",
     "packages": [
         {
             "name": "composer/pcre",
@@ -322,59 +322,6 @@
             "time": "2021-06-11T22:34:44+00:00"
         },
         {
-            "name": "microsoft/tolerant-php-parser",
-            "version": "dev-main",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phan/phan-tolerant.git",
-                "reference": "329ef9577642c52e1f1495f3f00c199e898d873d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phan/phan-tolerant/zipball/329ef9577642c52e1f1495f3f00c199e898d873d",
-                "reference": "329ef9577642c52e1f1495f3f00c199e898d873d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "require-dev": {
-                "phpstan/phpstan": "^1.8",
-                "phpunit/phpunit": "^8.5.15"
-            },
-            "default-branch": true,
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Microsoft\\PhpParser\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "autoload-dev": {
-                "psr-4": {
-                    "Microsoft\\PhpParser\\Tests\\Unit\\": [
-                        "tests/unit/"
-                    ]
-                }
-            },
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Rob Lourens",
-                    "email": "roblou@microsoft.com"
-                }
-            ],
-            "description": "Tolerant PHP-to-AST parser designed for IDE usage scenarios",
-            "support": {
-                "source": "https://github.com/phan/phan-tolerant/tree/main",
-                "issues": "https://github.com/phan/phan-tolerant/issues"
-            },
-            "time": "2025-10-22T14:25:01+00:00"
-        },
-        {
             "name": "netresearch/jsonmapper",
             "version": "v4.5.0",
             "source": {
@@ -424,6 +371,16 @@
                 "source": "https://github.com/cweiske/jsonmapper/tree/v4.5.0"
             },
             "time": "2024-09-08T10:13:13+00:00"
+        },
+        {
+            "name": "phan/tolerant-php-parser",
+            "version": "dev-main",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phan/phan-tolerant.git",
+                "reference": "main"
+            },
+            "type": "library"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -3331,7 +3288,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "microsoft/tolerant-php-parser": 20
+        "phan/tolerant-php-parser": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0a2abbd1fef100abb009409ce68c3f32",
+    "content-hash": "7275e2abbf39229fbc77f595d7a3863f",
     "packages": [
         {
             "name": "composer/pcre",
@@ -378,9 +378,46 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phan/phan-tolerant.git",
-                "reference": "main"
+                "reference": "aceb541776559ff34a1812a1189a3ceae88f3e56"
             },
-            "type": "library"
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phan/phan-tolerant/zipball/aceb541776559ff34a1812a1189a3ceae88f3e56",
+                "reference": "aceb541776559ff34a1812a1189a3ceae88f3e56",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.8",
+                "phpunit/phpunit": "^8.5.15"
+            },
+            "default-branch": true,
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Microsoft\\PhpParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Rob Lourens",
+                    "email": "roblou@microsoft.com"
+                }
+            ],
+            "description": "Tolerant PHP-to-AST parser designed for IDE usage scenarios",
+            "support": {
+                "issues": "https://github.com/phan/phan-tolerant/issues",
+                "source": "https://github.com/phan/phan-tolerant/tree/main"
+            },
+            "time": "2025-10-23T11:37:07+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -5,7 +5,7 @@ RUN pecl install ast-1.1.3 && docker-php-ext-enable ast
 # Use Composer 2.8.x for PHP 8.5 compatibility (symfony/process __serialize support)
 RUN curl https://getcomposer.org/download/2.8.3/composer.phar -o /usr/bin/composer.phar && chmod a+x /usr/bin/composer.phar
 WORKDIR /phan
-RUN apt-get update && apt-get install -y unzip parallel colordiff sqlite3 && apt-get clean
+RUN apt-get update && apt-get install -y unzip parallel colordiff sqlite3 git && apt-get clean
 
 ADD composer.json composer.lock ./
 ADD patches patches

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -5,7 +5,7 @@ RUN pecl install ast-1.1.3 && docker-php-ext-enable ast
 # Use Composer 2.8.x for PHP 8.5 compatibility (symfony/process __serialize support)
 RUN curl https://getcomposer.org/download/2.8.3/composer.phar -o /usr/bin/composer.phar && chmod a+x /usr/bin/composer.phar
 WORKDIR /phan
-RUN apt-get update && apt-get install -y unzip parallel colordiff sqlite3 git && apt-get clean
+RUN apt-get update && apt-get install -y unzip parallel colordiff sqlite3 && apt-get clean
 
 ADD composer.json composer.lock ./
 ADD patches patches


### PR DESCRIPTION
Use https://packagist.org/packages/phan/tolerant-php-parser (once it is released), instead of https://packagist.org/packages/microsoft/tolerant-php-parser.