### PR TITLE
fixes #4419

### DIFF
--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -1958,16 +1958,13 @@ class BlockAnalysisVisitor extends AnalysisVisitor
             // equivalent to !willUnconditionallyThrowOrReturn()
             if (($block_exit_status & ~BlockExitStatusChecker::STATUS_THROW_OR_RETURN_BITMASK)) {
                 if ($block_exit_status & BlockExitStatusChecker::STATUS_PROCEED) {
-                    // @phan-suppress-next-line PhanPossiblyUndeclaredVariable the finally block is not perfectly analyzed by Phan
                     $previous_child_context = $child_context;
                     if ($i === count($node->children) - 1) {
                         // last case falls through to end of switch, include the accumulated context once
-                        // @phan-suppress-next-line PhanPossiblyUndeclaredVariable the finally block is not perfectly analyzed by Phan
                         $child_context_list[] = $child_context;
                     }
                 } elseif (count($stmts_node->children ?? []) !== 0 || $i === count($node->children) - 1) {
                     // Skip over case statements that only ever throw or return or are empty in the middle of a fallthrough chain
-                    // @phan-suppress-next-line PhanPossiblyUndeclaredVariable the finally block is not perfectly analyzed by Phan
                     $child_context_list[] = $child_context;
                     $previous_child_context = null;
                 }
@@ -1994,7 +1991,6 @@ class BlockAnalysisVisitor extends AnalysisVisitor
             }
         }
 
-        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable Phan cannot infer child_context_list was non-empty due to finally block
         return $this->postOrderAnalyze($context, $node);
     }
 

--- a/src/Phan/BlockAnalysisVisitor.php
+++ b/src/Phan/BlockAnalysisVisitor.php
@@ -2888,7 +2888,7 @@ class BlockAnalysisVisitor extends AnalysisVisitor
         $catch_context_list = [$try_context];
 
         $catch_nodes = $node->children['catches']->children ?? [];
-        $all_catches_skip_remaining = (bool)$catch_nodes;
+        $all_catches_skip_remaining = true;
 
         foreach ($catch_nodes as $catch_node) {
             // Note: ContextMergeVisitor expects to get each individual catch

--- a/tests/files/expected/4884_try_possibly_undefined.php.expected
+++ b/tests/files/expected/4884_try_possibly_undefined.php.expected
@@ -2,4 +2,3 @@
 %s:61 PhanPossiblyUndeclaredVariable Variable $val4 is possibly undeclared
 %s:74 PhanPossiblyUndeclaredVariable Variable $val5 is possibly undeclared
 %s:87 PhanPossiblyUndeclaredVariable Variable $val6 is possibly undeclared
-%s:97 PhanPossiblyUndeclaredVariable Variable $val7 is possibly undeclared

--- a/tests/files/expected/5921_try_catch_finally_possibly_undefined.php.expected
+++ b/tests/files/expected/5921_try_catch_finally_possibly_undefined.php.expected
@@ -1,2 +1,1 @@
 %s:53 PhanPossiblyUndeclaredVariable Variable $variable is possibly undeclared
-%s:62 PhanPossiblyUndeclaredVariable Variable $variable is possibly undeclared

--- a/tests/files/src/4884_try_possibly_undefined.php
+++ b/tests/files/src/4884_try_possibly_undefined.php
@@ -88,7 +88,7 @@ function test6() {
 }
 
 // Test case 7: No catch blocks
-// Should warn: exception will propagate
+// Should NOT warn: exception propagates, so this is only reachable if try succeeded
 function test7() {
     try {
         $val7 = mayThrow();

--- a/tests/files/src/4884_try_possibly_undefined.php
+++ b/tests/files/src/4884_try_possibly_undefined.php
@@ -94,5 +94,5 @@ function test7() {
         $val7 = mayThrow();
     } finally {
     }
-    echo $val7;  // PhanPossiblyUndeclaredVariable
+    echo $val7;  // No warning: exception propagates, $val7 is always defined here
 }

--- a/tests/files/src/5921_try_catch_finally_possibly_undefined.php
+++ b/tests/files/src/5921_try_catch_finally_possibly_undefined.php
@@ -59,5 +59,5 @@ function test_no_catch_with_finally(): void {
     } finally {
         // cleanup
     }
-    echo $variable; // should warn: PhanPossiblyUndeclaredVariable
+    echo $variable; // should not warn: no catch means exception propagates, so this is only reachable if try succeeded
 }


### PR DESCRIPTION
# Fix false positive PhanPossiblyUndeclaredVariable in try/finally with no catch

Fixes #4419

## Problem

Phan incorrectly warns about variables assigned in a `try` block being "possibly undefined" after a `try/finally` block that has **no catch**:

```php
try {
    $jwt = JWT::decode($cookies[$expected_cookie_name], self::decodeKeys());
} finally {
    JWT::$leeway = $previous_leeway;
}

// Phan warns: PhanPossiblyUndeclaredVariable Variable $jwt is possibly undeclared
if ($scope !== $jwt->scope) { ... }
```

This is a false positive because if `JWT::decode()` throws, the `finally` block runs and then the exception **propagates**, code after the `try/finally` is unreachable. The only path to code after `try/finally` is if the `try` block completed successfully, meaning `$jwt` is always defined at that point.

## Bug

In `BlockAnalysisVisitor::visitTry()`, the flag controlling whether to clear possibly-undefined markers was initialized as:

```php
$all_catches_skip_remaining = (bool)$catch_nodes;
```

When there are no catch blocks, `$catch_nodes` is empty, so this evaluated to `false`. This prevented `clearPossiblyUndefinedFromTryContext()` from running after the finally block. However, having no catch blocks means exceptions propagate unconditionally, semantically equivalent to "all catches exit."

## Fix

Changed the initialization to:

```php
$all_catches_skip_remaining = true;
```

The `foreach` loop over catch nodes still correctly sets it to `false` if any catch block falls through without exiting. When there are no catch blocks, the loop doesn't execute and the value stays `true`, which correctly reflects that uncaught exceptions always propagate.