### PR TITLE
Tweak array_merge shapes a bit

### DIFF
--- a/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
@@ -480,10 +480,11 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
                             $types = $merged_shape->withIntegerKeyArraysAsLists();
                         } else {
                             // Shape is from a later argument (last argument in array_merge).
-                            // Merge it with the accumulated types from earlier arguments.
-                            // This preserves the generic array type from the first argument
-                            // while adding the guaranteed keys from the last argument.
-                            $types = $types->withUnionType($merged_shape)->withIntegerKeyArraysAsLists();
+                            // Flatten away shapes from earlier non-pure arguments (they're not guaranteed),
+                            // keeping only generic array types, then merge with the guaranteed last shape.
+                            // This preserves generic element access while adding the guaranteed keys.
+                            $flattened_types = $types->withFlattenedTopLevelArrayShapeTypeInstances();
+                            $types = $flattened_types->withUnionType($merged_shape)->withIntegerKeyArraysAsLists();
                         }
 
                         if ($has_non_array || !$types->hasRealTypeSet()) {
@@ -566,12 +567,17 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
                     } else {
                         // Not all arguments are pure, but we know the ACTUAL LAST argument IS pure.
                         // In array_merge, the last argument's keys are guaranteed to be in the result.
-                        // Merge the last argument's shape with the accumulated types from earlier arguments
-                        // to preserve both the guaranteed keys and any generic array elements.
+                        // However, shapes from non-pure earlier arguments must be removed because they
+                        // may not actually be present (the argument could match its generic alternative).
+                        // We flatten the shapes away and keep only the generic array types, then merge
+                        // with the guaranteed shape from the last argument.
                         if ($last_shape_info !== null) {
                             $last_shape = $last_shape_info['shapes'][0];
                             $last_shape_union = $last_shape->asPHPDocUnionType();
-                            $types = $types->withUnionType($last_shape_union)->withIntegerKeyArraysAsLists();
+                            // Flatten shapes from non-pure arguments, keeping only generic arrays
+                            $flattened_types = $types->withFlattenedTopLevelArrayShapeTypeInstances();
+                            // Merge the flattened types with the guaranteed last shape
+                            $types = $flattened_types->withUnionType($last_shape_union)->withIntegerKeyArraysAsLists();
                             if ($has_non_array || !$types->hasRealTypeSet()) {
                                 $types = $types->withRealTypeSet([ArrayType::instance(true)]);
                             }

--- a/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
@@ -478,14 +478,14 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
                 }
             } elseif (count($array_shapes_per_arg) > 1) {
                 // Multiple arguments, each with exactly one shape: merge them
-                // This is safe if:
-                // 1. Each argument contributes exactly one shape (no union alternatives)
-                // 2. All early arguments are pure shapes, OR the last argument is a pure shape
-                //    (in array_merge semantics, rightmost values win, so a pure last shape's keys are guaranteed)
+                // This is safe if the last argument's array union consists ONLY of shapes,
+                // regardless of what the earlier arguments contain.
+                // In array_merge semantics, rightmost values win, so the last argument's keys are guaranteed.
                 $all_single_shape = true;
                 $shapes_to_merge = [];
                 $is_empty_flags = [];
-                $all_arg_infos_only_shapes = true;
+                $last_arg_index = count($array_shapes_per_arg) - 1;
+                $last_arg_only_shapes = true;  // Assume true until proven otherwise
 
                 foreach ($array_shapes_per_arg as $i => $arg_info) {
                     if (count($arg_info['shapes']) !== 1) {
@@ -493,38 +493,29 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
                         break;
                     }
 
-                    // IMPORTANT: Verify the argument's array union consists ONLY of the one shape
-                    // (no ArrayType or GenericArrayType alternatives that could override keys)
-                    $array_union = $arg_info['array_union'];
-                    $only_shapes = true;
-                    foreach ($array_union->getTypeSet() as $type) {
-                        if ($type instanceof ArrayType && !($type instanceof ArrayShapeType)) {
-                            $only_shapes = false;
-                            break;
-                        }
-                    }
-
-                    if (!$only_shapes) {
-                        // Allow non-pure-shape arguments UNLESS this is not the last argument
-                        // (rightmost argument in array_merge wins for all keys)
-                        $is_last_arg = ($i === count($array_shapes_per_arg) - 1);
-                        if (!$is_last_arg) {
-                            $all_single_shape = false;
-                            break;
-                        }
-                        $all_arg_infos_only_shapes = false;
-                    }
-
                     $shapes_to_merge[] = $arg_info['shapes'][0];
                     $is_empty_flags[] = $arg_info['has_empty'];
+
+                    // For the last argument, verify it consists ONLY of shapes
+                    // (no ArrayType or GenericArrayType alternatives that could override keys)
+                    if ($i === $last_arg_index) {
+                        $array_union = $arg_info['array_union'];
+                        foreach ($array_union->getTypeSet() as $type) {
+                            if ($type instanceof ArrayType && !($type instanceof ArrayShapeType)) {
+                                $last_arg_only_shapes = false;
+                                break;
+                            }
+                        }
+                    }
                 }
 
-                if ($all_single_shape) {
+                // Only merge if all arguments have exactly one shape AND the last one is pure shapes
+                if ($all_single_shape && $last_arg_only_shapes) {
                     $merged_shape = $merge_array_shapes($shapes_to_merge, $is_empty_flags);
                     if ($merged_shape !== null) {
                         // Use the merged shape and also apply integer key as list conversion
                         $types = $merged_shape->withIntegerKeyArraysAsLists();
-                        if ($has_non_array || !$types->hasRealTypeSet() || !$all_arg_infos_only_shapes) {
+                        if ($has_non_array || !$types->hasRealTypeSet()) {
                             $types = $types->withRealTypeSet([ArrayType::instance(true)]);
                         }
                         return $types;

--- a/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
@@ -438,90 +438,124 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
             // We only merge shapes from different arguments, never from the same argument
             // (which would be union alternatives).
             if (count($array_shapes_per_arg) === 1 && count($array_shapes_per_arg[0]['shapes']) === 1) {
-                // Only preserve shape if it's from the FIRST argument
-                // (array_merge with first arg being pure shape is safe to preserve)
-                // If the shape is from a later argument, don't preserve it (earlier args might be generic)
-                $first_shape_info = $array_shapes_per_arg[0];
+                // Single argument with one shape. This could be from the first argument or a later argument.
+                $shape_info = $array_shapes_per_arg[0];
                 /** @phan-suppress-next-line PhanTypeInvalidDimOffset */
-                if ($first_shape_info['arg_index'] === 0) {
-                    // First argument has exactly one shape
-                    // This handles cases like: array_merge(['key' => value], ...) where we preserve the shape
-                    $shape_only = $first_shape_info['shapes'][0];
-                    /** @phan-suppress-next-line PhanTypeInvalidDimOffset */
-                    $first_arg_union = $first_shape_info['array_union'];
+                $shape_arg_index = $shape_info['arg_index'];
+                $shape_only = $shape_info['shapes'][0];
+                /** @phan-suppress-next-line PhanTypeInvalidDimOffset */
+                $shape_arg_union = $shape_info['array_union'];
 
-                    // Check that all array types in first arg are shapes (no union with generic arrays)
-                    $first_arg_all_shapes = true;
-                    /** @phan-suppress-next-line PhanNonClassMethodCall,PhanPluginUnknownObjectMethodCall */
-                    foreach ($first_arg_union->getTypeSet() as $type) {
-                        if ($type instanceof ArrayType && !($type instanceof ArrayShapeType)) {
-                            $first_arg_all_shapes = false;
+                // Check if this argument's union consists only of shapes (no generic alternatives)
+                $shape_arg_all_shapes = true;
+                /** @phan-suppress-next-line PhanNonClassMethodCall,PhanPluginUnknownObjectMethodCall */
+                foreach ($shape_arg_union->getTypeSet() as $type) {
+                    if ($type instanceof ArrayType && !($type instanceof ArrayShapeType)) {
+                        $shape_arg_all_shapes = false;
+                        break;
+                    }
+                }
+
+                // Preserve the shape if:
+                // 1. It's from the first argument (arg_index 0), OR
+                // 2. It's from a later argument AND there are multiple arguments to merge
+                //    (meaning it's the last argument in array_merge, guaranteed by the check)
+                if ($shape_arg_all_shapes && ($shape_arg_index === 0 || count($args) > 1)) {
+                    // Check if this shape has any non-integer keys
+                    $has_non_int_keys = false;
+                    /** @phan-suppress-next-line PhanUnusedVariableValueOfForeachWithKey */
+                    foreach ($shape_only->getFieldTypes() as $key => $_type) {
+                        if (!is_int($key)) {
+                            $has_non_int_keys = true;
                             break;
                         }
                     }
 
-                    // If the first arg contains only shapes (not union with generics), check if we should preserve
-                    if ($first_arg_all_shapes) {
-                        // Check if this shape has any non-integer keys
-                        $has_non_int_keys = false;
-                        /** @phan-suppress-next-line PhanUnusedVariableValueOfForeachWithKey */
-                        foreach ($shape_only->getFieldTypes() as $key => $_type) {
-                            if (!is_int($key)) {
-                                $has_non_int_keys = true;
-                                break;
+                    // Only preserve as shape if we have non-integer keys
+                    if ($has_non_int_keys) {
+                        $merged_shape = $shape_only->asPHPDocUnionType();
+
+                        if ($shape_arg_index === 0) {
+                            // Shape is from the first argument, return it directly
+                            $types = $merged_shape->withIntegerKeyArraysAsLists();
+                        } else {
+                            // Shape is from a later argument (last argument in array_merge).
+                            // Merge it with the accumulated types from earlier arguments.
+                            // This preserves the generic array type from the first argument
+                            // while adding the guaranteed keys from the last argument.
+                            $types = $types->withUnionType($merged_shape)->withIntegerKeyArraysAsLists();
+                        }
+
+                        if ($has_non_array || !$types->hasRealTypeSet()) {
+                            $types = $types->withRealTypeSet([ArrayType::instance(true)]);
+                        }
+                        return $types;
+                    }
+                }
+            } elseif (count($array_shapes_per_arg) > 1) {
+                // Multiple arguments, each with exactly one shape: merge them
+                // In array_merge, the rightmost (last) argument's values always win for string keys.
+                // So if the last argument is a pure shape, its keys are guaranteed in the result,
+                // even if earlier arguments are mixed (shape|generic).
+
+                // First, check if the last argument is pure shapes
+                $last_arg_info = $array_shapes_per_arg[count($array_shapes_per_arg) - 1];
+                $last_is_pure = true;
+                foreach ($last_arg_info['array_union']->getTypeSet() as $type) {
+                    if ($type instanceof ArrayType && !($type instanceof ArrayShapeType)) {
+                        $last_is_pure = false;
+                        break;
+                    }
+                }
+
+                if (!$last_is_pure || count($last_arg_info['shapes']) !== 1) {
+                    // Last argument is not a pure single shape, can't preserve shapes from any argument
+                    // Fall through to generic handling below
+                } else {
+                    // Last argument is pure with exactly one shape
+                    // Check if ALL arguments are pure (so we can merge all)
+                    $all_single_shape = true;
+                    $all_args_pure_shapes = true;
+                    $shapes_to_merge = [];
+                    $is_empty_flags = [];
+
+                    foreach ($array_shapes_per_arg as $arg_info) {
+                        if (count($arg_info['shapes']) !== 1) {
+                            $all_single_shape = false;
+                            break;
+                        }
+
+                        $array_union = $arg_info['array_union'];
+                        foreach ($array_union->getTypeSet() as $type) {
+                            if ($type instanceof ArrayType && !($type instanceof ArrayShapeType)) {
+                                // This argument has non-shape alternatives
+                                $all_args_pure_shapes = false;
+                                break;  // Just break the inner foreach, not both
                             }
                         }
 
-                        // Only preserve as shape if we have non-integer keys
-                        if ($has_non_int_keys) {
-                            $merged_shape = $shape_only->asPHPDocUnionType();
-                            // Use the shape and also apply integer key as list conversion
+                        $shapes_to_merge[] = $arg_info['shapes'][0];
+                        $is_empty_flags[] = $arg_info['has_empty'];
+                    }
+
+                    // If all arguments have exactly one shape AND all are pure shapes, merge them
+                    if ($all_single_shape && $all_args_pure_shapes) {
+                        $merged_shape = $merge_array_shapes($shapes_to_merge, $is_empty_flags);
+                        if ($merged_shape !== null) {
+                            // Use the merged shape and also apply integer key as list conversion
                             $types = $merged_shape->withIntegerKeyArraysAsLists();
                             if ($has_non_array || !$types->hasRealTypeSet()) {
                                 $types = $types->withRealTypeSet([ArrayType::instance(true)]);
                             }
                             return $types;
                         }
-                    }
-                }
-            } elseif (count($array_shapes_per_arg) > 1) {
-                // Multiple arguments, each with exactly one shape: merge them
-                // This is safe ONLY if ALL arguments' array unions consist ONLY of shapes.
-                // If any argument has generic/other array type alternatives, we cannot safely merge
-                // their shapes because we can't guarantee those keys are present at runtime.
-                // For example, array{a:int}|list<int> might be a list, so we can't guarantee 'a'.
-                $all_single_shape = true;
-                $all_args_pure_shapes = true;
-                $shapes_to_merge = [];
-                $is_empty_flags = [];
-
-                foreach ($array_shapes_per_arg as $arg_info) {
-                    if (count($arg_info['shapes']) !== 1) {
-                        $all_single_shape = false;
-                        break;
-                    }
-
-                    // CRITICAL: Verify EVERY argument's union consists ONLY of shapes
-                    // If an argument has generic/other array alternatives, it's not guaranteed to have those keys
-                    $array_union = $arg_info['array_union'];
-                    foreach ($array_union->getTypeSet() as $type) {
-                        if ($type instanceof ArrayType && !($type instanceof ArrayShapeType)) {
-                            // This argument has non-shape alternatives - can't safely merge
-                            $all_args_pure_shapes = false;
-                            break 2;  // Break out of both loops
-                        }
-                    }
-
-                    $shapes_to_merge[] = $arg_info['shapes'][0];
-                    $is_empty_flags[] = $arg_info['has_empty'];
-                }
-
-                // Only merge if all arguments have exactly one shape AND all are pure shapes
-                if ($all_single_shape && $all_args_pure_shapes) {
-                    $merged_shape = $merge_array_shapes($shapes_to_merge, $is_empty_flags);
-                    if ($merged_shape !== null) {
-                        // Use the merged shape and also apply integer key as list conversion
-                        $types = $merged_shape->withIntegerKeyArraysAsLists();
+                    } else {
+                        // Not all arguments are pure, but we know the last argument IS pure
+                        // (from the condition on line 503).
+                        // In array_merge, the last argument's keys are guaranteed to be in the result.
+                        // Return at least the last argument's shape to preserve those guaranteed keys.
+                        $last_shape = $last_arg_info['shapes'][0];
+                        $types = $last_shape->asPHPDocUnionType()->withIntegerKeyArraysAsLists();
                         if ($has_non_array || !$types->hasRealTypeSet()) {
                             $types = $types->withRealTypeSet([ArrayType::instance(true)]);
                         }

--- a/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
@@ -478,14 +478,16 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
                 }
             } elseif (count($array_shapes_per_arg) > 1) {
                 // Multiple arguments, each with exactly one shape: merge them
-                // This is safe only if:
+                // This is safe if:
                 // 1. Each argument contributes exactly one shape (no union alternatives)
-                // 2. Each argument's array union consists ONLY of shapes (no generic/other array variants)
+                // 2. All early arguments are pure shapes, OR the last argument is a pure shape
+                //    (in array_merge semantics, rightmost values win, so a pure last shape's keys are guaranteed)
                 $all_single_shape = true;
                 $shapes_to_merge = [];
                 $is_empty_flags = [];
+                $all_arg_infos_only_shapes = true;
 
-                foreach ($array_shapes_per_arg as $arg_info) {
+                foreach ($array_shapes_per_arg as $i => $arg_info) {
                     if (count($arg_info['shapes']) !== 1) {
                         $all_single_shape = false;
                         break;
@@ -503,8 +505,14 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
                     }
 
                     if (!$only_shapes) {
-                        $all_single_shape = false;
-                        break;
+                        // Allow non-pure-shape arguments UNLESS this is not the last argument
+                        // (rightmost argument in array_merge wins for all keys)
+                        $is_last_arg = ($i === count($array_shapes_per_arg) - 1);
+                        if (!$is_last_arg) {
+                            $all_single_shape = false;
+                            break;
+                        }
+                        $all_arg_infos_only_shapes = false;
                     }
 
                     $shapes_to_merge[] = $arg_info['shapes'][0];
@@ -516,7 +524,7 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
                     if ($merged_shape !== null) {
                         // Use the merged shape and also apply integer key as list conversion
                         $types = $merged_shape->withIntegerKeyArraysAsLists();
-                        if ($has_non_array || !$types->hasRealTypeSet()) {
+                        if ($has_non_array || !$types->hasRealTypeSet() || !$all_arg_infos_only_shapes) {
                             $types = $types->withRealTypeSet([ArrayType::instance(true)]);
                         }
                         return $types;

--- a/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
@@ -458,9 +458,9 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
 
                 // Preserve the shape if:
                 // 1. It's from the first argument (arg_index 0), OR
-                // 2. It's from a later argument AND there are multiple arguments to merge
-                //    (meaning it's the last argument in array_merge, guaranteed by the check)
-                if ($shape_arg_all_shapes && ($shape_arg_index === 0 || count($args) > 1)) {
+                // 2. It's from the ACTUAL LAST argument (arg_index == count($args) - 1)
+                //    (shapes from middle arguments are not guaranteed after later arguments override them)
+                if ($shape_arg_all_shapes && ($shape_arg_index === 0 || $shape_arg_index === count($args) - 1)) {
                     // Check if this shape has any non-integer keys
                     $has_non_int_keys = false;
                     /** @phan-suppress-next-line PhanUnusedVariableValueOfForeachWithKey */
@@ -495,20 +495,34 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
             } elseif (count($array_shapes_per_arg) > 1) {
                 // Multiple arguments, each with exactly one shape: merge them
                 // In array_merge, the rightmost (last) argument's values always win for string keys.
-                // So if the last argument is a pure shape, its keys are guaranteed in the result,
-                // even if earlier arguments are mixed (shape|generic).
+                // So if the actual last argument passed to array_merge is a pure shape, its keys are guaranteed.
+                // NOTE: $array_shapes_per_arg only contains arguments WITH shapes, so we must verify
+                // that the last shape we collected is actually from the final argument position.
 
-                // First, check if the last argument is pure shapes
-                $last_arg_info = $array_shapes_per_arg[count($array_shapes_per_arg) - 1];
-                $last_is_pure = true;
-                foreach ($last_arg_info['array_union']->getTypeSet() as $type) {
-                    if ($type instanceof ArrayType && !($type instanceof ArrayShapeType)) {
-                        $last_is_pure = false;
+                // Check if there's a shape from the actual last argument (arg_index == count($args) - 1)
+                $last_arg_index = count($args) - 1;
+                $last_arg_is_pure_shape = false;
+                $last_shape_info = null;
+
+                foreach ($array_shapes_per_arg as $arg_info) {
+                    if ($arg_info['arg_index'] === $last_arg_index) {
+                        $last_shape_info = $arg_info;
+                        // Check if this last argument is pure shapes
+                        if (count($arg_info['shapes']) === 1) {
+                            $is_pure = true;
+                            foreach ($arg_info['array_union']->getTypeSet() as $type) {
+                                if ($type instanceof ArrayType && !($type instanceof ArrayShapeType)) {
+                                    $is_pure = false;
+                                    break;
+                                }
+                            }
+                            $last_arg_is_pure_shape = $is_pure;
+                        }
                         break;
                     }
                 }
 
-                if (!$last_is_pure || count($last_arg_info['shapes']) !== 1) {
+                if (!$last_arg_is_pure_shape) {
                     // Last argument is not a pure single shape, can't preserve shapes from any argument
                     // Fall through to generic handling below
                 } else {
@@ -550,16 +564,17 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
                             return $types;
                         }
                     } else {
-                        // Not all arguments are pure, but we know the last argument IS pure
-                        // (from the condition on line 503).
+                        // Not all arguments are pure, but we know the ACTUAL LAST argument IS pure.
                         // In array_merge, the last argument's keys are guaranteed to be in the result.
                         // Return at least the last argument's shape to preserve those guaranteed keys.
-                        $last_shape = $last_arg_info['shapes'][0];
-                        $types = $last_shape->asPHPDocUnionType()->withIntegerKeyArraysAsLists();
-                        if ($has_non_array || !$types->hasRealTypeSet()) {
-                            $types = $types->withRealTypeSet([ArrayType::instance(true)]);
+                        if ($last_shape_info !== null) {
+                            $last_shape = $last_shape_info['shapes'][0];
+                            $types = $last_shape->asPHPDocUnionType()->withIntegerKeyArraysAsLists();
+                            if ($has_non_array || !$types->hasRealTypeSet()) {
+                                $types = $types->withRealTypeSet([ArrayType::instance(true)]);
+                            }
+                            return $types;
                         }
-                        return $types;
                     }
                 }
             }

--- a/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
@@ -394,14 +394,14 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
                 return NullType::instance(false)->asRealUnionType();
             }
             $has_non_array = false;
-            /** @var array<int,array{shapes:list<ArrayShapeType>,has_empty:bool,array_union:UnionType}> $array_shapes_per_arg */
+            /** @var array<int,array{shapes:list<ArrayShapeType>,has_empty:bool,array_union:UnionType,arg_index:int}> $array_shapes_per_arg */
             $array_shapes_per_arg = [];  // Track shapes per argument to avoid merging union alternatives
             $types = null;
 
             // Collect array types and track if we have array shapes
             // We track shapes per argument because union types within an argument are alternatives (OR),
             // not combinations to merge. Only merge shapes from different arguments.
-            foreach ($args as $arg) {
+            foreach ($args as $arg_index => $arg) {
                 $passed_array_type = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $arg);
                 $new_types = $passed_array_type->genericArrayTypes();
 
@@ -423,6 +423,7 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
                 // Also track the full array union to validate no other array variants exist
                 if (!empty($arg_shapes)) {
                     $array_shapes_per_arg[] = [
+                        'arg_index' => $arg_index,  // Track which argument this came from
                         'shapes' => $arg_shapes,
                         'has_empty' => $arg_has_empty,
                         'array_union' => $new_types  // Full union for validation
@@ -437,43 +438,50 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
             // We only merge shapes from different arguments, never from the same argument
             // (which would be union alternatives).
             if (count($array_shapes_per_arg) === 1 && count($array_shapes_per_arg[0]['shapes']) === 1) {
-                // First argument has exactly one shape (the first must be $args[0])
-                // This handles cases like: array_merge(['key' => value], ...) where we preserve the shape
-                $shape_only = $array_shapes_per_arg[0]['shapes'][0];
+                // Only preserve shape if it's from the FIRST argument
+                // (array_merge with first arg being pure shape is safe to preserve)
+                // If the shape is from a later argument, don't preserve it (earlier args might be generic)
+                $first_shape_info = $array_shapes_per_arg[0];
                 /** @phan-suppress-next-line PhanTypeInvalidDimOffset */
-                $first_arg_union = $array_shapes_per_arg[0]['array_union'];
+                if ($first_shape_info['arg_index'] === 0) {
+                    // First argument has exactly one shape
+                    // This handles cases like: array_merge(['key' => value], ...) where we preserve the shape
+                    $shape_only = $first_shape_info['shapes'][0];
+                    /** @phan-suppress-next-line PhanTypeInvalidDimOffset */
+                    $first_arg_union = $first_shape_info['array_union'];
 
-                // Check that all array types in first arg are shapes (no union with generic arrays)
-                $first_arg_all_shapes = true;
-                /** @phan-suppress-next-line PhanNonClassMethodCall,PhanPluginUnknownObjectMethodCall */
-                foreach ($first_arg_union->getTypeSet() as $type) {
-                    if ($type instanceof ArrayType && !($type instanceof ArrayShapeType)) {
-                        $first_arg_all_shapes = false;
-                        break;
-                    }
-                }
-
-                // If the first arg contains only shapes (not union with generics), check if we should preserve
-                if ($first_arg_all_shapes) {
-                    // Check if this shape has any non-integer keys
-                    $has_non_int_keys = false;
-                    /** @phan-suppress-next-line PhanUnusedVariableValueOfForeachWithKey */
-                    foreach ($shape_only->getFieldTypes() as $key => $_type) {
-                        if (!is_int($key)) {
-                            $has_non_int_keys = true;
+                    // Check that all array types in first arg are shapes (no union with generic arrays)
+                    $first_arg_all_shapes = true;
+                    /** @phan-suppress-next-line PhanNonClassMethodCall,PhanPluginUnknownObjectMethodCall */
+                    foreach ($first_arg_union->getTypeSet() as $type) {
+                        if ($type instanceof ArrayType && !($type instanceof ArrayShapeType)) {
+                            $first_arg_all_shapes = false;
                             break;
                         }
                     }
 
-                    // Only preserve as shape if we have non-integer keys
-                    if ($has_non_int_keys) {
-                        $merged_shape = $shape_only->asPHPDocUnionType();
-                        // Use the shape and also apply integer key as list conversion
-                        $types = $merged_shape->withIntegerKeyArraysAsLists();
-                        if ($has_non_array || !$types->hasRealTypeSet()) {
-                            $types = $types->withRealTypeSet([ArrayType::instance(true)]);
+                    // If the first arg contains only shapes (not union with generics), check if we should preserve
+                    if ($first_arg_all_shapes) {
+                        // Check if this shape has any non-integer keys
+                        $has_non_int_keys = false;
+                        /** @phan-suppress-next-line PhanUnusedVariableValueOfForeachWithKey */
+                        foreach ($shape_only->getFieldTypes() as $key => $_type) {
+                            if (!is_int($key)) {
+                                $has_non_int_keys = true;
+                                break;
+                            }
                         }
-                        return $types;
+
+                        // Only preserve as shape if we have non-integer keys
+                        if ($has_non_int_keys) {
+                            $merged_shape = $shape_only->asPHPDocUnionType();
+                            // Use the shape and also apply integer key as list conversion
+                            $types = $merged_shape->withIntegerKeyArraysAsLists();
+                            if ($has_non_array || !$types->hasRealTypeSet()) {
+                                $types = $types->withRealTypeSet([ArrayType::instance(true)]);
+                            }
+                            return $types;
+                        }
                     }
                 }
             } elseif (count($array_shapes_per_arg) > 1) {

--- a/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
@@ -478,39 +478,38 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
                 }
             } elseif (count($array_shapes_per_arg) > 1) {
                 // Multiple arguments, each with exactly one shape: merge them
-                // This is safe if the last argument's array union consists ONLY of shapes,
-                // regardless of what the earlier arguments contain.
-                // In array_merge semantics, rightmost values win, so the last argument's keys are guaranteed.
+                // This is safe ONLY if ALL arguments' array unions consist ONLY of shapes.
+                // If any argument has generic/other array type alternatives, we cannot safely merge
+                // their shapes because we can't guarantee those keys are present at runtime.
+                // For example, array{a:int}|list<int> might be a list, so we can't guarantee 'a'.
                 $all_single_shape = true;
+                $all_args_pure_shapes = true;
                 $shapes_to_merge = [];
                 $is_empty_flags = [];
-                $last_arg_index = count($array_shapes_per_arg) - 1;
-                $last_arg_only_shapes = true;  // Assume true until proven otherwise
 
-                foreach ($array_shapes_per_arg as $i => $arg_info) {
+                foreach ($array_shapes_per_arg as $arg_info) {
                     if (count($arg_info['shapes']) !== 1) {
                         $all_single_shape = false;
                         break;
                     }
 
-                    $shapes_to_merge[] = $arg_info['shapes'][0];
-                    $is_empty_flags[] = $arg_info['has_empty'];
-
-                    // For the last argument, verify it consists ONLY of shapes
-                    // (no ArrayType or GenericArrayType alternatives that could override keys)
-                    if ($i === $last_arg_index) {
-                        $array_union = $arg_info['array_union'];
-                        foreach ($array_union->getTypeSet() as $type) {
-                            if ($type instanceof ArrayType && !($type instanceof ArrayShapeType)) {
-                                $last_arg_only_shapes = false;
-                                break;
-                            }
+                    // CRITICAL: Verify EVERY argument's union consists ONLY of shapes
+                    // If an argument has generic/other array alternatives, it's not guaranteed to have those keys
+                    $array_union = $arg_info['array_union'];
+                    foreach ($array_union->getTypeSet() as $type) {
+                        if ($type instanceof ArrayType && !($type instanceof ArrayShapeType)) {
+                            // This argument has non-shape alternatives - can't safely merge
+                            $all_args_pure_shapes = false;
+                            break 2;  // Break out of both loops
                         }
                     }
+
+                    $shapes_to_merge[] = $arg_info['shapes'][0];
+                    $is_empty_flags[] = $arg_info['has_empty'];
                 }
 
-                // Only merge if all arguments have exactly one shape AND the last one is pure shapes
-                if ($all_single_shape && $last_arg_only_shapes) {
+                // Only merge if all arguments have exactly one shape AND all are pure shapes
+                if ($all_single_shape && $all_args_pure_shapes) {
                     $merged_shape = $merge_array_shapes($shapes_to_merge, $is_empty_flags);
                     if ($merged_shape !== null) {
                         // Use the merged shape and also apply integer key as list conversion

--- a/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/ArrayReturnTypeOverridePlugin.php
@@ -566,10 +566,12 @@ final class ArrayReturnTypeOverridePlugin extends PluginV3 implements
                     } else {
                         // Not all arguments are pure, but we know the ACTUAL LAST argument IS pure.
                         // In array_merge, the last argument's keys are guaranteed to be in the result.
-                        // Return at least the last argument's shape to preserve those guaranteed keys.
+                        // Merge the last argument's shape with the accumulated types from earlier arguments
+                        // to preserve both the guaranteed keys and any generic array elements.
                         if ($last_shape_info !== null) {
                             $last_shape = $last_shape_info['shapes'][0];
-                            $types = $last_shape->asPHPDocUnionType()->withIntegerKeyArraysAsLists();
+                            $last_shape_union = $last_shape->asPHPDocUnionType();
+                            $types = $types->withUnionType($last_shape_union)->withIntegerKeyArraysAsLists();
                             if ($has_non_array || !$types->hasRealTypeSet()) {
                                 $types = $types->withRealTypeSet([ArrayType::instance(true)]);
                             }

--- a/tests/files/expected/array_merge_shape_preservation.php.expected
+++ b/tests/files/expected/array_merge_shape_preservation.php.expected
@@ -1,0 +1,6 @@
+%s:65 PhanRedundantCondition Redundant attempt to cast true of type true to truthy
+%s:65 PhanTypeInvalidBitwiseBinaryOperator Invalid non-int/non-string operand provided to operator '|' between types array{a:1} and array{b:'string'}
+%s:65 PhanTypeInvalidLeftOperandOfBitwiseOp Invalid operator: left operand of | is array{a:1} (expected int|string)
+%s:65 PhanTypeInvalidRightOperandOfBitwiseOp Invalid operator: right operand of | is array{b:'string'} (expected int|string)
+%s:66 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($arrays) is $data of type int (real type int|string) but \array_merge() takes array
+%s:101 PhanTypeMismatchArgument Argument 1 ($mixed) is [] of type array{} but \test_param_union_with_pure_last() takes array{a:int}|array{b:string} defined at %s:75

--- a/tests/files/expected/array_merge_shape_preservation.php.expected
+++ b/tests/files/expected/array_merge_shape_preservation.php.expected
@@ -1,6 +1,0 @@
-%s:65 PhanRedundantCondition Redundant attempt to cast true of type true to truthy
-%s:65 PhanTypeInvalidBitwiseBinaryOperator Invalid non-int/non-string operand provided to operator '|' between types array{a:1} and array{b:'string'}
-%s:65 PhanTypeInvalidLeftOperandOfBitwiseOp Invalid operator: left operand of | is array{a:1} (expected int|string)
-%s:65 PhanTypeInvalidRightOperandOfBitwiseOp Invalid operator: right operand of | is array{b:'string'} (expected int|string)
-%s:66 PhanTypeMismatchArgumentInternalProbablyReal Argument 1 ($arrays) is $data of type int (real type int|string) but \array_merge() takes array
-%s:101 PhanTypeMismatchArgument Argument 1 ($mixed) is [] of type array{} but \test_param_union_with_pure_last() takes array{a:int}|array{b:string} defined at %s:75

--- a/tests/files/src/array_merge_shape_preservation.php
+++ b/tests/files/src/array_merge_shape_preservation.php
@@ -48,6 +48,28 @@ function g() {
     h($params['shop_section']);
 }
 
+// Test case 5: Mixed first argument with pure last shape (Etsyweb case)
+// First arg is generic array (from array_map), last arg is pure shape
+function test_mixed_with_pure_last() {
+    $encoded = array_map('json_encode', [
+        'summary_history' => [],
+        'user_input' => 'hello',
+    ]);
+    $result = array_merge($encoded, ['role' => 'user']);
+    // The last argument is pure shape, so 'role' key is guaranteed
+    h($result['role']);  // Should NOT warn - type is string literal 'user'
+}
+
+// Test case 6: Shape union as parameter merged with pure shape
+/**
+ * @param array{a:int}|array{b:string} $mixed
+ */
+function test_param_union_with_pure_last($mixed) {
+    $result = array_merge($mixed, ['status' => 'ok']);
+    // Last argument is pure shape, so 'status' key is guaranteed
+    h($result['status']);  // Should NOT warn - type is string literal
+}
+
 // Helper functions
 function h(?string $arg) {
     echo $arg;
@@ -59,3 +81,8 @@ function h_null(?string $arg) {
 
 f();
 g();
+test_merge_shape_with_generic();
+test_merge_two_shapes();
+test_merge_overlapping_shapes();
+test_mixed_with_pure_last();
+test_param_union_with_pure_last(['a' => 1]);


### PR DESCRIPTION
The previous fix was too conservative - when the first argument had both shapes AND generic array types in its union, it would bail out entirely and lose shape information from the second (or last) argument.

Example: `array_merge(array_map(...), ['role' => string])` where array_map returns a generic array but we're merging it with a pure shape as the last argument.

