### PR TITLE
Handle empty() type narrowing for static properties (self::$prop)

### DIFF
--- a/src/Phan/Analysis/ConditionVisitor.php
+++ b/src/Phan/Analysis/ConditionVisitor.php
@@ -1369,7 +1369,7 @@ class ConditionVisitor extends KindVisitorImplementation implements ConditionVis
             return $this->context;
         }
         // Should always be a node for valid ASTs, tolerant-php-parser may produce invalid nodes
-        if (\in_array($var_node->kind, [ast\AST_VAR, ast\AST_PROP, ast\AST_DIM], true)) {
+        if (\in_array($var_node->kind, [ast\AST_VAR, ast\AST_PROP, ast\AST_STATIC_PROP, ast\AST_DIM], true)) {
             // Don't emit notices for if (empty($x)) {}, etc. We already do that in RedundantConditionPlugin.
             return $this->removeTruthyFromVariable($var_node, $this->context, true, true);
         }

--- a/src/Phan/Analysis/NegatedConditionVisitor.php
+++ b/src/Phan/Analysis/NegatedConditionVisitor.php
@@ -1014,6 +1014,9 @@ class NegatedConditionVisitor extends KindVisitorImplementation implements Condi
                 return $this->removeTypesNotSupportingAccessFromVariable($expr, $context, ConditionVisitor::ACCESS_IS_OBJECT);
             }
             return $context;
+        } elseif ($var_node->kind === ast\AST_STATIC_PROP) {
+            // e.g. !empty(self::$prop) means the property is non-falsey
+            return $this->removeFalseyFromVariable($var_node, $context, true);
         } else {
             $context = $this->checkComplexNegatedEmpty($var_node);
         }

--- a/tests/files/expected/5916_empty_static_property_narrowing.php.expected
+++ b/tests/files/expected/5916_empty_static_property_narrowing.php.expected
@@ -1,0 +1,3 @@
+%s:10 PhanDebugAnnotation @phan-debug-var requested for variable $n - it has union type non-empty-string(real=non-empty-mixed)
+%s:25 PhanDebugAnnotation @phan-debug-var requested for variable $i - it has union type array{}|null(real=?''|?'0'|?0|?0.0|?array{}|?false)
+%s:25 PhanUnusedVariable Unused definition of variable $i

--- a/tests/files/src/5916_empty_static_property_narrowing.php
+++ b/tests/files/src/5916_empty_static_property_narrowing.php
@@ -1,0 +1,31 @@
+<?php
+
+// Test 1: !empty(self::$prop) should narrow static property to non-falsey
+class NotEmptyNarrow5916 {
+    /** @var string|null */
+    private static $name = null;
+
+    public static function getName(): ?string {
+        if (!empty(self::$name)) {
+            $n = self::$name;
+            '@phan-debug-var $n';
+            return $n;
+        }
+        return null;
+    }
+}
+
+// Test 2: empty(self::$prop) should narrow static property to falsey types
+class EmptyNarrow5916 {
+    /** @var array<string>|null */
+    private static $items = null;
+
+    public static function hasItems(): bool {
+        if (empty(self::$items)) {
+            $i = self::$items;
+            '@phan-debug-var $i';
+            return false;
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary
- Add `AST_STATIC_PROP` handling to `empty()` condition narrowing in both `ConditionVisitor::visitEmpty` and `NegatedConditionVisitor::visitEmpty`
- `empty(self::$prop)` now narrows the static property to falsey types
- `!empty(self::$prop)` now narrows the static property to non-falsey types

Previously, `empty(self::$prop)` and `!empty(self::$prop)` did not narrow the static property's type in the local scope, even though the analogous handling for `AST_VAR`, `AST_PROP`, and `AST_DIM` was already present.

## Test plan
- [x] New test `5916_empty_static_property_narrowing.php` demonstrates narrowing works
- [x] Test fails without the fix (wrong types: `null|string` instead of `non-empty-string`, `null|string[]` instead of `array{}|null`)
- [x] Test passes with the fix
- [x] Full test suite passes (1118 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)