### PR TITLE
Fixes #5491

### DIFF
--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -5272,7 +5272,7 @@ e.g. [this issue](https://github.com/phan/phan/tree/v6/tests/files/expected/0951
 ## PhanPropertyHookWithDefaultValue
 
 ```
-Property {PROPERTY} has both hooks and a default value - hooks with default values are not allowed
+Virtual property {PROPERTY} cannot have a default value - only properties with a set hook or backing storage can have defaults
 ```
 
 e.g. [this issue](https://github.com/phan/phan/tree/v6/tests/php84_files/expected/property_hooks_errors.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/v6/tests/php84_files/src/property_hooks_errors.php#L10).

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -2884,6 +2884,8 @@ Cannot override final property hook {PROPERTY}::{METHOD} defined at {FILE}:{LINE
 Property hook {PROPERTY}::{METHOD} parameter {PARAMETER} has type {TYPE} which is incompatible with property type {TYPE}
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/v6/tests/php84_files/expected/property_hooks_errors.php.expected#L5) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/v6/tests/php84_files/src/property_hooks_errors.php#L28).
+
 ## PhanPropertyHookIncompatibleReturnType
 
 ```
@@ -5273,11 +5275,15 @@ e.g. [this issue](https://github.com/phan/phan/tree/v6/tests/files/expected/0951
 Property {PROPERTY} has both hooks and a default value - hooks with default values are not allowed
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/v6/tests/php84_files/expected/property_hooks_errors.php.expected#L1) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/v6/tests/php84_files/src/property_hooks_errors.php#L10).
+
 ## PhanReadonlyPropertyHasSetHook
 
 ```
 Readonly property {PROPERTY} cannot have a set hook
 ```
+
+e.g. [this issue](https://github.com/phan/phan/tree/v6/tests/php84_files/expected/property_hooks_errors.php.expected#L3) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/v6/tests/php84_files/src/property_hooks_errors.php#L16).
 
 ## PhanReadonlyPropertyMissingType
 

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -1294,6 +1294,33 @@ class AssignmentVisitor extends AnalysisVisitor
             $property_union_type = $property->getPHPDocUnionType()->withStaticResolvedInContext($property->getContext());
         }
 
+        // If the property has a set hook with an explicit parameter type, external
+        // assignments are intercepted by the hook, so check against the hook's
+        // parameter type instead of the property's declared storage type.
+        // Skip this when we're inside the property's own hook body — those
+        // assignments write directly to backing storage, bypassing the hook.
+        $set_hook = $property->getSetHook();
+        if ($set_hook !== null) {
+            $is_inside_own_hook = false;
+            // Walk the scope chain to find a PropertyScope for this property.
+            // The hook body has a BranchScope whose parent is the PropertyScope.
+            for ($scope = $this->context->getScope(); !($scope instanceof \Phan\Language\Scope\GlobalScope); $scope = $scope->getParentScope()) {
+                if ($scope->isInPropertyScope()) {
+                    $is_inside_own_hook = $scope->getPropertyFQSEN() === $property->getFQSEN();
+                    break;
+                }
+            }
+            if (!$is_inside_own_hook) {
+                $params = $set_hook->getParameterList();
+                if (!empty($params)) {
+                    $hook_param_type = $params[0]->getNonVariadicUnionType();
+                    if (!$hook_param_type->isEmpty()) {
+                        $property_union_type = $hook_param_type;
+                    }
+                }
+            }
+        }
+
         $resolved_right_type = $this->right_type->withStaticResolvedInContext($this->context);
         if ($this->dim_depth > 0) {
             // Check compatibility without expanding property type to include parent classes.

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -30,6 +30,7 @@ use Phan\Exception\RecursionDepthException;
 use Phan\Language\Context;
 use Phan\Language\Element\Clazz;
 use Phan\Language\Element\Comment\Builder;
+use Phan\Language\Element\Parameter;
 use Phan\Language\Element\Variable;
 use Phan\Language\FQSEN\FullyQualifiedClassConstantName;
 use Phan\Language\FQSEN\FullyQualifiedClassName;
@@ -94,6 +95,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
         \ast\AST_FUNC_DECL => true,
         \ast\AST_METHOD => true,
         \ast\AST_CLASS => true,
+        \ast\AST_PROPERTY_HOOK => true,
     ];
 
     /**
@@ -3677,7 +3679,74 @@ class BlockAnalysisVisitor extends AnalysisVisitor
             $context = $this->analyzeAndGetUpdatedContext($context, $node, $default);
         }
 
+        // Recurse into property hook bodies so that function/class references
+        // inside hooks are tracked (prevents false PhanUnreferencedUseFunction, etc.)
+        $hooks = $node->children['hooks'] ?? null;
+        if ($hooks instanceof Node) {
+            $this->analyzeAndGetUpdatedContext($context, $node, $hooks);
+        }
+
         return $this->postOrderAnalyze($context, $node);
+    }
+
+    /**
+     * Visit a property hook (AST_PROPERTY_HOOK) to set up a function-like scope
+     * so that hook bodies are properly analyzed with $this and parameters available.
+     *
+     * Without this, function/class references inside hook bodies would not be
+     * tracked, causing false PhanUnreferencedUseFunction warnings.
+     *
+     * @param Node $node
+     * A node of kind AST_PROPERTY_HOOK
+     *
+     * @return Context
+     * The updated context after visiting the node
+     */
+    public function visitPropertyHook(Node $node): Context
+    {
+        $context = $this->context;
+        $context->setLineNumberStart($node->lineno);
+
+        // Create a branch scope for the hook body. We use BranchScope rather than
+        // FunctionLikeScope because hooks don't have their own method FQSEN in the
+        // codebase, and using a synthetic one causes PostOrderAnalysisVisitor to fail.
+        $hook_context = $context->withScope(
+            new BranchScope($context->getScope())
+        );
+
+        // Add $this — hooks are always non-static, but the parent PropertyScope
+        // is a ClosedScope that doesn't inherit $this from the class scope.
+        if ($context->isInClassScope()) {
+            $clazz = $context->getClassInScope($this->code_base);
+            if ($clazz->getInternalScope()->hasVariableWithName('this')) {
+                $hook_context->addScopeVariable(
+                    $clazz->getInternalScope()->getVariableByName('this')
+                );
+            }
+        }
+
+        // Add hook parameters to scope (set hooks have a parameter)
+        $params_node = $node->children['params'] ?? null;
+        if ($params_node instanceof Node) {
+            foreach (Parameter::listFromNode($hook_context, $this->code_base, $params_node) as $parameter) {
+                $hook_context->addScopeVariable(
+                    $parameter->cloneAsNonVariadic()
+                );
+            }
+        }
+
+        // Recurse into children (params, stmts, etc.)
+        foreach ($node->children as $child_node) {
+            if (!($child_node instanceof Node)) {
+                continue;
+            }
+            $this->analyzeAndGetUpdatedContext($hook_context, $node, $child_node);
+        }
+
+        $this->postOrderAnalyze($hook_context, $node);
+
+        // Return the outer context — hook is a closed scope
+        return $this->context;
     }
 
     /**

--- a/src/Phan/Issue.php
+++ b/src/Phan/Issue.php
@@ -1056,7 +1056,7 @@ class Issue
                 self::PropertyHookWithDefaultValue,
                 self::CATEGORY_SYNTAX,
                 self::SEVERITY_NORMAL,
-                'Property {PROPERTY} has both hooks and a default value - hooks with default values are not allowed',
+                'Virtual property {PROPERTY} cannot have a default value - only properties with a set hook or backing storage can have defaults',
                 self::REMEDIATION_A,
                 17022
             ),

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -760,13 +760,26 @@ class ParseVisitor extends ScopeVisitor
             return;
         }
 
-        // Check for hooks with default value - not allowed in PHP
+        // A default value is only disallowed for virtual properties (get-only, without $field
+        // reference). Any property with a set hook has backing storage and can have a default.
         if ($default_node !== null) {
-            $this->emitIssue(
-                Issue::PropertyHookWithDefaultValue,
-                $property->getContext()->getLineNumberStart(),
-                $property->asPropertyFQSENString()
-            );
+            $has_set_hook = false;
+            foreach ($hooks_node->children as $hook_node) {
+                if ($hook_node instanceof Node
+                    && $hook_node->kind === \ast\AST_PROPERTY_HOOK
+                    && $hook_node->children['name'] === 'set'
+                ) {
+                    $has_set_hook = true;
+                    break;
+                }
+            }
+            if (!$has_set_hook) {
+                $this->emitIssue(
+                    Issue::PropertyHookWithDefaultValue,
+                    $property->getContext()->getLineNumberStart(),
+                    $property->asPropertyFQSENString()
+                );
+            }
         }
 
         // Check for readonly property with set hook

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -760,8 +760,10 @@ class ParseVisitor extends ScopeVisitor
             return;
         }
 
-        // A default value is only disallowed for virtual properties (get-only, without $field
-        // reference). Any property with a set hook has backing storage and can have a default.
+        // A property with a set hook always has backing storage and can have a default.
+        // Get-only virtual properties (no $field reference) cannot have defaults, but
+        // detecting $field usage requires body traversal, so we approximate by checking
+        // for the presence of a set hook.
         if ($default_node !== null) {
             $has_set_hook = false;
             foreach ($hooks_node->children as $hook_node) {

--- a/tests/php84_files/expected/5491_property_hook_false_positives.php.expected
+++ b/tests/php84_files/expected/5491_property_hook_false_positives.php.expected
@@ -1,0 +1,5 @@
+%s:21 PhanWriteOnlyPublicProperty Possibly zero read references to public property \Bug5491\WithFunctionInHook->value
+%s:31 PhanWriteOnlyPublicProperty Possibly zero read references to public property \Bug5491\WithSetHookAndDefault->value
+%s:49 PhanWriteOnlyPublicProperty Possibly zero read references to public property \Bug5491\WithWidenedSetHook->someValue
+%s:59 PhanWriteOnlyPublicProperty Possibly zero read references to public property \Bug5491\WithNarrowingSetHook->strict
+%s:73 PhanTypeMismatchPropertyReal Assigning [] of type array{} to property but \Bug5491\WithWidenedSetHook->someValue is int|string

--- a/tests/php84_files/expected/5491_property_hook_false_positives.php.expected
+++ b/tests/php84_files/expected/5491_property_hook_false_positives.php.expected
@@ -2,4 +2,5 @@
 %s:31 PhanWriteOnlyPublicProperty Possibly zero read references to public property \Bug5491\WithSetHookAndDefault->value
 %s:49 PhanWriteOnlyPublicProperty Possibly zero read references to public property \Bug5491\WithWidenedSetHook->someValue
 %s:59 PhanWriteOnlyPublicProperty Possibly zero read references to public property \Bug5491\WithNarrowingSetHook->strict
-%s:73 PhanTypeMismatchPropertyReal Assigning [] of type array{} to property but \Bug5491\WithWidenedSetHook->someValue is int|string
+%s:65 PhanTypeMismatchPropertyReal Assigning 'not an int' of type string to property but \Bug5491\WithNarrowingSetHook->strict is int
+%s:75 PhanTypeMismatchPropertyReal Assigning [] of type array{} to property but \Bug5491\WithWidenedSetHook->someValue is int|string

--- a/tests/php84_files/expected/property_hooks_basic.php.expected
+++ b/tests/php84_files/expected/property_hooks_basic.php.expected
@@ -1,0 +1,5 @@
+%s:10 PhanReadOnlyPublicProperty Possibly zero write references to public property \PropertyHookBasic->upperName
+%s:36 PhanReadOnlyPrivateProperty Possibly zero write references to private property \PropertyHookBasic->firstName
+%s:37 PhanReadOnlyPrivateProperty Possibly zero write references to private property \PropertyHookBasic->lastName
+%s:40 PhanReadOnlyPublicProperty Possibly zero write references to public property \PropertyHookBasic->formatted
+%s:48 PhanReadOnlyPublicProperty Possibly zero write references to public property \PropertyHookBasic->finalProp

--- a/tests/php84_files/expected/property_hooks_errors.php.expected
+++ b/tests/php84_files/expected/property_hooks_errors.php.expected
@@ -1,3 +1,7 @@
-%s:%d PhanPropertyHookWithDefaultValue Property \PropertyHookErrors->withDefault has both hooks and a default value - hooks with default values are not allowed
-%s:%d PhanReadonlyPropertyHasSetHook Readonly property \PropertyHookErrors->readonlyWithSet cannot have a set hook
-%s:%d PhanPropertyHookIncompatibleParamType Property hook \PropertyHookErrors::set parameter $value has type int which is incompatible with property type string
+%s:10 PhanPropertyHookWithDefaultValue Property \PropertyHookErrors->withDefault has both hooks and a default value - hooks with default values are not allowed
+%s:10 PhanReadOnlyPublicProperty Possibly zero write references to public property \PropertyHookErrors->withDefault
+%s:16 PhanReadonlyPropertyHasSetHook Readonly property \PropertyHookErrors->readonlyWithSet cannot have a set hook
+%s:27 PhanWriteOnlyPublicProperty Possibly zero read references to public property \PropertyHookErrors->paramMismatch
+%s:28 PhanPropertyHookIncompatibleParamType Property hook \PropertyHookErrors::set parameter $value has type int which is incompatible with property type string
+%s:36 PhanReadOnlyPublicProperty Possibly zero write references to public property \ParentWithFinalHook->name
+%s:50 PhanReadOnlyPublicProperty Possibly zero write references to public property \TypeCompatibility->flexible

--- a/tests/php84_files/expected/property_hooks_errors.php.expected
+++ b/tests/php84_files/expected/property_hooks_errors.php.expected
@@ -1,4 +1,4 @@
-%s:10 PhanPropertyHookWithDefaultValue Property \PropertyHookErrors->withDefault has both hooks and a default value - hooks with default values are not allowed
+%s:10 PhanPropertyHookWithDefaultValue Virtual property \PropertyHookErrors->withDefault cannot have a default value - only properties with a set hook or backing storage can have defaults
 %s:10 PhanReadOnlyPublicProperty Possibly zero write references to public property \PropertyHookErrors->withDefault
 %s:16 PhanReadonlyPropertyHasSetHook Readonly property \PropertyHookErrors->readonlyWithSet cannot have a set hook
 %s:27 PhanWriteOnlyPublicProperty Possibly zero read references to public property \PropertyHookErrors->paramMismatch

--- a/tests/php84_files/src/5491_property_hook_false_positives.php
+++ b/tests/php84_files/src/5491_property_hook_false_positives.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Bug5491Helpers;
+
+function sanitize_value(int|string $val): int {
+    return (int)$val;
+}
+
+namespace Bug5491;
+
+use function Bug5491Helpers\sanitize_value;
+
+/**
+ * Regression tests for https://github.com/phan/phan/issues/5491
+ * @phan-file-suppress PhanUnreferencedClass, PhanUnreferencedPublicProperty
+ */
+
+// Bug #1: PhanUnreferencedUseFunction false positive.
+// Functions used inside property hook bodies must be tracked as referenced.
+class WithFunctionInHook {
+    public int $value = 0 {
+        set(int|string $num) {
+            $this->value = sanitize_value($num);
+        }
+    }
+}
+
+// Bug #2: PhanPropertyHookWithDefaultValue false positive.
+// A property with a set hook has backing storage, so a default value is allowed.
+class WithSetHookAndDefault {
+    public int $value = -1 {
+        set(int|string $num) {
+            $this->value = (int)$num;
+        }
+    }
+
+    // Both hooks with default: also has backing storage, default allowed
+    public int $both = 0 {
+        get => $this->both * 2;
+        set(int $num) {
+            $this->both = $num;
+        }
+    }
+}
+
+// Bug #3: PhanTypeMismatchPropertyReal false positive.
+// Assignment must be checked against the set hook parameter type, not the property's declared type.
+class WithWidenedSetHook {
+    public int $someValue = -1 {
+        set(int|string $num) {
+            $this->someValue = (int)$num;
+        }
+    }
+}
+
+// Bug #3 edge case: Inside the hook body, assignments to backing storage should
+// check against the property's declared type, not the hook parameter type.
+class WithNarrowingSetHook {
+    public int $strict = 0 {
+        set(int|string $num) {
+            // This assigns string to int property — should warn, but only against
+            // the property type (int), NOT the hook param type (int|string).
+            $this->strict = $num;  // Should warn PhanTypeMismatchProperty
+        }
+    }
+}
+
+$obj = new WithWidenedSetHook();
+$obj->someValue = '0815';  // Should NOT warn: set hook accepts int|string
+$obj->someValue = 42;      // Should NOT warn: int is fine too
+
+// Assigning a genuinely incompatible type should still warn
+$obj->someValue = [];  // Should warn PhanTypeMismatchPropertyReal

--- a/tests/php84_files/src/5491_property_hook_false_positives.php
+++ b/tests/php84_files/src/5491_property_hook_false_positives.php
@@ -62,7 +62,7 @@ class WithNarrowingSetHook {
             // Assigning a string literal is incompatible with the property type.
             // Without the edge case fix, this would incorrectly check against the
             // hook param type (int|string) and not warn.
-            $this->strict = 'not an int';  // Should warn PhanTypeMismatchProperty
+            $this->strict = 'not an int';  // Should warn PhanTypeMismatchPropertyReal
         }
     }
 }

--- a/tests/php84_files/src/5491_property_hook_false_positives.php
+++ b/tests/php84_files/src/5491_property_hook_false_positives.php
@@ -58,9 +58,11 @@ class WithWidenedSetHook {
 class WithNarrowingSetHook {
     public int $strict = 0 {
         set(int|string $num) {
-            // This assigns string to int property — should warn, but only against
-            // the property type (int), NOT the hook param type (int|string).
-            $this->strict = $num;  // Should warn PhanTypeMismatchProperty
+            // Inside the hook body, this writes directly to backing storage (int).
+            // Assigning a string literal is incompatible with the property type.
+            // Without the edge case fix, this would incorrectly check against the
+            // hook param type (int|string) and not warn.
+            $this->strict = 'not an int';  // Should warn PhanTypeMismatchProperty
         }
     }
 }


### PR DESCRIPTION
Fixes three false positives related to PHP 8.4 property hooks.

### PhanUnreferencedUseFunction for functions used in hook bodies

Property hook bodies were never visited during the analysis phase. When a function imported via `use function` was called inside a hook body, the reference was never tracked, causing a false `PhanUnreferencedUseFunction` warning.

The root cause was that the property element visitor only recursed into the default value child, completely ignoring the hooks child. Additionally, there was no visitor for property hook nodes, so even when reached, no scope was set up for the hook body.

The fix adds hook body traversal to the property element visitor and introduces a dedicated property hook visitor that creates a proper scope with `$this` and hook parameters before recursing into the body. Hook nodes are also added to the closed scope list to prevent variable leaking between sibling hooks.

### PhanPropertyHookWithDefaultValue for properties with set hooks

A property with a set hook has backing storage and can legitimately have a default value. Only pure virtual properties (get-only without a `$field` reference) are disallowed from having defaults. The warning was being emitted unconditionally for any hooked property with a default value.

The fix skips the warning when the property has a set hook.

### PhanTypeMismatchPropertyReal for assignments to hooked properties

When a property has a set hook with a widened parameter type (e.g., `set(int|string $num)` on an `int` property), external assignments are intercepted by the hook and should be checked against the hook's parameter type, not the property's declared storage type.

The fix checks assignments against the set hook parameter type when one exists. It also handles the edge case where the assignment is inside the hook body itself (e.g., `$this->prop = (int)$num`) — these write directly to backing storage and bypass the hook, so they correctly check against the property's declared type instead. This is detected by walking the scope chain to find whether the assignment context is inside the property's own scope.