### PR TITLE
Fixes #5440: Wrong type assumptions on typed class members

### DIFF
--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -1499,6 +1499,7 @@ class AssignmentVisitor extends AnalysisVisitor
     {
         if ($this->dim_depth === 0) {
             $new_type = $this->right_type;
+            $new_type = $this->narrowTypeToDeclaredPropertyType($new_type, $prop_name);
         } else {
             // Copied from visitVar
             $old_type = UnionTypeVisitor::unionTypeFromNode($this->code_base, $this->context, $node);
@@ -1519,10 +1520,47 @@ class AssignmentVisitor extends AnalysisVisitor
         $this->context = $this->context->withThisPropertySetToTypeByName($prop_name, $new_type);
     }
 
+    /**
+     * Narrows a union type to only include types compatible with the declared property type.
+     * If the filter produces an empty result (complete type mismatch), returns the original type unchanged
+     * since Phan reports the mismatch elsewhere via analyzePropAssignment.
+     */
+    private function narrowTypeToDeclaredPropertyType(UnionType $type, string $prop_name): UnionType
+    {
+        $class_fqsen = $this->context->getClassFQSENOrNull();
+        if ($class_fqsen === null) {
+            return $type;
+        }
+        if (!$this->code_base->hasClassWithFQSEN($class_fqsen)) {
+            return $type;
+        }
+        $clazz = $this->code_base->getClassByFQSEN($class_fqsen);
+        if (!$clazz->hasPropertyWithName($this->code_base, $prop_name)) {
+            return $type;
+        }
+        $property = $clazz->getPropertyByName($this->code_base, $prop_name);
+        $declared_type = $property->getRealUnionType();
+        if ($declared_type->isEmpty()) {
+            $declared_type = $property->getPHPDocUnionType();
+        }
+        if ($declared_type->isEmpty()) {
+            return $type;
+        }
+        $code_base = $this->code_base;
+        $narrowed = $type->makeFromFilter(static function (Type $single_type) use ($declared_type, $code_base): bool {
+            return $single_type->asPHPDocUnionType()->canCastToUnionType($declared_type, $code_base);
+        });
+        if ($narrowed->isEmpty()) {
+            return $type;
+        }
+        return $narrowed;
+    }
+
     private function handleStaticPropertyAssignmentInLocalScopeByName(Node $node, string $prop_name): void
     {
         if ($this->dim_depth === 0) {
             $new_type = $this->right_type;
+            $new_type = $this->narrowTypeToDeclaredPropertyType($new_type, $prop_name);
         } else {
             // Copied from visitVar
             $old_type = UnionTypeVisitor::unionTypeFromNode($this->code_base, $this->context, $node);

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -1552,7 +1552,7 @@ class AssignmentVisitor extends AnalysisVisitor
             // Strip nullability for the check — nullable-to-non-null mismatches are
             // already reported via analyzePropAssignment, and we want ?Foo to be
             // recognized as compatible with a non-null Foo declared type.
-            return $single_type->withIsNullable(false)->asPHPDocUnionType()->canCastToUnionType($declared_type, $code_base);
+            return $single_type->withIsNullable(false)->asPHPDocUnionType()->canCastToUnionTypeWithoutConfig($declared_type, $code_base);
         });
         if ($narrowed->isEmpty()) {
             return $type;
@@ -1567,9 +1567,9 @@ class AssignmentVisitor extends AnalysisVisitor
 
     private function handleStaticPropertyAssignmentInLocalScopeByName(Node $node, string $prop_name): void
     {
+        $target = $this->getStaticPropertyAssignmentTarget($node);
         if ($this->dim_depth === 0) {
             $new_type = $this->right_type;
-            $target = $this->getStaticPropertyAssignmentTarget($node);
             $new_type = $this->narrowTypeToDeclaredPropertyType($new_type, $prop_name, $target[0] ?? null);
         } else {
             // Copied from visitVar
@@ -1589,14 +1589,11 @@ class AssignmentVisitor extends AnalysisVisitor
             }
         }
         $this->context = $this->context->withStaticPropertySetToTypeByName($prop_name, $new_type);
-        if ($this->context->isInFunctionLikeScope()) {
+        if ($target && $this->context->isInFunctionLikeScope()) {
             $function_like = $this->context->getFunctionLikeInScope($this->code_base);
             if ($function_like instanceof Method) {
-                $target = $this->getStaticPropertyAssignmentTarget($node);
-                if ($target) {
-                    [$target_class, $is_late_static] = $target;
-                    $function_like->recordStaticPropertyModification($target_class, $prop_name, $new_type, $is_late_static);
-                }
+                [$target_class, $is_late_static] = $target;
+                $function_like->recordStaticPropertyModification($target_class, $prop_name, $new_type, $is_late_static);
             }
         }
     }

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -1549,10 +1549,18 @@ class AssignmentVisitor extends AnalysisVisitor
         }
         $code_base = $this->code_base;
         $narrowed = $type->makeFromFilter(static function (Type $single_type) use ($declared_type, $code_base): bool {
-            return $single_type->asPHPDocUnionType()->canCastToUnionType($declared_type, $code_base);
+            // Strip nullability for the check — nullable-to-non-null mismatches are
+            // already reported via analyzePropAssignment, and we want ?Foo to be
+            // recognized as compatible with a non-null Foo declared type.
+            return $single_type->withIsNullable(false)->asPHPDocUnionType()->canCastToUnionType($declared_type, $code_base);
         });
         if ($narrowed->isEmpty()) {
             return $type;
+        }
+        // If the declared type is non-null, strip nullability from the result.
+        // If the assignment succeeded at runtime, the property holds a non-null value.
+        if (!$declared_type->containsNullableOrUndefined()) {
+            $narrowed = $narrowed->nonNullableClone();
         }
         return $narrowed;
     }

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -1522,12 +1522,16 @@ class AssignmentVisitor extends AnalysisVisitor
 
     /**
      * Narrows a union type to only include types compatible with the declared property type.
+     * Only narrows based on native (runtime-enforced) property types, not PHPDoc annotations.
      * If the filter produces an empty result (complete type mismatch), returns the original type unchanged
      * since Phan reports the mismatch elsewhere via analyzePropAssignment.
+     *
+     * @param ?FullyQualifiedClassName $target_class_fqsen The class owning the property (for static properties
+     *        this may differ from the current class, e.g. parent::$prop). Falls back to the current class context.
      */
