### PR TITLE
fixes #5374

### DIFF
--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -1023,13 +1023,13 @@ class ParameterTypesAnalyzer
         ?int $lineno,
         int|string ...$args
     ): void {
-        if ($method->isFromPHPDoc() || $overridden_method->isFromPHPDoc()) {
-            if ($method->isFromPHPDoc() && $overridden_method->isPHPInternal()) {
-                $overridden_class = $overridden_method->getClass($code_base);
-                if ($overridden_class->isInterface() && self::hasNonInterfaceAncestorOverride($code_base, $method)) {
-                    return;
-                }
+        if ($method->isFromPHPDoc() && $overridden_method->isPHPInternal()) {
+            $overridden_class = $overridden_method->getClass($code_base);
+            if ($overridden_class->isInterface() && self::hasNonInterfaceAncestorOverride($code_base, $method)) {
+                return;
             }
+        }
+        if ($method->isFromPHPDoc() || $overridden_method->isFromPHPDoc()) {
             Issue::maybeEmit(
                 $code_base,
                 $method->getContext(),
@@ -1043,12 +1043,6 @@ class ParameterTypesAnalyzer
                 ])
             );
         } elseif ($overridden_method->isPHPInternal()) {
-            if ($method->isFromPHPDoc()) {
-                $overridden_class = $overridden_method->getClass($code_base);
-                if ($overridden_class->isInterface() && self::hasNonInterfaceAncestorOverride($code_base, $method)) {
-                    return;
-                }
-            }
             Issue::maybeEmit(
                 $code_base,
                 $method->getContext(),

--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -1043,6 +1043,12 @@ class ParameterTypesAnalyzer
                 ])
             );
         } elseif ($overridden_method->isPHPInternal()) {
+            if ($method->isFromPHPDoc()) {
+                $overridden_class = $overridden_method->getClass($code_base);
+                if ($overridden_class->isInterface() && self::hasNonInterfaceAncestorOverride($code_base, $method)) {
+                    return;
+                }
+            }
             Issue::maybeEmit(
                 $code_base,
                 $method->getContext(),


### PR DESCRIPTION
The internal-signature warning on the `@method` override was happening for the same reason: we were comparing PHPDoc-only overrides against every ancestor, even when the concrete parent method already satisfied the interface. I extended the earlier guard so that when a PHPDoc method ends up comparing against an internal interface method, we skip both the PHPDoc and internal real-mismatch issues if there’s also a non-interface ancestor implementing the method. That covers `PhanParamSignatureMismatchInternal` in the reproducer while keeping interface-only cases intact.