### PR TITLE
fix static property type narrowing for type-check functions

### DIFF
--- a/src/Phan/Analysis/ConditionVisitorUtil.php
+++ b/src/Phan/Analysis/ConditionVisitorUtil.php
@@ -1641,6 +1641,9 @@ trait ConditionVisitorUtil
                         return $this->modifyPropertyOfVariable($node, $type_modification_callback, $context, $args);
                     }
                     return $context;
+                case ast\AST_STATIC_PROP:
+                    // Handle self::$prop and static::$prop for type checks like is_null(self::$instance)
+                    return $this->modifyStaticPropertyOfSelfOrStatic($node, $type_modification_callback, $context, $args);
                 case ast\AST_ASSIGN:
                 case ast\AST_ASSIGN_REF:
                     $var_node = $node->children['var'];
@@ -1788,6 +1791,37 @@ trait ConditionVisitorUtil
 
         // Store the narrowed property type in the context
         return $context->withVariablePropertySetToTypeByName($variable_name, $property_name, $new_property_type);
+    }
+
+    /**
+     * Handle type checks like is_null(self::$instance) and update the context with narrowed static property type.
+     *
+     * @param Node $node a node of kind ast\AST_STATIC_PROP (e.g. the argument of is_null(self::$instance))
+     * @param Closure(CodeBase,Context,Variable,list<mixed>):void $type_modification_callback
+     *        A closure acting on a Variable instance (not really a variable) to modify its type
+     *
+     *        This is a function such as is_array, is_null, etc.
+     * @param Context $context
+     * @param list<mixed> $args
+     */
+    protected function modifyStaticPropertyOfSelfOrStatic(Node $node, Closure $type_modification_callback, Context $context, array $args): Context
+    {
+        if (!self::isSelfOrStaticClassNode($node->children['class'])) {
+            return $context;
+        }
+        $property_name = $node->children['prop'];
+        if (!is_string($property_name)) {
+            return $context;
+        }
+        // Give the static property a type and compute the new type
+        $old_property_type = UnionTypeVisitor::unionTypeFromNode($this->code_base, $context, $node);
+        $property_variable = new Variable($context, "__phan", $old_property_type, 0);
+        $type_modification_callback($this->code_base, $context, $property_variable, $args);
+        $new_property_type = $property_variable->getUnionType();
+        if ($new_property_type->isIdenticalTo($old_property_type)) {
+            return $context;
+        }
+        return $context->withStaticPropertySetToTypeByName($property_name, $new_property_type);
     }
 
     /**

--- a/tests/files/expected/5257_static_property_narrowing.php.expected
+++ b/tests/files/expected/5257_static_property_narrowing.php.expected
@@ -1,0 +1,5 @@
+%s:22 PhanStaticPropIsStaticType Static property \Singleton::$instance is declared to have type null|static, but the only instance is shared among all subclasses (Did you mean \Singleton|null)
+%s:65 PhanTypeMismatchArgumentInternalReal Argument 1 ($string) is self::$stringOrNull of type null but \strlen() takes string
+%s:79 PhanTypeMismatchArgumentInternalReal Argument 1 ($string) is self::$stringOrNull of type null but \strlen() takes string
+%s:103 PhanUnusedVariable Unused definition of variable $hash
+%s:110 PhanStaticPropIsStaticType Static property \StaticKeywordTest::$instanceStatic is declared to have type null|static, but the only instance is shared among all subclasses (Did you mean \StaticKeywordTest|null)

--- a/tests/files/src/5257_static_property_narrowing.php
+++ b/tests/files/src/5257_static_property_narrowing.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * Test that static properties are narrowed correctly with type-check functions.
+ */
+
+interface SingletonInterface
+{
+    /**
+     * @return static
+     */
+    public static function getInstance(): static;
+
+    /**
+     * @param static|null $instance
+     */
+    public static function setInstance($instance): void;
+}
+
+class Singleton implements SingletonInterface
+{
+    /** @var static|null */
+    private static $instance = null;
+
+    public static function getInstance(): static
+    {
+        // After this check, self::$instance should be narrowed to exclude null
+        if (is_null(self::$instance)) {
+            self::$instance = new static();
+        }
+
+        // Should NOT warn - type is narrowed to static (non-null)
+        return self::$instance;
+    }
+
+    public static function setInstance($instance): void
+    {
+        self::$instance = $instance;
+    }
+
+    public static function resetInstance(): void
+    {
+        self::setInstance(null);
+    }
+}
+
+class TypeNarrowingTests
+{
+    /** @var string|null */
+    private static $stringOrNull = null;
+
+    /** @var array|null */
+    private static $arrayOrNull = null;
+
+    /** @var object|null */
+    private static $objectOrNull = null;
+
+    /** @var mixed */
+    private static $mixed;
+
+    public static function testIsNull(): void
+    {
+        if (is_null(self::$stringOrNull)) {
+            // In this branch, type should be null
+            echo strlen(self::$stringOrNull); // Should warn - type is null
+        } else {
+            // In this branch, type should be string (non-null)
+            echo strlen(self::$stringOrNull); // Should NOT warn
+        }
+    }
+
+    public static function testNotIsNull(): void
+    {
+        if (!is_null(self::$stringOrNull)) {
+            // In this branch, type should be string (non-null)
+            echo strlen(self::$stringOrNull); // Should NOT warn
+        } else {
+            // In this branch, type should be null
+            echo strlen(self::$stringOrNull); // Should warn - type is null
+        }
+    }
+
+    public static function testIsString(): void
+    {
+        if (is_string(self::$mixed)) {
+            // In this branch, type should be string
+            echo strlen(self::$mixed); // Should NOT warn
+        }
+    }
+
+    public static function testIsArray(): void
+    {
+        if (is_array(self::$arrayOrNull)) {
+            // In this branch, type should be array (non-null)
+            echo count(self::$arrayOrNull); // Should NOT warn
+        }
+    }
+
+    public static function testIsObject(): void
+    {
+        if (is_object(self::$objectOrNull)) {
+            // In this branch, type should be object (non-null)
+            $hash = spl_object_hash(self::$objectOrNull); // Should NOT warn
+        }
+    }
+}
+
+class StaticKeywordTest
+{
+    /** @var static|null */
+    protected static $instanceStatic = null;
+
+    public static function getInstanceStatic(): static
+    {
+        if (is_null(static::$instanceStatic)) {
+            static::$instanceStatic = new static();
+        }
+
+        // Should NOT warn - type is narrowed to static (non-null)
+        return static::$instanceStatic;
+    }
+}


### PR DESCRIPTION
There was a missed `AST_PROP` case in `modifyComplexExpression()` which meant a check on `self::$instance !== null` would work to narrow the type but `!is_null(self::$instance)` did not.