### PR TITLE
Replace felixfbecker/advanced-json-rpc with danog/advanced-json-rpc, allow sabre/event 6.0

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -462,7 +462,7 @@ return [
         'tests/Phan',
         'vendor/composer/semver/src',
         'vendor/composer/xdebug-handler/src',
-        'vendor/felixfbecker/advanced-json-rpc/lib',
+        'vendor/danog/advanced-json-rpc/lib',
         'vendor/phan/tolerant-php-parser/src',
         'vendor/netresearch/jsonmapper/src',
         'vendor/phpdocumentor/reflection-docblock/src',

--- a/composer.json
+++ b/composer.json
@@ -31,14 +31,14 @@
         "ext-tokenizer": "*",
         "composer/semver": "^1.4|^2.0|^3.0",
         "composer/xdebug-handler": "^2.0|^3.0",
-        "felixfbecker/advanced-json-rpc": "^3.0.4",
+        "danog/advanced-json-rpc": "^3.0.4",
         "netresearch/jsonmapper": "^1.6.0|^2.0|^3.0|^4.0|^5.0",
         "phan/tolerant-php-parser": "v0.2.0",
-        "sabre/event": "^5.1.3",
+        "phan/var_representation_polyfill": "^0.1.4",
+        "sabre/event": "^5.1.3|^6.0",
         "symfony/console": "^6.0|^7.0|^8.0",
         "symfony/polyfill-mbstring": "^1.11.0",
-        "symfony/string": "^6.0|^7.0|^8.0",
-        "phan/var_representation_polyfill": "^0.1.4"
+        "symfony/string": "^6.0|^7.0|^8.0"
     },
     "suggest": {
         "ext-ast": "Needed for parsing ASTs (unless --use-fallback-parser is used). 1.1.3+ is needed.",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "da987b3847e1213a08f6b6c39d5522ce",
+    "content-hash": "f668362c63f6bb703c446baa4018bd92",
     "packages": [
         {
             "name": "composer/pcre",
@@ -229,6 +229,51 @@
             "time": "2024-05-06T16:37:16+00:00"
         },
         {
+            "name": "danog/advanced-json-rpc",
+            "version": "v3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/danog/php-advanced-json-rpc.git",
+                "reference": "b5f37dbff9a8ad360ca341f3240dc1c168b45447"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/danog/php-advanced-json-rpc/zipball/b5f37dbff9a8ad360ca341f3240dc1c168b45447",
+                "reference": "b5f37dbff9a8ad360ca341f3240dc1c168b45447",
+                "shasum": ""
+            },
+            "require": {
+                "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
+                "php": "^7.1 || ^8.0",
+                "phpdocumentor/reflection-docblock": "^4.3.4 || ^5.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "AdvancedJsonRpc\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Felix Becker",
+                    "email": "felix.b@outlook.com"
+                }
+            ],
+            "description": "A more advanced JSONRPC implementation",
+            "support": {
+                "issues": "https://github.com/danog/php-advanced-json-rpc/issues",
+                "source": "https://github.com/danog/php-advanced-json-rpc/tree/v3.2.1"
+            },
+            "time": "2021-06-11T22:34:44+00:00"
+        },
+        {
             "name": "doctrine/deprecations",
             "version": "1.1.5",
             "source": {
@@ -275,51 +320,6 @@
                 "source": "https://github.com/doctrine/deprecations/tree/1.1.5"
             },
             "time": "2025-04-07T20:06:18+00:00"
-        },
-        {
-            "name": "felixfbecker/advanced-json-rpc",
-            "version": "v3.2.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/felixfbecker/php-advanced-json-rpc.git",
-                "reference": "b5f37dbff9a8ad360ca341f3240dc1c168b45447"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/felixfbecker/php-advanced-json-rpc/zipball/b5f37dbff9a8ad360ca341f3240dc1c168b45447",
-                "reference": "b5f37dbff9a8ad360ca341f3240dc1c168b45447",
-                "shasum": ""
-            },
-            "require": {
-                "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
-                "php": "^7.1 || ^8.0",
-                "phpdocumentor/reflection-docblock": "^4.3.4 || ^5.0.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^7.0 || ^8.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "AdvancedJsonRpc\\": "lib/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "ISC"
-            ],
-            "authors": [
-                {
-                    "name": "Felix Becker",
-                    "email": "felix.b@outlook.com"
-                }
-            ],
-            "description": "A more advanced JSONRPC implementation",
-            "support": {
-                "issues": "https://github.com/felixfbecker/php-advanced-json-rpc/issues",
-                "source": "https://github.com/felixfbecker/php-advanced-json-rpc/tree/v3.2.1"
-            },
-            "time": "2021-06-11T22:34:44+00:00"
         },
         {
             "name": "netresearch/jsonmapper",
@@ -803,25 +803,28 @@
         },
         {
             "name": "sabre/event",
-            "version": "5.1.7",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sabre-io/event.git",
-                "reference": "86d57e305c272898ba3c28e9bd3d65d5464587c2"
+                "reference": "70525d519b6fbd8e2cbef4e0dbe69c9d4a3e2db7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sabre-io/event/zipball/86d57e305c272898ba3c28e9bd3d65d5464587c2",
-                "reference": "86d57e305c272898ba3c28e9bd3d65d5464587c2",
+                "url": "https://api.github.com/repos/sabre-io/event/zipball/70525d519b6fbd8e2cbef4e0dbe69c9d4a3e2db7",
+                "reference": "70525d519b6fbd8e2cbef4e0dbe69c9d4a3e2db7",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0"
+                "php": "^7.4 || ^8.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "~2.17.1||^3.63",
-                "phpstan/phpstan": "^0.12",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6"
+                "friendsofphp/php-cs-fixer": "^3.64",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^1.12",
+                "phpstan/phpstan-phpunit": "^1.4",
+                "phpstan/phpstan-strict-rules": "^1.6",
+                "phpunit/phpunit": "^9.6"
             },
             "type": "library",
             "autoload": {
@@ -865,7 +868,7 @@
                 "issues": "https://github.com/sabre-io/event/issues",
                 "source": "https://github.com/fruux/sabre-event"
             },
-            "time": "2024-08-27T11:23:05+00:00"
+            "time": "2024-09-06T10:14:28+00:00"
         },
         {
             "name": "symfony/console",


### PR DESCRIPTION
Replaces unmaintained `felixfbecker/advanced-json-rpc` dependency with recently updated `danog/advanced-json-rpc`.
Also allows `sabre/event` 6.0.