### PR TITLE
Cache PHP extension stubs

### DIFF
--- a/src/Phan/Phan.php
+++ b/src/Phan/Phan.php
@@ -986,6 +986,11 @@ class Phan implements IgnoredFilesFilterInterface
             $stubs['standard'] = "$bundled_stubs_dir/$standard_stub";
         }
 
+        // Cache loaded stubs to avoid issues, especially in tests (https://github.com/phan/phan/issues/5312)
+        // But do it per-file, to support multiple runs with different configs.
+        static $loaded_stub_paths = [];
+        $stubs = array_diff( $stubs, $loaded_stub_paths );
+
         foreach ($stubs as $extension_name => $path_to_extension) {
             $extension_name = (string)$extension_name;
 
@@ -1021,6 +1026,7 @@ class Phan implements IgnoredFilesFilterInterface
             }
 
             Analysis::parseFile($code_base, $path_to_extension, false, null, true);
+            $loaded_stub_paths[] = $path_to_extension;
         }
     }
 }


### PR DESCRIPTION
So that we don't try to parse the same stubs over and over again for each invocation of `analyzeFileList`, as is the case in tests.

Closes #5312.