### PR TITLE
Fixes #5454

### DIFF
--- a/src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php
@@ -460,11 +460,7 @@ final class DependentReturnTypeOverridePlugin extends PluginV3 implements
             // class name, not a parameterized type (e.g. class-string<Foo>
             // not class-string<Foo<T>>). This also avoids crashes when
             // template type names like T can't be parsed as standalone types.
-            $erased_types = [];
-            foreach ($object_types->getTypeSet() as $type) {
-                $erased_types[] = $type->eraseTemplatesRecursive();
-            }
-            $erased_union = UnionType::of($erased_types, []);
+            $erased_union = $object_types->eraseTemplatesRecursive();
             $class_string_type = Type::fromType(ClassStringType::instance(false), [$erased_union]);
             return $class_string_type->asPHPDocUnionType();
         };

--- a/src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php
@@ -455,10 +455,18 @@ final class DependentReturnTypeOverridePlugin extends PluginV3 implements
                 return ClassStringType::instance(false)->asPHPDocUnionType();
             }
 
-            // Create class-string<T> where T is the union of object types
-            // Build the string representation and parse it
-            $type_string = 'class-string<' . $object_types->__toString() . '>';
-            return UnionType::fromFullyQualifiedPHPDocString($type_string);
+            // Create class-string<T> where T is the union of object types.
+            // Erase template parameters since get_class() returns a runtime
+            // class name, not a parameterized type (e.g. class-string<Foo>
+            // not class-string<Foo<T>>). This also avoids crashes when
+            // template type names like T can't be parsed as standalone types.
+            $erased_types = [];
+            foreach ($object_types->getTypeSet() as $type) {
+                $erased_types[] = $type->eraseTemplatesRecursive();
+            }
+            $erased_union = UnionType::of($erased_types, []);
+            $class_string_type = Type::fromType(ClassStringType::instance(false), [$erased_union]);
+            return $class_string_type->asPHPDocUnionType();
         };
 
         // TODO: Handle flags of preg_split.

--- a/tests/files/expected/5913_get_class_template.php.expected
+++ b/tests/files/expected/5913_get_class_template.php.expected
@@ -1,0 +1,4 @@
+%s:14 PhanDebugAnnotation @phan-debug-var requested for variable $class - it has union type class-string<static>(real=string)
+%s:22 PhanDebugAnnotation @phan-debug-var requested for variable $class - it has union type class-string<static>(real=string)
+%s:30 PhanDebugAnnotation @phan-debug-var requested for variable $class - it has union type class-string<static>(real=string)
+%s:38 PhanDebugAnnotation @phan-debug-var requested for variable $class - it has union type class-string<static>(real=string)

--- a/tests/files/src/5913_get_class_template.php
+++ b/tests/files/src/5913_get_class_template.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * Test for GitHub issue #5454
+ * get_class($this) in a class with template parameters should not crash.
+ * Template parameters should be erased from the inferred class-string type
+ * since get_class() returns a runtime class name, not a parameterized type.
+ * @phan-file-suppress PhanUnreferencedClass,PhanUnusedVariable
+ */
+
+/** @template T */
+class SingleTemplate {
+    public function test(): void {
+        $class = get_class($this);
+        '@phan-debug-var $class';
+    }
+}
+
+/** @template K @template V */
+class MultiTemplate {
+    public function test(): void {
+        $class = get_class($this);
+        '@phan-debug-var $class';
+    }
+}
+
+/** @template T of object */
+class BoundTemplate {
+    public function test(): void {
+        $class = get_class($this);
+        '@phan-debug-var $class';
+    }
+}
+
+// Non-template class for comparison
+class PlainClass {
+    public function test(): void {
+        $class = get_class($this);
+        '@phan-debug-var $class';
+    }
+}


### PR DESCRIPTION
- Replaced string-based type construction with programmatic construction via `Type::fromType()`
- Erase template parameters from object types before wrapping in `class-string<>`, since `get_class()` returns a runtime class name (e.g., `class-string<static>` not `class-string<static<T>>`)