### PR TITLE
allow mixed to satisfy template constraints

### DIFF
--- a/src/Phan/Language/Type/TemplateType.php
+++ b/src/Phan/Language/Type/TemplateType.php
@@ -258,8 +258,14 @@ final class TemplateType extends Type
         if ($bound->isEmpty()) {
             return true;
         }
-        if ($actual->isEmpty() || $actual->hasMixedOrNonEmptyMixedType()) {
+        if ($actual->isEmpty()) {
             return false;
+        }
+        // Allow mixed types to satisfy bounds (consistent with regular type checking).
+        // Mixed could be compatible with any type at runtime, so we don't warn.
+        // This minimizes false positives when type information is unavailable.
+        if ($actual->hasMixedOrNonEmptyMixedType()) {
+            return true;
         }
 
         foreach ($actual->getTypeSet() as $type) {

--- a/tests/files/expected/5258_template_mixed_types.php.expected
+++ b/tests/files/expected/5258_template_mixed_types.php.expected
@@ -1,0 +1,2 @@
+%s:49 PhanUnusedVariable Unused definition of variable $obj3
+%s:52 PhanUnusedVariable Unused definition of variable $obj4

--- a/tests/files/src/5258_template_mixed_types.php
+++ b/tests/files/src/5258_template_mixed_types.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * Test that mixed types are allowed to satisfy template constraints (issue #5274).
+ * This ensures consistency with how regular typed parameters handle mixed types.
+ */
+
+class TestClass {}
+
+/**
+ * @template T of TestClass
+ * @param class-string<T> $class
+ * @return T
+ */
+function getObjectByClass(string $class) {
+    return new $class;
+}
+
+/**
+ * Regular function with typed parameter for comparison
+ */
+function takesObject(TestClass $class): int {
+    return 42;
+}
+
+// Should NOT warn - mixed could be compatible with template constraint
+// Previously would emit: PhanTemplateTypeConstraintViolation
+$obj1 = getObjectByClass($GLOBALS['x']);
+
+// Should NOT warn - for consistency with template function above
+$result1 = takesObject($GLOBALS['x']);
+
+// Test with explicit mixed annotation
+/** @var mixed $mixed */
+$mixed = getMixed();
+
+// Should NOT warn - mixed satisfies template constraint
+$obj2 = getObjectByClass($mixed);
+
+// Should NOT warn - mixed satisfies regular type
+$result2 = takesObject($mixed);
+
+/**
+ * Test with multiple mixed sources
+ */
+function testVariousMixedSources(): void {
+    // Array access of mixed type
+    $arr = getArray();
+    $obj3 = getObjectByClass($arr['key']);
+
+    // Function return of mixed type
+    $obj4 = getObjectByClass(getMixedValue());
+}
+
+/**
+ * @template T of TestClass
+ * @param T $instance
+ * @return T
+ */
+function identity($instance) {
+    return $instance;
+}
+
+// Should NOT warn - mixed satisfies constraint
+$obj6 = identity($GLOBALS['y']);
+
+/**
+ * @return mixed
+ */
+function getMixed() {
+    return null;
+}
+
+/**
+ * @return array
+ */
+function getArray(): array {
+    return [];
+}
+
+/**
+ * @return mixed
+ */
+function getMixedValue() {
+    return null;
+}


### PR DESCRIPTION
Fix for bug 5274
Mixed was accepted for regular typed parameters but rejected for template constraints which was not consistent and produced false positives which goes against Phan's mission.