### PR TITLE
Fixes 5374 again

### DIFF
--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -332,6 +332,11 @@ class ParameterTypesAnalyzer
         $processed_class_override = false;
         foreach ($overridden_method_list as $overridden_method) {
             $overridden_class = $overridden_method->getClass($code_base);
+            if ($method->isFromPHPDoc() && $overridden_method->isPHPInternal() && $overridden_class->isInterface()) {
+                if (self::hasNonInterfaceAncestorOverride($code_base, $method)) {
+                    continue;
+                }
+            }
             if (!$overridden_class->isInterface()) {
                 if ($overridden_class->isTrait()) {
                     // trait overrides should not suppress checking the actual parent class

--- a/tests/files/expected/0904_magic_method_suppressions.php.expected
+++ b/tests/files/expected/0904_magic_method_suppressions.php.expected
@@ -1,5 +1,4 @@
 %s:10 PhanGenericMissingParameters Class \TestSuppressInClassComment must substitute all 2 template parameters when inheriting \SplObjectStorage (found 0) defined at internal:%d (use @extends or @inherit)
-%s:16 PhanParamSignatureMismatchInternal Declaration of function offsetGet() : object should be compatible with internal function offsetGet(mixed $offset) : mixed (Saw fewer optional parameters in the override)
 %s:16 PhanParamSignatureMismatchInternal Declaration of function offsetGet() : object should be compatible with internal function offsetGet(object $object) : mixed (Saw fewer optional parameters in the override)
 %s:16 PhanParamSignaturePHPDocMismatchTooFewParameters Declaration of real/@method function offsetGet() should be compatible with real/@method function offsetGet($object) : mixed (the method override accepts 0 parameter(s), but the overridden method can accept 1) defined in internal:%d
 %s:18 PhanGenericMissingParameters Class \TestNoSuppression must substitute all 2 template parameters when inheriting \SplObjectStorage (found 0) defined at internal:%d (use @extends or @inherit)


### PR DESCRIPTION
Added the remaining guard for interface overrides so PHPDoc-only magic methods stop comparing against internal signatures when a concrete parent already matches