### PR TITLE
Bug5310

### DIFF
--- a/src/Phan/AST/ASTNormalizer.php
+++ b/src/Phan/AST/ASTNormalizer.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phan\AST;
+
+use ast\Node;
+
+/**
+ * Normalizes AST nodes to a consistent representation across different AST versions and parsers.
+ *
+ * This class handles differences in how various AST versions represent certain language constructs.
+ * For example, AST version 120 represents `clone` as an AST_CALL node instead of AST_CLONE,
+ * which requires normalization for consistency.
+ */
+class ASTNormalizer
+{
+    /**
+     * Normalize an AST tree by converting AST_CALL nodes representing 'clone' to AST_CLONE nodes.
+     *
+     * AST versions 110+ (including 120) from php-ast represent `clone $expr` as:
+     * ```
+     * AST_CALL(
+     *     expr: AST_NAME('clone'),
+     *     args: AST_ARG_LIST([expr])
+     * )
+     * ```
+     *
+     * This method normalizes such nodes to the standard AST_CLONE format:
+     * ```
+     * AST_CLONE(
+     *     expr: expr
+     * )
+     * ```
+     *
+     * This ensures downstream visitors don't need to special-case clone handling.
+     *
+     * @param Node $node The root AST node to normalize
+     * @return Node The normalized AST
+     */
+    public static function normalizeCloneNodes(Node $node): Node
+    {
+        // Process children recursively to find and normalize clone nodes
+        self::normalizeCloneNodesRecursive($node);
+        return $node;
+    }
+
+    /**
+     * Recursively traverse the AST and normalize clone nodes.
+     *
+     * @param Node $node The current node being processed
+     */
+    private static function normalizeCloneNodesRecursive(Node $node): void
+    {
+        foreach ($node->children as $key => $child) {
+            if ($child instanceof Node) {
+                // Check if this is an AST_CALL node representing 'clone'
+                if ($child->kind === \ast\AST_CALL && self::isCloneCall($child)) {
+                    // Replace with normalized AST_CLONE node
+                    $node->children[$key] = self::convertCallToClone($child);
+                } else {
+                    // Recursively process child nodes
+                    self::normalizeCloneNodesRecursive($child);
+                }
+            }
+        }
+    }
+
+    /**
+     * Check if an AST_CALL node represents a clone operation.
+     *
+     * @param Node $node An AST_CALL node
+     * @return bool True if the call is to 'clone'
+     */
+    private static function isCloneCall(Node $node): bool
+    {
+        $expr = $node->children['expr'] ?? null;
+        if (!($expr instanceof Node) || $expr->kind !== \ast\AST_NAME) {
+            return false;
+        }
+        return ($expr->children['name'] ?? null) === 'clone';
+    }
+
+    /**
+     * Convert an AST_CALL node representing 'clone' to an AST_CLONE node.
+     *
+     * @param Node $call_node The AST_CALL node
+     * @return Node The normalized AST_CLONE node
+     */
+    private static function convertCallToClone(Node $call_node): Node
+    {
+        $args = $call_node->children['args'] ?? null;
+        $expr = null;
+
+        if ($args instanceof Node && isset($args->children[0])) {
+            $expr = $args->children[0];
+        }
+
+        // Create a new AST_CLONE node with the proper structure
+        return new Node(
+            \ast\AST_CLONE,
+            0,
+            ['expr' => $expr],
+            $call_node->lineno
+        );
+    }
+}

--- a/src/Phan/AST/ASTReverter.php
+++ b/src/Phan/AST/ASTReverter.php
@@ -372,19 +372,6 @@ class ASTReverter
             },
             ast\AST_CALL => static function (Node $node): string {
                 $expr = $node->children['expr'];
-                // AST version 120 represents clone as AST_CALL with AST_NAME 'clone'
-                // Format it the same way as AST_CLONE for consistency
-                if ($expr instanceof Node &&
-                    $expr->kind === \ast\AST_NAME &&
-                    $expr->children['name'] === 'clone') {
-                    $args = $node->children['args'];
-                    if ($args instanceof Node && isset($args->children[0])) {
-                        return sprintf(
-                            '(clone(%s))',
-                            self::toShortString($args->children[0])
-                        );
-                    }
-                }
                 return sprintf(
                     '%s%s',
                     self::toShortString($expr),

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -1046,11 +1046,6 @@ class ContextNode
         }
         if ($expression->kind === ast\AST_NAME) {
             $name = $expression->children['name'];
-            // AST version 120 represents clone as AST_CALL with AST_NAME 'clone'
-            // Don't try to look up 'clone' as a function - it's a language construct
-            if ($name === 'clone') {
-                return [];
-            }
             try {
                 if (!\is_string($name)) {
                     // Impossible?

--- a/src/Phan/AST/Parser.php
+++ b/src/Phan/AST/Parser.php
@@ -165,6 +165,9 @@ class Parser
                     $error['message']
                 );
             }
+            // Normalize AST to handle differences between PHP versions
+            // (e.g., AST 120+ represents 'clone' as AST_CALL instead of AST_CLONE)
+            ASTNormalizer::normalizeCloneNodes($root_node);
             return $root_node;
         } finally {
             $__no_echo_phan_errors = false;
@@ -435,6 +438,9 @@ class Parser
             }
         }
         if (!$errors) {
+            // Normalize AST to handle differences between PHP versions
+            // (e.g., AST 120+ represents 'clone' as AST_CALL instead of AST_CLONE)
+            ASTNormalizer::normalizeCloneNodes($node);
             return $node;
         }
         $file_position_map = new FilePositionMap($file_contents);
