### PR TITLE
Export stubs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 # Files and directories with the attribute export-ignore won't be added to archive files
 # (such as zips/tarballs in GitHub Releases)
 # Some of the tests are edge cases that would crash older versions of Phan or other static analyzers, which is why they're included.
+/internal/stubs    export-subst
 /.appveyor.yml     export-ignore
 /.azure            export-ignore
 /.codeclimate.yml  export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,6 @@
 # Files and directories with the attribute export-ignore won't be added to archive files
 # (such as zips/tarballs in GitHub Releases)
 # Some of the tests are edge cases that would crash older versions of Phan or other static analyzers, which is why they're included.
-/internal/stubs    export-subst
 /.appveyor.yml     export-ignore
 /.azure            export-ignore
 /.codeclimate.yml  export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -15,3 +15,5 @@
 /plugins           export-ignore
 /test              export-ignore
 /tests             export-ignore
+/internal/stubs    export-subst
+/internal/*        export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -23,3 +23,4 @@
 /internal/*.sh            export-ignore
 /internal/phpcbf          export-ignore
 /internal/phpcs           export-ignore
+/internal/make_phar       export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -9,7 +9,6 @@
 /.gitignore        export-ignore
 /.github           export-ignore
 /.travis.yml       export-ignore
-/internal          export-ignore
 /phpcs.xml         export-ignore
 /phpdoc.dist.xml   export-ignore
 /phpunit.xml       export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -15,5 +15,5 @@
 /plugins           export-ignore
 /test              export-ignore
 /tests             export-ignore
-/internal/stubs    export-subst
 /internal/*        export-ignore
+/internal/stubs    export-subst

--- a/.gitattributes
+++ b/.gitattributes
@@ -15,5 +15,11 @@
 /plugins           export-ignore
 /test              export-ignore
 /tests             export-ignore
-/internal/*        export-ignore
-/internal/stubs    export-subst
+# Ignore everyting in /internal but /intenral/stubs
+/internal/lib             export-ignore
+/internal/PHP_CodeSniffer export-ignore
+/internal/*.php           export-ignore
+/internal/*.md            export-ignore
+/internal/*.sh            export-ignore
+/internal/phpcbf          export-ignore
+/internal/phpcs           export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,7 @@
 /.gitignore        export-ignore
 /.github           export-ignore
 /.travis.yml       export-ignore
+/CLAUDE.md         export-ignore
 /phpcs.xml         export-ignore
 /phpdoc.dist.xml   export-ignore
 /phpunit.xml       export-ignore


### PR DESCRIPTION
Recently stubs have been moved to [internal/stubs](https://github.com/phan/phan/tree/v6/internal/stubs), but `/internal` path [is excluded from the releases](https://github.com/phan/phan/blob/d4d3532fbf430a1af42a07d0e9dac54db23ef157/.gitattributes#L12). And because of that the following error was happening:
```
ERROR: InvalidArgumentException: Invalid autoload_internal_extension_signatures: path for igbinary is not a file: 
value: '/XXX/vendor/phan/phan/internal/stubs/igbinary.phan_php' in /XXX/vendor/phan/phan/src/Phan/Phan.php:1004
```