### PR TITLE
PhanAccessOwnConstructor should only trigger on infinite recursion possibilities

### DIFF
--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -3046,8 +3046,14 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         if ($node->children['class']->kind !== ast\AST_NAME) {
             return;
         }
-        // TODO: check for self/static/<class name of self> and warn about recursion?
-        // TODO: Only allow calls to __construct from other constructors?
+        // Only warn about self::__construct() recursion when called from within a constructor.
+        // Calling self::__construct() from other methods is unusual but valid (e.g., for re-initialization).
+        $is_in_constructor = false;
+        if ($this->context->isInMethodScope()) {
+            $method = $this->context->getFunctionLikeInScope($this->code_base);
+            $is_in_constructor = $method instanceof Method && $method->isNewConstructor();
+        }
+
         $found_ancestor_constructor = false;
         if ($this->context->isInMethodScope()) {
             try {
@@ -3068,22 +3074,26 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             // (other code should check visibility and existence and args of __construct)
 
             if (!$possible_ancestor_type->isEmpty()) {
-                // but forbid 'self::__construct', 'static::__construct'
+                // but forbid 'self::__construct', 'static::__construct' when called from __construct
                 $type = $this->context->getClassFQSEN()->asType();
                 if ($possible_ancestor_type->hasStaticType()) {
-                    $this->emitIssue(
-                        Issue::AccessOwnConstructor,
-                        $node->lineno,
-                        $static_class
-                    );
-                    $found_ancestor_constructor = true;
-                } elseif ($type->asPHPDocUnionType()->canCastToUnionType($possible_ancestor_type, $this->code_base)) {
-                    if ($possible_ancestor_type->hasType($type)) {
+                    if ($is_in_constructor) {
                         $this->emitIssue(
                             Issue::AccessOwnConstructor,
                             $node->lineno,
                             $static_class
                         );
+                    }
+                    $found_ancestor_constructor = true;
+                } elseif ($type->asPHPDocUnionType()->canCastToUnionType($possible_ancestor_type, $this->code_base)) {
+                    if ($possible_ancestor_type->hasType($type)) {
+                        if ($is_in_constructor) {
+                            $this->emitIssue(
+                                Issue::AccessOwnConstructor,
+                                $node->lineno,
+                                $static_class
+                            );
+                        }
                     }
                     $found_ancestor_constructor = true;
                 }

--- a/tests/files/expected/0310_self_construct.php.expected
+++ b/tests/files/expected/0310_self_construct.php.expected
@@ -1,7 +1,5 @@
 %s:8 PhanUndeclaredStaticMethod Static call to undeclared method \Baz310::__construct
-%s:19 PhanAccessOwnConstructor Accessing own constructor directly via self::__construct
 %s:19 PhanTypeMismatchArgumentReal Argument 1 ($arg) is 'y' of type string but \Foo310::__construct() takes int defined at %s:14
-%s:20 PhanAccessOwnConstructor Accessing own constructor directly via static::__construct
 %s:20 PhanTypeMismatchArgumentReal Argument 1 ($arg) is 'z' of type string but \Foo310::__construct() takes int defined at %s:14
 %s:21 PhanParamTooMany Call with 1 arg(s) to \Bar310::__construct() which only takes 0 arg(s) defined at %s:7
 %s:25 PhanTypeMismatchArgumentReal Argument 1 ($arg) is 'x' of type string but \Foo310::__construct() takes int defined at %s:14

--- a/tests/files/expected/0901_self_construct_reinit.php.expected
+++ b/tests/files/expected/0901_self_construct_reinit.php.expected
@@ -1,0 +1,4 @@
+%s:39 PhanAccessOwnConstructor Accessing own constructor directly via self::__construct
+%s:39 PhanInfiniteRecursion __construct() is calling itself in a way that may cause infinite recursion.
+%s:45 PhanAccessOwnConstructor Accessing own constructor directly via static::__construct
+%s:45 PhanInfiniteRecursion __construct() is calling itself in a way that may cause infinite recursion.

--- a/tests/files/src/0901_self_construct_reinit.php
+++ b/tests/files/src/0901_self_construct_reinit.php
@@ -1,0 +1,47 @@
+<?php
+
+// Test that self::__construct() is allowed when called from non-constructor methods
+// This is a valid re-initialization pattern (e.g., for unserialize())
+
+class Item901 {
+    private int $updatedAt;
+
+    public function __construct(
+        private ?string $value = null
+    ) {
+        $this->updatedAt = time();
+    }
+
+    // Valid: calling self::__construct() from a non-constructor method for re-initialization
+    public function unserialize(string $value): void {
+        self::__construct($value);
+    }
+
+    // Valid: calling static::__construct() from a non-constructor method
+    public function reset(): void {
+        static::__construct(null);
+    }
+}
+
+class ExtendedItem901 extends Item901 {
+    public function __construct(?string $value = null) {
+        parent::__construct($value);
+    }
+
+    // Invalid: calling self::__construct() from constructor causes recursion
+    public function badConstructor(): void {
+        self::__construct('test');  // This is in a regular method, should be OK
+    }
+}
+
+class RecursiveItem901 {
+    public function __construct() {
+        self::__construct();  // Invalid: recursion in constructor
+    }
+}
+
+class StaticRecursiveItem901 {
+    public function __construct() {
+        static::__construct();  // Invalid: recursion in constructor
+    }
+}


### PR DESCRIPTION
`PhanAccessOwnConstructor` was triggering for ALL calls to `self::__construct()`, including valid use cases like re-initialization from non-constructor methods (e.g., `unserialize()`).

Refined the warning to only trigger when `self::__construct()` is called from within a constructor, which prevents infinite recursion. Calls from other methods are now considered valid.