### PR TITLE
Simplify template definitions in Set and Map

### DIFF
--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -1259,7 +1259,7 @@ class CodeBase
     {
         $set = clone($this->method_set);
         foreach ($this->fqsen_func_map as $value) {
-            // @phan-suppress-next-line  PhanPartialTypeMismatchArgument deliberately adding different class instances to an existing set
+            // @phan-suppress-next-line PhanPartialTypeMismatchArgumentInternal deliberately adding different class instances to an existing set
             $set->offsetSet($value);
         }
         return $set;

--- a/src/Phan/Library/Map.php
+++ b/src/Phan/Library/Map.php
@@ -17,15 +17,6 @@ use SplObjectStorage;
  * @template V
  * @extends SplObjectStorage<K,V>
  * @suppress PhanTemplateTypeNotDeclaredInFunctionParams
- * @phan-file-suppress PhanParamSignaturePHPDocMismatchHasParamType, PhanParamSignatureMismatchInternal
- * TODO: Add a way to indicate in Phan that T is subtype of object for keys K
- *
- * @method void attach(K $object,V $data = null)
- * @method void detach(K $object)
- * @method bool offsetExists(K $object)
- * @method V offsetGet(K $object )
- * @method void offsetSet(K $object,V $data = null)
- * @method void offsetUnset(K $object)
  */
 class Map extends SplObjectStorage
 {
@@ -48,6 +39,7 @@ class Map extends SplObjectStorage
      * We redefine the current value to the current value rather
      * than the current key
      * @return V
+     * @suppress PhanParamSignatureMismatchInternal
      * @suppress PhanParamSignatureRealMismatchReturnTypeInternal - ReturnTypeWillChange attribute handles this.
      */
     #[ReturnTypeWillChange]

--- a/src/Phan/Library/Set.php
+++ b/src/Phan/Library/Set.php
@@ -12,24 +12,7 @@ use TypeError;
  * intersection
  *
  * @template T of object
- * @extends \SplObjectStorage<T,T>
- *
- * TODO: Start tracking that SplObjectStorage<T,T> extends ArrayAccess<T,T>
- *
- * - Afterwards, remove this boilerplate overriding methods of SplObjectStorage<T,T>
- *
- * @phan-file-suppress PhanParamSignaturePHPDocMismatchHasParamType TODO: Add a way to indicate in Phan that T is subtype of object
- * @method void attach(T $object,mixed $data = null)
- * @method void detach(T $object)
- * @method bool offsetExists(T $object)
- * @method bool offsetGet(T $object )
- * @method void offsetSet(T $object,mixed $data = null)
- * @method void offsetUnset(T $object)
- * @phan-suppress-next-line PhanParamSignaturePHPDocMismatchReturnType TODO: Add a way to indicate that T is subtype of object
- * @method T current()
- *
- * @phan-file-suppress PhanParamSignatureMismatchInternal for these comment method overrides
- * TODO: Make suppressions in the class doc comment work for magic methods.
+ * @extends \SplObjectStorage<T,null>
  */
 class Set extends \SplObjectStorage
 {


### PR DESCRIPTION
With the improvements to generics in v6, we only need the `@extends` and nothing else.

Also fix the type for Set, where the object template is only used for keys, but not values.