### PR TITLE
Handle isset() type narrowing for static properties (self::$prop)

### DIFF
--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -477,6 +477,15 @@ class ConditionVisitor extends KindVisitorImplementation implements ConditionVis
                     return $context;
                 }
                 continue;
+            } elseif ($kind === ast\AST_STATIC_PROP) {
+                // isset(self::$prop) means the property is non-null
+                return $this->modifyStaticPropertySimple(
+                    $var_node,
+                    static function (UnionType $type): UnionType {
+                        return $type->nonNullableClone();
+                    },
+                    $context
+                );
             }
 
             // TODO: Handle more than one level of nesting

--- a/src/Phan/Analysis/NegatedConditionVisitor.php
+++ b/src/Phan/Analysis/NegatedConditionVisitor.php
@@ -931,6 +931,11 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
             $context = $this->modifyPropertySimple($var_node, static function (UnionType $_): UnionType {
                 return NullType::instance(false)->asPHPDocUnionType();
             }, $context);
+        } elseif ($var_node->kind === ast\AST_STATIC_PROP) {
+            // !isset(self::$prop) means the property is null
+            $context = $this->modifyStaticPropertySimple($var_node, static function (UnionType $_): UnionType {
+                return NullType::instance(false)->asPHPDocUnionType();
+            }, $context);
         }
         return $context;
     }

--- a/tests/files/expected/5915_isset_static_property_narrowing.php.expected
+++ b/tests/files/expected/5915_isset_static_property_narrowing.php.expected
@@ -1,0 +1,4 @@
+%s:11 PhanDebugAnnotation @phan-debug-var requested for variable $v - it has union type string(real=non-null-mixed)
+%s:28 PhanDebugAnnotation @phan-debug-var requested for variable $d - it has union type null
+%s:28 PhanUnusedVariable Unused definition of variable $d
+%s:43 PhanDebugAnnotation @phan-debug-var requested for variable $d - it has union type 42|int|string(real=42|non-null-mixed)

--- a/tests/files/src/5915_isset_static_property_narrowing.php
+++ b/tests/files/src/5915_isset_static_property_narrowing.php
@@ -1,0 +1,47 @@
+<?php
+
+// Test 1: isset(self::$prop) should narrow static property to non-null
+// (tests ConditionVisitor::checkComplexIsset)
+class IssetNarrow5915 {
+    /** @var string|null */
+    private static $value = null;
+
+    public static function getValue(): ?string {
+        if (isset(self::$value)) {
+            $v = self::$value;
+            '@phan-debug-var $v';
+            return $v;
+        }
+        return null;
+    }
+}
+
+// Test 2: !isset(self::$prop) should narrow to null before any assignment
+// (tests NegatedConditionVisitor::checkComplexIsset)
+class NotIssetNarrow5915 {
+    /** @var int|string|null */
+    private static $data = null;
+
+    public static function check(): void {
+        if (!isset(self::$data)) {
+            // Before any assignment, self::$data should be narrowed to null
+            $d = self::$data;
+            '@phan-debug-var $d';
+        }
+    }
+}
+
+// Test 3: !isset + assignment pattern should preserve phpdoc types through merge
+class IssetAssign5915 {
+    /** @var int|string|null */
+    private static $data = null;
+
+    public static function getData(): int|string {
+        if (!isset(self::$data)) {
+            self::$data = 42;
+        }
+        $d = self::$data;
+        '@phan-debug-var $d';
+        return $d;
+    }
+}


### PR DESCRIPTION
## Summary
- Add `AST_STATIC_PROP` handling to `isset()` condition narrowing in both `ConditionVisitor::checkComplexIsset` and `NegatedConditionVisitor::checkComplexIsset`
- `isset(self::$prop)` now narrows the static property to non-null
- `!isset(self::$prop)` now narrows the static property to null
- This ensures both branches of `if (!isset(self::$prop))` have static property overrides, so the scope merge properly unions them

Previously, patterns like `if (!isset(self::$delegate)) { self::$delegate = SomeClass::class; }` would only narrow the static property type in the if-true branch. The fallthrough branch (where isset was true) had no type override, so the scope merge would keep only the narrow assignment type, losing the broader phpdoc types.

This is analogous to the existing `AST_PROP` handling for instance properties.

## Test plan
- [x] New test `5915_isset_static_property_narrowing.php` demonstrates narrowing works
- [x] Test fails without the fix (wrong types: `null|string` instead of `string`, `42` instead of `42|int|string`)
- [x] Test passes with the fix
- [x] Full test suite passes (1118 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)