### PR TITLE
check offsetget signature

### DIFF
--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -2065,12 +2065,71 @@ class UnionTypeVisitor extends AnalysisVisitor
                                 return $value_type->asRealUnionType();
                             }
                         }
-                        // No template parameters found
+                        // No template parameters found - try using offsetGet() method signature
+                        if ($class->hasMethodWithName($code_base, 'offsetGet', true)) {
+                            try {
+                                $offset_get_method = $class->getMethodByName($code_base, 'offsetGet');
+
+                                // Get return type from offsetGet()
+                                $return_type = $offset_get_method->getUnionType();
+
+                                // Resolve template types in the return type if present
+                                if ($return_type->hasTemplateTypeRecursive()) {
+                                    foreach ($union_type->getTypeSet() as $type) {
+                                        $template_param_map = $type->getTemplateParameterTypeMap($code_base);
+                                        if (!empty($template_param_map)) {
+                                            $return_type = $return_type->withTemplateParameterTypeMap($template_param_map);
+                                            break;
+                                        }
+                                    }
+                                }
+
+                                // Validate key type against offsetGet parameter if key is provided
+                                if (!$dim_type->isEmpty()) {
+                                    $param_list = $offset_get_method->getParameterList();
+                                    if (!empty($param_list)) {
+                                        $expected_key_type = $param_list[0]->getUnionType();
+
+                                        // Resolve template types in the expected key type if present
+                                        if ($expected_key_type->hasTemplateTypeRecursive()) {
+                                            foreach ($union_type->getTypeSet() as $type) {
+                                                $template_param_map = $type->getTemplateParameterTypeMap($code_base);
+                                                if (!empty($template_param_map)) {
+                                                    $expected_key_type = $expected_key_type->withTemplateParameterTypeMap($template_param_map);
+                                                    break;
+                                                }
+                                            }
+                                        }
+
+                                        // Only check if expected type is not mixed/empty
+                                        if (!$expected_key_type->isEmpty() && !$expected_key_type->hasMixedOrNonEmptyMixedType()) {
+                                            if (!$dim_type->canCastToUnionType($expected_key_type, $code_base)) {
+                                                $this->emitIssue(
+                                                    Issue::TypeMismatchDimFetch,
+                                                    $node->lineno,
+                                                    (string)$union_type,
+                                                    (string)$dim_type,
+                                                    (string)$expected_key_type
+                                                );
+                                            }
+                                        }
+                                    }
+                                }
+
+                                // Use return type from offsetGet() instead of mixed
+                                if (!$return_type->isEmpty()) {
+                                    return $return_type->asRealUnionType();
+                                }
+                            } catch (CodeBaseException) {
+                                // Fall through to mixed fallback if method lookup fails
+                            }
+                        }
+
                         if ($expanded_types->hasType($simple_xml_element_type)) {
                             // SimpleXMLElement has special handling - return empty to avoid false positives
                             return $element_types;
                         }
