### PR TITLE
Fix bug 5339

### DIFF
--- a/src/Phan/Language/Type/FunctionLikeDeclarationType.php
+++ b/src/Phan/Language/Type/FunctionLikeDeclarationType.php
@@ -1045,7 +1045,7 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
                 static function (UnionType $union_type, Context $context) use ($code_base, $i, $param_closure): UnionType {
                     $result = UnionType::empty();
                     foreach ($union_type->getTypeSet() as $type) {
-                        $func = $type->asFunctionInterfaceOrNull($code_base, $context);
+                        $func = $type->asFunctionInterfaceOrNull($code_base, $context, false);
                         if (!$func) {
                             continue;
                         }
@@ -1077,7 +1077,7 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
         return static function (UnionType $union_type, Context $context) use ($code_base, $return_closure): UnionType {
             $result = UnionType::empty();
             foreach ($union_type->getTypeSet() as $type) {
-                $func = $type->asFunctionInterfaceOrNull($code_base, $context);
+                $func = $type->asFunctionInterfaceOrNull($code_base, $context, false);
                 if ($func) {
                     $result = $result->withUnionType($return_closure($func->getUnionType(), $context));
                 }

--- a/tests/files/src/5903_callable_or_class_string.php
+++ b/tests/files/src/5903_callable_or_class_string.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * @template T
+ * @param class-string<T>|callable(mixed ...$args):T $spec
+ * @return T
+ */
+function create_object($spec) {
+    return $GLOBALS['x'];
+}
+
+class Example5399 {}
+
+$instance = create_object(Example5399::class);
+
+/**
+ * @phan-template T
+ * @phan-param callable(mixed ...$args):T|array{class?:class-string<T>,args?:array,services?:array<string|null>} $spec
+ * @phan-return T|object
+ */
+function create_object_from_spec($spec) {
+    return $GLOBALS['x'];
+}
+
+if (rand(0, 1)) {
+    $spec = [
+        'class' => Example5399::class,
+        'args' => [],
+    ];
+} else {
+    $spec = [
+        'class' => Example5399::class,
+        'services' => [],
+    ];
+}
+
+$transform = create_object_from_spec($spec);
+
+/**
+ * @phan-template T
+ * @phan-param callable(mixed ...$args):T|array{class:class-string<T>} $spec
+ * @phan-return T|object
+ */
+function create_object_from_simple_spec($spec) {
+    return $GLOBALS['x'];
+}
+
+$simple_spec = [
+    'class' => Example5399::class,
+    'args' => [],
+];
+$transform2 = create_object_from_simple_spec($simple_spec);

--- a/tests/plugin_test/expected/071_other_callable_methods.php.expected
+++ b/tests/plugin_test/expected/071_other_callable_methods.php.expected
@@ -2,14 +2,11 @@ src/071_other_callable_methods.php:22 PhanTypeMismatchArgumentInternal Argument 
 src/071_other_callable_methods.php:23 PhanUndeclaredStaticMethodInCallable Reference to undeclared static method \InvokableTemplateTest::missingMethod in callable
 src/071_other_callable_methods.php:24 PhanTypeMismatchArgumentInternal Argument 1 ($string) is template_return_test([$o,'createArrayObject']) of type \ArrayAccess|\ArrayObject|\Countable|\IteratorAggregate|\Serializable|\Traversable|iterable but \strlen() takes string
 src/071_other_callable_methods.php:25 PhanUndeclaredMethodInCallable Call to undeclared method missingMethod in callable. Possible object type(s) for that method are \InvokableTemplateTest
-src/071_other_callable_methods.php:26 PhanUndeclaredInvokeInCallable Possible attempt to access missing magic method __invoke of '\ArrayObject'
 src/071_other_callable_methods.php:28 PhanParamTooFew Call with 0 arg(s) to \InvokableTemplateTest::__invoke($arg) which requires 1 arg(s) defined at src/071_other_callable_methods.php:4
 src/071_other_callable_methods.php:29 PhanUndeclaredInvokeInCallable Possible attempt to access missing magic method __invoke of '\stdClass'
-src/071_other_callable_methods.php:30 PhanTypeInvalidCallableArraySize In a place where phan was expecting a callable, saw an array of size 1, but callable arrays must be of size 2
 src/071_other_callable_methods.php:35 PhanUndeclaredStaticMethodInCallable Reference to undeclared static method \InvokableTemplateTest::missingMethod in callable
 src/071_other_callable_methods.php:37 PhanUndeclaredMethodInCallable Call to undeclared method missingMethod in callable. Possible object type(s) for that method are \InvokableTemplateTest
 src/071_other_callable_methods.php:38 PhanTypeMismatchArgument Argument 1 ($c) is new ArrayObject() of type \ArrayAccess|\ArrayObject|\Countable|\IteratorAggregate|\Serializable|\Traversable|iterable but \non_template_return_test() takes callable defined at src/071_other_callable_methods.php:31
 src/071_other_callable_methods.php:39 PhanTypeMismatchArgumentReal Argument 1 ($c) is $c of type array{0:\InvokableTemplateTest} but \non_template_return_test() takes callable defined at src/071_other_callable_methods.php:31
 src/071_other_callable_methods.php:41 PhanUnreferencedFunction Possibly zero references to function \create_from_closure()
-src/071_other_callable_methods.php:59 PhanUndeclaredInvokeInCallable Possible attempt to access missing magic method __invoke of '\stdClass'
 src/071_other_callable_methods.php:60 PhanTypeMismatchArgumentInternal Argument 1 ($string) is template_return_test_array(['strlen']) of type int[] but \strlen() takes string


### PR DESCRIPTION
Update both call sites in `FunctionLikeDeclarationType` to call `asFunctionInterfaceOrNull(..., false)`, so template inference merely checks for callable metadata without logging issues. Actual callable validation remains handled elsewhere (plugins/type checking), so legitimate problems will still be reported.