### PR TITLE
Fixes #5361

### DIFF
--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -480,10 +480,7 @@ class AssignmentVisitor extends AnalysisVisitor
                 $element_type = $get_fallback_element_type();
             }
 
-            if (!($element_type instanceof UnionType)) {
-                // This should not happen, but handle it safely
-                $element_type = $get_fallback_element_type();
-            }
+            '@phan-var UnionType $element_type';
             $this->analyzeValueNodeOfShapedArray($element_type, $child_node->children['value']);
         }
 

--- a/src/Phan/Analysis/ContextMergeVisitor.php
+++ b/src/Phan/Analysis/ContextMergeVisitor.php
@@ -483,7 +483,7 @@ class ContextMergeVisitor extends KindVisitorImplementation
                     continue;
                 }
                 $variable = clone($variable);
-                $variable->setUnionType($union_type($name)->nullableClone()->withIsPossiblyUndefined(true));
+                $variable->setUnionType($union_type($name)->withIsPossiblyUndefined(true));
                 if (ConfigPluginSet::$mergeVariableInfoClosure) {
                     // @phan-suppress-next-line PhanTypePossiblyInvalidCallable
                     (ConfigPluginSet::$mergeVariableInfoClosure)($variable, $scope_list, false);

--- a/tests/files/expected/0158_conditional_assignment.php.expected
+++ b/tests/files/expected/0158_conditional_assignment.php.expected
@@ -1,3 +1,3 @@
-%s:3 PhanDebugAnnotation @phan-debug-var requested for variable $important_variable - it has union type ?true=(real=?true=)
+%s:3 PhanDebugAnnotation @phan-debug-var requested for variable $important_variable - it has union type true=(real=true=)
 %s:7 PhanPossiblyUndeclaredGlobalVariable Global variable $important_variable is possibly undeclared
-%s:8 PhanTypeMismatchArgumentInternal Argument 1 ($value) is $use_variable of type ?true but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array
+%s:8 PhanTypeMismatchArgumentInternal Argument 1 ($value) is $use_variable of type true but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array

--- a/tests/files/expected/0489_crash.php.expected
+++ b/tests/files/expected/0489_crash.php.expected
@@ -1,2 +1,2 @@
 %s:7 PhanPossiblyUndeclaredVariable Variable $42 is possibly undeclared
-%s:7 PhanTypeMismatchArgumentInternalReal Argument 1 ($value) is ${42} of type ?int (value: 24) but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array (real type \Countable|array)
+%s:7 PhanTypeMismatchArgumentInternalReal Argument 1 ($value) is ${42} of type int (value: 24) but \count() takes \Countable|\ResourceBundle|\SimpleXMLElement|array (real type \Countable|array)

--- a/tests/files/expected/0837_possibly_undef_merged.php.expected
+++ b/tests/files/expected/0837_possibly_undef_merged.php.expected
@@ -1,3 +1,2 @@
-%s:21 PhanDebugAnnotation @phan-debug-var requested for variable $obj - it has union type ?object=
-%s:33 PhanNonClassMethodCall Call to method func on non-class type ?object=
+%s:21 PhanDebugAnnotation @phan-debug-var requested for variable $obj - it has union type object=
 %s:33 PhanPossiblyUndeclaredGlobalVariable Global variable $obj is possibly undeclared

--- a/tests/files/expected/0920_flatten.php.expected
+++ b/tests/files/expected/0920_flatten.php.expected
@@ -1,4 +1,4 @@
-%s:20 PhanDebugAnnotation @phan-debug-var requested for variable $excep - it has union type ?\RuntimeException=
+%s:20 PhanDebugAnnotation @phan-debug-var requested for variable $excep - it has union type \RuntimeException|null=
 %s:20 PhanDebugAnnotation @phan-debug-var requested for variable $flag - it has union type 'error'|false|int(real='error'|false|int)
 %s:23 PhanDebugAnnotation @phan-debug-var requested for variable $e - it has union type \Error|\RuntimeException|null=
 %s:28 PhanParamTooFew Call with 0 arg(s) to \check920(int $flag) which requires 1 arg(s) defined at %s:11

--- a/tests/files/expected/0961_possibly_undefined_try.php.expected
+++ b/tests/files/expected/0961_possibly_undefined_try.php.expected
@@ -1,4 +1,4 @@
 %s:5 PhanUnusedVariableCaughtException Unused definition of variable $e2 as a caught exception
 %s:7 PhanUnusedVariableCaughtException Unused definition of variable $e as a caught exception
-%s:10 PhanDebugAnnotation @phan-debug-var requested for variable $e2 - it has union type ?\LogicException=
+%s:10 PhanDebugAnnotation @phan-debug-var requested for variable $e2 - it has union type \LogicException=
 %s:10 PhanDebugAnnotation @phan-debug-var requested for variable $t - it has union type 'exception'|'logic'(real='exception'|'logic')

--- a/tests/files/expected/1137_possibly_undefined_variable.php.expected
+++ b/tests/files/expected/1137_possibly_undefined_variable.php.expected
@@ -1,0 +1,1 @@
+%s:8 PhanPossiblyUndeclaredVariable Variable $var is possibly undeclared

--- a/tests/files/src/1137_possibly_undefined_variable.php
+++ b/tests/files/src/1137_possibly_undefined_variable.php
@@ -1,0 +1,9 @@
+<?php
+
+function test_possibly_undefined_variable(): void {
+    if (rand(0, 1) > -1) {
+        $var = 'foo';
+    }
+
+    strlen($var);
+}


### PR DESCRIPTION
Issue #5361 was caused by `ContextMergeVisitor` adding a nullable clone whenever a variable was only defined on some branches. That artificial null stuck around even after we emitted `PhanPossiblyUndeclaredVariable`, so later argument analysis saw the value as `?string` and raised `PhanTypeMismatchArgumentNullableInternal`. The fix is to keep the merged union type exactly as inferred from the branches and simply mark it as `isPossiblyUndefined`, instead of forcing `nullableClone()`.  That way we still warn about the undeclared variable, but we no longer pretend it might be null unless some branch actually assigned null.