### PR TITLE
Stub cache

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
          - PHP_VERSION: '8.2'
          - PHP_VERSION: '8.3'
          - PHP_VERSION: '8.4'
-         - PHP_VERSION: '8.5.0RC1-cli'
+         - PHP_VERSION: '8.5-rc-cli'
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -41,4 +41,3 @@ jobs:
       # Runs a single command using the runners shell
       - name: Build and test in docker
         run: bash tests/run_all_tests_dockerized ${{ matrix.PHP_VERSION }} ${{ matrix.DOCKER_ARCHITECTURE }}
-

--- a/NEWS.md
+++ b/NEWS.md
@@ -110,7 +110,7 @@ Performance improvements:
   - Optional C extension for 2-3x faster AST hashing and type deduplication
   - Overall analysis speedup: 5-15% for large projects
   - Automatically detected and used when available
-- Internal PHP stub ASTs are now cached between CodeBase instances, so repeated test runs and daemon/server reloads no longer reparse dozens of stub files on every initialization.
+- Internal PHP stub definitions are now cached between CodeBase instances, so repeated test runs and daemon/server reloads reuse the previously parsed classes/functions without reparsing dozens of stub files on every initialization.
 - Conditional visitor optimization ([#5186](https://github.com/phan/phan/pull/5186)):
   - Skip visitor creation for ~60-70% of if statements (those without else/elseif)
   - Reduces memory usage and improves analysis speed

--- a/NEWS.md
+++ b/NEWS.md
@@ -110,6 +110,7 @@ Performance improvements:
   - Optional C extension for 2-3x faster AST hashing and type deduplication
   - Overall analysis speedup: 5-15% for large projects
   - Automatically detected and used when available
+- Internal PHP stub ASTs are now cached between CodeBase instances, so repeated test runs and daemon/server reloads no longer reparse dozens of stub files on every initialization.
 - Conditional visitor optimization ([#5186](https://github.com/phan/phan/pull/5186)):
   - Skip visitor creation for ~60-70% of if statements (those without else/elseif)
   - Reduces memory usage and improves analysis speed

--- a/internal/stubs/pcntl.phan_php
+++ b/internal/stubs/pcntl.phan_php
@@ -25,6 +25,82 @@ const WUNTRACED = UNKNOWN;
  */
 const WCONTINUED = UNKNOWN;
 #endif
+#if defined (HAVE_DECL_WEXITED) && HAVE_DECL_WEXITED == 1
+/**
+ * @var int
+ * @cvalue LONG_CONST(WEXITED)
+ */
+const WEXITED = UNKNOWN;
+#endif
+#if defined (HAVE_DECL_WSTOPPED) && HAVE_DECL_WSTOPPED == 1
+/**
+ * @var int
+ * @cvalue LONG_CONST(WSTOPPED)
+ */
+const WSTOPPED = UNKNOWN;
+#endif
+#if defined (HAVE_DECL_WNOWAIT) && HAVE_DECL_WNOWAIT== 1
+/**
+ * @var int
+ * @cvalue LONG_CONST(WNOWAIT)
+ */
+const WNOWAIT = UNKNOWN;
+#endif
+
+#ifdef HAVE_WAITID
+/* First argument to waitid */
+#ifdef HAVE_POSIX_IDTYPES
+/**
+ * @var int
+ * @cvalue LONG_CONST(P_ALL)
+ */
+const P_ALL = UNKNOWN;
+/**
+ * @var int
+ * @cvalue LONG_CONST(P_PID)
+ */
+const P_PID = UNKNOWN;
+/**
+ * @var int
+ * @cvalue LONG_CONST(P_PGID)
+ */
+const P_PGID = UNKNOWN;
+#endif
+/* Linux specific idtype */
+#ifdef HAVE_LINUX_IDTYPES
+/**
+ * @var int
+ * @cvalue LONG_CONST(P_PIDFD)
+ */
+const P_PIDFD = UNKNOWN;
+#endif
+/* NetBSD specific idtypes */
+#ifdef HAVE_NETBSD_IDTYPES
+/**
+ * @var int
+ * @cvalue LONG_CONST(P_UID)
+ */
+const P_UID = UNKNOWN;
+/**
+ * @var int
+ * @cvalue LONG_CONST(P_GID)
+ */
+const P_GID = UNKNOWN;
+/**
+ * @var int
+ * @cvalue LONG_CONST(P_SID)
+ */
+const P_SID = UNKNOWN;
+#endif
+/* FreeBSD specific idtype */
+#ifdef HAVE_FREEBSD_IDTYPES
+/**
+ * @var int
+ * @cvalue LONG_CONST(P_JAILID)
+ */
+const P_JAILID = UNKNOWN;
+#endif
+#endif
 
 /* Signal Constants */
 
@@ -908,15 +984,23 @@ const PCNTL_ECAPMODE = UNKNOWN;
 function pcntl_fork(): int {}
 
 /**
- * @param int $status
- * @param array $resource_usage
- */
+* @param int $status
+* @param array $resource_usage
+*/
 function pcntl_waitpid(int $process_id, &$status, int $flags = 0, &$resource_usage = []): int {}
 
+#if defined (HAVE_WAITID) && defined (HAVE_POSIX_IDTYPES) && defined (HAVE_DECL_WEXITED) && HAVE_DECL_WEXITED == 1
 /**
- * @param int $status
- * @param array $resource_usage
- */
+* @param array $info
+* @param array $resource_usage
+*/
+function pcntl_waitid(int $idtype = P_ALL, ?int $id = null, &$info = [], int $flags = WEXITED, &$resource_usage = []): bool {}
+#endif
+
+/**
+* @param int $status
+* @param array $resource_usage
+*/
 function pcntl_wait(&$status, int $flags = 0, &$resource_usage = []): int {}
 
 /** @param callable|int $handler */

--- a/internal/stubs/pcntl_php84.phan_php
+++ b/internal/stubs/pcntl_php84.phan_php
@@ -4,6 +4,8 @@
 
 /* Wait Constants */
 
+namespace
+{
 #ifdef WNOHANG
 /**
  * @var int
@@ -24,6 +26,82 @@ const WUNTRACED = UNKNOWN;
  * @cvalue LONG_CONST(WCONTINUED)
  */
 const WCONTINUED = UNKNOWN;
+#endif
+#if defined (HAVE_DECL_WEXITED) && HAVE_DECL_WEXITED == 1
+/**
+ * @var int
+ * @cvalue LONG_CONST(WEXITED)
+ */
+const WEXITED = UNKNOWN;
+#endif
+#if defined (HAVE_DECL_WSTOPPED) && HAVE_DECL_WSTOPPED == 1
+/**
+ * @var int
+ * @cvalue LONG_CONST(WSTOPPED)
+ */
+const WSTOPPED = UNKNOWN;
+#endif
+#if defined (HAVE_DECL_WNOWAIT) && HAVE_DECL_WNOWAIT== 1
+/**
+ * @var int
+ * @cvalue LONG_CONST(WNOWAIT)
+ */
+const WNOWAIT = UNKNOWN;
+#endif
+
+#ifdef HAVE_WAITID
+/* First argument to waitid */
+#ifdef HAVE_POSIX_IDTYPES
+/**
+ * @var int
+ * @cvalue LONG_CONST(P_ALL)
+ */
+const P_ALL = UNKNOWN;
+/**
+ * @var int
+ * @cvalue LONG_CONST(P_PID)
+ */
+const P_PID = UNKNOWN;
+/**
+ * @var int
+ * @cvalue LONG_CONST(P_PGID)
+ */
+const P_PGID = UNKNOWN;
+#endif
+/* Linux specific idtype */
+#ifdef HAVE_LINUX_IDTYPES
+/**
+ * @var int
+ * @cvalue LONG_CONST(P_PIDFD)
+ */
+const P_PIDFD = UNKNOWN;
+#endif
+/* NetBSD specific idtypes */
+#ifdef HAVE_NETBSD_IDTYPES
+/**
+ * @var int
+ * @cvalue LONG_CONST(P_UID)
+ */
+const P_UID = UNKNOWN;
+/**
+ * @var int
+ * @cvalue LONG_CONST(P_GID)
+ */
+const P_GID = UNKNOWN;
+/**
+ * @var int
+ * @cvalue LONG_CONST(P_SID)
+ */
+const P_SID = UNKNOWN;
+#endif
+/* FreeBSD specific idtype */
+#ifdef HAVE_FREEBSD_IDTYPES
+/**
+ * @var int
+ * @cvalue LONG_CONST(P_JAILID)
+ */
+const P_JAILID = UNKNOWN;
+#endif
 #endif
 
 /* Signal Constants */
@@ -242,6 +320,20 @@ const SIGSYS = UNKNOWN;
  * @cvalue LONG_CONST(SIGSYS)
  */
 const SIGBABY = UNKNOWN;
+#endif
+#ifdef SIGCKPT
+/**
+ * @var int
+ * @cvalue LONG_CONST(SIGCKPT)
+ */
+const SIGCKPT = UNKNOWN;
+#endif
+#ifdef SIGCKPTEXIT
+/**
+ * @var int
+ * @cvalue LONG_CONST(SIGCKPTEXIT)
+ */
+const SIGCKPTEXIT = UNKNOWN;
 #endif
 #ifdef SIGRTMIN
 /**
@@ -905,88 +997,123 @@ const PCNTL_EUSERS = UNKNOWN;
 const PCNTL_ECAPMODE = UNKNOWN;
 #endif
 
-function pcntl_fork(): int {}
+    function pcntl_fork(): int {}
 
-/**
- * @param int $status
- * @param array $resource_usage
- */
-function pcntl_waitpid(int $process_id, &$status, int $flags = 0, &$resource_usage = []): int {}
+    /**
+    * @param int $status
+    * @param array $resource_usage
+    */
+    function pcntl_waitpid(int $process_id, &$status, int $flags = 0, &$resource_usage = []): int {}
 
-/**
- * @param int $status
- * @param array $resource_usage
- */
-function pcntl_wait(&$status, int $flags = 0, &$resource_usage = []): int {}
+#if defined (HAVE_WAITID) && defined (HAVE_POSIX_IDTYPES) && defined (HAVE_DECL_WEXITED) && HAVE_DECL_WEXITED == 1
+    /** @param array $info */
+    function pcntl_waitid(int $idtype = P_ALL, ?int $id = null, array &$info = [], int $flags = WEXITED): bool {}
+#endif
 
-/** @param callable|int $handler */
-function pcntl_signal(int $signal, $handler, bool $restart_syscalls = true): bool {}
+    /**
+    * @param int $status
+    * @param array $resource_usage
+    */
+    function pcntl_wait(&$status, int $flags = 0, &$resource_usage = []): int {}
 
-/** @return callable|int */
-function pcntl_signal_get_handler(int $signal) {}
+    /** @param callable|int $handler */
+    function pcntl_signal(int $signal, $handler, bool $restart_syscalls = true): bool {}
 
-function pcntl_signal_dispatch(): bool {}
+    /** @return callable|int */
+    function pcntl_signal_get_handler(int $signal) {}
+
+    function pcntl_signal_dispatch(): bool {}
 
 #ifdef HAVE_SIGPROCMASK
 /** @param array $old_signals */
-function pcntl_sigprocmask(int $mode, array $signals, &$old_signals = null): bool {}
+    function pcntl_sigprocmask(int $mode, array $signals, &$old_signals = null): bool {}
 #endif
 
 #ifdef HAVE_STRUCT_SIGINFO_T
 #if (defined(HAVE_SIGWAITINFO) && defined(HAVE_SIGTIMEDWAIT))
-/** @param array $info */
-function pcntl_sigwaitinfo(array $signals, &$info = []): int|false {}
+    /** @param array $info */
+    function pcntl_sigwaitinfo(array $signals, &$info = []): int|false {}
 
-/** @param array $info */
-function pcntl_sigtimedwait(array $signals, &$info = [], int $seconds = 0, int $nanoseconds = 0): int|false {}
+    /** @param array $info */
+    function pcntl_sigtimedwait(array $signals, &$info = [], int $seconds = 0, int $nanoseconds = 0): int|false {}
 #endif
 #endif
 
-function pcntl_wifexited(int $status): bool {}
+    function pcntl_wifexited(int $status): bool {}
 
-function pcntl_wifstopped(int $status): bool {}
+    function pcntl_wifstopped(int $status): bool {}
 
 #ifdef HAVE_WCONTINUED
 function pcntl_wifcontinued(int $status): bool {}
 #endif
 
-function pcntl_wifsignaled(int $status): bool {}
+    function pcntl_wifsignaled(int $status): bool {}
 
-function pcntl_wexitstatus(int $status): int|false {}
+    function pcntl_wexitstatus(int $status): int|false {}
 
-function pcntl_wtermsig(int $status): int|false {}
+    function pcntl_wtermsig(int $status): int|false {}
 
-function pcntl_wstopsig(int $status): int|false {}
+    function pcntl_wstopsig(int $status): int|false {}
 
-function pcntl_exec(string $path, array $args = [], array $env_vars = []): false {}
+    function pcntl_exec(string $path, array $args = [], array $env_vars = []): false {}
 
-function pcntl_alarm(int $seconds): int {}
+    function pcntl_alarm(int $seconds): int {}
 
-function pcntl_get_last_error(): int {}
+    function pcntl_get_last_error(): int {}
 
-/** @alias pcntl_get_last_error */
-function pcntl_errno(): int {}
+    /** @alias pcntl_get_last_error */
+    function pcntl_errno(): int {}
 
 #ifdef HAVE_GETPRIORITY
-function pcntl_getpriority(?int $process_id = null, int $mode = PRIO_PROCESS): int|false {}
+    function pcntl_getpriority(?int $process_id = null, int $mode = PRIO_PROCESS): int|false {}
 #endif
 
 #ifdef HAVE_SETPRIORITY
-function pcntl_setpriority(int $priority, ?int $process_id = null, int $mode = PRIO_PROCESS): bool{}
+    function pcntl_setpriority(int $priority, ?int $process_id = null, int $mode = PRIO_PROCESS): bool{}
 #endif
 
-function pcntl_strerror(int $error_code): string {}
+    function pcntl_strerror(int $error_code): string {}
 
-function pcntl_async_signals(?bool $enable = null): bool {}
+    function pcntl_async_signals(?bool $enable = null): bool {}
 
 #ifdef HAVE_UNSHARE
-function pcntl_unshare(int $flags): bool {}
+    function pcntl_unshare(int $flags): bool {}
 #endif
 
 #ifdef HAVE_RFORK
-function pcntl_rfork(int $flags, int $signal = 0): int{}
+    function pcntl_rfork(int $flags, int $signal = 0): int{}
 #endif
 
 #ifdef HAVE_FORKX
-function pcntl_forkx(int $flags): int{}
+    function pcntl_forkx(int $flags): int{}
 #endif
+
+#ifdef HAVE_PIDFD_OPEN
+    function pcntl_setns(?int $process_id = null, int $nstype = CLONE_NEWNET): bool {}
+#endif
+
+#ifdef HAVE_SCHED_SETAFFINITY
+    function pcntl_getcpuaffinity(?int $process_id = null): array|false {}
+    function pcntl_setcpuaffinity(?int $process_id = null, array $cpu_ids = []): bool {}
+#endif
+
+#ifdef HAVE_SCHED_GETCPU
+    function pcntl_getcpu(): int {}
+#endif
+#ifdef HAVE_PTHREAD_SET_QOS_CLASS_SELF_NP
+    function pcntl_getqos_class(): Pcntl\QosClass {}
+    function pcntl_setqos_class(Pcntl\QosClass $qos_class = Pcntl\QosClass::Default): void {}
+#endif
+}
+
+namespace Pcntl
+{
+    enum QosClass
+    {
+	case UserInteractive;
+	case UserInitiated;
+	case Default;
+	case Utility;
+	case Background;
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -45,6 +45,7 @@
     <testsuite name="UtilTest">
       <file>tests/Phan/AnalyzerTest.php</file>
       <file>tests/Phan/DebugTest.php</file>
+      <file>tests/Phan/InternalStubCacheTest.php</file>
       <directory>tests/Phan/Analysis</directory>
       <directory>tests/Phan/AST</directory>
       <directory>tests/Phan/Debug</directory>

--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -139,7 +139,7 @@ class Analysis
         $cache_hash = null;
         $pre_parse_snapshot = null;
         if ($should_cache_stub) {
-            $cache_key = self::normalizeInternalStubPath($real_file_path);
+            $cache_key = self::computeInternalStubCacheKey($real_file_path);
             $cache_hash = self::hashStubContents($file_contents);
             $cached_context = self::tryApplyInternalStubCache($code_base, $cache_key, $cache_hash);
             if ($cached_context instanceof Context) {
@@ -258,6 +258,13 @@ class Analysis
     {
         $real = \realpath($file_path);
         return $real !== false ? $real : $file_path;
+    }
+
+    private static function computeInternalStubCacheKey(string $file_path): string
+    {
+        $normalized_path = self::normalizeInternalStubPath($file_path);
+        $target_version = Config::get_closest_target_php_version_id();
+        return $normalized_path . '|' . $target_version;
     }
 
     private static function hashStubContents(string $contents): string

--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -236,18 +236,27 @@ class Analysis
 
     private static function deepCloneNode(Node $node): Node
     {
-        $children = [];
-        foreach ($node->children as $key => $child) {
-            $children[$key] = self::cloneNodeChild($child);
-        }
-        return new Node($node->kind, $node->flags, $children, $node->lineno);
+        return new Node($node->kind, $node->flags, self::cloneNodeChildren($node->children), $node->lineno);
     }
 
     /**
-     * @param mixed $child
-     * @return mixed
+     * @param array<int|string,mixed> $children
+     * @return array<int|string,mixed>
      */
-    private static function cloneNodeChild($child)
+    private static function cloneNodeChildren(array $children): array
+    {
+        $result = [];
+        foreach ($children as $key => $child) {
+            $result[$key] = self::cloneNodeChild($child);
+        }
+        return $result;
+    }
+
+    /**
+     * @return Node|array<int|string,mixed>|int|string|float|bool|null
+     *     Returns the cloned value for a child entry in an ast\Node.
+     */
+    private static function cloneNodeChild(mixed $child): mixed
     {
         if ($child instanceof Node) {
             return self::deepCloneNode($child);

--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -1,5 +1,7 @@
 <?php
 
+/** @phan-file-suppress PhanAccessMethodInternal */
+
 declare(strict_types=1);
 
 namespace Phan;
@@ -22,21 +24,27 @@ use Phan\AST\Visitor\Element;
 use Phan\Daemon\Request;
 use Phan\Exception\FQSENException;
 use Phan\Exception\RecursionDepthException;
+use Phan\Internal\InternalStubCacheEntry;
 use Phan\Language\Context;
+use Phan\Language\Element\Clazz;
+use Phan\Language\Element\ClassConstant;
 use Phan\Language\Element\Func;
 use Phan\Language\Element\FunctionInterface;
 use Phan\Language\Element\Method;
+use Phan\Language\Element\Property;
 use Phan\Language\FQSEN\FullyQualifiedClassName;
 use Phan\Language\FQSEN\FullyQualifiedFunctionName;
 use Phan\Language\FQSEN\FullyQualifiedMethodName;
 use Phan\Language\Scope\GlobalScope;
 use Phan\Library\FileCache;
+use Phan\Library\Map;
 use Phan\Library\StringUtil;
 use Phan\Parse\ParseVisitor;
 use Phan\Plugin\ConfigPluginSet;
 use Throwable;
 
 use function count;
+use function spl_object_id;
 use function strlen;
 
 use const STDERR;
@@ -47,15 +55,14 @@ use const STDERR;
 class Analysis
 {
     /**
-     * @var array<string,array{hash:string,node:Node}> caches parsed ASTs for internal stubs to avoid reparsing them for each CodeBase.
+     * @var array<string,InternalStubCacheEntry>
      */
-    private static array $internal_stub_ast_cache = [];
+    private static array $internal_stub_cache = [];
 
-    /** @var int number of times the internal stub cache was used */
-    private static int $internal_stub_ast_cache_hits = 0;
-
-    /** @var int number of times parsing occurred because a cache entry was missing or stale */
-    private static int $internal_stub_ast_cache_misses = 0;
+    /** @var int number of times the internal stub cache handled a request */
+    private static int $internal_stub_cache_hits = 0;
+    /** @var int number of times the internal stub cache missed a request */
+    private static int $internal_stub_cache_misses = 0;
 
     /**
      * This first pass parses code and looks for the subset
@@ -81,6 +88,7 @@ class Analysis
      * See autoload_internal_extension_signatures.
      * @param ?Request $request probably a \Phan\Daemon\ParseRequest during language server mode.
      * @throws InvalidArgumentException for invalid stub files
+     * @throws FQSENException if cached class members cannot be collected
      */
     public static function parseFile(CodeBase $code_base, string $file_path, bool $suppress_parse_errors = false, ?string $override_contents = null, bool $is_php_internal_stub = false, ?Request $request = null): Context
     {
@@ -126,22 +134,25 @@ class Analysis
 
             return $context;
         }
-        $should_use_stub_cache = $is_php_internal_stub && $override_contents === null;
-        $node = null;
-        if ($should_use_stub_cache) {
-            $node = self::getCachedInternalStubNode($real_file_path, $file_contents);
+        $should_cache_stub = $is_php_internal_stub && $override_contents === null && !Config::getValue('dump_ast');
+        $cache_key = null;
+        $cache_hash = null;
+        $pre_parse_snapshot = null;
+        if ($should_cache_stub) {
+            $cache_key = self::normalizeInternalStubPath($real_file_path);
+            $cache_hash = self::hashStubContents($file_contents);
+            $cached_context = self::tryApplyInternalStubCache($code_base, $cache_key, $cache_hash);
+            if ($cached_context instanceof Context) {
+                return $cached_context;
+            }
+            $pre_parse_snapshot = self::snapshotCodeBaseState($code_base);
         }
 
-        if ($node === null) {
-            // TODO: Figure out why Phan doesn't suggest combining these catches except in language server mode
-            try {
-                $node = Parser::parseCode($code_base, $context, $request, $file_path, $file_contents, $suppress_parse_errors);
-            } catch (ParseError | CompileError | ParseException) {
-                return $context;
-            }
-            if ($should_use_stub_cache) {
-                self::storeCachedInternalStubNode($real_file_path, $file_contents, $node);
-            }
+        // TODO: Figure out why Phan doesn't suggest combining these catches except in language server mode
+        try {
+            $node = Parser::parseCode($code_base, $context, $request, $file_path, $file_contents, $suppress_parse_errors);
+        } catch (ParseError | CompileError | ParseException) {
+            return $context;
         }
 
         if (Config::getValue('dump_ast')) {
@@ -175,52 +186,72 @@ class Analysis
         );
         // @phan-suppress-next-line PhanAccessMethodInternal
         $code_base->addParsedNamespaceMap($context->getFile(), $context->getNamespace(), $context->getNamespaceId(), $context->getNamespaceMap());
+        if ($should_cache_stub && $cache_key !== null && $cache_hash !== null && $pre_parse_snapshot !== null) {
+            self::storeInternalStubCacheEntry($cache_key, $cache_hash, $code_base, $context, $pre_parse_snapshot);
+        }
         return $context;
     }
 
     /**
-     * Clears any cached ASTs for internal stubs. Useful for long-running processes and tests.
+     * Clears any cached parse results for internal stubs. Useful for long-running processes and tests.
      */
-    public static function clearInternalStubAstCache(): void
+    public static function clearInternalStubCache(): void
     {
-        self::$internal_stub_ast_cache = [];
-        self::$internal_stub_ast_cache_hits = 0;
-        self::$internal_stub_ast_cache_misses = 0;
+        self::$internal_stub_cache = [];
+        self::$internal_stub_cache_hits = 0;
+        self::$internal_stub_cache_misses = 0;
     }
 
     /**
-     * @return array{hits:int,misses:int} statistics about cached internal stub AST usage.
+     * @return array{hits:int,misses:int} statistics about cached internal stub parse usage.
      */
-    public static function getInternalStubAstCacheStats(): array
+    public static function getInternalStubCacheStats(): array
     {
         return [
-            'hits' => self::$internal_stub_ast_cache_hits,
-            'misses' => self::$internal_stub_ast_cache_misses,
+            'hits' => self::$internal_stub_cache_hits,
+            'misses' => self::$internal_stub_cache_misses,
         ];
     }
 
-    private static function getCachedInternalStubNode(string $file_path, string $file_contents): ?Node
+    private static function tryApplyInternalStubCache(CodeBase $code_base, string $cache_key, string $hash): ?Context
     {
-        $cache_key = self::normalizeInternalStubPath($file_path);
-        $entry = self::$internal_stub_ast_cache[$cache_key] ?? null;
-        if (!$entry) {
+        $entry = self::$internal_stub_cache[$cache_key] ?? null;
+        if (!$entry || !$entry->matchesHash($hash)) {
             return null;
         }
-        if ($entry['hash'] !== self::hashStubContents($file_contents)) {
-            return null;
-        }
-        self::$internal_stub_ast_cache_hits++;
-        return self::deepCloneNode($entry['node']);
+        self::$internal_stub_cache_hits++;
+        return $entry->applyToCodeBase($code_base);
     }
 
-    private static function storeCachedInternalStubNode(string $file_path, string $file_contents, Node $node): void
-    {
-        $cache_key = self::normalizeInternalStubPath($file_path);
-        self::$internal_stub_ast_cache[$cache_key] = [
-            'hash' => self::hashStubContents($file_contents),
-            'node' => self::deepCloneNode($node),
-        ];
-        self::$internal_stub_ast_cache_misses++;
+    /**
+     * @param array<string,array<string,int>> $snapshot
+     * @throws FQSENException if collecting class members fails
+     */
+    private static function storeInternalStubCacheEntry(
+        string $cache_key,
+        string $hash,
+        CodeBase $code_base,
+        Context $context,
+        array $snapshot
+    ): void {
+        $classes = self::collectChangedElements($code_base->getUserDefinedClassMap(), $snapshot['classes'] ?? []);
+        $functions = self::collectChangedElements($code_base->getFunctionMap(), $snapshot['functions'] ?? []);
+        $global_constants = self::collectChangedElements($code_base->getGlobalConstantMap(), $snapshot['global_constants'] ?? []);
+        if (!$classes && !$functions && !$global_constants) {
+            return;
+        }
+        $class_members = self::collectClassMembers($code_base, $classes);
+        $file_level_suppressions = $code_base->getFileLevelSuppressions($context->getFile());
+        self::$internal_stub_cache[$cache_key] = new InternalStubCacheEntry(
+            $hash,
+            clone($context),
+            $classes,
+            $functions,
+            $global_constants,
+            $file_level_suppressions,
+            $class_members
+        );
+        self::$internal_stub_cache_misses++;
     }
 
     private static function normalizeInternalStubPath(string $file_path): string
@@ -234,41 +265,99 @@ class Analysis
         return \hash('sha256', $contents);
     }
 
-    private static function deepCloneNode(Node $node): Node
+    /**
+     * @return array<string,array<string,int>>
+     */
+    private static function snapshotCodeBaseState(CodeBase $code_base): array
     {
-        return new Node($node->kind, $node->flags, self::cloneNodeChildren($node->children), $node->lineno);
+        return [
+            'classes' => self::snapshotMapState($code_base->getUserDefinedClassMap()),
+            'functions' => self::snapshotMapState($code_base->getFunctionMap()),
+            'global_constants' => self::snapshotMapState($code_base->getGlobalConstantMap()),
+        ];
     }
 
     /**
-     * @param array<int|string,mixed> $children
-     * @return array<int|string,mixed>
+     * @return array<string,int>
      */
-    private static function cloneNodeChildren(array $children): array
+    private static function snapshotMapState(Map $map): array
     {
         $result = [];
-        foreach ($children as $key => $child) {
-            $result[$key] = self::cloneNodeChild($child);
+        foreach ($map as $fqsen => $element) {
+            $result[(string)$fqsen] = spl_object_id($element);
         }
         return $result;
     }
 
     /**
-     * @return Node|array<int|string,mixed>|int|string|float|bool|null
-     *     Returns the cloned value for a child entry in an ast\Node.
+     * @param array<string,int> $previous
+     * @return list<object>
      */
-    private static function cloneNodeChild(mixed $child): mixed
+    private static function collectChangedElements(Map $map, array $previous): array
     {
-        if ($child instanceof Node) {
-            return self::deepCloneNode($child);
-        }
-        if (\is_array($child)) {
-            $result = [];
-            foreach ($child as $key => $value) {
-                $result[$key] = self::cloneNodeChild($value);
+        $result = [];
+        foreach ($map as $fqsen => $element) {
+            $id = spl_object_id($element);
+            $key = (string)$fqsen;
+            if (($previous[$key] ?? null) !== $id) {
+                $result[] = self::cloneElementForCache($element);
             }
-            return $result;
         }
-        return $child;
+        return $result;
+    }
+
+    private static function cloneElementForCache(object $element): object
+    {
+        return clone $element;
+    }
+
+    /**
+     * @param list<Clazz> $classes
+     * @return array<string,array{methods:list<Method>,properties:list<Property>,constants:list<ClassConstant>}>
+     * @throws FQSENException if class names cannot be parsed while collecting members
+     */
+    private static function collectClassMembers(CodeBase $code_base, array $classes): array
+    {
+        $result = [];
+        foreach ($classes as $class) {
+            if (!$class instanceof Clazz) {
+                continue;
+            }
+            $fqsen = $class->getFQSEN();
+            $result[(string)$fqsen] = [
+                'methods' => self::cloneMethodList($code_base->getMethodMapByFullyQualifiedClassName($fqsen)),
+                'properties' => self::clonePropertyList($code_base->getPropertyMapByFullyQualifiedClassName($fqsen)),
+                'constants' => self::cloneClassConstantList($code_base->getClassConstantMapByFullyQualifiedClassName($fqsen)),
+            ];
+        }
+        return $result;
+    }
+
+    /**
+     * @param array<string,Method> $methods
+     * @return list<Method>
+     */
+    private static function cloneMethodList(array $methods): array
+    {
+        return array_map(static fn (Method $method): Method => clone $method, array_values($methods));
+    }
+
+    /**
+     * @param array<string,Property> $properties
+     * @return list<Property>
+     */
+    private static function clonePropertyList(array $properties): array
+    {
+        return array_map(static fn (Property $property): Property => clone $property, array_values($properties));
+    }
+
+    /**
+     * @param array<string,ClassConstant> $constants
+     * @return list<ClassConstant>
+     */
+    private static function cloneClassConstantList(array $constants): array
+    {
+        return array_map(static fn (ClassConstant $constant): ClassConstant => clone $constant, array_values($constants));
     }
 
     /**

--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -47,6 +47,17 @@ use const STDERR;
 class Analysis
 {
     /**
+     * @var array<string,array{hash:string,node:Node}> caches parsed ASTs for internal stubs to avoid reparsing them for each CodeBase.
+     */
+    private static array $internal_stub_ast_cache = [];
+
+    /** @var int number of times the internal stub cache was used */
+    private static int $internal_stub_ast_cache_hits = 0;
+
+    /** @var int number of times parsing occurred because a cache entry was missing or stale */
+    private static int $internal_stub_ast_cache_misses = 0;
+
+    /**
      * This first pass parses code and looks for the subset
      * of issues that can be found without having to have
      * an understanding of the entire code base.
@@ -115,11 +126,22 @@ class Analysis
 
             return $context;
         }
-        // TODO: Figure out why Phan doesn't suggest combining these catches except in language server mode
-        try {
-            $node = Parser::parseCode($code_base, $context, $request, $file_path, $file_contents, $suppress_parse_errors);
-        } catch (ParseError | CompileError | ParseException) {
-            return $context;
+        $should_use_stub_cache = $is_php_internal_stub && $override_contents === null;
+        $node = null;
+        if ($should_use_stub_cache) {
+            $node = self::getCachedInternalStubNode($real_file_path, $file_contents);
+        }
+
+        if ($node === null) {
+            // TODO: Figure out why Phan doesn't suggest combining these catches except in language server mode
+            try {
+                $node = Parser::parseCode($code_base, $context, $request, $file_path, $file_contents, $suppress_parse_errors);
+            } catch (ParseError | CompileError | ParseException) {
+                return $context;
+            }
+            if ($should_use_stub_cache) {
+                self::storeCachedInternalStubNode($real_file_path, $file_contents, $node);
+            }
         }
 
         if (Config::getValue('dump_ast')) {
@@ -154,6 +176,90 @@ class Analysis
         // @phan-suppress-next-line PhanAccessMethodInternal
         $code_base->addParsedNamespaceMap($context->getFile(), $context->getNamespace(), $context->getNamespaceId(), $context->getNamespaceMap());
         return $context;
+    }
+
+    /**
+     * Clears any cached ASTs for internal stubs. Useful for long-running processes and tests.
+     */
+    public static function clearInternalStubAstCache(): void
+    {
+        self::$internal_stub_ast_cache = [];
+        self::$internal_stub_ast_cache_hits = 0;
+        self::$internal_stub_ast_cache_misses = 0;
+    }
+
+    /**
+     * @return array{hits:int,misses:int} statistics about cached internal stub AST usage.
+     */
+    public static function getInternalStubAstCacheStats(): array
+    {
+        return [
+            'hits' => self::$internal_stub_ast_cache_hits,
+            'misses' => self::$internal_stub_ast_cache_misses,
+        ];
+    }
+
+    private static function getCachedInternalStubNode(string $file_path, string $file_contents): ?Node
+    {
+        $cache_key = self::normalizeInternalStubPath($file_path);
+        $entry = self::$internal_stub_ast_cache[$cache_key] ?? null;
+        if (!$entry) {
+            return null;
+        }
+        if ($entry['hash'] !== self::hashStubContents($file_contents)) {
+            return null;
+        }
+        self::$internal_stub_ast_cache_hits++;
+        return self::deepCloneNode($entry['node']);
+    }
+
+    private static function storeCachedInternalStubNode(string $file_path, string $file_contents, Node $node): void
+    {
+        $cache_key = self::normalizeInternalStubPath($file_path);
+        self::$internal_stub_ast_cache[$cache_key] = [
+            'hash' => self::hashStubContents($file_contents),
+            'node' => self::deepCloneNode($node),
+        ];
+        self::$internal_stub_ast_cache_misses++;
+    }
+
+    private static function normalizeInternalStubPath(string $file_path): string
+    {
+        $real = \realpath($file_path);
+        return $real !== false ? $real : $file_path;
+    }
+
+    private static function hashStubContents(string $contents): string
+    {
+        return \hash('sha256', $contents);
+    }
+
+    private static function deepCloneNode(Node $node): Node
+    {
+        $children = [];
+        foreach ($node->children as $key => $child) {
+            $children[$key] = self::cloneNodeChild($child);
+        }
+        return new Node($node->kind, $node->flags, $children, $node->lineno);
+    }
+
+    /**
+     * @param mixed $child
+     * @return mixed
+     */
+    private static function cloneNodeChild($child)
+    {
+        if ($child instanceof Node) {
+            return self::deepCloneNode($child);
+        }
+        if (\is_array($child)) {
+            $result = [];
+            foreach ($child as $key => $value) {
+                $result[$key] = self::cloneNodeChild($value);
+            }
+            return $result;
+        }
+        return $child;
     }
 
     /**

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -39,6 +39,7 @@ use Phan\Library\StringSuggester;
 use Phan\Plugin\ConfigPluginSet;
 use ReflectionClass;
 
+use function array_keys;
 use function count;
 use function get_defined_constants;
 use function get_extension_funcs;
@@ -1397,6 +1398,16 @@ class CodeBase
     }
 
     /**
+     * Marks that the given internal function (canonical alternate id) has been fully loaded,
+     * preventing lazy loading from signature maps.
+     */
+    public function markFunctionFullyLoaded(FullyQualifiedFunctionName $fqsen): void
+    {
+        $canonical = $fqsen->withAlternateId(0);
+        unset($this->internal_function_fqsen_set[$canonical]);
+    }
+
+    /**
      * @param ClassConstant $class_constant
      * A class constant to add to the code base
      */
@@ -1823,6 +1834,14 @@ class CodeBase
             return true;
         }
         return false;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getFileLevelSuppressions(string $file): array
+    {
+        return array_keys($this->file_level_suppression_set[$file] ?? []);
     }
 
     /**

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -1284,6 +1284,12 @@ class Config
             ? 'spl.phan_php'
             : 'spl_php81.phan_php';
 
+        // pcntl stub: PHP 8.4 adds new functions/constants/enums, so keep an
+        // older stub for PHP 8.1-8.3
+        $pcntl_stub = $effective_version >= 80400
+            ? 'pcntl_php84.phan_php'
+            : 'pcntl.phan_php';
+
         // Standard library stub: Choose based on PHP version
         // PHP 8.1-8.3: uses standard_templates_php81.phan_php (no 8.4+ functions)
         // PHP 8.4: uses standard_templates_php84.phan_php (includes array_find, array_any, array_all, array_find_key)
@@ -1302,7 +1308,7 @@ class Config
                 'ctype'       => "$bundled_stubs_dir/ctype.phan_php",
                 'igbinary'    => "$bundled_stubs_dir/igbinary.phan_php",
                 'mbstring'    => "$bundled_stubs_dir/mbstring.phan_php",
-                'pcntl'       => "$bundled_stubs_dir/pcntl.phan_php",
+                'pcntl'       => "$bundled_stubs_dir/$pcntl_stub",
                 'phar'        => "$bundled_stubs_dir/phar.phan_php",
                 'posix'       => "$bundled_stubs_dir/posix.phan_php",
                 'readline'    => "$bundled_stubs_dir/readline.phan_php",

--- a/src/Phan/Internal/InternalStubCacheEntry.php
+++ b/src/Phan/Internal/InternalStubCacheEntry.php
@@ -1,0 +1,96 @@
+<?php
+
+/** @phan-file-suppress PhanAccessMethodInternal */
+
+declare(strict_types=1);
+
+namespace Phan\Internal;
+
+use Phan\CodeBase;
+use Phan\Language\Context;
+use Phan\Language\Element\Clazz;
+use Phan\Language\Element\ClassConstant;
+use Phan\Language\Element\Func;
+use Phan\Language\Element\GlobalConstant;
+use Phan\Language\Element\Method;
+use Phan\Language\Element\Property;
+use Phan\Language\FQSEN\FullyQualifiedFunctionName;
+
+/**
+ * Tracks the results of parsing a PHP internal stub file so that it can be restored without reparsing.
+ *
+ * @internal
+ */
+final class InternalStubCacheEntry
+{
+    /**
+     * @param list<Clazz> $classes
+     * @param list<Func> $functions
+     * @param list<GlobalConstant> $global_constants
+     * @param list<string> $file_level_suppressions
+     * @param array<string,array{methods:list<Method>,properties:list<Property>,constants:list<ClassConstant>}> $class_members
+     */
+    public function __construct(
+        private string $hash,
+        private Context $context,
+        private array $classes,
+        private array $functions,
+        private array $global_constants,
+        private array $file_level_suppressions,
+        private array $class_members
+    ) {
+    }
+
+    /**
+     * Checks whether the cached entry matches the provided hash.
+     */
+    public function matchesHash(string $hash): bool
+    {
+        return $this->hash === $hash;
+    }
+
+    /**
+     * Replays cached definitions into the provided code base.
+     */
+    public function applyToCodeBase(CodeBase $code_base): Context
+    {
+        foreach ($this->classes as $class) {
+            $code_base->addClass(clone $class);
+        }
+        foreach ($this->functions as $function) {
+            $cloned_function = clone $function;
+            $code_base->addFunction($cloned_function);
+            $fqsen = $cloned_function->getFQSEN();
+            if ($fqsen instanceof FullyQualifiedFunctionName) {
+                $code_base->markFunctionFullyLoaded($fqsen);
+            }
+        }
+        foreach ($this->global_constants as $constant) {
+            $code_base->addGlobalConstant(clone $constant);
+        }
+        foreach ($this->class_members as $members) {
+            foreach ($members['constants'] as $constant) {
+                $code_base->addClassConstant(clone $constant);
+            }
+            foreach ($members['properties'] as $property) {
+                $code_base->addProperty(clone $property);
+            }
+            foreach ($members['methods'] as $method) {
+                $code_base->addMethod(clone $method);
+            }
+        }
+        $file = $this->context->getFile();
+        foreach ($this->file_level_suppressions as $issue_type) {
+            $code_base->addFileLevelSuppression($file, $issue_type);
+        }
+        $context_clone = clone $this->context;
+        $code_base->addParsedNamespaceMap(
+            $context_clone->getFile(),
+            $context_clone->getNamespace(),
+            $context_clone->getNamespaceId(),
+            $context_clone->getNamespaceMap()
+        );
+        return $context_clone;
+    }
+
+}

--- a/src/Phan/Phan.php
+++ b/src/Phan/Phan.php
@@ -942,6 +942,7 @@ class Phan implements IgnoredFilesFilterInterface
      * User configs are merged with defaults via Config::setValue().
      *
      * @throws InvalidArgumentException if the stubs or stub config is invalid
+     * @throws \Phan\Exception\FQSENException if parsing cached stubs fails
      */
     private static function loadConfiguredPHPExtensionStubs(CodeBase $code_base): void
     {

--- a/tests/Phan/InternalStubCacheTest.php
+++ b/tests/Phan/InternalStubCacheTest.php
@@ -9,6 +9,8 @@ use Phan\CodeBase;
 use PHPUnit\Framework\TestCase;
 
 /**
+ * Ensures the internal stub AST cache avoids reparsing identical files.
+ *
  * @covers \Phan\Analysis
  */
 final class InternalStubCacheTest extends TestCase

--- a/tests/Phan/InternalStubCacheTest.php
+++ b/tests/Phan/InternalStubCacheTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phan\Tests;
+
+use Phan\Analysis;
+use Phan\CodeBase;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Phan\Analysis
+ */
+final class InternalStubCacheTest extends TestCase
+{
+    public function testInternalStubCacheHits(): void
+    {
+        Analysis::clearInternalStubAstCache();
+        $stub_file = \tempnam(\sys_get_temp_dir(), 'phan_stub_cache_');
+        if ($stub_file === false) {
+            $this->fail('Failed to create a temporary stub file for cache test');
+        }
+        \file_put_contents($stub_file, "<?php function stub_cache_example() {}");
+
+        try {
+            $first_code_base = new CodeBase([], [], [], [], []);
+            Analysis::parseFile($first_code_base, $stub_file, false, null, true);
+            $stats = Analysis::getInternalStubAstCacheStats();
+            $this->assertSame(['hits' => 0, 'misses' => 1], $stats, 'First parse should record one miss and zero hits');
+
+            $second_code_base = new CodeBase([], [], [], [], []);
+            Analysis::parseFile($second_code_base, $stub_file, false, null, true);
+            $stats = Analysis::getInternalStubAstCacheStats();
+            $this->assertSame(['hits' => 1, 'misses' => 1], $stats, 'Second parse should reuse cached AST');
+        } finally {
+            @\unlink($stub_file);
+            Analysis::clearInternalStubAstCache();
+        }
+    }
+}

--- a/tests/Phan/InternalStubCacheTest.php
+++ b/tests/Phan/InternalStubCacheTest.php
@@ -6,18 +6,22 @@ namespace Phan\Tests;
 
 use Phan\Analysis;
 use Phan\CodeBase;
+use Phan\Language\FQSEN\FullyQualifiedFunctionName;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Ensures the internal stub AST cache avoids reparsing identical files.
+ * Ensures the internal stub cache avoids reparsing identical files.
  *
  * @covers \Phan\Analysis
  */
 final class InternalStubCacheTest extends TestCase
 {
+    /**
+     * @throws \Phan\Exception\FQSENException
+     */
     public function testInternalStubCacheHits(): void
     {
-        Analysis::clearInternalStubAstCache();
+        Analysis::clearInternalStubCache();
         $stub_file = \tempnam(\sys_get_temp_dir(), 'phan_stub_cache_');
         if ($stub_file === false) {
             $this->fail('Failed to create a temporary stub file for cache test');
@@ -27,16 +31,19 @@ final class InternalStubCacheTest extends TestCase
         try {
             $first_code_base = new CodeBase([], [], [], [], []);
             Analysis::parseFile($first_code_base, $stub_file, false, null, true);
-            $stats = Analysis::getInternalStubAstCacheStats();
+            $stats = Analysis::getInternalStubCacheStats();
             $this->assertSame(['hits' => 0, 'misses' => 1], $stats, 'First parse should record one miss and zero hits');
+            $function_fqsen = FullyQualifiedFunctionName::fromFullyQualifiedString('\\stub_cache_example');
+            $this->assertTrue($first_code_base->hasFunctionWithFQSEN($function_fqsen));
 
             $second_code_base = new CodeBase([], [], [], [], []);
             Analysis::parseFile($second_code_base, $stub_file, false, null, true);
-            $stats = Analysis::getInternalStubAstCacheStats();
+            $stats = Analysis::getInternalStubCacheStats();
             $this->assertSame(['hits' => 1, 'misses' => 1], $stats, 'Second parse should reuse cached AST');
+            $this->assertTrue($second_code_base->hasFunctionWithFQSEN($function_fqsen));
         } finally {
             @\unlink($stub_file);
-            Analysis::clearInternalStubAstCache();
+            Analysis::clearInternalStubCache();
         }
     }
 }


### PR DESCRIPTION
This is a full parse-phase cache for internal stubs:
- When Analysis::parseFile() handles an internal stub, it snapshots the CodeBase’s user-defined classes/functions/constants. After parsing, it records which elements were added or modified and stores deep clones of those plus their namespace maps, file suppressions, and class members (methods/properties/constants) in InternalStubCacheEntry.
- On subsequent runs (same stub path + content hash), the cache bypasses parsing entirely: it replays the cached definitions into the new CodeBase, marking cloned functions as already loaded so Phan’s lazy signature map doesn’t conflict.
- The cache exposes hit/miss stats and a clear helper for tests/long-running modes. Tests now verify the cache behavior, and loading internal stubs in Phan::loadConfiguredPHPExtensionStubs() can throw an FQSENException because of this rehydration step.