### PR TITLE
Fix bug 5299

### DIFF
--- a/internal/Phan-Config-Settings.md
+++ b/internal/Phan-Config-Settings.md
@@ -1080,3 +1080,13 @@ Maximum number of distinct types that may be tracked in a union before Phan summ
 array/mixed types to conserve memory.
 
 (Default: `1024`)
+
+## strict_array_checking
+
+If enabled, Phan will warn about possibly invalid array offsets in unions containing
+both array shape types and generic mixed array types.
+When disabled (default), Phan is more lenient and only warns if the offset is invalid
+across all union members. This avoids false positives when an array can be a generic
+mixed array (which accepts any key) or a shape with specific keys.
+
+(Default: `false`)

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -2235,18 +2235,15 @@ class UnionTypeVisitor extends AnalysisVisitor
     }
 
     /**
-     * Check if the union type contains any generic array type (including plain arrays and arrays with mixed types)
-     * that would accept arbitrary key access. This is used to avoid false positives when a union contains both
-     * shape types and generic arrays.
+     * Check if the union type contains any array-like type that would accept arbitrary key access.
+     * This is used to avoid false positives when a union contains both shape types and generic arrays.
+     * Note: bare `mixed` is excluded because it could be a scalar or object at runtime.
      */
     private static function hasGenericArrayAcceptingArbitraryKeys(UnionType $union_type, CodeBase $code_base): bool
     {
         foreach ($union_type->getTypeSet() as $type) {
-            if ($type instanceof MixedType) {
-                return true;
-            }
             if ($type instanceof ArrayType && !($type instanceof ArrayShapeType)) {
-                // Plain array type or generic array type
+                // Plain array type or generic array type that accepts arbitrary keys
                 return true;
             }
             if ($type->isArrayLike($code_base) && !($type instanceof ArrayShapeType) && !($type instanceof ListType)) {

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -2237,18 +2237,27 @@ class UnionTypeVisitor extends AnalysisVisitor
     /**
      * Check if the union type contains any array-like type that would accept arbitrary key access.
      * This is used to avoid false positives when a union contains both shape types and generic arrays.
+     *
+     * An array accepts arbitrary keys if:
+     * - It's a plain `array` type (not a shape or list)
+     * - It's a GenericArrayType with KEY_MIXED (accepts both int and string keys)
+     *
+     * Arrays with restricted key types (e.g., array<int, T> or array<string, T>) do NOT accept arbitrary keys.
      * Note: bare `mixed` is excluded because it could be a scalar or object at runtime.
      */
     private static function hasGenericArrayAcceptingArbitraryKeys(UnionType $union_type, CodeBase $code_base): bool
     {
         foreach ($union_type->getTypeSet() as $type) {
-            if ($type instanceof ArrayType && !($type instanceof ArrayShapeType)) {
-                // Plain array type or generic array type that accepts arbitrary keys
+            // Plain `array` type without shape or generic parameters (accepts arbitrary keys)
+            if ($type instanceof ArrayType && !($type instanceof ArrayShapeType) && !($type instanceof GenericArrayInterface)) {
                 return true;
             }
-            if ($type->isArrayLike($code_base) && !($type instanceof ArrayShapeType) && !($type instanceof ListType)) {
-                // Other array-like types (e.g., GenericArrayType with mixed values)
-                return true;
+            // GenericArrayType (including NonEmptyGenericArrayType) with mixed key type (accepts arbitrary keys)
+            if ($type instanceof GenericArrayType) {
+                // KEY_MIXED = 3 means it accepts both int and string keys (both int and string keys are allowed)
+                if (($type->getKeyType() ?? GenericArrayType::KEY_MIXED) === GenericArrayType::KEY_MIXED) {
+                    return true;
+                }
             }
         }
         return false;

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1906,7 +1906,7 @@ class UnionTypeVisitor extends AnalysisVisitor
                     // 1. strict_array_checking is enabled, OR
                     // 2. There's no generic array type that would accept arbitrary keys in the union
                     $should_warn = Config::get_strict_array_checking() ||
-                        !self::hasGenericArrayAcceptingArbitraryKeys($union_type, $code_base);
+                        !self::hasGenericArrayAcceptingArbitraryKeys($union_type);
 
                     if ($should_warn) {
                         $this->emitIssue(
@@ -2245,7 +2245,7 @@ class UnionTypeVisitor extends AnalysisVisitor
      * Arrays with restricted key types (e.g., array<int, T> or array<string, T>) do NOT accept arbitrary keys.
      * Note: bare `mixed` is excluded because it could be a scalar or object at runtime.
      */
-    private static function hasGenericArrayAcceptingArbitraryKeys(UnionType $union_type, CodeBase $code_base): bool
+    private static function hasGenericArrayAcceptingArbitraryKeys(UnionType $union_type): bool
     {
         foreach ($union_type->getTypeSet() as $type) {
             // Plain `array` type without shape or generic parameters (accepts arbitrary keys)
@@ -2254,8 +2254,8 @@ class UnionTypeVisitor extends AnalysisVisitor
             }
             // GenericArrayType (including NonEmptyGenericArrayType) with mixed key type (accepts arbitrary keys)
             if ($type instanceof GenericArrayType) {
-                // KEY_MIXED = 3 means it accepts both int and string keys (both int and string keys are allowed)
-                if (($type->getKeyType() ?? GenericArrayType::KEY_MIXED) === GenericArrayType::KEY_MIXED) {
+                // KEY_MIXED = 3 means it accepts both int and string keys
+                if ($type->getKeyType() === GenericArrayType::KEY_MIXED) {
                     return true;
                 }
             }

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1902,13 +1902,21 @@ class UnionTypeVisitor extends AnalysisVisitor
             $element_type = $this->resolveArrayShapeElementTypes($node, $union_type);
             if ($element_type !== null) {
                 if ($element_type->isPossiblyUndefined() && !($node->flags & PhanAnnotationAdder::FLAG_IGNORE_UNDEF)) {
-                    $this->emitIssue(
-                        Issue::TypePossiblyInvalidDimOffset,
-                        $node->lineno,
-                        ASTReverter::toShortString($node->children['dim']),
-                        ASTReverter::toShortString($node->children['expr']),
-                        $union_type
-                    );
+                    // Check if we should emit the warning. Only emit if:
+                    // 1. strict_array_checking is enabled, OR
+                    // 2. There's no generic array type that would accept arbitrary keys in the union
+                    $should_warn = Config::get_strict_array_checking() ||
+                        !self::hasGenericArrayAcceptingArbitraryKeys($union_type, $code_base);
+
+                    if ($should_warn) {
+                        $this->emitIssue(
+                            Issue::TypePossiblyInvalidDimOffset,
+                            $node->lineno,
+                            ASTReverter::toShortString($node->children['dim']),
+                            ASTReverter::toShortString($node->children['expr']),
+                            $union_type
+                        );
+                    }
                     if ($treat_undef_as_nullable || Config::getValue('convert_possibly_undefined_offset_to_nullable')) {
                         return $element_type->nullableClone()->withIsPossiblyUndefined(false);
                     }
@@ -2220,6 +2228,29 @@ class UnionTypeVisitor extends AnalysisVisitor
     {
         foreach ($union_type->getTypeSet() as $type) {
             if ($type instanceof ArrayShapeType || $type instanceof ListType) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Check if the union type contains any generic array type (including plain arrays and arrays with mixed types)
+     * that would accept arbitrary key access. This is used to avoid false positives when a union contains both
+     * shape types and generic arrays.
+     */
+    private static function hasGenericArrayAcceptingArbitraryKeys(UnionType $union_type, CodeBase $code_base): bool
+    {
+        foreach ($union_type->getTypeSet() as $type) {
+            if ($type instanceof MixedType) {
+                return true;
+            }
+            if ($type instanceof ArrayType && !($type instanceof ArrayShapeType)) {
+                // Plain array type or generic array type
+                return true;
+            }
+            if ($type->isArrayLike($code_base) && !($type instanceof ArrayShapeType) && !($type instanceof ListType)) {
+                // Other array-like types (e.g., GenericArrayType with mixed values)
                 return true;
             }
         }

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -110,6 +110,9 @@ class Config
     /** @var bool replicates Config::getValue('strict_object_checking') */
     private static $strict_object_checking = false;
 
+    /** @var bool replicates Config::getValue('strict_array_checking') */
+    private static $strict_array_checking = false;
+
     /** @var bool replicates Config::getValue('track_references') */
     private static $track_references = false;
 
@@ -420,6 +423,13 @@ class Config
         // If enabled, Phan will warn if **any** type of the object expression for a property access
         // does not contain that property.
         'strict_object_checking' => false,
+
+        // If enabled, Phan will warn about possibly invalid array offsets in unions containing
+        // both array shape types and generic mixed array types.
+        // When disabled (default), Phan is more lenient and only warns if the offset is invalid
+        // across all union members. This avoids false positives when an array can be a generic
+        // mixed array (which accepts any key) or a shape with specific keys.
+        'strict_array_checking' => false,
 
         // If enabled, Phan will act as though it's certain of real return types of a subset of internal functions,
         // even if those return types aren't available in reflection (real types were taken from php 8.4).
@@ -1177,6 +1187,15 @@ class Config
         return self::$strict_object_checking;
     }
 
+    /**
+     * If enabled, Phan will warn about potentially invalid offsets even when some union
+     * members allow them.
+     */
+    public static function get_strict_array_checking(): bool
+    {
+        return self::$strict_array_checking;
+    }
+
     /** If enabled, allow null to cast to any array-like type. */
     public static function get_null_casts_as_array(): bool
     {
@@ -1380,6 +1399,9 @@ class Config
                 break;
             case 'strict_object_checking':
                 self::$strict_object_checking = $value;
+                break;
+            case 'strict_array_checking':
+                self::$strict_array_checking = $value;
                 break;
             case 'dead_code_detection':
             case 'force_tracking_references':

--- a/tests/files/expected/0999_issue_5299_union_array_strict.php.expected
+++ b/tests/files/expected/0999_issue_5299_union_array_strict.php.expected
@@ -1,0 +1,1 @@
+%s:14 PhanDebugAnnotation @phan-debug-var requested for variable $var - it has union type array{y:mixed,x?:null}|non-empty-array<mixed,mixed>(real=array)

--- a/tests/files/src/0999_issue_5299_union_array_strict.php
+++ b/tests/files/src/0999_issue_5299_union_array_strict.php
@@ -1,0 +1,37 @@
+<?php
+// Test case for issue #5299: Array unions containing mixed types are checked too strictly
+// When a union type contains both shape types and generic mixed arrays,
+// the warning should not be emitted by default (unless strict_array_checking is enabled)
+
+// Example from issue #5299
+( function ( $var ) {
+    if ( !is_array( $var ) ) {
+        $var = [];
+    }
+
+    if ( isset( $var['x'] ) && $var['x'] === 'a' ) {
+        // Empty
+    } elseif ( isset( $var['y'] ) ) {
+        // This should NOT warn about possibly invalid offset 'x' by default
+        // because the union includes non-empty-array<mixed,mixed>
+        '@phan-debug-var $var';
+        var_dump( $var['x'] );
+    }
+} )( $GLOBALS['x'] );
+
+// Simpler example: Union of shape and mixed array
+function testUnionWithMixed(array $arr = []) {
+    if (isset($arr['key1'])) {
+        // $arr is now array{key1:mixed} | non-empty-array<mixed,mixed>
+        // This should NOT warn with strict_array_checking = false
+        return $arr['unknown_key'];
+    }
+    return null;
+}
+
+// Should still warn for truly invalid access with pure shapes
+function testPureShape(array $shape) {
+    // @phan-param array{required:string} $shape
+    // This SHOULD warn because there's no generic fallback
+    return $shape['nonexistent'];
+}

--- a/tests/strict_array_checking_test/.phan/config.php
+++ b/tests/strict_array_checking_test/.phan/config.php
@@ -1,0 +1,40 @@
+<?php
+
+return [
+    'target_php_version' => null,
+
+    'directory_list' => [
+        'src'
+    ],
+
+    'exclude_analysis_directory_list' => [],
+    'exclude_file_list' => [],
+
+    'allow_missing_properties' => false,
+
+    'null_casts_as_any_type' => false,
+
+    'null_casts_as_array' => false,
+
+    'array_casts_as_null' => false,
+
+    'strict_object_checking' => false,
+
+    'strict_array_checking' => true,
+
+    'strict_method_checking' => false,
+
+    'strict_param_checking' => false,
+
+    'strict_property_checking' => false,
+
+    'strict_return_checking' => false,
+
+    'ignore_undeclared_variables_in_global_scope' => false,
+
+    'ignore_internal_functions' => false,
+
+    'suppress_issue_types' => [],
+
+    'plugins' => [],
+];

--- a/tests/strict_array_checking_test/expected.txt
+++ b/tests/strict_array_checking_test/expected.txt
@@ -1,0 +1,4 @@
+src/Phan/AST/ASTReverter.php:72 PhanUndeclaredConstant Reference to undeclared constant \VAR_REPRESENTATION_SINGLE_LINE. This would throw an Error.
+src/Phan/AST/ASTReverter.php:107 PhanParamNameIndicatingUnusedInClosure Saw a parameter named $_. If this was used to indicate that a parameter is unused to Phan, consider using @unused-param after a param comment, or suppressing unused parameter warnings, or renaming the parameter if backwards-compatibility for named parameters is not needed.
+src/test.php:13 PhanDebugAnnotation @phan-debug-var requested for variable $var - it has union type array{y:mixed,x?:null}|non-empty-array<mixed,mixed>(real=array)
+src/test.php:16 PhanTypePossiblyInvalidDimOffset Possibly invalid offset 'x' of $var of array type array{y:mixed,x?:null}|non-empty-array<mixed,mixed>

--- a/tests/strict_array_checking_test/src/test.php
+++ b/tests/strict_array_checking_test/src/test.php
@@ -1,0 +1,18 @@
+<?php
+// Test case for strict_array_checking = true
+// With strict checking enabled, PhanTypePossiblyInvalidDimOffset should be emitted
+// when array shapes are accessed with potentially undefined offsets
+
+( function ( $var ) {
+    if ( !is_array( $var ) ) {
+        $var = [];
+    }
+
+    if ( isset( $var['x'] ) && $var['x'] === 'a' ) {
+        // Empty
+    } elseif ( isset( $var['y'] ) ) {
+        '@phan-debug-var $var';
+        // This SHOULD warn about possibly invalid offset 'x' when strict_array_checking is true
+        var_dump( $var['x'] );
+    }
+} )( $GLOBALS['x'] );


### PR DESCRIPTION
Bug #5299 

Phan was incorrectly reporting `PhanTypePossiblyInvalidDimOffset` when accessing array keys in union types that contain both:
- Shape types with partial key definitions (e.g., `array{y:mixed,x?:null}`)
- Generic mixed/array types (e.g., `non-empty-array<mixed,mixed>`)
Since generic mixed arrays permit any key access, accessing `$var['x']` should not be flagged as "possibly invalid".

Added a new configuration option strict_array_checking (default: false) that:
- When disabled (default): Only warns about array offset access if the offset is invalid across ALL union members
- When enabled: Warns about potentially invalid offsets even when some union members allow them (the previous behavior)

Added `hasGenericArrayAcceptingArbitraryKeys()` helper method to check if a union contains generic array types and modified the `visitDim()` method to check `strict_array_checking` config before emitting `PhanTypePossiblyInvalidDimOffset`