### PR TITLE
Fixes #5479

### DIFF
--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -589,7 +589,7 @@ class ContextNode
                         return $this->node->flags !== ast\flags\TYPE_STATIC;
                     }
                 }
-                return $type->isObject() || ($type instanceof MixedType) || ($expected_type_categories !== self::CLASS_LIST_ACCEPT_OBJECT && $type instanceof StringType);
+                return $type->isObject() || ($type instanceof MixedType) || $type->hasTemplateTypeRecursive() || ($expected_type_categories !== self::CLASS_LIST_ACCEPT_OBJECT && $type instanceof StringType);
             })) {
                 if ($warn_if_wrong_type) {
                     if ($custom_issue_type === Issue::TypeExpectedObjectPropAccess) {

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -47,6 +47,7 @@ use Phan\Language\Type\MixedType;
 use Phan\Language\Type\NullType;
 use Phan\Language\Type\ObjectType;
 use Phan\Language\Type\StringType;
+use Phan\Language\Type\TemplateType;
 use Phan\Language\UnionType;
 use Phan\Library\None;
 
@@ -589,7 +590,7 @@ class ContextNode
                         return $this->node->flags !== ast\flags\TYPE_STATIC;
                     }
                 }
-                return $type->isObject() || ($type instanceof MixedType) || $type->hasTemplateTypeRecursive() || ($expected_type_categories !== self::CLASS_LIST_ACCEPT_OBJECT && $type instanceof StringType);
+                return $type->isObject() || ($type instanceof MixedType) || ($type instanceof TemplateType) || ($expected_type_categories !== self::CLASS_LIST_ACCEPT_OBJECT && $type instanceof StringType);
             })) {
                 if ($warn_if_wrong_type) {
                     if ($custom_issue_type === Issue::TypeExpectedObjectPropAccess) {

--- a/tests/files/src/5918_template_prop_access.php
+++ b/tests/files/src/5918_template_prop_access.php
@@ -1,0 +1,49 @@
+<?php
+
+// Test that accessing properties on a template type variable doesn't emit
+// PhanTypeExpectedObjectPropAccess (false positive for issue #5479).
+
+class DemoItem {
+    public int $type = 42;
+}
+
+class Demo {
+
+    /**
+     * @template T
+     * @param class-string<T> $class
+     * @param T[] $a
+     * @return T|null
+     */
+    public function getItem(string $class, array $a) {
+        // Should not emit PhanTypeExpectedObjectPropAccess — $i is template type T
+        $matching = array_filter(
+            $a,
+            static fn($i) => $i->type === 42
+        );
+        return $matching ? reset($matching) : null;
+    }
+
+    /**
+     * @template T of object
+     * @param T[] $a
+     * @return T|null
+     */
+    public function getItemBounded(array $a) {
+        // Should not emit PhanTypeExpectedObjectPropAccess — $i is T bounded to object
+        $matching = array_filter(
+            $a,
+            static fn($i) => $i->type === 42
+        );
+        return $matching ? reset($matching) : null;
+    }
+
+    public function getItem2(array $a) {
+        // Should not emit PhanTypeExpectedObjectPropAccess — $i is mixed
+        $matching = array_filter(
+            $a,
+            static fn($i) => $i->type === 42
+        );
+        return $matching ? reset($matching) : null;
+    }
+}


### PR DESCRIPTION
This adds `$type instanceof TemplateType` to the acceptable-type check in `getClassList()`. This suppresses `PhanTypeExpectedObjectPropAccess` warnings for top-level template types while preserving correct warnings for non-object wrapper types like `array<T>` (`T[]`) and `class-string<T>`, which are definitively not objects regardless of T.