### PR TITLE
Fix bug 5326

### DIFF
--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -250,9 +250,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         if ($var_node->kind === ast\AST_VAR &&
             $expr_node instanceof Node &&
             self::exprHasTypeNarrowingPotential($expr_node) &&
-            $right_type->hasTypeMatchingCallback(static function (Type $type): bool {
-                return $type->getName() === 'bool' || $type->getName() === 'true' || $type->getName() === 'false';
-            })) {
+            $right_type->isExclusivelyBoolTypes()) {
             // Get the variable name
             $var_name = $var_node->children['name'];
             if (\is_string($var_name) && !self::exprReferencesVariable($expr_node, $var_name)) {

--- a/tests/files/src/0937_branch_scope.php
+++ b/tests/files/src/0937_branch_scope.php
@@ -1,0 +1,23 @@
+<?php
+
+function render_dev_css(bool $flag, string $asset, int $port): string
+{
+    if ($flag) {
+        $css = maybe_get_css($asset);
+        if ($css === '') {
+            $uri = "http://localhost:$port/?type=css&asset=$asset";
+            $context = stream_context_create(['http' => ['ignore_errors' => true]]);
+            $css = file_get_contents($uri, false, $context);
+        }
+    } else {
+        $context = stream_context_create(['http' => ['ignore_errors' => true]]);
+        $css = file_get_contents($asset, false, $context);
+    }
+
+    return $css;
+}
+
+function maybe_get_css(string $asset): string
+{
+    return '';
+}


### PR DESCRIPTION
Updated `PostOrderAnalysisVisitor.php` to only cache a conditional expression for reuse when the assignment’s RHS is exclusively boolean. Previously any expression whose inferred type merely included false (e.g., `false|string` from `file_get_contents`) was cached. When `ConditionVisitor`
later re‑applied that expression in a new scope, it re‑analyzed the entire call and flagged branch‑local variables as possibly undefined, which is exactly what happened in `modules/CssRenderer`. Requiring `UnionType::isExclusivelyBoolTypes()` prevents non‑boolean expressions from being cached and eliminates the false positive.