### PR TITLE
Fixed false positive for private property static/non-static mismatch

### DIFF
--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -942,7 +942,9 @@ class Clazz extends AddressableElement
         }
         // original_property is the one that the class is using.
         // We added $property after that (so it likely in a base class, or a trait's property added after this property was added)
-        if ($overriding_property->isStatic() != $inherited_property->isStatic()) {
+        // Private properties are not inherited, so they can have the same name with different static/instance characteristics without conflict
+        if ($overriding_property->isStatic() != $inherited_property->isStatic() &&
+            !($inherited_property->isPrivate() || $overriding_property->isPrivate())) {
             Issue::maybeEmit(
                 $code_base,
                 new ElementContext($overriding_property),

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -942,9 +942,10 @@ class Clazz extends AddressableElement
         }
         // original_property is the one that the class is using.
         // We added $property after that (so it likely in a base class, or a trait's property added after this property was added)
-        // Private properties are not inherited, so they can have the same name with different static/instance characteristics without conflict
+        // Private properties are not inherited, so if the parent's property is private, it's invisible to the child
+        // and the child can declare any property with the same name without conflict (regardless of static/instance).
         if ($overriding_property->isStatic() != $inherited_property->isStatic() &&
-            !($inherited_property->isPrivate() || $overriding_property->isPrivate())) {
+            !$inherited_property->isPrivate()) {
             Issue::maybeEmit(
                 $code_base,
                 new ElementContext($overriding_property),

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -942,10 +942,13 @@ class Clazz extends AddressableElement
         }
         // original_property is the one that the class is using.
         // We added $property after that (so it likely in a base class, or a trait's property added after this property was added)
-        // Private properties are not inherited, so if the parent's property is private, it's invisible to the child
-        // and the child can declare any property with the same name without conflict (regardless of static/instance).
+        // Private properties from parent classes are not inherited, so if the parent class's property is private,
+        // it's invisible to the child and the child can declare any property with the same name without conflict.
+        // However, trait properties are merged into the class, not inherited, so they must remain compatible.
+        $is_private_from_ancestor_class = $inherited_property->isPrivate() &&
+            !$code_base->getClassByFQSEN($inherited_property->getDefiningFQSEN()->getFullyQualifiedClassName())->isTrait();
         if ($overriding_property->isStatic() != $inherited_property->isStatic() &&
-            !$inherited_property->isPrivate()) {
+            !$is_private_from_ancestor_class) {
             Issue::maybeEmit(
                 $code_base,
                 new ElementContext($overriding_property),

--- a/tests/files/expected/5205_private_property_static_mismatch.php.expected
+++ b/tests/files/expected/5205_private_property_static_mismatch.php.expected
@@ -1,0 +1,2 @@
+%s:44 PhanAccessStaticToNonStaticProperty Cannot make static property \Parent3::$prop into the non static property \Child3->prop
+%s:53 PhanAccessStaticToNonStaticProperty Cannot make static property \Parent4::$field into the non static property \Child4->field

--- a/tests/files/expected/5205_private_property_static_mismatch.php.expected
+++ b/tests/files/expected/5205_private_property_static_mismatch.php.expected
@@ -1,2 +1,4 @@
 %s:44 PhanAccessStaticToNonStaticProperty Cannot make static property \Parent3::$prop into the non static property \Child3->prop
 %s:53 PhanAccessStaticToNonStaticProperty Cannot make static property \Parent4::$field into the non static property \Child4->field
+%s:62 PhanAccessStaticToNonStaticProperty Cannot make static property \Parent5::$data into the non static property \Child5->data
+%s:62 PhanPropertyAccessSignatureMismatch Access level to private $data must be compatible with public static $data defined in %s:58

--- a/tests/files/expected/5205_private_property_static_mismatch.php.expected
+++ b/tests/files/expected/5205_private_property_static_mismatch.php.expected
@@ -2,3 +2,4 @@
 %s:53 PhanAccessStaticToNonStaticProperty Cannot make static property \Parent4::$field into the non static property \Child4->field
 %s:62 PhanAccessStaticToNonStaticProperty Cannot make static property \Parent5::$data into the non static property \Child5->data
 %s:62 PhanPropertyAccessSignatureMismatch Access level to private $data must be compatible with public static $data defined in %s:58
+%s:82 PhanAccessStaticToNonStaticProperty Cannot make static property \TraitWithPrivateStatic::$traitProp into the non static property \ClassUsingTrait->traitProp

--- a/tests/files/src/5205_private_property_static_mismatch.php
+++ b/tests/files/src/5205_private_property_static_mismatch.php
@@ -71,6 +71,17 @@ class Child6 extends Parent6 {
     public $info;  // Should NOT warn (parent's private property doesn't conflict)
 }
 
+// Case 8: Trait with private static + class with private instance SHOULD warn
+// Trait properties are merged, not inherited, so they must be compatible
+trait TraitWithPrivateStatic {
+    private static $traitProp;
+}
+
+class ClassUsingTrait {
+    use TraitWithPrivateStatic;
+    private $traitProp;  // SHOULD warn: trait properties must be compatible
+}
+
 // Instantiate to trigger analysis
 new ParameterizedHeader();
 new Child1();
@@ -79,3 +90,4 @@ new Child3();
 new Child4();
 new Child5();
 new Child6();
+new ClassUsingTrait();

--- a/tests/files/src/5205_private_property_static_mismatch.php
+++ b/tests/files/src/5205_private_property_static_mismatch.php
@@ -53,9 +53,29 @@ class Child4 extends Parent4 {
     public $field;  // SHOULD warn: AccessStaticToNonStaticProperty
 }
 
+// Case 6: Public static parent + private instance child SHOULD warn
+class Parent5 {
+    public static $data;
+}
+
+class Child5 extends Parent5 {
+    private $data;  // SHOULD warn: AccessStaticToNonStaticProperty (visibility reduction + static change = fatal)
+}
+
+// Case 7: Private static parent + public instance child should NOT warn (parent private is invisible)
+class Parent6 {
+    private static $info;
+}
+
+class Child6 extends Parent6 {
+    public $info;  // Should NOT warn (parent's private property doesn't conflict)
+}
+
 // Instantiate to trigger analysis
 new ParameterizedHeader();
 new Child1();
 new Child2();
 new Child3();
 new Child4();
+new Child5();
+new Child6();

--- a/tests/files/src/5205_private_property_static_mismatch.php
+++ b/tests/files/src/5205_private_property_static_mismatch.php
@@ -1,0 +1,61 @@
+<?php
+
+// Test that private properties with the same name can coexist
+// even when one is static and the other is not.
+// Private properties are not inherited in PHP.
+
+/**
+ * @phan-file-suppress PhanNoopNewNoSideEffects
+ */
+
+// Case 1: Private static in parent, private instance in child
+abstract class AbstractHeader {
+    private static $encoder;
+}
+
+final class ParameterizedHeader extends AbstractHeader {
+    private ?int $encoder = null;  // Should NOT warn
+}
+
+// Case 2: Private instance in parent, private static in child
+class Parent1 {
+    private $value;
+}
+
+class Child1 extends Parent1 {
+    private static $value;  // Should NOT warn
+}
+
+// Case 3: Both private static
+class Parent2 {
+    private static $config;
+}
+
+class Child2 extends Parent2 {
+    private static $config;  // Should NOT warn
+}
+
+// Case 4: Protected properties SHOULD still warn (inherited)
+class Parent3 {
+    protected static $prop;
+}
+
+class Child3 extends Parent3 {
+    protected $prop;  // SHOULD warn: AccessStaticToNonStaticProperty
+}
+
+// Case 5: Public properties SHOULD still warn (inherited)
+class Parent4 {
+    public static $field;
+}
+
+class Child4 extends Parent4 {
+    public $field;  // SHOULD warn: AccessStaticToNonStaticProperty
+}
+
+// Instantiate to trigger analysis
+new ParameterizedHeader();
+new Child1();
+new Child2();
+new Child3();
+new Child4();


### PR DESCRIPTION
- Added check to skip static/non-static compatibility warning for private properties since they are not inherited