### PR TITLE
Fix class-string and add psalm generics aliases

### DIFF
--- a/src/Phan/Language/Element/Comment/Builder.php
+++ b/src/Phan/Language/Element/Comment/Builder.php
@@ -59,6 +59,16 @@ final class Builder
     public $inherited_type;
     /** @var list<Type> the list of (at)implements annotations with template parameters */
     public $implemented_types = [];
+
+    /** @var array<string,string> */
+    private const TAG_ALIAS_MAP = [
+        'psalm-template' => 'template',
+        'psalm-template-covariant' => 'template-covariant',
+        'psalm-template-contravariant' => 'template-contravariant',
+        'psalm-param' => 'param',
+        'psalm-return' => 'return',
+        'psalm-var' => 'var',
+    ];
     /** @var list<Type> the list of (at)use annotations with template parameters for traits */
     public $used_trait_types = [];
     // TODO: Warn about multiple (at)returns
@@ -119,7 +129,7 @@ final class Builder
 
     /** @internal */
     public const PARAM_COMMENT_REGEX =
-        '/@(?:phan-)?(param|var)\b\s*(' . UnionType::union_type_regex . ')?(?:\s*(\.\.\.)?\s*&?(?:\\$' . self::WORD_REGEX . '))?/';
+        '/@(?:phan-|psalm-)?(param|var)\b\s*(' . UnionType::union_type_regex . ')?(?:\s*(\.\.\.)?\s*&?(?:\\$' . self::WORD_REGEX . '))?/';
 
     /** @internal */
     public const UNUSED_PARAM_COMMENT_REGEX =
@@ -226,9 +236,9 @@ final class Builder
     }
 
     /** @internal */
-    public const RETURN_COMMENT_REGEX = '/@(?:phan-)?(?:real-)?return\s+(&\s*)?(' . UnionType::union_type_regex_or_this . ')/';
+    public const RETURN_COMMENT_REGEX = '/@(?:phan-|psalm-)?(?:real-)?return\s+(&\s*)?(' . UnionType::union_type_regex_or_this . ')/';
     /** @internal */
