### PR TITLE
Drop support for old-style constructors

### DIFF
--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -2041,11 +2041,7 @@ class Clazz extends AddressableElement
             if ('__construct' === $name) {
                 // Create a default constructor if it's requested
                 // but doesn't exist yet
-                $default_constructor =
-                    Method::defaultConstructorForClass(
-                        $this,
-                        $code_base
-                    );
+                $default_constructor = Method::defaultConstructorForClass($this);
 
                 $this->addMethod($code_base, $default_constructor, $this->getParentTypeOption());
 

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -360,37 +360,20 @@ class Method extends ClassElement implements FunctionInterface
      * @return Method
      * A default constructor for the given class
      */
-    public static function defaultConstructorForClass(
-        Clazz $clazz,
-        CodeBase $code_base
-    ): Method {
-        if ($clazz->getFQSEN()->getNamespace() === '\\' && $clazz->hasMethodWithName($code_base, $clazz->getName(), true)) {
-            $old_style_constructor = $clazz->getMethodByName($code_base, $clazz->getName());
-        } else {
-            $old_style_constructor = null;
-        }
-
+    public static function defaultConstructorForClass(Clazz $clazz): Method {
         $method_fqsen = FullyQualifiedMethodName::make(
             $clazz->getFQSEN(),
             '__construct'
         );
 
         $method = new Method(
-            $old_style_constructor ? $old_style_constructor->getContext() : $clazz->getContext(),
+            $clazz->getContext(),
             '__construct',
             $clazz->getUnionType(),
             0,
             $method_fqsen,
-            $old_style_constructor ? $old_style_constructor->getParameterList() : null
+            null
         );
-
-        if ($old_style_constructor) {
-            $method->setRealParameterList($old_style_constructor->getRealParameterList());
-            $method->setNumberOfRequiredParameters($old_style_constructor->getNumberOfRequiredParameters());
-            $method->setNumberOfOptionalParameters($old_style_constructor->getNumberOfOptionalParameters());
-            $method->setRealReturnType($old_style_constructor->getRealReturnType());
-            $method->setUnionType($old_style_constructor->getUnionType());
-        }
 
         $method->setPhanFlags($method->getPhanFlags() | Flags::IS_FAKE_CONSTRUCTOR);
 

--- a/tests/files/expected/1160_default_constructor.php.expected
+++ b/tests/files/expected/1160_default_constructor.php.expected
@@ -1,0 +1,1 @@
+%s:6 PhanParamTooMany Call with 1 arg(s) to \Test1160DefaultConstructor::__construct() which only takes 0 arg(s) defined at %s:3

--- a/tests/files/src/1160_default_constructor.php
+++ b/tests/files/src/1160_default_constructor.php
@@ -1,0 +1,6 @@
+<?php
+
+class Test1160DefaultConstructor {
+    public function test1160DefaultConstructor(int $arg) {}
+}
+return new Test1160DefaultConstructor(1); // Extra argument


### PR DESCRIPTION
PHP 8 no longer uses them.

Closes #4322