### PR TITLE
Fixes #5496

### DIFF
--- a/src/Phan/Analysis/ContextMergeVisitor.php
+++ b/src/Phan/Analysis/ContextMergeVisitor.php
@@ -185,13 +185,9 @@ class ContextMergeVisitor extends KindVisitorImplementation
 
         if (!$catch_scope_list) {
             // All of the catch statements will unconditionally rethrow or return.
-            // The code after the try-catch block can only be reached if the try block succeeded.
-            // Return the raw try context (first child), not the merged try context from mergeTryContext.
-            // When a finally block is present, mergeTryContext conservatively combines the original scope
-            // with the try scope (marking variables as possibly undefined), but that merged scope is only
-            // needed for analyzing the finally block itself. Here, since all catches exit, the context
-            // for code that follows must reflect that try succeeded (variables are definitely defined).
-            return \reset($this->child_context_list);
+            // So, after the try and catch blocks (finally is analyzed separately),
+            // the context is the same as the merged try context (which may have possibly undefined variables).
+            return $this->context;
         }
 
         if (\count($catch_scope_list) > 1) {

--- a/src/Phan/Analysis/ContextMergeVisitor.php
+++ b/src/Phan/Analysis/ContextMergeVisitor.php
@@ -185,9 +185,13 @@ class ContextMergeVisitor extends KindVisitorImplementation
 
         if (!$catch_scope_list) {
             // All of the catch statements will unconditionally rethrow or return.
-            // So, after the try and catch blocks (finally is analyzed separately),
-            // the context is the same as the merged try context (which may have possibly undefined variables).
-            return $this->context;
+            // The code after the try-catch block can only be reached if the try block succeeded.
+            // Return the raw try context (first child), not the merged try context from mergeTryContext.
+            // When a finally block is present, mergeTryContext conservatively combines the original scope
+            // with the try scope (marking variables as possibly undefined), but that merged scope is only
+            // needed for analyzing the finally block itself. Here, since all catches exit, the context
+            // for code that follows must reflect that try succeeded (variables are definitely defined).
+            return \reset($this->child_context_list);
         }
 
         if (\count($catch_scope_list) > 1) {

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -2986,18 +2986,21 @@ class BlockAnalysisVisitor extends AnalysisVisitor
     {
         $post_finally_scope = $context->getScope();
         $try_scope = $try_context->getScope();
-        foreach ($post_finally_scope->getVariableMap() as $variable_name => $variable) {
+        // Iterate over the try scope (typically small) rather than the
+        // post-finally scope (which may include many inherited variables
+        // from parent scopes via BranchScope::getVariableMap()).
+        foreach ($try_scope->getVariableMap() as $variable_name => $try_variable) {
             $variable_name = (string)$variable_name;
-            $union_type = $variable->getUnionType();
-            if (!$union_type->isPossiblyUndefined()) {
-                continue;
-            }
-            $try_variable = $try_scope->getVariableByNameOrNull($variable_name);
-            if ($try_variable === null) {
-                continue;
-            }
             $try_type = $try_variable->getUnionType();
-            if (!$try_type->isPossiblyUndefined() && !$try_type->isDefinitelyUndefined()) {
+            if ($try_type->isPossiblyUndefined() || $try_type->isDefinitelyUndefined()) {
+                continue;
+            }
+            $variable = $post_finally_scope->getVariableByNameOrNull($variable_name);
+            if ($variable === null) {
+                continue;
+            }
+            $union_type = $variable->getUnionType();
+            if ($union_type->isPossiblyUndefined()) {
                 // Definitely defined in try: clear the possibly-undefined flag
                 $variable->setUnionType($union_type->withIsPossiblyUndefined(false));
             }

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -2955,12 +2955,70 @@ class BlockAnalysisVisitor extends AnalysisVisitor
             // Don't bother checking if finally unconditionally returns here
             // If it does, dead code detection would also warn.
             $context = $this->analyzeAndGetUpdatedContext($context, $node, $finally_node);
+
+            // If all catch blocks unconditionally exit (return/throw), then code
+            // after the try-catch-finally can only be reached if the try block
+            // succeeded. In that case, variables definitely assigned in try are
+            // definitely defined here too — clear any possibly-undefined flags
+            // that were conservatively added by mergeTryContext for the finally
+            // analysis path.
+            if ($catch_nodes && $this->allCatchesUnconditionallyExit($catch_nodes, $context)) {
+                $this->clearPossiblyUndefinedFromTryContext($context, $try_context);
+            }
         }
 
         // When coming out of a scoped element, we pop the
         // context to be the incoming context. Otherwise,
         // we pass our new context up to our parent
         return $this->postOrderAnalyze($context, $node);
+    }
+
+    /**
+     * Returns true if all catch nodes unconditionally exit (return, throw, etc.).
+     *
+     * @param list<Node> $catch_nodes
+     */
+    private function allCatchesUnconditionallyExit(array $catch_nodes, Context $context): bool
+    {
+        foreach ($catch_nodes as $catch_node) {
+            if (!($catch_node instanceof Node)) {
+                continue;
+            }
+            $catch_stmts = $catch_node->children['stmts'];
+            if (!($catch_stmts instanceof Node) ||
+                !BlockExitStatusChecker::willUnconditionallySkipRemainingStatements($catch_stmts, $this->code_base, $context)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * After analyzing a finally block when all catches exit, clear possibly-undefined flags
+     * for variables that were definitely defined in the try block.
+     * Code after the try-catch-finally can only be reached via the try-succeeded path,
+     * so variables definitely assigned in try are definitely defined at that point.
+     */
+    private static function clearPossiblyUndefinedFromTryContext(Context $context, Context $try_context): void
+    {
+        $post_finally_scope = $context->getScope();
+        $try_scope = $try_context->getScope();
+        foreach ($post_finally_scope->getVariableMap() as $variable_name => $variable) {
+            $variable_name = (string)$variable_name;
+            $union_type = $variable->getUnionType();
+            if (!$union_type->isPossiblyUndefined()) {
+                continue;
+            }
+            $try_variable = $try_scope->getVariableByNameOrNull($variable_name);
+            if ($try_variable === null) {
+                continue;
+            }
+            $try_type = $try_variable->getUnionType();
+            if (!$try_type->isPossiblyUndefined() && !$try_type->isDefinitelyUndefined()) {
+                // Definitely defined in try: clear the possibly-undefined flag
+                $variable->setUnionType($union_type->withIsPossiblyUndefined(false));
+            }
+        }
     }
 
     /**

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -2888,6 +2888,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
         $catch_context_list = [$try_context];
 
         $catch_nodes = $node->children['catches']->children ?? [];
+        $all_catches_exit = (bool)$catch_nodes;
 
         foreach ($catch_nodes as $catch_node) {
             // Note: ContextMergeVisitor expects to get each individual catch
@@ -2914,6 +2915,8 @@ class BlockAnalysisVisitor extends AnalysisVisitor
                 if (!BlockExitStatusChecker::willUnconditionallyThrowOrReturn($catch_stmts_node, $this->code_base, $catch_context)) {
                     $this->recordLoopContextForBreakOrContinue($catch_context);
                 }
+            } else {
+                $all_catches_exit = false;
             }
             // NOTE: We let ContextMergeVisitor->mergeCatchContext decide if the block exit status is valid.
             $catch_context_list[] = $catch_context;
@@ -2962,8 +2965,8 @@ class BlockAnalysisVisitor extends AnalysisVisitor
             // definitely defined here too — clear any possibly-undefined flags
             // that were conservatively added by mergeTryContext for the finally
             // analysis path.
-            if ($catch_nodes && $this->allCatchesUnconditionallyExit($catch_nodes, $context)) {
-                $this->clearPossiblyUndefinedFromTryContext($context, $try_context);
+            if ($all_catches_exit) {
+                self::clearPossiblyUndefinedFromTryContext($context, $try_context);
             }
         }
 
@@ -2971,26 +2974,6 @@ class BlockAnalysisVisitor extends AnalysisVisitor
         // context to be the incoming context. Otherwise,
         // we pass our new context up to our parent
         return $this->postOrderAnalyze($context, $node);
-    }
-
-    /**
-     * Returns true if all catch nodes unconditionally exit (return, throw, etc.).
-     *
-     * @param list<Node> $catch_nodes
-     */
-    private function allCatchesUnconditionallyExit(array $catch_nodes, Context $context): bool
-    {
-        foreach ($catch_nodes as $catch_node) {
-            if (!($catch_node instanceof Node)) {
-                continue;
-            }
-            $catch_stmts = $catch_node->children['stmts'];
-            if (!($catch_stmts instanceof Node) ||
-                !BlockExitStatusChecker::willUnconditionallySkipRemainingStatements($catch_stmts, $this->code_base, $context)) {
-                return false;
-            }
-        }
-        return true;
     }
 
     /**

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -2959,12 +2959,12 @@ class BlockAnalysisVisitor extends AnalysisVisitor
             // If it does, dead code detection would also warn.
             $context = $this->analyzeAndGetUpdatedContext($context, $node, $finally_node);
 
-            // If all catch blocks unconditionally exit (return/throw), then code
-            // after the try-catch-finally can only be reached if the try block
-            // succeeded. In that case, variables definitely assigned in try are
-            // definitely defined here too — clear any possibly-undefined flags
-            // that were conservatively added by mergeTryContext for the finally
-            // analysis path.
+            // If all catch blocks unconditionally skip remaining statements
+            // (return/throw/break/continue), then code after the try-catch-finally
+            // can only be reached if the try block succeeded. In that case,
+            // variables definitely assigned in try are definitely defined here
+            // too — clear any possibly-undefined flags that were conservatively
+            // added by mergeTryContext for the finally analysis path.
             if ($all_catches_skip_remaining) {
                 self::clearPossiblyUndefinedFromTryContext($context, $try_context);
             }

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -2888,7 +2888,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
         $catch_context_list = [$try_context];
 
         $catch_nodes = $node->children['catches']->children ?? [];
-        $all_catches_exit = (bool)$catch_nodes;
+        $all_catches_skip_remaining = (bool)$catch_nodes;
 
         foreach ($catch_nodes as $catch_node) {
             // Note: ContextMergeVisitor expects to get each individual catch
@@ -2916,7 +2916,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
                     $this->recordLoopContextForBreakOrContinue($catch_context);
                 }
             } else {
-                $all_catches_exit = false;
+                $all_catches_skip_remaining = false;
             }
             // NOTE: We let ContextMergeVisitor->mergeCatchContext decide if the block exit status is valid.
             $catch_context_list[] = $catch_context;
@@ -2965,7 +2965,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
             // definitely defined here too — clear any possibly-undefined flags
             // that were conservatively added by mergeTryContext for the finally
             // analysis path.
-            if ($all_catches_exit) {
+            if ($all_catches_skip_remaining) {
                 self::clearPossiblyUndefinedFromTryContext($context, $try_context);
             }
         }
@@ -2986,10 +2986,10 @@ class BlockAnalysisVisitor extends AnalysisVisitor
     {
         $post_finally_scope = $context->getScope();
         $try_scope = $try_context->getScope();
-        // Iterate over the try scope (typically small) rather than the
-        // post-finally scope (which may include many inherited variables
-        // from parent scopes via BranchScope::getVariableMap()).
-        foreach ($try_scope->getVariableMap() as $variable_name => $try_variable) {
+        // Iterate only over variables defined in the try branch itself,
+        // excluding inherited parent-scope variables. This avoids the
+        // full BranchScope::getVariableMap() merge on large scopes.
+        foreach ($try_scope->getVariableMapExcludingScope($try_scope->getParentScope()) as $variable_name => $try_variable) {
             $variable_name = (string)$variable_name;
             $try_type = $try_variable->getUnionType();
             if ($try_type->isPossiblyUndefined() || $try_type->isDefinitelyUndefined()) {

--- a/tests/files/expected/5921_try_catch_finally_possibly_undefined.php.expected
+++ b/tests/files/expected/5921_try_catch_finally_possibly_undefined.php.expected
@@ -1,0 +1,2 @@
+%s:53 PhanPossiblyUndeclaredVariable Variable $variable is possibly undeclared
+%s:62 PhanPossiblyUndeclaredVariable Variable $variable is possibly undeclared

--- a/tests/files/src/5921_try_catch_finally_possibly_undefined.php
+++ b/tests/files/src/5921_try_catch_finally_possibly_undefined.php
@@ -1,0 +1,63 @@
+<?php
+// Tests for false positive PhanPossiblyUndeclaredVariable with try-catch-finally.
+// When all catch blocks unconditionally exit (return/throw), code after the
+// try-catch-finally block can only be reached if the try block succeeded,
+// so variables assigned in try should be considered definitely defined.
+// @see https://github.com/phan/phan/issues/5496
+
+function test_catch_returns_with_finally(): void {
+    try {
+        $variable = 42;
+    } catch (Exception) {
+        return;
+    } finally {
+        // cleanup
+    }
+    echo $variable; // should not warn
+}
+
+function test_catch_throws_with_finally(): void {
+    try {
+        $variable = 42;
+    } catch (Exception) {
+        throw new RuntimeException('failed');
+    } finally {
+        // cleanup
+    }
+    echo $variable; // should not warn
+}
+
+function test_multiple_catches_all_exit_with_finally(): void {
+    try {
+        $variable = 42;
+    } catch (InvalidArgumentException) {
+        return;
+    } catch (RuntimeException $e) {
+        throw $e;
+    } finally {
+        // cleanup
+    }
+    echo $variable; // should not warn
+}
+
+// These should still warn: catch falls through
+
+function test_catch_falls_through_with_finally(): void {
+    try {
+        $variable = 42;
+    } catch (Exception) {
+        // falls through, no exit
+    } finally {
+        // cleanup
+    }
+    echo $variable; // should warn: PhanPossiblyUndeclaredVariable
+}
+
+function test_no_catch_with_finally(): void {
+    try {
+        $variable = 42;
+    } finally {
+        // cleanup
+    }
+    echo $variable; // should warn: PhanPossiblyUndeclaredVariable
+}


### PR DESCRIPTION
The bug is in `ContextMergeVisitor::mergeCatchContext`. When a finally block is present, `mergeTryContext` conservatively merges the original scope with the try
scope (marking variables as possibly undefined) — this is needed for analyzing the finally block itself. But `mergeCatchContext` was then returning this merged
scope ($this->context) even when all catches unconditionally exit, carrying the "possibly undefined" flag into code after the block.

When a finally block is present and all catch blocks unconditionally exit, `mergeTryContext` conservatively marks try-block variables as possibly-undefined
(needed for analyzing finally, which runs even when try throws partway through). Previously this conservative context leaked through to code after the block.
Now, after finally is analyzed, `clearPossiblyUndefinedFromTryContext` restores the definitely-defined status for variables that were fully assigned in the try
block, since the only way to reach code past the try-catch-finally is if try completed successfully.