### PR TITLE
try to do intelligent array shape merging on an array_merge()

### DIFF
--- a/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
@@ -445,7 +445,7 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
 
                 // Check that all array types in first arg are shapes (no union with generic arrays)
                 $first_arg_all_shapes = true;
-                /** @phan-suppress-next-line PhanNonClassMethodCall */
+                /** @phan-suppress-next-line PhanNonClassMethodCall,PhanPluginUnknownObjectMethodCall */
                 foreach ($first_arg_union->getTypeSet() as $type) {
                     if ($type instanceof ArrayType && !($type instanceof ArrayShapeType)) {
                         $first_arg_all_shapes = false;

--- a/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
@@ -394,6 +394,7 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
                 return NullType::instance(false)->asRealUnionType();
             }
             $has_non_array = false;
+            /** @var array<int,array{shapes:list<ArrayShapeType>,has_empty:bool,array_union:UnionType}> $array_shapes_per_arg */
             $array_shapes_per_arg = [];  // Track shapes per argument to avoid merging union alternatives
             $types = null;
 
@@ -419,8 +420,13 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
                 }
 
                 // Track shapes from this argument (they may be union alternatives)
+                // Also track the full array union to validate no other array variants exist
                 if (!empty($arg_shapes)) {
-                    $array_shapes_per_arg[] = ['shapes' => $arg_shapes, 'has_empty' => $arg_has_empty];
+                    $array_shapes_per_arg[] = [
+                        'shapes' => $arg_shapes,
+                        'has_empty' => $arg_has_empty,
+                        'array_union' => $new_types  // Full union for validation
+                    ];
                 }
 
                 $types = $types instanceof UnionType ? $types->withUnionType($new_types) : $new_types;
@@ -434,12 +440,13 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
                 // First argument has exactly one shape (the first must be $args[0])
                 // This handles cases like: array_merge(['key' => value], ...) where we preserve the shape
                 $shape_only = $array_shapes_per_arg[0]['shapes'][0];
-                $first_arg_type = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $args[0]);
-                $first_arg_generic = $first_arg_type->genericArrayTypes();
+                /** @phan-suppress-next-line PhanTypeInvalidDimOffset */
+                $first_arg_union = $array_shapes_per_arg[0]['array_union'];
 
                 // Check that all array types in first arg are shapes (no union with generic arrays)
                 $first_arg_all_shapes = true;
-                foreach ($first_arg_generic->getTypeSet() as $type) {
+                /** @phan-suppress-next-line PhanNonClassMethodCall */
+                foreach ($first_arg_union->getTypeSet() as $type) {
                     if ($type instanceof ArrayType && !($type instanceof ArrayShapeType)) {
                         $first_arg_all_shapes = false;
                         break;
@@ -471,7 +478,9 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
                 }
             } elseif (count($array_shapes_per_arg) > 1) {
                 // Multiple arguments, each with exactly one shape: merge them
-                // This is safe because each argument contributes one shape (no union alternatives)
+                // This is safe only if:
+                // 1. Each argument contributes exactly one shape (no union alternatives)
+                // 2. Each argument's array union consists ONLY of shapes (no generic/other array variants)
                 $all_single_shape = true;
                 $shapes_to_merge = [];
                 $is_empty_flags = [];
@@ -481,6 +490,23 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
                         $all_single_shape = false;
                         break;
                     }
+
+                    // IMPORTANT: Verify the argument's array union consists ONLY of the one shape
+                    // (no ArrayType or GenericArrayType alternatives that could override keys)
+                    $array_union = $arg_info['array_union'];
+                    $only_shapes = true;
+                    foreach ($array_union->getTypeSet() as $type) {
+                        if ($type instanceof ArrayType && !($type instanceof ArrayShapeType)) {
+                            $only_shapes = false;
+                            break;
+                        }
+                    }
+
+                    if (!$only_shapes) {
+                        $all_single_shape = false;
+                        break;
+                    }
+
                     $shapes_to_merge[] = $arg_info['shapes'][0];
                     $is_empty_flags[] = $arg_info['has_empty'];
                 }

--- a/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
@@ -394,50 +394,50 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
                 return NullType::instance(false)->asRealUnionType();
             }
             $has_non_array = false;
-            $array_shapes = [];
-            $is_empty_array = [];
+            $array_shapes_per_arg = [];  // Track shapes per argument to avoid merging union alternatives
             $types = null;
-            $arg_count = count($args);
 
             // Collect array types and track if we have array shapes
+            // We track shapes per argument because union types within an argument are alternatives (OR),
+            // not combinations to merge. Only merge shapes from different arguments.
             foreach ($args as $arg) {
                 $passed_array_type = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $arg);
                 $new_types = $passed_array_type->genericArrayTypes();
 
