### PR TITLE
Fixes #5358

### DIFF
--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -2239,8 +2239,8 @@ class BlockAnalysisVisitor extends AnalysisVisitor
         $context = $this->context->withLineNumberStart(
             $node->lineno
         );
-
         $context = $this->preOrderAnalyze($context, $node);
+        $original_context = $context;
 
         // We collect all child context so that the
         // PostOrderAnalysisVisitor can optionally operate on
@@ -2642,6 +2642,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
         );
 
         $context = $this->preOrderAnalyze($context, $node);
+        $original_context_for_try = $context;
 
         // With a context that is inside of the node passed
         // to this method, we analyze all children of the
@@ -2675,6 +2676,14 @@ class BlockAnalysisVisitor extends AnalysisVisitor
             [$try_context],
             $this->code_base
         ))->mergeTryContext($node);
+        $catch_base_context = (new ContextMergeVisitor(
+            $original_context_for_try,
+            [$try_context],
+            $this->code_base
+        ))->combineScopeList([
+            $original_context_for_try->getScope(),
+            $try_context->getScope(),
+        ]);
 
         // We collect all child context so that the
         // PostOrderAnalysisVisitor can optionally operate on
@@ -2691,8 +2700,8 @@ class BlockAnalysisVisitor extends AnalysisVisitor
 
             // The conditions need to communicate to the outer
             // scope for things like assigning variables.
-            $catch_context = $context->withScope(
-                new BranchScope($context->getScope())
+            $catch_context = $catch_base_context->withScope(
+                new BranchScope($catch_base_context->getScope())
             );
 
             $catch_context->withLineNumberStart(

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -2236,10 +2236,10 @@ class BlockAnalysisVisitor extends AnalysisVisitor
      */
     public function visitIf(Node $node): Context
     {
-        $context = $this->context->withLineNumberStart(
-            $node->lineno
+        $context = $this->preOrderAnalyze(
+            $this->context->withLineNumberStart($node->lineno),
+            $node
         );
-        $context = $this->preOrderAnalyze($context, $node);
 
         // We collect all child context so that the
         // PostOrderAnalysisVisitor can optionally operate on

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -2240,7 +2240,6 @@ class BlockAnalysisVisitor extends AnalysisVisitor
             $node->lineno
         );
         $context = $this->preOrderAnalyze($context, $node);
-        $original_context = $context;
 
         // We collect all child context so that the
         // PostOrderAnalysisVisitor can optionally operate on

--- a/tests/files/src/1135_try_catch_var.php
+++ b/tests/files/src/1135_try_catch_var.php
@@ -1,0 +1,15 @@
+<?php
+
+function getObjectOrThrow(string $text): stdClass {
+    throw new Exception($text);
+}
+
+(function () {
+    $var = 'foo';
+    try {
+        $var = getObjectOrThrow($var);
+    } catch (Exception) {
+        // accessing $var as string should be allowed because assignment may not have happened
+        throw new Exception(substr($var, 0, 10));
+    }
+})();


### PR DESCRIPTION
Captured the pre-try context and merged it with the try-context to initialize each catch block (`src/Phan/BlockAnalysisVisitor.php`). This lets the catch branch see both the pre-try types and the post-try assignments, fixing the $var confusion.