### PR TITLE
ldap_connect_wallet() is conditionally defined

### DIFF
--- a/tests/php83_files/expected/002_new_functions.php.expected
+++ b/tests/php83_files/expected/002_new_functions.php.expected
@@ -2,7 +2,7 @@
 %s:17 PhanTypeMismatchArgumentInternal Argument 1 ($other) is 'some value' of type string but \DOMElement::contains() takes \DOMNameSpaceNode|\DOMNode|null
 %s:26 PhanTypeMismatchArgumentInternal Argument 2 ($month) is '1' of type string but \IntlCalendar::setDate() takes int
 %s:36 PhanTypeMismatchArgumentInternal Argument 2 ($depth) is false of type false but \json_validate() takes int
-%s:42 PhanTypeMismatchArgumentInternalReal Argument 4 ($auth_mode) is 'test' of type string but \ldap_connect_wallet() takes int
+%s:42 PhanTypeMismatchArgumentInternal%SReal Argument 4 ($auth_mode) is 'test' of type string but \ldap_connect_wallet() takes int
 %s:53 PhanTypeMismatchArgumentInternal Argument 2 ($length) is false of type false but \mb_str_pad() takes int
 %s:66 PhanTypeMismatchArgumentInternal Argument 2 ($max) is '1' of type string but \Random\Randomizer::getFloat() takes float
 %s:77 PhanTypeMismatchArgumentInternal Argument 1 ($string) is 12 of type int (value: 12) but \str_decrement() takes string


### PR DESCRIPTION
When a function exists in Phan's stub file but not in the actual PHP reflection API, Phan uses `PhanTypeMismatchArgumentInternalProbablyReal` instead of `PhanTypeMismatchArgumentInternalReal` to indicate reduced confidence in the type mismatch.
`ldap_connect_wallet()` is only conditionally available based on the ldap library the extension was compiled against, so it could show up as either.