### PR TITLE
Fix bug 5333

### DIFF
--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -2686,6 +2686,9 @@ class UnionTypeVisitor extends AnalysisVisitor
             );
             $union_type = $variable->getUnionType();
             if ($union_type->isPossiblyUndefined()) {
+                if (\Phan\Analysis\ConditionVisitor::isInRecursiveConditionalAnalysis()) {
+                    return $union_type->withIsPossiblyUndefined(false);
+                }
                 if ($node->flags & PhanAnnotationAdder::FLAG_IGNORE_UNDEF) {
                     if ($this->context->isInGlobalScope()) {
                         $union_type = $union_type->eraseRealTypeSet();

--- a/tests/files/src/5900_foreach_condition_var.php
+++ b/tests/files/src/5900_foreach_condition_var.php
@@ -1,0 +1,31 @@
+<?php
+
+class ForeachConditionVar
+{
+    /** @return array<int,array{content:mixed}> */
+    private function getTranslationsOf(): array
+    {
+        return [];
+    }
+
+    public function check(mixed $content): void
+    {
+        $translations = $this->getTranslationsOf();
+        $needsWarning = false;
+        if (is_array($content)) {
+            foreach ($translations as $translation) {
+                if (!isset($translation['content'])) {
+                    continue;
+                }
+                $needsWarning = !is_array($translation['content']);
+                if ($needsWarning) {
+                    break;
+                }
+            }
+        }
+
+        if ($needsWarning) {
+            echo 'needs warning';
+        }
+    }
+}


### PR DESCRIPTION
*ConditionVisitor* replays stored conditional expressions (e.g., `if ($needsWarning)` re-analyzes `!is_array($translation['content'])` after the loop), which re-entered `UnionTypeVisitor::visitVar` with a context where $translation was marked “possibly undefined.” I added a guard at `src/Phan/AST/UnionTypeVisitor.php` so that, while ConditionVisitor::isInRecursiveConditionalAnalysis() is true, we treat the variable as defined instead of emitting PhanPossiblyUndeclaredVariable. That keeps the recursive analysis for type refinement but stops the false positive.