### PR TITLE
Add symbol-based baselining

### DIFF
--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -6121,14 +6121,29 @@ class Issue
             return;
         }
 
-        Issue::emitWithParameters(
-            $issue_type,
+        $issue = self::fromType($issue_type);
+        $normalized_parameters = \array_map(
+            /**
+             * @return mixed
+             */
+            static function (mixed $param): mixed {
+                if (\is_bool($param)) {
+                    return $param ? 'true' : 'false';
+                }
+                return $param;
+            },
+            $parameters
+        );
+        $issue_instance = new IssueInstance(
+            $issue,
             $context->getFile(),
             $lineno,
-            $parameters,
+            $normalized_parameters,
             $suggestion,
             $column
         );
+        $issue_instance->setBaselineSymbol($context->getFileScopeSummaryForBaseline());
+        self::emitInstance($issue_instance);
     }
 
     /**

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -6044,7 +6044,7 @@ class Issue
         )) {
             return;
         }
-
+        $issue_instance->setBaselineSymbol($context->getFileScopeSummaryForBaseline());
         self::emitInstance($issue_instance);
     }
 

--- a/src/Phan/IssueInstance.php
+++ b/src/Phan/IssueInstance.php
@@ -44,6 +44,9 @@ class IssueInstance
     /** @var list<string|int|float> $template_parameters If this is non-null, this contains the arguments emitted for this instance of the issue. */
     private $template_parameters;
 
+    /** @var string summary of the scope this issue originated in, for baselines */
+    private $baseline_symbol;
+
     /**
      * @param Issue $issue
      * @param string $file
@@ -67,6 +70,7 @@ class IssueInstance
         $this->line = $line;
         $this->column = $column;
         $this->suggestion = $suggestion;
+        $this->baseline_symbol = $file;
 
         if ($issue->getExpectedArgumentCount() !== \count($template_parameters)) {
             CLI::printWarningToStderr(
@@ -216,6 +220,16 @@ class IssueInstance
     public function getMessage(): string
     {
         return $this->message;
+    }
+
+    public function setBaselineSymbol(string $symbol): void
+    {
+        $this->baseline_symbol = $symbol;
+    }
+
+    public function getBaselineSymbol(): string
+    {
+        return $this->baseline_symbol;
     }
 
     public function getMessageAndMaybeSuggestion(): string

--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -788,7 +788,7 @@ class Context extends FileRef
             $class_fqsen = $this->scope->getClassFQSEN();
             return (string)$class_fqsen;
         }
-        return $this->getFile();
+        return $this->file;
     }
 
     /**

--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -776,6 +776,22 @@ class Context extends FileRef
     }
 
     /**
+     * @return string a summary of the current symbol scope to use in baselines (class/method/function)
+     */
+    public function getFileScopeSummaryForBaseline(): string
+    {
+        if ($this->scope->isInFunctionLikeScope()) {
+            $fqsen = $this->scope->getFunctionLikeFQSEN();
+            return (string)$fqsen;
+        }
+        if ($this->scope->isInClassScope()) {
+            $class_fqsen = $this->scope->getClassFQSEN();
+            return (string)$class_fqsen;
+        }
+        return $this->getFile();
+    }
+
+    /**
      * @param CodeBase $code_base
      * The code base from which to retrieve a class constant in scope
      *

--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -788,7 +788,7 @@ class Context extends FileRef
             $class_fqsen = $this->scope->getClassFQSEN();
             return (string)$class_fqsen;
         }
-        return $this->file;
+        return FileRef::getProjectRelativePathForPath($this->file);
     }
 
     /**

--- a/src/Phan/Plugin/Internal/BaselineLoadingPlugin.php
+++ b/src/Phan/Plugin/Internal/BaselineLoadingPlugin.php
@@ -132,15 +132,15 @@ final class BaselineLoadingPlugin extends PluginV3 implements
         $result = [];
         foreach ($file_suppressions as $file => $entries) {
             $issue_map = [];
-            if (\array_values($entries) === $entries) {
-                foreach ($entries as $issue_type) {
-                    $issue_map[(string)$issue_type]['*'] = true;
-                }
-            } else {
-                foreach ($entries as $issue_type => $symbols) {
-                    if (\is_array($symbols)) {
+            foreach ($entries as $key => $value) {
+                if (\is_int($key)) {
+                    $issue_type = (string)$value;
+                    $issue_map[$issue_type]['*'] = true;
+                } else {
+                    $issue_type = (string)$key;
+                    if (\is_array($value)) {
                         $symbol_map = [];
-                        foreach ($symbols as $symbol) {
+                        foreach ($value as $symbol) {
                             $symbol_map[(string)$symbol] = true;
                         }
                         if (!$symbol_map) {
@@ -149,7 +149,11 @@ final class BaselineLoadingPlugin extends PluginV3 implements
                     } else {
                         $symbol_map = ['*' => true];
                     }
-                    $issue_map[(string)$issue_type] = $symbol_map;
+                    if (isset($issue_map[$issue_type])) {
+                        $issue_map[$issue_type] += $symbol_map;
+                    } else {
+                        $issue_map[$issue_type] = $symbol_map;
+                    }
                 }
             }
             $result[$file] = $issue_map;

--- a/src/Phan/Plugin/Internal/BaselineLoadingPlugin.php
+++ b/src/Phan/Plugin/Internal/BaselineLoadingPlugin.php
@@ -140,8 +140,12 @@ final class BaselineLoadingPlugin extends PluginV3 implements
                     $issue_type = (string)$key;
                     if (\is_array($value)) {
                         $symbol_map = [];
-                        foreach ($value as $symbol) {
-                            $symbol_map[(string)$symbol] = true;
+                        foreach ($value as $symbol_key => $symbol_value) {
+                            if (\is_string($symbol_key)) {
+                                $symbol_map[$symbol_key] = true;
+                            } else {
+                                $symbol_map[(string)$symbol_value] = true;
+                            }
                         }
                         if (!$symbol_map) {
                             $symbol_map['*'] = true;

--- a/src/Phan/Plugin/Internal/BaselineLoadingPlugin.php
+++ b/src/Phan/Plugin/Internal/BaselineLoadingPlugin.php
@@ -19,8 +19,8 @@ final class BaselineLoadingPlugin extends PluginV3 implements
     SubscribeEmitIssueCapability
 {
     /**
-     * @var array<string,list<string>>
-     * Maps relative file paths to a list of issue kinds that are suppressed everywhere in the file by the baseline.
+     * @var array<string,array<string,array<string,true>>>
+     * Maps relative file paths to a map of issue kinds to symbol names suppressed in that file.
      */
     private $file_suppressions = [];
 
