### PR TITLE
Fixes #5522

### DIFF
--- a/src/Phan/Language/Type/TemplateType.php
+++ b/src/Phan/Language/Type/TemplateType.php
@@ -411,17 +411,39 @@ final class TemplateType extends Type
     }
 
     /**
-     * @unused-param $code_base
      * @unused-param $context
-     * @unused-param $other
      */
     public function canCastToDeclaredType(CodeBase $code_base, Context $context, Type $other): bool
     {
         if (!$this->bound_union_type || $this->bound_union_type->isEmpty()) {
             return true;
         }
+        // T of Bound casts to $other only if every type in the bound is assignable to $other.
+        $other_union = $other->asPHPDocUnionType();
+        foreach ($this->bound_union_type->getTypeSet() as $bound_type) {
+            if (!$bound_type->asPHPDocUnionType()->canCastToUnionType($other_union, $code_base)) {
+                return false;
+            }
+        }
+        return true;
+    }
 
-        return $this->bound_union_type->canCastToUnionType($other->asPHPDocUnionType(), $code_base);
+    /**
+     * @param list<Type> $target_type_set
+     */
+    public function canCastToAnyTypeInSet(array $target_type_set, CodeBase $code_base): bool
+    {
+        if (!$this->bound_union_type || $this->bound_union_type->isEmpty()) {
+            return parent::canCastToAnyTypeInSet($target_type_set, $code_base);
+        }
+        // T of Bound casts to the target union if every type in the bound
+        // can cast to at least one type in the target set.
+        foreach ($this->bound_union_type->getTypeSet() as $bound_type) {
+            if (!$bound_type->canCastToAnyTypeInSet($target_type_set, $code_base)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**
@@ -430,15 +452,16 @@ final class TemplateType extends Type
     public function canCastToAnyTypeInSetWithoutConfig(array $target_type_set, CodeBase $code_base): bool
     {
         if (!$this->bound_union_type || $this->bound_union_type->isEmpty()) {
-            return true;
+            return parent::canCastToAnyTypeInSetWithoutConfig($target_type_set, $code_base);
         }
-
-        foreach ($target_type_set as $type) {
-            if ($this->bound_union_type->canCastToUnionType($type->asPHPDocUnionType(), $code_base)) {
-                return true;
+        // T of Bound casts to the target union if every type in the bound
+        // can cast to at least one type in the target set.
+        foreach ($this->bound_union_type->getTypeSet() as $bound_type) {
+            if (!$bound_type->canCastToAnyTypeInSetWithoutConfig($target_type_set, $code_base)) {
+                return false;
             }
         }
-        return false;
+        return true;
     }
 
     public function isPossiblyFalsey(): bool

--- a/src/Phan/Language/Type/TemplateType.php
+++ b/src/Phan/Language/Type/TemplateType.php
@@ -411,21 +411,20 @@ final class TemplateType extends Type
     }
 
     /**
+     * @unused-param $code_base
      * @unused-param $context
+     * @unused-param $other
      */
     public function canCastToDeclaredType(CodeBase $code_base, Context $context, Type $other): bool
     {
         if (!$this->bound_union_type || $this->bound_union_type->isEmpty()) {
             return true;
         }
-        // T of Bound casts to $other only if every type in the bound is assignable to $other.
-        $other_union = $other->asPHPDocUnionType();
-        foreach ($this->bound_union_type->getTypeSet() as $bound_type) {
-            if (!$bound_type->asPHPDocUnionType()->canCastToUnionType($other_union, $code_base)) {
-                return false;
-            }
-        }
-        return true;
+        // NOTE: UnionType::canCastToDeclaredType() iterates over target types one at a time
+        // and returns true on any match, so this uses "bound ∩ target non-empty" semantics
+        // rather than full-subtyping. Full subtyping is enforced by canCastToAnyTypeInSet()
+        // via the main canCastToUnionType() path.
+        return $this->bound_union_type->canCastToUnionType($other->asPHPDocUnionType(), $code_base);
     }
 
     /**

--- a/src/Phan/Language/Type/TemplateType.php
+++ b/src/Phan/Language/Type/TemplateType.php
@@ -436,6 +436,10 @@ final class TemplateType extends Type
         if (!$this->bound_union_type || $this->bound_union_type->isEmpty()) {
             return parent::canCastToAnyTypeInSet($target_type_set, $code_base);
         }
+        // A nullable bounded template cannot cast to a set of non-null-accepting targets.
+        if ($this->is_nullable && !NullType::instance(false)->canCastToAnyTypeInSet($target_type_set, $code_base)) {
+            return false;
+        }
         // T of Bound casts to the target union if every type in the bound
         // can cast to at least one type in the target set.
         foreach ($this->bound_union_type->getTypeSet() as $bound_type) {
@@ -452,7 +456,13 @@ final class TemplateType extends Type
     public function canCastToAnyTypeInSetWithoutConfig(array $target_type_set, CodeBase $code_base): bool
     {
         if (!$this->bound_union_type || $this->bound_union_type->isEmpty()) {
-            return parent::canCastToAnyTypeInSetWithoutConfig($target_type_set, $code_base);
+            // Preserve prior permissive behavior for unbounded templates in strict (without-config) casts:
+            // templates with no declared bound are treated as acceptable, matching earlier Phan releases.
+            return true;
+        }
+        // A nullable bounded template cannot cast to a set of non-null-accepting targets.
+        if ($this->is_nullable && !NullType::instance(false)->canCastToAnyTypeInSetWithoutConfig($target_type_set, $code_base)) {
+            return false;
         }
         // T of Bound casts to the target union if every type in the bound
         // can cast to at least one type in the target set.

--- a/tests/files/expected/5433_template_array_bounds.php.expected
+++ b/tests/files/expected/5433_template_array_bounds.php.expected
@@ -7,4 +7,3 @@
 %s:74 PhanTemplateTypeNotUsedInFunctionReturn Template type T not used in return value of function/method accessUnboundedTemplate5433()
 %s:76 PhanTypeArraySuspiciousNullable Suspicious array access to $value of nullable type T
 %s:86 PhanTemplateTypeNotUsedInFunctionReturn Template type T not used in return value of function/method accessStringTemplate5433()
-%s:88 PhanTypeArraySuspicious Suspicious array access to $str of type T

--- a/tests/files/expected/5928_template_bound_cast.php.expected
+++ b/tests/files/expected/5928_template_bound_cast.php.expected
@@ -1,0 +1,4 @@
+%s:19 PhanTypeMismatchArgument Argument 1 ($x) is $value of type T but \takesA() takes \A defined at %s:10
+%s:40 PhanTypeMismatchArgument Argument 1 ($x) is $value of type T but \takesAOrB() takes \A|\B defined at %s:9
+%s:57 PhanTypeMismatchReturn Returning $value of type T but returnA() is declared to return \A
+%s:62 PhanTypeMismatchPropertyReal Assigning $value of type T (no real type) to property but \Holder->prop is \A

--- a/tests/files/expected/5928_template_bound_cast.php.expected
+++ b/tests/files/expected/5928_template_bound_cast.php.expected
@@ -2,3 +2,4 @@
 %s:40 PhanTypeMismatchArgument Argument 1 ($x) is $value of type T but \takesAOrB() takes \A|\B defined at %s:9
 %s:57 PhanTypeMismatchReturn Returning $value of type T but returnA() is declared to return \A
 %s:62 PhanTypeMismatchPropertyReal Assigning $value of type T (no real type) to property but \Holder->prop is \A
+%s:72 PhanTypeMismatchArgumentNullable Argument 1 ($x) is $value of type ?T but \takesAOrB() takes \A|\B defined at %s:9 (expected type to be non-nullable)

--- a/tests/files/src/5928_template_bound_cast.php
+++ b/tests/files/src/5928_template_bound_cast.php
@@ -1,0 +1,64 @@
+<?php
+// Regression test for https://github.com/phan/phan/issues/5522
+// T of A|B should be accepted where A|B is expected.
+
+class A {}
+class B {}
+class C {}
+
+function takesAOrB(A|B $x): void {}
+function takesA(A $x): void {}
+
+/**
+ * @template T of A|B
+ */
+class Box {
+    /** @param T $value */
+    public function test($value): void {
+        takesAOrB($value);   // OK: T's bound A|B satisfies A|B
+        takesA($value);      // should warn: T could be B
+    }
+}
+
+/**
+ * @template T of A
+ */
+class BoxA {
+    /** @param T $value */
+    public function test($value): void {
+        takesAOrB($value);   // OK: T's bound A is subtype of A|B
+        takesA($value);      // OK
+    }
+}
+
+/**
+ * @template T of A|B|C
+ */
+class BoxABC {
+    /** @param T $value */
+    public function test($value): void {
+        takesAOrB($value);   // should warn: T could be C
+    }
+}
+
+class Holder {
+    public A $prop;
+}
+
+/**
+ * @template T of A|B
+ */
+class ReturnAndProperty {
+    /**
+     * @param T $value
+     * @return A
+     */
+    public function returnA($value) {
+        return $value;   // should warn: T could be B
+    }
+
+    /** @param T $value */
+    public function assignProp(Holder $h, $value): void {
+        $h->prop = $value;  // should warn: T could be B
+    }
+}

--- a/tests/files/src/5928_template_bound_cast.php
+++ b/tests/files/src/5928_template_bound_cast.php
@@ -62,3 +62,13 @@ class ReturnAndProperty {
         $h->prop = $value;  // should warn: T could be B
     }
 }
+
+/**
+ * @template T of A|B
+ */
+class NullableBox {
+    /** @param ?T $value */
+    public function test($value): void {
+        takesAOrB($value);   // should warn: nullable source to non-null target
+    }
+}


### PR DESCRIPTION
Fixes #5522


When a `@template T of A|B` parameter was passed to a function expecting `A|B`, Phan incorrectly emitted `PhanTypeMismatchArgument` treating `T` as an opaque type name rather than expanding it to its bound.

```php
class A {}
class B {}
class Consumer {
    public function doStuff(A|B $in): void {}
}
/**
 * @template T of A|B
 */
class Box {
    /** @param T $value */
    public function outer($value) {
        (new Consumer)->doStuff($value); // false positive: T but takes A|B
    }
}
```

### Root Cause

`TemplateType` in `src/Phan/Language/Type/TemplateType.php` used incorrect subtyping logic in two cast methods:

- `canCastToAnyTypeInSet()`: not overridden at all; base class treated T as opaque, so `T.canCastToType(A)` returned false.
- `canCastToAnyTypeInSetWithoutConfig()`: overridden but inverted: asked "can the whole bound cast to any single target type?" instead of "can each bound type cast to some target type?" For `T of A|B` → `A|B`, it asked "can `A|B` cast to `A`?" (no, because B is not A) and "can `A|B` cast to `B`?" (no), and returned false.

### Fix

All three cast methods now use consistent subtyping semantics: **`T of Bound` casts to target if every type in the bound is assignable to the target.**

- Added `canCastToAnyTypeInSet()` override.
- Rewrote `canCastToAnyTypeInSetWithoutConfig()` with the correct all-members rule.
- Nullable bounded templates (`?T` where `T of A|B`) are rejected against non-null targets via an explicit `NullType` probe in `canCastToAnyTypeInSet*()`, preserving the pre-fix nullability diagnostics.
- Unbounded templates: `canCastToAnyTypeInSet()` delegates to `parent::` (restrictive, unchanged from pre-fix); `canCastToAnyTypeInSetWithoutConfig()` returns `true` (permissive, preserving prior Phan behavior).
- `canCastToDeclaredType()` is intentionally left with its existing "bound ∩ target non-empty" semantics. Its caller in `UnionType::canCastToDeclaredType()` iterates targets one at a time, so strict all-members subtyping would wrongly reject `T of A|B` against union target `A|B` (neither `T→A` nor `T→B` alone would match). Full subtyping is enforced via the main `canCastToUnionType()` path (which uses `canCastToAnyTypeInSet()`).

### Side Effect

`T of string` array access (`$str[0]`) no longer emits `PhanTypeArraySuspicious`. This is consistent with how plain `string` is treated — Phan already doesn't warn about subscript access on plain `string` types, since the string-access path adds `string` to `$element_types` before the suspicious-access check runs. The old warning was an artifact of `T` not being expanded to its bound. Updated `tests/files/expected/5433_template_array_bounds.php.expected` accordingly.