### PR TITLE
Fix backslash regex bug

### DIFF
--- a/src/Phan/Language/Context.php
+++ b/src/Phan/Language/Context.php
@@ -794,7 +794,7 @@ class Context extends FileRef
     private static function normalizeBaselineSymbol(string $symbol): string
     {
         $symbol = \preg_replace('/anonymous_class_[0-9a-f]+/i', 'anonymous_class', $symbol) ?? $symbol;
-        $symbol = \preg_replace('/\\\\closure_[0-9a-f]+/i', '\\\\closure', $symbol) ?? $symbol;
+        $symbol = \preg_replace('/\\\\closure_[0-9a-f]+/i', '\\closure', $symbol) ?? $symbol;
         return $symbol;
     }
 

--- a/src/Phan/Plugin/Internal/BaselineLoadingPlugin.php
+++ b/src/Phan/Plugin/Internal/BaselineLoadingPlugin.php
@@ -202,7 +202,7 @@ final class BaselineLoadingPlugin extends PluginV3 implements
     private static function normalizeSymbol(string $symbol): string
     {
         $symbol = \preg_replace('/anonymous_class_[0-9a-f]+/i', 'anonymous_class', $symbol) ?? $symbol;
-        $symbol = \preg_replace('/\\\\closure_[0-9a-f]+/i', '\\\\closure', $symbol) ?? $symbol;
+        $symbol = \preg_replace('/\\\\closure_[0-9a-f]+/i', '\\closure', $symbol) ?? $symbol;
         return $symbol;
     }
 }


### PR DESCRIPTION
`Context::getFileScopeSummaryForBaseline()` and `BaselineLoadingPlugin::normalizeSymbol()` now properly normalize both anonymous class names and closure names.
The regexes have been corrected so a single leading backslash is matched, and the hash suffix is stripped, turning `\closure_deadbeef` into `\closure` (and
similarly for anonymous classes).