### PR TITLE
Fix bug 5284

### DIFF
--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -1467,6 +1467,44 @@ class BlockAnalysisVisitor extends AnalysisVisitor
     }
 
     /**
+     * Visit a declare block and analyze its statements
+     *
+     * @param Node $node
+     * An AST node of type AST_DECLARE
+     *
+     * @return Context
+     * The updated context after visiting the node
+     */
+    public function visitDeclare(Node $node): Context
+    {
+        // Start with the current context
+        $context = $this->context;
+        $context->setLineNumberStart($node->lineno);
+
+        // Handle strict_types directive
+        $declares = $node->children['declares'];
+        if ($declares instanceof Node) {
+            foreach ($declares->children as $elem) {
+                if ($elem instanceof Node) {
+                    ['name' => $name, 'value' => $value] = $elem->children;
+                    if ('strict_types' === $name && \is_int($value)) {
+                        $context = $context->withStrictTypes($value);
+                    }
+                }
+            }
+        }
+
+        // Analyze the statements inside the declare block
+        // Note: declare blocks do not create a new variable scope in PHP
+        $stmts_node = $node->children['stmts'];
+        if ($stmts_node instanceof Node) {
+            $context = $this->analyzeAndGetUpdatedContext($context, $node, $stmts_node);
+        }
+
+        return $context;
+    }
+
+    /**
      * @param Node $node
      * An AST node we'd like to analyze the statements for
      *

--- a/tests/files/expected/5284_declare_block.php.expected
+++ b/tests/files/expected/5284_declare_block.php.expected
@@ -1,0 +1,2 @@
+%s:74 PhanTypeMismatchArgumentReal Argument 1 ($x) is '123' of type string but \expect_int_5284() takes int defined at %s:69
+%s:102 PhanTypeMismatchArgumentReal Argument 1 ($x) is $typed_var of type string but \expect_int_5284() takes int defined at %s:69

--- a/tests/files/src/5284_declare_block.php
+++ b/tests/files/src/5284_declare_block.php
@@ -1,0 +1,103 @@
+<?php
+
+// Test 1: Variables defined before declare block should be accessible inside
+function test_variable_before_declare() {
+    $status = 42;
+    declare(ticks=1) {
+        echo $status;  // Should NOT error - PhanUndeclaredVariable
+    }
+}
+
+// Test 2: Variables defined inside declare block should be accessible after
+function test_variable_inside_declare() {
+    declare(ticks=1) {
+        $result = "Hello";
+    }
+    echo $result;  // Should NOT error - PhanUndeclaredVariable
+}
+
+// Test 3: $this should be accessible inside declare blocks in method context
+class TestDeclare5284 {
+    private $value = 123;
+
+    public function main() {
+        $status = 42;
+        declare(ticks=1) {
+            echo $status;  // Should NOT error - PhanUndeclaredVariable
+        }
+        var_dump($this);  // Should NOT error - PhanUndeclaredThis
+    }
+
+    public function testThisInside() {
+        declare(ticks=1) {
+            $x = $this->value;  // Should NOT error - PhanUndeclaredThis
+        }
+        echo $x;  // Should NOT error - PhanUndeclaredVariable
+    }
+}
+
+// Test 4: Nested declare blocks
+function test_nested_declare() {
+    $outer = "outer";
+    declare(ticks=1) {
+        $middle = "middle";
+        declare(ticks=2) {
+            $inner = "inner";
+            echo $outer;   // Should NOT error
+            echo $middle;  // Should NOT error
+        }
+        echo $inner;  // Should NOT error
+    }
+    echo $middle;  // Should NOT error
+}
+
+// Test 5: Multiple variables
+function test_multiple_variables() {
+    $a = 1;
+    $b = 2;
+    $c = 3;
+    declare(ticks=1) {
+        echo $a + $b + $c;  // Should NOT error for any variable
+        $d = 4;
+    }
+    echo $d;  // Should NOT error
+}
+
+// Test 6: strict_types directive should still work correctly
+declare(strict_types=1);
+
+function expect_int_5284(int $x): void {
+    echo $x;
+}
+
+function test_strict_types() {
+    expect_int_5284("123");  // SHOULD error - PhanTypeMismatchArgument (strict_types is active)
+}
+
+// Test 7: Variables used in declare block should be tracked for unused variable detection
+function test_unused_variable() {
+    $used_in_declare = 100;
+    declare(ticks=1) {
+        echo $used_in_declare;  // This uses the variable
+    }
+    // Should NOT warn about unused variable for $used_in_declare
+
+    $unused_var = 200;  // SHOULD warn - PhanUnusedVariable
+}
+
+// Test 8: Type narrowing should work inside declare blocks
+function test_type_narrowing(?string $param) {
+    if ($param !== null) {
+        declare(ticks=1) {
+            echo strlen($param);  // Should NOT error - $param is narrowed to string
+        }
+    }
+}
+
+// Test 9: Variables assigned in declare block should have proper types
+function test_type_tracking() {
+    declare(ticks=1) {
+        $typed_var = "string value";
+    }
+    expect_int_5284($typed_var);  // SHOULD error - PhanTypeMismatchArgument (string vs int)
+}


### PR DESCRIPTION
Phan wasn't analyzing code inside declare blocks, causing false positives.
Add a `visitDeclare()` method to the BlockAnalysisVisitor