### PR TITLE
Fix bug 5295

### DIFF
--- a/src/Phan/Analysis/NegatedConditionVisitor.php
+++ b/src/Phan/Analysis/NegatedConditionVisitor.php
@@ -1056,14 +1056,29 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
                     )));
                     return $context;
                 }
-                $context = $this->removeFalseyFromVariable($expr_node, $context, true);
 
                 $variable = $context->getScope()->getVariableByName($var_name);
                 $var_node_union_type = $variable->getUnionType();
 
-                if ($var_node_union_type->hasTopLevelArrayShapeTypeInstances()) {
+                // For array dimension checks like !empty($var['key']), we need to handle type narrowing carefully.
+                // If the variable has explicit array shape types, we narrow the specific key's type.
+                // If it's just a bare mixed or generic array from foreach, we don't narrow the entire variable
+                // since that would incorrectly affect other array accesses (issue #5295).
+                $hasExplicitArrayShapeTypes = $var_node_union_type->hasTopLevelArrayShapeTypeInstances();
+
+                // Check if the type is ONLY MixedType (not wrapped in null or other types)
+                // MixedType often comes from foreach iteration variables
+                $isBareArrayOrMixed = $var_node_union_type->isType(MixedType::instance(false)) ||
+                                      $var_node_union_type->isType(MixedType::instance(true));
+
+                if ($hasExplicitArrayShapeTypes) {
+                    // Has specific array shape, narrow the specific key
                     $context = $this->withNonFalseyArrayShapeTypes($variable, $parent_node->children['dim'], $context, true);
+                } elseif (!$isBareArrayOrMixed) {
+                    // Not just bare mixed, so it's explicitly typed (e.g., ?array), narrow the variable
+                    $context = $this->removeFalseyFromVariable($expr_node, $context, true);
                 }
+                // If it's just bare mixed/array, don't narrow the variable itself
                 $this->context = $context;
             }
         }

--- a/tests/files/expected/5295_empty_array_key_narrowing.php.expected
+++ b/tests/files/expected/5295_empty_array_key_narrowing.php.expected
@@ -1,0 +1,3 @@
+%s:41 PhanUnusedVariable Unused definition of variable $x
+%s:49 PhanSideEffectFreeForeachBody Saw a foreach loop which probably has no side effects
+%s:54 PhanUnusedVariable Unused definition of variable $val

--- a/tests/files/src/5295_empty_array_key_narrowing.php
+++ b/tests/files/src/5295_empty_array_key_narrowing.php
@@ -1,0 +1,69 @@
+<?php
+
+// Test case for issue #5295: Too strict type inference after !empty condition on array
+
+// Main reproduction case from the issue
+function test_issue_5295(array $arr) {
+    foreach ($arr as $el) {
+        if (!empty($el['x'])) {
+            // empty block - just checking the condition
+        }
+        // This should NOT be narrowed to falsey types since we only checked $el['x'], not $el['fn']
+        $fn = $el['fn'];
+        $fn();  // Should not emit any warnings about invalid callable
+    }
+}
+
+// Test with multiple keys checked
+function test_multiple_keys(array $arr) {
+    foreach ($arr as $el) {
+        if (!empty($el['x'])) {
+            // no-op
+        }
+        if (!empty($el['y'])) {
+            // no-op
+        }
+        // Accessing a different key should not be narrowed
+        $z = $el['z'];
+        $z->someMethod();
+    }
+}
+
+// Test that narrowing still works for the same key
+function test_same_key_narrowing(array $arr) {
+    foreach ($arr as $el) {
+        if (!empty($el['x'])) {
+            // In this block, $el['x'] should be narrowed to non-empty/truthy
+            $x = $el['x'];
+            $x->method();  // OK - should have truthy types
+        } else {
+            // In this block, $el['x'] should be narrowed to falsey
+            $x = $el['x'];
+            // Can't call method on falsey value
+        }
+    }
+}
+
+// Test with nested arrays
+function test_nested_array(array $data) {
+    foreach ($data as $item) {
+        if (!empty($item['nested']['key'])) {
+            // no-op
+        }
+        // Accessing different nested key should not be affected
+        $val = $item['nested']['other'];
+        // $val should be mixed, not falsey
+    }
+}
+
+// Test with literal key
+function test_literal_key(array $arr) {
+    foreach ($arr as $el) {
+        if (!empty($el['config'])) {
+            // no-op
+        }
+        // Different key should not be narrowed
+        $fn = $el['fn'];
+        $fn();
+    }
+}


### PR DESCRIPTION
bug #5295:
Phan was incorrectly narrowing the type of ALL array keys when checking `!empty()` on one specific key.
```php 
 foreach ($arr as $el) {
      if (!empty($el['x'])) {
          // check
      }
      $fn = $el['fn'];  // $fn incorrectly had type ?''|?'0'|?0|?0.0|?array{}|?false
      $fn();  // False positive warnings about invalid callable
  }
```
In `NegatedConditionVisitor.php`, the `checkComplexNegatedEmpty()` method was calling `removeFalseyFromVariable()` on the entire variable `$el`, not just the specific array key `$el['x']`. This caused the entire variable to be narrowed to falsey-only types, which then affected all other array accesses.

Modified `NegatedConditionVisitor.php`:
- If the variable has explicit array shape types, only narrow the specific key using `withNonFalseyArrayShapeTypes()`
- If the variable is bare mixed (typical for foreach iteration variables), don't narrow it at all
- If the variable is explicitly typed (e.g., `?array`), still narrow it as before