### PR TITLE
Fix bug 5332

### DIFF
--- a/.phan/plugins/AddNeverReturnTypePlugin.php
+++ b/.phan/plugins/AddNeverReturnTypePlugin.php
@@ -75,7 +75,7 @@ final class NeverReturnPlugin extends PluginV3 implements
         }
 
         // This modifies the nodes in place, check this last
-        if (!BlockExitStatusChecker::willUnconditionallyNeverReturn($stmts_list)) {
+        if (!BlockExitStatusChecker::willUnconditionallyNeverReturn($stmts_list, $code_base, $method->getContext())) {
             return;
         }
         self::emitIssue(
@@ -110,7 +110,7 @@ final class NeverReturnPlugin extends PluginV3 implements
             return;
         }
         // This modifies the nodes in place, check this last
-        if (!BlockExitStatusChecker::willUnconditionallyNeverReturn($stmts_list)) {
+        if (!BlockExitStatusChecker::willUnconditionallyNeverReturn($stmts_list, $code_base, $function->getContext())) {
             return;
         }
         self::emitIssue(

--- a/.phan/plugins/AlwaysReturnPlugin.php
+++ b/.phan/plugins/AlwaysReturnPlugin.php
@@ -72,7 +72,7 @@ final class AlwaysReturnPlugin extends PluginV3 implements
 
         if (self::returnTypeOfFunctionLikeAllowsNull($method)) {
             // This has at least one return statement with an expression
-            if (!BlockExitStatusChecker::willUnconditionallyThrowOrReturn($stmts_list)) {
+            if (!BlockExitStatusChecker::willUnconditionallyThrowOrReturn($stmts_list, $code_base, $method->getContext())) {
                 if ($method->getUnionType()->isEmpty() && $method->hasReturn()) {
                     if (!$method->checkHasSuppressIssueAndIncrementCount('PhanPluginInconsistentReturnMethod')) {
                         self::emitIssue(
@@ -103,7 +103,7 @@ final class AlwaysReturnPlugin extends PluginV3 implements
                 );
             }
         }
-        if (!$isNeverReturn && !BlockExitStatusChecker::willUnconditionallyThrowOrReturn($stmts_list)) {
+        if (!$isNeverReturn && !BlockExitStatusChecker::willUnconditionallyThrowOrReturn($stmts_list, $code_base, $method->getContext())) {
             if (!$method->checkHasSuppressIssueAndIncrementCount('PhanPluginAlwaysReturnMethod')) {
                 self::emitIssue(
                     $code_base,
@@ -138,7 +138,7 @@ final class AlwaysReturnPlugin extends PluginV3 implements
         if (self::returnTypeOfFunctionLikeAllowsNull($function)) {
             if ($function->getUnionType()->isEmpty() && $function->hasReturn()) {
                 // This has at least one return statement with an expression
-                if (!BlockExitStatusChecker::willUnconditionallyThrowOrReturn($stmts_list)) {
+                if (!BlockExitStatusChecker::willUnconditionallyThrowOrReturn($stmts_list, $code_base, $function->getContext())) {
                     if (!$function->checkHasSuppressIssueAndIncrementCount('PhanPluginInconsistentReturnFunction')) {
                         self::emitIssue(
                             $code_base,
@@ -168,7 +168,7 @@ final class AlwaysReturnPlugin extends PluginV3 implements
                 );
             }
         }
-        if (!$isNeverReturn && !BlockExitStatusChecker::willUnconditionallyThrowOrReturn($stmts_list)) {
+        if (!$isNeverReturn && !BlockExitStatusChecker::willUnconditionallyThrowOrReturn($stmts_list, $code_base, $function->getContext())) {
             if (!$function->checkHasSuppressIssueAndIncrementCount('PhanPluginAlwaysReturnFunction')) {
                 self::emitIssue(
                     $code_base,

--- a/.phan/plugins/UnreachableCodePlugin.php
+++ b/.phan/plugins/UnreachableCodePlugin.php
@@ -79,7 +79,7 @@ final class UnreachableCodeVisitor extends PluginAwarePostAnalysisVisitor
             if (!($node instanceof Node)) {
                 continue;
             }
-            if (!BlockExitStatusChecker::willUnconditionallySkipRemainingStatements($node)) {
+            if (!BlockExitStatusChecker::willUnconditionallySkipRemainingStatements($node, $this->code_base, $this->context)) {
                 continue;
             }
             // Skip over empty statements and scalar statements.

--- a/tests/plugin_test/expected/202_never_return.php.expected
+++ b/tests/plugin_test/expected/202_never_return.php.expected
@@ -1,1 +1,2 @@
 src/202_never_return.php:7 PhanUnusedProtectedMethodParameter Parameter $x is never used
+src/202_never_return.php:21 PhanPluginNeverReturnMethod Method \ChildClass::main() never returns and has a return type of (empty union type), but phpdoc type never could be used instead

--- a/tests/plugin_test/expected/316_never_return_try.php.expected
+++ b/tests/plugin_test/expected/316_never_return_try.php.expected
@@ -1,0 +1,3 @@
+src/316_never_return_try.php:3 PhanUnreferencedClass Possibly zero references to class \PluginNeverReturnTry
+src/316_never_return_try.php:5 PhanUnreferencedPublicMethod Possibly zero references to public method \PluginNeverReturnTry::run()
+src/316_never_return_try.php:14 PhanUnusedVariableCaughtException Unused definition of variable $e as a caught exception

--- a/tests/plugin_test/src/316_never_return_try.php
+++ b/tests/plugin_test/src/316_never_return_try.php
@@ -1,0 +1,25 @@
+<?php
+
+class PluginNeverReturnTry
+{
+    public function run(): void
+    {
+        $this->test('foo');
+    }
+
+    private function test(string $arg): void
+    {
+        try {
+            $value = $arg;
+        } catch (\RuntimeException $e) {
+            $this->noreturn();
+        }
+
+        echo $value;
+    }
+
+    private function noreturn(): never
+    {
+        exit;
+    }
+}


### PR DESCRIPTION
The BlockExitStatusChecker calls in the  `AddNeverReturnType`, `AlwaysReturn` and `UnreachableCode` plugins now receive the current CodeBase and Context.
Without that, the checker visited try/catch  blocks as demonstrated in issue #5332 before the real analysis ran and cached “may proceed” for the `returnsNever()` call,
and later ConditionVisitor treated the catch as falling through, producing `PhanPossiblyUndeclaredVariable`. Passing the context lets the checker resolve `never`
(and other exit statuses) on the first pass, so the `try/catch` merge sees that every failing path exits.