### PR TITLE
Fixes #5409

### DIFF
--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -2515,12 +2515,18 @@ class UnionTypeVisitor extends AnalysisVisitor
                 return null;
             }
             if ($resulting_element_type->hasRealTypeSet()) {
+                // Preserve the isPossiblyUndefined status when creating the new UnionType
+                // (UnionType::of creates a plain UnionType, which loses AnnotatedUnionType's isPossiblyUndefined flag)
+                $was_possibly_undefined = $resulting_element_type->isPossiblyUndefined();
                 $resulting_element_type = UnionType::of(
                     $resulting_element_type->getTypeSet(),
                     \array_map(static function (Type $type): Type {
                         return $type->withIsNullable(true);
                     }, $resulting_element_type->getRealTypeSet())
                 );
+                if ($was_possibly_undefined) {
+                    $resulting_element_type = $resulting_element_type->withIsPossiblyUndefined(true);
+                }
             }
         }
         if (!$resulting_element_type->containsNullableOrUndefined() && $union_type->containsNullableOrUndefined()) {

--- a/tests/files/expected/5409_possibly_invalid_dim_offset_consistency.php.expected
+++ b/tests/files/expected/5409_possibly_invalid_dim_offset_consistency.php.expected
@@ -1,0 +1,10 @@
+%s:11 PhanUndeclaredGlobalVariable Global variable $rows is undeclared
+%s:24 PhanTypePossiblyInvalidDimOffset Possibly invalid offset 'key1' of $row of array type array{key1?:non-empty-mixed,key2?:non-empty-mixed}|mixed|non-empty-mixed
+%s:26 PhanTypePossiblyInvalidDimOffset Possibly invalid offset 'key2' of $row of array type array{key1?:non-empty-mixed,key2?:non-empty-mixed}|mixed|non-empty-mixed
+%s:36 PhanUndeclaredGlobalVariable Global variable $data is undeclared
+%s:45 PhanTypePossiblyInvalidDimOffset Possibly invalid offset 'a' of $item of array type array{a?:non-empty-mixed,b?:non-empty-mixed,c?:non-empty-mixed}|mixed|non-empty-mixed
+%s:46 PhanTypePossiblyInvalidDimOffset Possibly invalid offset 'b' of $item of array type array{a?:non-empty-mixed,b?:non-empty-mixed,c?:non-empty-mixed}|mixed|non-empty-mixed
+%s:47 PhanTypePossiblyInvalidDimOffset Possibly invalid offset 'c' of $item of array type array{a?:non-empty-mixed,b?:non-empty-mixed,c?:non-empty-mixed}|mixed|non-empty-mixed
+%s:56 PhanTypePossiblyInvalidDimOffset Possibly invalid offset 'x' of $arr of array type array{x?:int,y?:int,z?:int}|mixed
+%s:57 PhanTypePossiblyInvalidDimOffset Possibly invalid offset 'y' of $arr of array type array{x?:int,y?:int,z?:int}|mixed
+%s:58 PhanTypePossiblyInvalidDimOffset Possibly invalid offset 'z' of $arr of array type array{x?:int,y?:int,z?:int}|mixed

--- a/tests/files/src/5409_possibly_invalid_dim_offset_consistency.php
+++ b/tests/files/src/5409_possibly_invalid_dim_offset_consistency.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Test for issue #5409: Inconsistent PhanTypePossiblyInvalidDimOffset in foreach loop
+ *
+ * When accessing array keys in multiple if-else-if chains, warnings should be
+ * consistent for all keys with the same possibly-undefined status.
+ *
+ * @var array $rows
+ */
+$rows = $rows;
+if (is_array($rows)) {
+    foreach ($rows as $row) {
+        // First if-else-if chain - builds the array shape type
+        // No warnings expected here since $row starts as mixed
+        if ($row['key1']) {
+            $a = 1;
+        } else if ($row['key2']) {
+            $b = 2;
+        }
+
+        // Second if-else-if chain - accesses keys on the built type
+        // Both keys should warn consistently since both are possibly undefined
+        if ($row['key1']) {        // Should warn
+            $c = 1;
+        } else if ($row['key2']) { // Should warn
+            $d = 2;
+        }
+    }
+}
+
+/**
+ * Test with three keys to ensure all warn consistently
+ * @var array $data
+ */
+$data = $data;
+if (is_array($data)) {
+    foreach ($data as $item) {
+        // Build type with three keys
+        if ($item['a']) { $x = 1; }
+        else if ($item['b']) { $x = 2; }
+        else if ($item['c']) { $x = 3; }
+
+        // Access all three - all should warn
+        if ($item['a']) { echo 'a'; }       // Should warn
+        else if ($item['b']) { echo 'b'; }  // Should warn
+        else if ($item['c']) { echo 'c'; }  // Should warn
+    }
+}
+
+/**
+ * Test with explicit array shape type - all keys should warn
+ * @param array{x?:int,y?:int,z?:int}|mixed $arr
+ */
+function testExplicitType($arr): void {
+    if ($arr['x']) { echo 'x'; }       // Should warn
+    else if ($arr['y']) { echo 'y'; }  // Should warn
+    else if ($arr['z']) { echo 'z'; }  // Should warn
+}


### PR DESCRIPTION
add code to preserve the `isPossiblyUndefined()` status before creating the new `UnionType`, then restore it afterwards