### PR TITLE
Add depth guard to ArrayShapeType::withStaticResolvedInContext

### DIFF
--- a/src/Phan/Language/Type/ArrayShapeType.php
+++ b/src/Phan/Language/Type/ArrayShapeType.php
@@ -1116,17 +1116,15 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
         return ArrayType::instance($this->is_nullable);
     }
 
-    /** @var int tracks recursion depth for withStaticResolvedInContext */
-    private static int $resolve_depth = 0;
-
     private const MAX_RESOLVE_DEPTH = 10;
 
     public function withStaticResolvedInContext(Context $context): Type
     {
-        if (self::$resolve_depth >= self::MAX_RESOLVE_DEPTH) {
+        static $resolve_depth = 0;
+        if ($resolve_depth >= self::MAX_RESOLVE_DEPTH) {
             return $this;
         }
-        self::$resolve_depth++;
+        $resolve_depth++;
         try {
             $did_change = false;
             $new_field_types = $this->field_types;
@@ -1143,7 +1141,7 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
             }
             return self::fromFieldTypes($new_field_types, $this->is_nullable);
         } finally {
-            self::$resolve_depth--;
+            $resolve_depth--;
         }
     }
 

--- a/src/Phan/Language/Type/ArrayShapeType.php
+++ b/src/Phan/Language/Type/ArrayShapeType.php
@@ -1116,8 +1116,18 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
         return ArrayType::instance($this->is_nullable);
     }
 
+    /** @var int tracks recursion depth for withStaticResolvedInContext */
+    private static int $resolve_depth = 0;
+
+    private const MAX_RESOLVE_DEPTH = 10;
+
     public function withStaticResolvedInContext(Context $context): Type
     {
+        if (self::$resolve_depth >= self::MAX_RESOLVE_DEPTH) {
+            return $this;
+        }
+        self::$resolve_depth++;
+
         $did_change = false;
         $new_field_types = $this->field_types;
         foreach ($new_field_types as $i => $field_type) {
@@ -1127,6 +1137,9 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
                 $new_field_types[$i] = $new_field_type;
             }
         }
+
+        self::$resolve_depth--;
+
         if (!$did_change) {
             return $this;
         }

--- a/src/Phan/Language/Type/ArrayShapeType.php
+++ b/src/Phan/Language/Type/ArrayShapeType.php
@@ -1127,23 +1127,24 @@ final class ArrayShapeType extends ArrayType implements GenericArrayInterface
             return $this;
         }
         self::$resolve_depth++;
