### PR TITLE
Pin forked phan/tolerant-php-parser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "composer/xdebug-handler": "^2.0|^3.0",
         "felixfbecker/advanced-json-rpc": "^3.0.4",
         "netresearch/jsonmapper": "^1.6.0|^2.0|^3.0|^4.0|^5.0",
-        "phan/tolerant-php-parser": "dev-main",
+        "phan/tolerant-php-parser": "v0.2.0",
         "sabre/event": "^5.1.3",
         "symfony/console": "^6.0|^7.0",
         "symfony/polyfill-mbstring": "^1.11.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6839fc5434627956d89bc87f34fc50d5",
+    "content-hash": "eca4b8cdf4a276efb8996c021b750e09",
     "packages": [
         {
             "name": "composer/pcre",
@@ -374,26 +374,25 @@
         },
         {
             "name": "phan/tolerant-php-parser",
-            "version": "dev-main",
+            "version": "v0.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phan/phan-tolerant.git",
-                "reference": "aceb541776559ff34a1812a1189a3ceae88f3e56"
+                "reference": "199a81a43531cea4872893f10adc3eefcacacea9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phan/phan-tolerant/zipball/aceb541776559ff34a1812a1189a3ceae88f3e56",
-                "reference": "aceb541776559ff34a1812a1189a3ceae88f3e56",
+                "url": "https://api.github.com/repos/phan/phan-tolerant/zipball/199a81a43531cea4872893f10adc3eefcacacea9",
+                "reference": "199a81a43531cea4872893f10adc3eefcacacea9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2"
+                "php": ">=8.1"
             },
             "require-dev": {
                 "phpstan/phpstan": "^1.8",
-                "phpunit/phpunit": "^8.5.15"
+                "phpunit/phpunit": "^10.0"
             },
-            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -415,9 +414,9 @@
             "description": "Tolerant PHP-to-AST parser designed for IDE usage scenarios",
             "support": {
                 "issues": "https://github.com/phan/phan-tolerant/issues",
-                "source": "https://github.com/phan/phan-tolerant/tree/main"
+                "source": "https://github.com/phan/phan-tolerant/tree/v0.2.0"
             },
-            "time": "2025-10-23T11:37:07+00:00"
+            "time": "2025-10-29T19:20:13+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -3324,9 +3323,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "phan/tolerant-php-parser": 20
-    },
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/tests/misc/fallback_test/expected/042_invalid_namespace_use.php.expected
+++ b/tests/misc/fallback_test/expected/042_invalid_namespace_use.php.expected
@@ -1,1 +1,5 @@
+src/042_invalid_namespace_use.php:3 PhanNoopConstant Unused constant
 src/042_invalid_namespace_use.php:3 PhanSyntaxError syntax error, unexpected token ",", expecting "{" (at column 21)
+src/042_invalid_namespace_use.php:3 PhanUndeclaredConstant Reference to undeclared constant \MissingGroupUseFn. This would throw an Error.
+src/042_invalid_namespace_use.php:3 PhanUnreferencedUseNormal Possibly zero references to use statement for classlike/namespace Inner (\A510\Inner)
+src/042_invalid_namespace_use.php:3 PhanUnreferencedUseNormal Possibly zero references to use statement for classlike/namespace function (\function)

--- a/tests/misc/fallback_test/expected/047_invalid_define.php.expected
+++ b/tests/misc/fallback_test/expected/047_invalid_define.php.expected
@@ -1,5 +1,6 @@
 src/047_invalid_define.php:3 PhanNoopConstant Unused constant
 src/047_invalid_define.php:3 PhanNoopStringLiteral Unused result of a string literal ");\nconst CON2 = " near this line
+src/047_invalid_define.php:3 PhanNoopStringLiteral Unused result of a string literal ";\n\nclass C {\n\n    /** @return int */\n    function f() {\n        return CON1;\n    }\n\n    /** @return int */\n    function g() {\n        return CON2;\n    }\n}" near this line
 src/047_invalid_define.php:3 PhanParamTooFewInternal Call with 1 arg(s) to \define(string $constant_name, $value, bool $case_insensitive = false) which requires 2 arg(s)
 src/047_invalid_define.php:3 PhanSyntaxError syntax error, unexpected identifier "a", expecting ")" (at column 12)
 src/047_invalid_define.php:3 PhanUndeclaredConstant Reference to undeclared constant \a. This would throw an Error.

--- a/tests/misc/fallback_test/expected/060_empty_string.php.expected
+++ b/tests/misc/fallback_test/expected/060_empty_string.php.expected
@@ -1,1 +1,1 @@
-src/060_empty_string.php:8 PhanSyntaxError syntax error, unexpected string content "unmatched" (at column 6)
+src/060_empty_string.php:8 PhanSyntaxError syntax error, unexpected string content "unmatched"

--- a/tests/misc/fallback_test/expected/062_test.php.expected
+++ b/tests/misc/fallback_test/expected/062_test.php.expected
@@ -1,3 +1,2 @@
-src/062_test.php:2 PhanCompatibleDimAlternativeSyntax Array and string offset access syntax with curly braces is no longer supported. Use square brackets instead. Seen for 'if'{}
-src/062_test.php:2 PhanNoopArrayAccess Unused array offset fetch
-src/062_test.php:3 PhanSyntaxError syntax error, unexpected token "}" (at column 1)
+src/062_test.php:1 PhanNoopStringLiteral Unused result of a string literal "if" near this line
+src/062_test.php:2 PhanSyntaxError syntax error, unexpected token "{" (at column 6)

--- a/tests/misc/fallback_test/expected/062_test.php.expected
+++ b/tests/misc/fallback_test/expected/062_test.php.expected
@@ -1,2 +1,2 @@
 src/062_test.php:1 PhanNoopStringLiteral Unused result of a string literal "if" near this line
-src/062_test.php:2 PhanSyntaxError syntax error, unexpected token "{" (at column 6)
+src/062_test.php:3 PhanSyntaxError syntax error, unexpected token "}" (at column 1)

--- a/tests/misc/fallback_test/expected/062_test.php.expected84
+++ b/tests/misc/fallback_test/expected/062_test.php.expected84
@@ -1,3 +1,2 @@
-src/062_test.php:2 PhanCompatibleDimAlternativeSyntax Array and string offset access syntax with curly braces is no longer supported. Use square brackets instead. Seen for 'if'{}
-src/062_test.php:2 PhanNoopArrayAccess Unused array offset fetch
+src/062_test.php:1 PhanNoopStringLiteral Unused result of a string literal "if" near this line
 src/062_test.php:2 PhanSyntaxError syntax error, unexpected token "{" (at column 6)


### PR DESCRIPTION
Pin https://github.com/phan/phan-tolerant/releases/tag/v0.2.0 (Instead of using the latest main).