### PR TITLE
fixes 5515

### DIFF
--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -3727,6 +3727,10 @@ class UnionType implements Serializable, Stringable
         $result = [];
         $is_possibly_string = false;
         foreach ($type_set as $type) {
+            if ($type instanceof ClassStringType) {
+                $result[] = $type->withIsNullable(false);
+                continue;
+            }
             if ($type instanceof LiteralStringType) {
                 if (!\preg_match(FullyQualifiedClassName::VALID_CLASS_REGEX, $type->getValue()) && !\preg_match('/^\\\\?oci-(lob|collection)$/iD', $type->getValue())) {
                     continue;


### PR DESCRIPTION
When `class_exists()` is called on a variable typed `class-string<T>` (from PHPDoc), the generic parameter `<T>` was being lost inside the if-branch.
Added an early check for ClassStringType before the LiteralStringType and StringType checks, preserving the original type (including its template parameters) instead of replacing it with a bare class-string.