### PR TITLE
Fix nested closure scope bug

### DIFF
--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -2705,6 +2705,20 @@ class UnionTypeVisitor extends AnalysisVisitor
             return NullType::instance(false)->asPHPDocUnionType();
         }
 
+        // Skip undeclared variable errors when recursively analyzing stored conditional expressions.
+        // This prevents false positives when re-analyzing expressions from a different scope
+        // (e.g., when analyzing a nested closure that uses a variable defined in the parent closure).
+        // See issue #5269 for a similar fix in ConditionVisitor::checkVariablesDefined().
+        if (\Phan\Analysis\ConditionVisitor::isInRecursiveConditionalAnalysis()) {
+            if ($variable_name === 'this') {
+                return ObjectType::instance(false)->asRealUnionType();
+            }
+            if (!$this->context->isInGlobalScope()) {
+                return NullType::instance(false)->asRealUnionType();
+            }
+            return UnionType::empty();
+        }
+
         if (!($this->context->isInGlobalScope() && Config::getValue('ignore_undeclared_variables_in_global_scope'))) {
             if (!$this->should_catch_issue_exception) {
                 throw new IssueException(

--- a/src/Phan/Analysis/ArgumentType.php
+++ b/src/Phan/Analysis/ArgumentType.php
@@ -1602,6 +1602,11 @@ final class ArgumentType
                     }
                 }
             }
+            // Skip argument type mismatch errors when recursively analyzing stored conditional expressions.
+            // This prevents false positives when types are inferred from variables in a different scope.
+            if (\Phan\Analysis\ConditionVisitor::isInRecursiveConditionalAnalysis()) {
+                return;
+            }
             if (\in_array($issue_type, [Issue::TypeMismatchArgumentInternalReal, Issue::TypeMismatchArgumentInternalProbablyReal], true)) {
                 Issue::maybeEmit(
                     $code_base,

--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -85,6 +85,21 @@ class ConditionVisitor extends KindVisitorImplementation implements ConditionVis
     }
 
     /**
+     * Check if we're currently recursively analyzing a stored conditional expression.
+     *
+     * This is used to suppress false positive undeclared variable errors when
+     * re-analyzing expressions from a different scope (e.g., when analyzing a
+     * nested closure that uses a variable defined in the parent closure).
+     *
+     * @return bool true if currently in recursive conditional analysis
+     * @see issue #5269 for a similar fix for checkVariablesDefined()
+     */
+    public static function isInRecursiveConditionalAnalysis(): bool
+    {
+        return self::$conditional_expr_depth > 0;
+    }
+
+    /**
      * Default visitor for node kinds that do not have
      * an overriding method
      *

--- a/src/Phan/Analysis/ConditionVisitorUtil.php
+++ b/src/Phan/Analysis/ConditionVisitorUtil.php
@@ -1510,6 +1510,13 @@ trait ConditionVisitorUtil
                 $context->addScopeVariable($variable);
                 return $variable;
             }
+            // Skip undeclared variable errors when recursively analyzing stored conditional expressions.
+            // This prevents false positives when re-analyzing expressions from a different scope.
+            // See issue #5269 for a similar fix in ConditionVisitor::checkVariablesDefined().
+            if (ConditionVisitor::isInRecursiveConditionalAnalysis()) {
+                // Return null to prevent creating a variable with incorrect scope/type
+                return null;
+            }
             if (!($var_node->flags & PhanAnnotationAdder::FLAG_IGNORE_UNDEF)) {
                 if ($is_in_global_scope) {
                     if (!Config::getValue('ignore_undeclared_variables_in_global_scope')) {

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -239,7 +239,15 @@ class BlockAnalysisVisitor extends AnalysisVisitor
             // Step into each child node and get an
             // updated context for the node
             try {
-                $context = $this->analyzeAndGetUpdatedContext($context, $node, $child_node);
+                $updated_context = $this->analyzeAndGetUpdatedContext($context, $node, $child_node);
+
+                // Don't propagate the internal scope of closures, arrow functions, functions, methods,
+                // or classes to subsequent sibling statements. These are "closed contexts" whose internal
+                // state should not leak out. For other statements, propagate the context so that subsequent
+                // statements can see variables defined earlier.
+                if (!\in_array($child_node->kind, [\ast\AST_CLOSURE, \ast\AST_ARROW_FUNC, \ast\AST_FUNC_DECL, \ast\AST_METHOD, \ast\AST_CLASS], true)) {
+                    $context = $updated_context;
+                }
             } catch (IssueException $e) {
                 // This is a fallback - Exceptions should be caught at a deeper level if possible
                 Issue::maybeEmitInstance($this->code_base, $context, $e->getIssueInstance());
@@ -598,7 +606,15 @@ class BlockAnalysisVisitor extends AnalysisVisitor
 
             // Step into each child node and get an
             // updated context for the node
-            $context = $this->analyzeAndGetUpdatedContext($context, $node, $child_node);
+            $updated_context = $this->analyzeAndGetUpdatedContext($context, $node, $child_node);
+
+            // Don't propagate the internal scope of closures, arrow functions, functions, methods,
+            // or classes to subsequent sibling children. These are "closed contexts" whose internal
+            // state should not leak out. For other children, propagate the context so that subsequent
+            // children can see variables defined earlier.
+            if (!\in_array($child_node->kind, [\ast\AST_CLOSURE, \ast\AST_ARROW_FUNC, \ast\AST_FUNC_DECL, \ast\AST_METHOD, \ast\AST_CLASS], true)) {
+                $context = $updated_context;
+            }
         }
 
         return $this->postOrderAnalyze($context, $node);
@@ -1617,9 +1633,17 @@ class BlockAnalysisVisitor extends AnalysisVisitor
 
             // Step into each child node and get an
             // updated context for the node
-            $child_context = $this->analyzeAndGetUpdatedContext($child_context, $node, $child_node);
+            $updated_context = $this->analyzeAndGetUpdatedContext($child_context, $node, $child_node);
 
-            $child_context_list[] = $child_context;
+            // Don't propagate the internal scope of closures, arrow functions, functions, methods,
+            // or classes to sibling statements. These are "closed contexts" whose internal state
+            // should not leak out. For other statements, propagate the context so that subsequent
+            // statements can see variables defined earlier.
+            if (!\in_array($child_node->kind, [\ast\AST_CLOSURE, \ast\AST_ARROW_FUNC, \ast\AST_FUNC_DECL, \ast\AST_METHOD, \ast\AST_CLASS], true)) {
+                $child_context = $updated_context;
+            }
+
+            $child_context_list[] = $updated_context;
         }
 
         // For if statements, we need to merge the contexts


### PR DESCRIPTION
Variables in parent closures appeared as "undeclared" when used in nested closures via use clauses, but only when those variables were used in conditional contexts (ternary operators, if statements, comparisons).

The fix extends the existing $conditional_expr_depth mechanism (from issue #5269) to additional code paths. When ConditionVisitor recursively analyzes stored conditional expressions from variables defined in a different scope, we now:
- Skip undeclared variable errors
- Skip argument type mismatch errors
- Avoid creating variables with incorrect scope