### PR TITLE
Fixes #5360

### DIFF
--- a/src/Phan/Analysis/ContextMergeVisitor.php
+++ b/src/Phan/Analysis/ContextMergeVisitor.php
@@ -469,11 +469,12 @@ class ContextMergeVisitor extends KindVisitorImplementation
                             $new_field_types[$field_name] = $value->isDefinitelyUndefined() ? $value : $value->withIsPossiblyUndefined(true);
                         }
                         return ArrayShapeType::fromFieldTypes($new_field_types, $type->isNullable());
-                    })->withIsPossiblyUndefined(true);  // Also mark the union type itself as possibly undefined
+                    });
                     $existing_override = $this->context->getScope()->getVariableByNameOrNull($name);
                     if ($existing_override) {
                         $type = $type->withUnionType($existing_override->getUnionType());
                     }
+                    $type = $type->withIsPossiblyUndefined(true);  // Also mark the union type itself as possibly undefined
                     $variable = clone($variable);
                     $variable->setUnionType($type);
                     $scope->addVariable($variable);

--- a/src/Phan/Analysis/ContextMergeVisitor.php
+++ b/src/Phan/Analysis/ContextMergeVisitor.php
@@ -398,15 +398,13 @@ class ContextMergeVisitor extends KindVisitorImplementation
                 return true;
             };
 
