### PR TITLE
Fixes #5388

### DIFF
--- a/.phan/plugins/UncoveredEnumCasesInMatchPlugin.php
+++ b/.phan/plugins/UncoveredEnumCasesInMatchPlugin.php
@@ -437,14 +437,18 @@ final class UncoveredEnumCasesInMatchVisitor extends PluginAwarePostAnalysisVisi
             if ($type instanceof BoolType || $type instanceof TrueType || $type instanceof FalseType) {
                 continue;
             }
-            // Skip enum types (handled by enum check)
+            // Check object types - enums are handled separately, but non-enum objects are non-finite
             if ($type->isObjectWithKnownFQSEN()) {
                 $fqsen = $type->asFQSEN();
                 if ($fqsen instanceof FullyQualifiedClassName && $this->code_base->hasClassWithFQSEN($fqsen)) {
                     $class = $this->code_base->getClassByFQSEN($fqsen);
                     if ($class->isEnum()) {
+                        // Skip enum types (handled by enum check)
                         continue;
                     }
+                    // Non-enum object types are non-finite (can have infinite instances)
+                    $non_finite_types[] = $fqsen->__toString();
+                    continue;
                 }
             }
             // These types are non-finite

--- a/.phan/plugins/UncoveredEnumCasesInMatchPlugin.php
+++ b/.phan/plugins/UncoveredEnumCasesInMatchPlugin.php
@@ -376,8 +376,15 @@ final class UncoveredEnumCasesInMatchVisitor extends PluginAwarePostAnalysisVisi
             if (!isset($arm_info['covered_bool_values']['false'])) {
                 $missing[] = 'false';
             }
+        } elseif ($has_true_type && $has_false_type) {
+            // Both literal types present (e.g., PHPDoc @param true|false) - both need to be covered
+            if (!isset($arm_info['covered_bool_values']['true'])) {
+                $missing[] = 'true';
+            }
+            if (!isset($arm_info['covered_bool_values']['false'])) {
+                $missing[] = 'false';
+            }
         }
