### PR TITLE
Add NEWS entry for override_return_types deprecation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 Phan 6.0.5-dev
 --------------
+Deprecations:
+- Deprecate `override_return_types` config flag in favor of `track_all_inferred_types`, which subsumes its behavior and also accumulates concrete types on interface-typed properties ([#5476](https://github.com/phan/phan/pull/5476))
 
 Mar 23 2026, Phan 6.0.4
 --------------


### PR DESCRIPTION
## Summary

- Add a NEWS.md entry noting that the `override_return_types` config flag was deprecated in #5476 in favor of `track_all_inferred_types`

## Test plan

- [ ] Verify NEWS.md formatting looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)