### PR TITLE
Partially fix bug 5281

### DIFF
--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -49,6 +49,7 @@ use Phan\Language\Type\ClosureDeclarationType;
 use Phan\Language\Type\ClosureType;
 use Phan\Language\Type\FalseType;
 use Phan\Language\Type\FloatType;
+use Phan\Language\Type\GenericArrayInterface;
 use Phan\Language\Type\GenericArrayType;
 use Phan\Language\Type\IntersectionType;
 use Phan\Language\Type\IntType;
@@ -2372,7 +2373,7 @@ class UnionTypeVisitor extends AnalysisVisitor
          *           but have unknown array shapes in $union_type
          */
         $has_generic_array = false;
-        $has_truly_generic_array = false;  // Fix for #5281: Track truly generic array (not array<T>)
+        $has_truly_generic_array = false;  // Fix for #5281: Track plain untyped array (excludes types implementing GenericArrayInterface)
         $has_valid_string_access = false;
         $resulting_element_type = null;
         foreach ($union_type->getTypeSet() as $type) {
@@ -2399,8 +2400,9 @@ class UnionTypeVisitor extends AnalysisVisitor
                     }
                     // TODO: Could be more precise about check for ArrayAccess
                     $has_generic_array = true;
-                    // Track if this is a truly generic array (not GenericArrayType with known element types)
-                    if ($type instanceof ArrayType && !($type instanceof GenericArrayType)) {
+                    // Track if this is a plain untyped array (not typed arrays like callable[], int[], etc.)
+                    // GenericArrayInterface is implemented by all typed arrays: GenericArrayType, CallableArrayType, etc.
+                    if ($type instanceof ArrayType && !($type instanceof GenericArrayInterface)) {
                         $has_truly_generic_array = true;
                     }
                     continue;

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -2372,6 +2372,7 @@ class UnionTypeVisitor extends AnalysisVisitor
          *           but have unknown array shapes in $union_type
          */
         $has_generic_array = false;
+        $has_truly_generic_array = false;  // Fix for #5281: Track truly generic array (not array<T>)
         $has_valid_string_access = false;
         $resulting_element_type = null;
         foreach ($union_type->getTypeSet() as $type) {
@@ -2398,6 +2399,10 @@ class UnionTypeVisitor extends AnalysisVisitor
                     }
                     // TODO: Could be more precise about check for ArrayAccess
                     $has_generic_array = true;
+                    // Track if this is a truly generic array (not GenericArrayType with known element types)
+                    if ($type instanceof ArrayType && !($type instanceof GenericArrayType)) {
+                        $has_truly_generic_array = true;
+                    }
                     continue;
                 }
                 continue;
@@ -2422,6 +2427,13 @@ class UnionTypeVisitor extends AnalysisVisitor
                 // This is exclusively array shape and non-array types.
                 // Return false to indicate that the offset doesn't exist in any of those array shape types.
                 return false;
+            }
+            // Fix for issue #5281: When we have a truly generic array type (not array<T>)
+            // and the key doesn't exist in any array shapes, return mixed to avoid falling
+            // back to genericArrayElementTypes() which would incorrectly extract types from
+            // unrelated array shape fields.
+            if ($has_truly_generic_array) {
+                return MixedType::instance(false)->asPHPDocUnionType();
             }
             return null;
         }

--- a/tests/files/expected/5281_array_element_false_positive.php.expected
+++ b/tests/files/expected/5281_array_element_false_positive.php.expected
@@ -1,2 +1,3 @@
 %s:23 PhanCoalescingAlwaysNull Using $arr['callable'] of type null as the left hand side of a null coalescing (??) operation. The left hand side may be unnecessary.
 %s:24 PhanImpossibleCondition Impossible attempt to cast $callable of type null to truthy
+%s:38 PhanUndeclaredInvokeInCallable Possible attempt to access missing magic method __invoke of '\OtherClass'

--- a/tests/files/expected/5281_array_element_false_positive.php.expected
+++ b/tests/files/expected/5281_array_element_false_positive.php.expected
@@ -1,0 +1,2 @@
+%s:23 PhanCoalescingAlwaysNull Using $arr['callable'] of type null as the left hand side of a null coalescing (??) operation. The left hand side may be unnecessary.
+%s:24 PhanImpossibleCondition Impossible attempt to cast $callable of type null to truthy

--- a/tests/files/src/5281_array_element_false_positive.php
+++ b/tests/files/src/5281_array_element_false_positive.php
@@ -1,0 +1,27 @@
+<?php
+
+class OtherClass {}
+
+// Test case: union of generic array and array shape
+// Accessing non-existent key should return mixed, not extract types from shape
+/** @param array $generic */
+function test_union($generic) {
+    $specific = ['class' => new OtherClass];
+    $arr = rand() % 2 ? $generic : $specific;
+    $callable = $arr['callable'] ?? null;
+    if ($callable) {
+        // Before fix: false positive - Phan thought $callable could be OtherClass
+        // After fix: $callable is mixed, no false positive
+        $callable();
+    }
+}
+
+// Test case: pure array shape
+// Accessing non-existent key should return null
+function test_shape_only() {
+    $arr = ['class' => new OtherClass];
+    $callable = $arr['callable'] ?? null;
+    if ($callable) {
+        $callable();
+    }
+}

--- a/tests/files/src/5281_array_element_false_positive.php
+++ b/tests/files/src/5281_array_element_false_positive.php
@@ -25,3 +25,15 @@ function test_shape_only() {
         $callable();
     }
 }
+
+// Test case: callable[] union with array shape
+// Should preserve callable element type, not return mixed
+/** @param callable[] $callables */
+function test_callable_array($callables) {
+    $specific = ['class' => new OtherClass];
+    $arr = rand() % 2 ? $callables : $specific;
+    $item = $arr[0];
+    // $item should be callable|OtherClass, not mixed
+    // This verifies that CallableArrayType is not treated as "truly generic"
+    $item();
+}


### PR DESCRIPTION
Modified `src/Phan/AST/UnionTypeVisitor.php` to prevent false positives when accessing unknown keys in unions containing both generic array and specific array shapes.
- Added $has_truly_generic_array flag to distinguish plain array from typed arrays like Method[]
- When accessing a non-existent key and a truly generic array is present, return mixed instead of incorrectly extracting types from unrelated array shape fields

Note: The example in issue #5281 uses `$arr += ['class' => new OtherClass]`, which Phan currently infers as `array|array<string,\OtherClass>` (GenericArrayType) rather than `array|array{class:OtherClass} (ArrayShapeType)`. This is a separate type inference limitation. However, the fix works correctly for cases where array shapes ARE present, which addresses the core issue.