-        // If both $has_true_type and $has_false_type, then both need to be checked
 
         if (!empty($missing)) {
             $this->emitPluginIssue(

--- a/.phan/plugins/UncoveredEnumCasesInMatchPlugin.php
+++ b/.phan/plugins/UncoveredEnumCasesInMatchPlugin.php
@@ -300,8 +300,11 @@ final class UncoveredEnumCasesInMatchVisitor extends PluginAwarePostAnalysisVisi
      */
     private function checkBoolExhaustiveness(Node $node, Node|string|int|float $cond_node, UnionType $cond_type, array $arm_info): void
     {
-        // If there are no bool literals in the arms, don't warn (might be using other comparison)
-        if (empty($arm_info['covered_bool_values'])) {
+        // If there are no bool literals in the arms and there ARE variable arms,
+        // skip the check (variable arms like `$b => ...` could match the bool).
+        // But if there are only non-bool literal arms (like `1 => ...`), we should warn
+        // because those will never match a bool value due to strict identity comparison.
+        if (empty($arm_info['covered_bool_values']) && !$arm_info['all_arms_constant']) {
             return;
         }
 

--- a/.phan/plugins/UncoveredEnumCasesInMatchPlugin.php
+++ b/.phan/plugins/UncoveredEnumCasesInMatchPlugin.php
@@ -104,7 +104,7 @@ final class UncoveredEnumCasesInMatchVisitor extends PluginAwarePostAnalysisVisi
         // Check non-finite types need default
         // Use the real (declared) type if available, since the inferred type may be narrowed
         $real_cond_type = $cond_type->hasRealTypeSet() ? $cond_type->getRealUnionType() : $cond_type;
-        $this->checkNonFiniteTypeNeedsDefault($node, $real_cond_type, $arm_info);
+        $this->checkNonFiniteTypeNeedsDefault($node, $real_cond_type);
     }
 
     /**
@@ -395,24 +395,13 @@ final class UncoveredEnumCasesInMatchVisitor extends PluginAwarePostAnalysisVisi
 
     /**
      * Check if non-finite types (string, int, float, etc.) need a default arm
-     *
-     * @param array{has_default: bool, has_any_arm: bool, all_arms_constant: bool, covered_enum_cases: array<string, true>, covered_bool_values: array<string, true>, has_literal_arms: bool} $arm_info
      */
-    private function checkNonFiniteTypeNeedsDefault(Node $node, UnionType $cond_type, array $arm_info): void
+    private function checkNonFiniteTypeNeedsDefault(Node $node, UnionType $cond_type): void
     {
-        // If there's no literal arms, skip (enum-only checks are handled separately)
-        if (!$arm_info['has_literal_arms']) {
-            return;
-        }
-
-        // If there are enum cases covered, the enum check will handle it
-        if (!empty($arm_info['covered_enum_cases'])) {
-            return;
-        }
-
-        // Note: We intentionally do NOT return early when bool values are covered.
-        // For composite types like bool|string, even if true/false are covered,
+        // Note: We intentionally do NOT return early based on has_literal_arms or covered_enum_cases.
+        // For composite types like Suit|string, even if all enum cases are covered,
         // we still need to check if other types (like string) are non-finite.
+        // Similarly for bool|string - even if true/false are covered, string is non-finite.
 
         // Check if any type in the union is non-finite
         $non_finite_types = [];

--- a/.phan/plugins/UncoveredEnumCasesInMatchPlugin.php
+++ b/.phan/plugins/UncoveredEnumCasesInMatchPlugin.php
@@ -309,9 +309,24 @@ final class UncoveredEnumCasesInMatchVisitor extends PluginAwarePostAnalysisVisi
         }
 
         // If the condition itself is a literal boolean (e.g., match(true) or match(false)),
-        // don't warn - the match can only ever receive that literal value and cannot throw
-        // UnhandledMatchError for the opposite boolean.
-        if (self::getBoolLiteralFromExpression($cond_node) !== null) {
+        // only that specific value needs to be covered. For example:
+        // - match(true) { true => 'yes' } is exhaustive
+        // - match(true) { false => 'no' } will throw UnhandledMatchError
+        $literal_bool = self::getBoolLiteralFromExpression($cond_node);
+        if ($literal_bool !== null) {
+            // Check if the literal value is covered
+            if (!isset($arm_info['covered_bool_values'][$literal_bool])) {
+                $this->emitPluginIssue(
+                    $this->code_base,
+                    (clone $this->context)->withLineNumberStart($node->lineno),
+                    'PhanPluginNonExhaustiveBoolMatch',
+                    'Match expression with bool condition does not cover all cases - missing: {STRING_LITERAL}. Either add the missing cases or add a default arm.',
+                    [$literal_bool],
+                    \Phan\Issue::SEVERITY_NORMAL,
+                    \Phan\Issue::REMEDIATION_A,
+                    15091
+                );
+            }
             return;
         }
 

--- a/.phan/plugins/UncoveredEnumCasesInMatchPlugin.php
+++ b/.phan/plugins/UncoveredEnumCasesInMatchPlugin.php
@@ -98,8 +98,8 @@ final class UncoveredEnumCasesInMatchVisitor extends PluginAwarePostAnalysisVisi
         // Check enum exhaustiveness
         $this->checkEnumExhaustiveness($node, $cond_type, $arm_info);
 
-        // Check bool exhaustiveness
-        $this->checkBoolExhaustiveness($node, $cond_type, $arm_info);
+        // Check bool exhaustiveness (pass cond_node to detect literal booleans)
+        $this->checkBoolExhaustiveness($node, $cond_node, $cond_type, $arm_info);
 
         // Check non-finite types need default
         $this->checkNonFiniteTypeNeedsDefault($node, $cond_type, $arm_info);
@@ -296,10 +296,17 @@ final class UncoveredEnumCasesInMatchVisitor extends PluginAwarePostAnalysisVisi
      *
      * @param array{has_default: bool, has_any_arm: bool, all_arms_constant: bool, covered_enum_cases: array<string, true>, covered_bool_values: array<string, true>, has_literal_arms: bool} $arm_info
      */
-    private function checkBoolExhaustiveness(Node $node, UnionType $cond_type, array $arm_info): void
+    private function checkBoolExhaustiveness(Node $node, Node|string|int|float $cond_node, UnionType $cond_type, array $arm_info): void
     {
         // If there are no bool literals in the arms, don't warn (might be using other comparison)
         if (empty($arm_info['covered_bool_values'])) {
+            return;
+        }
+
+        // If the condition itself is a literal boolean (e.g., match(true) or match(false)),
+        // don't warn - the match can only ever receive that literal value and cannot throw
+        // UnhandledMatchError for the opposite boolean.
+        if (self::getBoolLiteralFromExpression($cond_node) !== null) {
             return;
         }
 

--- a/.phan/plugins/UncoveredEnumCasesInMatchPlugin.php
+++ b/.phan/plugins/UncoveredEnumCasesInMatchPlugin.php
@@ -102,7 +102,9 @@ final class UncoveredEnumCasesInMatchVisitor extends PluginAwarePostAnalysisVisi
         $this->checkBoolExhaustiveness($node, $cond_node, $cond_type, $arm_info);
 
         // Check non-finite types need default
-        $this->checkNonFiniteTypeNeedsDefault($node, $cond_type, $arm_info);
+        // Use the real (declared) type if available, since the inferred type may be narrowed
+        $real_cond_type = $cond_type->hasRealTypeSet() ? $cond_type->getRealUnionType() : $cond_type;
+        $this->checkNonFiniteTypeNeedsDefault($node, $real_cond_type, $arm_info);
     }
 
     /**
@@ -385,10 +387,9 @@ final class UncoveredEnumCasesInMatchVisitor extends PluginAwarePostAnalysisVisi
             return;
         }
 
-        // If there are bool values covered, the bool check will handle it
-        if (!empty($arm_info['covered_bool_values'])) {
-            return;
-        }
+        // Note: We intentionally do NOT return early when bool values are covered.
+        // For composite types like bool|string, even if true/false are covered,
+        // we still need to check if other types (like string) are non-finite.
 
         // Check if any type in the union is non-finite
         $non_finite_types = [];
@@ -413,8 +414,18 @@ final class UncoveredEnumCasesInMatchVisitor extends PluginAwarePostAnalysisVisi
                 }
             }
             // These types are non-finite
-            if (in_array($name, ['string', 'int', 'float', 'array', 'object', 'mixed', 'iterable', 'callable', 'resource'], true)) {
+            // Check both exact matches and refined types (e.g., non-zero-int, non-empty-string)
+            $base_non_finite = ['string', 'int', 'float', 'array', 'object', 'mixed', 'iterable', 'callable', 'resource'];
+            if (in_array($name, $base_non_finite, true)) {
                 $non_finite_types[] = $name;
+            } else {
+                // Check for refined types like non-zero-int, non-empty-string, etc.
+                foreach ($base_non_finite as $base_type) {
+                    if (str_contains($name, $base_type)) {
+                        $non_finite_types[] = $base_type;
+                        break;
+                    }
+                }
             }
         }
 

--- a/.phan/plugins/UncoveredEnumCasesInMatchPlugin.php
+++ b/.phan/plugins/UncoveredEnumCasesInMatchPlugin.php
@@ -205,11 +205,25 @@ final class UncoveredEnumCasesInMatchVisitor extends PluginAwarePostAnalysisVisi
             $node->kind === \ast\AST_METHOD_CALL ||
             $node->kind === \ast\AST_STATIC_CALL ||
             $node->kind === \ast\AST_PROP ||
-            $node->kind === \ast\AST_STATIC_PROP) {
+            $node->kind === \ast\AST_STATIC_PROP ||
+            $node->kind === \ast\AST_CLOSURE ||
+            $node->kind === \ast\AST_ARROW_FUNC) {
             return false;
         }
 
-        // For other node types, assume constant for now
+        // For compound expressions (binary ops, unary ops, ternary, etc.),
+        // recursively check all children - if any child is non-constant,
+        // the whole expression is non-constant
+        foreach ($node->children as $child) {
+            if ($child instanceof Node) {
+                if (!self::isConstantExpression($child)) {
+                    return false;
+                }
+            }
+            // Scalar children (int, string, float, null) are constant
+        }
+
+        // All children are constant (or scalars), so this expression is constant
         return true;
     }
 

--- a/.phan/plugins/UncoveredEnumCasesInMatchPlugin.php
+++ b/.phan/plugins/UncoveredEnumCasesInMatchPlugin.php
@@ -7,19 +7,24 @@ use Phan\AST\UnionTypeVisitor;
 use Phan\Language\Element\Clazz;
 use Phan\Language\Element\EnumCase;
 use Phan\Language\FQSEN\FullyQualifiedClassName;
+use Phan\Language\Type\BoolType;
+use Phan\Language\Type\FalseType;
+use Phan\Language\Type\TrueType;
+use Phan\Language\UnionType;
 use Phan\PluginV3;
 use Phan\PluginV3\PluginAwarePostAnalysisVisitor;
 use Phan\PluginV3\PostAnalyzeNodeCapability;
 
 /**
- * This plugin checks for match statements that do not cover all cases of an enum.
+ * This plugin checks for non-exhaustive match expressions that could throw
+ * UnhandledMatchError at runtime.
  *
- * When a match statement's condition is an enum type and all match arm conditions
- * are enum cases from that enum, this plugin warns when:
- * - Not all enum cases are covered
- * - There is no default arm
+ * It detects:
+ * 1. Enum types where not all cases are covered (and no default arm)
+ * 2. Bool types where not both true and false are covered (and no default arm)
+ * 3. Non-finite types (string, int, float, etc.) without a default arm
  *
- * This is especially useful because uncovered enum cases in match expressions
+ * This is especially useful because uncovered cases in match expressions
  * will throw UnhandledMatchError at runtime.
  *
  * A plugin file must:
@@ -44,7 +49,7 @@ final class UncoveredEnumCasesInMatchPlugin extends PluginV3 implements PostAnal
 }
 
 /**
- * This visitor analyzes match expressions to detect uncovered enum cases.
+ * This visitor analyzes match expressions to detect non-exhaustive matches.
  *
  * When __invoke on this class is called with a node, a method
  * will be dispatched based on the `kind` of the given node.
@@ -52,7 +57,7 @@ final class UncoveredEnumCasesInMatchPlugin extends PluginV3 implements PostAnal
 final class UncoveredEnumCasesInMatchVisitor extends PluginAwarePostAnalysisVisitor
 {
     /**
-     * Visit a match expression and check for uncovered enum cases
+     * Visit a match expression and check for non-exhaustive matches
      *
      * @param Node $node a node of kind AST_MATCH
      */
@@ -72,19 +77,47 @@ final class UncoveredEnumCasesInMatchVisitor extends PluginAwarePostAnalysisVisi
             $cond_node
         );
 
-        // Get all enum classes from the condition's union type
-        $enum_classes = $this->getEnumClassesFromUnionType($cond_type);
+        // Parse all match arms
+        $arm_info = $this->parseMatchArms($stmts_node);
 
-        if (empty($enum_classes)) {
-            // No enum types in the condition
+        // Don't check empty match expressions
+        if (!$arm_info['has_any_arm']) {
             return;
         }
 
-        // Check if there's a default arm and collect covered cases
+        // If there's a default, all cases are effectively covered
+        if ($arm_info['has_default']) {
+            return;
+        }
+
+        // If any arm has a non-constant condition, skip checking to avoid false positives
+        if (!$arm_info['all_arms_constant']) {
+            return;
+        }
+
+        // Check enum exhaustiveness
+        $this->checkEnumExhaustiveness($node, $cond_type, $arm_info);
+
+        // Check bool exhaustiveness
+        $this->checkBoolExhaustiveness($node, $cond_type, $arm_info);
+
+        // Check non-finite types need default
+        $this->checkNonFiniteTypeNeedsDefault($node, $cond_type, $arm_info);
+    }
+
+    /**
+     * Parse match arms to extract information about covered cases
+     *
+     * @return array{has_default: bool, has_any_arm: bool, all_arms_constant: bool, covered_enum_cases: array<string, true>, covered_bool_values: array<string, true>, has_literal_arms: bool}
+     */
+    private function parseMatchArms(Node $stmts_node): array
+    {
         $has_default = false;
-        $covered_cases = [];
-        $all_arms_are_enum_cases = true;
         $has_any_arm = false;
+        $all_arms_constant = true;
+        $covered_enum_cases = [];
+        $covered_bool_values = [];
+        $has_literal_arms = false;
 
         foreach ($stmts_node->children as $arm_node) {
             if (!($arm_node instanceof Node)) {
@@ -105,30 +138,123 @@ final class UncoveredEnumCasesInMatchVisitor extends PluginAwarePostAnalysisVisi
 
             $has_any_arm = true;
 
-            // Collect all enum cases covered by this arm
+            // Check each condition in this arm
             foreach ($cond_list->children as $arm_cond) {
+                // Check for enum cases
                 $enum_case = $this->getEnumCaseFromExpression($arm_cond);
                 if ($enum_case !== null) {
-                    $covered_cases[$enum_case] = true;
-                } else {
-                    // This arm condition is not an enum case
-                    $all_arms_are_enum_cases = false;
+                    $covered_enum_cases[$enum_case] = true;
+                    continue;
+                }
+
+                // Check for bool literals (AST_CONST nodes with name 'true' or 'false')
+                $bool_value = self::getBoolLiteralFromExpression($arm_cond);
+                if ($bool_value !== null) {
+                    $covered_bool_values[$bool_value] = true;
+                    $has_literal_arms = true;
+                    continue;
+                }
+
+                // Check for other scalar literals (int, float, string)
+                if (is_int($arm_cond) || is_float($arm_cond) || is_string($arm_cond)) {
+                    $has_literal_arms = true;
+                    continue;
+                }
+
+                // If it's a node that's not an enum case, check if it's a constant expression
+                if ($arm_cond instanceof Node) {
+                    if (!self::isConstantExpression($arm_cond)) {
+                        $all_arms_constant = false;
+                    } else {
+                        $has_literal_arms = true;
+                    }
                 }
             }
         }
 
-        // Don't check empty match expressions
-        if (!$has_any_arm) {
+        return [
+            'has_default' => $has_default,
+            'has_any_arm' => $has_any_arm,
+            'all_arms_constant' => $all_arms_constant,
+            'covered_enum_cases' => $covered_enum_cases,
+            'covered_bool_values' => $covered_bool_values,
+            'has_literal_arms' => $has_literal_arms,
+        ];
+    }
+
+    /**
+     * Check if an expression is a constant (compile-time evaluable)
+     */
+    private static function isConstantExpression(Node $node): bool
+    {
+        // Class constants (including enum cases) are constant
+        if ($node->kind === \ast\AST_CLASS_CONST) {
+            return true;
+        }
+
+        // Global constants are constant
+        if ($node->kind === \ast\AST_CONST) {
+            return true;
+        }
+
+        // Variables, function calls, method calls, etc. are not constant
+        if ($node->kind === \ast\AST_VAR ||
+            $node->kind === \ast\AST_CALL ||
+            $node->kind === \ast\AST_METHOD_CALL ||
+            $node->kind === \ast\AST_STATIC_CALL ||
+            $node->kind === \ast\AST_PROP ||
+            $node->kind === \ast\AST_STATIC_PROP) {
+            return false;
+        }
+
+        // For other node types, assume constant for now
+        return true;
+    }
+
+    /**
+     * Get the bool literal name ('true' or 'false') from an expression, if it is one
+     *
+     * @return ?string 'true' or 'false' if this is a bool literal, null otherwise
+     */
+    private static function getBoolLiteralFromExpression(mixed $expr): ?string
+    {
+        if (!($expr instanceof Node)) {
+            return null;
+        }
+
+        // Check for AST_CONST (e.g., true, false, null, or other constants)
+        if ($expr->kind !== \ast\AST_CONST) {
+            return null;
+        }
+
+        $name_node = $expr->children['name'] ?? null;
+        if (!($name_node instanceof Node)) {
+            return null;
+        }
+
+        $name = $name_node->children['name'] ?? null;
+        if ($name === 'true' || $name === 'false') {
+            return $name;
+        }
+
+        return null;
+    }
+
+    /**
+     * Check for missing enum cases
+     *
+     * @param array{has_default: bool, has_any_arm: bool, all_arms_constant: bool, covered_enum_cases: array<string, true>, covered_bool_values: array<string, true>, has_literal_arms: bool} $arm_info
+     */
+    private function checkEnumExhaustiveness(Node $node, UnionType $cond_type, array $arm_info): void
+    {
+        $enum_classes = $this->getEnumClassesFromUnionType($cond_type);
+
+        if (empty($enum_classes)) {
             return;
         }
 
-        // If there's a default, all cases are effectively covered
-        if ($has_default) {
-            return;
-        }
-
-        // Only warn if all match arms are enum cases from the enum classes in the condition
-        if (!$all_arms_are_enum_cases) {
+        // Only warn if there are enum cases in the arms (or no other literal arms)
+        if (empty($arm_info['covered_enum_cases']) && $arm_info['has_literal_arms']) {
             return;
         }
 
@@ -143,7 +269,7 @@ final class UncoveredEnumCasesInMatchVisitor extends PluginAwarePostAnalysisVisi
         }
 
         // Find uncovered cases
-        $uncovered_cases = array_diff_key($all_required_cases, $covered_cases);
+        $uncovered_cases = array_diff_key($all_required_cases, $arm_info['covered_enum_cases']);
 
         if (!empty($uncovered_cases)) {
             $uncovered_list = implode(', ', array_values($uncovered_cases));
@@ -166,11 +292,146 @@ final class UncoveredEnumCasesInMatchVisitor extends PluginAwarePostAnalysisVisi
     }
 
     /**
+     * Check for missing bool values (true/false)
+     *
+     * @param array{has_default: bool, has_any_arm: bool, all_arms_constant: bool, covered_enum_cases: array<string, true>, covered_bool_values: array<string, true>, has_literal_arms: bool} $arm_info
+     */
+    private function checkBoolExhaustiveness(Node $node, UnionType $cond_type, array $arm_info): void
+    {
+        // If there are no bool literals in the arms, don't warn (might be using other comparison)
+        if (empty($arm_info['covered_bool_values'])) {
+            return;
+        }
+
+        // Check if the condition type contains bool-related types
+        $has_bool_type = false;
+        $has_true_type = false;
+        $has_false_type = false;
+
+        foreach ($cond_type->getTypeSet() as $type) {
+            if ($type instanceof BoolType && !($type instanceof TrueType) && !($type instanceof FalseType)) {
+                $has_bool_type = true;
+            } elseif ($type instanceof TrueType) {
+                $has_true_type = true;
+            } elseif ($type instanceof FalseType) {
+                $has_false_type = true;
+            }
+        }
+
+        // If there's no bool type at all, nothing to check
+        if (!$has_bool_type && !$has_true_type && !$has_false_type) {
+            return;
+        }
+
+        $missing = [];
+
+        // Use Phan's type narrowing to detect what's missing:
+        // - If type is `true` (narrowed), it means only `true` was in arms -> `false` is missing
+        // - If type is `false` (narrowed), it means only `false` was in arms -> `true` is missing
+        // - If type is `bool`, check what's covered
+
+        if ($has_bool_type) {
+            // Full bool type - check what's explicitly covered
+            if (!isset($arm_info['covered_bool_values']['true'])) {
+                $missing[] = 'true';
+            }
+            if (!isset($arm_info['covered_bool_values']['false'])) {
+                $missing[] = 'false';
+            }
+        } elseif ($has_true_type && !$has_false_type) {
+            // Type narrowed to `true` - means only `true` is covered, `false` is missing
+            $missing[] = 'false';
+        } elseif ($has_false_type && !$has_true_type) {
+            // Type narrowed to `false` - means only `false` is covered, `true` is missing
+            $missing[] = 'true';
+        }
+        // If both $has_true_type and $has_false_type, then both are covered
+
+        if (!empty($missing)) {
+            $this->emitPluginIssue(
+                $this->code_base,
+                (clone $this->context)->withLineNumberStart($node->lineno),
+                'PhanPluginNonExhaustiveBoolMatch',
+                'Match expression with bool condition does not cover all cases - missing: {STRING_LITERAL}. Either add the missing cases or add a default arm.',
+                [implode(', ', $missing)],
+                \Phan\Issue::SEVERITY_NORMAL,
+                \Phan\Issue::REMEDIATION_A,
+                15091
+            );
+        }
+    }
+
+    /**
+     * Check if non-finite types (string, int, float, etc.) need a default arm
+     *
+     * @param array{has_default: bool, has_any_arm: bool, all_arms_constant: bool, covered_enum_cases: array<string, true>, covered_bool_values: array<string, true>, has_literal_arms: bool} $arm_info
+     */
+    private function checkNonFiniteTypeNeedsDefault(Node $node, UnionType $cond_type, array $arm_info): void
+    {
+        // If there's no literal arms, skip (enum-only checks are handled separately)
+        if (!$arm_info['has_literal_arms']) {
+            return;
+        }
+
+        // If there are enum cases covered, the enum check will handle it
+        if (!empty($arm_info['covered_enum_cases'])) {
+            return;
+        }
+
+        // If there are bool values covered, the bool check will handle it
+        if (!empty($arm_info['covered_bool_values'])) {
+            return;
+        }
+
+        // Check if any type in the union is non-finite
+        $non_finite_types = [];
+        foreach ($cond_type->getTypeSet() as $type) {
+            $name = $type->getName();
+            // Skip null type (can be in a union)
+            if ($name === 'null') {
+                continue;
+            }
+            // Skip bool-related types (handled by bool check)
+            if ($type instanceof BoolType || $type instanceof TrueType || $type instanceof FalseType) {
+                continue;
+            }
+            // Skip enum types (handled by enum check)
+            if ($type->isObjectWithKnownFQSEN()) {
+                $fqsen = $type->asFQSEN();
+                if ($fqsen instanceof FullyQualifiedClassName && $this->code_base->hasClassWithFQSEN($fqsen)) {
+                    $class = $this->code_base->getClassByFQSEN($fqsen);
+                    if ($class->isEnum()) {
+                        continue;
+                    }
+                }
+            }
+            // These types are non-finite
+            if (in_array($name, ['string', 'int', 'float', 'array', 'object', 'mixed', 'iterable', 'callable', 'resource'], true)) {
+                $non_finite_types[] = $name;
+            }
+        }
+
+        if (!empty($non_finite_types)) {
+            $type_list = implode('|', array_unique($non_finite_types));
+            $this->emitPluginIssue(
+                $this->code_base,
+                (clone $this->context)->withLineNumberStart($node->lineno),
+                'PhanPluginNonExhaustiveMatchNeedsDefault',
+                'Match expression with {STRING_LITERAL} condition is non-exhaustive and has no default arm. Add a default arm to handle unexpected values.',
+                [$type_list],
+                \Phan\Issue::SEVERITY_NORMAL,
+                \Phan\Issue::REMEDIATION_A,
+                15092
+            );
+        }
+    }
+
+    /**
      * Extract enum classes from a union type
      *
      * @return list<Clazz>
      */
-    private function getEnumClassesFromUnionType(\Phan\Language\UnionType $union_type): array
+    private function getEnumClassesFromUnionType(UnionType $union_type): array
     {
         $enum_classes = [];
 

--- a/.phan/plugins/UncoveredEnumCasesInMatchPlugin.php
+++ b/.phan/plugins/UncoveredEnumCasesInMatchPlugin.php
@@ -312,12 +312,29 @@ final class UncoveredEnumCasesInMatchVisitor extends PluginAwarePostAnalysisVisi
             return;
         }
 
-        // Check if the condition type contains bool-related types
+        // For simple parameter variables, use the declared type for checking exhaustiveness
+        // instead of the potentially narrowed type. This avoids issues where match-arm analysis
+        // narrows the type, making it look like control flow narrowing.
+        // Note: This may give false positives for cases like `if ($b) { match($b) { true => ... } }`
+        // where control flow guarantees only one value. Users can suppress in such cases.
+        $check_type = $cond_type;  // Default to using the analyzed type
+        if ($cond_node instanceof Node && $cond_node->kind === \ast\AST_VAR) {
+            $var_name = $cond_node->children['name'] ?? null;
+            if (is_string($var_name)) {
+                $declared_type = $this->getDeclaredVariableType($var_name);
+                if ($declared_type !== null) {
+                    // Use the declared type for exhaustiveness checking
+                    $check_type = $declared_type;
+                }
+            }
+        }
+
+        // Check if the condition type (or declared type) contains bool-related types
         $has_bool_type = false;
         $has_true_type = false;
         $has_false_type = false;
 
-        foreach ($cond_type->getTypeSet() as $type) {
+        foreach ($check_type->getTypeSet() as $type) {
             if ($type instanceof BoolType && !($type instanceof TrueType) && !($type instanceof FalseType)) {
                 $has_bool_type = true;
             } elseif ($type instanceof TrueType) {
@@ -334,10 +351,9 @@ final class UncoveredEnumCasesInMatchVisitor extends PluginAwarePostAnalysisVisi
 
         $missing = [];
 
-        // Use Phan's type narrowing to detect what's missing:
-        // - If type is `true` (narrowed), it means only `true` was in arms -> `false` is missing
-        // - If type is `false` (narrowed), it means only `false` was in arms -> `true` is missing
-        // - If type is `bool`, check what's covered
+        // Check exhaustiveness based on the declared/checked type.
+        // For full bool type, both true and false must be covered.
+        // For literal types (true or false), only that value needs to be covered.
 
         if ($has_bool_type) {
             // Full bool type - check what's explicitly covered
@@ -348,13 +364,17 @@ final class UncoveredEnumCasesInMatchVisitor extends PluginAwarePostAnalysisVisi
                 $missing[] = 'false';
             }
         } elseif ($has_true_type && !$has_false_type) {
-            // Type narrowed to `true` - means only `true` is covered, `false` is missing
-            $missing[] = 'false';
+            // Declared as literal `true` - only true needs to be covered
+            if (!isset($arm_info['covered_bool_values']['true'])) {
+                $missing[] = 'true';
+            }
         } elseif ($has_false_type && !$has_true_type) {
-            // Type narrowed to `false` - means only `false` is covered, `true` is missing
-            $missing[] = 'true';
+            // Declared as literal `false` - only false needs to be covered
+            if (!isset($arm_info['covered_bool_values']['false'])) {
+                $missing[] = 'false';
+            }
         }
-        // If both $has_true_type and $has_false_type, then both are covered
+        // If both $has_true_type and $has_false_type, then both need to be checked
 
         if (!empty($missing)) {
             $this->emitPluginIssue(
@@ -560,6 +580,42 @@ final class UncoveredEnumCasesInMatchVisitor extends PluginAwarePostAnalysisVisi
         }
 
         return $cases;
+    }
+
+    /**
+     * Get the declared type of a variable from its definition (e.g., function parameter).
+     *
+     * This returns the original declared type before any control flow narrowing.
+     *
+     * @return ?UnionType the declared type, or null if not found
+     */
+    private function getDeclaredVariableType(string $var_name): ?UnionType
+    {
+        // Check if we're in a function/method scope
+        if (!$this->context->isInFunctionLikeScope()) {
+            return null;
+        }
+
+        try {
+            $function = $this->context->getFunctionLikeInScope($this->code_base);
+        } catch (\Exception) {
+            return null;
+        }
+
+        // Check if the variable is a parameter
+        foreach ($function->getParameterList() as $parameter) {
+            if ($parameter->getName() === $var_name) {
+                // Get the declared type from the parameter
+                $param_type = $parameter->getUnionType();
+                // Try to get the real (declared) type if available
+                if ($param_type->hasRealTypeSet()) {
+                    return $param_type->getRealUnionType();
+                }
+                return $param_type;
+            }
+        }
+
+        return null;
     }
 }
 

--- a/tests/plugin_test/expected/252_uncovered_enum_cases_in_match.php.expected
+++ b/tests/plugin_test/expected/252_uncovered_enum_cases_in_match.php.expected
@@ -50,3 +50,9 @@ src/252_uncovered_enum_cases_in_match.php:294 PhanPluginNonExhaustiveBoolMatch M
 src/252_uncovered_enum_cases_in_match.php:303 PhanUnreferencedFunction Possibly zero references to function \testTrueFalseUnion2()
 src/252_uncovered_enum_cases_in_match.php:305 PhanPluginNonExhaustiveBoolMatch Match expression with bool condition does not cover all cases - missing: true. Either add the missing cases or add a default arm.
 src/252_uncovered_enum_cases_in_match.php:314 PhanUnreferencedFunction Possibly zero references to function \testTrueFalseUnion3()
+src/252_uncovered_enum_cases_in_match.php:328 PhanUnreferencedFunction Possibly zero references to function \testLiteralBool1()
+src/252_uncovered_enum_cases_in_match.php:330 PhanPluginNonExhaustiveBoolMatch Match expression with bool condition does not cover all cases - missing: true. Either add the missing cases or add a default arm.
+src/252_uncovered_enum_cases_in_match.php:336 PhanUnreferencedFunction Possibly zero references to function \testLiteralBool2()
+src/252_uncovered_enum_cases_in_match.php:338 PhanPluginNonExhaustiveBoolMatch Match expression with bool condition does not cover all cases - missing: false. Either add the missing cases or add a default arm.
+src/252_uncovered_enum_cases_in_match.php:344 PhanUnreferencedFunction Possibly zero references to function \testLiteralBool3()
+src/252_uncovered_enum_cases_in_match.php:352 PhanUnreferencedFunction Possibly zero references to function \testLiteralBool4()

--- a/tests/plugin_test/expected/252_uncovered_enum_cases_in_match.php.expected
+++ b/tests/plugin_test/expected/252_uncovered_enum_cases_in_match.php.expected
@@ -42,4 +42,4 @@ src/252_uncovered_enum_cases_in_match.php:257 PhanUnreferencedFunction Possibly 
 src/252_uncovered_enum_cases_in_match.php:266 PhanUnreferencedFunction Possibly zero references to function \testFloat1()
 src/252_uncovered_enum_cases_in_match.php:268 PhanPluginNonExhaustiveMatchNeedsDefault Match expression with float condition is non-exhaustive and has no default arm. Add a default arm to handle unexpected values.
 src/252_uncovered_enum_cases_in_match.php:275 PhanUnreferencedFunction Possibly zero references to function \testMixed1()
-src/252_uncovered_enum_cases_in_match.php:277 PhanPluginNonExhaustiveMatchNeedsDefault Match expression with string|int condition is non-exhaustive and has no default arm. Add a default arm to handle unexpected values.
+src/252_uncovered_enum_cases_in_match.php:277 PhanPluginNonExhaustiveMatchNeedsDefault Match expression with mixed condition is non-exhaustive and has no default arm. Add a default arm to handle unexpected values.

--- a/tests/plugin_test/expected/252_uncovered_enum_cases_in_match.php.expected
+++ b/tests/plugin_test/expected/252_uncovered_enum_cases_in_match.php.expected
@@ -45,3 +45,8 @@ src/252_uncovered_enum_cases_in_match.php:266 PhanUnreferencedFunction Possibly 
 src/252_uncovered_enum_cases_in_match.php:268 PhanPluginNonExhaustiveMatchNeedsDefault Match expression with float condition is non-exhaustive and has no default arm. Add a default arm to handle unexpected values.
 src/252_uncovered_enum_cases_in_match.php:275 PhanUnreferencedFunction Possibly zero references to function \testMixed1()
 src/252_uncovered_enum_cases_in_match.php:277 PhanPluginNonExhaustiveMatchNeedsDefault Match expression with mixed condition is non-exhaustive and has no default arm. Add a default arm to handle unexpected values.
+src/252_uncovered_enum_cases_in_match.php:292 PhanUnreferencedFunction Possibly zero references to function \testTrueFalseUnion1()
+src/252_uncovered_enum_cases_in_match.php:294 PhanPluginNonExhaustiveBoolMatch Match expression with bool condition does not cover all cases - missing: false. Either add the missing cases or add a default arm.
+src/252_uncovered_enum_cases_in_match.php:303 PhanUnreferencedFunction Possibly zero references to function \testTrueFalseUnion2()
+src/252_uncovered_enum_cases_in_match.php:305 PhanPluginNonExhaustiveBoolMatch Match expression with bool condition does not cover all cases - missing: true. Either add the missing cases or add a default arm.
+src/252_uncovered_enum_cases_in_match.php:314 PhanUnreferencedFunction Possibly zero references to function \testTrueFalseUnion3()

--- a/tests/plugin_test/expected/252_uncovered_enum_cases_in_match.php.expected
+++ b/tests/plugin_test/expected/252_uncovered_enum_cases_in_match.php.expected
@@ -6,6 +6,7 @@ src/252_uncovered_enum_cases_in_match.php:55 PhanUnreferencedFunction Possibly z
 src/252_uncovered_enum_cases_in_match.php:57 PhanPluginUncoveredEnumCasesInMatch Match expression with \Suit|\Game condition does not cover all cases - missing: Poker, Solitaire, Blackjack. Either add the missing cases or add a default arm to handle them.
 src/252_uncovered_enum_cases_in_match.php:66 PhanUnreferencedFunction Possibly zero references to function \testMatchEnum5()
 src/252_uncovered_enum_cases_in_match.php:81 PhanUnreferencedFunction Possibly zero references to function \testMatchEnum6()
+src/252_uncovered_enum_cases_in_match.php:83 PhanPluginNonExhaustiveMatchNeedsDefault Match expression with string|int|array condition is non-exhaustive and has no default arm. Add a default arm to handle unexpected values.
 src/252_uncovered_enum_cases_in_match.php:83 PhanPluginUncoveredEnumCasesInMatch Match expression with \Suit condition does not cover all cases - missing: Clubs. Either add the missing cases or add a default arm to handle them.
 src/252_uncovered_enum_cases_in_match.php:91 PhanUnreferencedFunction Possibly zero references to function \testMatchEnum7()
 src/252_uncovered_enum_cases_in_match.php:101 PhanUnreferencedFunction Possibly zero references to function \testMatchEnum8()
@@ -23,6 +24,7 @@ src/252_uncovered_enum_cases_in_match.php:147 PhanNoopMatchArms This match expre
 src/252_uncovered_enum_cases_in_match.php:153 PhanUnreferencedFunction Possibly zero references to function \testMatchEnum14()
 src/252_uncovered_enum_cases_in_match.php:155 PhanPluginNonExhaustiveMatchNeedsDefault Match expression with int condition is non-exhaustive and has no default arm. Add a default arm to handle unexpected values.
 src/252_uncovered_enum_cases_in_match.php:162 PhanUnreferencedFunction Possibly zero references to function \testMatchEnum15()
+src/252_uncovered_enum_cases_in_match.php:164 PhanPluginNonExhaustiveMatchNeedsDefault Match expression with int condition is non-exhaustive and has no default arm. Add a default arm to handle unexpected values.
 src/252_uncovered_enum_cases_in_match.php:164 PhanPluginUncoveredEnumCasesInMatch Match expression with \Suit condition does not cover all cases - missing: Spades, Diamonds, Clubs. Either add the missing cases or add a default arm to handle them.
 src/252_uncovered_enum_cases_in_match.php:176 PhanUnreferencedFunction Possibly zero references to function \testBool1()
 src/252_uncovered_enum_cases_in_match.php:178 PhanPluginNonExhaustiveBoolMatch Match expression with bool condition does not cover all cases - missing: false. Either add the missing cases or add a default arm.

--- a/tests/plugin_test/expected/252_uncovered_enum_cases_in_match.php.expected
+++ b/tests/plugin_test/expected/252_uncovered_enum_cases_in_match.php.expected
@@ -63,3 +63,8 @@ src/252_uncovered_enum_cases_in_match.php:375 PhanPluginNonExhaustiveMatchNeedsD
 src/252_uncovered_enum_cases_in_match.php:381 PhanUnreferencedFunction Possibly zero references to function \testObjectMatch3()
 src/252_uncovered_enum_cases_in_match.php:390 PhanUnreferencedFunction Possibly zero references to function \testObjectMatch4()
 src/252_uncovered_enum_cases_in_match.php:392 PhanPluginNonExhaustiveMatchNeedsDefault Match expression with \DateTime|string condition is non-exhaustive and has no default arm. Add a default arm to handle unexpected values.
+src/252_uncovered_enum_cases_in_match.php:404 PhanUnreferencedFunction Possibly zero references to function \testNonConstantArm1()
+src/252_uncovered_enum_cases_in_match.php:412 PhanUnreferencedFunction Possibly zero references to function \testNonConstantArm2()
+src/252_uncovered_enum_cases_in_match.php:420 PhanUnreferencedFunction Possibly zero references to function \testNonConstantArm3()
+src/252_uncovered_enum_cases_in_match.php:428 PhanUnreferencedFunction Possibly zero references to function \testConstantArm1()
+src/252_uncovered_enum_cases_in_match.php:430 PhanPluginNonExhaustiveMatchNeedsDefault Match expression with int condition is non-exhaustive and has no default arm. Add a default arm to handle unexpected values.

--- a/tests/plugin_test/expected/252_uncovered_enum_cases_in_match.php.expected
+++ b/tests/plugin_test/expected/252_uncovered_enum_cases_in_match.php.expected
@@ -21,4 +21,25 @@ src/252_uncovered_enum_cases_in_match.php:140 PhanNoopMatchExpression The result
 src/252_uncovered_enum_cases_in_match.php:145 PhanUnreferencedFunction Possibly zero references to function \testMatchEnum13()
 src/252_uncovered_enum_cases_in_match.php:147 PhanNoopMatchArms This match expression only has the default arm in match ($suit) { default => 'Any suit' }
 src/252_uncovered_enum_cases_in_match.php:153 PhanUnreferencedFunction Possibly zero references to function \testMatchEnum14()
+src/252_uncovered_enum_cases_in_match.php:155 PhanPluginNonExhaustiveMatchNeedsDefault Match expression with int condition is non-exhaustive and has no default arm. Add a default arm to handle unexpected values.
 src/252_uncovered_enum_cases_in_match.php:162 PhanUnreferencedFunction Possibly zero references to function \testMatchEnum15()
+src/252_uncovered_enum_cases_in_match.php:164 PhanPluginUncoveredEnumCasesInMatch Match expression with \Suit condition does not cover all cases - missing: Spades, Diamonds, Clubs. Either add the missing cases or add a default arm to handle them.
+src/252_uncovered_enum_cases_in_match.php:176 PhanUnreferencedFunction Possibly zero references to function \testBool1()
+src/252_uncovered_enum_cases_in_match.php:178 PhanPluginNonExhaustiveBoolMatch Match expression with bool condition does not cover all cases - missing: false. Either add the missing cases or add a default arm.
+src/252_uncovered_enum_cases_in_match.php:184 PhanUnreferencedFunction Possibly zero references to function \testBool2()
+src/252_uncovered_enum_cases_in_match.php:186 PhanPluginNonExhaustiveBoolMatch Match expression with bool condition does not cover all cases - missing: true. Either add the missing cases or add a default arm.
+src/252_uncovered_enum_cases_in_match.php:192 PhanUnreferencedFunction Possibly zero references to function \testBool3()
+src/252_uncovered_enum_cases_in_match.php:201 PhanUnreferencedFunction Possibly zero references to function \testBool4()
+src/252_uncovered_enum_cases_in_match.php:210 PhanUnreferencedFunction Possibly zero references to function \testBool5()
+src/252_uncovered_enum_cases_in_match.php:212 PhanPluginNonExhaustiveBoolMatch Match expression with bool condition does not cover all cases - missing: false. Either add the missing cases or add a default arm.
+src/252_uncovered_enum_cases_in_match.php:218 PhanUnreferencedFunction Possibly zero references to function \testBoolVarArm()
+src/252_uncovered_enum_cases_in_match.php:230 PhanUnreferencedFunction Possibly zero references to function \testString1()
+src/252_uncovered_enum_cases_in_match.php:232 PhanPluginNonExhaustiveMatchNeedsDefault Match expression with string condition is non-exhaustive and has no default arm. Add a default arm to handle unexpected values.
+src/252_uncovered_enum_cases_in_match.php:239 PhanUnreferencedFunction Possibly zero references to function \testString2()
+src/252_uncovered_enum_cases_in_match.php:248 PhanUnreferencedFunction Possibly zero references to function \testInt1()
+src/252_uncovered_enum_cases_in_match.php:250 PhanPluginNonExhaustiveMatchNeedsDefault Match expression with int condition is non-exhaustive and has no default arm. Add a default arm to handle unexpected values.
+src/252_uncovered_enum_cases_in_match.php:257 PhanUnreferencedFunction Possibly zero references to function \testInt2()
+src/252_uncovered_enum_cases_in_match.php:266 PhanUnreferencedFunction Possibly zero references to function \testFloat1()
+src/252_uncovered_enum_cases_in_match.php:268 PhanPluginNonExhaustiveMatchNeedsDefault Match expression with float condition is non-exhaustive and has no default arm. Add a default arm to handle unexpected values.
+src/252_uncovered_enum_cases_in_match.php:275 PhanUnreferencedFunction Possibly zero references to function \testMixed1()
+src/252_uncovered_enum_cases_in_match.php:277 PhanPluginNonExhaustiveMatchNeedsDefault Match expression with string|int condition is non-exhaustive and has no default arm. Add a default arm to handle unexpected values.

--- a/tests/plugin_test/expected/252_uncovered_enum_cases_in_match.php.expected
+++ b/tests/plugin_test/expected/252_uncovered_enum_cases_in_match.php.expected
@@ -56,3 +56,10 @@ src/252_uncovered_enum_cases_in_match.php:336 PhanUnreferencedFunction Possibly 
 src/252_uncovered_enum_cases_in_match.php:338 PhanPluginNonExhaustiveBoolMatch Match expression with bool condition does not cover all cases - missing: false. Either add the missing cases or add a default arm.
 src/252_uncovered_enum_cases_in_match.php:344 PhanUnreferencedFunction Possibly zero references to function \testLiteralBool3()
 src/252_uncovered_enum_cases_in_match.php:352 PhanUnreferencedFunction Possibly zero references to function \testLiteralBool4()
+src/252_uncovered_enum_cases_in_match.php:365 PhanUnreferencedFunction Possibly zero references to function \testObjectMatch1()
+src/252_uncovered_enum_cases_in_match.php:367 PhanPluginNonExhaustiveMatchNeedsDefault Match expression with \DateTime condition is non-exhaustive and has no default arm. Add a default arm to handle unexpected values.
+src/252_uncovered_enum_cases_in_match.php:373 PhanUnreferencedFunction Possibly zero references to function \testObjectMatch2()
+src/252_uncovered_enum_cases_in_match.php:375 PhanPluginNonExhaustiveMatchNeedsDefault Match expression with \stdClass condition is non-exhaustive and has no default arm. Add a default arm to handle unexpected values.
+src/252_uncovered_enum_cases_in_match.php:381 PhanUnreferencedFunction Possibly zero references to function \testObjectMatch3()
+src/252_uncovered_enum_cases_in_match.php:390 PhanUnreferencedFunction Possibly zero references to function \testObjectMatch4()
+src/252_uncovered_enum_cases_in_match.php:392 PhanPluginNonExhaustiveMatchNeedsDefault Match expression with \DateTime|string condition is non-exhaustive and has no default arm. Add a default arm to handle unexpected values.

--- a/tests/plugin_test/src/252_uncovered_enum_cases_in_match.php
+++ b/tests/plugin_test/src/252_uncovered_enum_cases_in_match.php
@@ -355,3 +355,42 @@ function testLiteralBool4(): string
         false => 'no',
     };
 }
+
+// ============================================
+// Non-enum object type tests
+// (Objects are non-finite, need default arm)
+// ============================================
+
+// Test 35: Match on DateTime without default - should warn
+function testObjectMatch1(DateTime $dt): string
+{
+    return match ($dt) {
+        new DateTime('2020-01-01') => 'new year',
+    };
+}
+
+// Test 36: Match on stdClass without default - should warn
+function testObjectMatch2(stdClass $obj): string
+{
+    return match ($obj) {
+        new stdClass() => 'empty',
+    };
+}
+
+// Test 37: Match on DateTime with default - should NOT warn
+function testObjectMatch3(DateTime $dt): string
+{
+    return match ($dt) {
+        new DateTime('2020-01-01') => 'new year',
+        default => 'other date',
+    };
+}
+
+// Test 38: Match on union of object and string - should warn for both
+function testObjectMatch4(DateTime|string $val): string
+{
+    return match ($val) {
+        new DateTime('2020-01-01') => 'new year',
+        'hello' => 'greeting',
+    };
+}

--- a/tests/plugin_test/src/252_uncovered_enum_cases_in_match.php
+++ b/tests/plugin_test/src/252_uncovered_enum_cases_in_match.php
@@ -167,3 +167,115 @@ function testMatchEnum15(Suit|int $var): string
         2 => 'two',
     };
 }
+
+// ============================================
+// Bool exhaustiveness tests
+// ============================================
+
+// Test 16: Bool missing false - should warn
+function testBool1(bool $b): string
+{
+    return match ($b) {
+        true => 'yes',
+    };
+}
+
+// Test 17: Bool missing true - should warn
+function testBool2(bool $b): string
+{
+    return match ($b) {
+        false => 'no',
+    };
+}
+
+// Test 18: Bool all cases covered - should NOT warn
+function testBool3(bool $b): string
+{
+    return match ($b) {
+        true => 'yes',
+        false => 'no',
+    };
+}
+
+// Test 19: Bool with default - should NOT warn
+function testBool4(bool $b): string
+{
+    return match ($b) {
+        true => 'yes',
+        default => 'other',
+    };
+}
+
+// Test 20: Nullable bool - only checks true/false, not null - should warn
+function testBool5(?bool $b): string
+{
+    return match ($b) {
+        true => 'yes',
+    };
+}
+
+// Test 21: Variable arm condition - should NOT warn (false positive prevention)
+function testBoolVarArm(bool $a, bool $b): string
+{
+    return match ($a) {
+        $b => 'equal',
+    };
+}
+
+// ============================================
+// Non-finite type tests (need default)
+// ============================================
+
+// Test 22: String without default - should warn
+function testString1(string $s): string
+{
+    return match ($s) {
+        'a' => 'A',
+        'b' => 'B',
+    };
+}
+
+// Test 23: String with default - should NOT warn
+function testString2(string $s): string
+{
+    return match ($s) {
+        'a' => 'A',
+        default => 'other',
+    };
+}
+
+// Test 24: Int without default - should warn
+function testInt1(int $i): string
+{
+    return match ($i) {
+        1 => 'one',
+        2 => 'two',
+    };
+}
+
+// Test 25: Int with default - should NOT warn
+function testInt2(int $i): string
+{
+    return match ($i) {
+        1 => 'one',
+        default => 'other',
+    };
+}
+
+// Test 26: Float without default - should warn
+function testFloat1(float $f): string
+{
+    return match ($f) {
+        1.0 => 'one',
+        2.0 => 'two',
+    };
+}
+
+// Test 27: Mixed type - should warn (needs default)
+function testMixed1(mixed $m): string
+{
+    return match ($m) {
+        'a' => 'A',
+        1 => 'one',
+    };
+}

--- a/tests/plugin_test/src/252_uncovered_enum_cases_in_match.php
+++ b/tests/plugin_test/src/252_uncovered_enum_cases_in_match.php
@@ -318,3 +318,40 @@ function testTrueFalseUnion3($b): string
         false => 'no',
     };
 }
+
+// ============================================
+// Literal bool condition tests
+// (match(true) or match(false) as the condition)
+// ============================================
+
+// Test 31: match(true) with only false arm - should warn (missing true)
+function testLiteralBool1(): string
+{
+    return match (true) {
+        false => 'no',
+    };
+}
+
+// Test 32: match(false) with only true arm - should warn (missing false)
+function testLiteralBool2(): string
+{
+    return match (false) {
+        true => 'yes',
+    };
+}
+
+// Test 33: match(true) with true arm - should NOT warn (exhaustive)
+function testLiteralBool3(): string
+{
+    return match (true) {
+        true => 'yes',
+    };
+}
+
+// Test 34: match(false) with false arm - should NOT warn (exhaustive)
+function testLiteralBool4(): string
+{
+    return match (false) {
+        false => 'no',
+    };
+}

--- a/tests/plugin_test/src/252_uncovered_enum_cases_in_match.php
+++ b/tests/plugin_test/src/252_uncovered_enum_cases_in_match.php
@@ -279,3 +279,42 @@ function testMixed1(mixed $m): string
         1 => 'one',
     };
 }
