### PR TITLE
Fixes #5391

### DIFF
--- a/src/Phan/Analysis/ReferenceCountsAnalyzer.php
+++ b/src/Phan/Analysis/ReferenceCountsAnalyzer.php
@@ -274,11 +274,66 @@ class ReferenceCountsAnalyzer
                 if ($element->isDynamicProperty()) {
                     continue;
                 }
+                // Copy references from trait magic properties with same name (Issue #5391)
+                self::copyReferencesFromTraitMagicProperties($code_base, $element);
                 // TODO: may want to continue to skip `if ($defining_class->hasGetOrSetMethod($code_base)) {`
                 // E.g. a __get() method that is implemented as `return $this->"_$name"`.
                 // (at)phan-file-suppress is an easy enough workaround, though
             }
             yield $element;
+        }
+    }
+
+    /**
+     * For classes that use traits, copy references from the trait's magic properties
+     * (defined via @property) to the class's real properties with the same name.
+     * This handles the case where a trait method accesses $this->prop and the class
+     * defines its own property with the same name. (Issue #5391)
+     */
+    private static function copyReferencesFromTraitMagicProperties(
+        CodeBase $code_base,
+        Property $class_property
+    ): void {
+        // Only process real properties (not magic/dynamic properties)
+        if ($class_property->isFromPHPDoc() || $class_property->isDynamicProperty()) {
+            return;
+        }
+
+        $class_fqsen = $class_property->getClassFQSEN();
+        if (!$code_base->hasClassWithFQSEN($class_fqsen)) {
+            return;
+        }
+
+        $clazz = $code_base->getClassByFQSEN($class_fqsen);
+        $property_name = $class_property->getName();
+
+        // Iterate through traits used by this class
+        foreach ($clazz->getTraitFQSENList() as $trait_fqsen) {
+            if (!$code_base->hasClassWithFQSEN($trait_fqsen)) {
+                continue;
+            }
+
+            // Check if the trait has a magic property with the same name
+            $trait_property_fqsen = FullyQualifiedPropertyName::make(
+                $trait_fqsen,
+                $property_name
+            );
+
+            if (!$code_base->hasPropertyWithFQSEN($trait_property_fqsen)) {
+                continue;
+            }
+
+            $trait_property = $code_base->getPropertyByFQSEN($trait_property_fqsen);
+
+            // Only copy from magic properties (those defined via @property)
+            if (!$trait_property->isFromPHPDoc()) {
+                continue;
+            }
+
+            // Copy references from the trait's magic property to the class's real property
+            if ($trait_property->getReferenceCount($code_base) > 0) {
+                $class_property->copyReferencesFrom($trait_property);
+            }
         }
     }
 

--- a/src/Phan/Analysis/ReferenceCountsAnalyzer.php
+++ b/src/Phan/Analysis/ReferenceCountsAnalyzer.php
@@ -294,8 +294,9 @@ class ReferenceCountsAnalyzer
         CodeBase $code_base,
         Property $class_property
     ): void {
-        // Only process real properties (not magic/dynamic properties)
-        if ($class_property->isFromPHPDoc() || $class_property->isDynamicProperty()) {
+        // Only process real instance properties (not magic/dynamic/static properties)
+        // @property annotations only apply to instance properties accessed via $this->prop
+        if ($class_property->isFromPHPDoc() || $class_property->isDynamicProperty() || $class_property->isStatic()) {
             return;
         }
 

--- a/tests/files/src/5391_trait_property_reference.php
+++ b/tests/files/src/5391_trait_property_reference.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Test for Issue #5391: PhanUnreferencedPrivateProperty false positive when
+ * a trait method references a property defined by the class using the trait.
+ *
+ * @property string $prop
+ */
+trait MyTrait5391 {
+    public function printProp(): void {
+        echo $this->prop;
+    }
+}
+
+class MyClass5391 {
+    use MyTrait5391;
+
+    private string $prop = 'foo';
+
+    public function __construct() {
+        $this->prop = 'bar';  // Write reference
+    }
+}
+
+$x = new MyClass5391();
+$x->printProp();


### PR DESCRIPTION
  ## The Problem

  When a trait method accesses `$this->prop`, and a class uses that trait while defining its own private string $prop, Phan incorrectly reported
  `PhanUnreferencedPrivateProperty` because:
  1. Trait methods are analyzed in the trait's context
  2. When analyzing `$this->prop`, Phan finds the trait's magic property (from @property annotation)
  3. The class's real property never receives the reference

 ##  The Fix

  Added a new method `copyReferencesFromTraitMagicProperties()` in `src/Phan/Analysis/ReferenceCountsAnalyzer.php` that:
  1. For each real property on a class, checks if any used traits have a magic property with the same name
  2. If the trait's magic property has references, copies them to the class's real property
  3. This is done during the dead code detection phase, minimizing performance impact