### PR TITLE
Infer truthiness of func_get_args and array elements

### DIFF
--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -676,6 +676,31 @@ class ConditionVisitor extends KindVisitorImplementation implements ConditionVis
         );
     }
 
+    public function visitDim(Node $node): Context
+    {
+        $this->checkVariablesDefined($node);
+        if (Config::getValue('redundant_condition_detection')) {
+            $this->checkRedundantOrImpossibleTruthyCondition($node, $this->context, null, false);
+        }
+        return $this->updateDimExpressionWithConditionalFilter(
+            $node,
+            $this->context,
+            static function (UnionType $type): bool {
+                foreach ($type->getRealTypeSet() as $single_type) {
+                    if ($single_type->isPossiblyFalsey()) {
+                        return true;
+                    }
+                }
+                return $type->containsFalsey() || !$type->hasRealTypeSet();
+            },
+            static function (UnionType $type): UnionType {
+                return $type->nonFalseyClone();
+            },
+            false,
+            false
+        );
+    }
+
     /**
      * @param Node $node
      * A node to parse

--- a/src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php
@@ -400,6 +400,30 @@ final class DependentReturnTypeOverridePlugin extends PluginV3 implements
                 'non-empty-list<string>'
             );
         };
+        /**
+         * @param list<Node|int|float|string> $unused_args
+         */
+        $func_get_args_handler = static function (
+            CodeBase $code_base,
+            Context $context,
+            Func $unused_function,
+            array $unused_args
+        ): UnionType {
+            if ($context->isInFunctionLikeScope()) {
+                $func = $context->getFunctionLikeInScope($code_base);
+
+                if ($func->getNumberOfRequiredParameters() > 0) {
+                    return UnionType::fromFullyQualifiedPHPDocAndRealString(
+                        'non-empty-list<mixed>',
+                        'non-empty-list<mixed>'
+                    );
+                }
+            }
+            return UnionType::fromFullyQualifiedPHPDocAndRealString(
+                'list<mixed>',
+                'list<mixed>'
+            );
+        };
 
         // TODO: Handle flags of preg_split.
         return [
@@ -425,6 +449,7 @@ final class DependentReturnTypeOverridePlugin extends PluginV3 implements
             'bcdiv'                       => $bcdiv_callback,
             'explode'                     => $explode_handler,
             'constant'                    => $constant_handler,
+            'func_get_args'               => $func_get_args_handler,
         ];
     }
 

--- a/tests/files/expected/1161_emptiness_checks.php.expected
+++ b/tests/files/expected/1161_emptiness_checks.php.expected
@@ -1,0 +1,4 @@
+%s:8 PhanDebugAnnotation @phan-debug-var requested for variable $d - it has union type non-empty-list<mixed>(real=non-empty-list<mixed>)
+%s:13 PhanDebugAnnotation @phan-debug-var requested for variable $d - it has union type list<mixed>(real=list<mixed>)
+%s:19 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type non-empty-array<mixed,mixed>
+%s:28 PhanDebugAnnotation @phan-debug-var requested for variable $el - it has union type (empty union type)

--- a/tests/files/src/1161_emptiness_checks.php
+++ b/tests/files/src/1161_emptiness_checks.php
@@ -1,0 +1,31 @@
+<?php
+
+/* @phan-file-suppress PhanUnusedVariable */
+
+namespace NS1161;
+
+function testFuncGetArgs($req1, $req2) {
+    $d = func_get_args();
+    '@phan-debug-var $d';
+}
+
+function testFuncGetArgs__potentiallyEmpty($opt = 42) {
+    $d = func_get_args();
+    '@phan-debug-var $d';
+}
+
+function testNestedTruthinessCheck( array $data ) {
+    if ( is_array( $data['label'] ) && $data['label'] ) {
+        $x = $data['label'];
+        '@phan-debug-var $x';
+    }
+}
+
+/**
+ * @param non-empty-array[] $data
+ */
+function testArrayMap( array $data ) {
+    array_map( function ( $el ) {
+        '@phan-debug-var $el'; // TODO: Ideally, phan would infer `non-empty-array` here, but we don't infer closure param types
+    }, $data );
+}


### PR DESCRIPTION
For func_get_args, check if the current function has at least one required parameter, and if so infer that the return value of func_get_args is a non-empty list. Else just stick with list as we knew from reflection.

In ConditionVisitor, implement `visitDim` so that we can apply type modifications to individual array elements.

Also add a failing test for array_map from the issue. That one is not an immediate fix because we don't infer closure parameter/return types at all.

Closes #4734