-    public const RETURN_OR_THROWS_COMMENT_REGEX = '/@(?:phan-)?(?:real-)?(?:return|throws)\s+(&\s*)?(' . UnionType::union_type_regex_or_this . ')/';
+    public const RETURN_OR_THROWS_COMMENT_REGEX = '/@(?:phan-|psalm-)?(?:real-)?(?:return|throws)\s+(&\s*)?(' . UnionType::union_type_regex_or_this . ')/';
 
     /**
      * @param string $line
@@ -414,9 +424,10 @@ final class Builder
         // (?i) makes this case-sensitive, (?-1) makes it case-insensitive
         // phpcs:ignore Generic.Files.LineLength.MaxExceeded
         // Support both regular tags ("@something") and inline versions of tags ("optional_prefix {@something}").
-        if (\preg_match('/(?:^|{)@((?i)param|deprecated|var|return|throws|throw|returns|inherits|extends|implements|use|suppress|unused-param|no-named-arguments|phan-[a-z0-9_-]*(?-i)|method|property|property-read|property-write|abstract|template(?:-(?:co|contra)variant)?|PhanClosureScope|readonly|mixin|seal-(?:methods|properties))(?:[^a-zA-Z0-9_\x7f-\xff-]|$)/D', $trimmed, $matches)) {
+        if (\preg_match('/(?:^|{)@((?i)param|deprecated|var|return|throws|throw|returns|inherits|extends|implements|use|suppress|unused-param|no-named-arguments|phan-[a-z0-9_-]*|psalm-(?:template(?:-(?:co|contra)variant)?|param|var|return)(?-i)|method|property|property-read|property-write|abstract|template(?:-(?:co|contra)variant)?|PhanClosureScope|readonly|mixin|seal-(?:methods|properties))(?:[^a-zA-Z0-9_\x7f-\xff-]|$)/D', $trimmed, $matches)) {
             $case_sensitive_type = $matches[1];
             $type = \strtolower($case_sensitive_type);
+            $type = self::TAG_ALIAS_MAP[$type] ?? $type;
 
             switch ($type) {
                 case 'param':
@@ -1257,7 +1268,7 @@ final class Builder
         string $line
     ): ?array {
         // Backslashes or nested templates wouldn't make sense, so use WORD_REGEX.
-        if (\preg_match('/@(?:phan-)?template(?:-(?P<variance>co|contra)variant)?\s+(?P<identifier>' . self::WORD_REGEX . ')(?:\s+of\s+(?P<constraint>' . UnionType::union_type_regex . '))?/i', $line, $match)) {
+        if (\preg_match('/@(?:phan-|psalm-)?template(?:-(?P<variance>co|contra)variant)?\s+(?P<identifier>' . self::WORD_REGEX . ')(?:\s+of\s+(?P<constraint>' . UnionType::union_type_regex . '))?/i', $line, $match)) {
             $constraint = $match['constraint'] ?? null;
             $variance = TemplateType::VARIANCE_INVARIANT;
             $variance_keyword = strtolower($match['variance'] ?? '');

--- a/src/Phan/Language/Type/TemplateType.php
+++ b/src/Phan/Language/Type/TemplateType.php
@@ -287,6 +287,16 @@ final class TemplateType extends Type
                 continue;
             }
 
+            if ($type instanceof ClassStringType) {
+                $class_union_type = $type->getClassUnionType();
+                if (!$class_union_type->isEmpty()) {
+                    if (!self::unionTypeSatisfiesBound($code_base, $class_union_type, $bound, $seen_template_names)) {
+                        return false;
+                    }
+                    continue;
+                }
+            }
+
             if (!$type->asPHPDocUnionType()->canCastToUnionType($bound, $code_base)) {
                 return false;
             }

--- a/src/Phan/Language/Type/TemplateType.php
+++ b/src/Phan/Language/Type/TemplateType.php
@@ -290,10 +290,10 @@ final class TemplateType extends Type
             if ($type instanceof ClassStringType) {
                 $class_union_type = $type->getClassUnionType();
                 if (!$class_union_type->isEmpty()) {
-                    if (!self::unionTypeSatisfiesBound($code_base, $class_union_type, $bound, $seen_template_names)) {
-                        return false;
+                    if (self::unionTypeSatisfiesBound($code_base, $class_union_type, $bound, $seen_template_names)) {
+                        continue;
                     }
-                    continue;
+                    // Fall through to the generic check below if the class-string itself may still match.
                 }
             }
 

--- a/tests/files/expected/1102_psalm_annotations.php.expected
+++ b/tests/files/expected/1102_psalm_annotations.php.expected
@@ -1,0 +1,2 @@
+%s:10 PhanTypeMismatchArgumentProbablyReal Argument 1 ($value) is 'not an int' of type string but \takes_int() takes int (no real type) defined at %s:6 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
+%s:23 PhanTemplateTypeConstraintViolation Template type T of \require_countable() must be compatible with \Countable, but \stdClass was provided in call to \require_countable()

--- a/tests/files/src/1102_psalm_annotations.php
+++ b/tests/files/src/1102_psalm_annotations.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @psalm-param int $value
+ */
+function takes_int($value)
+{
+}
+
+takes_int('not an int');
+
+/**
+ * @psalm-template T of Countable
+ * @psalm-param T $countable
+ * @psalm-return T
+ */
+function require_countable($countable)
+{
+    return $countable;
+}
+
+require_countable(new ArrayObject());
+require_countable(new stdClass());


### PR DESCRIPTION
Add aliases for psalm template annotations since older versions of phpunit uses them.
Also make Phan recognize `class-string<Foo>` as satisfying template bounds on Foo.