### PR TITLE
Fixes #5490

### DIFF
--- a/src/Phan/AST/TolerantASTConverter/TolerantASTConverterTrait.php
+++ b/src/Phan/AST/TolerantASTConverter/TolerantASTConverterTrait.php
@@ -46,7 +46,7 @@ trait TolerantASTConverterTrait
             };
         }
         $callback = $callback_map[\get_class($n)] ?? $fallback_closure;
-        // @phan-suppress-next-line PhanThrowTypeMismatch
+        // @phan-suppress-next-line PhanThrowTypeMismatchForCall
         return $callback($n, TolerantASTConverter::getStartLine($n));
     }
 
@@ -71,7 +71,7 @@ trait TolerantASTConverterTrait
             };
         }
         $callback = $callback_map[\get_class($n)] ?? $fallback_closure;
-        // @phan-suppress-next-line PhanThrowTypeAbsent
+        // @phan-suppress-next-line PhanThrowTypeAbsentForCall
         $result = $callback($n, TolerantASTConverter::$file_position_map->getStartLine($n));
         if (($result instanceof ast\Node) && $result->kind === ast\AST_NAME) {
             return new ast\Node(ast\AST_CONST, 0, ['name' => $result], $result->lineno);

--- a/src/Phan/Plugin/Internal/ThrowAnalyzerPlugin.php
+++ b/src/Phan/Plugin/Internal/ThrowAnalyzerPlugin.php
@@ -155,10 +155,11 @@ class ThrowVisitor extends PluginAwarePostAnalysisVisitor
             return;
         }
         if (!$union_type->canCastToDeclaredType($this->code_base, $this->context, UnionType::fromFullyQualifiedRealString('\Throwable'))) {
-            // AST_THROW has children['expr'] (the thrown value); AST_STATIC_CALL does not
-            // (it uses children['class'/'method'/'args']). AST_CALL and AST_METHOD_CALL do
-            // have children['expr'], but for all call nodes we use $node itself to show the
-            // full call expression as the throw origin rather than just the callee/receiver.
+            // All call-context callers (visitCall, visitMethodCall, visitStaticCall,
+            // visitNullsafeMethodCall) pass $invoked_function as $call, so $call !== null
+            // for any call node. AST_STATIC_CALL has no children['expr'] (it uses
+            // children['class'/'method'/'args']), so we use $node itself to show the full
+            // call expression. AST_THROW always has children['expr'] and passes $call = null.
             $throw_expr = $call !== null ? $node : $node->children['expr'];
             $this->emitIssue(
                 Issue::TypeInvalidThrowStatementNonThrowable,
@@ -309,7 +310,8 @@ class ThrowRecursiveVisitor extends ThrowVisitor
                 $this->warnAboutPossiblyThrownType(
                     $node,
                     $analyzed_function,
-                    $this->withoutCaughtUnionTypes($invoked_function->getOwnThrowsUnionType(), false)
+                    $this->withoutCaughtUnionTypes($invoked_function->getOwnThrowsUnionType(), false),
+                    $invoked_function
                 );
             }
         } catch (CodeBaseException) {

--- a/src/Phan/Plugin/Internal/ThrowAnalyzerPlugin.php
+++ b/src/Phan/Plugin/Internal/ThrowAnalyzerPlugin.php
@@ -143,7 +143,7 @@ class ThrowVisitor extends PluginAwarePostAnalysisVisitor
     }
 
     /**
-     * @param Node $node a node of kind ast\AST_THROW
+     * @param Node $node a node of kind ast\AST_THROW, ast\AST_CALL, or ast\AST_STATIC_CALL
      */
     protected function warnAboutPossiblyThrownType(
         Node $node,
@@ -155,11 +155,14 @@ class ThrowVisitor extends PluginAwarePostAnalysisVisitor
             return;
         }
         if (!$union_type->canCastToDeclaredType($this->code_base, $this->context, UnionType::fromFullyQualifiedRealString('\Throwable'))) {
+            // When called from visitCall/visitStaticCall, $node is a call node (no 'expr' child).
+            // When called from visitThrow, $node is AST_THROW with $node->children['expr'].
+            $throw_expr = $call !== null ? $node : $node->children['expr'];
             $this->emitIssue(
                 Issue::TypeInvalidThrowStatementNonThrowable,
                 $node->lineno,
                 $analyzed_function->getRepresentationForIssue(),
-                ASTReverter::toShortString($node->children['expr']),
+                ASTReverter::toShortString($throw_expr),
                 (string)$union_type,
                 '\Throwable'
             );

--- a/src/Phan/Plugin/Internal/ThrowAnalyzerPlugin.php
+++ b/src/Phan/Plugin/Internal/ThrowAnalyzerPlugin.php
@@ -155,9 +155,10 @@ class ThrowVisitor extends PluginAwarePostAnalysisVisitor
             return;
         }
         if (!$union_type->canCastToDeclaredType($this->code_base, $this->context, UnionType::fromFullyQualifiedRealString('\Throwable'))) {
-            // AST_THROW has $node->children['expr']; call nodes (AST_STATIC_CALL, AST_METHOD_CALL,
-            // AST_NULLSAFE_METHOD_CALL) do not. AST_CALL does have 'expr', but using the call
-            // node itself is a clearer representation of where the throw originates.
+            // AST_THROW has children['expr'] (the thrown value); AST_STATIC_CALL does not
+            // (it uses children['class'/'method'/'args']). AST_CALL and AST_METHOD_CALL do
+            // have children['expr'], but for all call nodes we use $node itself to show the
+            // full call expression as the throw origin rather than just the callee/receiver.
             $throw_expr = $call !== null ? $node : $node->children['expr'];
             $this->emitIssue(
                 Issue::TypeInvalidThrowStatementNonThrowable,

--- a/src/Phan/Plugin/Internal/ThrowAnalyzerPlugin.php
+++ b/src/Phan/Plugin/Internal/ThrowAnalyzerPlugin.php
@@ -143,7 +143,7 @@ class ThrowVisitor extends PluginAwarePostAnalysisVisitor
     }
 
     /**
-     * @param Node $node a node of kind ast\AST_THROW, ast\AST_CALL, or ast\AST_STATIC_CALL
+     * @param Node $node a node of kind ast\AST_THROW, ast\AST_CALL, ast\AST_STATIC_CALL, ast\AST_METHOD_CALL, or ast\AST_NULLSAFE_METHOD_CALL
      */
     protected function warnAboutPossiblyThrownType(
         Node $node,
@@ -155,8 +155,9 @@ class ThrowVisitor extends PluginAwarePostAnalysisVisitor
             return;
         }
         if (!$union_type->canCastToDeclaredType($this->code_base, $this->context, UnionType::fromFullyQualifiedRealString('\Throwable'))) {
-            // When called from visitCall/visitStaticCall, $node is a call node (no 'expr' child).
-            // When called from visitThrow, $node is AST_THROW with $node->children['expr'].
+            // AST_THROW has $node->children['expr']; call nodes (AST_STATIC_CALL, AST_METHOD_CALL,
+            // AST_NULLSAFE_METHOD_CALL) do not. AST_CALL does have 'expr', but using the call
+            // node itself is a clearer representation of where the throw originates.
             $throw_expr = $call !== null ? $node : $node->children['expr'];
             $this->emitIssue(
                 Issue::TypeInvalidThrowStatementNonThrowable,

--- a/tests/plugin_test/expected/043_throws.php.expected
+++ b/tests/plugin_test/expected/043_throws.php.expected
@@ -1,5 +1,5 @@
 src/043_throws.php:6 PhanPluginNeverReturnFunction Function \throwOutOfBoundsException() never returns and has a return type of void, but phpdoc type never could be used instead
 src/043_throws.php:14 PhanPluginNeverReturnMethod Method \ExampleThrow43::throwInvalidArgumentException() never returns and has a return type of (empty union type), but phpdoc type never could be used instead
-src/043_throws.php:20 PhanThrowTypeAbsent \ExampleThrow43::example() can throw throwOutOfBoundsException of type \OutOfBoundsException here, but has no '@throws' declarations for that class
+src/043_throws.php:20 PhanThrowTypeAbsentForCall \ExampleThrow43::example() can throw \OutOfBoundsException because it calls \throwOutOfBoundsException(), but has no '@throws' declarations for that class
 src/043_throws.php:22 PhanThrowTypeAbsentForCall \ExampleThrow43::example() can throw \InvalidArgumentException because it calls \ExampleThrow43::throwInvalidArgumentException(), but has no '@throws' declarations for that class
 src/043_throws.php:30 PhanThrowTypeAbsentForCall \ExampleThrow43::example2() can throw \InvalidArgumentException because it calls \ExampleThrow43::throwInvalidArgumentException(), but has no '@throws' declarations for that class

--- a/tests/plugin_test/expected/072_custom_assertions.php.expected
+++ b/tests/plugin_test/expected/072_custom_assertions.php.expected
@@ -1,4 +1,5 @@
 src/072_custom_assertions.php:41 PhanTypeMismatchArgumentInternal Argument 1 ($num1) is $x of type string but \intdiv() takes int
+src/072_custom_assertions.php:42 PhanThrowTypeAbsentForCall \SomeNS\my_expect_mixed() can throw \InvalidArgumentException because it calls \SomeNS\my_assert_instance(), but has no '@throws' declarations for that class
 src/072_custom_assertions.php:43 PhanTypeMismatchArgumentInternal Argument 1 ($num1) is $y of type \stdClass but \intdiv() takes int
 src/072_custom_assertions.php:86 PhanTypeMismatchArgumentInternal Argument 1 ($num1) is $arg of type false|string but \intdiv() takes int
 src/072_custom_assertions.php:87 PhanTypeMismatchArgumentInternal Argument 1 ($num1) is $obj of type \stdClass but \intdiv() takes int

--- a/tests/plugin_test/expected/136_throw_non_throwable_from_call.php.expected
+++ b/tests/plugin_test/expected/136_throw_non_throwable_from_call.php.expected
@@ -1,0 +1,12 @@
+src/136_throw_non_throwable_from_call.php:10 PhanUnreferencedClass Possibly zero references to class \NS5490\NotAThrowable
+src/136_throw_non_throwable_from_call.php:12 PhanUnreferencedClass Possibly zero references to class \NS5490\Caller
+src/136_throw_non_throwable_from_call.php:16 PhanPluginUseReturnValueNoopVoid The function/method \NS5490\Caller::staticMethod() is declared to return void and it has no side effects
+src/136_throw_non_throwable_from_call.php:16 PhanTypeInvalidThrowsNonThrowable @throws annotation of staticMethod has suspicious class type \NS5490\NotAThrowable, which does not extend Error/Exception
+src/136_throw_non_throwable_from_call.php:21 PhanPluginUseReturnValueNoopVoid The function/method \NS5490\Caller::instanceMethod() is declared to return void and it has no side effects
+src/136_throw_non_throwable_from_call.php:21 PhanTypeInvalidThrowsNonThrowable @throws annotation of instanceMethod has suspicious class type \NS5490\NotAThrowable, which does not extend Error/Exception
+src/136_throw_non_throwable_from_call.php:26 PhanPluginUseReturnValueNoopVoid The function/method \NS5490\Caller::caller() is declared to return void and it has no side effects
+src/136_throw_non_throwable_from_call.php:26 PhanUnreferencedPublicMethod Possibly zero references to public method \NS5490\Caller::caller()
+src/136_throw_non_throwable_from_call.php:28 PhanThrowTypeMismatchForCall \NS5490\Caller::caller() throws \NS5490\NotAThrowable because it calls \NS5490\Caller::staticMethod(), but it only has declarations of '@throws \RuntimeException'
+src/136_throw_non_throwable_from_call.php:28 PhanTypeInvalidThrowStatementNonThrowable \NS5490\Caller::caller() can throw self::staticMethod() of type \NS5490\NotAThrowable here which can't cast to \Throwable
+src/136_throw_non_throwable_from_call.php:29 PhanThrowTypeMismatchForCall \NS5490\Caller::caller() throws \NS5490\NotAThrowable because it calls \NS5490\Caller::instanceMethod(), but it only has declarations of '@throws \RuntimeException'
+src/136_throw_non_throwable_from_call.php:29 PhanTypeInvalidThrowStatementNonThrowable \NS5490\Caller::caller() can throw $this->instanceMethod() of type \NS5490\NotAThrowable here which can't cast to \Throwable

--- a/tests/plugin_test/src/136_throw_non_throwable_from_call.php
+++ b/tests/plugin_test/src/136_throw_non_throwable_from_call.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+// Regression test for https://github.com/phan/phan/issues/5490
+// Phan crashed with "Undefined array key 'expr'" when
+// warnAboutPossiblyThrownType() was called from visitCall/visitStaticCall
+// with a @throws type that is not a Throwable subtype.
+
+namespace NS5490;
+
+class NotAThrowable {}
+
+class Caller {
+    /**
+     * @throws NotAThrowable
+     */
+    public static function staticMethod(): void {}
+
+    /**
+     * @throws NotAThrowable
+     */
+    public function instanceMethod(): void {}
+
+    /**
+     * @throws \RuntimeException
+     */
+    public function caller(): void {
+        // These should not crash; they should emit TypeInvalidThrowStatementNonThrowable
+        self::staticMethod();
+        $this->instanceMethod();
+    }
+}


### PR DESCRIPTION
compute `$throw_expr` conditionally: use `$node` (the call expression) when in a call context (`$call !== null`), or `$node->children['expr']` when in a throw context.