### PR TITLE
isset() and empty() shouldn't warn on undefined properties

### DIFF
--- a/.phan/plugins/ConstantVariablePlugin.php
+++ b/.phan/plugins/ConstantVariablePlugin.php
@@ -39,7 +39,6 @@ class ConstantVariableVisitor extends PluginAwarePostAnalysisVisitor
     /** @override */
     public function visitVar(Node $node): void
     {
-        // @phan-suppress-next-line PhanUndeclaredProperty
         if ($node->flags & PhanAnnotationAdder::FLAG_INITIALIZES || isset($node->is_reference)) {
             return;
         }

--- a/.phan/plugins/DuplicateExpressionPlugin.php
+++ b/.phan/plugins/DuplicateExpressionPlugin.php
@@ -436,14 +436,12 @@ class RedundantNodePreAnalysisVisitor extends PluginAwarePreAnalysisVisitor
             // There can't be any duplicates.
             return;
         }
-        // @phan-suppress-next-line PhanUndeclaredProperty
         if (isset($node->is_inside_else)) {
             return;
         }
         $children = self::extractIfElseifChain($node);
         // The checks of visitIf are done in pre-order (parent nodes analyzed before child nodes)
         // so that checked_duplicate_if can be set, to avoid redundant work.
-        // @phan-suppress-next-line PhanUndeclaredProperty
         if (isset($node->checked_duplicate_if)) {
             return;
         }

