### PR TITLE
fix as-clause in foreach loops

### DIFF
--- a/.phan/plugins/EmptyStatementListPlugin.php
+++ b/.phan/plugins/EmptyStatementListPlugin.php
@@ -313,7 +313,7 @@ final class EmptyStatementListVisitor extends PluginAwarePostAnalysisVisitor
      * Returns true for property/array element assignments, false for simple variables.
      * For array destructuring, recursively checks if any element has side effects.
      */
-    private static function assignmentTargetHasSideEffects($target): bool
+    private static function assignmentTargetHasSideEffects(Node|string|int|float|null $target): bool
     {
         if (!$target instanceof Node) {
             return false;

--- a/.phan/plugins/EmptyStatementListPlugin.php
+++ b/.phan/plugins/EmptyStatementListPlugin.php
@@ -268,6 +268,11 @@ final class EmptyStatementListVisitor extends PluginAwarePostAnalysisVisitor
             // the while loop has statements
             return;
         }
+        // Check if the 'as' clause has side effects (assignments to properties/array elements)
+        if (self::foreachHasSideEffectsInAsClause($node)) {
+            // Don't warn if foreach assigns to properties/array elements even with empty body
+            return;
+        }
         if ($this->hasTODOComment($stmts_node->lineno, $node)) {
             // Don't warn if there is a FIXME/TODO comment in/around the empty statement list
             return;
@@ -279,6 +284,72 @@ final class EmptyStatementListVisitor extends PluginAwarePostAnalysisVisitor
             'Empty statement list detected for the foreach loop',
             []
         );
+    }
+
+    /**
+     * Check if a foreach loop has side effects in its 'as' clause.
+     * Returns true if the value or key are assigned to properties, array elements, etc.
+     * Array destructuring like [$a, $b] is NOT considered a side effect (assigns to local vars).
+     */
+    private static function foreachHasSideEffectsInAsClause(Node $node): bool
+    {
+        // Check the value assignment
+        $value = $node->children['value'];
+        if (self::assignmentTargetHasSideEffects($value)) {
+            return true;
+        }
+
+        // Check the key assignment (if present)
+        $key = $node->children['key'];
+        if (self::assignmentTargetHasSideEffects($key)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if an assignment target in a foreach has side effects.
+     * Returns true for property/array element assignments, false for simple variables.
+     * For array destructuring, recursively checks if any element has side effects.
+     */
+    private static function assignmentTargetHasSideEffects($target): bool
+    {
+        if (!$target instanceof Node) {
+            return false;
+        }
+
+        switch ($target->kind) {
+            case ast\AST_VAR:
+            case ast\AST_REF:
+                // Simple variable or reference - no external side effects
+                return false;
+
+            case ast\AST_ARRAY:
+            case ast\AST_LIST:
+                // Array destructuring - check if any element has side effects
+                foreach ($target->children as $elem) {
+                    if (!$elem instanceof Node) {
+                        continue;
+                    }
+                    // AST_ARRAY_ELEM has 'value' child with the actual assignment target
+                    $elem_value = $elem->children['value'] ?? null;
+                    if (self::assignmentTargetHasSideEffects($elem_value)) {
+                        return true;
+                    }
+                }
+                return false;
+
+            case ast\AST_PROP:
+            case ast\AST_STATIC_PROP:
+            case ast\AST_DIM:
+                // Property or array element assignment - has side effects
+                return true;
+
+            default:
+                // Other node types - conservatively assume side effects
+                return true;
+        }
     }
 
     /**

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -1190,14 +1190,18 @@ class BlockAnalysisVisitor extends AnalysisVisitor
         }
         if (self::isDefinitelyNotObject($union_type)) {
             if (!($node->children['stmts']->children ?? null)) {
-                RedundantCondition::emitInstance(
-                    $node->children['expr'],
-                    $this->code_base,
-                    (clone $this->context)->withLineNumberStart($node->children['expr']->lineno ?? $node->lineno),
-                    Issue::EmptyForeachBody,
-                    [(string)$union_type],
-                    Closure::fromCallable([self::class, 'isDefinitelyNotObject'])
-                );
+                // Check if the 'as' clause has side effects (assignments to properties/array elements)
+                // If so, don't warn about empty body - the foreach has a purpose
+                if (!self::foreachHasSideEffectsInAsClause($node)) {
+                    RedundantCondition::emitInstance(
+                        $node->children['expr'],
+                        $this->code_base,
+                        (clone $this->context)->withLineNumberStart($node->children['expr']->lineno ?? $node->lineno),
+                        Issue::EmptyForeachBody,
+                        [(string)$union_type],
+                        Closure::fromCallable([self::class, 'isDefinitelyNotObject'])
+                    );
+                }
             }
         }
     }
@@ -1214,6 +1218,72 @@ class BlockAnalysisVisitor extends AnalysisVisitor
             }
         }
         return true;
+    }
+
+    /**
+     * Check if a foreach loop has side effects in its 'as' clause.
+     * Returns true if the value or key are assigned to properties, array elements, etc.
+     * Array destructuring like [$a, $b] is NOT considered a side effect (assigns to local vars).
+     */
+    private static function foreachHasSideEffectsInAsClause(Node $node): bool
+    {
+        // Check the value assignment
+        $value = $node->children['value'];
+        if (self::assignmentTargetHasSideEffects($value)) {
+            return true;
+        }
+
+        // Check the key assignment (if present)
+        $key = $node->children['key'];
+        if (self::assignmentTargetHasSideEffects($key)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if an assignment target in a foreach has side effects.
+     * Returns true for property/array element assignments, false for simple variables.
+     * For array destructuring, recursively checks if any element has side effects.
+     */
+    private static function assignmentTargetHasSideEffects($target): bool
+    {
+        if (!$target instanceof Node) {
+            return false;
+        }
+
+        switch ($target->kind) {
+            case ast\AST_VAR:
+            case ast\AST_REF:
+                // Simple variable or reference - no external side effects
+                return false;
+
+            case ast\AST_ARRAY:
+            case ast\AST_LIST:
+                // Array destructuring - check if any element has side effects
+                foreach ($target->children as $elem) {
+                    if (!$elem instanceof Node) {
+                        continue;
+                    }
+                    // AST_ARRAY_ELEM has 'value' child with the actual assignment target
+                    $elem_value = $elem->children['value'] ?? null;
+                    if (self::assignmentTargetHasSideEffects($elem_value)) {
+                        return true;
+                    }
+                }
+                return false;
+
+            case ast\AST_PROP:
+            case ast\AST_STATIC_PROP:
+            case ast\AST_DIM:
+                // Property or array element assignment - has side effects
+                return true;
+
+            default:
+                // Other node types - conservatively assume side effects
+                return true;
+        }
     }
 
     /**

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -1247,7 +1247,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
      * Returns true for property/array element assignments, false for simple variables.
      * For array destructuring, recursively checks if any element has side effects.
      */
-    private static function assignmentTargetHasSideEffects($target): bool
+    private static function assignmentTargetHasSideEffects(Node|string|int|float|null $target): bool
     {
         if (!$target instanceof Node) {
             return false;

--- a/tests/files/expected/0902_foreach_as_side_effects.php.expected
+++ b/tests/files/expected/0902_foreach_as_side_effects.php.expected
@@ -1,0 +1,1 @@
+%s:28 PhanEmptyForeachBody Saw a foreach statement with empty body over array of type array{k1:'v1',k2:'v2',k3:'v3'} (iterating has no side effects)

--- a/tests/files/src/0902_foreach_as_side_effects.php
+++ b/tests/files/src/0902_foreach_as_side_effects.php
@@ -1,0 +1,44 @@
+<?php
+
+// Test that foreach loops with assignments in the 'as' clause are not flagged as empty
+
+class Container {
+    public ?string $key = null;
+    public ?string $value = null;
+}
+
+$container = new Container();
+$arr = ['k1' => 'v1', 'k2' => 'v2', 'k3' => 'v3'];
+
+// Valid: foreach with property assignments in as clause (has side effects)
+foreach ($arr as $container->key => $container->value) {
+}
+
+// Valid: foreach with array element assignments in as clause (has side effects)
+$result = [];
+foreach ($arr as $result['last_key'] => $result['last_value']) {
+}
+
+// Valid: foreach with value-only property assignment
+$container2 = new Container();
+foreach ($arr as $container2->value) {
+}
+
+// Invalid: foreach with simple variable assignments and empty body (truly empty, should warn)
+foreach ($arr as $k => $v) {
+}
+
+// Valid: foreach with simple variables but has body
+foreach ($arr as $k2 => $v2) {
+    echo "$k2 => $v2\n";
+}
+
+// Edge case: Mix of property and variable (should not warn - has side effect)
+$container3 = new Container();
+foreach ($arr as $k3 => $container3->value) {
+}
+
+// Edge case: Array element for key only
+$keys = [];
+foreach ($arr as $keys[] => $temp_val) {
+}


### PR DESCRIPTION
Phan was incorrectly flagging foreach loops with empty bodies as false positives when the as clause had assignments to properties or array elements:
```php
  foreach ($arr as $obj->key => $obj->value)  {
  }
```
This was getting both `PhanEmptyForeachBody` and `PhanPluginEmptyStatementForeachLoop` warnings, even though the foreach has a legitimate purpose (updating object properties).

Enhanced both `BlockAnalysisVisitor.php` and `EmptyStatementListPlugin.php` to detect when the `as` clause has side effects.