### PR TITLE
Tweak for PHP 8.1/8.2

### DIFF
--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -861,6 +861,13 @@ class TolerantASTConverter
                             throw $e;
                         }
                     }
+                    if (\PHP_VERSION_ID < 80300 || self::$ast_version_parsing < 110) {
+                        return static::phpParserClassConstFetchToAstClassConstFetch(
+                            $n->scopeResolutionQualifier,
+                            self::INCOMPLETE_CLASS_CONST,
+                            $start_line
+                        );
+                    }
                     return static::phpParserClassConstFetchToAstClassConstFetch($n->scopeResolutionQualifier, $dynamic_name, $start_line);
                 }
                 throw new InvalidNodeException();


### PR DESCRIPTION
Avoid non-string class const names on PHP <8.3