-        // Get the intersection of all types for all versions of
-        // the variable from every side of the branch
-        $union_type =
-            static function (string $variable_name) use ($scope_list): UnionType {
-                $previous_type = null;
-                $type_list = [];
+        /** @param list<Scope> $scopes */
+        $compute_union_type = static function (string $variable_name, array $scopes): UnionType {
+            $previous_type = null;
+            $type_list = [];
                 // Get a list of all variables with the given name from
                 // each scope
-                foreach ($scope_list as $scope) {
+                foreach ($scopes as $scope) {
                     $variable = $scope->getVariableByNameOrNull($variable_name);
                     if (\is_null($variable)) {
                         continue;
@@ -443,6 +441,16 @@ class ContextMergeVisitor extends KindVisitorImplementation
                 return $result;
             };
 
+        $union_type = static function (string $variable_name) use ($scope_list, $compute_union_type): UnionType {
+            return $compute_union_type($variable_name, $scope_list);
+        };
+        $parent_scope = $this->context->getScope();
+        $union_type_with_parent = static function (string $variable_name) use ($scope_list, $compute_union_type, $parent_scope): UnionType {
+            $extended_scope_list = $scope_list;
+            $extended_scope_list[] = $parent_scope;
+            return $compute_union_type($variable_name, $extended_scope_list);
+        };
+
         // Clone the incoming scope so we can modify it
         // with the outgoing merged scope
         $scope = clone($this->context->getScope());
@@ -452,7 +460,7 @@ class ContextMergeVisitor extends KindVisitorImplementation
             // Skip variables that are only partially defined
             if (!$is_defined_on_all_branches($name)) {
                 if ($name === Context::VAR_NAME_THIS_PROPERTIES) {
-                    $type = $union_type($name)->asNormalizedTypes()->asMappedUnionType(static function (Type $type): Type {
+                    $type = $union_type_with_parent($name)->asNormalizedTypes()->asMappedUnionType(static function (Type $type): Type {
                         if (!$type instanceof ArrayShapeType) {
                             return $type;
                         }
@@ -462,6 +470,10 @@ class ContextMergeVisitor extends KindVisitorImplementation
                         }
                         return ArrayShapeType::fromFieldTypes($new_field_types, $type->isNullable());
                     })->withIsPossiblyUndefined(true);  // Also mark the union type itself as possibly undefined
+                    $existing_override = $this->context->getScope()->getVariableByNameOrNull($name);
+                    if ($existing_override) {
+                        $type = $type->withUnionType($existing_override->getUnionType());
+                    }
                     $variable = clone($variable);
                     $variable->setUnionType($type);
                     $scope->addVariable($variable);

--- a/src/Phan/Plugin/Internal/RedundantConditionVisitor.php
+++ b/src/Phan/Plugin/Internal/RedundantConditionVisitor.php
@@ -13,12 +13,14 @@ use Exception;
 use Phan\Analysis\PostOrderAnalysisVisitor;
 use Phan\Analysis\RedundantCondition;
 use Phan\AST\ASTReverter;
+use Phan\AST\ContextNode;
 use Phan\AST\InferValue;
 use Phan\AST\UnionTypeVisitor;
 use Phan\Issue;
 use Phan\Language\Context;
 use Phan\Language\Type;
 use Phan\Language\Type\ObjectType;
+use Phan\Language\Type\LiteralTypeInterface;
 use Phan\Language\UnionType;
 use Phan\PluginV3\PluginAwarePostAnalysisVisitor;
 
@@ -356,6 +358,10 @@ class RedundantConditionVisitor extends PluginAwarePostAnalysisVisitor
             $base_issue = Issue::SuspiciousValueComparison;
         }
 
+        if ($this->shouldSkipComparisonDueToMutableThisProperty($left_node, $right) ||
+            $this->shouldSkipComparisonDueToMutableThisProperty($right_node, $left)) {
+            return true;
+        }
         Issue::maybeEmit(
             $code_base,
             $context,
@@ -364,6 +370,36 @@ class RedundantConditionVisitor extends PluginAwarePostAnalysisVisitor
             ...$issue_args
         );
         return true;
+    }
+
+    private function shouldSkipComparisonDueToMutableThisProperty(Node|float|int|string|null $expr_node, UnionType $other_side_type): bool
+    {
+        if (!($expr_node instanceof Node) || $expr_node->kind !== \ast\AST_PROP) {
+            return false;
+        }
+        $prop_expr = $expr_node->children['expr'];
+        if (!($prop_expr instanceof Node) || $prop_expr->kind !== \ast\AST_VAR || $prop_expr->children['name'] !== 'this') {
+            return false;
+        }
+        $property_name = $expr_node->children['prop'];
+        if (!\is_string($property_name)) {
+            return false;
+        }
+        try {
+            $property = (new ContextNode($this->code_base, $this->context, $expr_node))->getProperty(false);
+        } catch (\Exception) {
+            return false;
+        }
+        $declared_type = $property->getUnionType();
+        if ($declared_type->isEmpty() || $other_side_type->isEmpty()) {
+            return false;
+        }
+        foreach ($declared_type->getTypeSet() as $type) {
+            if (!$type instanceof LiteralTypeInterface) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/tests/files/src/1136_property_literal_inference.php
+++ b/tests/files/src/1136_property_literal_inference.php
@@ -1,0 +1,24 @@
+<?php
+
+class TestPropTypeInferenceIssue5360 {
+    public bool $prop1 = false;
+    /** @var string */
+    public $prop2 = '';
+
+    private function doTest(): void
+    {
+        if (!$this->prop1) {
+            if ($this->prop2 === 'foo') {
+                $this->prop1 = true;
+            }
+        }
+
+        if ($this->prop1) {
+            // Intentionally empty block
+        }
+
+        if ($this->prop2 === 'foo') {
+            echo 'x';
+        }
+    }
+}


### PR DESCRIPTION
Prevent conditional property comparisons from being treated as permanently redundant outside their branch.
When a value comparison involves `$this->prop`, we now inspect the property’s declared union type.
If it contains any non-literal types (e.g., a bare string from PHPDoc), we skip emitting `PhanRedundantValueComparison`/`ImpossibleValueComparison` because the
property may still hold other values outside the branch—even if inference narrowed it to a literal inside the branch. This uses `ContextNode` to fetch the
property and checks for `LiteralTypeInterface` implementations before deciding whether to warn.
Adjusted context merging in `ContextMergeVisitor` to keep parent scope in mind when combining branch scopes, ensuring other variables continue to merge correctly.