### PR TITLE
suppress false positives on dynamic property access

### DIFF
--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -603,7 +603,7 @@ class ContextNode
                     if ($custom_issue_type === Issue::TypeExpectedObjectPropAccess
                         && $this->node instanceof Node
                         && ($this->node->kind === ast\AST_PROP || $this->node->kind === ast\AST_NULLSAFE_PROP)
-                        && $this->isExpressionPropertyAccessOnStdClass($this->node)
+                        && $this->isExpressionDynamicPropAccessOnPlainStdClass($this->node)
                     ) {
                         // Don't warn — the type from stdClass dynamic property is unreliable
                     } else {
@@ -654,11 +654,14 @@ class ContextNode
 
     /**
      * Check if the given AST_PROP/AST_NULLSAFE_PROP node accesses a dynamic
-     * property on a class with dynamic properties (e.g. stdClass).
-     * Dynamic property types on such classes are globally accumulated in the
-     * CodeBase and unreliable for type checking.
+     * property on a plain (unshaped) stdClass receiver.
+     *
+     * Dynamic property types on plain stdClass are globally accumulated in the
+     * CodeBase and unreliable for type checking. This returns true only when
+     * every object type in the receiver union is plain stdClass, so that unions
+     * like `C|stdClass` or shaped stdClass types still get proper warnings.
      */
-    private function isExpressionPropertyAccessOnStdClass(Node $prop_node): bool
+    private function isExpressionDynamicPropAccessOnPlainStdClass(Node $prop_node): bool
     {
         $expr_node = $prop_node->children['expr'] ?? null;
         if (!$expr_node instanceof Node) {
@@ -673,8 +676,13 @@ class ContextNode
         } catch (\Exception) {
             return false;
         }
+        $stdclass_fqsen = FullyQualifiedClassName::getStdClassFQSEN();
         $found_object_type = false;
         foreach ($expr_type->getTypeSet() as $type) {
+            if ($type instanceof \Phan\Language\Type\StdClassShapeType) {
+                // Shaped stdClass has locally reliable property types
+                return false;
+            }
             if ($type->isObjectWithKnownFQSEN()) {
                 $found_object_type = true;
                 try {
@@ -682,11 +690,7 @@ class ContextNode
                 } catch (\Exception) {
                     return false;
                 }
-                if (!$this->code_base->hasClassWithFQSEN($fqsen)) {
-                    return false;
-                }
-                $clazz = $this->code_base->getClassByFQSEN($fqsen);
-                if (!$clazz->hasDynamicProperties($this->code_base)) {
+                if ($fqsen !== $stdclass_fqsen) {
                     return false;
                 }
             }

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -673,23 +673,25 @@ class ContextNode
         } catch (\Exception) {
             return false;
         }
+        $found_object_type = false;
         foreach ($expr_type->getTypeSet() as $type) {
             if ($type->isObjectWithKnownFQSEN()) {
+                $found_object_type = true;
                 try {
                     $fqsen = FullyQualifiedClassName::fromType($type);
                 } catch (\Exception) {
-                    continue;
+                    return false;
                 }
                 if (!$this->code_base->hasClassWithFQSEN($fqsen)) {
-                    continue;
+                    return false;
                 }
                 $clazz = $this->code_base->getClassByFQSEN($fqsen);
-                if ($clazz->hasDynamicProperties($this->code_base)) {
-                    return true;
+                if (!$clazz->hasDynamicProperties($this->code_base)) {
+                    return false;
                 }
             }
         }
-        return false;
+        return $found_object_type;
     }
 
     /**

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -593,17 +593,32 @@ class ContextNode
                 return $type->isObject() || ($type instanceof MixedType) || ($type instanceof TemplateType) || ($expected_type_categories !== self::CLASS_LIST_ACCEPT_OBJECT && $type instanceof StringType);
             })) {
                 if ($warn_if_wrong_type) {
-                    if ($custom_issue_type === Issue::TypeExpectedObjectPropAccess) {
-                        if ($union_type->isType(NullType::instance(false))) {
-                            $custom_issue_type = Issue::TypeExpectedObjectPropAccessButGotNull;
+                    // Suppress PhanTypeExpectedObjectPropAccess when the expression is
+                    // a property access on a plain stdClass. Dynamic properties on
+                    // stdClass are globally shared in the CodeBase, so their accumulated
+                    // type is contaminated by unrelated usages across the codebase.
+                    // This prevents false positives on chained access like
+                    // json_decode($x)->data->field, where ->data's globally accumulated
+                    // type might be 'string' from other files.
+                    if ($custom_issue_type === Issue::TypeExpectedObjectPropAccess
+                        && $this->node instanceof Node
+                        && ($this->node->kind === ast\AST_PROP || $this->node->kind === ast\AST_NULLSAFE_PROP)
+                        && $this->isExpressionPropertyAccessOnStdClass($this->node)
+                    ) {
+                        // Don't warn — the type from stdClass dynamic property is unreliable
+                    } else {
+                        if ($custom_issue_type === Issue::TypeExpectedObjectPropAccess) {
+                            if ($union_type->isType(NullType::instance(false))) {
+                                $custom_issue_type = Issue::TypeExpectedObjectPropAccessButGotNull;
+                            }
                         }
+                        $this->emitIssue(
+                            $custom_issue_type ?? ($expected_type_categories !== self::CLASS_LIST_ACCEPT_OBJECT ? Issue::TypeExpectedObjectOrClassName : Issue::TypeExpectedObject),
+                            $this->node->lineno ?? $this->context->getLineNumberStart(),
+                            ASTReverter::toShortString($this->node),
+                            (string)$union_type->asNonLiteralType()
+                        );
                     }
-                    $this->emitIssue(
-                        $custom_issue_type ?? ($expected_type_categories !== self::CLASS_LIST_ACCEPT_OBJECT ? Issue::TypeExpectedObjectOrClassName : Issue::TypeExpectedObject),
-                        $this->node->lineno ?? $this->context->getLineNumberStart(),
-                        ASTReverter::toShortString($this->node),
-                        (string)$union_type->asNonLiteralType()
-                    );
                 }
             } elseif ($expected_type_categories !== self::CLASS_LIST_ACCEPT_OBJECT) {
                 foreach ($union_type->getTypeSet() as $type) {
@@ -635,6 +650,46 @@ class ContextNode
         }
 
         return $class_list;
+    }
+
+    /**
+     * Check if the given AST_PROP/AST_NULLSAFE_PROP node accesses a dynamic
+     * property on a class with dynamic properties (e.g. stdClass).
+     * Dynamic property types on such classes are globally accumulated in the
+     * CodeBase and unreliable for type checking.
+     */
+    private function isExpressionPropertyAccessOnStdClass(Node $prop_node): bool
+    {
+        $expr_node = $prop_node->children['expr'] ?? null;
+        if (!$expr_node instanceof Node) {
+            return false;
+        }
+        try {
+            $expr_type = UnionTypeVisitor::unionTypeFromNode(
+                $this->code_base,
+                $this->context,
+                $expr_node
+            );
+        } catch (\Exception) {
+            return false;
+        }
+        foreach ($expr_type->getTypeSet() as $type) {
+            if ($type->isObjectWithKnownFQSEN()) {
+                try {
+                    $fqsen = FullyQualifiedClassName::fromType($type);
+                } catch (\Exception) {
+                    continue;
+                }
+                if (!$this->code_base->hasClassWithFQSEN($fqsen)) {
+                    continue;
+                }
+                $clazz = $this->code_base->getClassByFQSEN($fqsen);
+                if ($clazz->hasDynamicProperties($this->code_base)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -683,16 +683,23 @@ class ContextNode
                 // Shaped stdClass has locally reliable property types
                 return false;
             }
-            if ($type->isObjectWithKnownFQSEN()) {
-                $found_object_type = true;
-                try {
-                    $fqsen = FullyQualifiedClassName::fromType($type);
-                } catch (\Exception) {
-                    return false;
-                }
-                if ($fqsen !== $stdclass_fqsen) {
-                    return false;
-                }
+            if (!$type->isObject()) {
+                // Skip non-object types in the union (e.g. int, string)
+                continue;
+            }
+            if (!$type->isObjectWithKnownFQSEN()) {
+                // Generic object type without a known FQSEN is not
+                // guaranteed to be plain stdClass
+                return false;
+            }
+            $found_object_type = true;
+            try {
+                $fqsen = FullyQualifiedClassName::fromType($type);
+            } catch (\Exception) {
+                return false;
+            }
+            if ($fqsen !== $stdclass_fqsen) {
+                return false;
             }
         }
         return $found_object_type;

--- a/tests/files/expected/5925_stdclass_dynamic_prop_false_positive.php.expected
+++ b/tests/files/expected/5925_stdclass_dynamic_prop_false_positive.php.expected
@@ -1,0 +1,3 @@
+%s:20 PhanTypeExpectedObjectPropAccess Expected an object instance when accessing an instance property, but saw an expression $obj->data with type string
+%s:31 PhanTypeExpectedObjectPropAccess Expected an object instance when accessing an instance property, but saw an expression $f->value with type int
+%s:39 PhanTypeExpectedObjectPropAccess Expected an object instance when accessing an instance property, but saw an expression $obj->value with type int

--- a/tests/files/src/5925_stdclass_dynamic_prop_false_positive.php
+++ b/tests/files/src/5925_stdclass_dynamic_prop_false_positive.php
@@ -1,0 +1,40 @@
+<?php
+
+// Test that chained property access on plain stdClass suppresses
+// PhanTypeExpectedObjectPropAccess (the globally accumulated dynamic
+// property type is unreliable), but that shaped stdClass, other typed
+// classes, and union types still warn correctly.
+
+// Case 1: Plain stdClass — should NOT warn (suppressed)
+function test_plain_stdclass(): void {
+    /** @var stdClass $obj */
+    $obj = json_decode('{"data":{"field":1}}');
+    echo $obj->data->field;
+}
+
+// Case 2: Shaped stdClass — SHOULD warn when shape type is non-object
+function test_shaped_stdclass(): void {
+    /** @var object{data:string} $obj */
+    $obj = (object)['data' => 'hello'];
+    // $obj->data is string, so ->length should warn
+    echo $obj->data->length;
+}
+
+// Case 3: Other class with typed property — SHOULD warn
+class Foo5925 {
+    public int $value = 42;
+}
+
+function test_typed_class(): void {
+    $f = new Foo5925();
+    // $f->value is int, so ->bar should warn
+    echo $f->value->bar;
+}
+
+// Case 4: Union type C|stdClass — SHOULD warn (not all types are plain stdClass)
+function test_union_type(): void {
+    /** @var Foo5925|stdClass $obj */
+    $obj = new Foo5925();
+    // Even though stdClass is in the union, Foo5925->value is int
+    echo $obj->value->bar;
+}


### PR DESCRIPTION
- Suppress `PhanTypeExpectedObjectPropAccess` false positives when the expression is a chained property access on a **plain (unshaped) `stdClass`** receiver
- Dynamic properties on plain `stdClass` are globally shared in the CodeBase, so their accumulated type gets contaminated by unrelated usages across the codebase
- This prevents false positives on chained access like `json_decode($x)->data->field`, where `->data`'s globally accumulated type might be `string` from other files
- Suppression only applies when **all** object types in the receiver union are plain `stdClass` — unions like `Foo|stdClass`, shaped stdClass (`object{data:string}`), and other `#[AllowDynamicProperties]` classes still get proper warnings
- Adds `isExpressionDynamicPropAccessOnPlainStdClass()` helper that checks the receiver is exclusively plain `stdClass` by comparing against `FullyQualifiedClassName::getStdClassFQSEN()`
- Adds regression test (`5925_stdclass_dynamic_prop_false_positive.php`) covering all four cases: plain stdClass (suppressed), shaped stdClass (warns), typed class (warns), union type (warns)