### PR TITLE
Update PHP_CodeSniffer repository link

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Phan attempts to adhere to the [PSR-2](http://www.php-fig.org/psr/psr-2/) and [P
 declare(strict_types=1);
 ```
 
-- [Phan's ruleset.xml](https://github.com/phan/phan/blob/master/ruleset.xml) can be used with [`phpcs` and `phpcbf`](https://github.com/squizlabs/PHP_CodeSniffer) to adhere to the style guide.
+- [Phan's ruleset.xml](https://github.com/phan/phan/blob/master/ruleset.xml) can be used with [`phpcs` and `phpcbf`](https://github.com/PHPCSStandards/PHP_CodeSniffer) to adhere to the style guide.
 - `internal/phpcbf` will automatically fix any style issues in your changes.
   Alternately, `phpcbf.phar --standard=ruleset.xml ...paths` can be used
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!-- This is a ruleset for https://github.com/squizlabs/PHP_CodeSniffer -->
+<!-- This is a ruleset for https://github.com/PHPCSStandards/PHP_CodeSniffer -->
 <!-- Usage:  phpcs.phar \-\-standard=path/toruleset.xml path/to/file_or_folder.php (Can't have double hyphen in xml comment) -->
 <!-- phpcbf.phar can be used to automatically fix many issues -->
 <!-- Use this with PHP_CodeSniffer 3.3.0 or newer -->


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932