### PR TITLE
Fix false positive PhanCoalescingNeverUndefined for static properties

### DIFF
--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -3234,6 +3234,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
                 }
                 return true;
             case ast\AST_PROP:
+            case ast\AST_STATIC_PROP:
             case ast\AST_DIM:
                 return false;
             default:

--- a/tests/files/expected/5917_static_prop_null_coalescing.php.expected
+++ b/tests/files/expected/5917_static_prop_null_coalescing.php.expected
@@ -1,0 +1,1 @@
+%s:20 PhanCoalescingNeverNull Using non-null self::$count of type int as the left hand side of a null coalescing (??) operation. The right hand side may be unnecessary.

--- a/tests/files/src/5917_static_prop_null_coalescing.php
+++ b/tests/files/src/5917_static_prop_null_coalescing.php
@@ -1,0 +1,22 @@
+<?php
+
+// Test: self::$prop ?? null should not warn about CoalescingNeverUndefined
+// because static properties can be unset or null
+class CoalesceTest5917 {
+    /** @var string|null */
+    private static $config = null;
+
+    public static function getConfig(): ?string {
+        // This should NOT emit PhanCoalescingNeverUndefined
+        return self::$config ?? null;
+    }
+
+    /** @var int */
+    private static int $count = 0;
+
+    public static function getCount(): int {
+        // This SHOULD still emit PhanCoalescingNeverNull because the
+        // real type is int (non-null), making ?? redundant
+        return self::$count ?? 0;
+    }
+}


### PR DESCRIPTION
## Summary
- Add `AST_STATIC_PROP` to the `isAlwaysDefined()` check in `BlockAnalysisVisitor` so that `self::$prop ?? null` does not incorrectly emit `PhanCoalescingNeverUndefined`

Previously, `AST_STATIC_PROP` fell through to the `default` case which returns `true`, incorrectly treating static property accesses as always defined. This caused false positive `PhanCoalescingNeverUndefined` warnings for legitimate uses of the null coalescing operator with static properties.

The fix adds `AST_STATIC_PROP` alongside the existing `AST_PROP` and `AST_DIM` cases that already return `false`.

## Test plan
- [x] New test `5917_static_prop_null_coalescing.php` demonstrates the false positive is gone
- [x] Test fails without the fix (extra `PhanCoalescingNeverUndefined` warning for `self::$config ?? null`)
- [x] Test passes with the fix (only the correct `PhanCoalescingNeverNull` for `self::$count ?? 0` remains)
- [x] Full test suite passes (1118 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)