### PR TITLE
Bug5512

### DIFF
--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -3777,6 +3777,19 @@ class BlockAnalysisVisitor extends AnalysisVisitor
                     $parameter->cloneAsNonVariadic()
                 );
             }
+        } elseif ($node->children['name'] === 'set') {
+            // Set hooks without explicit params have an implicit $value variable
+            // with the property's declared type (PHP 8.4 semantics)
+            $scope = $context->getScope();
+            if ($scope->isInPropertyScope()) {
+                $property_fqsen = $scope->getPropertyFQSEN();
+                if ($this->code_base->hasPropertyWithFQSEN($property_fqsen)) {
+                    $property = $this->code_base->getPropertyByFQSEN($property_fqsen);
+                    $hook_context->addScopeVariable(
+                        new Variable($hook_context, 'value', $property->getUnionType(), 0)
+                    );
+                }
+            }
         }
 
         // Recurse into children (params, stmts, etc.)

--- a/tests/php84_files/expected/5512_implicit_value_property_hook.php.expected
+++ b/tests/php84_files/expected/5512_implicit_value_property_hook.php.expected
@@ -1,0 +1,1 @@
+%s:41 PhanTypeMismatchPropertyReal Assigning 'not an int' of type string to property but \ImplicitValueTypeMismatch->strict is int

--- a/tests/php84_files/src/5512_implicit_value_property_hook.php
+++ b/tests/php84_files/src/5512_implicit_value_property_hook.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * Regression tests for https://github.com/phan/phan/issues/5512
+ * Implicit $value in set hooks should not trigger PhanUndeclaredVariable.
+ * @phan-file-suppress PhanUnreferencedClass, PhanUnreferencedPublicProperty, PhanWriteOnlyPublicProperty
+ */
+
+class ImplicitValueBasic {
+    // Set hook with implicit $value — should NOT warn about undeclared variable
+    public string $name {
+        set {
+            $this->name = $value;
+        }
+    }
+}
+
+class ImplicitValueWithValidation {
+    // Implicit $value used in expressions
+    public int $count {
+        set {
+            $this->count = max(0, $value);
+        }
+    }
+}
+
+class ImplicitValueWithBothHooks {
+    // Get + set with implicit $value
+    public string $title {
+        get => strtoupper($this->title);
+        set {
+            $this->title = trim($value);
+        }
+    }
+}
+
+class ImplicitValueTypeMismatch {
+    // Implicit $value assigned to incompatible backing store type
+    public int $strict {
+        set {
+            $this->strict = 'not an int';  // Should warn PhanTypeMismatchPropertyReal
+        }
+    }
+}
+
+$obj = new ImplicitValueBasic();
+$obj->name = 'hello';
+
+$obj2 = new ImplicitValueWithValidation();
+$obj2->count = 42;
+
+$obj3 = new ImplicitValueWithBothHooks();
+$obj3->title = 'test';
+
+$obj4 = new ImplicitValueTypeMismatch();
+$obj4->strict = 5;


### PR DESCRIPTION
When a set hook has no explicit params node in the AST, the implicit $value variable is now added to scope with the property's declared type. This is done by looking up the property via the PropertyScope FQSEN already available in the context.