### PR TITLE
fixes #5444 again

### DIFF
--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -2249,6 +2249,10 @@ class UnionTypeVisitor extends AnalysisVisitor
     private static function hasGenericArrayAcceptingArbitraryKeys(UnionType $union_type): bool
     {
         foreach ($union_type->getTypeSet() as $type) {
+            // mixed can be anything including an array with any keys
+            if ($type instanceof MixedType) {
+                return true;
+            }
             // Plain `array` type without shape or generic parameters (accepts arbitrary keys)
             if ($type instanceof ArrayType && !($type instanceof ArrayShapeType) && !($type instanceof GenericArrayInterface)) {
                 return true;

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -2236,15 +2236,15 @@ class UnionTypeVisitor extends AnalysisVisitor
     }
 
     /**
-     * Check if the union type contains any array-like type that would accept arbitrary key access.
+     * Check if the union type contains any type that would accept arbitrary key access.
      * This is used to avoid false positives when a union contains both shape types and generic arrays.
      *
-     * An array accepts arbitrary keys if:
+     * A type accepts arbitrary keys if:
+     * - It's `mixed` (could be any array with any keys)
      * - It's a plain `array` type (not a shape or list)
      * - It's a GenericArrayType with KEY_MIXED (accepts both int and string keys)
      *
      * Arrays with restricted key types (e.g., array<int, T> or array<string, T>) do NOT accept arbitrary keys.
-     * Note: bare `mixed` is excluded because it could be a scalar or object at runtime.
      */
     private static function hasGenericArrayAcceptingArbitraryKeys(UnionType $union_type): bool
     {

--- a/tests/files/expected/5409_possibly_invalid_dim_offset_consistency.php.expected
+++ b/tests/files/expected/5409_possibly_invalid_dim_offset_consistency.php.expected
@@ -1,10 +1,2 @@
 %s:11 PhanUndeclaredGlobalVariable Global variable $rows is undeclared
-%s:24 PhanTypePossiblyInvalidDimOffset Possibly invalid offset 'key1' of $row of array type array{key1?:non-empty-mixed,key2?:non-empty-mixed}|mixed|non-empty-mixed
-%s:26 PhanTypePossiblyInvalidDimOffset Possibly invalid offset 'key2' of $row of array type array{key1?:non-empty-mixed,key2?:non-empty-mixed}|mixed|non-empty-mixed
 %s:36 PhanUndeclaredGlobalVariable Global variable $data is undeclared
-%s:45 PhanTypePossiblyInvalidDimOffset Possibly invalid offset 'a' of $item of array type array{a?:non-empty-mixed,b?:non-empty-mixed,c?:non-empty-mixed}|mixed|non-empty-mixed
-%s:46 PhanTypePossiblyInvalidDimOffset Possibly invalid offset 'b' of $item of array type array{a?:non-empty-mixed,b?:non-empty-mixed,c?:non-empty-mixed}|mixed|non-empty-mixed
-%s:47 PhanTypePossiblyInvalidDimOffset Possibly invalid offset 'c' of $item of array type array{a?:non-empty-mixed,b?:non-empty-mixed,c?:non-empty-mixed}|mixed|non-empty-mixed
-%s:56 PhanTypePossiblyInvalidDimOffset Possibly invalid offset 'x' of $arr of array type array{x?:int,y?:int,z?:int}|mixed
-%s:57 PhanTypePossiblyInvalidDimOffset Possibly invalid offset 'y' of $arr of array type array{x?:int,y?:int,z?:int}|mixed
-%s:58 PhanTypePossiblyInvalidDimOffset Possibly invalid offset 'z' of $arr of array type array{x?:int,y?:int,z?:int}|mixed

--- a/tests/files/expected/5908_array_shape_ternary_dim.php.expected
+++ b/tests/files/expected/5908_array_shape_ternary_dim.php.expected
@@ -1,5 +1,0 @@
-%s:23 PhanTypePossiblyInvalidDimOffset Possibly invalid offset 'b' of $arr of array type array{b?:non-empty-mixed,a:non-empty-mixed}|mixed|non-empty-mixed
-%s:37 PhanTypePossiblyInvalidDimOffset Possibly invalid offset 'b' of $arr of array type array{b?:non-empty-mixed,a:non-empty-mixed}|mixed|non-empty-mixed
-%s:74 PhanTypePossiblyInvalidDimOffset Possibly invalid offset 'b' of $arr of array type array{b?:non-empty-mixed,a:non-empty-mixed}|mixed|non-empty-mixed
-%s:78 PhanTypePossiblyInvalidDimOffset Possibly invalid offset 'b' of $arr of array type array{b?:non-empty-mixed,a:non-empty-mixed}|mixed|non-empty-mixed
-%s:88 PhanTypePossiblyInvalidDimOffset Possibly invalid offset 'b' of $arr of array type array{b?:non-empty-mixed,a:non-empty-mixed}|mixed|non-empty-mixed


### PR DESCRIPTION
- Fix remaining false `PhanTypePossiblyInvalidDimOffset` warnings when accessing keys on `mixed`-typed variables (follow-up to #5444)
- The original fix in #5446 addressed established fields being invalidated during array shape merging, but accessing *new* keys still falsely warned

When a `mixed`-typed variable has array shape fields inferred through conditional expressions, subsequent accesses to different keys produce false `PhanTypePossiblyInvalidDimOffset` warnings:

```php
$arr = $GLOBALS['x'];              // type: mixed
$a = $arr['a'] ? $arr['a'] : [];   // no warning (good), refines type to array{a:non-empty-mixed}|mixed|non-empty-mixed
var_dump($arr['b'] ? [] : 'x');    // false PhanTypePossiblyInvalidDimOffset on 'b'
```

The first access `$arr['a']` is fine because there's no array shape yet, so the array shape checking logic is bypassed entirely. But that access creates an array shape as a side effect of type narrowing. When `$arr['b']` is then accessed, the shape logic finds `'b'` is not in the existing shape, marks it as possibly-undefined, and warns — even though `mixed` is still in the union and could be any array with any keys.

## Fix

`hasGenericArrayAcceptingArbitraryKeys()` in `UnionTypeVisitor.php` determines whether a `PhanTypePossiblyInvalidDimOffset` warning should be suppressed. It already recognized plain `array` types and `GenericArrayType` with mixed keys, but did not recognize `MixedType`. Since `mixed` can be anything including an array with arbitrary keys, it should suppress the warning.

The fix adds a `MixedType` check to `hasGenericArrayAcceptingArbitraryKeys()`.