### PR TITLE
Revise fix for bug 5337

### DIFF
--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -3944,10 +3944,7 @@ class Type implements Stringable
             }
             throw new InvalidArgumentException("Unmatched \"'\" of $part in " . \implode(',', $results));
         }
-        if ($N !== count($results)) {
-            return \array_values($results);
-        }
-        return $results;
+        return \array_values($results);
     }
 
     /**

--- a/src/Phan/Language/Type/AssociativeArrayType.php
+++ b/src/Phan/Language/Type/AssociativeArrayType.php
@@ -85,6 +85,23 @@ class AssociativeArrayType extends GenericArrayType
         return true;
     }
 
+    /**
+     * Associative arrays preserve original keys, so they can't be assumed to satisfy the requirements of list<...>
+     * @param array<int,Type> $target_type_set
+     */
+    public function canCastToAnyTypeInSet(array $target_type_set, CodeBase $code_base): bool
+    {
+        foreach ($target_type_set as $i => $target_type) {
+            if ($target_type instanceof ListType) {
+                unset($target_type_set[$i]);
+            }
+        }
+        if (!$target_type_set) {
+            return false;
+        }
+        return parent::canCastToAnyTypeInSet($target_type_set, $code_base);
+    }
+
     public function asNonFalseyType(): Type
     {
         return NonEmptyAssociativeArrayType::fromElementType(

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -317,10 +317,6 @@ class GenericArrayType extends ArrayType implements GenericArrayInterface
         $element_union_types = null;
         foreach ($target_type_set as $target_type) {
             if ($target_type instanceof GenericArrayType) {
-                if ($target_type instanceof ListType && !($this instanceof ListType)) {
-                    // Associative arrays and other generic arrays can't be assumed to satisfy list<...>
-                    continue;
-                }
                 if ((($this->key_type ?: self::KEY_MIXED) & ($target_type->key_type ?: self::KEY_MIXED)) === 0) {
                     continue;
                 }

--- a/src/Phan/Language/Type/GenericArrayType.php
+++ b/src/Phan/Language/Type/GenericArrayType.php
@@ -317,6 +317,10 @@ class GenericArrayType extends ArrayType implements GenericArrayInterface
         $element_union_types = null;
         foreach ($target_type_set as $target_type) {
             if ($target_type instanceof GenericArrayType) {
+                if ($target_type instanceof ListType && !($this instanceof ListType)) {
+                    // Associative arrays and other generic arrays can't be assumed to satisfy list<...>
+                    continue;
+                }
                 if ((($this->key_type ?: self::KEY_MIXED) & ($target_type->key_type ?: self::KEY_MIXED)) === 0) {
                     continue;
                 }

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -5494,7 +5494,7 @@ class UnionType implements Serializable, Stringable
                 }
             }
         }
-        return $result;
+        return \array_values($result);
     }
 
     /**
@@ -5543,7 +5543,7 @@ class UnionType implements Serializable, Stringable
         if ($empty_array_shape_type && !$has_other_array_type) {
             $result[] = ArrayType::instance($empty_array_shape_type->isNullable());
         }
-        return $result;
+        return \array_values($result);
     }
 
     /**
@@ -5602,7 +5602,7 @@ class UnionType implements Serializable, Stringable
                 }
             }
         }
-        return $result;
+        return \array_values($result);
     }
 
     /**

--- a/tests/files/expected/0794_associative_array_casting_rules.php.expected
+++ b/tests/files/expected/0794_associative_array_casting_rules.php.expected
@@ -1,3 +1,7 @@
 %s:19 PhanUndeclaredFunction Call to undeclared function \test_assoc()
+%s:22 PhanTypeMismatchArgument Argument 1 ($list) is $b of type associative-array<mixed,\stdClass> but \NS794\accepts_list() takes list<mixed> defined at %s:9
+%s:23 PhanTypeMismatchArgument Argument 1 ($list) is $a of type associative-array<int,string> but \NS794\accepts_list() takes list<mixed> defined at %s:9
+%s:24 PhanTypeMismatchArgumentInternal Argument 2 ($args) is $b of type associative-array<mixed,\stdClass> but \call_user_func_array() takes list<mixed>
+%s:25 PhanTypeMismatchArgumentInternal Argument 2 ($args) is $a of type associative-array<int,string> but \call_user_func_array() takes list<mixed>
 %s:27 PhanParamTooFewInternalUnpack Call with 0 or more arg(s) to \var_dump($value, ...$values) which requires 1 arg(s). This may throw an ArgumentCountError if there are too few args at runtime.
 %s:38 PhanTypeMismatchArgument Argument 1 ($a) is $b of type list<\stdClass> but \NS794\test_cannot_pass_associative_to_list() takes associative-array<int,string> defined at %s:17

--- a/tests/files/expected/0796_possibly_empty_associative_array.php.expected
+++ b/tests/files/expected/0796_possibly_empty_associative_array.php.expected
@@ -1,1 +1,2 @@
 %s:8 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type associative-array<int,\stdClass>(real=associative-array<int,\stdClass>)
+%s:11 PhanTypeMismatchReturn Returning $x of type non-empty-associative-array<int,\stdClass> but test_associative_array_possibly_empty() is declared to return ?list<\stdClass>

--- a/tests/files/expected/5902_array_unique_list.php.expected
+++ b/tests/files/expected/5902_array_unique_list.php.expected
@@ -1,2 +1,3 @@
 %s:6 PhanDebugAnnotation @phan-debug-var requested for variable $list - it has union type list<int>(real=array)
 %s:11 PhanDebugAnnotation @phan-debug-var requested for variable $list - it has union type associative-array<int,int>(real=?associative-array<mixed,mixed>)
+%s:13 PhanTypeMismatchArgument Argument 1 ($list) is $list of type associative-array<int,int> but \takes_list() takes list<int> defined at %s:6


### PR DESCRIPTION
Tightened `GenericArrayType::canCastToAnyTypeInSet()` so only actual `ListType` values are considered assignable to `list<…>` parameters, preventing associative arrays (including those produced by `array_unique()`) from slipping through the type check
This should catch the list case mentioned in bug #5337 