### PR TITLE
Move composer-patches to require to fix PHP 8.5 crash

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "ext-tokenizer": "*",
         "composer/semver": "^1.4|^2.0|^3.0",
         "composer/xdebug-handler": "^2.0|^3.0",
+        "cweagans/composer-patches": "^1.7",
         "felixfbecker/advanced-json-rpc": "^3.0.4",
         "netresearch/jsonmapper": "^1.6.0|^2.0|^3.0|^4.0|^5.0",
         "phan/tolerant-php-parser": "v0.2.0",
@@ -52,7 +53,6 @@
         "ext-var_representation": "Suggested for converting values to strings in issue messages"
     },
     "require-dev": {
-        "cweagans/composer-patches": "^1.7",
         "phpunit/phpunit": "^10.0"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eca4b8cdf4a276efb8996c021b750e09",
+    "content-hash": "d52ab1f8e85ced04ccdc223970af02c8",
     "packages": [
         {
             "name": "composer/pcre",
@@ -227,6 +227,54 @@
                 }
             ],
             "time": "2024-05-06T16:37:16+00:00"
+        },
+        {
+            "name": "cweagans/composer-patches",
+            "version": "1.7.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweagans/composer-patches.git",
+                "reference": "e190d4466fe2b103a55467dfa83fc2fecfcaf2db"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweagans/composer-patches/zipball/e190d4466fe2b103a55467dfa83fc2fecfcaf2db",
+                "reference": "e190d4466fe2b103a55467dfa83fc2fecfcaf2db",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "composer/composer": "~1.0 || ~2.0",
+                "phpunit/phpunit": "~4.6"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "cweagans\\Composer\\Patches"
+            },
+            "autoload": {
+                "psr-4": {
+                    "cweagans\\Composer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Cameron Eagans",
+                    "email": "me@cweagans.net"
+                }
+            ],
+            "description": "Provides a way to patch Composer packages.",
+            "support": {
+                "issues": "https://github.com/cweagans/composer-patches/issues",
+                "source": "https://github.com/cweagans/composer-patches/tree/1.7.3"
+            },
+            "time": "2022-12-20T22:53:13+00:00"
         },
         {
             "name": "doctrine/deprecations",
@@ -1603,54 +1651,6 @@
         }
     ],
     "packages-dev": [
-        {
-            "name": "cweagans/composer-patches",
-            "version": "1.7.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/cweagans/composer-patches.git",
-                "reference": "e190d4466fe2b103a55467dfa83fc2fecfcaf2db"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/cweagans/composer-patches/zipball/e190d4466fe2b103a55467dfa83fc2fecfcaf2db",
-                "reference": "e190d4466fe2b103a55467dfa83fc2fecfcaf2db",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^1.0 || ^2.0",
-                "php": ">=5.3.0"
-            },
-            "require-dev": {
-                "composer/composer": "~1.0 || ~2.0",
-                "phpunit/phpunit": "~4.6"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "cweagans\\Composer\\Patches"
-            },
-            "autoload": {
-                "psr-4": {
-                    "cweagans\\Composer\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Cameron Eagans",
-                    "email": "me@cweagans.net"
-                }
-            ],
-            "description": "Provides a way to patch Composer packages.",
-            "support": {
-                "issues": "https://github.com/cweagans/composer-patches/issues",
-                "source": "https://github.com/cweagans/composer-patches/tree/1.7.3"
-            },
-            "time": "2022-12-20T22:53:13+00:00"
-        },
         {
             "name": "myclabs/deep-copy",
             "version": "1.13.4",


### PR DESCRIPTION
## Summary

- Moves `cweagans/composer-patches` from `require-dev` to `require` to ensure the PHP 8.5 compatibility patch for `var_representation_polyfill` is applied when Phan is installed via Composer
- Fixes crash on PHP 8.5 when installing Phan as a Composer dependency (phar package was unaffected)
- The patch plugin was not being installed when users ran `composer require --dev phan/phan` because Composer doesn't install `require-dev` dependencies of packages

## Background

The existing PHP 8.5 compatibility patch for `var_representation_polyfill` (added in c8eaf64) fixes a deprecated semicolon in switch case syntax (`case 'NULL';` → `case 'NULL':`). This patch was only being applied when building the phar because the `cweagans/composer-patches` plugin was in `require-dev`.

When Phan is installed via `composer require --dev phan/phan`, Composer only installs the package's `require` dependencies, not its `require-dev` dependencies. This meant the patch plugin was never installed and the patch was never applied, causing crashes on PHP 8.5.

## Test plan

- [x] Verify composer.json correctly moves the dependency
- [x] Verify composer.lock reflects the change
- [x] Verify the patch is still applied in vendor after composer update

Fixes #5385

🤖 Generated with [Claude Code](https://claude.com/claude-code)