### PR TITLE
Implement require-extends and require-implements annotations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -148,6 +148,7 @@ Type Inference & Analysis:
 - Fixed `array_combine` signature being too strict for null values ([#5219](https://github.com/phan/phan/issues/5219))
 - Improved type inference for `get_class()` to return more specific class-string types ([#5274](https://github.com/phan/phan/issues/5274))
 - Improved handling of `getIterator()` returning Iterator with explicit generics ([#5108](https://github.com/phan/phan/pull/5108))
+- Traits can now declare `@require-extends` / `@require-implements` (and their Psalm aliases) to ensure consuming classes satisfy those requirements
 - Fixed `PhanPossiblyInfiniteRecursionSameParams` false positive for instance methods that guard recursion with property state ([#5371](https://github.com/phan/phan/issues/5371))
 - Improved parameter and property default type representation in error messages ([#5271](https://github.com/phan/phan/pull/5271))
 

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -4323,6 +4323,26 @@ This issue will be emitted from the following code
 trait T { function f() { return parent::f(); } }
 ```
 
+## PhanTraitRequireExtendsMissing
+
+This happens when a trait annotated with `@require-extends` (or `@psalm-require-extends`) is used by a class that does not extend the required class.
+
+```
+Trait {TRAIT} requires using class {CLASS} to extend {TYPE}
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/v6/tests/files/expected/5372_trait_require.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/v6/tests/files/src/5372_trait_require.php#L37).
+
+## PhanTraitRequireImplementsMissing
+
+This happens when a trait annotated with `@require-implements` (or `@psalm-require-implements`) is used by a class that does not implement the required interface.
+
+```
+Trait {TRAIT} requires using class {CLASS} to implement {TYPE}
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/v6/tests/files/expected/5372_trait_require.php.expected#L2) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/v6/tests/files/src/5372_trait_require.php#L42).
+
 ## PhanUndeclaredAliasedMethodOfTrait
 
 ```

--- a/src/Phan/Analysis/ClassInheritanceAnalyzer.php
+++ b/src/Phan/Analysis/ClassInheritanceAnalyzer.php
@@ -131,6 +131,9 @@ class ClassInheritanceAnalyzer
         return true;
     }
 
+    /**
+     * @param array<string,bool> $visited
+     */
     private static function enforceTraitRequirements(
         CodeBase $code_base,
         Clazz $using_class,

--- a/src/Phan/Analysis/ClassInheritanceAnalyzer.php
+++ b/src/Phan/Analysis/ClassInheritanceAnalyzer.php
@@ -72,10 +72,17 @@ class ClassInheritanceAnalyzer
                 Issue::UndeclaredTrait
             );
             if ($class_exists) {
+                $trait = $code_base->getClassByFQSEN($fqsen);
                 self::testClassAccess(
                     $clazz,
-                    $code_base->getClassByFQSEN($fqsen),
+                    $trait,
                     $code_base
+                );
+                self::enforceTraitRequirements(
+                    $code_base,
+                    $clazz,
+                    $trait,
+                    $clazz->getLinenoOfAncestorReference($fqsen)
                 );
             }
         }
@@ -119,6 +126,48 @@ class ClassInheritanceAnalyzer
         }
 
         return true;
+    }
+
+    private static function enforceTraitRequirements(
+        CodeBase $code_base,
+        Clazz $using_class,
+        Clazz $trait,
+        int $lineno
+    ): void {
+        $required_extends = $trait->getRequiredExtendsFQSENList();
+        $required_implements = $trait->getRequiredImplementsFQSENList();
+        if (!$required_extends && !$required_implements) {
+            return;
+        }
+        $expanded_types = $using_class->getFQSEN()->asType()->asExpandedTypes($code_base);
+        foreach ($required_extends as $required_fqsen) {
+            if ($expanded_types->hasType($required_fqsen->asType())) {
+                continue;
+            }
+            Issue::maybeEmit(
+                $code_base,
+                $using_class->getInternalContext(),
+                Issue::TraitRequireExtendsMissing,
+                $lineno,
+                (string)$trait->getFQSEN(),
+                (string)$using_class->getFQSEN(),
+                (string)$required_fqsen
+            );
+        }
+        foreach ($required_implements as $required_fqsen) {
+            if ($expanded_types->hasType($required_fqsen->asType())) {
+                continue;
+            }
+            Issue::maybeEmit(
+                $code_base,
+                $using_class->getInternalContext(),
+                Issue::TraitRequireImplementsMissing,
+                $lineno,
+                (string)$trait->getFQSEN(),
+                (string)$using_class->getFQSEN(),
+                (string)$required_fqsen
+            );
+        }
     }
 
     /**

--- a/src/Phan/Analysis/ClassInheritanceAnalyzer.php
+++ b/src/Phan/Analysis/ClassInheritanceAnalyzer.php
@@ -64,6 +64,7 @@ class ClassInheritanceAnalyzer
             }
         }
 
+        $visited_trait_requirements = [];
         foreach ($clazz->getTraitFQSENList() as $fqsen) {
             $class_exists = self::fqsenExistsForClass(
                 $fqsen,
@@ -84,7 +85,7 @@ class ClassInheritanceAnalyzer
                         $clazz,
                         $trait,
                         $clazz->getLinenoOfAncestorReference($fqsen),
-                        []
+                        $visited_trait_requirements
                     );
                 }
             }
@@ -139,7 +140,7 @@ class ClassInheritanceAnalyzer
         Clazz $using_class,
         Clazz $trait,
         int $lineno,
-        array $visited
+        array &$visited
     ): void {
         $trait_key = (string)$trait->getFQSEN();
         if (isset($visited[$trait_key])) {

--- a/src/Phan/Analysis/ClassInheritanceAnalyzer.php
+++ b/src/Phan/Analysis/ClassInheritanceAnalyzer.php
@@ -78,12 +78,15 @@ class ClassInheritanceAnalyzer
                     $trait,
                     $code_base
                 );
-                self::enforceTraitRequirements(
-                    $code_base,
-                    $clazz,
-                    $trait,
-                    $clazz->getLinenoOfAncestorReference($fqsen)
-                );
+                if (!$clazz->isTrait()) {
+                    self::enforceTraitRequirements(
+                        $code_base,
+                        $clazz,
+                        $trait,
+                        $clazz->getLinenoOfAncestorReference($fqsen),
+                        []
+                    );
+                }
             }
         }
     }
@@ -132,13 +135,16 @@ class ClassInheritanceAnalyzer
         CodeBase $code_base,
         Clazz $using_class,
         Clazz $trait,
-        int $lineno
+        int $lineno,
+        array $visited
     ): void {
-        $required_extends = $trait->getRequiredExtendsFQSENList();
-        $required_implements = $trait->getRequiredImplementsFQSENList();
-        if (!$required_extends && !$required_implements) {
+        $trait_key = (string)$trait->getFQSEN();
+        if (isset($visited[$trait_key])) {
             return;
         }
+        $visited[$trait_key] = true;
+        $required_extends = $trait->getRequiredExtendsFQSENList();
+        $required_implements = $trait->getRequiredImplementsFQSENList();
         $expanded_types = $using_class->getFQSEN()->asType()->asExpandedTypes($code_base);
         foreach ($required_extends as $required_fqsen) {
             if ($expanded_types->hasType($required_fqsen->asType())) {
@@ -166,6 +172,18 @@ class ClassInheritanceAnalyzer
                 (string)$trait->getFQSEN(),
                 (string)$using_class->getFQSEN(),
                 (string)$required_fqsen
+            );
+        }
+        foreach ($trait->getTraitFQSENList() as $nested_fqsen) {
+            if (!$code_base->hasClassWithFQSEN($nested_fqsen)) {
+                continue;
+            }
+            self::enforceTraitRequirements(
+                $code_base,
+                $using_class,
+                $code_base->getClassByFQSEN($nested_fqsen),
+                $lineno,
+                $visited
             );
         }
     }

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -88,6 +88,8 @@ class Issue
     public const UndeclaredStaticMethod    = 'PhanUndeclaredStaticMethod';
     public const UndeclaredStaticProperty  = 'PhanUndeclaredStaticProperty';
     public const UndeclaredTrait           = 'PhanUndeclaredTrait';
+    public const TraitRequireExtendsMissing = 'PhanTraitRequireExtendsMissing';
+    public const TraitRequireImplementsMissing = 'PhanTraitRequireImplementsMissing';
     public const UndeclaredTypeParameter   = 'PhanUndeclaredTypeParameter';
     public const UndeclaredTypeReturnType  = 'PhanUndeclaredTypeReturnType';
     public const UndeclaredTypeProperty    = 'PhanUndeclaredTypeProperty';
@@ -1393,6 +1395,22 @@ class Issue
                 "Trait alias {METHOD} has an ambiguous source method {METHOD} with more than one possible source trait. Possibilities: {TRAIT}",
                 self::REMEDIATION_B,
                 11026
+            ),
+            new Issue(
+                self::TraitRequireExtendsMissing,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_NORMAL,
+                "Trait {TRAIT} requires using class {CLASS} to extend {TYPE}",
+                self::REMEDIATION_B,
+                11090
+            ),
+            new Issue(
+                self::TraitRequireImplementsMissing,
+                self::CATEGORY_UNDEFINED,
+                self::SEVERITY_NORMAL,
+                "Trait {TRAIT} requires using class {CLASS} to implement {TYPE}",
+                self::REMEDIATION_B,
+                11091
             ),
             new Issue(
                 self::UndeclaredVariableDim,

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -136,6 +136,18 @@ class Clazz extends AddressableElement
     private $trait_fqsen_lineno = [];
 
     /**
+     * @var list<FullyQualifiedClassName>
+     * Trait requirements specifying that the consuming class must extend the given classes.
+     */
+    private $required_extends_fqsen_list = [];
+
+    /**
+     * @var list<FullyQualifiedClassName>
+     * Trait requirements specifying that the consuming class must implement the given interfaces.
+     */
+    private $required_implements_fqsen_list = [];
+
+    /**
      * @var array<string,TraitAdaptations>
      * Maps lowercase fqsen of a method to the trait names which are hidden
      * and the trait aliasing info
@@ -821,6 +833,32 @@ class Clazz extends AddressableElement
     {
         $type = $this->trait_type_map[(string)$fqsen] ?? null;
         return $type !== null ? new Some($type) : None::instance();
+    }
+
+    public function addRequiredExtendsFQSEN(FullyQualifiedClassName $fqsen): void
+    {
+        $this->required_extends_fqsen_list[] = $fqsen;
+    }
+
+    public function addRequiredImplementsFQSEN(FullyQualifiedClassName $fqsen): void
+    {
+        $this->required_implements_fqsen_list[] = $fqsen;
+    }
+
+    /**
+     * @return list<FullyQualifiedClassName>
+     */
+    public function getRequiredExtendsFQSENList(): array
+    {
+        return $this->required_extends_fqsen_list;
+    }
+
+    /**
+     * @return list<FullyQualifiedClassName>
+     */
+    public function getRequiredImplementsFQSENList(): array
+    {
+        return $this->required_implements_fqsen_list;
     }
 
     /**

--- a/src/Phan/Language/Element/Comment.php
+++ b/src/Phan/Language/Element/Comment.php
@@ -134,6 +134,18 @@ class Comment
     protected $used_trait_types = [];
 
     /**
+     * @var list<Type>
+     * Trait requirements declaring that the consuming class must extend the given class.
+     */
+    protected $required_extends_types = [];
+
+    /**
+     * @var list<Type>
+     * Trait requirements declaring that the consuming class must implement the given interface.
+     */
+    protected $required_implements_types = [];
+
+    /**
      * @var ReturnComment|null
      * the representation of an (at)return directive
      */
@@ -208,6 +220,12 @@ class Comment
      * @param list<Type> $used_trait_types
      * A list of used trait types with template parameters
      *
+     * @param list<Type> $required_extends_types
+     * Trait requirements declaring that consuming classes must extend each type
+     *
+     * @param list<Type> $required_implements_types
+     * Trait requirements declaring that consuming classes must implement each type
+     *
      * @param ?ReturnComment $return_comment
      *
      * @param array<string,int> $suppress_issue_set
@@ -237,6 +255,8 @@ class Comment
         Option $inherited_type,
         array $implemented_types,
         array $used_trait_types,
+        array $required_extends_types,
+        array $required_implements_types,
         $return_comment,
         array $suppress_issue_set,
         array $magic_property_list,
@@ -255,6 +275,8 @@ class Comment
         $this->inherited_type = $inherited_type;
         $this->implemented_types = $implemented_types;
         $this->used_trait_types = $used_trait_types;
+        $this->required_extends_types = $required_extends_types;
+        $this->required_implements_types = $required_implements_types;
         $this->return_comment = $return_comment;
         $this->suppress_issue_set = $suppress_issue_set;
         $this->closure_scope = $closure_scope;
@@ -700,6 +722,24 @@ class Comment
     public function getUsedTraitTypes(): array
     {
         return $this->used_trait_types;
+    }
+
+    /**
+     * @return list<Type>
+     * A list of class types that a trait requires the using class to extend.
+     */
+    public function getRequiredExtendsTypes(): array
+    {
+        return $this->required_extends_types;
+    }
+
+    /**
+     * @return list<Type>
+     * A list of interface types that a trait requires the using class to implement.
+     */
+    public function getRequiredImplementsTypes(): array
+    {
+        return $this->required_implements_types;
     }
 
     /**

--- a/src/Phan/Language/Element/Comment/Builder.php
+++ b/src/Phan/Language/Element/Comment/Builder.php
@@ -68,6 +68,8 @@ final class Builder
         'psalm-param' => 'param',
         'psalm-return' => 'return',
         'psalm-var' => 'var',
+        'psalm-require-extends' => 'require-extends',
+        'psalm-require-implements' => 'require-implements',
     ];
     /** @var list<Type> the list of (at)use annotations with template parameters for traits */
     public $used_trait_types = [];
@@ -92,6 +94,12 @@ final class Builder
     public $throw_union_type;
     /** @var array<string,Assertion> assertions about each parameter */
     public $param_assertion_map = [];
+
+    /** @var list<Type> */
+    private $required_extends_types = [];
+
+    /** @var list<Type> */
+    private $required_implements_types = [];
 
     /** @var bool did we add template types already */
     protected $did_add_template_types;
@@ -368,6 +376,8 @@ final class Builder
             $this->inherited_type instanceof None &&
             !$this->implemented_types &&
             !$this->used_trait_types &&
+            !$this->required_extends_types &&
+            !$this->required_implements_types &&
             !$this->suppress_issue_set &&
             !$this->magic_property_list &&
             !$this->magic_method_list &&
@@ -388,6 +398,8 @@ final class Builder
             $this->inherited_type,
             $this->implemented_types,
             $this->used_trait_types,
+            $this->required_extends_types,
+            $this->required_implements_types,
             $this->return_comment,
             $this->suppress_issue_set,
             $this->magic_property_list,
@@ -424,7 +436,7 @@ final class Builder
         // (?i) makes this case-sensitive, (?-1) makes it case-insensitive
         // phpcs:ignore Generic.Files.LineLength.MaxExceeded
         // Support both regular tags ("@something") and inline versions of tags ("optional_prefix {@something}").
-        if (\preg_match('/(?:^|{)@((?i)param|deprecated|var|return|throws|throw|returns|inherits|extends|implements|use|suppress|unused-param|no-named-arguments|phan-[a-z0-9_-]*|psalm-(?:template(?:-(?:co|contra)variant)?|param|var|return)(?-i)|method|property|property-read|property-write|abstract|template(?:-(?:co|contra)variant)?|PhanClosureScope|readonly|mixin|seal-(?:methods|properties))(?:[^a-zA-Z0-9_\x7f-\xff-]|$)/D', $trimmed, $matches)) {
+        if (\preg_match('/(?:^|{)@((?i)param|deprecated|var|return|throws|throw|returns|inherits|extends|implements|use|require-extends|require-implements|suppress|unused-param|no-named-arguments|phan-[a-z0-9_-]*|psalm-(?:template(?:-(?:co|contra)variant)?|param|var|return|require-extends|require-implements)(?-i)|method|property|property-read|property-write|abstract|template(?:-(?:co|contra)variant)?|PhanClosureScope|readonly|mixin|seal-(?:methods|properties))(?:[^a-zA-Z0-9_\x7f-\xff-]|$)/D', $trimmed, $matches)) {
             $case_sensitive_type = $matches[1];
             $type = \strtolower($case_sensitive_type);
             $type = self::TAG_ALIAS_MAP[$type] ?? $type;
@@ -453,6 +465,12 @@ final class Builder
                     break;
                 case 'use':
                     $this->maybeParseUse($i, $line);
+                    break;
+                case 'require-extends':
+                    $this->maybeParseRequireExtends($i, $line);
+                    break;
+                case 'require-implements':
+                    $this->maybeParseRequireImplements($i, $line);
                     break;
                 case 'return':
                     $this->maybeParseReturn($i, $line);
@@ -778,6 +796,28 @@ final class Builder
         }
     }
 
+    private function maybeParseRequireExtends(int $i, string $line): void
+    {
+        if (!$this->checkCompatible('@require-extends', [Comment::ON_CLASS], $i)) {
+            return;
+        }
+        $type = $this->requireFromCommentLine($line, 'require-extends');
+        if ($type !== null) {
+            $this->required_extends_types[] = $type;
+        }
+    }
+
+    private function maybeParseRequireImplements(int $i, string $line): void
+    {
+        if (!$this->checkCompatible('@require-implements', [Comment::ON_CLASS], $i)) {
+            return;
+        }
+        $type = $this->requireFromCommentLine($line, 'require-implements');
+        if ($type !== null) {
+            $this->required_implements_types[] = $type;
+        }
+    }
+
     private function maybeParsePhanUse(int $i, string $line): void
     {
         if (!$this->checkCompatible('@phan-use', [Comment::ON_CLASS], $i)) {
@@ -818,6 +858,21 @@ final class Builder
         $param_name = $match[17];
 
         return new Assertion($union_type, $param_name, $assertion_type);
+    }
+
+    private function requireFromCommentLine(string $line, string $tag): ?Type
+    {
+        $pattern = '/@(?:psalm-)?' . \preg_quote($tag, '/') . '\s+(' . Type::type_regex . ')/';
+        if (\preg_match($pattern, $line, $match)) {
+            $type_string = $match[1];
+            return Type::fromStringInContext(
+                $type_string,
+                $this->context,
+                Type::FROM_PHPDOC,
+                $this->code_base
+            );
+        }
+        return null;
     }
 
     private function maybeParsePhanAssert(int $i, string $line): void

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -295,6 +295,20 @@ class ParseVisitor extends ScopeVisitor
                 $trait_fqsen = FullyQualifiedClassName::fromType($used_trait_type);
                 $class->setTraitType($trait_fqsen, $used_trait_type);
             }
+
+            foreach ($comment->getRequiredExtendsTypes() as $required_type) {
+                if (!$required_type->isObjectWithKnownFQSEN()) {
+                    continue;
+                }
+                $class->addRequiredExtendsFQSEN(FullyQualifiedClassName::fromType($required_type));
+            }
+
+            foreach ($comment->getRequiredImplementsTypes() as $required_type) {
+                if (!$required_type->isObjectWithKnownFQSEN()) {
+                    continue;
+                }
+                $class->addRequiredImplementsFQSEN(FullyQualifiedClassName::fromType($required_type));
+            }
         } finally {
             $class->setDidFinishParsing(true);
         }

--- a/tests/files/expected/5372_trait_require.php.expected
+++ b/tests/files/expected/5372_trait_require.php.expected
@@ -1,0 +1,2 @@
+%s:37 PhanTraitRequireExtendsMissing Trait \NS5372\RequiresBase requires using class \NS5372\InvalidChild to extend \NS5372\BaseClass
+%s:42 PhanTraitRequireImplementsMissing Trait \NS5372\RequiresInterface requires using class \NS5372\InvalidImplementation to implement \NS5372\FooInterface

--- a/tests/files/expected/5372_trait_require.php.expected
+++ b/tests/files/expected/5372_trait_require.php.expected
@@ -1,2 +1,3 @@
-%s:37 PhanTraitRequireExtendsMissing Trait \NS5372\RequiresBase requires using class \NS5372\InvalidChild to extend \NS5372\BaseClass
-%s:42 PhanTraitRequireImplementsMissing Trait \NS5372\RequiresInterface requires using class \NS5372\InvalidImplementation to implement \NS5372\FooInterface
+%s:47 PhanTraitRequireExtendsMissing Trait \NS5372\RequiresBase requires using class \NS5372\InvalidChild to extend \NS5372\BaseClass
+%s:52 PhanTraitRequireExtendsMissing Trait \NS5372\RequiresBase requires using class \NS5372\IndirectInvalidChild to extend \NS5372\BaseClass
+%s:57 PhanTraitRequireImplementsMissing Trait \NS5372\RequiresInterface requires using class \NS5372\InvalidImplementation to implement \NS5372\FooInterface

--- a/tests/files/src/5372_trait_require.php
+++ b/tests/files/src/5372_trait_require.php
@@ -14,6 +14,11 @@ trait RequiresBase
     public function mustExtendBase(): void {}
 }
 
+trait RequiresBaseViaTrait
+{
+    use RequiresBase;
+}
+
 /**
  * @psalm-require-implements FooInterface
  */
@@ -32,9 +37,19 @@ class ValidImplementation implements FooInterface
     use RequiresInterface;
 }
 
+class IndirectValidChild extends BaseClass
+{
+    use RequiresBaseViaTrait;
+}
+
 class InvalidChild
 {
     use RequiresBase;
+}
+
+class IndirectInvalidChild
+{
+    use RequiresBaseViaTrait;
 }
 
 class InvalidImplementation

--- a/tests/files/src/5372_trait_require.php
+++ b/tests/files/src/5372_trait_require.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace NS5372;
+
+class BaseClass {}
+
+interface FooInterface {}
+
+/**
+ * @require-extends BaseClass
+ */
+trait RequiresBase
+{
+    public function mustExtendBase(): void {}
+}
+
+/**
+ * @psalm-require-implements FooInterface
+ */
+trait RequiresInterface
+{
+    public function mustImplementInterface(): void {}
+}
+
+class ValidChild extends BaseClass
+{
+    use RequiresBase;
+}
+
+class ValidImplementation implements FooInterface
+{
+    use RequiresInterface;
+}
+
+class InvalidChild
+{
+    use RequiresBase;
+}
+
+class InvalidImplementation
+{
+    use RequiresInterface;
+}
+
+function test(ValidChild $child, ValidImplementation $impl): void
+{
+    $child->mustExtendBase();
+    $impl->mustImplementInterface();
+}


### PR DESCRIPTION
- Added parser support for @require-extends / @require-implements (plus Psalm aliases) and stored the requirements on traits so they survive hydration
- Enforced the new requirements when applying traits and reported violations via the new issue types `PhanTraitRequireExtendsMissing` / `PhanTraitRequireImplementsMissing`