### PR TITLE
Fix readonly class flag in fromReflectionClass()

### DIFF
--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -295,7 +295,10 @@ class Clazz extends AddressableElement
         } elseif ($class->isTrait()) {
             $flags = \ast\flags\CLASS_TRAIT;
         }
-        // FIXME readonly flag
+        // @phan-suppress-next-line PhanUndeclaredMethod reflection API added in PHP 8.2
+        if (method_exists($class, 'isReadonly') && $class->isReadonly()) {
+            $flags |= \ast\flags\CLASS_READONLY;
+        }
         if ($class->isAbstract()) {
             $flags |= \ast\flags\CLASS_ABSTRACT;
         }


### PR DESCRIPTION
## Summary
- Set `CLASS_READONLY` AST flag when reconstructing flags from `ReflectionClass` in `Clazz::fromReflectionClass()`, resolving the FIXME at Clazz.php:298
- Uses the existing `method_exists` guard pattern (consistent with lines 491, 497, 523) for PHP 8.2+ compatibility

## Test plan
- [x] `./phan` self-analysis passes
- [x] `./tests/run_test __FakeSelfTest` passes
- [x] `./vendor/bin/phpunit` full suite passes (2321 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)