### PR TITLE
better error messages for parameter and property defaults

### DIFF
--- a/src/Phan/Language/Element/Parameter.php
+++ b/src/Phan/Language/Element/Parameter.php
@@ -807,10 +807,13 @@ class Parameter extends Variable
                 $default_repr = ASTReverter::toShortString($default_value);
             } elseif ($kind === ast\AST_NAME) {
                 $default_repr = (string)$default_value->children['name'];
-            } elseif ($kind === ast\AST_ARRAY) {
-                return '[]';
             } else {
-                return 'unknown';
+                // Use ASTReverter for all other node types (binary ops, unary ops, arrays, casts, etc.)
+                $default_repr = ASTReverter::toShortString($default_value);
+                // Limit the length to keep error messages readable
+                if (strlen($default_repr) >= 50) {
+                    return 'unknown';
+                }
             }
         } else {
             $default_repr = StringUtil::varExportPretty($default_value);
@@ -870,10 +873,13 @@ class Parameter extends Variable
                     $default_repr = ASTReverter::toShortString($default_value);
                 } elseif ($kind === ast\AST_NAME) {
                     $default_repr = (string)$default_value->children['name'];
-                } elseif ($kind === ast\AST_ARRAY) {
-                    $default_repr = '[]';
                 } else {
-                    $default_repr = 'unknown';
+                    // Use ASTReverter for all other node types (binary ops, unary ops, arrays, casts, etc.)
+                    $default_repr = ASTReverter::toShortString($default_value);
+                    // Limit the length to keep error messages readable
+                    if (strlen($default_repr) >= 50) {
+                        $default_repr = 'unknown';
+                    }
                 }
             } else {
                 $default_repr = StringUtil::varExportPretty($default_value);

--- a/tests/files/expected/0868_param_default_rendering.php.expected
+++ b/tests/files/expected/0868_param_default_rendering.php.expected
@@ -1,1 +1,1 @@
-%s:10 PhanParamTooFew Call with 0 arg(s) to \X::test(int $x, bool $flag = true, int $y = self::X, int $z = unknown) which requires 1 arg(s) defined at %s:6
+%s:10 PhanParamTooFew Call with 0 arg(s) to \X::test(int $x, bool $flag = true, int $y = self::X, int $z = (2 + 2)) which requires 1 arg(s) defined at %s:6


### PR DESCRIPTION
Enhance Parameter::generateDefaultNodeRepresentation() to provide better error messages for parameter and property defaults