### PR TITLE
Fix bug 5342

### DIFF
--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -1535,6 +1535,12 @@ class AssignmentVisitor extends AnalysisVisitor
             }
         }
         $this->context = $this->context->withStaticPropertySetToTypeByName($prop_name, $new_type);
+        if ($this->context->isInFunctionLikeScope()) {
+            $function_like = $this->context->getFunctionLikeInScope($this->code_base);
+            if ($function_like instanceof Method) {
+                $function_like->recordStaticPropertyModification($prop_name, $new_type);
+            }
+        }
     }
 
     private function analyzeAssignmentToReadOnlyProperty(Property $property, Node $node): void

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -1538,9 +1538,44 @@ class AssignmentVisitor extends AnalysisVisitor
         if ($this->context->isInFunctionLikeScope()) {
             $function_like = $this->context->getFunctionLikeInScope($this->code_base);
             if ($function_like instanceof Method) {
-                $function_like->recordStaticPropertyModification($prop_name, $new_type);
+                $target_class = $this->getStaticPropertyAssignmentClassFQSEN($node);
+                if ($target_class) {
+                    $function_like->recordStaticPropertyModification($target_class, $prop_name, $new_type);
+                }
             }
         }
+    }
+
+    private function getStaticPropertyAssignmentClassFQSEN(Node $node): ?FullyQualifiedClassName
+    {
+        $class_node = $node->children['class'] ?? null;
+        if (!($class_node instanceof Node) || $class_node->kind !== ast\AST_NAME) {
+            return null;
+        }
+        $name = $class_node->children['name'] ?? null;
+        if (!\is_string($name)) {
+            return null;
+        }
+        $context_class_fqsen = $this->context->getClassFQSENOrNull();
+        if (!$context_class_fqsen) {
+            return null;
+        }
+        $normalized = \strtolower($name);
+        if ($normalized === 'self' || $normalized === 'static') {
+            return $context_class_fqsen;
+        }
+        if ($normalized === 'parent') {
+            try {
+                $clazz = $this->context->getClassInScope($this->code_base);
+            } catch (CodeBaseException) {
+                return null;
+            }
+            if (!$clazz->hasParentType()) {
+                return null;
+            }
+            return $clazz->getParentClassFQSEN();
+        }
+        return null;
     }
 
     private function analyzeAssignmentToReadOnlyProperty(Property $property, Node $node): void

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -1538,15 +1538,19 @@ class AssignmentVisitor extends AnalysisVisitor
         if ($this->context->isInFunctionLikeScope()) {
             $function_like = $this->context->getFunctionLikeInScope($this->code_base);
             if ($function_like instanceof Method) {
-                $target_class = $this->getStaticPropertyAssignmentClassFQSEN($node);
-                if ($target_class) {
-                    $function_like->recordStaticPropertyModification($target_class, $prop_name, $new_type);
+                $target = $this->getStaticPropertyAssignmentTarget($node);
+                if ($target) {
+                    [$target_class, $is_late_static] = $target;
+                    $function_like->recordStaticPropertyModification($target_class, $prop_name, $new_type, $is_late_static);
                 }
             }
         }
     }
 
