### PR TITLE
Fixes #5421

### DIFF
--- a/src/Phan/Language/Type/KeyOfType.php
+++ b/src/Phan/Language/Type/KeyOfType.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Phan\Language\Type;
 
+use Generator;
+use Phan\CodeBase;
 use Phan\Language\UnionType;
 use Phan\Language\UnionTypeBuilder;
 
@@ -41,16 +43,109 @@ final class KeyOfType extends \Phan\Language\Type implements MultiType
      */
     public function asIndividualTypeInstances(): array
     {
+        // Don't expand if inner type contains unresolved template types
+        $inner_union = $this->template_parameter_type_list[0] ?? UnionType::empty();
+        if ($inner_union->hasTemplateTypeRecursive()) {
+            return [$this];
+        }
         return $this->resolved_type_set ?? ($this->resolved_type_set = $this->computeResolvedTypeSet());
+    }
+
+    /**
+     * @param array<string,UnionType> $template_parameter_type_map
+     */
+    public function withTemplateParameterTypeMap(
+        array $template_parameter_type_map
+    ): UnionType {
+        if (!$template_parameter_type_map) {
+            return $this->asPHPDocUnionType();
+        }
+        $inner_union = $this->template_parameter_type_list[0] ?? UnionType::empty();
+        $new_inner = $inner_union->withTemplateParameterTypeMap($template_parameter_type_map);
+        if ($new_inner === $inner_union) {
+            return $this->asPHPDocUnionType();
+        }
+        // Create new KeyOfType with substituted inner type and resolve it
+        return (new KeyOfType(
+            '\\',
+            'key-of',
+            [$new_inner],
+            $this->is_nullable
+        ))->asPHPDocUnionType();
     }
 
     public function asPHPDocUnionType(): UnionType
     {
+        // If inner type contains unresolved template types, don't expand
+        // Create UnionType directly to avoid infinite recursion via UnionType::of
+        $inner_union = $this->template_parameter_type_list[0] ?? UnionType::empty();
+        if ($inner_union->hasTemplateTypeRecursive()) {
+            return new UnionType([$this], true);
+        }
         return UnionType::of($this->asIndividualTypeInstances());
     }
 
     public function asRealUnionType(): UnionType
     {
+        return $this->asPHPDocUnionType();
+    }
+
+    /**
+     * @return Generator<\Phan\Language\Type>
+     * @override
+     */
+    public function getReferencedClasses(): Generator
+    {
+        // key-of<T> represents primitive values (array keys), not classes
+        // Yield referenced classes from inner type for validation purposes
+        $inner_union = $this->template_parameter_type_list[0] ?? UnionType::empty();
+        yield from $inner_union->getReferencedClasses();
+    }
+
+    /**
+     * @override
+     */
+    public function isObject(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @override
+     */
+    public function isObjectWithKnownFQSEN(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @override
+     */
+    public function isPossiblyObject(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @override
+     */
+    public function asFQSENString(): string
+    {
+        return 'key-of';
+    }
+
+    /**
+     * key-of is not a class type, so it doesn't have parent classes to expand to.
+     * @param CodeBase $code_base @phan-unused-param
+     * @param int $recursion_depth @phan-unused-param
+     * @param bool $preserving_template @phan-unused-param
+     * @override
+     */
+    public function asExpandedTypes(
+        CodeBase $code_base,
+        int $recursion_depth = 0,
+        bool $preserving_template = false
+    ): UnionType {
         return $this->asPHPDocUnionType();
     }
 

--- a/src/Phan/Language/Type/KeyOfType.php
+++ b/src/Phan/Language/Type/KeyOfType.php
@@ -43,12 +43,50 @@ final class KeyOfType extends \Phan\Language\Type implements MultiType
      */
     public function asIndividualTypeInstances(): array
     {
-        // Don't expand if inner type contains unresolved template types
+        // Don't expand if KEY types contain unresolved template types
+        // (Value types having templates is fine - we only care about keys)
         $inner_union = $this->template_parameter_type_list[0] ?? UnionType::empty();
-        if ($inner_union->hasTemplateTypeRecursive()) {
+        if (self::hasTemplateInKeyPosition($inner_union)) {
             return [$this];
         }
         return $this->resolved_type_set ?? ($this->resolved_type_set = $this->computeResolvedTypeSet());
+    }
+
+    /**
+     * Check if any key types in the union have template types.
+     * This ignores template types in value positions.
+     */
+    private static function hasTemplateInKeyPosition(UnionType $union): bool
+    {
+        foreach ($union->getTypeSet() as $type) {
+            if ($type instanceof TemplateType) {
+                // The array type itself is a template - can't resolve keys
+                return true;
+            }
+            if ($type instanceof ArrayShapeType) {
+                // Array shapes have literal keys, check if any field type keys have templates
+                // For array shapes, keys are literals (string/int), not types with templates
+                // So we don't need to check further - array shape keys are always resolved
+                continue;
+            } elseif ($type instanceof GenericArrayInterface) {
+                $key_type = $type->getKeyType();
+                // KEY_INT and KEY_STRING are resolved, KEY_MIXED could be template-dependent
+                if ($key_type === GenericArrayType::KEY_MIXED) {
+                    // Check if the original type has template in key position
+                    // For generic arrays like array<T, V>, check if T is a template
+                    if ($type instanceof GenericArrayType) {
+                        // GenericArrayType doesn't store key type as UnionType, just key_type constant
+                        // So we can't check for templates directly - assume resolved
+                        continue;
+                    }
+                }
+            } elseif ($type instanceof GenericIterableType) {
+                if ($type->getKeyUnionType()->hasTemplateTypeRecursive()) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     /**
@@ -76,10 +114,10 @@ final class KeyOfType extends \Phan\Language\Type implements MultiType
 
     public function asPHPDocUnionType(): UnionType
     {
-        // If inner type contains unresolved template types, don't expand
+        // If KEY types contain unresolved template types, don't expand
         // Create UnionType directly to avoid infinite recursion via UnionType::of
         $inner_union = $this->template_parameter_type_list[0] ?? UnionType::empty();
-        if ($inner_union->hasTemplateTypeRecursive()) {
+        if (self::hasTemplateInKeyPosition($inner_union)) {
             return new UnionType([$this], true);
         }
         return UnionType::of($this->asIndividualTypeInstances());

--- a/src/Phan/Language/Type/KeyOfType.php
+++ b/src/Phan/Language/Type/KeyOfType.php
@@ -64,22 +64,17 @@ final class KeyOfType extends \Phan\Language\Type implements MultiType
                 return true;
             }
             if ($type instanceof ArrayShapeType) {
-                // Array shapes have literal keys, check if any field type keys have templates
-                // For array shapes, keys are literals (string/int), not types with templates
+                // Array shapes have literal keys (string/int), not types with templates
                 // So we don't need to check further - array shape keys are always resolved
                 continue;
+            } elseif ($type instanceof GenericArrayTemplateKeyType) {
+                // GenericArrayTemplateKeyType stores template key types
+                // Its hasTemplateTypeRecursive() returns true, meaning keys have templates
+                return true;
             } elseif ($type instanceof GenericArrayInterface) {
-                $key_type = $type->getKeyType();
-                // KEY_INT and KEY_STRING are resolved, KEY_MIXED could be template-dependent
-                if ($key_type === GenericArrayType::KEY_MIXED) {
-                    // Check if the original type has template in key position
-                    // For generic arrays like array<T, V>, check if T is a template
-                    if ($type instanceof GenericArrayType) {
-                        // GenericArrayType doesn't store key type as UnionType, just key_type constant
-                        // So we can't check for templates directly - assume resolved
-                        continue;
-                    }
-                }
+                // Regular GenericArrayType with KEY_INT/KEY_STRING/KEY_MIXED
+                // These are resolved key types, not template-dependent
+                continue;
             } elseif ($type instanceof GenericIterableType) {
                 if ($type->getKeyUnionType()->hasTemplateTypeRecursive()) {
                     return true;

--- a/src/Phan/Language/Type/ValueOfType.php
+++ b/src/Phan/Language/Type/ValueOfType.php
@@ -41,12 +41,41 @@ final class ValueOfType extends \Phan\Language\Type implements MultiType
      */
     public function asIndividualTypeInstances(): array
     {
-        // Don't expand if inner type contains unresolved template types
+        // Don't expand if VALUE types contain unresolved template types
+        // (Key types having templates is fine - we only care about values)
         $inner_union = $this->template_parameter_type_list[0] ?? UnionType::empty();
-        if ($inner_union->hasTemplateTypeRecursive()) {
+        if (self::hasTemplateInValuePosition($inner_union)) {
             return [$this];
         }
         return $this->resolved_type_set ?? ($this->resolved_type_set = $this->computeResolvedTypeSet());
+    }
+
+    /**
+     * Check if any value/element types in the union have template types.
+     * This ignores template types in key positions.
+     */
+    private static function hasTemplateInValuePosition(UnionType $union): bool
+    {
+        foreach ($union->getTypeSet() as $type) {
+            if ($type instanceof TemplateType) {
+                // The array type itself is a template - can't resolve values
+                return true;
+            }
+            if ($type instanceof ArrayShapeType) {
+                if ($type->genericArrayElementUnionType()->hasTemplateTypeRecursive()) {
+                    return true;
+                }
+            } elseif ($type instanceof GenericArrayInterface) {
+                if ($type->genericArrayElementUnionType()->hasTemplateTypeRecursive()) {
+                    return true;
+                }
+            } elseif ($type instanceof GenericIterableType) {
+                if ($type->getElementUnionType()->hasTemplateTypeRecursive()) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     /**
@@ -74,10 +103,10 @@ final class ValueOfType extends \Phan\Language\Type implements MultiType
 
     public function asPHPDocUnionType(): UnionType
     {
-        // If inner type contains unresolved template types, don't expand
+        // If VALUE types contain unresolved template types, don't expand
         // Create UnionType directly to avoid infinite recursion via UnionType::of
         $inner_union = $this->template_parameter_type_list[0] ?? UnionType::empty();
-        if ($inner_union->hasTemplateTypeRecursive()) {
+        if (self::hasTemplateInValuePosition($inner_union)) {
             return new UnionType([$this], true);
         }
         return UnionType::of($this->asIndividualTypeInstances());
@@ -122,8 +151,8 @@ final class ValueOfType extends \Phan\Language\Type implements MultiType
     public function isPossiblyObject(): bool
     {
         $inner_union = $this->template_parameter_type_list[0] ?? UnionType::empty();
-        // If we have unresolved templates, we don't know - assume possibly object
-        if ($inner_union->hasTemplateTypeRecursive()) {
+        // If VALUE types have unresolved templates, we don't know - assume possibly object
+        if (self::hasTemplateInValuePosition($inner_union)) {
             return true;
         }
         // Otherwise, check if resolved types could produce objects

--- a/src/Phan/Language/Type/ValueOfType.php
+++ b/src/Phan/Language/Type/ValueOfType.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Phan\Language\Type;
 
+use Generator;
+use Phan\CodeBase;
 use Phan\Language\UnionType;
 use Phan\Language\UnionTypeBuilder;
 
@@ -39,16 +41,109 @@ final class ValueOfType extends \Phan\Language\Type implements MultiType
      */
     public function asIndividualTypeInstances(): array
     {
+        // Don't expand if inner type contains unresolved template types
+        $inner_union = $this->template_parameter_type_list[0] ?? UnionType::empty();
+        if ($inner_union->hasTemplateTypeRecursive()) {
+            return [$this];
+        }
         return $this->resolved_type_set ?? ($this->resolved_type_set = $this->computeResolvedTypeSet());
+    }
+
+    /**
+     * @param array<string,UnionType> $template_parameter_type_map
+     */
+    public function withTemplateParameterTypeMap(
+        array $template_parameter_type_map
+    ): UnionType {
+        if (!$template_parameter_type_map) {
+            return $this->asPHPDocUnionType();
+        }
+        $inner_union = $this->template_parameter_type_list[0] ?? UnionType::empty();
+        $new_inner = $inner_union->withTemplateParameterTypeMap($template_parameter_type_map);
+        if ($new_inner === $inner_union) {
+            return $this->asPHPDocUnionType();
+        }
+        // Create new ValueOfType with substituted inner type and resolve it
+        return (new ValueOfType(
+            '\\',
+            'value-of',
+            [$new_inner],
+            $this->is_nullable
+        ))->asPHPDocUnionType();
     }
 
     public function asPHPDocUnionType(): UnionType
     {
+        // If inner type contains unresolved template types, don't expand
+        // Create UnionType directly to avoid infinite recursion via UnionType::of
+        $inner_union = $this->template_parameter_type_list[0] ?? UnionType::empty();
+        if ($inner_union->hasTemplateTypeRecursive()) {
+            return new UnionType([$this], true);
+        }
         return UnionType::of($this->asIndividualTypeInstances());
     }
 
     public function asRealUnionType(): UnionType
     {
+        return $this->asPHPDocUnionType();
+    }
+
+    /**
+     * @return Generator<\Phan\Language\Type>
+     * @override
+     */
+    public function getReferencedClasses(): Generator
+    {
+        // value-of<T> represents primitive values, not classes
+        // Yield referenced classes from inner type for validation purposes
+        $inner_union = $this->template_parameter_type_list[0] ?? UnionType::empty();
+        yield from $inner_union->getReferencedClasses();
+    }
+
+    /**
+     * @override
+     */
+    public function isObject(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @override
+     */
+    public function isObjectWithKnownFQSEN(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @override
+     */
+    public function isPossiblyObject(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @override
+     */
+    public function asFQSENString(): string
+    {
+        return 'value-of';
+    }
+
+    /**
+     * value-of is not a class type, so it doesn't have parent classes to expand to.
+     * @param CodeBase $code_base @phan-unused-param
+     * @param int $recursion_depth @phan-unused-param
+     * @param bool $preserving_template @phan-unused-param
+     * @override
+     */
+    public function asExpandedTypes(
+        CodeBase $code_base,
+        int $recursion_depth = 0,
+        bool $preserving_template = false
+    ): UnionType {
         return $this->asPHPDocUnionType();
     }
 

--- a/src/Phan/Language/Type/ValueOfType.php
+++ b/src/Phan/Language/Type/ValueOfType.php
@@ -121,6 +121,27 @@ final class ValueOfType extends \Phan\Language\Type implements MultiType
      */
     public function isPossiblyObject(): bool
     {
+        $inner_union = $this->template_parameter_type_list[0] ?? UnionType::empty();
+        // If we have unresolved templates, we don't know - assume possibly object
+        if ($inner_union->hasTemplateTypeRecursive()) {
+            return true;
+        }
+        // Otherwise, check if resolved types could produce objects
+        foreach ($inner_union->getTypeSet() as $type) {
+            if ($type instanceof ArrayShapeType) {
+                if ($type->genericArrayElementUnionType()->hasPossiblyObjectTypes()) {
+                    return true;
+                }
+            } elseif ($type instanceof GenericArrayInterface) {
+                if ($type->genericArrayElementUnionType()->hasPossiblyObjectTypes()) {
+                    return true;
+                }
+            } elseif ($type instanceof GenericIterableType) {
+                if ($type->getElementUnionType()->hasPossiblyObjectTypes()) {
+                    return true;
+                }
+            }
+        }
         return false;
     }
 

--- a/src/Phan/Language/Type/ValueOfType.php
+++ b/src/Phan/Language/Type/ValueOfType.php
@@ -140,6 +140,9 @@ final class ValueOfType extends \Phan\Language\Type implements MultiType
                 if ($type->getElementUnionType()->hasPossiblyObjectTypes()) {
                     return true;
                 }
+            } elseif ($type instanceof IterableType || $type instanceof ArrayType || $type instanceof MixedType) {
+                // Plain array/iterable/mixed without element type info - values could be objects
+                return true;
             }
         }
         return false;

--- a/tests/files/expected/5421_value_of_template.php.expected
+++ b/tests/files/expected/5421_value_of_template.php.expected
@@ -1,0 +1,4 @@
+%s:33 PhanDebugAnnotation @phan-debug-var requested for variable $b - it has union type 1|2|3
+%s:38 PhanDebugAnnotation @phan-debug-var requested for variable $d - it has union type 'bar'|'qux'
+%s:43 PhanDebugAnnotation @phan-debug-var requested for variable $f - it has union type 'bar'|'foo'|null
+%s:51 PhanDebugAnnotation @phan-debug-var requested for variable $v - it has union type int

--- a/tests/files/src/5421_value_of_template.php
+++ b/tests/files/src/5421_value_of_template.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * Test case for GitHub issue #5421
+ * value-of<T> and key-of<T> with template types
+ *
+ * @see https://github.com/phan/phan/issues/5421
+ */
+
+/**
+ * @template T of array
+ * @param T $arr
+ * @param int|string $key
+ * @return value-of<T>
+ */
+function getValue5421(array $arr, $key) {
+    // @phan-suppress-next-line PhanTypeArraySuspicious
+    return $arr[$key];
+}
+
+/**
+ * @template T of array
+ * @param T $arr
+ * @return key-of<T>|null
+ */
+function getKey5421(array $arr) {
+    // @phan-suppress-next-line PhanTypeMismatchArgumentInternal
+    return array_key_first($arr);
+}
+
+// Test value-of<T> with list
+$a = [1, 2, 3];
+$b = getValue5421($a, 0);
+'@phan-debug-var $b';  // Should be int (1|2|3), not mixed
+
+// Test value-of<T> with associative array
+$c = ['foo' => 'bar', 'baz' => 'qux'];
+$d = getValue5421($c, 'foo');
+'@phan-debug-var $d';  // Should be 'bar'|'qux', not mixed
+
+// Test key-of<T> with associative array
+$e = ['foo' => 1, 'bar' => 2];
+$f = getKey5421($e);
+'@phan-debug-var $f';  // Should be 'foo'|'bar'|null, not array-key|null
+
+/**
+ * @param int[] $arr
+ * @return void
+ */
+function testWithIntArray5421(array $arr) {
+    $v = getValue5421($arr, 0);
+    '@phan-debug-var $v';  // Should be int
+    echo $v;  // Use $v to avoid unused warning
+}
+testWithIntArray5421([1, 2, 3]);


### PR DESCRIPTION
The ValueOfType and KeyOfType classes implement the MultiType interface, which meant their asIndividualTypeInstances() method was called during type normalization. When this happened with unresolved template types (e.g., value-of<T>), the computeResolvedTypeSet() method would see the TemplateType and fall back to mixed/array-key, losing the template information before substitution could occur at call sites.

Modified both ValueOfType.php and KeyOfType.php with the following changes:

1. Defer expansion for template types: Modified asIndividualTypeInstances() to check if the inner type contains unresolved template types (hasTemplateTypeRecursive()). If so, return [$this] instead of expanding, preserving the type for later substitution.
2. Override withTemplateParameterTypeMap(): Added a custom implementation that properly substitutes template types in the inner union type and creates a new resolved instance.
3. Override asPHPDocUnionType(): Modified to create a UnionType directly when template types are present, avoiding infinite recursion through UnionType::of().
4. Added type safety overrides: Added isObject(), isObjectWithKnownFQSEN(), isPossiblyObject(), asFQSENString(), getReferencedClasses(), and asExpandedTypes() overrides to properly indicate that these utility types are not object types and don't have FQSENs.