### PR TITLE
Fixes bug 5402

### DIFF
--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -2054,7 +2054,6 @@ trait FunctionTrait
             }
             $new_closure = $this->createClosureForAssertion($code_base, $assertion, $i);
             if ($new_closure) {
-                // @phan-suppress-next-line PhanTypeMismatchArgument
                 $closure = ConfigPluginSet::mergeAnalyzeFunctionCallClosures($new_closure, $closure);
             }
         }

--- a/src/Phan/Language/Type/FunctionLikeDeclarationType.php
+++ b/src/Phan/Language/Type/FunctionLikeDeclarationType.php
@@ -175,9 +175,6 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
         if ($this->required_param_count > $type->required_param_count) {
             return false;
         }
-        if ($this->getNumberOfParameters() < $type->getNumberOfParameters()) {
-            return false;
-        }
         if ($this->returns_reference !== $type->returns_reference) {
             return false;
         }
@@ -213,9 +210,6 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
             return parent::canCastToNonNullableTypeHandlingTemplates($type, $code_base);
         }
         if ($this->required_param_count > $type->required_param_count) {
-            return false;
-        }
-        if ($this->getNumberOfParameters() < $type->getNumberOfParameters()) {
             return false;
         }
         if ($this->returns_reference !== $type->returns_reference) {

--- a/tests/files/expected/0455_closure_type_cast.php.expected
+++ b/tests/files/expected/0455_closure_type_cast.php.expected
@@ -7,7 +7,6 @@
 %s:26 PhanTypeMismatchArgumentProbablyReal Argument 1 ($p0) is null of type null but Closure(int=):void takes int (no real type) defined at %s:22 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
 %s:28 PhanTypeMismatchArgumentSuperType Argument 1 ($fn) is (function) of type Closure(int):void but \expects_optional_int_param() takes Closure(int=):void defined at %s:22 (expected type to be the same or a subtype, but saw a supertype instead)
 %s:31 PhanTypeMismatchArgumentSuperType Argument 1 ($fn) is (function) of type Closure(int,string):void but \expects_optional_int_param() takes Closure(int=):void defined at %s:22 (expected type to be the same or a subtype, but saw a supertype instead)
-%s:32 PhanTypeMismatchArgumentSuperType Argument 1 ($fn) is (function) of type Closure():void but \expects_optional_int_param() takes Closure(int=):void defined at %s:22 (expected type to be the same or a subtype, but saw a supertype instead)
 %s:33 PhanTypeMismatchArgumentSuperType Argument 1 ($fn) is (function) of type Closure(int&=):void but \expects_optional_int_param() takes Closure(int=):void defined at %s:22 (expected type to be the same or a subtype, but saw a supertype instead)
 %s:41 PhanParamTooMany Call with 1 arg(s) to Closure():int which only takes 0 arg(s) defined at %s:40
 %s:42 PhanTypeMismatchReturn Returning $fn() of type int but expects_int_return() is declared to return \stdClass
@@ -15,7 +14,6 @@
 %s:49 PhanTypeMismatchArgumentSuperType Argument 1 ($fn) is (function) of type Closure(array):int but \expects_int_return() takes Closure():int defined at %s:40 (expected type to be the same or a subtype, but saw a supertype instead)
 %s:57 PhanTypeVoidAssignment Cannot assign void return value
 %s:57 PhanUnusedVariable Unused definition of variable $result
-%s:58 PhanTypeMismatchArgument Argument 1 ($fn) is $fn of type Closure():void but \expects_int_param() takes Closure(int):void defined at %s:6
 %s:59 PhanTypeMismatchArgument Argument 1 ($fn) is $fn of type Closure():void but \expects_int_return() takes Closure():int defined at %s:40
 %s:61 PhanPossiblyInfiniteRecursionSameParams expects_void() is calling itself with the same parameters it was called with. This may cause infinite recursion (Phan does not check for changes to global or shared state).
 %s:67 PhanTypeMismatchArgumentSuperType Argument 1 ($fn) is (function) of type Closure(mixed):void but \expects_void() takes Closure():void defined at %s:56 (expected type to be the same or a subtype, but saw a supertype instead)
@@ -24,3 +22,4 @@
 %s:77 PhanTypeMismatchArgumentProbablyReal Argument 1 ($p0) is ['arg'] of type array{0:'arg'} but Closure(string...):void takes string (no real type) defined at %s:74 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
 %s:80 PhanTypeMismatchArgumentSuperType Argument 1 ($fn) is (function) of type Closure(int...):void but \expects_void_variadic() takes Closure(string...):void defined at %s:74 (expected type to be the same or a subtype, but saw a supertype instead)
 %s:82 PhanTypeMismatchArgumentSuperType Argument 1 ($fn) is (function) of type Closure(string):void but \expects_void_variadic() takes Closure(string...):void defined at %s:74 (expected type to be the same or a subtype, but saw a supertype instead)
+%s:97 PhanTypeMismatchArgumentSuperType Argument 1 ($fn) is (function) of type Closure(string,int,bool):void but \expects_two_params() takes Closure(string,int):mixed defined at %s:89 (expected type to be the same or a subtype, but saw a supertype instead)

--- a/tests/files/expected/0456_closure_return.php.expected
+++ b/tests/files/expected/0456_closure_return.php.expected
@@ -1,3 +1,2 @@
 %s:11 PhanTypeMismatchReturnSuperType Returning (function) of type Closure(int):int but return_closure() is declared to return Closure(int):string (saw a supertype instead of a subtype)
 %s:15 PhanTypeMismatchReturnSuperType Returning Closure::fromCallable('strlen') of type Closure(string):int but return_closure() is declared to return Closure(int):string (saw a supertype instead of a subtype)
-%s:17 PhanTypeMismatchReturnSuperType Returning (function) of type Closure():string but return_closure() is declared to return Closure(int):string (saw a supertype instead of a subtype)

--- a/tests/files/expected/0457_callable_type_cast.php.expected
+++ b/tests/files/expected/0457_callable_type_cast.php.expected
@@ -7,7 +7,6 @@
 %s:26 PhanTypeMismatchArgumentProbablyReal Argument 1 ($p0) is null of type null but callable(int=):void takes int (no real type) defined at %s:22 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
 %s:28 PhanTypeMismatchArgumentSuperType Argument 1 ($fn) is (function) of type Closure(int):void but \expects_cb_optional_int_param() takes callable(int=):void defined at %s:22 (expected type to be the same or a subtype, but saw a supertype instead)
 %s:31 PhanTypeMismatchArgumentSuperType Argument 1 ($fn) is (function) of type Closure(int,string):void but \expects_cb_optional_int_param() takes callable(int=):void defined at %s:22 (expected type to be the same or a subtype, but saw a supertype instead)
-%s:32 PhanTypeMismatchArgumentSuperType Argument 1 ($fn) is (function) of type Closure():void but \expects_cb_optional_int_param() takes callable(int=):void defined at %s:22 (expected type to be the same or a subtype, but saw a supertype instead)
 %s:33 PhanTypeMismatchArgumentSuperType Argument 1 ($fn) is (function) of type Closure(int&=):void but \expects_cb_optional_int_param() takes callable(int=):void defined at %s:22 (expected type to be the same or a subtype, but saw a supertype instead)
 %s:41 PhanParamTooMany Call with 1 arg(s) to callable():int which only takes 0 arg(s) defined at %s:40
 %s:42 PhanTypeMismatchReturn Returning $fn() of type int but expects_cb_int_return() is declared to return \stdClass
@@ -15,7 +14,6 @@
 %s:49 PhanTypeMismatchArgumentSuperType Argument 1 ($fn) is (function) of type Closure(array):int but \expects_cb_int_return() takes callable():int defined at %s:40 (expected type to be the same or a subtype, but saw a supertype instead)
 %s:55 PhanTypeVoidAssignment Cannot assign void return value
 %s:55 PhanUnusedVariable Unused definition of variable $result
-%s:56 PhanTypeMismatchArgument Argument 1 ($fn) is $fn of type callable():void but \expects_cb_int_param() takes callable(int):void defined at %s:6
 %s:57 PhanTypeMismatchArgument Argument 1 ($fn) is $fn of type callable():void but \expects_cb_int_return() takes callable():int defined at %s:40
 %s:59 PhanPossiblyInfiniteRecursionSameParams expects_cb_void() is calling itself with the same parameters it was called with. This may cause infinite recursion (Phan does not check for changes to global or shared state).
 %s:65 PhanTypeMismatchArgumentSuperType Argument 1 ($fn) is (function) of type Closure(mixed):void but \expects_cb_void() takes callable():void defined at %s:54 (expected type to be the same or a subtype, but saw a supertype instead)

--- a/tests/files/src/0455_closure_type_cast.php
+++ b/tests/files/src/0455_closure_type_cast.php
@@ -80,3 +80,18 @@ expects_void_variadic(function(string ...$args) { var_export($args); });
 expects_void_variadic(function(int ...$args) { var_export($args); });  // should warn
 expects_void_variadic(function(...$args) { var_export($args); });
 expects_void_variadic(function(string $arg) { var_export($arg); });  // should warn
+
+/**
+ * Test case for issue #5402: Closure with fewer parameters than expected callable
+ * This is valid in PHP - extra arguments are simply ignored.
+ * @param Closure(string, int):mixed $fn
+ */
+function expects_two_params(Closure $fn) {
+    $fn('item', 0);
+}
+
+expects_two_params(function(string $item) { echo $item; });  // valid - fewer params is OK
+expects_two_params(function(string $item, int $key) { echo $item, $key; });  // valid - exact params
+expects_two_params(function(string $item, int $key = 0) { echo $item, $key; });  // valid
+expects_two_params(function() { echo "no params"; });  // valid - no required params
+expects_two_params(function(string $item, int $key, bool $extra) { echo $item; });  // should warn - requires 3 params


### PR DESCRIPTION
Phan was incorrectly emitting `PhanTypeMismatchArgumentSuperType` when passing a closure with fewer parameters than the expected callable signature. This is valid  - extra arguments passed to a closure are simply ignored.