-
-        $did_change = false;
-        $new_field_types = $this->field_types;
-        foreach ($new_field_types as $i => $field_type) {
-            $new_field_type = $field_type->withStaticResolvedInContext($context);
-            if ($new_field_type !== $field_type) {
-                $did_change = true;
-                $new_field_types[$i] = $new_field_type;
+        try {
+            $did_change = false;
+            $new_field_types = $this->field_types;
+            foreach ($new_field_types as $i => $field_type) {
+                $new_field_type = $field_type->withStaticResolvedInContext($context);
+                if ($new_field_type !== $field_type) {
+                    $did_change = true;
+                    $new_field_types[$i] = $new_field_type;
+                }
             }
-        }
 
-        self::$resolve_depth--;
-
-        if (!$did_change) {
-            return $this;
+            if (!$did_change) {
+                return $this;
+            }
+            return self::fromFieldTypes($new_field_types, $this->is_nullable);
+        } finally {
+            self::$resolve_depth--;
         }
-        return self::fromFieldTypes($new_field_types, $this->is_nullable);
     }
 
     public function withStaticResolvedTo(Type $static_type): Type

--- a/tests/Phan/Language/Type/ArrayShapeTypeTest.php
+++ b/tests/Phan/Language/Type/ArrayShapeTypeTest.php
@@ -57,6 +57,7 @@ final class ArrayShapeTypeTest extends TestBase
      * This reproduces a real-world issue where mutually recursive methods
      * returning array shapes caused type lengths to grow to 950K+ characters
      * and withStaticResolvedInContext took 130+ seconds per call.
+     * @throws \Phan\Exception\FQSENException
      */
     public function testWithStaticResolvedInContextDepthGuard(): void
     {

--- a/tests/Phan/Language/Type/ArrayShapeTypeTest.php
+++ b/tests/Phan/Language/Type/ArrayShapeTypeTest.php
@@ -4,7 +4,12 @@ declare(strict_types=1);
 
 namespace Phan\Tests\Language\Type;
 
+use Phan\Language\Context;
+use Phan\Language\FQSEN\FullyQualifiedClassName;
+use Phan\Language\Scope\ClassScope;
+use Phan\Language\Scope\GlobalScope;
 use Phan\Language\Type\ArrayShapeType;
+use Phan\Language\Type\StaticType;
 use Phan\Tests\TestBase;
 
 /**
@@ -43,5 +48,46 @@ final class ArrayShapeTypeTest extends TestBase
         $this->assertEscapedKeyEquals("\\x7e", "~");
         $this->assertEscapedKeyEquals("\\x1c", "\x1c");
         $this->assertEscapedKeyEquals("\\n\\t\\r\\\\\\x3a", "\n\t\r\\:");
+    }
+
+    /**
+     * Tests that withStaticResolvedInContext does not recurse indefinitely
+     * on deeply nested array shapes containing `static` types.
+     *
+     * This reproduces a real-world issue where mutually recursive methods
+     * returning array shapes caused type lengths to grow to 950K+ characters
+     * and withStaticResolvedInContext took 130+ seconds per call.
+     */
+    public function testWithStaticResolvedInContextDepthGuard(): void
+    {
+        $context = (new Context())->withScope(
+            new ClassScope(
+                new GlobalScope(),
+                FullyQualifiedClassName::fromFullyQualifiedString('\\TestClass'),
+                0
+            )
+        );
+
+        // Build a deeply nested array shape where each level has a `static` field:
+        // array{nested: array{nested: ..., s: static}, s: static}
+        // 20 levels deep, well beyond the MAX_RESOLVE_DEPTH of 10
+        $static_type = StaticType::instance(false)->asPHPDocUnionType();
+        $inner = ArrayShapeType::fromFieldTypes(['s' => $static_type], false);
+        for ($i = 0; $i < 19; $i++) {
+            $inner = ArrayShapeType::fromFieldTypes(
+                ['nested' => $inner->asPHPDocUnionType(), 's' => $static_type],
+                false
+            );
+        }
+
+        // This should complete quickly due to the depth guard, not hang
+        $resolved = $inner->withStaticResolvedInContext($context);
+        $this->assertInstanceOf(ArrayShapeType::class, $resolved);
+
+        // The outer levels (depth < 10) should have `static` resolved to `\TestClass`,
+        // but the innermost levels (depth >= 10) should retain `static`
+        $resolved_str = $resolved->__toString();
+        $this->assertStringContainsString('TestClass', $resolved_str);
+        $this->assertStringContainsString('static', $resolved_str);
     }
 }

--- a/tests/Phan/Language/Type/ArrayShapeTypeTest.php
+++ b/tests/Phan/Language/Type/ArrayShapeTypeTest.php
@@ -86,7 +86,18 @@ final class ArrayShapeTypeTest extends TestBase
         $this->assertInstanceOf(ArrayShapeType::class, $resolved);
 
         // The outer levels (depth < 10) should have `static` resolved to `\TestClass`,
-        // but the innermost levels (depth >= 10) should retain `static`
+        // but the innermost levels (depth >= 10) should retain `static`.
+        //
+        // Raw: array{nested:array{nested:array{nested:array{nested:array{nested:array{nested:array{nested:array{nested:array{nested:array{nested:array{nested:array{nested:array{nested:array{nested:array{nested:array{nested:array{nested:array{nested:array{nested:array{s:static},s:static},s:static},s:static},s:static},s:static},s:static},s:static},s:static},s:static},s:\TestClass},s:\TestClass},s:\TestClass},s:\TestClass},s:\TestClass},s:\TestClass},s:\TestClass},s:\TestClass},s:\TestClass},s:\TestClass}
+        //
+        // Formatted for readability:
+        //   depth  1: array{nested: ..., s: \TestClass}   <-- resolved
+        //   depth  2: array{nested: ..., s: \TestClass}
+        //   ...
+        //   depth 10: array{nested: ..., s: \TestClass}
+        //   depth 11: array{nested: ..., s: static}       <-- retained (beyond limit)
+        //   ...
+        //   depth 20: array{s: static}
         $resolved_str = $resolved->__toString();
         $this->assertStringContainsString('TestClass', $resolved_str);
         $this->assertStringContainsString('static', $resolved_str);


### PR DESCRIPTION
## Summary

- Adds a recursion depth limit (10) to `ArrayShapeType::withStaticResolvedInContext` to prevent exponential blowup on deeply nested array shapes
- When `track_all_inferred_types` is enabled with `--analyze-until-convergence`, return types can accumulate deeply nested array shapes across convergence passes. `Method::getUnionType` calls `withStaticResolvedInContext` on every method's return type, which recursively descends into each `ArrayShapeType`'s fields. With types growing to 950K+ characters and 15-18 levels of nesting, a single method can take over 2 minutes.
- Matches the existing `RecursionDepthException` pattern used in `computeExpandedTypesPreservingTemplate`. At 10+ levels of nested array shapes, any `static` type references are extremely unlikely to matter for practical analysis.

## Evidence

phpspy profiling (4,712 samples) showed the depth distribution during a stall:

| Depth | Samples | % |
|-------|---------|---|
| 1–7 | 155 | 3% |
| 8–10 | 153 | 3% |
| 11–13 | 916 | 19% |
| **14–16** | **2,186** | **46%** |
| 17–18 | 64 | 1% |

Debug logging confirmed max depths of 16-17 for the worst offenders (`getMailboxData`: 131.9s, type length 950K chars; `getAccountData`: 7.9s, type length 355K chars).

## Test plan

- [x] Phan self-analysis passes cleanly
- [ ] Run on large codebase with `track_all_inferred_types` + `--analyze-until-convergence` to verify stall is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)