### PR TITLE
template inheritance fix

### DIFF
--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -1114,8 +1114,11 @@ class Method extends ClassElement implements FunctionInterface
         // (the final union type may not have been computed yet)
         if ($comment = $method->getComment()) {
             $comment = clone($comment);
+            // Track which parameters had template types so we only update those
+            $params_with_templates = [];
             foreach ($comment->getAndMutateParameters() as &$comment_param) {
                 if ($comment_param->getUnionType()->hasTemplateTypeRecursive()) {
+                    $params_with_templates[$comment_param->getName()] = true;
                     $comment_param = clone($comment_param);
                     // @phan-suppress-next-line PhanAccessMethodInternal
                     $comment_param->setUnionType(
@@ -1124,15 +1127,18 @@ class Method extends ClassElement implements FunctionInterface
                 }
             }
 
-            // Copy the updated PHPDoc parameter types to the method's actual parameters
-            // This is necessary for stub methods where PHPDoc types may differ from signature types
-            $comment_param_map = $comment->getParameterMap();
-            foreach ($method->getParameterList() as $method_param) {
-                $param_name = $method_param->getName();
-                if (isset($comment_param_map[$param_name])) {
-                    $comment_param_type = $comment_param_map[$param_name]->getUnionType();
-                    if (!$comment_param_type->isEmpty()) {
-                        $method_param->setUnionType($comment_param_type);
+            // Copy the updated PHPDoc parameter types to the method's actual parameters,
+            // but only for parameters that originally had template types.
+            // This preserves native signature types (like ?int) for non-template parameters.
+            if ($params_with_templates) {
+                $comment_param_map = $comment->getParameterMap();
+                foreach ($method->getParameterList() as $method_param) {
+                    $param_name = $method_param->getName();
+                    if (isset($params_with_templates[$param_name]) && isset($comment_param_map[$param_name])) {
+                        $comment_param_type = $comment_param_map[$param_name]->getUnionType();
+                        if (!$comment_param_type->isEmpty()) {
+                            $method_param->setUnionType($comment_param_type);
+                        }
                     }
                 }
             }

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -1123,6 +1123,20 @@ class Method extends ClassElement implements FunctionInterface
                     );
                 }
             }
+
+            // Copy the updated PHPDoc parameter types to the method's actual parameters
+            // This is necessary for stub methods where PHPDoc types may differ from signature types
+            $comment_param_map = $comment->getParameterMap();
+            foreach ($method->getParameterList() as $method_param) {
+                $param_name = $method_param->getName();
+                if (isset($comment_param_map[$param_name])) {
+                    $comment_param_type = $comment_param_map[$param_name]->getUnionType();
+                    if (!$comment_param_type->isEmpty()) {
+                        $method_param->setUnionType($comment_param_type);
+                    }
+                }
+            }
+
             // Also map the return type's PHPDoc template types
             // This is important for stub methods where the signature returns mixed
             // but the PHPDoc has template types like @return TValue

--- a/src/Phan/Library/Map.php
+++ b/src/Phan/Library/Map.php
@@ -17,7 +17,7 @@ use SplObjectStorage;
  * @template V
  * @extends SplObjectStorage<K,V>
  * @suppress PhanTemplateTypeNotDeclaredInFunctionParams
- * @phan-file-suppress PhanParamSignaturePHPDocMismatchHasParamType, PhanParamSignaturePHPDocMismatchParamType, PhanParamSignatureMismatchInternal
+ * @phan-file-suppress PhanParamSignaturePHPDocMismatchHasParamType, PhanParamSignatureMismatchInternal
  * TODO: Add a way to indicate in Phan that T is subtype of object for keys K
  *
  * @method void attach(K $object,V $data = null)

--- a/src/Phan/Library/Set.php
+++ b/src/Phan/Library/Set.php
@@ -18,7 +18,6 @@ use TypeError;
  *
  * - Afterwards, remove this boilerplate overriding methods of SplObjectStorage<T,T>
  *
- * @phan-file-suppress PhanParamSignaturePHPDocMismatchParamType TODO: Add a way to indicate in Phan that T is subtype of object
  * @phan-file-suppress PhanParamSignaturePHPDocMismatchHasParamType TODO: Add a way to indicate in Phan that T is subtype of object
  * @method void attach(T $object,mixed $data = null)
  * @method void detach(T $object)

--- a/tests/files/expected/5255_inherited_template_offsetset.php.expected
+++ b/tests/files/expected/5255_inherited_template_offsetset.php.expected
@@ -1,0 +1,2 @@
+%s:20 PhanDebugAnnotation @phan-debug-var requested for variable $s1 - it has union type \Set<\Class1>(real=\Set)
+%s:23 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($object) is new Class2() of type \Class2 but \Set::offsetSet() takes \Class1

--- a/tests/files/src/5255_inherited_template_offsetset.php
+++ b/tests/files/src/5255_inherited_template_offsetset.php
@@ -1,0 +1,24 @@
+<?php
+
+class Class1 {}
+class Class2 {}
+
+/**
+ * @template T of object
+ * @extends \SplObjectStorage<T,null>
+ */
+class Set extends \SplObjectStorage {
+    /**
+     * @param iterable<T> $element_iterator @phan-unused-param
+     */
+    public function __construct($element_iterator = null){}
+}
+
+/**
+ * @param Set<Class1> $s1
+ */
+function test(Set $s1) {
+    '@phan-debug-var $s1';
+    $s1->offsetSet(new Class1());  // Should be OK
+    $s1->offsetSet(new Class2());  // Should error: Class2 != Class1
+}


### PR DESCRIPTION
Issue #5255: Template types were not being inherited from `SplObjectStorage::offsetSet()` and other methods
- Added code to copy updated PHPDoc parameter types to method's actual parameters after template substitution
- This ensures that when template types are substituted (e.g., TObject --> T --> Class1), the substituted types are available for argument type checking