### PR TITLE
Minor map scope fix

### DIFF
--- a/src/Phan/Analysis/ConditionVisitorUtil.php
+++ b/src/Phan/Analysis/ConditionVisitorUtil.php
@@ -1497,7 +1497,7 @@ trait ConditionVisitorUtil
         $variable_name = (string)$var_name_node;
 
         if (!$context->getScope()->hasVariableWithName($variable_name)) {
-            // FIXME other uses were not sound for $argv outside of global scope.
+            // Handle hardcoded variables: superglobals work in any scope, $argv/$argc only in global scope.
             $is_in_global_scope = $context->isInGlobalScope();
             $new_type = Variable::getUnionTypeOfHardcodedVariableInScopeWithName($variable_name, $is_in_global_scope);
             if ($new_type) {

--- a/src/Phan/Language/Element/Variable.php
+++ b/src/Phan/Language/Element/Variable.php
@@ -236,7 +236,9 @@ class Variable extends UnaddressableTypedElement implements TypedElementInterfac
         if (\array_key_exists($name, $is_in_global_scope ? self::_BUILTIN_GLOBAL_TYPES : self::_BUILTIN_SUPERGLOBAL_TYPES)) {
             // More efficient than using context.
             // Note that global constants can be modified by user code
-            return UnionType::fromFullyQualifiedPHPDocString(self::_BUILTIN_GLOBAL_TYPES[$name]);
+            return UnionType::fromFullyQualifiedPHPDocString(
+                ($is_in_global_scope ? self::_BUILTIN_GLOBAL_TYPES : self::_BUILTIN_SUPERGLOBAL_TYPES)[$name]
+            );
         }
 
         if (($is_in_global_scope && \array_key_exists($name, Config::getValue('globals_type_map')))


### PR DESCRIPTION
  In Variable.php:239, the code was always using self::_BUILTIN_GLOBAL_TYPES[$name] even when checking _BUILTIN_SUPERGLOBAL_TYPES for non-global scopes.
  This was a latent bug that didn't cause issues in practice because:
  - All superglobals are duplicated in both maps with identical types
  - $argv/$argc don't match the condition when not in global scope

  The Fix

  File: src/Phan/Language/Element/Variable.php (lines 236-241)

  Changed from:
```php
  if (\array_key_exists($name, $is_in_global_scope ? self::_BUILTIN_GLOBAL_TYPES : self::_BUILTIN_SUPERGLOBAL_TYPES)) {
      return UnionType::fromFullyQualifiedPHPDocString(self::_BUILTIN_GLOBAL_TYPES[$name]);
  }
```
  To:
```php
  if (\array_key_exists($name, $is_in_global_scope ? self::_BUILTIN_GLOBAL_TYPES : self::_BUILTIN_SUPERGLOBAL_TYPES)) {
      return UnionType::fromFullyQualifiedPHPDocString(
          ($is_in_global_scope ? self::_BUILTIN_GLOBAL_TYPES : self::_BUILTIN_SUPERGLOBAL_TYPES)[$name]
      );
  }
```
  File: src/Phan/Analysis/ConditionVisitorUtil.php (line 1500)

  Removed the FIXME and replaced it with a clarifying comment explaining the correct behavior.