### PR TITLE
Use getAnalyzeCallableArgumentClosure()

### DIFF
--- a/src/Phan/Plugin/Internal/PhoundPlugin.php
+++ b/src/Phan/Plugin/Internal/PhoundPlugin.php
@@ -1197,14 +1197,14 @@ final class PhoundVisitor extends PluginAwarePostAnalysisVisitor
 use Phan\PluginV3;
 use Phan\PluginV3\PostAnalyzeNodeCapability;
 use Phan\PluginV3\FinalizeProcessCapability;
-use Phan\PluginV3\AnalyzeFunctionCallCapability;
+use Phan\PluginV3\AnalyzeCallableArgumentCapability;
 use Phan\AST\UnionTypeVisitor;
 use Phan\Language\Element\FunctionInterface;
 
 /**
  * Plugin to go with PhoundVisitor.
  */
-final class PhoundPlugin extends PluginV3 implements PostAnalyzeNodeCapability, AnalyzeFunctionCallCapability, FinalizeProcessCapability
+final class PhoundPlugin extends PluginV3 implements PostAnalyzeNodeCapability, AnalyzeCallableArgumentCapability, FinalizeProcessCapability
 {
 
     /**
@@ -1224,47 +1224,23 @@ final class PhoundPlugin extends PluginV3 implements PostAnalyzeNodeCapability, 
     }
 
     /**
-     * @param CodeBase $code_base @phan-unused-param
-     * @return array<string,Closure(CodeBase,Context,FunctionInterface,list<mixed>,?Node)>
-     * maps FQSEN of function or method to a closure used to analyze the function in question.
-     * '\A::foo' or 'A::foo' as a key will override a method, and '\foo' or 'foo' as a key will override a function.
-     * Closure Type: function(CodeBase $code_base, Context $context, Func|Method $function, array $args, ?Node $node) : void {...}
-     *
-     * If compatibility with older Phan versions is needed, make the param for $node optional.
-     *
-     * Note that $function->getMostRecentParentNodeListForCall() can be used to get the parent node list of the current call (will be the empty array if fetching it failed).
+     * @return Closure(CodeBase,Context,FunctionInterface,int,Node|int|string|float):void
+     * @unused-param $code_base
      */
-    public function getAnalyzeFunctionCallClosures(CodeBase $code_base): array
-    {
-        // Unit tests invoke this repeatedly. Cache it.
-        static $analyzers = null;
-        if ($analyzers === null) {
-            $analyzers = self::getAnalyzeFunctionCallClosuresStatic();
-        }
-        return $analyzers;
-    }
-
-    /**
-     * Ensure that we track callsites in callables passed to call_user_func,
-     * forward_static_call, call_user_func_array, forward_static_call_array,
-     * Closure::fromCallable, etc.
-     *
-     * Much of the logic in here was cribbed from https://github.com/phan/phan/blob/0fd8121798fa1c77d7f7608cf36d71f0b8325880/src/Phan/Plugin/Internal/ClosureReturnTypeOverridePlugin.php#L199
-     *
-     * @return array<string,\Closure>
-     */
-    private static function getAnalyzeFunctionCallClosuresStatic(): array
+    public function getAnalyzeCallableArgumentClosure(CodeBase $code_base): Closure
     {
         /**
-         * @param list<Node|int|string|float> $args
-         * @throws Exception
+         * @param Node|int|string|float $arg_node
+         * @throws \Exception
          */
-        $generic_callback = static function(
+        return static function (
             CodeBase $code_base,
             Context $context,
-            array $args
+            FunctionInterface $unused_callee,
+            int $unused_param_index,
+            Node|int|string|float $arg_node
         ): void {
-            $function_like_list = UnionTypeVisitor::functionLikeListFromNodeAndContext($code_base, $context, $args[0], true);
+            $function_like_list = UnionTypeVisitor::functionLikeListFromNodeAndContext($code_base, $context, $arg_node, true);
             if (\count($function_like_list) === 0) {
                 return;
             }
@@ -1281,50 +1257,6 @@ final class PhoundPlugin extends PluginV3 implements PostAnalyzeNodeCapability, 
                 $phound_visitor->genericVisitClassElements($elements, 'method');
             }
         };
-
-        /**
-         * Factory for higher-order function handlers where the callable is at a specific arg index.
-         */
-        $make_hof_callback = static function (int $callable_arg_idx, int $min_args) use ($generic_callback): Closure {
-            /**
-             * @param list<Node|int|string|float> $args
-             * @throws Exception
-             */
-            return static function (
-                CodeBase $code_base,
-                Context $context,
-                FunctionInterface $unused_function,
-                array $args,
-                ?Node $_
-            ) use ($generic_callback, $callable_arg_idx, $min_args): void {
-                if (\count($args) < $min_args || !\array_key_exists($callable_arg_idx, $args)) {
-                    return;
-                }
-                $generic_callback($code_base, $context, [$args[$callable_arg_idx]]);
-            };
-        };
-
-        return [
-            // call_user_func family: callable at arg 0
-            'call_user_func'            => $make_hof_callback(0, 1),
-            'forward_static_call'       => $make_hof_callback(0, 1),
-            'call_user_func_array'      => $make_hof_callback(0, 2),
-            'forward_static_call_array' => $make_hof_callback(0, 2),
-            'Closure::fromCallable'     => $make_hof_callback(0, 1),
-
-            // Higher-order functions: callable at arg 0
-            'array_map'               => $make_hof_callback(0, 2),
-
-            // Higher-order functions: callable at arg 1
-            'array_filter'            => $make_hof_callback(1, 2),
-            'array_reduce'            => $make_hof_callback(1, 2),
-            'array_walk'              => $make_hof_callback(1, 2),
-            'array_walk_recursive'    => $make_hof_callback(1, 2),
-            'usort'                   => $make_hof_callback(1, 2),
-            'uasort'                  => $make_hof_callback(1, 2),
-            'uksort'                  => $make_hof_callback(1, 2),
-            'preg_replace_callback'   => $make_hof_callback(1, 3),
-        ];
     }
 
     /**

--- a/tests/phound_test/expected/005_phound_missed_callsites.php.expected
+++ b/tests/phound_test/expected/005_phound_missed_callsites.php.expected
@@ -28,6 +28,9 @@
 \PhoundMissedCallsites\Target005::method|method|src/005_phound_missed_callsites.php:112
 \PhoundMissedCallsites\Target005::filter|method|src/005_phound_missed_callsites.php:115
 \PhoundMissedCallsites\Target005::replace|method|src/005_phound_missed_callsites.php:118
+\PhoundMissedCallsites\Target005::method|method|src/005_phound_missed_callsites.php:127
+\Closure::fromCallable|method|src/005_phound_missed_callsites.php:134
+\PhoundMissedCallsites\Target005::filter|method|src/005_phound_missed_callsites.php:134
 <-----------> Classes <----------->
 \PhoundMissedCallsites\Chain005|src/005_phound_missed_callsites.php
 \PhoundMissedCallsites\Child005|src/005_phound_missed_callsites.php
@@ -70,7 +73,9 @@
 \PhoundMissedCallsites\TargetImpl005::method	method	\PhoundMissedCallsites\TargetImpl005	method	void	0	public	src/005_phound_missed_callsites.php	19
 \PhoundMissedCallsites\TargetInterface005::class	const	\PhoundMissedCallsites\TargetInterface005	class	'PhoundMissedCallsites\\TargetInterface005'	0	public	src/005_phound_missed_callsites.php	14
 \PhoundMissedCallsites\TargetInterface005::method	method	\PhoundMissedCallsites\TargetInterface005	method	void	0	public	src/005_phound_missed_callsites.php	15
+\PhoundMissedCallsites\apply_callback	function		apply_callback	void	0		src/005_phound_missed_callsites.php	123
 \PhoundMissedCallsites\myGen005	function		myGen005	\Generator	0		src/005_phound_missed_callsites.php	53
+\PhoundMissedCallsites\run_closure	function		run_closure	void	0		src/005_phound_missed_callsites.php	130
 \PhoundMissedCallsites\testInterface005	function		testInterface005	void	0		src/005_phound_missed_callsites.php	82
 \closure_43bf1d7948bb	function		{closure}	void	0		src/005_phound_missed_callsites.php	47
 \closure_c22c3d4d21bf	function		{closure}	int	0		src/005_phound_missed_callsites.php	100
@@ -78,7 +83,10 @@
 \closure_ee1bd3b008c0	function		{closure}	void	0		src/005_phound_missed_callsites.php	50
 <-----------> Parameters <----------->
 \PhoundMissedCallsites\Target005::replace	0	matches	array	0	0	0	
+\PhoundMissedCallsites\apply_callback	0	callback	callable	0	0	0	
+\PhoundMissedCallsites\apply_callback	1	target	\PhoundMissedCallsites\Target005	0	0	0	
 \PhoundMissedCallsites\myGen005	0	t	\PhoundMissedCallsites\Target005	0	0	0	
+\PhoundMissedCallsites\run_closure	0	fn	\Closure	0	0	0	
 \PhoundMissedCallsites\testInterface005	0	i	\PhoundMissedCallsites\TargetInterface005	0	0	0	
 \closure_c22c3d4d21bf	0	a	\PhoundMissedCallsites\Target005	0	0	0	
 \closure_c22c3d4d21bf	1	b	\PhoundMissedCallsites\Target005	0	0	0	

--- a/tests/phound_test/src/005_phound_missed_callsites.php
+++ b/tests/phound_test/src/005_phound_missed_callsites.php
@@ -117,6 +117,22 @@ array_filter([$t2], [$t2, 'filter']);  // captured: \Target005::filter
 // B5: preg_replace_callback with array callable at arg 1 — captured by HOF handler
 preg_replace_callback('/x/', [$t2, 'replace'], 'test');  // captured: \Target005::replace
 
+// GROUP D: User-defined functions with callable params (newly covered by AnalyzeCallableArgumentCapability)
+
+/** User-defined higher-order function that accepts a callable */
+function apply_callback(callable $callback, Target005 $target): void {
+    $callback($target);
+}
+
+apply_callback([$t2, 'method'], $t2);  // D1: callable tracked via user-defined function
+
+/** User-defined function with Closure type hint */
+function run_closure(\Closure $fn): void {
+    $fn();
+}
+
+run_closure(\Closure::fromCallable([$t2, 'filter']));  // D2: Closure param tracked
+
 // GROUP C: Patterns EXPECTED to be missed (design limitations)
 
 // C1: Variable callable invocation — stored in variable as array callable


### PR DESCRIPTION
Converted PhoundPlugin from AnalyzeFunctionCallCapability to AnalyzeCallableArgumentCapability:
- Replaced the hardcoded list of 13 functions + factory pattern (~100 lines) with a single getAnalyzeCallableArgumentClosure() method (~25 lines)
- The framework now automatically discovers all functions/methods with callable parameters, so PhoundPlugin will track callsites through any callable argument including user-defined functions, and built-in functions the old list missed (e.g., array_udiff, set_error_handler, register_shutdown_function, etc.)