### PR TITLE
Fixes #5463

### DIFF
--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -3497,7 +3497,7 @@ class UnionTypeVisitor extends AnalysisVisitor
             $this->context,
             $node->children['expr'],
             $this->should_catch_issue_exception
-        )->getRealUnionType();
+        );
         $result = $this->visitMethodCall($node);
         if ($result->isEmpty()) {
             return $result->nullableClone();


### PR DESCRIPTION
Don't call `getRealUnionType()` from `visitNullsafeMethodCall()` or we miss nullables if they are only in phpdoc