-                $has_shape_in_arg = false;
-                $is_arg_empty = false;
+                $arg_shapes = [];
+                $arg_has_empty = false;
 
                 // Check if this argument is or contains an array shape or generic array
                 foreach ($new_types->getTypeSet() as $type) {
                     if ($type instanceof ArrayShapeType) {
-                        $array_shapes[] = $type;
-                        $has_shape_in_arg = true;
+                        $arg_shapes[] = $type;
                         // Check if it's an empty shape
                         if (!$type->isNotEmptyArrayShape()) {
-                            $is_arg_empty = true;
+                            $arg_has_empty = true;
                         }
                     }
                 }
 
-                // Track whether this argument appears to be empty
-                if ($has_shape_in_arg) {
-                    $is_empty_array[] = $is_arg_empty;
+                // Track shapes from this argument (they may be union alternatives)
+                if (!empty($arg_shapes)) {
+                    $array_shapes_per_arg[] = ['shapes' => $arg_shapes, 'has_empty' => $arg_has_empty];
                 }
 
                 $types = $types instanceof UnionType ? $types->withUnionType($new_types) : $new_types;
                 $has_non_array = $has_non_array || (!$passed_array_type->hasRealTypeSet() || !$passed_array_type->asRealUnionType()->nonArrayTypes()->isEmpty());
             }
 
-            // Special case: if we have exactly one array shape in the first argument,
-            // and all other arguments are generic arrays (possibly empty), preserve the shape.
-            // This handles cases like: array_merge(['key' => value], $generic_array)
-            // NOTE: Array shapes with only integer keys will be converted to lists by withIntegerKeyArraysAsLists()
-            if (count($array_shapes) === 1 && $arg_count >= 1) {
-                $first_arg = $args[0];
-                $first_arg_type = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $first_arg);
+            // Only process shape merging if we have shapes and can do it safely.
+            // We only merge shapes from different arguments, never from the same argument
+            // (which would be union alternatives).
+            if (count($array_shapes_per_arg) === 1 && count($array_shapes_per_arg[0]['shapes']) === 1) {
+                // First argument has exactly one shape (the first must be $args[0])
+                // This handles cases like: array_merge(['key' => value], ...) where we preserve the shape
+                $shape_only = $array_shapes_per_arg[0]['shapes'][0];
+                $first_arg_type = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $args[0]);
                 $first_arg_generic = $first_arg_type->genericArrayTypes();
 
-                // Check that all array types in first arg are shapes
+                // Check that all array types in first arg are shapes (no union with generic arrays)
                 $first_arg_all_shapes = true;
                 foreach ($first_arg_generic->getTypeSet() as $type) {
                     if ($type instanceof ArrayType && !($type instanceof ArrayShapeType)) {
@@ -446,10 +446,8 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
                     }
                 }
 
-                // If the first arg contains only array shapes, preserve that structure
-                // But ONLY if we have non-integer keys (integer keys should become lists)
+                // If the first arg contains only shapes (not union with generics), check if we should preserve
                 if ($first_arg_all_shapes) {
-                    $shape_only = $array_shapes[0];
                     // Check if this shape has any non-integer keys
                     $has_non_int_keys = false;
                     /** @phan-suppress-next-line PhanUnusedVariableValueOfForeachWithKey */
@@ -471,18 +469,32 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
                         return $types;
                     }
                 }
