### PR TITLE
suppress PhanGenericConstructorTypes warnings for promoted properties with generic default values

### DIFF
--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -97,6 +97,14 @@ class UnionTypeVisitor extends AnalysisVisitor
 
     /**
      * @var bool
+     * Set to true when analyzing default parameter values
+     * This is used to suppress certain warnings (e.g., PhanGenericConstructorTypes)
+     * for instantiations in default values where the developer has explicit control
+     */
+    private static $analyzing_default_value = false;
+
+    /**
+     * @var bool
      * Set to true to cause loggable issues to be thrown
      * instead of emitted as issues to the log.
      */
@@ -126,6 +134,29 @@ class UnionTypeVisitor extends AnalysisVisitor
 
         $this->should_catch_issue_exception =
             $should_catch_issue_exception;
+    }
+
+    /**
+     * Set or get the flag indicating whether we're analyzing a default parameter value
+     * @param bool $analyzing Whether we're analyzing a default value
+     * @return bool The previous value
+     * @internal
+     */
+    public static function setAnalyzingDefaultValue(bool $analyzing): bool
+    {
+        $previous = self::$analyzing_default_value;
+        self::$analyzing_default_value = $analyzing;
+        return $previous;
+    }
+
+    /**
+     * Check if we're currently analyzing a default parameter value
+     * @return bool
+     * @internal
+     */
+    public static function isAnalyzingDefaultValue(): bool
+    {
+        return self::$analyzing_default_value;
     }
 
     /**
@@ -1771,7 +1802,7 @@ class UnionTypeVisitor extends AnalysisVisitor
             // Get closures to extract template types based on the types of the constructor
             // so that we can figure out what template types we're going to be mapping
             // Pass the instantiation context so that error messages point to the NEW expression
-            $template_type_resolvers = $class->getGenericConstructorBuilder($this->code_base, $this->context);
+            $template_type_resolvers = $class->getGenericConstructorBuilder($this->code_base, $this->context, self::isAnalyzingDefaultValue());
 
             // And use those closures to infer the (possibly transformed) types
             $template_type_list = [];

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -140,7 +140,6 @@ class UnionTypeVisitor extends AnalysisVisitor
      * Set or get the flag indicating whether we're analyzing a default parameter value
      * @param bool $analyzing Whether we're analyzing a default value
      * @return bool The previous value
-     * @internal
      */
     public static function setAnalyzingDefaultValue(bool $analyzing): bool
     {
@@ -151,8 +150,6 @@ class UnionTypeVisitor extends AnalysisVisitor
 
     /**
      * Check if we're currently analyzing a default parameter value
-     * @return bool
-     * @internal
      */
     public static function isAnalyzingDefaultValue(): bool
     {

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -4483,7 +4483,7 @@ class Clazz extends AddressableElement
     public function getGenericConstructorBuilder(CodeBase $code_base, ?Context $instantiation_context = null, bool $is_default_value = false): array
     {
         return $this->memoize(
-            'template_type_resolvers',
+            'template_type_resolvers_' . ($is_default_value ? 'default' : 'normal'),
             /**
              * @return list<Closure(list<Node|string|int|float|UnionType>, Context):UnionType>
              */

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -4480,14 +4480,14 @@ class Clazz extends AddressableElement
     /**
      * @return list<Closure(list<Node|string|int|float|UnionType>, Context):UnionType>
      */
-    public function getGenericConstructorBuilder(CodeBase $code_base, ?Context $instantiation_context = null): array
+    public function getGenericConstructorBuilder(CodeBase $code_base, ?Context $instantiation_context = null, bool $is_default_value = false): array
     {
         return $this->memoize(
             'template_type_resolvers',
             /**
              * @return list<Closure(list<Node|string|int|float|UnionType>, Context):UnionType>
              */
-            function () use ($code_base, $instantiation_context): array {
+            function () use ($code_base, $instantiation_context, $is_default_value): array {
                 // Get the constructor so that we can figure out what
                 // template types we're going to be mapping
                 $constructor_method =
@@ -4501,9 +4501,10 @@ class Clazz extends AddressableElement
                     );
                     if (!$template_type_resolver) {
                         // PhanTemplateTypeNotDeclaredInFunctionParams can be suppressed both on the class and on __construct()
-                        // Don't warn about missing template parameters for internal/built-in classes (e.g., SplObjectStorage, WeakMap)
-                        // where template parameters are optional
-                        if (!$this->isPHPInternal() && !$this->checkHasSuppressIssueAndIncrementCount(Issue::TemplateTypeNotDeclaredInFunctionParams)) {
+                        // Don't warn about missing template parameters for:
+                        // 1. Internal/built-in classes (e.g., SplObjectStorage, WeakMap) where template parameters are optional
+                        // 2. Default value expressions in promoted properties - the developer has explicit control and can use @var annotations
+                        if (!$this->isPHPInternal() && !$is_default_value && !$this->checkHasSuppressIssueAndIncrementCount(Issue::TemplateTypeNotDeclaredInFunctionParams)) {
                             // Use instantiation context if provided (for better error location)
                             // Otherwise fall back to class/constructor definition context
                             if ($instantiation_context) {

--- a/src/Phan/Language/Element/Parameter.php
+++ b/src/Phan/Language/Element/Parameter.php
@@ -504,7 +504,8 @@ class Parameter extends Variable
                     $parameter->setDefaultValueFutureType(new FutureUnionType(
                         $code_base,
                         (clone $context)->withLineNumberStart($default_node->lineno ?? 0),
-                        $default_node
+                        $default_node,
+                        true  // Mark as default value analysis
                     ));
                 }
             }

--- a/src/Phan/Language/FutureUnionType.php
+++ b/src/Phan/Language/FutureUnionType.php
@@ -25,19 +25,25 @@ class FutureUnionType
     /** @var Node|string|int|bool|float the node which we will be fetching the type of. */
     private $node;
 
+    /** @var bool whether this future type is analyzing a default parameter value */
+    private $is_default_value;
+
     /**
      * @param CodeBase $code_base
      * @param Context $context
      * @param Node|string|int|bool|float $node
+     * @param bool $is_default_value whether this is analyzing a default parameter value
      */
     public function __construct(
         CodeBase $code_base,
         Context $context,
-        $node
+        $node,
+        bool $is_default_value = false
     ) {
         $this->code_base = $code_base;
         $this->context = $context;
         $this->node = $node;
+        $this->is_default_value = $is_default_value;
     }
 
     /**
@@ -55,12 +61,24 @@ class FutureUnionType
     public function get(): UnionType
     {
         $this->context->clearCachedUnionTypes();
-        return UnionTypeVisitor::unionTypeFromNode(
-            $this->code_base,
-            $this->context,
-            $this->node,
-            false
-        );
+
+        // Temporarily set a flag to indicate we're analyzing a default value
+        if ($this->is_default_value) {
+            $previous = UnionTypeVisitor::setAnalyzingDefaultValue(true);
+        }
+
+        try {
+            return UnionTypeVisitor::unionTypeFromNode(
+                $this->code_base,
+                $this->context,
+                $this->node,
+                false
+            );
+        } finally {
+            if ($this->is_default_value) {
+                UnionTypeVisitor::setAnalyzingDefaultValue($previous ?? false);
+            }
+        }
     }
 
     /**
@@ -81,6 +99,15 @@ class FutureUnionType
     public function getContext(): Context
     {
         return $this->context;
+    }
+
+    /**
+     * @return bool whether this future type is analyzing a default parameter value
+     * @internal
+     */
+    public function isDefaultValue(): bool
+    {
+        return $this->is_default_value;
     }
 
     /**

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -967,7 +967,8 @@ class ParseVisitor extends ScopeVisitor
                 $this->code_base,
                 new ElementContext($property),
                 //new ElementContext($property),
-                $future_union_type_node
+                $future_union_type_node,
+                true  // Mark as default value analysis
             );
         } else {
             $future_union_type = null;

--- a/tests/files/expected/5324_promoted_property_generic_default.php.expected
+++ b/tests/files/expected/5324_promoted_property_generic_default.php.expected
@@ -1,0 +1,1 @@
+%s:14 PhanGenericConstructorTypes Missing template parameter for type T on constructor for generic class \Test\PromotedPropertyGenericDefault\Deferred defined at %s:13

--- a/tests/files/expected/5325_generic_instantiation_after_default.php.expected
+++ b/tests/files/expected/5325_generic_instantiation_after_default.php.expected
@@ -1,0 +1,2 @@
+%s:13 PhanGenericConstructorTypes Missing template parameter for type T on constructor for generic class \Test\GenericInstantiationAfterDefault\GenericClass defined at %s:12
+%s:30 PhanUnusedVariable Unused definition of variable $x

--- a/tests/files/src/5324_promoted_property_generic_default.php
+++ b/tests/files/src/5324_promoted_property_generic_default.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Test that promoted properties with generic default values don't trigger
+ * PhanGenericConstructorTypes warnings when @var annotations are used.
+ * Issue #5324
+ */
+
+namespace Test\PromotedPropertyGenericDefault;
+
+interface ResponseInterface {}
+
+/** @template T */
+class Deferred {
+    public function __construct() {}
+}
+
+// Test 1: Promoted property with @var annotation - should NOT warn
+class TestWithVarAnnotation {
+    public function __construct(
+        /**
+         * @var Deferred<ResponseInterface>
+         */
+        protected readonly Deferred $deferred = new Deferred(),
+    ) {
+    }
+}
+
+// Test 2: Promoted property without default - should NOT warn (no default value to analyze)
+class TestNoDefault {
+    public function __construct(
+        /**
+         * @var Deferred<ResponseInterface>
+         */
+        protected readonly Deferred $deferred,
+    ) {
+    }
+}
+
+// Test 3: Regular (non-promoted) parameter with @param annotation - should NOT warn
+class TestRegularParameterWithParam {
+    /**
+     * @param Deferred<ResponseInterface> $deferred
+     */
+    public function __construct(
+        Deferred $deferred = new Deferred(),
+    ) {
+        $this->deferred = $deferred;
+    }
+
+    protected Deferred $deferred;
+}
+
+// Test 4: Regular property with @var annotation - should NOT warn
+class TestRegularPropertyWithVar {
+    public function __construct() {
+        $this->deferred = new Deferred();
+    }
+
+    /**
+     * @var Deferred<ResponseInterface>
+     */
+    protected Deferred $deferred;
+}
+
+// Test 5: Promoted property without @var (baseline to verify the fix)
+// This would warn if we didn't suppress for default values
+class TestWithoutVar {
+    public function __construct(
+        protected readonly Deferred $deferred = new Deferred(),
+    ) {
+    }
+}

--- a/tests/files/src/5325_generic_instantiation_after_default.php
+++ b/tests/files/src/5325_generic_instantiation_after_default.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Test that regular instantiations of generic classes still warn after analyzing
+ * a default value instantiation of the same class.
+ * This verifies the memoization cache key includes the is_default_value flag.
+ * Issue #5324 / GitHub Review
+ */
+
+namespace Test\GenericInstantiationAfterDefault;
+
+/** @template T */
+class GenericClass {
+    public function __construct() {}
+}
+
+class TestClass {
+    // First: Analyze default value (with is_default_value = true)
+    public function __construct(
+        /**
+         * @var GenericClass<int>
+         */
+        protected readonly GenericClass $default = new GenericClass(),
+    ) {
+    }
+
+    // Second: Regular instantiation (with is_default_value = false)
+    // This should still warn about missing template parameter,
+    // not be suppressed by the memoization of the default value
+    public function otherMethod() {
+        $x = new GenericClass();  // Should warn about missing template T
+    }
+}


### PR DESCRIPTION
This suppresses `PhanGenericConstructorTypes` warnings for promoted properties with default values that have generic instantiations (like `new Deferred()`). This allows developers to use `@var` annotations to properly specify template types without triggering false warnings.