### PR TITLE
Fixes #5423

### DIFF
--- a/src/Phan/Analysis/ConditionVisitorUtil.php
+++ b/src/Phan/Analysis/ConditionVisitorUtil.php
@@ -311,6 +311,18 @@ trait ConditionVisitorUtil
                 return;
             }
             $node->did_check_redundant_condition = true;
+            // Skip redundant condition checks for static properties accessed via self/static/parent
+            // These can change between requests and the check is a reasonable defensive pattern
+            // See https://github.com/phan/phan/issues/4839 and https://github.com/phan/phan/issues/5423
+            if ($node->kind === ast\AST_STATIC_PROP) {
+                $class_node = $node->children['class'] ?? null;
+                if ($class_node instanceof Node && $class_node->kind === ast\AST_NAME) {
+                    $name = $class_node->children['name'] ?? null;
+                    if (\is_string($name) && \in_array(\strtolower($name), ['self', 'static', 'parent'], true)) {
+                        return;
+                    }
+                }
+            }
         } elseif ($is_negated) {
             return;
         }

--- a/tests/files/src/5423_static_property_condition.php
+++ b/tests/files/src/5423_static_property_condition.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * Test case for GitHub issue #5423
+ * Static property conditions should not produce false positives
+ *
+ * @see https://github.com/phan/phan/issues/5423
+ */
+
+class Test5423 {
+    public static stdClass $obj;
+    public static ?stdClass $nullableObj;
+    public static string $str;
+    public static int $num;
+
+    public static function checkObject(): void {
+        // Should NOT warn - static properties can be uninitialized or change between invocations
+        if (self::$obj) {
+            echo "Has object\n";
+        }
+    }
+
+    public static function checkNullable(): void {
+        // Should NOT warn - nullable is expected to be checked
+        if (self::$nullableObj) {
+            echo "Has nullable object\n";
+        }
+    }
+
+    public static function checkNegated(): void {
+        // Should NOT warn - negated condition on static property
+        if (!self::$obj) {
+            echo "No object\n";
+        }
+    }
+
+    public static function checkString(): void {
+        // Should NOT warn - string can be empty
+        if (self::$str) {
+            echo "Has string\n";
+        }
+    }
+
+    public static function checkNum(): void {
+        // Should NOT warn - int can be 0
+        if (self::$num) {
+            echo "Has number\n";
+        }
+    }
+}
+
+class Test5423Static {
+    public static stdClass $obj;
+
+    public static function check(): void {
+        // Should NOT warn - using 'static' keyword
+        if (static::$obj) {
+            echo "Has object\n";
+        }
+    }
+}
+
+class Test5423Parent extends Test5423 {
+    public static function check(): void {
+        // Should NOT warn - using 'parent' keyword
+        if (parent::$obj) {
+            echo "Has object\n";
+        }
+    }
+}


### PR DESCRIPTION
Added a check to skip redundant condition analysis for static properties accessed via `self::`, `static::`, or `parent::` - the same pattern that was already applied to `visitEmpty()` in `RedundantConditionVisitor.php`. This prevents false `PhanImpossibleCondition` and `PhanRedundantCondition` warnings when checking static properties in `if()` conditions.