### PR TITLE
Fix stdClass shape leakage across unrelated scopes

### DIFF
--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -3330,12 +3330,26 @@ class UnionTypeVisitor extends AnalysisVisitor
         if (!$expr_node instanceof Node) {
             return null;
         }
-        $expr_union_type = UnionTypeVisitor::unionTypeFromNode(
-            $this->code_base,
-            $this->context,
-            $expr_node,
-            $this->should_catch_issue_exception
-        );
+        if ($expr_node->kind === ast\AST_VAR) {
+            $variable_name = $expr_node->children['name'] ?? null;
+            if (\is_string($variable_name) && $variable_name !== '' && $this->context->getScope()->hasVariableWithName($variable_name)) {
+                $expr_union_type = $this->context->getScope()->getVariableByName($variable_name)->getUnionType();
+            } else {
+                $expr_union_type = UnionTypeVisitor::unionTypeFromNode(
+                    $this->code_base,
+                    $this->context,
+                    $expr_node,
+                    $this->should_catch_issue_exception
+                );
+            }
+        } else {
+            $expr_union_type = UnionTypeVisitor::unionTypeFromNode(
+                $this->code_base,
+                $this->context,
+                $expr_node,
+                $this->should_catch_issue_exception
+            );
+        }
         if ($expr_union_type->isEmpty()) {
             return null;
         }

--- a/tests/files/expected/5918_stdclass_shape_scope_isolation.php.expected
+++ b/tests/files/expected/5918_stdclass_shape_scope_isolation.php.expected
@@ -1,0 +1,1 @@
+%s:11 PhanDebugAnnotation @phan-debug-var requested for variable $var - it has union type string

--- a/tests/files/src/5918_stdclass_shape_scope_isolation.php
+++ b/tests/files/src/5918_stdclass_shape_scope_isolation.php
@@ -1,0 +1,12 @@
+<?php
+
+function scope_a_5918() {
+    $data = (object)[];
+    $data->status = 3;
+}
+
+function scope_b_5918() {
+    $data = (object)['status' => 'string'];
+    $var = $data->status;
+    '@phan-debug-var $var';
+}


### PR DESCRIPTION
## Summary
- prefer the current-scope variable union type for `AST_VAR` reads in `inferStdClassShapePropertyType()` when the local variable exists
- keep fallback behavior unchanged for non-variable expressions and unresolved variables
- add regression test `5918_stdclass_shape_scope_isolation.php` for issue #4789 so unrelated stdClass writes do not affect a fresh object's property type

## Testing
- `php -v` *(fails in this environment: `php: command not found`, so Phan tests could not be executed here)*
- manual validation via new regression fixture + expected output asserting `@phan-debug-var $var` resolves to `string`

## Related
Fixes #4789
