### PR TITLE
enhance type inference for get_class()

### DIFF
--- a/src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php
@@ -15,6 +15,7 @@ use Phan\Language\FQSEN\FullyQualifiedGlobalConstantName;
 use Phan\Language\Type;
 use Phan\Language\Type\ArrayShapeType;
 use Phan\Language\Type\CallableArrayType;
+use Phan\Language\Type\ClassStringType;
 use Phan\Language\Type\FloatType;
 use Phan\Language\Type\IntType;
 use Phan\Language\Type\LiteralIntType;
@@ -425,6 +426,41 @@ final class DependentReturnTypeOverridePlugin extends PluginV3 implements
             );
         };
 
+        /**
+         * get_class() return type handler - infers class-string<T> based on argument type
+         * Issue #5275 - Improve type inference for get_class
+         *
+         * @param list<Node|int|float|string> $args
+         */
+        $get_class_handler = static function (
+            CodeBase $code_base,
+            Context $context,
+            Func $unused_function,
+            array $args
+        ): UnionType {
+            // get_class() without args is deprecated in PHP 7.2+
+            // Return generic class-string for safety
+            if (count($args) === 0) {
+                return ClassStringType::instance(false)->asPHPDocUnionType();
+            }
+
+            // Get the type of the argument
+            $arg_type = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $args[0]);
+
+            // Extract object types with known FQSENs
+            $object_types = $arg_type->objectTypesWithKnownFQSENs();
+
+            // If no object types or unknown type, return generic class-string
+            if ($object_types->isEmpty()) {
+                return ClassStringType::instance(false)->asPHPDocUnionType();
+            }
+
+            // Create class-string<T> where T is the union of object types
+            // Build the string representation and parse it
+            $type_string = 'class-string<' . $object_types->__toString() . '>';
+            return UnionType::fromFullyQualifiedPHPDocString($type_string);
+        };
+
         // TODO: Handle flags of preg_split.
         return [
             // commonly used functions where the return type depends on a passed in boolean
@@ -450,6 +486,7 @@ final class DependentReturnTypeOverridePlugin extends PluginV3 implements
             'explode'                     => $explode_handler,
             'constant'                    => $constant_handler,
             'func_get_args'               => $func_get_args_handler,
+            'get_class'                   => $get_class_handler,
         ];
     }
 

--- a/tests/files/expected/5259_get_class_inference.php.expected
+++ b/tests/files/expected/5259_get_class_inference.php.expected
@@ -1,0 +1,6 @@
+%s:26 PhanDebugAnnotation @phan-debug-var requested for variable $direct - it has union type class-string<\TestClass>(real=string)
+%s:30 PhanDebugAnnotation @phan-debug-var requested for variable $fromFunc - it has union type class-string<\TestClass>(real=string)
+%s:34 PhanDebugAnnotation @phan-debug-var requested for variable $union - it has union type class-string<\OtherClass|\TestClass>(real=string)
+%s:40 PhanDebugAnnotation @phan-debug-var requested for variable $fromMixed - it has union type class-string(real=string)
+%s:40 PhanTypeMismatchArgumentInternalReal Argument 1 ($object) is $mixed of type null but \get_class() takes object
+%s:44 PhanDebugAnnotation @phan-debug-var requested for variable $fromGlobals - it has union type class-string(real=string)

--- a/tests/files/src/5259_get_class_inference.php
+++ b/tests/files/src/5259_get_class_inference.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * Test enhanced type inference for get_class() - Issue #5275
+ * get_class() should return class-string<T> based on the argument type
+ */
+
+class TestClass {}
+class OtherClass {}
+
+/**
+ * @return TestClass
+ */
+function getTestClass(): TestClass {
+    return new TestClass();
+}
+
+/**
+ * @return TestClass|OtherClass
+ */
+function getUnion() {
+    return new TestClass();
+}
+
+// Test 1: Direct object creation - should infer class-string<TestClass>
+$direct = get_class(new TestClass());
+'@phan-debug-var $direct';
+
+// Test 2: Function return (PHPDoc) - should infer class-string<TestClass>
+$fromFunc = get_class(getTestClass());
+'@phan-debug-var $fromFunc';
+
+// Test 3: Union type - should infer class-string<TestClass|OtherClass>
+$union = get_class(getUnion());
+'@phan-debug-var $union';
+
+// Test 4: Mixed type - should fallback to class-string
+/** @var mixed $mixed */
+$mixed = null;
+$fromMixed = get_class($mixed);
+'@phan-debug-var $fromMixed';
+
+// Test 5: Unknown type from $GLOBALS - should fallback to class-string
+$fromGlobals = get_class($GLOBALS['x']);
+'@phan-debug-var $fromGlobals';
+
+// Test 6: Verify the inferred type can be used correctly
+/**
+ * @param class-string<TestClass> $className
+ */
+function requiresTestClassString(string $className): void {
+    echo $className;
+}
+
+// Should NOT warn - $direct is class-string<TestClass>
+requiresTestClassString($direct);
+
+// Test 7: Verify warning for wrong type
+/**
+ * @param class-string<OtherClass> $className
+ */
+function requiresOtherClassString(string $className): void {
+    echo $className;
+}
+
+// SHOULD warn - $direct is class-string<TestClass>, not class-string<OtherClass>
+requiresOtherClassString($direct);
+
+// Test 8: Union type should work with broader requirement
+/**
+ * @param class-string<TestClass|OtherClass> $className
+ */
+function requiresUnionClassString(string $className): void {
+    echo $className;
+}
+
+// Should NOT warn - $union is class-string<TestClass|OtherClass>
+requiresUnionClassString($union);
+
+// Should NOT warn - class-string<TestClass> is subset of class-string<TestClass|OtherClass>
+requiresUnionClassString($direct);


### PR DESCRIPTION
#Bug #5275 enhance type inference for get_class()
## Before:
  get_class(new TestClass);       // class-string (generic)
  get_class(getTestClass());      // class-string (generic)
  get_class(getUnion());          // class-string (generic)

## After:
  get_class(new TestClass);       // class-string<\TestClass>
  get_class(getTestClass());      // class-string<\TestClass>
  get_class(getUnion());          // class-string<\OtherClass|\TestClass>
  get_class($mixed);              // class-string (fallback)
  get_class($GLOBALS['x']);       // class-string (fallback)