-    private function narrowTypeToDeclaredPropertyType(UnionType $type, string $prop_name): UnionType
+    private function narrowTypeToDeclaredPropertyType(UnionType $type, string $prop_name, ?FullyQualifiedClassName $target_class_fqsen = null): UnionType
     {
-        $class_fqsen = $this->context->getClassFQSENOrNull();
+        $class_fqsen = $target_class_fqsen ?? $this->context->getClassFQSENOrNull();
         if ($class_fqsen === null) {
             return $type;
         }
@@ -1540,9 +1544,6 @@ class AssignmentVisitor extends AnalysisVisitor
         }
         $property = $clazz->getPropertyByName($this->code_base, $prop_name);
         $declared_type = $property->getRealUnionType();
-        if ($declared_type->isEmpty()) {
-            $declared_type = $property->getPHPDocUnionType();
-        }
         if ($declared_type->isEmpty()) {
             return $type;
         }
@@ -1560,7 +1561,8 @@ class AssignmentVisitor extends AnalysisVisitor
     {
         if ($this->dim_depth === 0) {
             $new_type = $this->right_type;
-            $new_type = $this->narrowTypeToDeclaredPropertyType($new_type, $prop_name);
+            $target = $this->getStaticPropertyAssignmentTarget($node);
+            $new_type = $this->narrowTypeToDeclaredPropertyType($new_type, $prop_name, $target[0] ?? null);
         } else {
             // Copied from visitVar
             $old_type = UnionTypeVisitor::unionTypeFromNode($this->code_base, $this->context, $node);

--- a/tests/files/expected/5911_property_type_narrowing.php.expected
+++ b/tests/files/expected/5911_property_type_narrowing.php.expected
@@ -1,1 +1,2 @@
 %s:62 PhanPossiblyNullTypeMismatchProperty Assigning $config->handler of type ?\Reader5911|?\Writer5911|\CsvReader5911 to property but \WrongMethodProcessor5911->writer is \Writer5911 (null is incompatible)
+%s:64 PhanUndeclaredMethod Call to undeclared method \Writer5911::readLines

--- a/tests/files/expected/5911_property_type_narrowing.php.expected
+++ b/tests/files/expected/5911_property_type_narrowing.php.expected
@@ -1,0 +1,1 @@
+%s:62 PhanPossiblyNullTypeMismatchProperty Assigning $config->handler of type ?\Reader5911|?\Writer5911|\CsvReader5911 to property but \WrongMethodProcessor5911->writer is \Writer5911 (null is incompatible)

--- a/tests/files/src/5911_property_type_narrowing.php
+++ b/tests/files/src/5911_property_type_narrowing.php
@@ -60,7 +60,7 @@ class WrongMethodProcessor5911 {
     function process(): string {
         $config = Config5911::create();
         $this->writer = $config->handler;
-        // readLines() does NOT exist on Writer5911 - this SHOULD warn
+        // After narrowing, $this->writer is typed as Writer5911 (the declared type)
         return $this->writer->readLines();
     }
 }

--- a/tests/files/src/5911_property_type_narrowing.php
+++ b/tests/files/src/5911_property_type_narrowing.php
@@ -1,0 +1,66 @@
+<?php
+
+// Bug 5440: When assigning a wider union type to a typed property,
+// Phan should narrow the local scope type to match the declared property type.
+
+class Config5911 {
+    public Reader5911|Writer5911|null $handler = null;
+    public static function create(): self {
+        $c = new self();
+        $c->handler = new CsvReader5911();
+        return $c;
+    }
+}
+
+abstract class Reader5911 {
+    abstract public function readLines(): string;
+}
+
+class CsvReader5911 extends Reader5911 {
+    public function readLines(): string {
+        return '';
+    }
+}
+
+abstract class Writer5911 {
+    abstract public function writeLines(string $data): void;
+}
+
+// Test 1: static property with wider union type assignment
+abstract class StaticProcessor5911 {
+    private static Reader5911 $reader;
+
+    static function process(): string {
+        $config = Config5911::create();
+        self::$reader = $config->handler;
+        // readLines() exists on Reader5911 but not Writer5911
+        // Since self::$reader is declared as Reader5911, this should be fine
+        return self::$reader->readLines();
+    }
+}
+
+// Test 2: instance property with wider union type assignment
+class InstanceProcessor5911 {
+    private Reader5911 $reader;
+    public function __construct() { $this->reader = new CsvReader5911(); }
+
+    function process(): string {
+        $config = Config5911::create();
+        $this->reader = $config->handler;
+        // Same as Test 1 but for instance property
+        return $this->reader->readLines();
+    }
+}
+
+// Test 3: Should still warn for genuinely wrong method calls
+class WrongMethodProcessor5911 {
+    private Writer5911 $writer;
+    public function __construct(Writer5911 $w) { $this->writer = $w; }
+
+    function process(): string {
+        $config = Config5911::create();
+        $this->writer = $config->handler;
+        // readLines() does NOT exist on Writer5911 - this SHOULD warn
+        return $this->writer->readLines();
+    }
+}


### PR DESCRIPTION
When assigning a wider union type to a typed property (e.g. `self::$reader = $config->handler` where `$reader` is declared as `Reader` but `$handler` is `Reader|Writer|null`), Phan stored the raw RHS type in the local scope override without narrowing it to the declared property type. Subsequent reads of the property within the same method used the wider type, producing false `PhanPossiblyUndeclaredMethod` and `PhanPossiblyNonClassMethodCall` warnings.

The fix adds a helper method `narrowTypeToDeclaredPropertyType()` in `AssignmentVisitor.php` that filters the RHS union type to only include types compatible with the declared property type. It is called from both `handleThisPropertyAssignmentInLocalScopeByName()` and `handleStaticPropertyAssignmentInLocalScopeByName()` for direct assignments (`dim_depth === 0`). If the filter produces an empty result (complete type mismatch), the original type is returned unchanged since Phan already reports that mismatch via `analyzePropAssignment`.