### PR TITLE
Normalize closures and anonymous classes to keep baseline stable across runs

### DIFF
--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -781,14 +781,21 @@ class Context extends FileRef
     public function getFileScopeSummaryForBaseline(): string
     {
         if ($this->scope->isInFunctionLikeScope()) {
-            $fqsen = $this->scope->getFunctionLikeFQSEN();
-            return (string)$fqsen;
+            $fqsen = (string)$this->scope->getFunctionLikeFQSEN();
+            return self::normalizeBaselineSymbol($fqsen);
         }
         if ($this->scope->isInClassScope()) {
-            $class_fqsen = $this->scope->getClassFQSEN();
-            return (string)$class_fqsen;
+            $class_fqsen = (string)$this->scope->getClassFQSEN();
+            return self::normalizeBaselineSymbol($class_fqsen);
         }
         return FileRef::getProjectRelativePathForPath($this->file);
+    }
+
+    private static function normalizeBaselineSymbol(string $symbol): string
+    {
+        $symbol = \preg_replace('/anonymous_class_[0-9a-f]+/i', 'anonymous_class', $symbol) ?? $symbol;
+        $symbol = \preg_replace('/\\\\closure_[0-9a-f]+/i', '\\\\closure', $symbol) ?? $symbol;
+        return $symbol;
     }
 
     /**

--- a/src/Phan/Plugin/Internal/BaselineLoadingPlugin.php
+++ b/src/Phan/Plugin/Internal/BaselineLoadingPlugin.php
@@ -75,13 +75,9 @@ final class BaselineLoadingPlugin extends PluginV3 implements
      */
     public function shouldSuppressIssue(string $issue_type, string $file, string $symbol): bool
     {
+        $normalized_symbol = self::normalizeSymbol($symbol);
         $issue_map = $this->file_suppressions[$file][$issue_type] ?? null;
-        if ($issue_map && isset($issue_map[$symbol])) {
-            return true;
-        }
-
-        // Fallback: allow wildcard '*' to suppress issue type in entire file
-        if ($issue_map && isset($issue_map['*'])) {
+        if ($issue_map && (isset($issue_map[$normalized_symbol]) || isset($issue_map['*']))) {
             return true;
         }
 
@@ -90,7 +86,7 @@ final class BaselineLoadingPlugin extends PluginV3 implements
 
         // Check normalized path to suppress file paths with backslashes on Windows
         $issue_map = $this->file_suppressions[$normalized_file][$issue_type] ?? null;
-        if ($issue_map && (isset($issue_map[$symbol]) || isset($issue_map['*']))) {
+        if ($issue_map && (isset($issue_map[$normalized_symbol]) || isset($issue_map['*']))) {
             return true;
         }
 
@@ -142,9 +138,9 @@ final class BaselineLoadingPlugin extends PluginV3 implements
                         $symbol_map = [];
                         foreach ($value as $symbol_key => $symbol_value) {
                             if (\is_string($symbol_key)) {
-                                $symbol_map[$symbol_key] = true;
+                                $symbol_map[self::normalizeSymbol($symbol_key)] = true;
                             } else {
-                                $symbol_map[(string)$symbol_value] = true;
+                                $symbol_map[self::normalizeSymbol((string)$symbol_value)] = true;
                             }
                         }
                         if (!$symbol_map) {
@@ -201,5 +197,12 @@ final class BaselineLoadingPlugin extends PluginV3 implements
             return '';
         }
         return $path;
+    }
+
+    private static function normalizeSymbol(string $symbol): string
+    {
+        $symbol = \preg_replace('/anonymous_class_[0-9a-f]+/i', 'anonymous_class', $symbol) ?? $symbol;
+        $symbol = \preg_replace('/\\\\closure_[0-9a-f]+/i', '\\\\closure', $symbol) ?? $symbol;
+        return $symbol;
     }
 }

--- a/tests/Phan/Plugin/Internal/BaselineLoadingPluginTest.php
+++ b/tests/Phan/Plugin/Internal/BaselineLoadingPluginTest.php
@@ -40,5 +40,7 @@ final class BaselineLoadingPluginTest extends TestBase
 
         $assertShouldSuppressIssueEquals(true, 'lib/symbol.php', 'PhanTypeMismatchArgument', 'Foo::bar');
         $assertShouldSuppressIssueEquals(false, 'lib/symbol.php', 'PhanTypeMismatchArgument', 'Other::baz');
+        $assertShouldSuppressIssueEquals(true, 'lib/closure.php', 'PhanTypeMismatchArgument', '\closure_deadbeef');
+        $assertShouldSuppressIssueEquals(true, 'lib/anon.php', 'PhanTypeMismatchArgument', '\anonymous_class_beefcafe::foo');
     }
 }

--- a/tests/Phan/Plugin/Internal/baseline.php.example
+++ b/tests/Phan/Plugin/Internal/baseline.php.example
@@ -3,6 +3,8 @@ return [
     'file_suppressions' => [
         'src/test.php' => ['PhanUndeclaredMethod' => ['*']],
         'lib/symbol.php' => ['PhanTypeMismatchArgument' => ['Foo::bar']],
+        'lib/closure.php' => ['PhanTypeMismatchArgument' => ['\closure']],
+        'lib/anon.php' => ['PhanTypeMismatchArgument' => ['\anonymous_class::foo']],
     ],
     'directory_suppressions' => [
         'src/' => ['PhanUnreferencedUseNormal'],


### PR DESCRIPTION
- The baseline symbol normalization was extended to cover closures as well as anonymous classes: `Context::getFileScopeSummaryForBaseline()` now strips the hash
  suffix from both `anonymous_class_*` and `closure_*` names, so newly saved baselines no longer record unpredictable identifiers.
- BaselineLoadingPlugin gained the same normalization when reading and matching entries. It now normalizes every symbol.