### PR TITLE
prevent type accumulation for interface-typed properties

### DIFF
--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -2052,7 +2052,6 @@ class AssignmentVisitor extends AnalysisVisitor
         // its declared interface type based on assignments, causing methods to be validated
         // incorrectly. Interface-typed properties should only allow methods from the interface,
         // not from potential implementations.
-        // See: https://github.com/phan/phan/issues/5299
         $declared_type = $property->getPHPDocUnionType();
         foreach ($declared_type->getTypeSet() as $type) {
             try {

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -9,6 +9,7 @@ use ast;
 use ast\Node;
 use Closure;
 use Exception;
+use Throwable;
 use Phan\AST\AnalysisVisitor;
 use Phan\AST\ASTReverter;
 use Phan\AST\ContextNode;
@@ -2043,6 +2044,31 @@ class AssignmentVisitor extends AnalysisVisitor
         $new_types = $new_types->withStaticResolvedInContext($this->context)->withFlattenedArrayShapeTypeInstances();
 
         $updated_property_types = $original_property_types;
+
+        // For interface-typed properties, don't accumulate inferred types.
+        // Keep the declared type as-is to ensure method calls and other operations
+        // are validated against the declared contract, not runtime assignments.
+        // This prevents false negatives where a property type is expanded beyond
+        // its declared interface type based on assignments, causing methods to be validated
+        // incorrectly. Interface-typed properties should only allow methods from the interface,
+        // not from potential implementations.
+        // See: https://github.com/phan/phan/issues/5299
+        $declared_type = $property->getPHPDocUnionType();
+        foreach ($declared_type->getTypeSet() as $type) {
+            try {
+                $type_fqsen = $type->asFQSEN();
+                if ($type_fqsen instanceof FullyQualifiedClassName && $this->code_base->hasClassWithFQSEN($type_fqsen)) {
+                    $class = $this->code_base->getClassByFQSEN($type_fqsen);
+                    if ($class->isInterface()) {
+                        // Don't modify interface-typed properties - keep the declared type as-is
+                        return;
+                    }
+                }
+            } catch (Throwable) {
+                // Ignore types that don't have valid FQSENs
+            }
+        }
+
         foreach ($new_types->getTypeSet() as $new_type) {
             if ($new_type instanceof MixedType) {
                 // Don't add MixedType to a non-empty property - It makes inferences on that property useless.

--- a/src/Phan/Language/Scope.php
+++ b/src/Phan/Language/Scope.php
@@ -120,7 +120,7 @@ abstract class Scope
     /**
      * @return FQSEN in which this scope was declared
      * (e.g. a FullyQualifiedFunctionName, FullyQualifiedClassName, etc.)
-     * @suppress PhanPartialTypeMismatchReturn callers should call hasFQSEN
+     * @suppress PhanPossiblyNullTypeReturn callers should call hasFQSEN
      */
     public function getFQSEN(): FQSEN
     {

--- a/tests/files/expected/5299_typed_property_method_validation.php.expected
+++ b/tests/files/expected/5299_typed_property_method_validation.php.expected
@@ -1,0 +1,1 @@
+%s:28 PhanUndeclaredMethod Call to undeclared method \Interface2::someMethod1

--- a/tests/files/src/5299_typed_property_method_validation.php
+++ b/tests/files/src/5299_typed_property_method_validation.php
@@ -1,0 +1,47 @@
+<?php
+
+// Test case for issue #5299 - Method calls on typed properties should validate against declared type, not inferred type
+
+interface Interface2 {
+}
+
+interface Interface1 extends Interface2 {
+    public function someMethod1();
+}
+
+class Class1 implements Interface1 {
+    public function someMethod1() {
+        echo "Hello there";
+    }
+}
+
+class Class2 {
+    protected Interface2 $my_internal_instance;
+
+    public function __construct() {
+        // Assignment is allowed: Class1 implements Interface1 which extends Interface2
+        $this->my_internal_instance = new Class1();
+    }
+
+    public function someMethod1() {
+        // ERROR: Interface2 does not have someMethod1(), even though we assigned Class1 to it
+        return $this->my_internal_instance->someMethod1();
+    }
+}
+
+// This class implements Interface2 but doesn't have someMethod1()
+class Class4 implements Interface2 {
+}
+
+class Class3 extends Class2 {
+    public function setWrong() {
+        // This is allowed at assignment time (Class4 implements Interface2)
+        // but demonstrates the problem at runtime
+        $this->my_internal_instance = new Class4();
+    }
+}
+
+$instance = new Class3();
+$instance->setWrong();
+// Runtime error: Class4 doesn't have someMethod1()
+$instance->someMethod1();


### PR DESCRIPTION
This prevents type accumulation for interface-typed properties, ensuring method calls on such properties are validated against the declared interface contract rather than inferred implementation types.
See `tests/files/src/5299_typed_property_method_validation.php` for an example