### PR TITLE
fixes #5489

### DIFF
--- a/src/Phan/Phan.php
+++ b/src/Phan/Phan.php
@@ -966,25 +966,12 @@ class Phan implements IgnoredFilesFilterInterface
         }
 
         $stubs = Config::getValue('autoload_internal_extension_signatures');
-        // If null (e.g., in -n mode), use bundled stubs
-        // Note: If user provided a config, setValue() already merged it with defaults
+        // If null (e.g., in -n mode), use bundled stubs.
+        // Note: If user provided a config, setValue() already merged it with defaults.
+        // $default_config already selects the correct stubs based on min(target_php_version, runtime),
+        // so we use it directly rather than recomputing based on PHP_VERSION_ID alone.
         if ($stubs === null) {
             $stubs = $default_config['autoload_internal_extension_signatures'];
-
-            // Select the appropriate stubs based on runtime PHP version
-            // PHP 8.4+ has typed constants in SPL and new array functions in standard
-            $spl_stub = \PHP_VERSION_ID >= 80400
-                ? 'spl.phan_php'
-                : 'spl_php81.phan_php';
-            $standard_stub = \PHP_VERSION_ID >= 80400
-                ? 'standard_templates.phan_php'
-                : 'standard_templates_php81.phan_php';
-
-            // Update the stub paths based on runtime version
-            $phan_dir = \dirname(\dirname(__DIR__));
-            $bundled_stubs_dir = $phan_dir . '/internal/stubs';
-            $stubs['spl'] = "$bundled_stubs_dir/$spl_stub";
-            $stubs['standard'] = "$bundled_stubs_dir/$standard_stub";
         }
 
         foreach ($stubs as $extension_name => $path_to_extension) {

--- a/tests/files/expected/0480_array_access_iteration.php.expected84
+++ b/tests/files/expected/0480_array_access_iteration.php.expected84
@@ -1,2 +1,2 @@
-%s:12 PhanTypeMismatchArgumentInternal%SReal Argument 1 ($string) is $this->prop of type \ArrayAccess|\Countable|\Iterator|\SeekableIterator|\Serializable|\SplObjectStorage|\SplObjectStorage<mixed,mixed>|\Traversable|iterable but \strlen() takes string
-%s:14 PhanTypeMismatchArgumentInternal Argument 1 ($string) is $this->prop of type \ArrayAccess|\Countable|\Iterator|\SeekableIterator|\Serializable|\SplObjectStorage|\SplObjectStorage<mixed,mixed>|\Traversable|iterable but \strlen() takes string
+%s:12 PhanTypeMismatchArgumentInternalReal Argument 1 ($string) is $this->prop of type \ArrayAccess|\Countable|\Iterator|\Serializable|\SplObjectStorage|\SplObjectStorage<mixed,mixed>|\Traversable|iterable but \strlen() takes string
+%s:14 PhanTypeMismatchArgumentInternal Argument 1 ($string) is $this->prop of type \ArrayAccess|\Countable|\Iterator|\Serializable|\SplObjectStorage|\SplObjectStorage<mixed,mixed>|\Traversable|iterable but \strlen() takes string

--- a/tests/files/expected/5207_template_constraint_iteration.php.expected84
+++ b/tests/files/expected/5207_template_constraint_iteration.php.expected84
@@ -1,4 +1,4 @@
 %s:28 PhanUnusedVariableValueOfForeachWithKey Unused definition of variable $element as the value of a foreach loop that included keys
 %s:38 PhanGenericMissingParameters Class \StdClassSet must substitute all 1 template parameters when inheriting \Set (found 0) defined at %s:13 (use @extends or @inherit)
 %s:44 PhanUnusedVariable Unused definition of variable $element
-%s:54 PhanGenericMissingParameters Class \MySet must substitute all 2 template parameters when inheriting \SplObjectStorage (found 0) defined at internal:747 (use @extends or @inherit)
+%s:54 PhanGenericMissingParameters Class \MySet must substitute all 2 template parameters when inheriting \SplObjectStorage (found 0) defined at internal:746 (use @extends or @inherit)

--- a/tests/files/expected/5489_array_first_last_pre85.php.expected
+++ b/tests/files/expected/5489_array_first_last_pre85.php.expected
@@ -1,0 +1,4 @@
+%s:10 PhanDebugAnnotation @phan-debug-var requested for variable $last - it has union type (empty union type)
+%s:10 PhanUndeclaredFunction Call to undeclared function \array_last()
+%s:12 PhanDebugAnnotation @phan-debug-var requested for variable $first - it has union type (empty union type)
+%s:12 PhanUndeclaredFunction Call to undeclared function \array_first()

--- a/tests/files/expected/5489_array_first_last_pre85.php.expected85
+++ b/tests/files/expected/5489_array_first_last_pre85.php.expected85
@@ -1,0 +1,2 @@
+%s:10 PhanDebugAnnotation @phan-debug-var requested for variable $last - it has union type (empty union type)
+%s:12 PhanDebugAnnotation @phan-debug-var requested for variable $first - it has union type (empty union type)

--- a/tests/files/src/5489_array_first_last_pre85.php
+++ b/tests/files/src/5489_array_first_last_pre85.php
@@ -1,0 +1,18 @@
+<?php
+
+// Regression test for https://github.com/phan/phan/issues/5489
+// array_first() and array_last() are PHP 8.5+ functions.
+// When targeting PHP < 8.5, the 8.5 stub (which has @template TValue) must not
+// be loaded, or TValue leaks into the inferred type and causes false
+// PhanTypeArraySuspiciousNullable warnings after truthiness checks.
+
+$array = [1, 2, 3];
+$last = array_last($array);
+'@phan-debug-var $last';
+$first = array_first($array);
+'@phan-debug-var $first';
+
+// Should NOT warn PhanTypeArraySuspiciousNullable - $last is not TValue|mixed|null
+if ($last) {
+    echo $last['test'];
+}


### PR DESCRIPTION
`Phan::loadConfiguredPHPExtensionStubs()` had a fallback stub-selection path that used only `PHP_VERSION_ID >= 80400` to choose
`standard_templates.phan_php`. This ignored `target_php_version` entirely, causing the PHP 8.5 stub (containing `array_first`/`array_last` with `@template TValue`) to
be loaded on any PHP 8.4+ runtime regardless of target. `TValue` then leaked into inferred types, producing false `PhanTypeArraySuspiciousNullable` warnings.

Fix: Remove the manual stub override in Phan.php and use the already-computed `$default_config` from `Config::getDefaultInternalStubConfiguration()`, which
correctly selects stubs based on `min(target_php_version, runtime)`.

Side effect (also correct): The SPL stub selection threshold changed from `PHP_VERSION_ID >= 80400` to `effective_version >= 80300`. For target PHP 8.1 config
(test suite default), this means `spl_php81.phan_php` is now loaded instead of spl.phan_php, which correctly omits `SeekableIterator` from `SplObjectStorage` (added
in PHP 8.3). Two .expected84 files were updated to reflect this accurate behavior.