### PR TITLE
Fixes #5389

### DIFF
--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -4366,9 +4366,16 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             }
 
             $kind = $argument->kind;
-            if ($kind === ast\AST_CLOSURE) {
+            if ($kind === ast\AST_CLOSURE || $kind === ast\AST_ARROW_FUNC) {
                 if (Config::get_track_references()) {
                     $this->trackReferenceToClosure($argument);
+                }
+            } elseif ($kind === ast\AST_ARRAY) {
+                // When dead_code_detection_prefer_false_negative is true (default),
+                // mark closures inside arrays passed as function arguments as referenced
+                // to avoid false positives (fixes #5389)
+                if (Config::get_track_references() && Config::getValue('dead_code_detection_prefer_false_negative')) {
+                    $this->trackReferencesToClosuresInArray($argument);
                 }
             }
 
@@ -4673,6 +4680,32 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             $method->addReference($inner_context);
         } catch (Exception) {
             // Swallow it
+        }
+    }
+
+    /**
+     * Recursively find and track references to closures inside an array node.
+     * This prevents false positive PhanUnreferencedClosure warnings for closures
+     * passed inside arrays to function arguments.
+     */
+    private function trackReferencesToClosuresInArray(Node $array_node): void
+    {
+        foreach ($array_node->children as $child) {
+            if (!$child instanceof Node) {
+                continue;
+            }
+            // Handle AST_ARRAY_ELEM nodes
+            if ($child->kind === ast\AST_ARRAY_ELEM) {
+                $value = $child->children['value'];
+                if ($value instanceof Node) {
+                    if ($value->kind === ast\AST_CLOSURE || $value->kind === ast\AST_ARROW_FUNC) {
+                        $this->trackReferenceToClosure($value);
+                    } elseif ($value->kind === ast\AST_ARRAY) {
+                        // Recursively handle nested arrays
+                        $this->trackReferencesToClosuresInArray($value);
+                    }
+                }
+            }
         }
     }
 

--- a/tests/plugin_test/expected/017_unreferenced_closure.php.expected
+++ b/tests/plugin_test/expected/017_unreferenced_closure.php.expected
@@ -1,1 +1,1 @@
-src/017_unreferenced_closure.php:10 PhanUnreferencedClosure Possibly zero references to Closure(string $x)
+src/017_unreferenced_closure.php:12 PhanUnreferencedClosure Possibly zero references to Closure(string $x)

--- a/tests/plugin_test/src/017_unreferenced_closure.php
+++ b/tests/plugin_test/src/017_unreferenced_closure.php
@@ -1,13 +1,48 @@
 <?php
 /**
  * Simple test of Phan's ability to infer if a closure is unused.
- * Phan has false positives with arrays, as well as closures being returned from functions.
+ * Closures in arrays that are not passed to functions are correctly flagged as unused.
+ * Closures in arrays passed as function arguments should NOT be flagged (issue #5389).
  * @suppress PhanNoopArray
  */
 function test17() {
     [
         (static function(string $x) { echo "$x\n"; })('test'),
+        // This closure IS unreferenced - it's in an unused array literal
         [static function(string $x) { echo "$x\n"; }],
     ];
 }
 test17();
+
+/**
+ * Test for issue #5389: Closures in arrays passed to functions should be referenced.
+ * @param list<Closure> $closures
+ */
+function takesClosures17(array $closures): void {
+    $closures[0]();
+}
+
+// This closure should NOT trigger PhanUnreferencedClosure (issue #5389 fix)
+takesClosures17([
+    static function(): void {
+        echo "Hello world\n";
+    }
+]);
+
+// Test arrow functions in arrays passed to functions
+takesClosures17([
+    static fn(): string => "Arrow function"
+]);
+
+/**
+ * Test nested arrays - closures inside should also be referenced.
+ * @param array<int,array<int,Closure>> $closures
+ */
+function takesNestedClosures17(array $closures): void {
+    $closures[0][0]();
+}
+
+// Nested array with closure should also be referenced
+takesNestedClosures17([
+    [static function(): void { echo "Nested\n"; }]
+]);


### PR DESCRIPTION
- Modified `analyzeCallToFunctionLike()` to also check for `AST_ARRAY` arguments (in addition to closures and arrow functions)
- Added new helper method `trackReferencesToClosuresInArray()` that recursively finds closures inside array arguments and marks them as referenced
- The fix only applies when dead_code_detection_prefer_false_negative is true (the default), aligning with Phan's philosophy of preferring false negatives over false positives for dead code detection