### PR TITLE
inside array shapes now correctly contribute the inferred template argument instead of falling back to the whole array type

### DIFF
--- a/src/Phan/Language/Type/ClassStringType.php
+++ b/src/Phan/Language/Type/ClassStringType.php
@@ -85,6 +85,14 @@ final class ClassStringType extends StringType
         // @phan-suppress-next-line PhanUnusedClosureParameter - Context parameter required for parent signature compatibility
         return static function (UnionType $type, \Phan\Language\Context $_context): UnionType {
             $result = UnionType::empty();
+            foreach ($type->getTypeSet() as $inner_type) {
+                if ($inner_type instanceof ClassStringType) {
+                    $result = $result->withUnionType($inner_type->getClassUnionType());
+                }
+            }
+            if (!$result->isEmpty()) {
+                return $result;
+            }
             foreach ($type->asStringScalarValues() as $string) {
                 // Convert string arguments to the classes they represent
                 try {

--- a/tests/files/expected/template_class_string_constraint.php.expected
+++ b/tests/files/expected/template_class_string_constraint.php.expected
@@ -1,0 +1,1 @@
+%s:20 PhanTemplateTypeConstraintViolation Template type T of \newObject() must be compatible with \TestClass, but \OtherClass was provided in call to \newObject()

--- a/tests/files/src/template_class_string_constraint.php
+++ b/tests/files/src/template_class_string_constraint.php
@@ -1,0 +1,24 @@
+<?php
+
+class TestClass {}
+class OtherClass {}
+/**
+ * @template T of TestClass
+ * @param array{class:class-string<T>} $data
+ * @return T
+ */
+function newObject(array $data) {
+    $class = $data['class'];
+    return new $class();
+}
+/** @param array{class:class-string<TestClass>} $arr */
+function good(array $arr) {
+    newObject($arr);
+}
+/** @param array{class:class-string<OtherClass>} $arr */
+function bad(array $arr) {
+    newObject($arr);
+}
+
+good(['class' => TestClass::class]);
+bad(['class' => OtherClass::class]);


### PR DESCRIPTION
Updated the template extractor for class-string to first collect the class unions declared on any class-string<...> types in the argument union. Literal class-string scalars remain supported as a fallback. This produces the actual T union instead of the containing array type, so constraint checking compares TestClass instead of array{...}.