### PR TITLE
Fixes #5357

### DIFF
--- a/src/Phan/Analysis/AssignOperatorAnalysisVisitor.php
+++ b/src/Phan/Analysis/AssignOperatorAnalysisVisitor.php
@@ -632,10 +632,8 @@ class AssignOperatorAnalysisVisitor extends FlagVisitorImplementation
         $this->warnForInvalidOperandsOfModOp($node);
         return $this->updateTargetWithType($node, function (UnionType $left) use ($node): UnionType {
             $right = UnionTypeVisitor::unionTypeFromNode($this->code_base, $this->context, $node->children['expr']);
-            if (!$this->context->isInLoop()) {
-                if ($left->isNonNullNumberType() && $right->isNonNullNumberType()) {
-                    return BinaryOperatorFlagVisitor::computeIntOrFloatOperationResult($node, $left, $right);
-                }
+            if ($left->isNonNullNumberType() && $right->isNonNullNumberType()) {
+                return IntType::instance(false)->asPHPDocUnionType();
             }
             // TODO: Check if both sides can cast to int and warn if they can't.
             return IntType::instance(false)->asRealUnionType();

--- a/src/Phan/Analysis/AssignOperatorAnalysisVisitor.php
+++ b/src/Phan/Analysis/AssignOperatorAnalysisVisitor.php
@@ -633,7 +633,7 @@ class AssignOperatorAnalysisVisitor extends FlagVisitorImplementation
         return $this->updateTargetWithType($node, function (UnionType $left) use ($node): UnionType {
             $right = UnionTypeVisitor::unionTypeFromNode($this->code_base, $this->context, $node->children['expr']);
             if ($left->isNonNullNumberType() && $right->isNonNullNumberType()) {
-                return IntType::instance(false)->asPHPDocUnionType();
+                return IntType::instance(false)->asRealUnionType();
             }
             // TODO: Check if both sides can cast to int and warn if they can't.
             return IntType::instance(false)->asRealUnionType();

--- a/src/Phan/Analysis/AssignOperatorAnalysisVisitor.php
+++ b/src/Phan/Analysis/AssignOperatorAnalysisVisitor.php
@@ -24,6 +24,8 @@ use Phan\Language\Type;
 use Phan\Language\Type\ArrayType;
 use Phan\Language\Type\FloatType;
 use Phan\Language\Type\IntType;
+use Phan\Language\Type\LiteralFloatType;
+use Phan\Language\Type\LiteralIntType;
 use Phan\Language\Type\MixedType;
 use Phan\Language\Type\NullType;
 use Phan\Language\Type\ScalarType;
@@ -633,7 +635,16 @@ class AssignOperatorAnalysisVisitor extends FlagVisitorImplementation
         return $this->updateTargetWithType($node, function (UnionType $left) use ($node): UnionType {
             $right = UnionTypeVisitor::unionTypeFromNode($this->code_base, $this->context, $node->children['expr']);
             if ($left->isNonNullNumberType() && $right->isNonNullNumberType()) {
-                return IntType::instance(false)->asRealUnionType();
+                $result = BinaryOperatorFlagVisitor::computeIntOrFloatOperationResult($node, $left, $right);
+                return $result->asMappedUnionType(static function (Type $type): Type {
+                    if ($type instanceof LiteralIntType) {
+                        return $type;
+                    }
+                    if ($type instanceof LiteralFloatType) {
+                        return LiteralIntType::instanceForValue((int)$type->getValue(), false);
+                    }
+                    return IntType::instance(false);
+                });
             }
             // TODO: Check if both sides can cast to int and warn if they can't.
             return IntType::instance(false)->asRealUnionType();

--- a/tests/Phan/Language/UnionTypeTest.php
+++ b/tests/Phan/Language/UnionTypeTest.php
@@ -143,9 +143,9 @@ final class UnionTypeTest extends TestBase
         $this->assertUnionTypeStringEqual('$x=2; $x *= 3; $x', '6');
         $this->assertUnionTypeStringEqual('$x=2; $x **= 3; $x', '8');
         $this->assertUnionTypeStringEqual('$x=4; $x **= 3.5; $x', '128.0');
-        $this->assertUnionTypeStringEqual('$x=5; $x %= 3; $x', 'int');
-        $this->assertUnionTypeStringEqual('$x=21.2; $x %= 3.5; $x', 'int');
-        $this->assertUnionTypeStringEqual('$x=23.2; $x %= 3.5; $x', 'int');
+        $this->assertUnionTypeStringEqual('$x=5; $x %= 3; $x', '2');
+        $this->assertUnionTypeStringEqual('$x=21.2; $x %= 3.5; $x', '0');
+        $this->assertUnionTypeStringEqual('$x=23.2; $x %= 3.5; $x', '2');
         $this->assertUnionTypeStringEqual('$x=5;    $x ^= 3;    $x', '6');
         $this->assertUnionTypeStringEqual('$x="ab"; $x ^= "ac"; $x', 'string');
         $this->assertUnionTypeStringEqual('$x=5;    $x |= 3;    $x', '7');

--- a/tests/Phan/Language/UnionTypeTest.php
+++ b/tests/Phan/Language/UnionTypeTest.php
@@ -52,11 +52,11 @@ final class UnionTypeTest extends TestBase
     protected function setUp(): void
     {
         // Deliberately not calling parent::setUp()
+        global $internal_class_name_list;
+        global $internal_interface_name_list;
+        global $internal_trait_name_list;
+        global $internal_function_name_list;
         if (self::$code_base === null) {
-            $internal_class_name_list = \get_declared_classes();
-            $internal_interface_name_list = \get_declared_interfaces();
-            $internal_trait_name_list = \get_declared_traits();
-            $internal_function_name_list = \get_defined_functions()['internal'];
             self::$code_base = new CodeBase(
                 $internal_class_name_list,
                 $internal_interface_name_list,

--- a/tests/Phan/Language/UnionTypeTest.php
+++ b/tests/Phan/Language/UnionTypeTest.php
@@ -143,9 +143,9 @@ final class UnionTypeTest extends TestBase
         $this->assertUnionTypeStringEqual('$x=2; $x *= 3; $x', '6');
         $this->assertUnionTypeStringEqual('$x=2; $x **= 3; $x', '8');
         $this->assertUnionTypeStringEqual('$x=4; $x **= 3.5; $x', '128.0');
-        $this->assertUnionTypeStringEqual('$x=5; $x %= 3; $x', '2');  // This casts to float
-        $this->assertUnionTypeStringEqual('$x=21.2; $x %= 3.5; $x', '0');
-        $this->assertUnionTypeStringEqual('$x=23.2; $x %= 3.5; $x', '2');
+        $this->assertUnionTypeStringEqual('$x=5; $x %= 3; $x', 'int');
+        $this->assertUnionTypeStringEqual('$x=21.2; $x %= 3.5; $x', 'int');
+        $this->assertUnionTypeStringEqual('$x=23.2; $x %= 3.5; $x', 'int');
         $this->assertUnionTypeStringEqual('$x=5;    $x ^= 3;    $x', '6');
         $this->assertUnionTypeStringEqual('$x="ab"; $x ^= "ac"; $x', 'string');
         $this->assertUnionTypeStringEqual('$x=5;    $x |= 3;    $x', '7');

--- a/tests/Phan/Language/UnionTypeTest.php
+++ b/tests/Phan/Language/UnionTypeTest.php
@@ -52,12 +52,11 @@ final class UnionTypeTest extends TestBase
     protected function setUp(): void
     {
         // Deliberately not calling parent::setUp()
-        global $internal_class_name_list;
-        global $internal_interface_name_list;
-        global $internal_trait_name_list;
-        global $internal_function_name_list;
-
         if (self::$code_base === null) {
+            $internal_class_name_list = \get_declared_classes();
+            $internal_interface_name_list = \get_declared_interfaces();
+            $internal_trait_name_list = \get_declared_traits();
+            $internal_function_name_list = \get_defined_functions()['internal'];
             self::$code_base = new CodeBase(
                 $internal_class_name_list,
                 $internal_interface_name_list,

--- a/tests/files/expected/1134_mod_assign.php.expected
+++ b/tests/files/expected/1134_mod_assign.php.expected
@@ -1,0 +1,4 @@
+%s:3 PhanDebugAnnotation @phan-debug-var requested for variable $a1 - it has union type int(real=int)
+%s:3 PhanUnusedVariable Unused definition of variable $a1 (Did you mean $a)
+%s:5 PhanDebugAnnotation @phan-debug-var requested for variable $a - it has union type int
+%s:5 PhanUnusedVariable Unused definition of variable $a

--- a/tests/files/expected/1134_mod_assign.php.expected
+++ b/tests/files/expected/1134_mod_assign.php.expected
@@ -1,4 +1,4 @@
 %s:3 PhanDebugAnnotation @phan-debug-var requested for variable $a1 - it has union type int(real=int)
 %s:3 PhanUnusedVariable Unused definition of variable $a1 (Did you mean $a)
-%s:5 PhanDebugAnnotation @phan-debug-var requested for variable $a - it has union type int
+%s:5 PhanDebugAnnotation @phan-debug-var requested for variable $a - it has union type int(real=int)
 %s:5 PhanUnusedVariable Unused definition of variable $a

--- a/tests/files/src/1134_mod_assign.php
+++ b/tests/files/src/1134_mod_assign.php
@@ -1,0 +1,7 @@
+<?php
+function test_mod_assign(int $a): void {
+    $a1 = $a % 2;
+    '@phan-debug-var $a1';
+    $a %= 2;
+    '@phan-debug-var $a';
+}


### PR DESCRIPTION
`AssignOperatorAnalysisVisitor::visitBinaryMod()` now always returns int when both operands are numeric, matching the behavior of the regular % operator instead of propagating float into the result type