### PR TITLE
make plain class-string arguments satisfy @template T of object

### DIFF
--- a/src/Phan/Language/Type/TemplateType.php
+++ b/src/Phan/Language/Type/TemplateType.php
@@ -294,6 +294,9 @@ final class TemplateType extends Type
                         continue;
                     }
                     // Fall through to the generic check below if the class-string itself may still match.
+                } elseif (self::boundAcceptsAnyObject($bound)) {
+                    // A bare class-string is compatible with a constraint of plain "object" (or nullable object).
+                    continue;
                 }
             }
 
@@ -303,6 +306,26 @@ final class TemplateType extends Type
         }
 
         return true;
+    }
+
+    /**
+     * Returns true if the bound is effectively "object" (optionally nullable),
+     * meaning any object-like class-string should be accepted.
+     */
+    private static function boundAcceptsAnyObject(UnionType $bound): bool
+    {
+        $has_object = false;
+        foreach ($bound->getTypeSet() as $type) {
+            if ($type instanceof ObjectType) {
+                $has_object = true;
+                continue;
+            }
+            if ($type instanceof NullType) {
+                continue;
+            }
+            return false;
+        }
+        return $has_object;
     }
 
     /**

--- a/tests/files/src/5901_template_class_string.php
+++ b/tests/files/src/5901_template_class_string.php
@@ -1,0 +1,26 @@
+<?php
+
+class ClassStringFoo {}
+
+/**
+ * @template T of object
+ * @param class-string<T> $class
+ * @return T
+ */
+function buildObject(string $class)
+{
+    return new $class();
+}
+
+/**
+ * @param class-string $cls
+ */
+function demo(string $cls): object
+{
+    // Passing a class-string should satisfy the "object" template constraint.
+    return buildObject($cls);
+}
+
+/** @var class-string $literal */
+$literal = ClassStringFoo::class;
+buildObject($literal);


### PR DESCRIPTION
Tightened template-bound checking so plain `class-string` arguments satisfy `@template T of object` without forcing projects to annotate them as `class-string<object>`. Specifically, `TemplateType::unionTypeSatisfiesBound()` now treats a bare `class-string` as meeting any “object” (optionally nullable) constraint