### PR TITLE
Fix #5259

### DIFF
--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -2099,13 +2099,22 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         if ($type_list_count > 1) {
             $yield_key_node = $node->children['key'];
             if ($yield_key_node === null) {
+                // When yielding without a key, PHP automatically assigns auto-incrementing integer keys.
+                // We use VoidType to represent "no explicit key", but it's compatible with int (and void).
                 $yield_key_type = VoidType::instance(false)->asRealUnionType();
             } else {
                 $yield_key_type = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $yield_key_node);
             }
-            // TODO: finalize syntax to indicate the absence of a key or value (e.g. use void instead?)
             $expected_key_type = $template_type_list[0];
-            if (!$yield_key_type->withStaticResolvedInContext($context)->canCastToUnionType($expected_key_type->withStaticResolvedInContext($context), $code_base)) {
+            // Check if the yield key type is compatible with the expected key type.
+            // Special case: VoidType (missing key) is compatible with IntType (PHP auto-increments)
+            // and with VoidType itself (no key expected).
+            $is_compatible = $yield_key_type->withStaticResolvedInContext($context)->canCastToUnionType($expected_key_type->withStaticResolvedInContext($context), $code_base);
+            if (!$is_compatible && $yield_key_node === null) {
+                // Missing key produces int keys in PHP, so void (missing key) is compatible with int
+                $is_compatible = $expected_key_type->hasType(IntType::instance(false));
+            }
+            if (!$is_compatible) {
                 $this->emitIssue(
                     Issue::TypeMismatchGeneratorYieldKey,
                     $node->lineno,

--- a/tests/files/expected/0476_generator_extended.php.expected
+++ b/tests/files/expected/0476_generator_extended.php.expected
@@ -1,8 +1,6 @@
 %s:10 PhanTypeMismatchArgumentInternal Argument 1 ($string) is $x of type array but \strlen() takes string
-%s:12 PhanTypeMismatchGeneratorYieldKey Yield statement has a key null with type void but generator_4() is declared to yield keys of type int in \Generator<int,string,array,bool>
 %s:12 PhanTypeMismatchGeneratorYieldValue Yield statement has a value false with type false but generator_4() is declared to yield values of type string in \Generator<int,string,array,bool>
 %s:17 PhanTypeMismatchReturn Returning 'invalid' of type string but generator_4() is declared to return bool
 %s:26 PhanTypeMismatchArgumentInternal Argument 1 ($string) is $x of type bool but \strlen() takes string
-%s:28 PhanTypeMismatchGeneratorYieldKey Yield statement has a key null with type void but generator_3() is declared to yield keys of type int in \Generator<int,string,bool>
 %s:28 PhanTypeMismatchGeneratorYieldValue Yield statement has a value false with type false but generator_3() is declared to yield values of type string in \Generator<int,string,bool>
 %s:45 PhanTypeMismatchReturnProbablyReal Returning 'invalid' of type string but generator_void() is declared to return void (no real type) (the inferred real return type has nothing in common with the declared phpdoc return type)

--- a/tests/files/expected/0903_generator_yield_key_types.php.expected
+++ b/tests/files/expected/0903_generator_yield_key_types.php.expected
@@ -1,0 +1,3 @@
+%s:18 PhanTypeMismatchGeneratorYieldKey Yield statement has a key null with type void but invalidStringKeyGenerator() is declared to yield keys of type string in \Generator<string,int>
+%s:20 PhanTypeMismatchGeneratorYieldKey Yield statement has a key null with type void but invalidStringKeyGenerator() is declared to yield keys of type string in \Generator<string,int>
+%s:44 PhanTypeMismatchGeneratorYieldKey Yield statement has a key 'str_key' with type 'str_key' but invalidExplicitStringKey() is declared to yield keys of type int in \Generator<int,string>

--- a/tests/files/src/0903_generator_yield_key_types.php
+++ b/tests/files/src/0903_generator_yield_key_types.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * @return Generator<int, string>
+ */
+function validIntKeyGenerator(): Generator {
+    yield 'test1';           // Valid: auto-increments to 0
+    yield 1 => 'test2';      // Valid: explicit int key
+    yield 'test3';           // Valid: auto-increments to 2
+    yield 10 => 'test4';     // Valid: explicit int key
+    yield 'test5';           // Valid: auto-increments to 11
+}
+
+/**
+ * @return Generator<string, int>
+ */
+function invalidStringKeyGenerator(): Generator {
+    yield 100;               // Invalid: int key when string expected
+    yield 'key' => 200;      // Valid: explicit string key
+    yield 300;               // Invalid: int key when string expected
+}
+
+/**
+ * @return Generator<int|string, mixed>
+ */
+function mixedKeyGenerator(): Generator {
+    yield 'test1';           // Valid: int key is part of int|string
+    yield 'key' => 'test2';  // Valid: string key is part of int|string
+    yield 123 => 'test3';    // Valid: int key is part of int|string
+}
+
+/**
+ * @return Generator<string, string>
+ */
+function explicitStringKeyGenerator(): Generator {
+    yield 'key1' => 'value1';  // Valid: explicit string key
+    yield 'key2' => 'value2';  // Valid: explicit string key
+}
+
+/**
+ * @return Generator<int, string>
+ */
+function invalidExplicitStringKey(): Generator {
+    yield 'str_key' => 'value';  // Invalid: string key when int expected
+}
+
+/**
+ * @return Generator<mixed, string>
+ */
+function mixedKeyAllowed(): Generator {
+    yield 'test1';             // Valid: int key is part of mixed
+    yield 'key' => 'test2';    // Valid: string key is part of mixed
+    yield 123 => 'test3';      // Valid: int key is part of mixed
+}


### PR DESCRIPTION
False positive `PhanTypeMismatchGeneratorYieldKey` warnings when using yield without a key in generators typed as `Generator<int, T>`.
```php
  /**
   * @return Generator<int, string>
   */
  function getItem(): Generator {
      yield 'test1';  // False positive: "key null with type void"
      yield 1 => 'test2';
      yield 'test3';  // False positive: "key null with type void"
  }
```
When yielding without a key, Phan was treating the key type as void, but void couldn't cast to int, causing false positives. In reality, PHP automatically assigns auto-incrementing integer keys when no key is provided.
Modified `PostOrderAnalysisVisitor` to:
1. Continue treating missing keys as void internally (to preserve backward compatibility with `Generator<void, T>` convention)
2. Add special logic to allow void (missing key) to be compatible with int expected key type
3. This maintains existing behavior where `Generator<void, T>` means "keys are not specified" while fixing the false positive for `Generator<int, T>`
Key Behavior:
- `Generator<int, T> + yield 'value'` → No warning (void compatible with int)
- `Generator<void, T> + yield 'value'` → No warning (void compatible with void)
- `Generator<void, T> + yield 'key' => 'value'` → Warning (explicit string key not compatible with void)
- `Generator<string, T> + yield 'value'` → Warning (void not compatible with string)