+
+// ============================================
+// PHPDoc true|false literal type tests
+// (These have both TrueType and FalseType in the union)
+// ============================================
+
+/**
+ * Test 28: PHPDoc true|false missing false - should warn
+ * @param true|false $b
+ */
+function testTrueFalseUnion1($b): string
+{
+    return match ($b) {
+        true => 'yes',
+    };
+}
+
+/**
+ * Test 29: PHPDoc true|false missing true - should warn
+ * @param true|false $b
+ */
+function testTrueFalseUnion2($b): string
+{
+    return match ($b) {
+        false => 'no',
+    };
+}
+
+/**
+ * Test 30: PHPDoc true|false all covered - should NOT warn
+ * @param true|false $b
+ */
+function testTrueFalseUnion3($b): string
+{
+    return match ($b) {
+        true => 'yes',
+        false => 'no',
+    };
+}

--- a/tests/plugin_test/src/252_uncovered_enum_cases_in_match.php
+++ b/tests/plugin_test/src/252_uncovered_enum_cases_in_match.php
@@ -394,3 +394,40 @@ function testObjectMatch4(DateTime|string $val): string
         'hello' => 'greeting',
     };
 }
+
+// ============================================
+// Non-constant arm expression tests
+// (Arms containing variables should not trigger exhaustiveness warnings)
+// ============================================
+
+// Test 39: Variable in binary expression - should NOT warn (not constant arm)
+function testNonConstantArm1(bool $b): string
+{
+    return match ($b) {
+        $b && true => 'ok',
+    };
+}
+
+// Test 40: Variable in arithmetic - should NOT warn
+function testNonConstantArm2(int $x): string
+{
+    return match ($x) {
+        $x + 0 => 'same',
+    };
+}
+
+// Test 41: Function call in arm - should NOT warn (not constant)
+function testNonConstantArm3(int $x): string
+{
+    return match ($x) {
+        rand(0, 10) => 'random',
+    };
+}
+
+// Test 42: Constant binary expression (no variables) - SHOULD warn
+function testConstantArm1(int $x): string
+{
+    return match ($x) {
+        1 + 2 => 'three',
+    };
+}

