### PR TITLE
Fix bug #5322

### DIFF
--- a/src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php
@@ -22,6 +22,11 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN
     use \Phan\Memoize;
 
     /**
+     * @var array<string,string> maps canonicalized FQSEN keys to their preferred display name
+     */
+    private static array $preferred_name_map = [];
+
+    /**
      * @var string
      * The namespace in this elements scope
      * @readonly
@@ -473,8 +478,53 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN
     {
         return $this->as_string ?? $this->as_string = static::toString(
             $this->namespace,
-            $this->name,
+            $this->getPreferredName(),
             $this->getAlternateId()
         );
+    }
+
+    protected static function preferredNameKey(string $namespace, string $name, int $alternate_id): string
+    {
+        return static::class . '|' . static::toString(\strtolower($namespace), static::canonicalLookupKey($name), $alternate_id);
+    }
+
+    private function getPreferredName(): string
+    {
+        $key = static::preferredNameKey($this->namespace, $this->name, $this->getAlternateId());
+        return self::$preferred_name_map[$key] ?? static::canonicalName($this->name);
+    }
+
+    /**
+     * Record the preferred display name for this FQSEN (e.g. to preserve the case used in the declaration).
+     */
+    public function setPreferredName(string $preferred_name): void
+    {
+        $key = static::preferredNameKey($this->namespace, $this->name, $this->getAlternateId());
+        if ($preferred_name === '') {
+            unset(self::$preferred_name_map[$key]);
+        } else {
+            self::$preferred_name_map[$key] = $preferred_name;
+        }
+        $this->as_string = null;
+    }
+
+    /**
+     * Clear all preferred display names (used between independent analyses/tests).
+     */
+    public static function clearPreferredNameMap(): void
+    {
+        self::$preferred_name_map = [];
+    }
+
+    /**
+     * Look up the preferred display name for the given structural element, if any.
+     */
+    public static function lookupPreferredName(
+        string $namespace,
+        string $name,
+        int $alternate_id = 0
+    ): ?string {
+        $key = static::preferredNameKey($namespace, $name, $alternate_id);
+        return self::$preferred_name_map[$key] ?? null;
     }
 }

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -3610,15 +3610,20 @@ class Type implements Stringable
     public function asFQSENString(): string
     {
         $namespace = $this->namespace;
-        if (!$namespace) {
-            return $this->name;
+        $name = $this->name;
+        if ($namespace) {
+            if ($preferred = FullyQualifiedClassName::lookupPreferredName($namespace, $name)) {
+                $name = $preferred;
+            }
+        } else {
+            return $name;
         }
 
         if ('\\' === $namespace) {
-            return '\\' . $this->name;
+            return '\\' . $name;
         }
 
-        return "{$namespace}\\{$this->name}";
+        return "{$namespace}\\{$name}";
     }
 
     /**

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -130,6 +130,8 @@ class ParseVisitor extends ScopeVisitor
             $class_fqsen = $class_fqsen->withAlternateId(++$alternate_id);
         }
 
+        $class_fqsen->setPreferredName($class_name);
+
         if ($alternate_id > 0) {
             Daemon::debugf("Using an alternate for %s: %d\n", $class_fqsen, $alternate_id);
         }

--- a/tests/Phan/AbstractPhanFileTestBase.php
+++ b/tests/Phan/AbstractPhanFileTestBase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phan\Tests;
 
 use Phan\Config;
+use Phan\Language\FQSEN\FullyQualifiedGlobalStructuralElement;
 use Phan\Language\Type;
 use Phan\Library\StringUtil;
 use Phan\Output\Collector\BufferingCollector;
@@ -58,6 +59,7 @@ abstract class AbstractPhanFileTestBase extends CodeBaseAwareTestBase
         parent::setUp();
 
         Type::clearAllMemoizations();
+        FullyQualifiedGlobalStructuralElement::clearPreferredNameMap();
     }
 
     /**
@@ -68,6 +70,7 @@ abstract class AbstractPhanFileTestBase extends CodeBaseAwareTestBase
         parent::tearDown();
 
         Type::clearAllMemoizations();
+        FullyQualifiedGlobalStructuralElement::clearPreferredNameMap();
 
         // Force garbage collection to reclaim memory from circular references
         // created by template type instantiations (e.g., SplObjectStorage<T,TInfo>)


### PR DESCRIPTION
This keeps global caches for performance but decouples “how we display a name” from the cached objects themselves, so class names always reflect the casing of the file currently being analyzed, even when tests (or separate analyses) reuse the same identifiers with different casing.