### PR TITLE
Fixes #5362

### DIFF
--- a/src/Phan/Analysis/ArgumentType.php
+++ b/src/Phan/Analysis/ArgumentType.php
@@ -1366,8 +1366,7 @@ final class ArgumentType
             if ($argument_fragment === null) {
                 $extractor = $parameter_union_type->getTemplateTypeExtractorClosure($code_base, $type);
                 if ($extractor) {
-                    $fragment = $extractor($argument_union_type, $context);
-                    $argument_fragment = $fragment->isEmpty() ? $argument_union_type : $fragment;
+                    $argument_fragment = $extractor($argument_union_type, $context);
                 } else {
                     $argument_fragment = $argument_union_type;
                 }

--- a/src/Phan/Language/Type/TemplateType.php
+++ b/src/Phan/Language/Type/TemplateType.php
@@ -259,7 +259,10 @@ final class TemplateType extends Type
             return true;
         }
         if ($actual->isEmpty()) {
-            return false;
+            // The actual type couldn't be inferred (e.g. untyped argument),
+            // so don't treat it as a violation. Other checks (e.g. PossiblyUndeclaredVariable)
+            // already cover cases where a value may be undefined.
+            return true;
         }
         // Allow mixed types to satisfy bounds (consistent with regular type checking).
         // Mixed could be compatible with any type at runtime, so we don't warn.

--- a/tests/files/src/1138_template_constraint_untyped.php
+++ b/tests/files/src/1138_template_constraint_untyped.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @template T of object
+ * @param T $x
+ * @return T
+ */
+function simpleTemplate($x) {
+    return $x;
+}
+
+/**
+ * @template T of object
+ * @param array{obj:T} $x
+ * @return T
+ */
+function arrayTemplate($x) {
+    return $x['obj'];
+}
+
+(function ($untyped) {
+    simpleTemplate($untyped);
+})( $GLOBALS['x'] );
+
+(function (array $untypedArray) {
+    arrayTemplate($untypedArray);
+})( $GLOBALS['x'] );


### PR DESCRIPTION
Template bounds now treat “unknown” arguments as compliant instead of causing spurious errors.
- `TemplateType::unionTypeSatisfiesBound()` now returns true when the actual union type is empty, reflecting cases where Phan can’t infer a concrete argument type. Previously this returned false and triggered `PhanTemplateTypeConstraintViolation`.
- `ArgumentType::analyzeTemplateTypesInParameter()` no longer substitutes the entire argument union type when the extractor fails to locate a template occurrence. It now keeps the (possibly empty) fragment. Combined with the change above, this suppresses constraint warnings when we simply lack type information.