### PR TITLE
Fix class-string<T> template resolution dropping literal string types

### DIFF
--- a/src/Phan/Language/Type/ClassStringType.php
+++ b/src/Phan/Language/Type/ClassStringType.php
@@ -90,9 +90,6 @@ final class ClassStringType extends StringType
                     $result = $result->withUnionType($inner_type->getClassUnionType());
                 }
             }
-            if (!$result->isEmpty()) {
-                return $result;
-            }
             foreach ($type->asStringScalarValues() as $string) {
                 // Convert string arguments to the classes they represent
                 try {

--- a/tests/files/expected/template_class_string_literal_union.php.expected
+++ b/tests/files/expected/template_class_string_literal_union.php.expected
@@ -1,0 +1,2 @@
+%s:31 PhanDebugAnnotation @phan-debug-var requested for variable $result - it has union type \C5916|\I5916
+%s:31 PhanUnusedVariable Unused definition of variable $result

--- a/tests/files/src/template_class_string_literal_union.php
+++ b/tests/files/src/template_class_string_literal_union.php
@@ -1,0 +1,33 @@
+<?php
+
+// Regression test for f54e54cff: template resolution through class-string<T>
+// must resolve literal class-string values even when the union also contains
+// a generic class-string<Interface> type.
+
+interface I5916 {}
+class C5916 implements I5916 {}
+
+/**
+ * @template T
+ * @param class-string<T> $class_name
+ * @return T
+ */
+function create5916(string $class_name) {
+    return new $class_name();
+}
+
+/** @return class-string<I5916> */
+function getClass5916(): string {
+    return C5916::class;
+}
+
+function test5916(bool $flag): void {
+    if ($flag) {
+        $class = getClass5916();  // class-string<I5916>
+    } else {
+        $class = C5916::class;   // literal 'C5916'
+    }
+    // $class is: class-string<I5916>|'C5916'
+    $result = create5916($class);
+    '@phan-debug-var $result';
+}


### PR DESCRIPTION
## Summary

- The template type extractor closure in `ClassStringType::getTemplateTypeExtractorClosure()` had an early return after processing `ClassStringType` instances in the union, which skipped any literal string values (e.g. from `Foo::class`).
- This caused template resolution to lose concrete types when the argument was a union of `class-string<SomeInterface>` and a literal class string.
- For example, given a variable typed as `class-string<I>|'ConcreteClass'` passed to a function with `@param class-string<T>`, the early return meant `T` resolved to only `I`, dropping `ConcreteClass`.

The early return was introduced in f54e54cff ("inside array shapes now correctly contribute the inferred template argument"). The intent of that commit was to handle `class-string<T>` inside array shapes, but the early return had the side effect of skipping literal string processing whenever a `ClassStringType` was present in the union.

The fix removes the early return so both `ClassStringType` and literal string components contribute to the resolved template type.

## Test plan

- Added `template_class_string_literal_union.php` test case that creates a union of `class-string<I5916>` and literal `'C5916'`, passes it to a template function, and verifies the resolved type includes both `\C5916` and `\I5916`.
- Test fails without the fix (`$result` resolves to only `\I5916`), passes with it (`\C5916|\I5916`).
- All existing PhanTest tests pass (1335 tests, 2669 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)