-    private function getStaticPropertyAssignmentClassFQSEN(Node $node): ?FullyQualifiedClassName
+    /**
+     * @return array{0:FullyQualifiedClassName,1:bool}|null
+     */
+    private function getStaticPropertyAssignmentTarget(Node $node): ?array
     {
         $class_node = $node->children['class'] ?? null;
         if (!($class_node instanceof Node) || $class_node->kind !== ast\AST_NAME) {
@@ -1561,8 +1565,11 @@ class AssignmentVisitor extends AnalysisVisitor
             return null;
         }
         $normalized = \strtolower($name);
-        if ($normalized === 'self' || $normalized === 'static') {
-            return $context_class_fqsen;
+        if ($normalized === 'self') {
+            return [$context_class_fqsen, false];
+        }
+        if ($normalized === 'static') {
+            return [$context_class_fqsen, true];
         }
         if ($normalized === 'parent') {
             try {
@@ -1573,7 +1580,7 @@ class AssignmentVisitor extends AnalysisVisitor
             if (!$clazz->hasParentType()) {
                 return null;
             }
-            return $clazz->getParentClassFQSEN();
+            return [$clazz->getParentClassFQSEN(), false];
         }
         return null;
     }

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -1566,7 +1566,12 @@ class AssignmentVisitor extends AnalysisVisitor
         }
         $normalized = \strtolower($name);
         if ($normalized === 'self') {
-            return [$context_class_fqsen, false];
+            $is_trait = false;
+            if ($this->code_base->hasClassWithFQSEN($context_class_fqsen)) {
+                $class = $this->code_base->getClassByFQSEN($context_class_fqsen);
+                $is_trait = $class->isTrait();
+            }
+            return [$context_class_fqsen, $is_trait];
         }
         if ($normalized === 'static') {
             return [$context_class_fqsen, true];

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -2999,6 +2999,19 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             // this is, don't worry about it
             return $this->context;
         }
+
+        if ($class_node instanceof Node && $class_node->kind === ast\AST_NAME) {
+            $class_name = $class_node->children['name'] ?? null;
+            if (\is_string($class_name)) {
+                $class_name_lower = \strtolower($class_name);
+                if (\in_array($class_name_lower, ['self', 'static'], true)) {
+                    $this->context = $this->context->withoutStaticPropertyOverrides();
+                    foreach ($method->getStaticPropertyModifications() as $property_name => $property_type) {
+                        $this->context = $this->context->withStaticPropertySetToTypeByName($property_name, $property_type);
+                    }
+                }
+            }
+        }
         return $this->context;
     }
 

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -3025,9 +3025,21 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                             }
                         }
                         if ($should_apply) {
-                            $this->context = $this->context->withoutStaticPropertyOverrides(\array_keys($modifications));
+                            $overrides_to_clear = [];
+                            $updates = [];
                             foreach ($modifications as $property_name => $property_type) {
-                                $this->context = $this->context->withStaticPropertySetToTypeByName($property_name, $property_type);
+                                $old_override = $this->context->getStaticPropertyIfOverridden($property_name);
+                                if ($old_override === null) {
+                                    continue;
+                                }
+                                $overrides_to_clear[] = $property_name;
+                                $updates[$property_name] = $property_type;
+                            }
+                            if ($overrides_to_clear) {
+                                $this->context = $this->context->withoutStaticPropertyOverrides($overrides_to_clear);
+                                foreach ($updates as $property_name => $property_type) {
+                                    $this->context = $this->context->withStaticPropertySetToTypeByName($property_name, $property_type);
+                                }
                             }
                         }
                     }

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -3004,7 +3004,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             $class_name = $class_node->children['name'] ?? null;
             if (\is_string($class_name)) {
                 $class_name_lower = \strtolower($class_name);
-                if (\in_array($class_name_lower, ['self', 'static'], true)) {
+                if (\in_array($class_name_lower, ['self', 'static', 'parent'], true)) {
                     $modifications = $method->getStaticPropertyModifications();
                     if ($modifications) {
                         $should_apply = true;

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -3008,15 +3008,13 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                     $modifications = $method->getStaticPropertyModifications();
                     if ($modifications) {
                         $should_apply = true;
-                        if ($class_name_lower === 'self') {
-                            $calling_class = $this->context->getClassFQSENOrNull();
-                            if ($calling_class === null) {
+                        $calling_class = $this->context->getClassFQSENOrNull();
+                        if ($calling_class === null) {
+                            $should_apply = false;
+                        } else {
+                            $defining_class = $method->getDefiningFQSEN()->getFullyQualifiedClassName();
+                            if ($calling_class->__toString() !== $defining_class->__toString()) {
                                 $should_apply = false;
-                            } else {
-                                $defining_class = $method->getDefiningFQSEN()->getFullyQualifiedClassName();
-                                if ($calling_class->__toString() !== $defining_class->__toString()) {
-                                    $should_apply = false;
-                                }
                             }
                         }
                         if ($should_apply) {

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -5399,7 +5399,11 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         if ($defining_class->__toString() === $target_class->__toString()) {
             return true;
         }
-        return $is_late_static && $defining_class->__toString() === $calling_class->__toString();
+        if ($is_late_static) {
+            $defining_type = $defining_class->asType();
+            return $calling_class->asType()->isSubtypeOf($defining_type, $this->code_base);
+        }
+        return false;
     }
 
 

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -3020,8 +3020,11 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                                 }
                                 $overrides_to_clear = [];
                                 $updates = [];
-                                foreach ($property_modifications as $property_name => $property_type) {
-                                    if (!$this->doesStaticOverrideMatchTargetClass($property_name, $target_class_fqsen)) {
+                                foreach ($property_modifications as $property_name => $property_info) {
+                                    /** @var array{type:UnionType,is_late_static:bool} $property_info */
+                                    $property_type = $property_info['type'];
+                                    $is_late_static = $property_info['is_late_static'];
+                                    if (!$this->doesStaticOverrideMatchTargetClass($property_name, $target_class_fqsen, $calling_class, $is_late_static)) {
                                         continue;
                                     }
                                     $old_override = $this->context->getStaticPropertyIfOverridden($property_name);
@@ -5370,21 +5373,17 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         return $calling_type->isSubtypeOf($target_type, $this->code_base);
     }
 
-    private function doesStaticOverrideMatchTargetClass(string $property_name, FullyQualifiedClassName $target_class): bool
+    private function doesStaticOverrideMatchTargetClass(string $property_name, FullyQualifiedClassName $target_class, FullyQualifiedClassName $calling_class, bool $is_late_static): bool
     {
-        $calling_class_fqsen = $this->context->getClassFQSENOrNull();
-        if ($calling_class_fqsen === null) {
+        if (!$this->code_base->hasClassWithFQSEN($calling_class)) {
             return false;
         }
-        if (!$this->code_base->hasClassWithFQSEN($calling_class_fqsen)) {
-            return false;
-        }
-        $calling_class = $this->code_base->getClassByFQSEN($calling_class_fqsen);
-        if (!$calling_class->hasPropertyWithName($this->code_base, $property_name)) {
+        $calling_class_instance = $this->code_base->getClassByFQSEN($calling_class);
+        if (!$calling_class_instance->hasPropertyWithName($this->code_base, $property_name)) {
             return false;
         }
         try {
-            $property = $calling_class->getPropertyByNameInContext(
+            $property = $calling_class_instance->getPropertyByNameInContext(
                 $this->code_base,
                 $property_name,
                 $this->context,
@@ -5396,7 +5395,10 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             return false;
         }
         $defining_class = $property->getRealDefiningFQSEN()->getFullyQualifiedClassName();
-        return $defining_class->__toString() === $target_class->__toString();
+        if ($defining_class->__toString() === $target_class->__toString()) {
+            return true;
+        }
+        return $is_late_static && $defining_class->__toString() === $calling_class->__toString();
     }
 
 

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -3028,14 +3028,15 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                                         continue;
                                     }
                                     $old_override = $this->context->getStaticPropertyIfOverridden($property_name);
-                                    if ($old_override === null) {
-                                        continue;
+                                    if ($old_override !== null) {
+                                        $overrides_to_clear[] = $property_name;
                                     }
-                                    $overrides_to_clear[] = $property_name;
                                     $updates[$property_name] = $property_type;
                                 }
                                 if ($overrides_to_clear) {
                                     $this->context = $this->context->withoutStaticPropertyOverrides($overrides_to_clear);
+                                }
+                                if ($updates) {
                                     foreach ($updates as $property_name => $property_type) {
                                         $this->context = $this->context->withStaticPropertySetToTypeByName($property_name, $property_type);
                                     }

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -3012,8 +3012,15 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                         if ($calling_class === null) {
                             $should_apply = false;
                         } else {
-                            $defining_class = $method->getDefiningFQSEN()->getFullyQualifiedClassName();
-                            if ($calling_class->__toString() !== $defining_class->__toString()) {
+                            $defining_class_fqsen = $method->getDefiningFQSEN()->getFullyQualifiedClassName();
+                            $defining_class_type = $defining_class_fqsen->asType();
+                            $calling_class_type = $calling_class->asType();
+                            $defining_is_trait = false;
+                            if ($this->code_base->hasClassWithFQSEN($defining_class_fqsen)) {
+                                $defining_class = $this->code_base->getClassByFQSEN($defining_class_fqsen);
+                                $defining_is_trait = $defining_class->isTrait();
+                            }
+                            if (!$defining_is_trait && !$calling_class_type->isSubtypeOf($defining_class_type, $this->code_base)) {
                                 $should_apply = false;
                             }
                         }

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -3031,7 +3031,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                                     if ($old_override !== null) {
                                         $overrides_to_clear[] = $property_name;
                                     }
-                                    $updates[$property_name] = $property_type;
+                                    $updates[$property_name] = $old_override ? $old_override->withUnionType($property_type) : $property_type;
                                 }
                                 if ($overrides_to_clear) {
                                     $this->context = $this->context->withoutStaticPropertyOverrides($overrides_to_clear);

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -3032,7 +3032,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                                         continue;
                                     }
                                     $overrides_to_clear[] = $property_name;
-                                    $updates[$property_name] = $old_override->withUnionType($property_type);
+                                    $updates[$property_name] = $property_type;
                                 }
                                 if ($overrides_to_clear) {
                                     $this->context = $this->context->withoutStaticPropertyOverrides($overrides_to_clear);

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -5380,9 +5380,6 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             return false;
         }
         $calling_class_instance = $this->code_base->getClassByFQSEN($calling_class);
-        if (!$calling_class_instance->hasPropertyWithName($this->code_base, $property_name)) {
-            return false;
-        }
         try {
             $property = $calling_class_instance->getPropertyByNameInContext(
                 $this->code_base,

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -3005,40 +3005,37 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             if (\is_string($class_name)) {
                 $class_name_lower = \strtolower($class_name);
                 if (\in_array($class_name_lower, ['self', 'static', 'parent'], true)) {
-                    $modifications = $method->getStaticPropertyModifications();
-                    if ($modifications) {
-                        $should_apply = true;
+                    $modifications_by_class = $method->getStaticPropertyModifications();
+                    if ($modifications_by_class) {
                         $calling_class = $this->context->getClassFQSENOrNull();
-                        if ($calling_class === null) {
-                            $should_apply = false;
-                        } else {
-                            $defining_class_fqsen = $method->getDefiningFQSEN()->getFullyQualifiedClassName();
-                            $defining_class_type = $defining_class_fqsen->asType();
-                            $calling_class_type = $calling_class->asType();
-                            $defining_is_trait = false;
-                            if ($this->code_base->hasClassWithFQSEN($defining_class_fqsen)) {
-                                $defining_class = $this->code_base->getClassByFQSEN($defining_class_fqsen);
-                                $defining_is_trait = $defining_class->isTrait();
-                            }
-                            if (!$defining_is_trait && !$calling_class_type->isSubtypeOf($defining_class_type, $this->code_base)) {
-                                $should_apply = false;
-                            }
-                        }
-                        if ($should_apply) {
-                            $overrides_to_clear = [];
-                            $updates = [];
-                            foreach ($modifications as $property_name => $property_type) {
-                                $old_override = $this->context->getStaticPropertyIfOverridden($property_name);
-                                if ($old_override === null) {
+                        if ($calling_class) {
+                            foreach ($modifications_by_class as $entry) {
+                                $target_class_fqsen = $entry['class'];
+                                $property_modifications = $entry['properties'];
+                                if (!$property_modifications) {
                                     continue;
                                 }
-                                $overrides_to_clear[] = $property_name;
-                                $updates[$property_name] = $old_override->withUnionType($property_type);
-                            }
-                            if ($overrides_to_clear) {
-                                $this->context = $this->context->withoutStaticPropertyOverrides($overrides_to_clear);
-                                foreach ($updates as $property_name => $property_type) {
-                                    $this->context = $this->context->withStaticPropertySetToTypeByName($property_name, $property_type);
+                                if (!$this->canApplyStaticPropertyOverride($calling_class, $target_class_fqsen)) {
+                                    continue;
+                                }
+                                $overrides_to_clear = [];
+                                $updates = [];
+                                foreach ($property_modifications as $property_name => $property_type) {
+                                    if (!$this->doesStaticOverrideMatchTargetClass($property_name, $target_class_fqsen)) {
+                                        continue;
+                                    }
+                                    $old_override = $this->context->getStaticPropertyIfOverridden($property_name);
+                                    if ($old_override === null) {
+                                        continue;
+                                    }
+                                    $overrides_to_clear[] = $property_name;
+                                    $updates[$property_name] = $old_override->withUnionType($property_type);
+                                }
+                                if ($overrides_to_clear) {
+                                    $this->context = $this->context->withoutStaticPropertyOverrides($overrides_to_clear);
+                                    foreach ($updates as $property_name => $property_type) {
+                                        $this->context = $this->context->withStaticPropertySetToTypeByName($property_name, $property_type);
+                                    }
                                 }
                             }
                         }
@@ -5353,6 +5350,53 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
         // Otherwise, 'stmts' would always be a Node due to preconditions.
         $stmts_node = $node->children['stmts'];
         return $stmts_node instanceof Node && BlockExitStatusChecker::willUnconditionallyNeverReturn($stmts_node);
+    }
+
+    private function canApplyStaticPropertyOverride(FullyQualifiedClassName $calling_class, FullyQualifiedClassName $target_class): bool
+    {
+        if ($calling_class->__toString() === $target_class->__toString()) {
+            return true;
+        }
+        $is_trait = false;
+        if ($this->code_base->hasClassWithFQSEN($target_class)) {
+            $class = $this->code_base->getClassByFQSEN($target_class);
+            $is_trait = $class->isTrait();
+        }
+        if ($is_trait) {
+            return true;
+        }
+        $calling_type = $calling_class->asType();
+        $target_type = $target_class->asType();
+        return $calling_type->isSubtypeOf($target_type, $this->code_base);
+    }
+
+    private function doesStaticOverrideMatchTargetClass(string $property_name, FullyQualifiedClassName $target_class): bool
+    {
+        $calling_class_fqsen = $this->context->getClassFQSENOrNull();
+        if ($calling_class_fqsen === null) {
+            return false;
+        }
+        if (!$this->code_base->hasClassWithFQSEN($calling_class_fqsen)) {
+            return false;
+        }
+        $calling_class = $this->code_base->getClassByFQSEN($calling_class_fqsen);
+        if (!$calling_class->hasPropertyWithName($this->code_base, $property_name)) {
+            return false;
+        }
+        try {
+            $property = $calling_class->getPropertyByNameInContext(
+                $this->code_base,
+                $property_name,
+                $this->context,
+                true,
+                null,
+                true
+            );
+        } catch (IssueException | CodeBaseException) {
+            return false;
+        }
+        $defining_class = $property->getRealDefiningFQSEN()->getFullyQualifiedClassName();
+        return $defining_class->__toString() === $target_class->__toString();
     }
 
 

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -3005,9 +3005,23 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             if (\is_string($class_name)) {
                 $class_name_lower = \strtolower($class_name);
                 if (\in_array($class_name_lower, ['self', 'static'], true)) {
-                    $this->context = $this->context->withoutStaticPropertyOverrides();
-                    foreach ($method->getStaticPropertyModifications() as $property_name => $property_type) {
-                        $this->context = $this->context->withStaticPropertySetToTypeByName($property_name, $property_type);
+                    $should_apply = true;
+                    if ($class_name_lower === 'self') {
+                        $calling_class = $this->context->getClassFQSENOrNull();
+                        if ($calling_class === null) {
+                            $should_apply = false;
+                        } else {
+                            $defining_class = $method->getDefiningFQSEN()->getFullyQualifiedClassName();
+                            if ($calling_class->__toString() !== $defining_class->__toString()) {
+                                $should_apply = false;
+                            }
+                        }
+                    }
+                    if ($should_apply) {
+                        $this->context = $this->context->withoutStaticPropertyOverrides();
+                        foreach ($method->getStaticPropertyModifications() as $property_name => $property_type) {
+                            $this->context = $this->context->withStaticPropertySetToTypeByName($property_name, $property_type);
+                        }
                     }
                 }
             }

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -3005,22 +3005,25 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             if (\is_string($class_name)) {
                 $class_name_lower = \strtolower($class_name);
                 if (\in_array($class_name_lower, ['self', 'static'], true)) {
-                    $should_apply = true;
-                    if ($class_name_lower === 'self') {
-                        $calling_class = $this->context->getClassFQSENOrNull();
-                        if ($calling_class === null) {
-                            $should_apply = false;
-                        } else {
-                            $defining_class = $method->getDefiningFQSEN()->getFullyQualifiedClassName();
-                            if ($calling_class->__toString() !== $defining_class->__toString()) {
+                    $modifications = $method->getStaticPropertyModifications();
+                    if ($modifications) {
+                        $should_apply = true;
+                        if ($class_name_lower === 'self') {
+                            $calling_class = $this->context->getClassFQSENOrNull();
+                            if ($calling_class === null) {
                                 $should_apply = false;
+                            } else {
+                                $defining_class = $method->getDefiningFQSEN()->getFullyQualifiedClassName();
+                                if ($calling_class->__toString() !== $defining_class->__toString()) {
+                                    $should_apply = false;
+                                }
                             }
                         }
-                    }
-                    if ($should_apply) {
-                        $this->context = $this->context->withoutStaticPropertyOverrides();
-                        foreach ($method->getStaticPropertyModifications() as $property_name => $property_type) {
-                            $this->context = $this->context->withStaticPropertySetToTypeByName($property_name, $property_type);
+                        if ($should_apply) {
+                            $this->context = $this->context->withoutStaticPropertyOverrides(\array_keys($modifications));
+                            foreach ($modifications as $property_name => $property_type) {
+                                $this->context = $this->context->withStaticPropertySetToTypeByName($property_name, $property_type);
+                            }
                         }
                     }
                 }

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -3033,7 +3033,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                                     continue;
                                 }
                                 $overrides_to_clear[] = $property_name;
-                                $updates[$property_name] = $property_type;
+                                $updates[$property_name] = $old_override->withUnionType($property_type);
                             }
                             if ($overrides_to_clear) {
                                 $this->context = $this->context->withoutStaticPropertyOverrides($overrides_to_clear);

--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -1336,4 +1336,15 @@ class Context extends FileRef
         }
         return $result;
     }
+
+    /**
+     * Returns a clone of this context without any overrides for static property types.
+     */
+    public function withoutStaticPropertyOverrides(): Context
+    {
+        if (!$this->scope->hasVariableWithName(self::VAR_NAME_STATIC_PROPERTIES)) {
+            return $this;
+        }
+        return $this->withScope($this->scope->withUnsetVariable(self::VAR_NAME_STATIC_PROPERTIES));
+    }
 }

--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -1338,13 +1338,34 @@ class Context extends FileRef
     }
 
     /**
-     * Returns a clone of this context without any overrides for static property types.
+     * Returns a clone of this context without overrides for the provided static property names.
+     * If no property names are provided, removes all static property overrides.
+     *
+     * @param list<string>|null $property_names
      */
-    public function withoutStaticPropertyOverrides(): Context
+    public function withoutStaticPropertyOverrides(?array $property_names = null): Context
     {
         if (!$this->scope->hasVariableWithName(self::VAR_NAME_STATIC_PROPERTIES)) {
             return $this;
         }
-        return $this->withScope($this->scope->withUnsetVariable(self::VAR_NAME_STATIC_PROPERTIES));
+        if ($property_names === null) {
+            return $this->withScope($this->scope->withUnsetVariable(self::VAR_NAME_STATIC_PROPERTIES));
+        }
+        if (!$property_names) {
+            return $this;
+        }
+        $variable = clone($this->scope->getVariableByName(self::VAR_NAME_STATIC_PROPERTIES));
+        $type = $variable->getUnionType();
+        foreach ($property_names as $property_name) {
+            $type = $type->withoutArrayShapeField($property_name);
+        }
+        if ($type->isEmpty()) {
+            return $this->withScope($this->scope->withUnsetVariable(self::VAR_NAME_STATIC_PROPERTIES));
+        }
+
+        $variable->setUnionType($type);
+        $new_scope = clone($this->scope);
+        $new_scope->addVariable($variable);
+        return $this->withScope($new_scope);
     }
 }

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -73,6 +73,11 @@ class Method extends ClassElement implements FunctionInterface
     private $overridden_methods_cache = null;
 
     /**
+     * @var array<string,UnionType> map of static property names to the union types assigned within this method.
+     */
+    private $static_property_set_types = [];
+
+    /**
      * @param Context $context
      * The context in which the structural element lives
      *
@@ -1215,4 +1220,28 @@ class Method extends ClassElement implements FunctionInterface
         $this->inherited_throws_union_type = $type;
     }
 
+    /**
+     * Record that this method assigns the given union type to a static property.
+     */
+    public function recordStaticPropertyModification(string $property_name, UnionType $union_type): void
+    {
+        if ($union_type->isEmpty()) {
+            return;
+        }
+        if (isset($this->static_property_set_types[$property_name])) {
+            $this->static_property_set_types[$property_name] = $this->static_property_set_types[$property_name]->withUnionType($union_type);
+            return;
+        }
+        $this->static_property_set_types[$property_name] = $union_type;
+    }
+
+    /**
+     * Returns the union types that were inferred for static properties modified within this method.
+     *
+     * @return array<string,UnionType>
+     */
+    public function getStaticPropertyModifications(): array
+    {
+        return $this->static_property_set_types;
+    }
 }

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -77,7 +77,7 @@ class Method extends ClassElement implements FunctionInterface
      * @var array<string,UnionType> map of static property names to the union types assigned within this method.
      */
     /**
-     * @var array<string,array{class:FullyQualifiedClassName,properties:array<string,UnionType>}>
+     * @var array<string,array{class:FullyQualifiedClassName,properties:array<string,array{type:UnionType,is_late_static:bool}>}>
      */
     private $static_property_set_types = [];
 
@@ -1227,7 +1227,7 @@ class Method extends ClassElement implements FunctionInterface
     /**
      * Record that this method assigns the given union type to a static property.
      */
-    public function recordStaticPropertyModification(FullyQualifiedClassName $class_fqsen, string $property_name, UnionType $union_type): void
+    public function recordStaticPropertyModification(FullyQualifiedClassName $class_fqsen, string $property_name, UnionType $union_type, bool $is_late_static): void
     {
         if ($union_type->isEmpty()) {
             return;
@@ -1241,16 +1241,27 @@ class Method extends ClassElement implements FunctionInterface
         }
         $property_map = &$this->static_property_set_types[$class_key]['properties'];
         if (isset($property_map[$property_name])) {
-            $property_map[$property_name] = $property_map[$property_name]->withUnionType($union_type);
+            $entry = $property_map[$property_name];
+            $entry_type = $entry['type'] ?? null;
+            if ($entry_type !== null) {
+                $entry['type'] = $entry_type->withUnionType($union_type);
+            } else {
+                $entry['type'] = $union_type;
+            }
+            $entry['is_late_static'] = $entry['is_late_static'] || $is_late_static;
+            $property_map[$property_name] = $entry;
             return;
         }
-        $property_map[$property_name] = $union_type;
+        $property_map[$property_name] = [
+            'type' => $union_type,
+            'is_late_static' => $is_late_static,
+        ];
     }
 
     /**
-     * Returns the union types that were inferred for static properties modified within this method.
+     * Returns the metadata for static properties modified within this method.
      *
-     * @return array<string,array{class:FullyQualifiedClassName,properties:array<string,UnionType>}>
+     * @return array<string,array{class:FullyQualifiedClassName,properties:array<string,array{type:UnionType,is_late_static:bool}>}>
      */
     public function getStaticPropertyModifications(): array
     {

--- a/src/Phan/Language/Element/Method.php
+++ b/src/Phan/Language/Element/Method.php
@@ -15,6 +15,7 @@ use Phan\Issue;
 use Phan\Language\Context;
 use Phan\Language\ElementContext;
 use Phan\Language\FileRef;
+use Phan\Language\FQSEN\FullyQualifiedClassName;
 use Phan\Language\FQSEN\FullyQualifiedMethodName;
 use Phan\Language\Scope\ClassScope;
 use Phan\Language\Scope\FunctionLikeScope;
@@ -74,6 +75,9 @@ class Method extends ClassElement implements FunctionInterface
 
     /**
      * @var array<string,UnionType> map of static property names to the union types assigned within this method.
+     */
+    /**
+     * @var array<string,array{class:FullyQualifiedClassName,properties:array<string,UnionType>}>
      */
     private $static_property_set_types = [];
 
@@ -1223,22 +1227,30 @@ class Method extends ClassElement implements FunctionInterface
     /**
      * Record that this method assigns the given union type to a static property.
      */
-    public function recordStaticPropertyModification(string $property_name, UnionType $union_type): void
+    public function recordStaticPropertyModification(FullyQualifiedClassName $class_fqsen, string $property_name, UnionType $union_type): void
     {
         if ($union_type->isEmpty()) {
             return;
         }
-        if (isset($this->static_property_set_types[$property_name])) {
-            $this->static_property_set_types[$property_name] = $this->static_property_set_types[$property_name]->withUnionType($union_type);
+        $class_key = $class_fqsen->__toString();
+        if (!isset($this->static_property_set_types[$class_key])) {
+            $this->static_property_set_types[$class_key] = [
+                'class' => $class_fqsen,
+                'properties' => [],
+            ];
+        }
+        $property_map = &$this->static_property_set_types[$class_key]['properties'];
+        if (isset($property_map[$property_name])) {
+            $property_map[$property_name] = $property_map[$property_name]->withUnionType($union_type);
             return;
         }
-        $this->static_property_set_types[$property_name] = $union_type;
+        $property_map[$property_name] = $union_type;
     }
 
     /**
      * Returns the union types that were inferred for static properties modified within this method.
      *
-     * @return array<string,UnionType>
+     * @return array<string,array{class:FullyQualifiedClassName,properties:array<string,UnionType>}>
      */
     public function getStaticPropertyModifications(): array
     {

--- a/tests/files/src/0798_static_property_setter.php
+++ b/tests/files/src/0798_static_property_setter.php
@@ -1,0 +1,16 @@
+<?php
+
+class StaticPropSetterExample {
+    private static $prop;
+
+    public static function setProperty(stdClass $val): void {
+        self::$prop = $val;
+    }
+
+    public static function getProperty(): stdClass {
+        if (self::$prop === null) {
+            self::setProperty(new stdClass());
+        }
+        return self::$prop;
+    }
+}


### PR DESCRIPTION
Static assignments now flow across self/static calls: AssignmentVisitor records the union types written to each static property in the enclosing method, Method stores that metadata, and PostOrderAnalysisVisitor clears stale overrides and reapplies the recorded types whenever self::/static:: calls are analyzed. With that, code like:
```php
if (self::$prop === null) { 
    self::setProperty(new stdClass);
} 
return self::$prop;
```
no longer reports `PhanTypeMismatchReturnReal`