@@ -475,6 +481,9 @@ class Parser
                 }
             }
         }
+        // Normalize AST to handle differences between PHP versions
+        // (e.g., AST 120+ represents 'clone' as AST_CALL instead of AST_CLONE)
+        ASTNormalizer::normalizeCloneNodes($node);
         return $node;
     }
 

--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
@@ -877,25 +877,10 @@ class TolerantASTConverter
             },
             'Microsoft\PhpParser\Node\Expression\CloneExpression' => static function (PhpParser\Node\Expression\CloneExpression $n, int $start_line): ast\Node {
                 // AST version 120 represents clone as AST_CALL instead of AST_CLONE
-                if (self::$ast_version_parsing >= 120) {
-                    $args = [];
-                    $expr_node = static::phpParserNodeToAstNode($n->expression);
-                    $args[] = $expr_node;
-                    $modifications = $n->modifications;
-                    if ($modifications instanceof PhpParser\Node) {
-                        $args[] = static::phpParserNodeToAstNode($modifications);
-                    }
-                    $args_line = isset($args[0]) && $args[0] instanceof ast\Node ? $args[0]->lineno : $start_line;
-                    return new ast\Node(
-                        ast\AST_CALL,
-                        0,
-                        [
-                            'expr' => new ast\Node(ast\AST_NAME, flags\NAME_FQ, ['name' => 'clone'], $start_line),
-                            'args' => new ast\Node(ast\AST_ARG_LIST, 0, $args, $args_line),
-                        ],
-                        $start_line
-                    );
-                }
+                // Normalize clone to AST_CLONE for all AST versions.
+                // Even though AST version 120+ represents clone as AST_CALL in php-ast,
+                // we normalize it here to AST_CLONE for consistency and to simplify
+                // downstream visitor logic (no special-casing needed in visitCall methods).
                 return new ast\Node(ast\AST_CLONE, 0, ['expr' => static::phpParserNodeToAstNode($n->expression)], $start_line);
             },
             'Microsoft\PhpParser\Node\Expression\ErrorControlExpression' => static function (PhpParser\Node\Expression\ErrorControlExpression $n, int $start_line): ast\Node {

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -3336,26 +3336,6 @@ class UnionTypeVisitor extends AnalysisVisitor
     public function visitCall(Node $node): UnionType
     {
         $expression = $node->children['expr'];
-        // AST version 120 represents clone as AST_CALL instead of AST_CLONE
-        // Redirect to visitClone to handle it correctly
-        if ($expression instanceof Node &&
-            $expression->kind === \ast\AST_NAME &&
-            $expression->children['name'] === 'clone') {
-            // Convert AST_CALL structure to AST_CLONE structure
-            // AST_CALL has args in children['args']->children[0]
-            // AST_CLONE has expr in children['expr']
-            $args = $node->children['args'];
-            if ($args instanceof Node && isset($args->children[0])) {
-                $clone_node = new Node(
-                    \ast\AST_CLONE,
-                    0,
-                    ['expr' => $args->children[0]],
-                    $node->lineno
-                );
-                return $this->visitClone($clone_node);
-            }
-            return UnionType::empty();
-        }
         $function_list_generator = (new ContextNode(
             $this->code_base,
             $this->context,

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -2598,26 +2598,6 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
     public function visitCall(Node $node): Context
     {
         $expression = $node->children['expr'];
-        // AST version 110+ represents clone as AST_CALL instead of AST_CLONE
-        // Redirect to visitClone to handle it correctly
-        if ($expression instanceof Node &&
-            $expression->kind === \ast\AST_NAME &&
-            $expression->children['name'] === 'clone') {
-            // Convert AST_CALL structure to AST_CLONE structure
-            // AST_CALL has args in children['args']->children[0]
-            // AST_CLONE has expr in children['expr']
-            $args = $node->children['args'];
-            if ($args instanceof Node && isset($args->children[0])) {
-                $clone_node = new Node(
-                    \ast\AST_CLONE,
-                    0,
-                    ['expr' => $args->children[0]],
-                    $node->lineno
-                );
-                return $this->visitClone($clone_node);
-            }
-            return $this->context;
-        }
         try {
             // Get the function.
             // If the function is undefined, always try to create a placeholder from Phan's type signatures for internal functions so they can still be type checked.

--- a/tests/Phan/AST/TolerantASTConverter/ConversionTest.php
+++ b/tests/Phan/AST/TolerantASTConverter/ConversionTest.php
@@ -265,6 +265,11 @@ PHP;
                 unset($node->children['__declId']);
                 $node->children['__declId'] = $declId;
             }
+            // Normalize clone nodes: AST version 120+ represents clone as AST_CALL
+            // Convert to AST_CLONE for consistency with our normalization
+            if ($kind === ast\AST_CALL && self::isCloneCall($node)) {
+                self::convertCallToClone($node);
+            }
             foreach ($node->children as $c) {
                 self::normalizeOriginalAST($c);
             }
@@ -274,6 +279,35 @@ PHP;
                 self::normalizeOriginalAST($c);
             }
         }
+    }
+
+    /**
+     * Check if an AST_CALL node represents a clone operation.
+     */
+    private static function isCloneCall(ast\Node $node): bool
+    {
+        $expr = $node->children['expr'] ?? null;
+        if (!($expr instanceof ast\Node) || $expr->kind !== ast\AST_NAME) {
+            return false;
+        }
+        return ($expr->children['name'] ?? null) === 'clone';
+    }
+
+    /**
+     * Convert an AST_CALL node representing 'clone' to an AST_CLONE node.
+     */
+    private static function convertCallToClone(ast\Node &$node): void
+    {
+        $args = $node->children['args'] ?? null;
+        $expr = null;
+
+        if ($args instanceof ast\Node && isset($args->children[0])) {
+            $expr = $args->children[0];
+        }
+
+        // Modify the node in-place to convert from AST_CALL to AST_CLONE
+        $node->kind = ast\AST_CLONE;
+        $node->children = ['expr' => $expr];
     }
 
     // TODO: TolerantPHPParser gets more information than PHP-Parser for statement lists,


### PR DESCRIPTION
Bug #5310 : Plugins can't easily analyse clone statements in phan v6
Plus there was a lot of boilerplate code to handle this in multiple places and we needed a check on every function call to check if the function was a clone. By converting a clone AST_CALL to an AST_CLONE node we can handle it much more cleanly.

  1. src/Phan/AST/TolerantASTConverter/TolerantASTConverter.php
    - Simplified clone handling to always create AST_CLONE nodes instead of AST_CALL nodes
    - Removed the version 120+ special handling that created AST_CALL with 'clone' name
  2. src/Phan/AST/UnionTypeVisitor.php
    - Removed clone special-casing from visitCall() method
    - Deleted ~20 lines of AST_CALL-to-AST_CLONE conversion logic
  3. src/Phan/Analysis/PostOrderAnalysisVisitor.php
    - Removed clone special-casing from visitCall() method
    - Deleted ~20 lines of AST_CALL-to-AST_CLONE conversion logic
  4. src/Phan/AST/ContextNode.php
    - Removed the clone check in getFunctionFromNode() that returned early
    - No longer needs to prevent looking up 'clone' as a function
  5. src/Phan/AST/ASTReverter.php
    - Removed clone special-casing from AST_CALL handler
    - Simplified the handler to just use default function call formatting
  6. src/Phan/AST/Parser.php
    - Added calls to ASTNormalizer::normalizeCloneNodes() after both native and polyfill parsing
    - Ensures consistent AST representation regardless of parser used

  Files Created:

  7. src/Phan/AST/ASTNormalizer.php (NEW)
    - New utility class for AST normalization
    - Provides normalizeCloneNodes() static method
    - Recursively converts AST_CALL nodes representing 'clone' to AST_CLONE nodes
    - Handles both php-ast and fallback parser outputs
  8. tests/Phan/AST/TolerantASTConverter/ConversionTest.php (UPDATED)
    - Added clone normalization to normalizeOriginalAST() method
    - New helper methods: isCloneCall() and convertCallToClone()
    - Ensures test comparisons work with normalized AST