--- a/tests/plugin_test/src/252_uncovered_enum_cases_in_match.php
+++ b/tests/plugin_test/src/252_uncovered_enum_cases_in_match.php
@@ -76,8 +76,8 @@ function testMatchEnum5(Suit|Game $var): string
     };
 }
 
-// Test 6: Union with non-enum types - should NOT warn
-// (because not all arms are enum cases)
+// Test 6: Union with non-enum types - should warn about non-finite types needing default
+// (string|int|array are non-finite and need a default arm)
 function testMatchEnum6(Suit|string|int|array $suit): string
 {
     return match ($suit) {
@@ -158,7 +158,7 @@ function testMatchEnum14(int $x): string
     };
 }
 
-// Test 15: Mixed types but some arms are not enum cases - should NOT warn
+// Test 15: Mixed types with int - should warn about int needing default
 function testMatchEnum15(Suit|int $var): string
 {
     return match ($var) {


### PR DESCRIPTION
Enhanced `.phan/plugins/UncoveredEnumCasesInMatchPlugin.php`:
  - Added bool exhaustiveness checking (`PhanPluginNonExhaustiveBoolMatch`)
  - Added non-finite type warning (`PhanPluginNonExhaustiveMatchNeedsDefault`)
  - Added false positive prevention for variable arm conditions
  - Added helper methods: `getBoolLiteralFromExpression()`, `isConstantExpression()`

  New Issue Types

  | Issue Type                               | When Triggered                                             |
  |------------------------------------------|------------------------------------------------------------|
  | PhanPluginNonExhaustiveBoolMatch         | Bool match missing true or false                           |
  | PhanPluginNonExhaustiveMatchNeedsDefault | Non-finite type (string, int, float, etc.) without default |
  | PhanPluginUncoveredEnumCasesInMatch      | (existing) Enum match missing cases                        |