### PR TITLE
use xxh3-128 when available instead of md5 for hashing

### DIFF
--- a/src/Phan/AST/ASTHasher.php
+++ b/src/Phan/AST/ASTHasher.php
@@ -27,10 +27,14 @@ class ASTHasher
      */
     public static function hash(Node|float|int|null|string $node): string
     {
+        static $string_hash_algo = null;
+        if ($string_hash_algo === null) {
+            $string_hash_algo = \in_array('xxh128', hash_algos(), true) ? 'xxh128' : 'md5';
+        }
         // Handle primitives with raw representation (not hashed)
         if (!is_object($node)) {
             if (is_string($node)) {
-                return md5($node, true);
+                return hash($string_hash_algo, $node, true);
             } elseif (is_int($node)) {
                 if (\PHP_INT_SIZE >= 8) {
                     return "\0\0\0\0\0\0\0\0" . \pack('J', $node);

--- a/src/Phan/polyfills/phan_ast_hash.php
+++ b/src/Phan/polyfills/phan_ast_hash.php
@@ -7,8 +7,8 @@ use ast\Node;
 /**
  * Polyfill for phan_ast_hash() when the phan_helpers extension is not available.
  *
- * This function generates a 16-byte MD5 hash of an AST node, ignoring line numbers
- * and spacing to detect semantically identical code.
+ * This function generates a 16-byte hash (XXH3-128 when available, otherwise MD5) of an AST node,
+ * ignoring line numbers and spacing to detect semantically identical code.
  *
  * @param Node|string|int|float|null $node
  * @return string 16-byte binary hash
@@ -16,10 +16,14 @@ use ast\Node;
  */
 function phan_ast_hash(Node|string|int|float|null $node): string
 {
+    static $hash_algo = null;
+    if ($hash_algo === null) {
+        $hash_algo = \in_array('xxh128', hash_algos(), true) ? 'xxh128' : 'md5';
+    }
     // Handle non-objects (primitives)
     if (!is_object($node)) {
         if (is_string($node)) {
-            return md5($node, true);
+            return hash($hash_algo, $node, true);
         } elseif (is_int($node)) {
             if (\PHP_INT_SIZE >= 8) {
                 return "\0\0\0\0\0\0\0\0" . \pack('J', $node);
@@ -35,7 +39,11 @@ function phan_ast_hash(Node|string|int|float|null $node): string
     }
 
     // Handle AST nodes
-    $str = 'N' . $node->kind . ':' . ($node->flags & 0x3ffffff);
+    $ctx = hash_init($hash_algo);
+    hash_update($ctx, 'N');
+    hash_update($ctx, (string)$node->kind);
+    hash_update($ctx, ':');
+    hash_update($ctx, (string)($node->flags & 0x3ffffff));
     foreach ($node->children as $key => $child) {
         // Skip keys starting with "phan" (added by PhanAnnotationAdder)
         if (\is_string($key) && \strncmp($key, 'phan', 4) === 0) {
@@ -44,20 +52,20 @@ function phan_ast_hash(Node|string|int|float|null $node): string
 
         // Hash the key
         if (is_string($key)) {
-            $str .= md5($key, true);
+            hash_update($ctx, hash($hash_algo, $key, true));
         } elseif (is_int($key)) {
             if (\PHP_INT_SIZE >= 8) {
-                $str .= "\0\0\0\0\0\0\0\0" . \pack('J', $key);
+                hash_update($ctx, "\0\0\0\0\0\0\0\0" . \pack('J', $key));
             } else {
-                $str .= "\0\0\0\0\0\0\0\0\0\0\0\0" . \pack('N', $key);
+                hash_update($ctx, "\0\0\0\0\0\0\0\0\0\0\0\0" . \pack('N', $key));
             }
         } else {
-            $str .= md5((string) $key, true);
+            hash_update($ctx, hash($hash_algo, (string)$key, true));
         }
 
         // Hash the child value (recursive)
-        $str .= phan_ast_hash($child);
+        hash_update($ctx, phan_ast_hash($child));
     }
 
-    return md5($str, true);
+    return hash_final($ctx, true);
 }

--- a/tests/Phan/AST/ASTHasherTest.php
+++ b/tests/Phan/AST/ASTHasherTest.php
@@ -49,10 +49,11 @@ final class ASTHasherTest extends TestBase
             $this->assertSameBinaryString($expected, ASTHasher::hash($key));
         }
         $this->assertSameBinaryString("\0\0\0\0\0\0\0\2\0\0\0\0\0\0\0\0", ASTHasher::hash(null));
-        $expected1 = hex2bin('3c6e0b8a9c15224a8228b9a98ca1531d');
+        $hash_algo = \in_array('xxh128', \hash_algos(), true) ? 'xxh128' : 'md5';
+        $expected1 = hex2bin(hash($hash_algo, 'key'));
         $this->assertSameBinaryString($expected1, ASTHasher::hash('key'));
 
-        $expected2 = hex2bin('d41d8cd98f00b204e9800998ecf8427e');
+        $expected2 = hex2bin(hash($hash_algo, ''));
         $this->assertSameBinaryString($expected2, ASTHasher::hash(''));
 
         $expected2 = hex2bin('0000000000000001000000000000f83f');


### PR DESCRIPTION
Swapped the polyfill and public hashing API over to XXH3-128 (matching the C helper) while keeping MD5 as a fallback when xxHash isn’t available:
- src/Phan/polyfills/phan_ast_hash.php: polyfill now builds hashes with hash_init/hash_update/hash_final using xxh128 when possible; falls back to MD5 only when that algorithm isn’t compiled in. The recursion now streams the same byte layout that the phan_helpers extension produces.
- src/Phan/AST/ASTHasher.php: string inputs also use XXH128 (or MD5 fallback), so primitives and AST nodes share the same hash family.
- tests/Phan/AST/ASTHasherTest.php: expectations dynamically pick whichever algorithm PHP is using so the test suite passes in both xxHash and MD5 environments.