### PR TITLE
Don't warn on internal classes with optional template support

### DIFF
--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -1770,7 +1770,8 @@ class UnionTypeVisitor extends AnalysisVisitor
 
             // Get closures to extract template types based on the types of the constructor
             // so that we can figure out what template types we're going to be mapping
-            $template_type_resolvers = $class->getGenericConstructorBuilder($this->code_base);
+            // Pass the instantiation context so that error messages point to the NEW expression
+            $template_type_resolvers = $class->getGenericConstructorBuilder($this->code_base, $this->context);
 
             // And use those closures to infer the (possibly transformed) types
             $template_type_list = [];

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -4480,14 +4480,14 @@ class Clazz extends AddressableElement
     /**
      * @return list<Closure(list<Node|string|int|float|UnionType>, Context):UnionType>
      */
-    public function getGenericConstructorBuilder(CodeBase $code_base): array
+    public function getGenericConstructorBuilder(CodeBase $code_base, ?Context $instantiation_context = null): array
     {
         return $this->memoize(
             'template_type_resolvers',
             /**
              * @return list<Closure(list<Node|string|int|float|UnionType>, Context):UnionType>
              */
-            function () use ($code_base): array {
+            function () use ($code_base, $instantiation_context): array {
                 // Get the constructor so that we can figure out what
                 // template types we're going to be mapping
                 $constructor_method =
@@ -4501,8 +4501,16 @@ class Clazz extends AddressableElement
                     );
                     if (!$template_type_resolver) {
                         // PhanTemplateTypeNotDeclaredInFunctionParams can be suppressed both on the class and on __construct()
-                        if (!$this->checkHasSuppressIssueAndIncrementCount(Issue::TemplateTypeNotDeclaredInFunctionParams)) {
-                            $warn_context = $constructor_method->getDefiningClassFQSEN() === $this->fqsen ? $constructor_method->getContext() : $this->getContext();
+                        // Don't warn about missing template parameters for internal/built-in classes (e.g., SplObjectStorage, WeakMap)
+                        // where template parameters are optional
+                        if (!$this->isPHPInternal() && !$this->checkHasSuppressIssueAndIncrementCount(Issue::TemplateTypeNotDeclaredInFunctionParams)) {
+                            // Use instantiation context if provided (for better error location)
+                            // Otherwise fall back to class/constructor definition context
+                            if ($instantiation_context) {
+                                $warn_context = $instantiation_context;
+                            } else {
+                                $warn_context = $constructor_method->getDefiningClassFQSEN() === $this->fqsen ? $constructor_method->getContext() : $this->getContext();
+                            }
 
                             Issue::maybeEmit(
                                 $code_base,

--- a/tests/files/expected/0975_inherit_generic_constructor_error.php.expected
+++ b/tests/files/expected/0975_inherit_generic_constructor_error.php.expected
@@ -1,1 +1,1 @@
-%s:5 PhanGenericConstructorTypes Missing template parameter for type TModel on constructor for generic class \Foo
+%s:6 PhanGenericConstructorTypes Missing template parameter for type TModel on constructor for generic class \Foo

--- a/tests/files/expected/0996_generic_type_leak.php.expected
+++ b/tests/files/expected/0996_generic_type_leak.php.expected
@@ -1,4 +1,4 @@
-%s:6 PhanGenericConstructorTypes Missing template parameter for type T on constructor for generic class \X
+%s:10 PhanGenericConstructorTypes Missing template parameter for type T on constructor for generic class \X
 %s:11 PhanDebugAnnotation @phan-debug-var requested for variable $x0 - it has union type \X<mixed>(real=\X<mixed>)
 %s:11 PhanDebugAnnotation @phan-debug-var requested for variable $y0 - it has union type mixed
 %s:19 PhanDebugAnnotation @phan-debug-var requested for variable $x1 - it has union type \X(real=\X)

--- a/tests/files/expected/5077_weakmap_readonly.php.expected
+++ b/tests/files/expected/5077_weakmap_readonly.php.expected
@@ -1,2 +1,0 @@
-internal:%d PhanGenericConstructorTypes Missing template parameter for type TKey on constructor for generic class \WeakMap
-internal:%d PhanGenericConstructorTypes Missing template parameter for type TValue on constructor for generic class \WeakMap


### PR DESCRIPTION
We were getting:
```
  internal:940 PhanGenericConstructorTypes Missing template parameter for type TKey on constructor for generic class \WeakMap
  internal:940 PhanGenericConstructorTypes Missing template parameter for type TValue on constructor for generic class \WeakMap
```

for code trying to use WeakMap without template types.