### PR TITLE
Fix bug 5301

### DIFF
--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -2276,6 +2276,9 @@ class AssignmentVisitor extends AnalysisVisitor
             // as we replace it.
             $variable = clone($variable);
 
+            // Invalidate any stale condition expressions that reference this variable (issue #5301)
+            $this->invalidateStaleConditionExpressions($variable_name);
+
             // If we're assigning to an array element then we don't
             // know what the array structure of the parameter is
             // outside of the scope of this assignment, so we add to
@@ -2657,6 +2660,34 @@ class AssignmentVisitor extends AnalysisVisitor
         }
 
         return UnionType::empty();
+    }
+
+    /**
+     * Invalidate any stored conditional expressions (phan_condition_expr) that reference the given variable.
+     * This is necessary because when a variable is reassigned, any cached condition expressions that
+     * reference it become stale and would cause incorrect type narrowing.
+     * See issue #5301 for details.
+     *
+     * @param string $assigned_var_name The name of the variable that was just assigned
+     */
+    private function invalidateStaleConditionExpressions(string $assigned_var_name): void
+    {
+        $scope = $this->context->getScope();
+        foreach ($scope->getVariableMap() as $var) {
+            // Check if this variable has a cached condition expression
+            if (!isset($var->phan_condition_expr)) {
+                continue;
+            }
+            $expr_node = $var->phan_condition_expr;
+            if (!($expr_node instanceof Node)) {
+                continue;
+            }
+
+            // If the stored expression references the variable being assigned, clear it
+            if (PostOrderAnalysisVisitor::exprReferencesVariable($expr_node, $assigned_var_name)) {
+                unset($var->phan_condition_expr);
+            }
+        }
     }
 
     /**

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -155,7 +155,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
      * @param string $var_name The variable name to look for
      * @return bool True if the expression references the variable
      */
-    private static function exprReferencesVariable(Node $node, string $var_name): bool
+    public static function exprReferencesVariable(Node $node, string $var_name): bool
     {
         if ($node->kind === ast\AST_VAR) {
             $name = $node->children['name'];

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -1016,7 +1016,6 @@ class BlockAnalysisVisitor extends AnalysisVisitor
         if ($expr_node instanceof Node) {
             if ($expr_node->kind === ast\AST_ARRAY) {
                 // e.g. foreach ([1, 2] as $value) has at least one
-                // @phan-suppress-next-line PhanPossiblyUndeclaredProperty - false positive exposed by issue #4854 fix, see visitVar()
                 $has_at_least_one_iteration = \count($expr_node->children) > 0;
             } else {
                 // e.g. look up global constants and class constants.

--- a/tests/files/expected/5301_stale_condition_expr.php.expected
+++ b/tests/files/expected/5301_stale_condition_expr.php.expected
@@ -1,0 +1,2 @@
+%s:7 PhanRedundantCondition Redundant attempt to cast $data of type \stdClass to object
+%s:21 PhanUnusedVariable Unused definition of variable $casted

--- a/tests/files/src/5301_stale_condition_expr.php
+++ b/tests/files/src/5301_stale_condition_expr.php
@@ -1,0 +1,23 @@
+<?php
+// Test case for issue #5301: Stale condition expressions causing false positive warnings
+
+function test_issue_5301(): void {
+    // Original issue code from #5301
+    $data = new stdClass();
+    $isObj = is_object($data);
+
+    if ($isObj) {
+        // At this point, $data is correctly narrowed to object
+    }
+
+    // Reassign $data to an array
+    $data = ['foo'];
+
+    if ($isObj) {
+        // Before the fix: Phan incorrectly narrows $data to object due to the stale
+        // condition expression, causing a false positive "redundant cast" warning
+        // After the fix: The condition expression is invalidated when $data is reassigned,
+        // so no type narrowing happens and no warning is emitted
+        $casted = (object)$data;
+    }
+}


### PR DESCRIPTION
Bug #5301 - Phan had false positive warnings about "redundant casts" when:
- A variable is assigned a condition expression (e.g., `$isObj = is_object($data)`)
- The variable referenced in that condition gets reassigned
- The stored condition expression becomes stale and causes incorrect type narrowing

Fix:
- Changed `exprReferencesVariable()` from private to public so AssignmentVisitor can use it
- Added `invalidateStaleConditionExpressions()` method that clears stale cached condition expressions
- Integrated invalidation call in visitVar() method when variables are assigned