### PR TITLE
Fixes #5390

### DIFF
--- a/src/Phan/Analysis/ReferenceCountsAnalyzer.php
+++ b/src/Phan/Analysis/ReferenceCountsAnalyzer.php
@@ -464,8 +464,12 @@ class ReferenceCountsAnalyzer
             if (Config::get_closest_minimum_target_php_version_id() < 80200) {
                 $default_type = $property->getDefaultType();
                 // Check that the property has an actual initializer value, not just a declaration.
-                // Properties without initializers have a default_type of NullType (see ParseVisitor line 894).
-                if ($default_type !== null && !$default_type->isType(NullType::instance(false))) {
+                // Properties without initializers have a default_type of NullType with real type set
+                // (see ParseVisitor line 894). Properties initialized to literal `null` also have
+                // NullType but WITHOUT real type set (erased in resolveDefaultPropertyNode).
+                $is_uninitialized = $default_type === null ||
+                    ($default_type->isType(NullType::instance(false)) && $default_type->hasRealTypeSet());
+                if (!$is_uninitialized) {
                     $class_fqsen = $property->getClassFQSEN();
                     if ($code_base->hasClassWithFQSEN($class_fqsen)) {
                         $class = $code_base->getClassByFQSEN($class_fqsen);

--- a/src/Phan/Analysis/ReferenceCountsAnalyzer.php
+++ b/src/Phan/Analysis/ReferenceCountsAnalyzer.php
@@ -461,7 +461,7 @@ class ReferenceCountsAnalyzer
         // Traits cannot have constants before PHP 8.2, so using initialized properties
         // as pseudo-constants is a common pattern (fixes #5390).
         if (Config::getValue('dead_code_detection_prefer_false_negative')) {
-            if (Config::get_closest_minimum_target_php_version_id() < 80200) {
+            if (Config::get_closest_target_php_version_id() < 80200) {
                 $default_type = $property->getDefaultType();
                 // Check that the property has an actual initializer value, not just a declaration.
                 // Properties without initializers have a default_type of NullType with real type set

--- a/src/Phan/Analysis/ReferenceCountsAnalyzer.php
+++ b/src/Phan/Analysis/ReferenceCountsAnalyzer.php
@@ -455,6 +455,23 @@ class ReferenceCountsAnalyzer
             // Handle annotations such as property-read and phan-read-only.
             return;
         }
+        // When dead_code_detection_prefer_false_negative is true (default),
+        // skip warnings for initialized properties in traits when targeting PHP < 8.2.
+        // Traits cannot have constants before PHP 8.2, so using initialized properties
+        // as pseudo-constants is a common pattern (fixes #5390).
+        if (Config::getValue('dead_code_detection_prefer_false_negative')) {
+            if (Config::get_closest_minimum_target_php_version_id() < 80200) {
+                if ($property->getDefaultType() !== null) {
+                    $class_fqsen = $property->getClassFQSEN();
+                    if ($code_base->hasClassWithFQSEN($class_fqsen)) {
+                        $class = $code_base->getClassByFQSEN($class_fqsen);
+                        if ($class->isTrait()) {
+                            return;
+                        }
+                    }
+                }
+            }
+        }
         if ($property->isFromPHPDoc()) {
             $issue_type = Issue::ReadOnlyPHPDocProperty;
         } elseif ($property->isPrivate()) {

--- a/src/Phan/Analysis/ReferenceCountsAnalyzer.php
+++ b/src/Phan/Analysis/ReferenceCountsAnalyzer.php
@@ -27,6 +27,7 @@ use Phan\Language\FQSEN\FullyQualifiedGlobalConstantName;
 use Phan\Language\FQSEN\FullyQualifiedGlobalStructuralElement;
 use Phan\Language\FQSEN\FullyQualifiedMethodName;
 use Phan\Language\FQSEN\FullyQualifiedPropertyName;
+use Phan\Language\Type\NullType;
 use TypeError;
 
 /**
@@ -461,7 +462,10 @@ class ReferenceCountsAnalyzer
         // as pseudo-constants is a common pattern (fixes #5390).
         if (Config::getValue('dead_code_detection_prefer_false_negative')) {
             if (Config::get_closest_minimum_target_php_version_id() < 80200) {
-                if ($property->getDefaultType() !== null) {
+                $default_type = $property->getDefaultType();
+                // Check that the property has an actual initializer value, not just a declaration.
+                // Properties without initializers have a default_type of NullType (see ParseVisitor line 894).
+                if ($default_type !== null && !$default_type->isType(NullType::instance(false))) {
                     $class_fqsen = $property->getClassFQSEN();
                     if ($code_base->hasClassWithFQSEN($class_fqsen)) {
                         $class = $code_base->getClassByFQSEN($class_fqsen);

--- a/tests/plugin_test/expected/084_read_only_property.php.expected
+++ b/tests/plugin_test/expected/084_read_only_property.php.expected
@@ -1,3 +1,4 @@
 src/084_read_only_property.php:4 PhanReadOnlyPrivateProperty Possibly zero write references to private property \X84->arr
 src/084_read_only_property.php:5 PhanReadOnlyProtectedProperty Possibly zero write references to protected property \X84->count
 src/084_read_only_property.php:10 PhanPluginUseReturnValueKnown Expected to use the return value of the user-defined function/method \X84::main() defined at src/084_read_only_property.php:6
+src/084_read_only_property.php:37 PhanReadOnlyPrivateProperty Possibly zero write references to private property \TraitWithUninitializedProperty84->uninitializedProp

--- a/tests/plugin_test/src/084_read_only_property.php
+++ b/tests/plugin_test/src/084_read_only_property.php
@@ -27,3 +27,22 @@ class UsesTraitWithPseudoConstant84 {
 }
 
 (new UsesTraitWithPseudoConstant84())->getConst();
+
+/**
+ * Test that trait properties WITHOUT initializers still trigger warnings.
+ * Only initialized properties should be exempt from read-only warnings.
+ */
+trait TraitWithUninitializedProperty84 {
+    /** @var int */
+    private $uninitializedProp;
+
+    public function getUninit(): int {
+        return $this->uninitializedProp;
+    }
+}
+
+class UsesTraitWithUninitializedProperty84 {
+    use TraitWithUninitializedProperty84;
+}
+
+(new UsesTraitWithUninitializedProperty84())->getUninit();

--- a/tests/plugin_test/src/084_read_only_property.php
+++ b/tests/plugin_test/src/084_read_only_property.php
@@ -8,3 +8,22 @@ class X84 {
     }
 }
 (new X84())->main();
+
+/**
+ * Test for issue #5390 - traits can't have constants in PHP < 8.2,
+ * so initialized properties used as pseudo-constants should NOT
+ * trigger PhanReadOnlyPrivateProperty when dead_code_detection_prefer_false_negative is true.
+ */
+trait TraitWithPseudoConstant84 {
+    private static $ALMOST_CONST = 42;
+
+    public function getConst(): int {
+        return self::$ALMOST_CONST;
+    }
+}
+
+class UsesTraitWithPseudoConstant84 {
+    use TraitWithPseudoConstant84;
+}
+
+(new UsesTraitWithPseudoConstant84())->getConst();

--- a/tests/plugin_test/src/084_read_only_property.php
+++ b/tests/plugin_test/src/084_read_only_property.php
@@ -46,3 +46,21 @@ class UsesTraitWithUninitializedProperty84 {
 }
 
 (new UsesTraitWithUninitializedProperty84())->getUninit();
+
+/**
+ * Test that trait properties initialized to null are also exempt.
+ * The null literal is a valid initializer for pseudo-constants.
+ */
+trait TraitWithNullInitializer84 {
+    private static $NULL_CONST = null;
+
+    public function getNullConst(): ?int {
+        return self::$NULL_CONST;
+    }
+}
+
+class UsesTraitWithNullInitializer84 {
+    use TraitWithNullInitializer84;
+}
+
+(new UsesTraitWithNullInitializer84())->getNullConst();


### PR DESCRIPTION
Added a check in `maybeWarnReadOnlyProperty()` to skip `PhanReadOnlyPrivateProperty` (and similar) warnings for initialized properties in traits when:
  - dead_code_detection_prefer_false_negative is true (the default)
  - Target PHP version is < 8.2
  - The property has a default value (initialization)
  - The property is defined in a trait