### PR TITLE
Fix 5269

### DIFF
--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -111,6 +111,15 @@ class ConditionVisitor extends KindVisitorImplementation implements ConditionVis
      */
     protected function checkVariablesDefined(Node $node): void
     {
+        // Fix for issue #5269: When recursively analyzing stored conditional expressions
+        // (e.g., $var = $x === foo(); if ($var) { ... }), skip variable definition checks.
+        // The variables were already checked when the expression was originally assigned.
+        // Re-checking with the current context can produce false positives for variables
+        // that were defined in a different scope.
+        if (self::$conditional_expr_depth > 0) {
+            return;
+        }
+
         while ($node->kind === ast\AST_UNARY_OP) {
             $node = $node->children['expr'];
             if (!($node instanceof Node)) {

--- a/tests/files/expected/0906_array_key_exists_optional.php.expected
+++ b/tests/files/expected/0906_array_key_exists_optional.php.expected
@@ -1,0 +1,4 @@
+%s:15 PhanTypePossiblyInvalidDimOffset Possibly invalid offset 'value' of $input of array type array{inputko?:int,name?:string,value?:string}
+%s:37 PhanTypeInvalidDimOffset Invalid offset "key" of $arr of array type array{}
+%s:37 PhanTypeSuspiciousEcho Suspicious argument $arr['key'] of type null for an echo/print statement
+%s:49 PhanTypePossiblyInvalidDimOffset Possibly invalid offset 'optional' of $mixed of array type array{optional?:string,required:int}

--- a/tests/files/expected/0907_possibly_undeclared_false_positive.php.expected
+++ b/tests/files/expected/0907_possibly_undeclared_false_positive.php.expected
@@ -1,0 +1,4 @@
+%s:14 PhanPossiblyUndeclaredVariable Variable $possiblyUndeclared is possibly undeclared
+%s:24 PhanSuspiciousValueComparison Suspicious attempt to compare $n2 of type int (value: 42) to 5 of type int (value: 5) with operator '==='
+%s:27 PhanPossiblyUndeclaredVariable Variable $possiblyUndeclared2 is possibly undeclared
+%s:37 PhanUnusedVariable Unused definition of variable $possiblyUndeclared3

--- a/tests/files/src/0906_array_key_exists_optional.php
+++ b/tests/files/src/0906_array_key_exists_optional.php
@@ -1,0 +1,58 @@
+<?php
+
+// Test that array_key_exists properly narrows optional array shape keys
+
+/**
+ * @param array{inputko?:int,name?:string,value?:string} $input
+ */
+function test_array_key_exists($input) {
+    // This should NOT warn - array_key_exists makes 'inputko' non-optional
+    if (array_key_exists('inputko', $input) && $input['inputko'] == 1) {
+        echo $input['inputko'];
+    }
+
+    // This SHOULD warn - 'value' is still optional
+    echo $input['value'];
+}
+
+/**
+ * @param array{name?:null|string,inputko?:int} $data
+ */
+function test_combined_checks($data) {
+    // Both checks should make the keys non-optional
+    if (array_key_exists('inputko', $data) && $data['inputko'] == 1 && isset($data['name'])) {
+        // This should NOT warn
+        echo $data['name'];
+        // This should NOT warn
+        echo $data['inputko'];
+    }
+}
+
+/**
+ * @param array{key?:int} $arr
+ */
+function test_negated_array_key_exists($arr) {
+    if (!array_key_exists('key', $arr)) {
+        // This SHOULD warn - key is still possibly undefined in the negated branch
+        echo $arr['key'];
+    } else {
+        // This should NOT warn
+        echo $arr['key'];
+    }
+}
+
+/**
+ * @param array{optional?:string,required:int} $mixed
+ */
+function test_mixed_optional_required($mixed) {
+    // This SHOULD warn - 'optional' is optional
+    echo $mixed['optional'];
+
+    // This should NOT warn - 'required' is required
+    echo $mixed['required'];
+
+    if (array_key_exists('optional', $mixed)) {
+        // This should NOT warn - 'optional' is now non-optional
+        echo $mixed['optional'];
+    }
+}

--- a/tests/files/src/0907_possibly_undeclared_false_positive.php
+++ b/tests/files/src/0907_possibly_undeclared_false_positive.php
@@ -1,0 +1,39 @@
+<?php
+
+// Test for issue #5269 - False positive PhanPossiblyUndeclaredVariable
+// when a function call is involved and a later statement uses an undeclared variable
+
+// This triggers the bug: combination of strlen() call and second if using undeclared var
+( function ( string $s ) {
+	if ( rand() ) {
+		$n = 42;
+		// FALSE POSITIVE: $n is declared on the previous line
+		$possiblyUndeclared = ( $n === strlen( $s ) );
+	}
+	// CORRECT: $possiblyUndeclared may not be declared
+	if ( $possiblyUndeclared ) {
+		return;
+	}
+} )( 'foo' );
+
+// Without strlen(), the false positive doesn't occur
+( function ( string $s ) {
+	if ( rand() ) {
+		$n2 = 42;
+		// This should NOT warn - $n2 is clearly declared
+		$possiblyUndeclared2 = ( $n2 === 5 );
+	}
+	// This SHOULD warn - $possiblyUndeclared2 may not be declared
+	if ( $possiblyUndeclared2 ) {
+		return;
+	}
+} )( 'foo' );
+
+// Without the second if, no false positive
+( function ( string $s ) {
+	if ( rand() ) {
+		$n3 = 42;
+		// This should NOT warn
+		$possiblyUndeclared3 = ( $n3 === strlen( $s ) );
+	}
+} )( 'foo' );


### PR DESCRIPTION
  The bug occurred when all three conditions were met:
  1. A variable was assigned within an if block (e.g., `$n = 42;`)
  2. That variable was used in an expression with a function call (e.g., `$n === strlen($s)`)
  3. A later if statement used a different possibly undeclared variable (e.g., `if ($possiblyUndeclared)`)

  The issue was in `ConditionVisitor::visitVar()`. When analyzing `if ($possiblyUndeclared)`, Phan would:
  1. Find that `$possiblyUndeclared` was assigned from a conditional expression
  2. Re-analyze that stored expression to narrow types
  3. But use the CURRENT context (after the first if block), not the original context
  4. In that context, `$n` was possibly undefined, causing a false positive

  Modified `ConditionVisitor::checkVariablesDefined()` to skip variable definition checks when recursively analyzing stored conditional expressions (when
  `$conditional_expr_depth > 0`). The variables were already checked when the expression was originally assigned, so re-checking with a different context
  produces false positives.