@@ -45,7 +45,7 @@ final class BaselineLoadingPlugin extends PluginV3 implements
         }
 
         // file_suppressions and directory suppressions are currently the only way to suppress issues in a baseline. Other ways may be added later.
-        $this->file_suppressions = $baseline['file_suppressions'] ?? [];
+        $this->file_suppressions = self::normalizeFileSuppressions($baseline['file_suppressions'] ?? []);
         $this->directory_suppressions = self::normalizeDirectorySuppressions($baseline['directory_suppressions'] ?? []);
     }
 
@@ -62,9 +62,10 @@ final class BaselineLoadingPlugin extends PluginV3 implements
      */
     public function onEmitIssue(IssueInstance $issue_instance): bool
     {
-        return $this->shouldSuppressIssueTypeInFile(
+        return $this->shouldSuppressIssue(
             $issue_instance->getIssue()->getType(),
-            $issue_instance->getFile()
+            $issue_instance->getFile(),
+            $issue_instance->getBaselineSymbol()
         );
     }
 
@@ -72,10 +73,15 @@ final class BaselineLoadingPlugin extends PluginV3 implements
      * Check if the given issue type should be suppressed in the given file path.
      * @internal - used for testing
      */
-    public function shouldSuppressIssueTypeInFile(string $issue_type, string $file): bool
+    public function shouldSuppressIssue(string $issue_type, string $file, string $symbol): bool
     {
-        $suppressed_by_file = \in_array($issue_type, $this->file_suppressions[$file] ?? [], true);
-        if ($suppressed_by_file) {
+        $issue_map = $this->file_suppressions[$file][$issue_type] ?? null;
+        if ($issue_map && isset($issue_map[$symbol])) {
+            return true;
+        }
+
+        // Fallback: allow wildcard '*' to suppress issue type in entire file
+        if ($issue_map && isset($issue_map['*'])) {
             return true;
         }
 
@@ -83,8 +89,8 @@ final class BaselineLoadingPlugin extends PluginV3 implements
         $normalized_file = self::normalizeDirectoryPathString($file);
 
         // Check normalized path to suppress file paths with backslashes on Windows
-        $suppressed_by_normalized_file = \in_array($issue_type, $this->file_suppressions[$normalized_file] ?? [], true);
-        if ($suppressed_by_normalized_file) {
+        $issue_map = $this->file_suppressions[$normalized_file][$issue_type] ?? null;
+        if ($issue_map && (isset($issue_map[$symbol]) || isset($issue_map['*']))) {
             return true;
         }
 
@@ -115,6 +121,40 @@ final class BaselineLoadingPlugin extends PluginV3 implements
         }
 
         return false;
+    }
+
+    /**
+     * @param array<string,mixed> $file_suppressions
+     * @return array<string,array<string,array<string,true>>>
+     */
+    private static function normalizeFileSuppressions(array $file_suppressions): array
+    {
+        $result = [];
+        foreach ($file_suppressions as $file => $entries) {
+            $issue_map = [];
+            if (\array_values($entries) === $entries) {
+                foreach ($entries as $issue_type) {
+                    $issue_map[(string)$issue_type]['*'] = true;
+                }
+            } else {
+                foreach ($entries as $issue_type => $symbols) {
+                    if (\is_array($symbols)) {
+                        $symbol_map = [];
+                        foreach ($symbols as $symbol) {
+                            $symbol_map[(string)$symbol] = true;
+                        }
+                        if (!$symbol_map) {
+                            $symbol_map['*'] = true;
+                        }
+                    } else {
+                        $symbol_map = ['*' => true];
+                    }
+                    $issue_map[(string)$issue_type] = $symbol_map;
+                }
+            }
+            $result[$file] = $issue_map;
+        }
+        return $result;
     }
 
     /**

--- a/src/Phan/Plugin/Internal/BaselineSavingPlugin.php
+++ b/src/Phan/Plugin/Internal/BaselineSavingPlugin.php
@@ -29,8 +29,8 @@ final class BaselineSavingPlugin extends PluginV3 implements
     private $baseline_path;
 
     /**
-     * Maps project file paths to a set of issue types emitted in that file.
-     * @var array<string,array<string, true>>
+     * Maps project file paths to map of issue type => map of symbols to true.
+     * @var array<string,array<string,array<string,true>>>
      */
     private $suppressions_by_file = [];
 
@@ -69,7 +69,11 @@ final class BaselineSavingPlugin extends PluginV3 implements
         // Would prefer to use formatSortableKey, but this doesn't provide the IssueInstance, and plugins have issues that can't be fetched with Issue::fromType.
         $hash = \sha1($issue_instance->__toString());
         $issue_type = $issue_instance->getIssue()->getType();
-        $this->suppressions_by_file[$file_path][$issue_type] = true;
+        $symbol = $issue_instance->getBaselineSymbol();
+        if (!isset($this->suppressions_by_file[$file_path][$issue_type])) {
+            $this->suppressions_by_file[$file_path][$issue_type] = [];
+        }
+        $this->suppressions_by_file[$file_path][$issue_type][$symbol] = true;
         $this->suppressions_by_type[$issue_type][$hash] = true;
         return false;
     }
@@ -181,12 +185,16 @@ EOT;
         $result .= "    // Currently, file_suppressions and directory_suppressions are the only supported suppressions\n";
         $result .= "    'file_suppressions' => [\n";
         \uksort($this->suppressions_by_file, 'strcmp');
-        foreach ($this->suppressions_by_file as $file_name => $type_set) {
-            $types = \array_map('strval', \array_keys($type_set));
-            \usort($types, 'strcmp');
-            $result .= "        '$file_name' => [" . \implode(', ', \array_map(static function (string $type): string {
-                    return "'" . $type . "'";
-            }, $types)) . "],\n";
+        foreach ($this->suppressions_by_file as $file_name => $type_map) {
+            $entries = [];
+            foreach ($type_map as $type_name => $symbols) {
+                $symbol_list = \array_keys($symbols);
+                \sort($symbol_list);
+                $entries[] = "            '$type_name' => [" . \implode(', ', \array_map(static function (string $symbol): string {
+                    return "'" . \addslashes($symbol) . "'";
+                }, $symbol_list)) . "]";
+            }
+            $result .= "        '$file_name' => [\n" . \implode(",\n", $entries) . "\n        ],\n";
         }
         $result .= "    ],\n";
         $result .= "    // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.\n";

--- a/src/Phan/Plugin/Internal/BaselineSavingPlugin.php
+++ b/src/Phan/Plugin/Internal/BaselineSavingPlugin.php
@@ -186,6 +186,7 @@ EOT;
         $result .= "    'file_suppressions' => [\n";
         \uksort($this->suppressions_by_file, 'strcmp');
         foreach ($this->suppressions_by_file as $file_name => $type_map) {
+            \ksort($type_map, \SORT_STRING);
             $entries = [];
             foreach ($type_map as $type_name => $symbols) {
                 $symbol_list = \array_keys($symbols);

--- a/tests/Phan/Plugin/Internal/BaselineLoadingPluginTest.php
+++ b/tests/Phan/Plugin/Internal/BaselineLoadingPluginTest.php
@@ -15,9 +15,9 @@ final class BaselineLoadingPluginTest extends TestBase
     public function testShouldSuppressIssue(): void
     {
         $plugin = new BaselineLoadingPlugin(__DIR__ . '/baseline.php.example');
-        $assertShouldSuppressIssueEquals = function (bool $expected, string $file, string $issue_type) use ($plugin): void {
+        $assertShouldSuppressIssueEquals = function (bool $expected, string $file, string $issue_type, string $symbol = '*') use ($plugin): void {
             // @phan-suppress-next-line PhanAccessMethodInternal
-            $this->assertSame($expected, $plugin->shouldSuppressIssueTypeInFile($issue_type, $file));
+            $this->assertSame($expected, $plugin->shouldSuppressIssue($issue_type, $file, $symbol));
         };
         $assertShouldSuppressIssueEquals(false, 'src/test.php.php', 'PhanUndeclaredMethod');
         $assertShouldSuppressIssueEquals(true, 'src/test.php', 'PhanUndeclaredMethod');
@@ -37,5 +37,8 @@ final class BaselineLoadingPluginTest extends TestBase
         $assertShouldSuppressIssueEquals(true, 'lib/test.php', 'PhanUndeclaredProperty');
         $assertShouldSuppressIssueEquals(true, 'index.php', 'PhanUndeclaredProperty');
         $assertShouldSuppressIssueEquals(false, '../Other/test.php', 'PhanUndeclaredProperty');
+
+        $assertShouldSuppressIssueEquals(true, 'lib/symbol.php', 'PhanTypeMismatchArgument', 'Foo::bar');
+        $assertShouldSuppressIssueEquals(false, 'lib/symbol.php', 'PhanTypeMismatchArgument', 'Other::baz');
     }
 }

--- a/tests/Phan/Plugin/Internal/baseline.php.example
+++ b/tests/Phan/Plugin/Internal/baseline.php.example
@@ -1,7 +1,8 @@
 <?php
 return [
     'file_suppressions' => [
-        'src/test.php' => ['PhanUndeclaredMethod'],
+        'src/test.php' => ['PhanUndeclaredMethod' => ['*']],
+        'lib/symbol.php' => ['PhanTypeMismatchArgument' => ['Foo::bar']],
     ],
     'directory_suppressions' => [
         'src/' => ['PhanUnreferencedUseNormal'],


### PR DESCRIPTION
- Every IssueInstance carries a “baseline symbol” (defaulting to the current file, but overwritten with the class/method/function name when available).
  `Context::getFileScopeSummaryForBaseline()` centralizes that logic, and `Issue::maybeEmitInstance()` stamps the symbol before plugins see the issue.
- BaselineSavingPlugin records issues as `file => issue type => [symbol => true]` and prints the same nested structure. Symbols fall back to file-level wildcards
  when you manually use '*'.
- BaselineLoadingPlugin reads both the new format and the old per-file lists. Suppression now matches on (file, issue type, symbol) first, with a '*' symbol
  meaning “whole file”. Directory suppressions continue to work unchanged.