### PR TITLE
Fix inheritdoc false positives

### DIFF
--- a/src/Phan/Analysis/ParameterTypesAnalyzer.php
+++ b/src/Phan/Analysis/ParameterTypesAnalyzer.php
@@ -408,6 +408,11 @@ class ParameterTypesAnalyzer
         if ($method->isMagic()) {
             return;
         }
+        // Traits are designed to be composed into classes that may implement
+        // interfaces declaring these methods, so @inheritDoc is reasonable.
+        if ($class->isTrait()) {
+            return;
+        }
         // Only emit this issue on the base class, not for the subclass which inherited it
         if ($method->getDefiningFQSEN() !== $method->getFQSEN()) {
             return;

--- a/tests/files/src/5922_inheritdoc_without_parent.php
+++ b/tests/files/src/5922_inheritdoc_without_parent.php
@@ -46,3 +46,23 @@ class ChildClass extends ParentClass {
      */
     function noWarnOnProse() {}
 }
+
+// Trait methods with @inheritDoc should not warn, even if the trait
+// itself doesn't extend or implement anything. Traits are composed
+// into classes that may implement interfaces declaring these methods.
+interface TraitTargetInterface {
+    /** Interface method doc. */
+    function interfaceMethod(): void;
+}
+
+trait TraitWithInheritDoc {
+    /** @inheritDoc */
+    function interfaceMethod(): void {}  // should NOT warn
+
+    /** @inheritDoc */
+    function traitOnlyMethod(): void {}  // should NOT warn
+}
+
+class UsesTraitAndInterface implements TraitTargetInterface {
+    use TraitWithInheritDoc;
+}


### PR DESCRIPTION
Trait methods with @inheritDoc should not warn, even if the trait itself doesn't extend or implement anything. Traits are composed into classes that may implement interfaces declaring these methods