### PR TITLE
Fix bug 5348

### DIFF
--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -2310,6 +2310,11 @@ class UnionTypeVisitor extends AnalysisVisitor
                 }
             }
             if (!$has_non_empty_array) {
+                if ($this->shouldTreatArrayShapeOffsetAsPossiblyInitializedByLoop($node)) {
+                    $has_non_empty_array = true;
+                }
+            }
+            if (!$has_non_empty_array) {
                 $exception = new IssueException(
                     Issue::fromType(Issue::TypeInvalidDimOffset)(
                         $this->context->getFile(),
@@ -2339,6 +2344,9 @@ class UnionTypeVisitor extends AnalysisVisitor
             return null;
         }
         if ($resulting_element_type === false) {
+            if ($this->shouldTreatArrayShapeOffsetAsPossiblyInitializedByLoop($node)) {
+                return MixedType::instance(false)->asPHPDocUnionType();
+            }
             // XXX not sure what to do here. For now, just return null and only warn in cases where requested to.
             if ($check_invalid_dim) {
                 $exception = new IssueException(
@@ -2367,6 +2375,31 @@ class UnionTypeVisitor extends AnalysisVisitor
             return null;
         }
         return $resulting_element_type;
+    }
+
+    /**
+     * Heuristic: inside loops, allow accessing offsets that might have been added in previous iterations.
+     */
+    private function shouldTreatArrayShapeOffsetAsPossiblyInitializedByLoop(Node $node): bool
+    {
+        if (!$this->context->isInLoop()) {
+            return false;
+        }
+        $expr_node = $node->children['expr'];
+        if (!($expr_node instanceof Node) || $expr_node->kind !== ast\AST_VAR) {
+            return false;
+        }
+        try {
+            $variable_name = (new ContextNode($this->code_base, $this->context, $expr_node))->getVariableName();
+        } catch (IssueException|NodeException) {
+            return false;
+        }
+        foreach (\array_reverse($this->context->getLoopNodeList()) as $loop_node) {
+            if ($this->context->doesLoopRecordDimWrite($loop_node, $variable_name)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -866,13 +866,14 @@ class AssignmentVisitor extends AnalysisVisitor
             );
             return $this->context;
         }
+        $loop_assignment_var_name = null;
         if ($expr_node->kind === \ast\AST_VAR) {
             $variable_name = (new ContextNode(
                 $this->code_base,
                 $this->context,
                 $node
             ))->getVariableName();
-
+            $loop_assignment_var_name = $variable_name;
             if (Variable::isHardcodedVariableInScopeWithName($variable_name, $this->context->isInGlobalScope())) {
                 if ($variable_name === 'GLOBALS') {
                     return $this->analyzeSuperglobalDim($node, $variable_name);
@@ -958,6 +959,11 @@ class AssignmentVisitor extends AnalysisVisitor
             $this->suppress_dim_property_mismatch,
             $this->is_conditional_check  // Propagate the flag for nested dimensions
         ))->__invoke($expr_node);
+
+        if (!$this->is_conditional_check && $loop_assignment_var_name !== null && $this->context->isInLoop()) {
+            $loop_node = $this->context->getInnermostLoopNode();
+            $this->context->markLoopDimWrite($loop_node, $loop_assignment_var_name);
+        }
 
         return $context;
     }

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -961,8 +961,11 @@ class AssignmentVisitor extends AnalysisVisitor
         ))->__invoke($expr_node);
 
         if (!$this->is_conditional_check && $loop_assignment_var_name !== null && $this->context->isInLoop()) {
-            $loop_node = $this->context->getInnermostLoopNode();
-            $this->context->markLoopDimWrite($loop_node, $loop_assignment_var_name);
+            foreach ($this->context->getLoopNodeList() as $loop_node) {
+                if ($loop_node instanceof Node) {
+                    $this->context->markLoopDimWrite($loop_node, $loop_assignment_var_name);
+                }
+            }
         }
 
         return $context;

--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -391,7 +391,12 @@ class Context extends FileRef
         $context = clone($this);
 
         while ($context->loop_nodes) {
-            if (\array_pop($context->loop_nodes) === $node) {
+            $popped_node = \array_pop($context->loop_nodes);
+            if (!($popped_node instanceof Node)) {
+                continue;
+            }
+            self::clearLoopDimWritesForLoop($popped_node);
+            if ($popped_node === $node) {
                 if (\count($context->loop_nodes) === 0) {
                     // @phan-suppress-next-line PhanUndeclaredProperty
                     foreach ($node->phan_deferred_checks ?? [] as $cb) {
@@ -465,8 +470,19 @@ class Context extends FileRef
     public function withoutLoops(): Context
     {
         $context = clone($this);
+        foreach ($context->loop_nodes as $loop_node) {
+            if ($loop_node instanceof Node) {
+                self::clearLoopDimWritesForLoop($loop_node);
+            }
+        }
         $context->loop_nodes = [];
         return $context;
+    }
+
+    private static function clearLoopDimWritesForLoop(Node $loop_node): void
+    {
+        $loop_id = \spl_object_id($loop_node);
+        unset(self::$loop_dim_written_map[$loop_id]);
     }
 
     /**

--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -470,11 +470,6 @@ class Context extends FileRef
     public function withoutLoops(): Context
     {
         $context = clone($this);
-        foreach ($context->loop_nodes as $loop_node) {
-            if ($loop_node instanceof Node) {
-                self::clearLoopDimWritesForLoop($loop_node);
-            }
-        }
         $context->loop_nodes = [];
         return $context;
     }

--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -90,6 +90,13 @@ class Context extends FileRef
     protected $loop_nodes = [];
 
     /**
+     * @var array<int,array<string,bool>>
+     * Tracks per-loop metadata such as which array variables have been written to via dimension assignment.
+     * Keyed by spl_object_id($loop_node).
+     */
+    private static $loop_dim_written_map = [];
+
+    /**
      * @var Scope
      * The current scope in this context
      */
@@ -426,6 +433,33 @@ class Context extends FileRef
     public function getInnermostLoopNode(): Node
     {
         return \end($this->loop_nodes);
+    }
+
+    /**
+     * @return list<Node>
+     * Returns the list of loop nodes entered for this context, ordered from outermost to innermost.
+     */
+    public function getLoopNodeList(): array
+    {
+        return $this->loop_nodes;
+    }
+
+    /**
+     * Records that the given array variable had a dimension written within the specified loop.
+     */
+    public function markLoopDimWrite(Node $loop_node, string $variable_name): void
+    {
+        $loop_id = \spl_object_id($loop_node);
+        self::$loop_dim_written_map[$loop_id][$variable_name] = true;
+    }
+
+    /**
+     * Returns true if the loop node recorded a dimension write for the given variable.
+     */
+    public function doesLoopRecordDimWrite(Node $loop_node, string $variable_name): bool
+    {
+        $loop_id = \spl_object_id($loop_node);
+        return isset(self::$loop_dim_written_map[$loop_id][$variable_name]);
     }
 
     public function withoutLoops(): Context

--- a/tests/files/expected/loop_array_dim.php.expected
+++ b/tests/files/expected/loop_array_dim.php.expected
@@ -1,0 +1,2 @@
+%s:19 PhanUnusedVariable Unused definition of variable $arr
+%s:21 PhanTypeInvalidDimOffset Invalid offset "key" of $arr of array type array{}

--- a/tests/files/src/loop_array_dim.php
+++ b/tests/files/src/loop_array_dim.php
@@ -1,0 +1,23 @@
+<?php
+
+function test_loop_assignment_is_seen() {
+    $arr = [];
+    for ($i = 0; $i < 3; $i++) {
+        $k = $GLOBALS['x'];
+        if (rand()) {
+            $arr[$k] = 42;
+        } else {
+            echo $arr[$k];  // should not warn - previous iterations may have added $k
+        }
+    }
+}
+
+function test_non_loop_still_warns() {
+    $arr = [];
+    $k = 'key';
+    if (rand()) {
+        $arr[$k] = 1;
+    } else {
+        echo $arr[$k];  // should continue to warn
+    }
+}


### PR DESCRIPTION
- Added explicit access to the active loop stack so analyses can consult which loops are currently executing (src/Phan/Language/Context.php:431).
- When an array dimension assignment occurs inside a loop, the innermost loop node now records that variable, allowing later checks to know the loop can
    populate arbitrary keys (src/Phan/Analysis/AssignmentVisitor.php:869 and src/Phan/Analysis/AssignmentVisitor.php:963).
- UnionTypeVisitor consults the recorded loop metadata to skip TypeInvalidDimOffset when a loop can populate array entries: it treats such arrays as possibly
    non-empty in the real-type precheck and returns a conservative mixed element type instead of emitting an error when a shape key is missing (src/Phan/AST/
    UnionTypeVisitor.php:2296 and src/Phan/AST/UnionTypeVisitor.php:2341, helper at src/Phan/AST/UnionTypeVisitor.php:2380)