### PR TITLE
normalize types to avoid signature false positives

### DIFF
--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -1058,28 +1058,39 @@ class ParameterTypesAnalyzer
     ): void {
         $context = $method->getContext();
         $resolved_real_param_type = $real_param_type->withStaticResolvedInContext($context);
-        $is_exclusively_narrowed = true;
-        foreach ($phpdoc_param_union_type->getTypeSet() as $phpdoc_type) {
-            // Make sure that the commented type is a narrowed
-            // or equivalent form of the syntax-level declared
-            // return type.
-            if (!$phpdoc_type->isExclusivelyNarrowedFormOrEquivalentTo(
-                $resolved_real_param_type,
-                $context,
-                $code_base
-            )
-            ) {
-                $is_exclusively_narrowed = false;
-                Issue::maybeEmit(
-                    $code_base,
+
+        // Normalize both types to handle cases like ?string|?int vs string|int|null
+        // This prevents false positives when different nullability styles represent the same type
+        $normalized_phpdoc = $phpdoc_param_union_type->asNormalizedTypes();
+        $normalized_real = $resolved_real_param_type->asNormalizedTypes();
+
+        // If the normalized types are equal, they're compatible - skip individual type checks
+        if ($normalized_phpdoc->isEqualTo($normalized_real)) {
+            $is_exclusively_narrowed = true;
+        } else {
+            $is_exclusively_narrowed = true;
+            foreach ($phpdoc_param_union_type->getTypeSet() as $phpdoc_type) {
+                // Make sure that the commented type is a narrowed
+                // or equivalent form of the syntax-level declared
+                // return type.
+                if (!$phpdoc_type->isExclusivelyNarrowedFormOrEquivalentTo(
+                    $resolved_real_param_type,
                     $context,
-                    Issue::TypeMismatchDeclaredParam,
-                    self::guessCommentParamLineNumber($method, $parameter) ?: $context->getLineNumberStart(),
-                    $parameter->getName(),
-                    $method->getName(),
-                    $phpdoc_type->__toString(),
-                    $real_param_type->__toString()
-                );
+                    $code_base
+                )
+                ) {
+                    $is_exclusively_narrowed = false;
+                    Issue::maybeEmit(
+                        $code_base,
+                        $context,
+                        Issue::TypeMismatchDeclaredParam,
+                        self::guessCommentParamLineNumber($method, $parameter) ?: $context->getLineNumberStart(),
+                        $parameter->getName(),
+                        $method->getName(),
+                        $phpdoc_type->__toString(),
+                        $real_param_type->__toString()
+                    );
+                }
             }
         }
         // TODO: test edge cases of variadic signatures

--- a/tests/files/expected/0905_nullable_styles.php.expected
+++ b/tests/files/expected/0905_nullable_styles.php.expected
@@ -1,0 +1,3 @@
+%s:32 PhanTypeMismatchDeclaredParam Doc-block of $bar in test5 contains phpdoc param type ?string which is incompatible with the param type int declared in the signature
+%s:38 PhanTypeMismatchDeclaredParam Doc-block of $baz in test6 contains phpdoc param type int which is incompatible with the param type ?float declared in the signature
+%s:38 PhanTypeMismatchDeclaredParam Doc-block of $baz in test6 contains phpdoc param type string which is incompatible with the param type ?float declared in the signature

--- a/tests/files/src/0905_nullable_styles.php
+++ b/tests/files/src/0905_nullable_styles.php
@@ -1,0 +1,41 @@
+<?php
+
+// Test different nullability styles representing the same type
+
+/** @param ?string|?int $foo */
+function test1(string|int|null $foo) {
+    echo $foo;
+}
+
+/** @param string|int|null $foo */
+function test2(string|int|null $foo) {
+    echo $foo;
+}
+
+/** @param int|null $foo */
+function test3(?int $foo) {
+    echo $foo;
+}
+
+/** @param string|int|null $foo */
+function test4(string|int|null $foo) {
+    echo $foo;
+}
+
+// Closure test from original issue
+/** @param ?string|?int $foo */
+( function(string|int|null $foo) {
+    echo $foo;
+} )( 42 );
+
+// This should still warn - incompatible types
+/** @param ?string $bar */
+function test5(int $bar) {
+    echo $bar;
+}
+
+// This should still warn - incompatible types
+/** @param string|int $baz */
+function test6(?float $baz) {
+    echo $baz;
+}


### PR DESCRIPTION
Bug #5142: When a PHPDoc comment used `?string|?int` (multiple nullable types) and the function signature used `string|int|null` (union with explicit null), Phan incorrectly reported them as incompatible, even though they represent the same type.
Modified `tryToAssignPHPDocTypeToParameter()` to normalize both the PHPDoc union type and the real parameter type using `asNormalizedTypes()` before comparison