### PR TITLE
Fixes #5398

### DIFF
--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -2319,7 +2319,10 @@ class BlockAnalysisVisitor extends AnalysisVisitor
                     // For multiple conditions in a match arm (OR semantics), each condition should be
                     // analyzed with a CLONE of the original context. The results should be merged
                     // because any one of the conditions could match. (Issue #5398)
-                    $condition_contexts = [$child_context];  // Include original for merge
+                    // Do NOT include the original $child_context in the merge - only include the
+                    // narrowed contexts from each condition. Including the original would undo
+                    // the type narrowing since combineChildContextList() unions all types together.
+                    $condition_contexts = [];
                     foreach ($arm_cond_node->children as $single_cond) {
                         // Clone context for each condition to prevent type narrowing from one
                         // condition affecting the analysis of another condition
@@ -2328,8 +2331,13 @@ class BlockAnalysisVisitor extends AnalysisVisitor
                         $condition_contexts[] = $match_variable_condition($cloned_child_context, $single_cond);
                     }
                     // Merge all condition contexts - since any one of them could be true,
-                    // the resulting type should be the union of all possibilities
-                    $child_context = (new ContextMergeVisitor($child_context, $condition_contexts, $this->code_base))->combineChildContextList();
+                    // the resulting type should be the union of what each condition proves
+                    // (e.g., is_null($i), is_string($i) => body sees null|string, not null|string|int)
+                    if (\count($condition_contexts) >= 2) {
+                        $child_context = (new ContextMergeVisitor($child_context, $condition_contexts, $this->code_base))->combineChildContextList();
+                    } elseif (\count($condition_contexts) === 1) {
+                        $child_context = $condition_contexts[0];
+                    }
                 } else {
                     // Single condition - pass the original node (original behavior)
                     $child_context = $match_variable_condition($child_context, $arm_cond_node);

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -2283,19 +2283,14 @@ class BlockAnalysisVisitor extends AnalysisVisitor
                 \count($arm_cond_node->children) > 1;
 
             if ($has_multiple_conditions) {
-                // For multiple conditions in a match arm (OR semantics), analyze each condition
-                // with a CLONE of the original context. We don't want type narrowing from one
-                // condition to affect the analysis of another condition, since they're alternatives.
-                // Clear the union type cache to prevent cached types from one condition affecting another.
+                // For multiple conditions in a match arm (e.g., `($x = foo()), $x > 0 => ...`),
+                // we need to analyze them sequentially to propagate side effects (variable assignments),
+                // but avoid type narrowing cross-contamination for the type inference in $match_variable_condition.
                 // (Issue #5398)
-                foreach ($arm_cond_node->children as $single_cond) {
-                    if ($single_cond instanceof Node) {
-                        // Clone context and clear cache for each condition to prevent cross-contamination
-                        $cloned_context = $child_context->withClonedScope();
-                        $cloned_context->clearCachedUnionTypes();
-                        $this->analyzeAndGetUpdatedContext($cloned_context, $arm_node, $single_cond);
-                    }
-                }
+                //
+                // Analyze the AST_EXPR_LIST wrapper node which processes conditions sequentially,
+                // preserving side effects like variable assignments between conditions.
+                $child_context = $this->analyzeAndGetUpdatedContext($child_context, $arm_node, $arm_cond_node);
             } else {
                 // Single condition - analyze the wrapper node (original behavior)
                 if ($arm_cond_node instanceof Node) {

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -2275,9 +2275,22 @@ class BlockAnalysisVisitor extends AnalysisVisitor
         );
         ['expr' => $arm_expr_node, 'cond' => $arm_cond_node] = $arm_node->children;
         if ($arm_cond_node !== null) {
-            if ($arm_cond_node instanceof Node) {
-                $child_context = $this->analyzeAndGetUpdatedContext($child_context, $arm_node, $arm_cond_node);
+            // Handle multiple conditions in a match arm (e.g., `is_null($i), is_a($i, Foo::class) => ...`)
+            // which are represented as AST_EXPR_LIST containing multiple child conditions.
+            // Each condition needs to be analyzed individually for proper type narrowing. (Issue #5398)
+            if ($arm_cond_node instanceof Node && $arm_cond_node->kind === ast\AST_EXPR_LIST) {
+                $individual_conditions = $arm_cond_node->children;
+            } else {
+                $individual_conditions = [$arm_cond_node];
             }
+
+            // Analyze each condition in the list
+            foreach ($individual_conditions as $single_cond) {
+                if ($single_cond instanceof Node) {
+                    $child_context = $this->analyzeAndGetUpdatedContext($child_context, $arm_node, $single_cond);
+                }
+            }
+
             if ($cond_type) {
                 (new RedundantConditionVisitor($this->code_base, $child_context))->checkImpossibleMatchArm($match_cond_node, $cond_type, $arm_node);
             }
@@ -2290,12 +2303,18 @@ class BlockAnalysisVisitor extends AnalysisVisitor
                 // Add the variable type from the **conditions of the** above arms,
                 // if it was possible for it to fall through
                 // TODO: Also support match(get_class($variable))
-                $child_context = $match_variable_condition($child_context, $arm_cond_node);
+                // Apply type narrowing for each condition individually (Issue #5398)
+                foreach ($individual_conditions as $single_cond) {
+                    $child_context = $match_variable_condition($child_context, $single_cond);
+                }
             }
             if ($match_variable_negated_condition) {
                 // Add the variable types that were ruled out by the above case statements, if it was possible for it to fall through.
                 // TODO: Also support match(get_class($variable))
-                $fallthrough_context = $match_variable_negated_condition($fallthrough_context, $arm_cond_node);
+                // Apply negated type narrowing for each condition individually (Issue #5398)
+                foreach ($individual_conditions as $single_cond) {
+                    $fallthrough_context = $match_variable_negated_condition($fallthrough_context, $single_cond);
+                }
             }
         }
 

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -2277,17 +2277,29 @@ class BlockAnalysisVisitor extends AnalysisVisitor
         if ($arm_cond_node !== null) {
             // Handle multiple conditions in a match arm (e.g., `is_null($i), is_a($i, Foo::class) => ...`)
             // which are represented as AST_EXPR_LIST containing multiple child conditions.
-            // Each condition needs to be analyzed individually for proper type narrowing. (Issue #5398)
-            if ($arm_cond_node instanceof Node && $arm_cond_node->kind === ast\AST_EXPR_LIST) {
-                $individual_conditions = $arm_cond_node->children;
-            } else {
-                $individual_conditions = [$arm_cond_node];
-            }
+            // Each condition needs to be analyzed individually for proper analysis. (Issue #5398)
+            $has_multiple_conditions = $arm_cond_node instanceof Node &&
+                $arm_cond_node->kind === ast\AST_EXPR_LIST &&
+                \count($arm_cond_node->children) > 1;
 
-            // Analyze each condition in the list
-            foreach ($individual_conditions as $single_cond) {
-                if ($single_cond instanceof Node) {
-                    $child_context = $this->analyzeAndGetUpdatedContext($child_context, $arm_node, $single_cond);
+            if ($has_multiple_conditions) {
+                // For multiple conditions in a match arm (OR semantics), analyze each condition
+                // with a CLONE of the original context. We don't want type narrowing from one
+                // condition to affect the analysis of another condition, since they're alternatives.
+                // Clear the union type cache to prevent cached types from one condition affecting another.
+                // (Issue #5398)
+                foreach ($arm_cond_node->children as $single_cond) {
+                    if ($single_cond instanceof Node) {
+                        // Clone context and clear cache for each condition to prevent cross-contamination
+                        $cloned_context = $child_context->withClonedScope();
+                        $cloned_context->clearCachedUnionTypes();
+                        $this->analyzeAndGetUpdatedContext($cloned_context, $arm_node, $single_cond);
+                    }
+                }
+            } else {
+                // Single condition - analyze the wrapper node (original behavior)
+                if ($arm_cond_node instanceof Node) {
+                    $child_context = $this->analyzeAndGetUpdatedContext($child_context, $arm_node, $arm_cond_node);
                 }
             }
 
@@ -2303,17 +2315,37 @@ class BlockAnalysisVisitor extends AnalysisVisitor
                 // Add the variable type from the **conditions of the** above arms,
                 // if it was possible for it to fall through
                 // TODO: Also support match(get_class($variable))
-                // Apply type narrowing for each condition individually (Issue #5398)
-                foreach ($individual_conditions as $single_cond) {
-                    $child_context = $match_variable_condition($child_context, $single_cond);
+                if ($has_multiple_conditions) {
+                    // For multiple conditions in a match arm (OR semantics), each condition should be
+                    // analyzed with a CLONE of the original context. The results should be merged
+                    // because any one of the conditions could match. (Issue #5398)
+                    $condition_contexts = [$child_context];  // Include original for merge
+                    foreach ($arm_cond_node->children as $single_cond) {
+                        // Clone context for each condition to prevent type narrowing from one
+                        // condition affecting the analysis of another condition
+                        $cloned_child_context = $child_context->withClonedScope();
+                        $cloned_child_context->clearCachedUnionTypes();
+                        $condition_contexts[] = $match_variable_condition($cloned_child_context, $single_cond);
+                    }
+                    // Merge all condition contexts - since any one of them could be true,
+                    // the resulting type should be the union of all possibilities
+                    $child_context = (new ContextMergeVisitor($child_context, $condition_contexts, $this->code_base))->combineChildContextList();
+                } else {
+                    // Single condition - pass the original node (original behavior)
+                    $child_context = $match_variable_condition($child_context, $arm_cond_node);
                 }
             }
             if ($match_variable_negated_condition) {
                 // Add the variable types that were ruled out by the above case statements, if it was possible for it to fall through.
                 // TODO: Also support match(get_class($variable))
-                // Apply negated type narrowing for each condition individually (Issue #5398)
-                foreach ($individual_conditions as $single_cond) {
-                    $fallthrough_context = $match_variable_negated_condition($fallthrough_context, $single_cond);
+                if ($has_multiple_conditions) {
+                    // Apply negated type narrowing for each condition individually (Issue #5398)
+                    foreach ($arm_cond_node->children as $single_cond) {
+                        $fallthrough_context = $match_variable_negated_condition($fallthrough_context, $single_cond);
+                    }
+                } else {
+                    // Single condition - pass the original node (original behavior)
+                    $fallthrough_context = $match_variable_negated_condition($fallthrough_context, $arm_cond_node);
                 }
             }
         }

--- a/tests/files/expected/5398_match_multiple_conditions.php.expected
+++ b/tests/files/expected/5398_match_multiple_conditions.php.expected
@@ -1,0 +1,1 @@
+%s:19 PhanTypeMismatchArgumentNullableInternal Argument 1 ($object_or_class) is $i of type ?\stdClass|?int but \is_a() takes object|string (expected type to be non-nullable)

--- a/tests/files/src/5398_match_multiple_conditions.php
+++ b/tests/files/src/5398_match_multiple_conditions.php
@@ -5,18 +5,18 @@
  * phan doesn't detect the return value is used in comparisons or type updates.
  *
  * When a match arm has multiple comma-separated conditions like:
- *   is_null($i), is_a($i, StdClass::class) => "A"
+ *   is_null($i), is_a($i, stdClass::class) => "A"
  * Phan should:
  * 1. Recognize that the return values of is_null() and is_a() are used (as conditions)
  * 2. Properly narrow types after each condition check
  */
 
 // @phan-suppress-next-line PhanUnreferencedFunction
-function test_match_multiple_conditions(null|int|StdClass $i): void {
+function test_match_multiple_conditions(null|int|stdClass $i): void {
     var_dump(
         match(true) {
             \is_null($i),
-            \is_a($i, StdClass::class) => "A",
+            \is_a($i, stdClass::class) => "A",
             default => "B"
         }
     );

--- a/tests/files/src/5398_match_multiple_conditions.php
+++ b/tests/files/src/5398_match_multiple_conditions.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Test for Issue #5398: With multiple conditional expressions on 'match',
+ * phan doesn't detect the return value is used in comparisons or type updates.
+ *
+ * When a match arm has multiple comma-separated conditions like:
+ *   is_null($i), is_a($i, StdClass::class) => "A"
+ * Phan should:
+ * 1. Recognize that the return values of is_null() and is_a() are used (as conditions)
+ * 2. Properly narrow types after each condition check
+ */
+
+// @phan-suppress-next-line PhanUnreferencedFunction
+function test_match_multiple_conditions(null|int|StdClass $i): void {
+    var_dump(
+        match(true) {
+            \is_null($i),
+            \is_a($i, StdClass::class) => "A",
+            default => "B"
+        }
+    );
+}


### PR DESCRIPTION
When a match arm has multiple comma-separated conditions like:
```php
  match(true) {
      is_null($i), is_a($i, stdClass::class) => "A",
      default => "B"
  }
```
Phan was producing a false positive warning:
  `PhanTypeMismatchArgumentInternalProbablyReal ... is $i of type null`

This happened because type narrowing from `is_null($i)` (which narrows $i to null) was incorrectly affecting the analysis of `is_a($i, ...)`. Since these conditions have OR semantics (any one could match), the type narrowing from one condition should not contaminate the type inference for another.

The fix ensures proper handling of multiple conditions in match arms by:
  1. Preserving side effects: Analyzing the `AST_EXPR_LIST` wrapper node sequentially so that variable assignments like (`$x = foo()`) are visible to subsequent conditions and the arm body
  2. Isolating type narrowing: In the `$match_variable_condition` section, each condition is analyzed with a cloned context to prevent type narrowing cross-contamination, then results are merged

This approach correctly handles both:
  - `is_null($i)`, `is_a($i, stdClass::class) => ...` — type narrowing stays isolated
  - `($x = foo()), $x > 0 => $x` — variable assignments propagate correctly