-            }
+            } elseif (count($array_shapes_per_arg) > 1) {
+                // Multiple arguments, each with exactly one shape: merge them
+                // This is safe because each argument contributes one shape (no union alternatives)
+                $all_single_shape = true;
+                $shapes_to_merge = [];
+                $is_empty_flags = [];
 
-            // If we have multiple array shapes, try to merge them intelligently
-            if (!empty($array_shapes) && count($array_shapes) > 1) {
-                $merged_shape = $merge_array_shapes($array_shapes, $is_empty_array);
-                if ($merged_shape !== null) {
-                    // Use the merged shape and also apply integer key as list conversion
-                    $types = $merged_shape->withIntegerKeyArraysAsLists();
-                    if ($has_non_array || !$types->hasRealTypeSet()) {
-                        $types = $types->withRealTypeSet([ArrayType::instance(true)]);
+                foreach ($array_shapes_per_arg as $arg_info) {
+                    if (count($arg_info['shapes']) !== 1) {
+                        $all_single_shape = false;
+                        break;
                     }
-                    return $types;
+                    $shapes_to_merge[] = $arg_info['shapes'][0];
+                    $is_empty_flags[] = $arg_info['has_empty'];
+                }
+
+                if ($all_single_shape) {
+                    $merged_shape = $merge_array_shapes($shapes_to_merge, $is_empty_flags);
+                    if ($merged_shape !== null) {
+                        // Use the merged shape and also apply integer key as list conversion
+                        $types = $merged_shape->withIntegerKeyArraysAsLists();
+                        if ($has_non_array || !$types->hasRealTypeSet()) {
+                            $types = $types->withRealTypeSet([ArrayType::instance(true)]);
+                        }
+                        return $types;
+                    }
                 }
             }
 

--- a/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
@@ -334,20 +334,159 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
         };
 
         /**
+         * Merges array shapes intelligently, preserving key-to-type mappings when possible.
+         * For array_merge semantics: rightmost array's values win for overlapping keys.
+         * NOTE: If all keys are integers, this will return null to fallback to generic/list handling.
+         *
+         * @param list<ArrayShapeType> $shapes
+         * @param list<bool> $is_empty_array whether each corresponding shape argument is known to be empty
+         * @return ?UnionType The merged shape, or null if merging requires fallback to generic array
+         */
+        $merge_array_shapes = static function (array $shapes, array $is_empty_array): ?UnionType {
+            if (empty($shapes)) {
+                return null;
+            }
+
+            // Start with the first shape's fields
+            $merged_fields = $shapes[0]->getFieldTypes();
+
+            // Merge subsequent shapes, skipping those that are known to be empty
+            for ($i = 1; $i < count($shapes); $i++) {
+                // Skip merging in empty arrays - they don't contribute to the result
+                if ($is_empty_array[$i] ?? false) {
+                    continue;
+                }
+
+                $current_shape = $shapes[$i];
+                $current_fields = $current_shape->getFieldTypes();
+
+                // Merge the field types
+                // Later arrays' values override earlier ones for the same key
+                foreach ($current_fields as $key => $type) {
+                    $merged_fields[$key] = $type;
+                }
+            }
+
+            // If all keys are integers, don't return a shape (let normal list handling take over)
+            $all_int_keys = true;
+            /** @phan-suppress-next-line PhanUnusedVariableValueOfForeachWithKey */
+            foreach ($merged_fields as $key => $_type) {
+                if (!is_int($key)) {
+                    $all_int_keys = false;
+                    break;
+                }
+            }
+
+            // Only return a shape if we have at least one non-integer key
+            if ($all_int_keys) {
+                return null;
+            }
+
+            // Create and return the merged array shape
+            return ArrayShapeType::fromFieldTypes($merged_fields, false)->asPHPDocUnionType();
+        };
+
+        /**
          * @param list<Node|int|string|float> $args
          */
-        $merge_array_types_callback = static function (CodeBase $code_base, Context $context, Func $function, array $args) use ($array_type): UnionType {
+        $merge_array_types_callback = static function (CodeBase $code_base, Context $context, Func $function, array $args) use ($array_type, $merge_array_shapes): UnionType {
             if (!$args) {
                 return NullType::instance(false)->asRealUnionType();
             }
             $has_non_array = false;
+            $array_shapes = [];
+            $is_empty_array = [];
             $types = null;
+            $arg_count = count($args);
+
+            // Collect array types and track if we have array shapes
             foreach ($args as $arg) {
                 $passed_array_type = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $arg);
                 $new_types = $passed_array_type->genericArrayTypes();
+
+                $has_shape_in_arg = false;
+                $is_arg_empty = false;
+
+                // Check if this argument is or contains an array shape or generic array
+                foreach ($new_types->getTypeSet() as $type) {
+                    if ($type instanceof ArrayShapeType) {
+                        $array_shapes[] = $type;
+                        $has_shape_in_arg = true;
+                        // Check if it's an empty shape
+                        if (!$type->isNotEmptyArrayShape()) {
+                            $is_arg_empty = true;
+                        }
+                    }
+                }
+
+                // Track whether this argument appears to be empty
+                if ($has_shape_in_arg) {
+                    $is_empty_array[] = $is_arg_empty;
+                }
+
                 $types = $types instanceof UnionType ? $types->withUnionType($new_types) : $new_types;
                 $has_non_array = $has_non_array || (!$passed_array_type->hasRealTypeSet() || !$passed_array_type->asRealUnionType()->nonArrayTypes()->isEmpty());
             }
+
+            // Special case: if we have exactly one array shape in the first argument,
+            // and all other arguments are generic arrays (possibly empty), preserve the shape.
+            // This handles cases like: array_merge(['key' => value], $generic_array)
+            // NOTE: Array shapes with only integer keys will be converted to lists by withIntegerKeyArraysAsLists()
+            if (count($array_shapes) === 1 && $arg_count >= 1) {
+                $first_arg = $args[0];
+                $first_arg_type = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $first_arg);
+                $first_arg_generic = $first_arg_type->genericArrayTypes();
+
+                // Check that all array types in first arg are shapes
+                $first_arg_all_shapes = true;
+                foreach ($first_arg_generic->getTypeSet() as $type) {
+                    if ($type instanceof ArrayType && !($type instanceof ArrayShapeType)) {
+                        $first_arg_all_shapes = false;
+                        break;
+                    }
+                }
+
+                // If the first arg contains only array shapes, preserve that structure
+                // But ONLY if we have non-integer keys (integer keys should become lists)
+                if ($first_arg_all_shapes) {
+                    $shape_only = $array_shapes[0];
+                    // Check if this shape has any non-integer keys
+                    $has_non_int_keys = false;
+                    /** @phan-suppress-next-line PhanUnusedVariableValueOfForeachWithKey */
+                    foreach ($shape_only->getFieldTypes() as $key => $_type) {
+                        if (!is_int($key)) {
+                            $has_non_int_keys = true;
+                            break;
+                        }
+                    }
+
+                    // Only preserve as shape if we have non-integer keys
+                    if ($has_non_int_keys) {
+                        $merged_shape = $shape_only->asPHPDocUnionType();
+                        // Use the shape and also apply integer key as list conversion
+                        $types = $merged_shape->withIntegerKeyArraysAsLists();
+                        if ($has_non_array || !$types->hasRealTypeSet()) {
+                            $types = $types->withRealTypeSet([ArrayType::instance(true)]);
+                        }
+                        return $types;
+                    }
+                }
+            }
+
+            // If we have multiple array shapes, try to merge them intelligently
+            if (!empty($array_shapes) && count($array_shapes) > 1) {
+                $merged_shape = $merge_array_shapes($array_shapes, $is_empty_array);
+                if ($merged_shape !== null) {
+                    // Use the merged shape and also apply integer key as list conversion
+                    $types = $merged_shape->withIntegerKeyArraysAsLists();
+                    if ($has_non_array || !$types->hasRealTypeSet()) {
+                        $types = $types->withRealTypeSet([ArrayType::instance(true)]);
+                    }
+                    return $types;
+                }
+            }
+
+            // Fall back to the original behavior if we can't merge array shapes
             $types = $types->withFlattenedTopLevelArrayShapeTypeInstances()
                            ->withIntegerKeyArraysAsLists();
             if ($types->isEmpty()) {

--- a/tests/files/src/array_merge_shape_preservation.php
+++ b/tests/files/src/array_merge_shape_preservation.php
@@ -1,0 +1,61 @@
+<?php
+// Test case 1: array_merge with shape and generic array
+// Note: when merging with a generic array parameter, the generic array might
+// have different types for the same keys, so we do get false|... type
+function test_merge_shape_with_generic(array $params = []) {
+    $params = array_merge([
+        'shop_section' => null,
+        'with_count' => false,
+    ], $params);
+    h($params['shop_section']);  // Should NOT warn - type is null (from first array, not overridden by generic)
+    // Note: with_count could be overridden by $params to other types, so we don't test it
+}
+
+// Test case 2: array_merge with only shapes
+function test_merge_two_shapes() {
+    $result = array_merge(
+        ['name' => 'John', 'age' => 30],
+        ['email' => 'john@example.com']
+    );
+    // Result shape should have: name, age, email
+    h($result['name']);     // Should NOT warn - type is string
+    h($result['email']);    // Should NOT warn - type is string
+}
+
+// Test case 3: array_merge where later shape overrides earlier
+function test_merge_overlapping_shapes() {
+    $result = array_merge(
+        ['status' => 'active', 'count' => 10],
+        ['status' => null]  // This overrides the earlier 'active' with null
+    );
+    h_null($result['status']); // Should NOT warn - type is null
+}
+
+// Test case 4: Original example that triggered the bug
+function f(array $params = []) {
+    $params = array_merge([
+        'shop_section' => null,
+        'with_count' => false,
+    ], $params);
+    h($params['shop_section']);
+}
+
+function g() {
+    $params = [
+        'shop_section' => null,
+        'with_count' => false,
+    ];
+    h($params['shop_section']);
+}
+
+// Helper functions
+function h(?string $arg) {
+    echo $arg;
+}
+
+function h_null(?string $arg) {
+    echo $arg;
+}
+
+f();
+g();


### PR DESCRIPTION
Intelligent array shape merging for array_merge(), array_merge_recursive(), array_replace() and array_replace_recursive()
  1. Created $merge_array_shapes closure that intelligently merges array shapes
  2. Preserves non-integer keys in merged shapes (string keys like 'shop_section')
  3. Falls back to generic/list handling for shapes with only integer keys
  4. Special handling for first argument with shapes + remaining generic arrays