-                        // For ArrayAccess without templates, use mixed as fallback
+                        // For ArrayAccess without templates or offsetGet signature, use mixed as fallback
                         $element_types = UnionType::fromFullyQualifiedPHPDocString('mixed');
                     }
                 }

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -2118,7 +2118,7 @@ class UnionTypeVisitor extends AnalysisVisitor
 
                                 // Use return type from offsetGet() instead of mixed
                                 if (!$return_type->isEmpty()) {
-                                    return $return_type->asRealUnionType();
+                                    return $return_type;
                                 }
                             } catch (CodeBaseException) {
                                 // Fall through to mixed fallback if method lookup fails

--- a/tests/files/expected/5206_array_access_offsetget.php.expected
+++ b/tests/files/expected/5206_array_access_offsetget.php.expected
@@ -1,0 +1,5 @@
+%s:39 PhanTypeSuspiciousEcho Suspicious argument $container['field'] of type \stdClass for an echo/print statement
+%s:47 PhanTypeMismatchArgumentReal Argument 1 ($s) is $container['field'] of type \stdClass but \expects_string() takes string defined at %s:46
+%s:56 PhanTypeMismatchDimFetch When fetching an array index from a value of type \StringContainer, found an array index of type \stdClass, but expected the index to be of type string
+%s:65 PhanTypeMismatchDimFetch When fetching an array index from a value of type \StringContainer, found an array index of type 42, but expected the index to be of type string
+%s:101 PhanTypeMismatchArgumentReal Argument 1 ($o) is $value of type string but \expects_object() takes object defined at %s:42

--- a/tests/files/src/5206_array_access_offsetget.php
+++ b/tests/files/src/5206_array_access_offsetget.php
@@ -1,0 +1,150 @@
+<?php
+
+/**
+ * Test that Phan analyzes array access using signature of ArrayAccess->offsetGet
+ * Addresses issue #2679
+ */
+
+// Test 1: Basic offsetGet return type inference
+class StringContainer implements ArrayAccess {
+    /** @param string $key */
+    public function offsetExists($key): bool {
+        return true;
+    }
+
+    /**
+     * @param string $key
+     * @return stdClass
+     */
+    public function offsetGet($key): stdClass {
+        return new stdClass();
+    }
+
+    public function offsetSet($key, $value): void {
+        throw new RuntimeException();
+    }
+
+    public function offsetUnset($key): void {
+        throw new RuntimeException();
+    }
+}
+
+function test_return_type() {
+    $container = new StringContainer();
+    // @phan-suppress-next-line PhanUnusedVariable
+    $value = $container['field'];
+    // Should infer as stdClass, not mixed
+
+    // This should warn - stdClass cannot be echoed
+    echo $container['field'];
+
+    // This should NOT warn - stdClass is compatible with object
+    function expects_object(object $o): void {}
+    expects_object($container['field']);
+
+    // This should warn - stdClass is not compatible with string
+    function expects_string(string $s): void {}
+    expects_string($container['field']);
+}
+
+// Test 2: Key type validation
+function test_key_type() {
+    $container = new StringContainer();
+
+    // This should warn - stdClass is not compatible with string key
+    // @phan-suppress-next-line PhanUnusedVariable
+    $val = $container[new stdClass()];
+
+    // This should NOT warn - string is the expected key type
+    // @phan-suppress-next-line PhanUnusedVariable
+    $val2 = $container['valid_key'];
+
+    // This should warn - int literal 42 doesn't strictly match string type
+    // (In strict mode, int doesn't auto-cast to string for typed parameters)
+    // @phan-suppress-next-line PhanUnusedVariable
+    $val3 = $container[42];
+}
+
+// Test 3: ArrayAccess with templates should still use templates
+/**
+ * @template TKey
+ * @template TValue
+ * @implements ArrayAccess<TKey, TValue>
+ */
+class GenericContainer implements ArrayAccess {
+    /** @param TKey $key */
+    public function offsetExists($key): bool {
+        return true;
+    }
+
+    /** @param TKey $key @return TValue */
+    public function offsetGet($key): mixed {
+        throw new RuntimeException();
+    }
+
+    /** @param TKey $key @param TValue $value */
+    public function offsetSet($key, $value): void {}
+
+    /** @param TKey $key */
+    public function offsetUnset($key): void {}
+}
+
+/** @param GenericContainer<int, string> $container */
+function test_template_preference(GenericContainer $container) {
+    $value = $container[0];
+    // Should infer as string from template, not mixed from return type
+
+    // This should NOT warn - string is compatible with string
+    expects_string($value);
+
+    // This should warn - string is not compatible with object
+    expects_object($value);
+}
+
+// Test 4: Missing return type should fall back to mixed
+class UnTypedContainer implements ArrayAccess {
+    public function offsetExists($offset): bool {
+        return true;
+    }
+
+    public function offsetGet($offset) {
+        return 'something';
+    }
+
+    public function offsetSet($offset, $value): void {}
+
+    public function offsetUnset($offset): void {}
+}
+
+function test_untyped_fallback() {
+    $container = new UnTypedContainer();
+    // @phan-suppress-next-line PhanUnusedVariable
+    $value = $container['key'];
+    // Should be mixed since no type hint
+
+    // No warnings expected - mixed can be anything
+    expects_string($value);
+    expects_object($value);
+}
+
+// Test 5: No offsetGet method should fall back to mixed
+class MinimalArrayAccess implements ArrayAccess {
+    public function offsetExists($offset): bool {
+        return true;
+    }
+
+    public function offsetGet($offset): mixed {
+        return null;
+    }
+
+    public function offsetSet($offset, $value): void {}
+
+    public function offsetUnset($offset): void {}
+}
+
+function test_minimal() {
+    $container = new MinimalArrayAccess();
+    // @phan-suppress-next-line PhanUnusedVariable
+    $value = $container['key'];
+    // Should infer as mixed from offsetGet return type
+}

--- a/tests/files/src/5206_array_access_offsetget.php
+++ b/tests/files/src/5206_array_access_offsetget.php
@@ -148,3 +148,29 @@ function test_minimal() {
     $value = $container['key'];
     // Should infer as mixed from offsetGet return type
 }
+
+// Test 6: PHPDoc-only return type (no native type hint)
+class PhpDocOnlyContainer implements ArrayAccess {
+    public function offsetExists($offset): bool {
+        return true;
+    }
+
+    /**
+     * PHPDoc-only, no native return type
+     * @return stdClass
+     */
+    public function offsetGet($offset) {
+        return new stdClass();
+    }
+
+    public function offsetSet($offset, $value): void {}
+    public function offsetUnset($offset): void {}
+}
+
+function test_phpdoc_only() {
+    $container = new PhpDocOnlyContainer();
+    // @phan-suppress-next-line PhanUnusedVariable
+    $value = $container['key'];
+    // Should infer as stdClass from PHPDoc, but WITHOUT real type marker
+    // (compare with Test 1 which has native return type)
+}


### PR DESCRIPTION
## Problem

Phan was not analyzing ArrayAccess objects using the signature of `offsetGet()`. When using array access syntax on ArrayAccess objects (e.g., `$container['key']`), Phan would:
- Always infer the type as mixed instead of using the offsetGet() return type
- Not validate that the key type matches the offsetGet() parameter type

## Solution

Modified `UnionTypeVisitor::visitDim()` to check the `offsetGet()` method signature when analyzing array access expressions.

## Logic Flow

1. Template parameter check (existing code): First tries to infer type from `@implements ArrayAccess<TKey, TValue>` template parameters
2. NEW: `offsetGet()` signature check: If no template parameters found, looks up the `offsetGet()` method:
   - Extracts return type from `offsetGet()` and uses it for type inference
   - Validates key type against the first parameter of `offsetGet()`
   - Emits `TypeMismatchDimFetch` warning if key type doesn't match
   - Resolves template types in both return type and parameter type if present
3. Fallback: Only returns mixed if no type information is available