### PR TITLE
Fix bug 5304

### DIFF
--- a/.phan/plugins/UnusedSuppressionPlugin.php
+++ b/.phan/plugins/UnusedSuppressionPlugin.php
@@ -20,6 +20,7 @@ use Phan\PluginV3\AnalyzePropertyCapability;
 use Phan\PluginV3\BeforeAnalyzeFileCapability;
 use Phan\PluginV3\FinalizeProcessCapability;
 use Phan\PluginV3\SuppressionCapability;
+use Phan\Suggestion;
 
 /**
  * Check for unused (at)suppress annotations.
@@ -33,7 +34,8 @@ class UnusedSuppressionPlugin extends PluginV3 implements
     AnalyzeFunctionCapability,
     AnalyzeMethodCapability,
     AnalyzePropertyCapability,
-    FinalizeProcessCapability
+    FinalizeProcessCapability,
+    SuppressionCapability
 {
 
     /**
@@ -79,6 +81,11 @@ class UnusedSuppressionPlugin extends PluginV3 implements
         CodeBase $code_base,
         AddressableElement $element
     ): void {
+        // Skip magic methods from PHPDoc - their suppressions may come from the parent class
+        if ($element instanceof Method && $element->isFromPHPDoc()) {
+            return;
+        }
+
         // Get the set of suppressed issues on the element
         $suppress_issue_list =
             $element->getSuppressIssueList();
@@ -321,6 +328,42 @@ class UnusedSuppressionPlugin extends PluginV3 implements
         $file_name = Config::projectPath($file_path);
         $plugin_class = \get_class($plugin);
         $this->plugin_active_suppression_list[$plugin_class][$file_name][$issue_type][$line] = $line;
+    }
+
+    /**
+     * This plugin doesn't suppress issues itself - it only tracks suppressions.
+     * Return false to let other plugins handle suppression.
+     * @override
+     * @unused-param $code_base
+     * @unused-param $context
+     * @unused-param $issue_type
+     * @unused-param $lineno
+     * @unused-param $parameters
+     * @unused-param $suggestion
+     */
+    public function shouldSuppressIssue(
+        CodeBase $code_base,
+        Context $context,
+        string $issue_type,
+        int $lineno,
+        array $parameters,
+        ?Suggestion $suggestion
+    ): bool {
+        return false;
+    }
+
+    /**
+     * This plugin doesn't define suppressions itself.
+     * Return an empty array.
+     * @override
+     * @unused-param $code_base
+     * @unused-param $file_path
+     */
+    public function getIssueSuppressionList(
+        CodeBase $code_base,
+        string $file_path
+    ): array {
+        return [];
     }
 }
 

--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -15,6 +15,7 @@ use Phan\Issue;
 use Phan\Language\Element\ClassElement;
 use Phan\Language\Element\Clazz;
 use Phan\Language\Element\FunctionInterface;
+use Phan\Language\Element\Method;
 use Phan\Language\Element\Property;
 use Phan\Language\Element\TypedElement;
 use Phan\Language\Element\Variable;
@@ -832,8 +833,22 @@ class Context extends FileRef
         }
         $has_suppress_issue = $element->hasSuppressIssue($issue_name);
 
+        // For magic methods from PHPDoc, also check the parent class's suppressions
+        // This allows class-level @suppress annotations to apply to @method tags
+        if (!$has_suppress_issue && $element instanceof Method && $element->isFromPHPDoc()) {
+            try {
+                $class = $element->getClass($code_base);
+                $has_suppress_issue = $class->hasSuppressIssue($issue_name);
+                if ($has_suppress_issue) {
+                    $class->incrementSuppressIssueCount($issue_name);
+                }
+            } catch (Exception) {
+                // If we can't get the class, just use the method's suppression status
+            }
+        }
+
         // Increment the suppression use count
-        if ($has_suppress_issue) {
+        if ($has_suppress_issue && !($element instanceof Method && $element->isFromPHPDoc())) {
             $element->incrementSuppressIssueCount($issue_name);
         }
 


### PR DESCRIPTION
Bug #5304
UnusedSuppressionPlugin was incorrectly reporting class-level @suppress annotations as unused when they were actually suppressing issues related to magic methods defined via @method PHPDoc tags.

1. Context.php Enhancement (src/Phan/Language/Context.php)
  - Modified `hasSuppressIssue()` method to handle magic methods from PHPDoc
  - When checking suppressions for a magic method, if not found on the method itself, it now checks the parent class
  - The class's suppression use count is properly incremented when its suppression suppresses a magic method issue
  - Added proper exception handling for robustness

2. UnusedSuppressionPlugin.php Updates (.phan/plugins/UnusedSuppressionPlugin.php)
  - Implemented SuppressionCapability interface with required stub methods
  - Modified `analyzeAddressableElement()` to skip magic methods from PHPDoc during unused suppression analysis
  - This prevents false positive reports for magic methods whose suppressions come from the parent class
  - Added proper `@unused-param` annotations for interface implementation
  - Added Suggestion import for interface compatibility

How It Works

  1. When an issue is emitted for a magic method from PHPDoc, Phan checks for suppressions
  2. The suppression checking now looks up the parent class if not found on the method
  3. The class's suppression use count is incremented (not the method's)
  4. When UnusedSuppressionPlugin analyzes suppressions, it skips magic methods, allowing the class to be analyzed instead
  5. The class's suppression shows as "used" because its count was incremented