### PR TITLE
Detect object ordering comparison (TypeError in PHP 8.0+)

### DIFF
--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -3074,6 +3074,14 @@ An example would be
 if ([1, 2] == 'string') {}
 ```
 
+## PhanTypeComparisonObjectOrdering
+
+```
+Using ordering comparison operator with an object of type {TYPE} and a non-object of type {TYPE} will throw a TypeError in PHP 8.0+
+```
+
+e.g. [this issue](https://github.com/phan/phan/tree/v6/tests/files/expected/0718_suspicious_comparisons.php.expected#L3) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/v6/tests/files/src/0718_suspicious_comparisons.php#L9).
+
 ## PhanTypeComparisonToArray
 
 

--- a/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
+++ b/src/Phan/Analysis/BinaryOperatorFlagVisitor.php
@@ -157,7 +157,7 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
     /**
      * Analyzes the `<=>` operator.
      *
-     * @param Node $node @phan-unused-param
+     * @param Node $node
      * A node to check types on
      *
      * @return UnionType
@@ -165,7 +165,39 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
      */
     public function visitBinarySpaceship(Node $node): UnionType
     {
-        // TODO: Any sanity checks should go here.
+        $code_base = $this->code_base;
+        $context = $this->context;
+        $left = UnionTypeVisitor::unionTypeFromNode(
+            $code_base,
+            $context,
+            $node->children['left'],
+            $this->should_catch_issue_exception
+        );
+        $right = UnionTypeVisitor::unionTypeFromNode(
+            $code_base,
+            $context,
+            $node->children['right'],
+            $this->should_catch_issue_exception
+        );
+
+        // Check for object ordering comparison (TypeError in PHP 8.0+)
+        $left_is_object = $left->isObject();
+        $right_is_object = $right->isObject();
+        if ($left_is_object && !$right_is_object && !$right->isEmpty() && !$right->hasMixedOrNonEmptyMixedType()) {
+            $this->emitIssue(
+                Issue::TypeComparisonObjectOrdering,
+                $node->lineno,
+                (string)$left->asNonLiteralType(),
+                (string)$right->asNonLiteralType()
+            );
+        } elseif ($right_is_object && !$left_is_object && !$left->isEmpty() && !$left->hasMixedOrNonEmptyMixedType()) {
+            $this->emitIssue(
+                Issue::TypeComparisonObjectOrdering,
+                $node->lineno,
+                (string)$right->asNonLiteralType(),
+                (string)$left->asNonLiteralType()
+            );
+        }
 
         // <=> returns -1, 0, or 1
         return UnionType::fromFullyQualifiedRealString('-1|0|1');
@@ -587,6 +619,33 @@ final class BinaryOperatorFlagVisitor extends FlagVisitorImplementation
                 $node->lineno,
                 (string)$left->asNonLiteralType()
             );
+        }
+
+        // Check for object ordering comparison (TypeError in PHP 8.0+)
+        // Only applies to ordering operators, not equality operators
+        if (\in_array($node->flags, [
+            \ast\flags\BINARY_IS_SMALLER,
+            \ast\flags\BINARY_IS_SMALLER_OR_EQUAL,
+            \ast\flags\BINARY_IS_GREATER,
+            \ast\flags\BINARY_IS_GREATER_OR_EQUAL,
+        ], true)) {
+            $left_is_object = $left->isObject();
+            $right_is_object = $right->isObject();
+            if ($left_is_object && !$right_is_object && !$right->isEmpty() && !$right->hasMixedOrNonEmptyMixedType()) {
+                $this->emitIssue(
+                    Issue::TypeComparisonObjectOrdering,
+                    $node->lineno,
+                    (string)$left->asNonLiteralType(),
+                    (string)$right->asNonLiteralType()
+                );
+            } elseif ($right_is_object && !$left_is_object && !$left->isEmpty() && !$left->hasMixedOrNonEmptyMixedType()) {
+                $this->emitIssue(
+                    Issue::TypeComparisonObjectOrdering,
+                    $node->lineno,
+                    (string)$right->asNonLiteralType(),
+                    (string)$left->asNonLiteralType()
+                );
+            }
         }
 
         return BoolType::instance(false)->asRealUnionType();

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -128,6 +128,7 @@ class Issue
     public const TypeModifyImmutableObjectProperty            = 'PhanTypeModifyImmutableObjectProperty';
     public const TypeComparisonFromArray   = 'PhanTypeComparisonFromArray';
     public const TypeComparisonToArray     = 'PhanTypeComparisonToArray';
+    public const TypeComparisonObjectOrdering = 'PhanTypeComparisonObjectOrdering';
     public const TypeConversionFromArray   = 'PhanTypeConversionFromArray';
     public const TypeInstantiateAbstract   = 'PhanTypeInstantiateAbstract';
     public const TypeInstantiateAbstractStatic = 'PhanTypeInstantiateAbstractStatic';
@@ -1968,6 +1969,14 @@ class Issue
                 "array to {TYPE} comparison",
                 self::REMEDIATION_B,
                 10011
+            ),
+            new Issue(
+                self::TypeComparisonObjectOrdering,
+                self::CATEGORY_TYPE,
+                self::SEVERITY_NORMAL,
+                "Using ordering comparison operator with an object of type {TYPE} and a non-object of type {TYPE} will throw a TypeError in PHP 8.0+",
+                self::REMEDIATION_B,
+                10212
             ),
             new Issue(
                 self::TypeConversionFromArray,

--- a/tests/files/expected/0362_array_map_analyze.php.expected
+++ b/tests/files/expected/0362_array_map_analyze.php.expected
@@ -1,3 +1,4 @@
 %s:7 PhanTypeMismatchArgumentInternal Argument 1 ($string) is $values[0] of type int but \strlen() takes string
+%s:12 PhanTypeComparisonObjectOrdering Using ordering comparison operator with an object of type \stdClass and a non-object of type int will throw a TypeError in PHP 8.0+
 %s:14 PhanTypeMismatchArgumentInternal Argument 1 ($string) is $values[0] of type \stdClass but \strlen() takes string
 %s:18 PhanTypeMismatchArgumentInternal Argument 1 ($string) is $values[0] of type int but \strlen() takes string

--- a/tests/files/expected/0718_suspicious_comparisons.php.expected
+++ b/tests/files/expected/0718_suspicious_comparisons.php.expected
@@ -1,9 +1,13 @@
 %s:8 PhanTypeComparisonToArray iterable to array comparison
 %s:9 PhanSuspiciousWeakTypeComparison Suspicious attempt to compare $i of type iterable to $f of type \FinalClass718
+%s:9 PhanTypeComparisonObjectOrdering Using ordering comparison operator with an object of type \FinalClass718 and a non-object of type iterable will throw a TypeError in PHP 8.0+
 %s:10 PhanSuspiciousWeakTypeComparison Suspicious attempt to compare $a of type array to $f of type \FinalClass718
 %s:10 PhanTypeComparisonFromArray array to \FinalClass718 comparison
+%s:10 PhanTypeComparisonObjectOrdering Using ordering comparison operator with an object of type \FinalClass718 and a non-object of type array will throw a TypeError in PHP 8.0+
 %s:11 PhanSuspiciousWeakTypeComparison Suspicious attempt to compare $f of type \FinalClass718 to null of type null
+%s:11 PhanTypeComparisonObjectOrdering Using ordering comparison operator with an object of type \FinalClass718 and a non-object of type null will throw a TypeError in PHP 8.0+
 %s:12 PhanSuspiciousWeakTypeComparison Suspicious attempt to compare $f of type \FinalClass718 to false of type false
+%s:12 PhanTypeComparisonObjectOrdering Using ordering comparison operator with an object of type \FinalClass718 and a non-object of type false will throw a TypeError in PHP 8.0+
 %s:13 PhanSuspiciousWeakTypeComparison Suspicious attempt to compare $a of type array to 2.3 of type float (value: 2.3)
 %s:13 PhanTypeComparisonFromArray array to float comparison
 %s:14 PhanSuspiciousWeakTypeComparison Suspicious attempt to compare $a of type array to $f of type \FinalClass718
@@ -11,7 +15,9 @@
 %s:15 PhanSuspiciousWeakTypeComparison Suspicious attempt to compare $i of type iterable to $f of type \FinalClass718
 %s:16 PhanSuspiciousWeakTypeComparison Suspicious attempt to compare $f of type \FinalClass718 to false of type false
 %s:17 PhanSuspiciousWeakTypeComparison Suspicious attempt to compare $f of type \FinalClass718 to true of type true
+%s:17 PhanTypeComparisonObjectOrdering Using ordering comparison operator with an object of type \FinalClass718 and a non-object of type true will throw a TypeError in PHP 8.0+
 %s:18 PhanSuspiciousWeakTypeComparison Suspicious attempt to compare $f of type \FinalClass718 to $b of type bool
 %s:19 PhanSuspiciousWeakTypeComparison Suspicious attempt to compare $f of type \FinalClass718 to $b of type bool
+%s:19 PhanTypeComparisonObjectOrdering Using ordering comparison operator with an object of type \FinalClass718 and a non-object of type bool will throw a TypeError in PHP 8.0+
 %s:20 PhanSuspiciousWeakTypeComparison Suspicious attempt to compare $f of type \FinalClass718 to $b of type bool
 %s:21 PhanSuspiciousWeakTypeComparison Suspicious attempt to compare $f of type \FinalClass718 to $b of type bool

--- a/tests/files/expected/5906_object_ordering_comparison.php.expected
+++ b/tests/files/expected/5906_object_ordering_comparison.php.expected
@@ -1,0 +1,13 @@
+%s:7 PhanSuspiciousWeakTypeComparison Suspicious attempt to compare $obj of type \TestObj5906 to $i of type int
+%s:7 PhanTypeComparisonObjectOrdering Using ordering comparison operator with an object of type \TestObj5906 and a non-object of type int will throw a TypeError in PHP 8.0+
+%s:8 PhanSuspiciousWeakTypeComparison Suspicious attempt to compare $obj of type \TestObj5906 to $s of type string
+%s:8 PhanTypeComparisonObjectOrdering Using ordering comparison operator with an object of type \TestObj5906 and a non-object of type string will throw a TypeError in PHP 8.0+
+%s:9 PhanSuspiciousWeakTypeComparison Suspicious attempt to compare $obj of type \TestObj5906 to $f of type float
+%s:9 PhanTypeComparisonObjectOrdering Using ordering comparison operator with an object of type \TestObj5906 and a non-object of type float will throw a TypeError in PHP 8.0+
+%s:10 PhanSuspiciousWeakTypeComparison Suspicious attempt to compare $i of type int to $obj of type \TestObj5906
+%s:10 PhanTypeComparisonObjectOrdering Using ordering comparison operator with an object of type \TestObj5906 and a non-object of type int will throw a TypeError in PHP 8.0+
+%s:11 PhanSuspiciousWeakTypeComparison Suspicious attempt to compare $obj of type \TestObj5906 to $i of type int
+%s:11 PhanTypeComparisonObjectOrdering Using ordering comparison operator with an object of type \TestObj5906 and a non-object of type int will throw a TypeError in PHP 8.0+
+%s:22 PhanSuspiciousWeakTypeComparison Suspicious attempt to compare $obj of type \TestObj5906 to $i of type int
+%s:23 PhanImpossibleTypeComparison Impossible attempt to check if $obj of type \TestObj5906 is identical to $i of type int
+%s:24 PhanSuspiciousWeakTypeComparison Suspicious attempt to compare $obj of type \TestObj5906 to $i of type int

--- a/tests/files/src/5906_object_ordering_comparison.php
+++ b/tests/files/src/5906_object_ordering_comparison.php
@@ -1,0 +1,41 @@
+<?php
+
+class TestObj5906 {}
+
+function test_object_vs_scalar(TestObj5906 $obj, int $i, string $s, float $f) {
+    // Should warn - object ordering with non-object
+    var_export($obj < $i);
+    var_export($obj > $s);
+    var_export($obj <= $f);
+    var_export($i >= $obj);
+    var_export($obj <=> $i);
+}
+
+function test_object_vs_object(TestObj5906 $a, TestObj5906 $b) {
+    // Should NOT warn - object-to-object ordering is valid
+    var_export($a < $b);
+    var_export($a <=> $b);
+}
+
+function test_equality(TestObj5906 $obj, int $i) {
+    // Should NOT warn - equality operators are fine
+    var_export($obj == $i);
+    var_export($obj === $i);
+    var_export($obj != $i);
+}
+
+/**
+ * @param mixed $m
+ */
+function test_mixed(TestObj5906 $obj, $m) {
+    // Should NOT warn - mixed could be anything
+    var_export($obj < $m);
+}
+
+/**
+ * @param TestObj5906|int $u
+ */
+function test_union($u, int $i) {
+    // Should NOT warn - union includes non-object type
+    var_export($u < $i);
+}


### PR DESCRIPTION
## Summary
- Add `PhanTypeComparisonObjectOrdering` issue type to detect when ordering operators (`<`, `<=`, `>`, `>=`, `<=>`) are used to compare an object with a non-object value, which throws `TypeError` in PHP 8.0+
- Object-to-object ordering comparisons remain valid (PHP compares properties)
- Checks are guarded against false positives: no warning for empty types, mixed types, or union types containing non-object types
- Detection added to both `visitBinaryOpCommon()` (for `<`, `<=`, `>`, `>=`) and `visitBinarySpaceship()` (for `<=>`)

## Test plan
- [x] New test `5906_object_ordering_comparison.php` covers: object vs scalar, object vs object (no warning), equality operators (no warning), mixed parameter (no warning), union type parameter (no warning)
- [x] Updated expected output for `0718_suspicious_comparisons.php` and `0362_array_map_analyze.php` (both correctly receive new warnings)
- [x] `./phan` self-analysis passes
- [x] `./tests/run_test __FakeSelfTest` passes
- [x] `./vendor/bin/phpunit` full suite passes (2322 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)