### PR TITLE
fixes #5351

### DIFF
--- a/src/Phan/Analysis/BlockExitStatusChecker.php
+++ b/src/Phan/Analysis/BlockExitStatusChecker.php
@@ -803,7 +803,10 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
             $method_name = $method;
         }
         if ($var_name === 'this') {
-            $class_fqsen = $this->context->getClassFQSEN();
+            $class_fqsen = $this->context->getClassFQSENOrNull();
+            if ($class_fqsen === null) {
+                return self::STATUS_PROCEED;
+            }
         } else {
             // TODO not yet handled
             return self::STATUS_PROCEED;

--- a/tests/files/expected/nonclass_this_in_conditional.php.expected
+++ b/tests/files/expected/nonclass_this_in_conditional.php.expected
@@ -1,0 +1,1 @@
+%s:4 PhanUndeclaredThis Variable $this is undeclared

--- a/tests/files/src/nonclass_this_in_conditional.php
+++ b/tests/files/src/nonclass_this_in_conditional.php
@@ -1,0 +1,6 @@
+<?php
+function run() {
+    if (rand()) {
+        $this->addFields();
+    }
+}


### PR DESCRIPTION
Calling `$this->…` outside of a class now skips the exit-status lookup instead of crashing. `BlockExitStatusChecker::computeStatusOfMethodCall()` uses `getClassFQSENOrNull()` and bails when no class scope exists