--- a/.phan/plugins/EmptyStatementListPlugin.php
+++ b/.phan/plugins/EmptyStatementListPlugin.php
@@ -78,7 +78,6 @@ final class EmptyStatementListVisitor extends PluginAwarePostAnalysisVisitor
      */
     public function visitIf(Node $node): void
     {
-        // @phan-suppress-next-line PhanUndeclaredProperty set by ASTSimplifier
         if (isset($node->is_simplified)) {
             $first_child = end($node->children);
             if (!$first_child instanceof Node || $first_child->children['cond'] === null) {

--- a/.phan/plugins/FFIAnalysisPlugin.php
+++ b/.phan/plugins/FFIAnalysisPlugin.php
@@ -121,7 +121,6 @@ class FFIPostAnalysisVisitor extends PluginAwarePostAnalysisVisitor
      */
     public function visitAssign(Node $node): void
     {
-        // @phan-suppress-next-line PhanUndeclaredProperty
         if (isset($node->is_ffi)) {
             $this->analyzeFFIAssign($node);
         }

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -1767,24 +1767,26 @@ class ContextNode
                 $suggestion = IssueFixSuggester::suggestSimilarProperty($this->code_base, $this->context, $class, $property_name, $is_static);
             }
 
-            if ($is_static) {
-                throw new IssueException(
-                    Issue::fromType(Issue::UndeclaredStaticProperty)(
-                        $this->context->getFile(),
-                        $node->lineno,
-                        [ $property_name, (string)$class_fqsen ],
-                        $suggestion
-                    )
-                );
-            } else {
-                throw new IssueException(
-                    Issue::fromType(Issue::UndeclaredProperty)(
-                        $this->context->getFile(),
-                        $node->lineno,
-                        [ "$class_fqsen->$property_name" ],
-                        $suggestion
-                    )
-                );
+            if (!($node->flags & PhanAnnotationAdder::FLAG_IGNORE_UNDEF_IN_ISSET_EMPTY)) {
+                if ($is_static) {
+                    throw new IssueException(
+                        Issue::fromType(Issue::UndeclaredStaticProperty)(
+                            $this->context->getFile(),
+                            $node->lineno,
+                            [ $property_name, (string)$class_fqsen ],
+                            $suggestion
+                        )
+                    );
+                } else {
+                    throw new IssueException(
+                        Issue::fromType(Issue::UndeclaredProperty)(
+                            $this->context->getFile(),
+                            $node->lineno,
+                            [ "$class_fqsen->$property_name" ],
+                            $suggestion
+                        )
+                    );
+                }
             }
         }
 

--- a/src/Phan/AST/PhanAnnotationAdder.php
+++ b/src/Phan/AST/PhanAnnotationAdder.php
@@ -35,6 +35,7 @@ class PhanAnnotationAdder
     public const FLAG_INITIALIZES = 1 << 28;
     public const FLAG_IGNORE_NULLABLE = 1 << 29;
     public const FLAG_IGNORE_UNDEF = 1 << 30;
+    public const FLAG_IGNORE_UNDEF_IN_ISSET_EMPTY = 1 << 27;
 
     public const FLAG_IGNORE_NULLABLE_AND_UNDEF = self::FLAG_IGNORE_UNDEF | self::FLAG_IGNORE_NULLABLE;
 
@@ -157,13 +158,22 @@ class PhanAnnotationAdder
         };
 
         /**
-         * @param Node $node
-         * @return void
+         * Handler for isset() - also marks nodes to suppress undeclared property warnings
          */
-        $ignore_nullable_and_undef_expr_handler = static function (Node $node): void {
+        $isset_handler = static function (Node $node): void {
+            $inner_node = $node->children['var'];
+            if ($inner_node instanceof Node) {
+                self::markNode($inner_node, self::FLAG_IGNORE_NULLABLE_AND_UNDEF | self::FLAG_IGNORE_UNDEF_IN_ISSET_EMPTY);
+            }
+        };
+
+        /**
+         * Handler for empty() - also marks nodes to suppress undeclared property warnings
+         */
+        $empty_handler = static function (Node $node): void {
             $inner_node = $node->children['expr'];
             if ($inner_node instanceof Node) {
-                self::markNode($inner_node, self::FLAG_IGNORE_NULLABLE_AND_UNDEF);
+                self::markNode($inner_node, self::FLAG_IGNORE_NULLABLE_AND_UNDEF | self::FLAG_IGNORE_UNDEF_IN_ISSET_EMPTY);
             }
         };
         /**
@@ -186,8 +196,8 @@ class PhanAnnotationAdder
             ast\AST_ASSIGN_OP => $assign_op_handler,
             ast\AST_DIM => $dim_handler,
             ast\AST_PROP => $prop_handler,
-            ast\AST_EMPTY => $ignore_nullable_and_undef_expr_handler,
-            ast\AST_ISSET => $ignore_nullable_and_undef_handler,
+            ast\AST_EMPTY => $empty_handler,
+            ast\AST_ISSET => $isset_handler,
             ast\AST_UNSET => $ignore_nullable_and_undef_handler,
             ast\AST_ASSIGN => $initializes_handler,
             ast\AST_ASSIGN_REF => $initializes_handler,

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -2464,7 +2464,6 @@ class UnionTypeVisitor extends AnalysisVisitor
      *
      * @throws IssueException
      * if the unpack is on an invalid expression
-     * @suppress PhanUndeclaredProperty
      */
     public function visitUnpack(Node $node): UnionType
     {

--- a/src/Phan/Analysis/ArgumentType.php
+++ b/src/Phan/Analysis/ArgumentType.php
@@ -384,7 +384,6 @@ final class ArgumentType
             return false;
         }
         // Suppress because we intentionally set this dynamic analyzer flag in a plugin.
-        /** @phan-suppress-next-line PhanUndeclaredProperty */
         return !empty($node->__phan_skip_param_too_few_unpack);
     }
 

--- a/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
@@ -105,7 +105,6 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
                     $element_types = $array_type->genericArrayElementTypes(true, $code_base);
                     if (!$element_types->isEmpty()) {
                         // We set __phan_is_nonempty because the return type is computed after the original variable type is changed.
-                        // @phan-suppress-next-line PhanUndeclaredProperty
                         if ($array_type->containsFalsey() && !isset($arg_node->__phan_is_nonempty)) {
                             // This array can be empty, so these helpers can return false/null.
                             return $element_types->withType($default_type);
@@ -381,7 +380,6 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
             foreach ($function_like_list as $mapping_function) {
                 $mapping_node = $mapping_function->getNode();
                 if ($mapping_node instanceof Node) {
-                    /** @phan-suppress-next-line PhanUndeclaredProperty */
                     if (isset($mapping_node->__phan_skip_param_too_few_unpack)) {
                         /** @phan-suppress-next-line PhanUndeclaredProperty */
                         unset($mapping_node->__phan_skip_param_too_few_unpack);

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableGraph.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableGraph.php
@@ -109,7 +109,6 @@ final class VariableGraph
         }
         $node_id = \spl_object_id($node);
         $this->use_node_id_to_var_name[$node_id] = $name;
-        // @phan-suppress-next-line PhanUndeclaredProperty added by ArgumentType analyzer
         if (isset($node->is_reference)) {
             $this->markAsReference($name);
         }

--- a/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
+++ b/src/Phan/Plugin/Internal/VariableTracker/VariableTrackerVisitor.php
@@ -501,9 +501,6 @@ final class VariableTrackerVisitor extends AnalysisVisitor
         return $this->scope;
     }
 
-    /**
-     * @suppress PhanUndeclaredProperty
-     */
     private function analyzePropAssignmentTarget(Node $node): VariableTrackingScope
     {
         // Treat $y in `$x->$y = $z;` as a usage of $y
@@ -539,10 +536,8 @@ final class VariableTrackerVisitor extends AnalysisVisitor
                     //
                     // TODO: More aggressively warn if there is only a single dimension to $x
                     self::$variable_graph->recordVariableUsage($name, $expr, $this->scope);
-                    // @phan-suppress-next-line PhanUndeclaredProperty
                     if (isset($expr->phan_is_assignment_to_real_array)) {
                         self::$variable_graph->recordVariableDefinition($name, $expr, $this->scope, null);
-                    // @phan-suppress-next-line PhanUndeclaredProperty
                     } elseif (isset($node->is_unset_target)) {
                         self::$variable_graph->markAsUnset($expr);
                         self::$variable_graph->recordVariableDefinition($name, $expr, $this->scope, null);
@@ -680,9 +675,7 @@ final class VariableTrackerVisitor extends AnalysisVisitor
         $name = $node->children['name'];
         if (\is_string($name)) {
             self::$variable_graph->recordVariableUsage($name, $node, $this->scope);
-            // @phan-suppress-next-line PhanUndeclaredProperty
             if ($node === $this->top_level_statement || isset($node->modified_by_reference)) {
-                // @phan-suppress-next-line PhanUndeclaredProperty
                 if (isset($node->modified_by_reference)) {
                     self::$variable_graph->markAsDisabledWarnings($node);
                 }
@@ -717,7 +710,6 @@ final class VariableTrackerVisitor extends AnalysisVisitor
                     continue;
                 }
             }
-            // @phan-suppress-next-line PhanUndeclaredProperty set by ArgumentType analyzer
             if (!isset($argument->is_reference)) {
                 continue;
             }
@@ -1226,7 +1218,6 @@ final class VariableTrackerVisitor extends AnalysisVisitor
 
     private function checkIsSideEffectFreeLoopNode(Node $node): void
     {
-        // @phan-suppress-next-line PhanUndeclaredProperty
         if (isset($node->has_loop_body_without_side_effects)) {
             $this->side_effect_free_loop_nodes[] = $node;
         }

--- a/tests/files/expected/0839_undefined_global.php.expected
+++ b/tests/files/expected/0839_undefined_global.php.expected
@@ -1,6 +1,5 @@
 %s:2 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type \ArrayObject(real=\ArrayObject)
 %s:2 PhanUndeclaredGlobalVariable Global variable $x is undeclared
 %s:5 PhanUndeclaredThis Variable $this is undeclared
-%s:6 PhanTypeMismatchArgumentInternal%SReal Argument 1 ($string) is $this of type \ArrayAccess|\ArrayObject|\Countable|\IteratorAggregate|\Serializable|\Traversable|iterable but \strlen() takes string
-%s:8 PhanUndeclaredProperty Reference to undeclared property \ArrayObject->prop
+%s:6 PhanTypeMismatchArgumentInternalReal Argument 1 ($string) is $this of type \ArrayAccess|\ArrayObject|\Countable|\IteratorAggregate|\Serializable|\Traversable|iterable but \strlen() takes string
 %s:10 PhanUndeclaredProperty Reference to undeclared property \ArrayObject->prop2

--- a/tests/files/expected/5256_isset_empty_undefined.php.expected
+++ b/tests/files/expected/5256_isset_empty_undefined.php.expected
@@ -1,0 +1,4 @@
+%s:12 PhanUndeclaredProperty Reference to undeclared property \C->undefined
+%s:15 PhanImpossibleCondition Impossible attempt to cast $undefined_var of type null to isset
+%s:19 PhanTypeSuspiciousEcho Suspicious argument $undefined_var2 of type null= for an echo/print statement
+%s:19 PhanUndeclaredVariable Variable $undefined_var2 is undeclared (Did you mean $undefined_var)

--- a/tests/files/src/5256_isset_empty_undefined.php
+++ b/tests/files/src/5256_isset_empty_undefined.php
@@ -1,0 +1,21 @@
+<?php
+
+class C {
+    public int $existing = 1;
+
+    function test() {
+        // These should NOT warn - isset/empty are designed to check existence
+        if (isset($this->undefined)) echo "A\n";
+        if (empty($this->undefined)) echo "B\n";
+
+        // This SHOULD warn - normal property access outside isset/empty
+        echo $this->undefined;
+
+        // These should NOT warn - checking variables in isset/empty
+        if (isset($undefined_var)) echo "C\n";
+        if (empty($undefined_var)) echo "D\n";
+
+        // This SHOULD warn - using variable outside isset/empty
+        echo $undefined_var2;
+    }
+}


### PR DESCRIPTION
The fix ensures Phan follows PHP's intended behavior where isset() and empty() are meant to check for existence without triggering warnings, while still catching potential bugs in unset() and normal property access. technically PHP doesn't warn on an undefined property in an unset(), but this one seems more like a potential bug. But I may revisit that later.