### PR TITLE
Fix UnionType code quality issues

### DIFF
--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -1435,7 +1435,7 @@ class UnionType implements Serializable, Stringable
                 return false;
             }
         }
-        return !$union_type->isPossiblyUndefined();
+        return !$this->isPossiblyUndefined() && !$union_type->isPossiblyUndefined();
     }
 
     /**
@@ -1481,7 +1481,7 @@ class UnionType implements Serializable, Stringable
                 return false;
             }
         }
-        return !$union_type->isPossiblyUndefined();
+        return !$this->isPossiblyUndefined() && !$union_type->isPossiblyUndefined();
     }
 
     /**
@@ -1604,12 +1604,7 @@ class UnionType implements Serializable, Stringable
      */
     public function containsNonMixedNullable(): bool
     {
-        foreach ($this->type_set as $type) {
-            if ($type->isNullableLabeled()) {
-                return true;
-            }
-        }
-        return false;
+        return $this->containsNullableLabeled();
     }
 
     /**


### PR DESCRIPTION
## Summary
- Make `isEqualTo()`/`isIdenticalTo()` symmetric by checking `$this->isPossiblyUndefined()` in addition to `$union_type->isPossiblyUndefined()`. While the base `UnionType` always returns `false`, this ensures correctness by construction.
- Consolidate `containsNonMixedNullable()` to delegate to `containsNullableLabeled()` since both had identical implementations (same loop body checking `$type->isNullableLabeled()`).

## Test plan
- [x] `./phan` self-analysis passes
- [x] `./vendor/bin/phpunit` full suite passes (2321 tests, 0 failures)
- No behavioral changes expected; both fixes are defensive code quality improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)