### PR TITLE
Fixes #5528

### DIFF
--- a/src/Phan/Analysis/ClassConstantTypesAnalyzer.php
+++ b/src/Phan/Analysis/ClassConstantTypesAnalyzer.php
@@ -292,8 +292,8 @@ class ClassConstantTypesAnalyzer
                     continue;
                 }
 
-                // PHP enforces covariance for typed constants: child type must be a subtype of parent type
-                if (!$constant_real_type->canCastToUnionType($inherited_real_type, $code_base)) {
+                // PHP enforces covariance for typed constants: every type in the child must be a subtype of the parent
+                if (!$constant_real_type->canStrictCastToUnionType($code_base, $inherited_real_type)) {
                     Issue::maybeEmit(
                         $code_base,
                         $constant->getContext(),

--- a/src/Phan/Analysis/ClassConstantTypesAnalyzer.php
+++ b/src/Phan/Analysis/ClassConstantTypesAnalyzer.php
@@ -292,7 +292,7 @@ class ClassConstantTypesAnalyzer
                     continue;
                 }
 
-                // PHP enforces covariance for typed constants: every type in the child must be a strict subtype of the parent
+                // PHP enforces covariance for typed constants: every type in the child must be a subtype of (or equal to) the parent
                 if (!$constant_real_type->isStrictSubtypeOf($code_base, $inherited_real_type)) {
                     Issue::maybeEmit(
                         $code_base,

--- a/src/Phan/Analysis/ClassConstantTypesAnalyzer.php
+++ b/src/Phan/Analysis/ClassConstantTypesAnalyzer.php
@@ -292,8 +292,8 @@ class ClassConstantTypesAnalyzer
                     continue;
                 }
 
-                // PHP enforces covariance for typed constants: every type in the child must be a subtype of the parent
-                if (!$constant_real_type->canStrictCastToUnionType($code_base, $inherited_real_type)) {
+                // PHP enforces covariance for typed constants: every type in the child must be a strict subtype of the parent
+                if (!$constant_real_type->isStrictSubtypeOf($code_base, $inherited_real_type)) {
                     Issue::maybeEmit(
                         $code_base,
                         $constant->getContext(),

--- a/src/Phan/Analysis/ClassConstantTypesAnalyzer.php
+++ b/src/Phan/Analysis/ClassConstantTypesAnalyzer.php
@@ -292,9 +292,8 @@ class ClassConstantTypesAnalyzer
                     continue;
                 }
 
-                // Constants must be covariant: child type must be equal to parent type
-                // PHP enforces invariance for typed constants (types must match exactly)
-                if (!$constant_real_type->isEqualTo($inherited_real_type)) {
+                // PHP enforces covariance for typed constants: child type must be a subtype of parent type
+                if (!$constant_real_type->canCastToUnionType($inherited_real_type, $code_base)) {
                     Issue::maybeEmit(
                         $code_base,
                         $constant->getContext(),

--- a/tests/php83_files/expected/002_typed_class_constants.php.expected
+++ b/tests/php83_files/expected/002_typed_class_constants.php.expected
@@ -7,5 +7,6 @@
 %s:60 PhanTypeMismatchDeclaredConstant Constant \ComplexExpressions::WRONG_CALC is declared with type int but has value ('prefix' . self::BASE) of type 'prefix10'
 %s:67 PhanTypeMismatchDeclaredConstant Constant \UnionTypes::WRONG is declared with type int|string but has value 3.14 of type 3.14
 %s:74 PhanTypeMismatchDeclaredConstant Constant \NullableTypes::WRONG_NULL is declared with type ?int but has value 'not null' of type 'not null'
-%s:95 PhanConstantTypeMismatchInheritance Class constant \NonCovariantChild::STR is declared with type ?string which is not covariant with type string inherited from \NonCovariantParent (constant types must be invariant or covariant)
-%s:96 PhanConstantTypeMismatchInheritance Class constant \NonCovariantChild::NUM is declared with type int|string which is not covariant with type int inherited from \NonCovariantParent (constant types must be invariant or covariant)
+%s:96 PhanConstantTypeMismatchInheritance Class constant \NonCovariantChild::STR is declared with type ?string which is not covariant with type string inherited from \NonCovariantParent (constant types must be invariant or covariant)
+%s:97 PhanConstantTypeMismatchInheritance Class constant \NonCovariantChild::NUM is declared with type int|string which is not covariant with type int inherited from \NonCovariantParent (constant types must be invariant or covariant)
+%s:98 PhanConstantTypeMismatchInheritance Class constant \NonCovariantChild::MIXED_PARENT is declared with type mixed which is not covariant with type int inherited from \NonCovariantParent (constant types must be invariant or covariant)

--- a/tests/php83_files/expected/002_typed_class_constants.php.expected
+++ b/tests/php83_files/expected/002_typed_class_constants.php.expected
@@ -7,4 +7,5 @@
 %s:60 PhanTypeMismatchDeclaredConstant Constant \ComplexExpressions::WRONG_CALC is declared with type int but has value ('prefix' . self::BASE) of type 'prefix10'
 %s:67 PhanTypeMismatchDeclaredConstant Constant \UnionTypes::WRONG is declared with type int|string but has value 3.14 of type 3.14
 %s:74 PhanTypeMismatchDeclaredConstant Constant \NullableTypes::WRONG_NULL is declared with type ?int but has value 'not null' of type 'not null'
-%s:94 PhanConstantTypeMismatchInheritance Class constant \NonCovariantChild::STR is declared with type ?string which is not covariant with type string inherited from \NonCovariantParent (constant types must be invariant or covariant)
+%s:95 PhanConstantTypeMismatchInheritance Class constant \NonCovariantChild::STR is declared with type ?string which is not covariant with type string inherited from \NonCovariantParent (constant types must be invariant or covariant)
+%s:96 PhanConstantTypeMismatchInheritance Class constant \NonCovariantChild::NUM is declared with type int|string which is not covariant with type int inherited from \NonCovariantParent (constant types must be invariant or covariant)

--- a/tests/php83_files/expected/002_typed_class_constants.php.expected
+++ b/tests/php83_files/expected/002_typed_class_constants.php.expected
@@ -7,3 +7,4 @@
 %s:60 PhanTypeMismatchDeclaredConstant Constant \ComplexExpressions::WRONG_CALC is declared with type int but has value ('prefix' . self::BASE) of type 'prefix10'
 %s:67 PhanTypeMismatchDeclaredConstant Constant \UnionTypes::WRONG is declared with type int|string but has value 3.14 of type 3.14
 %s:74 PhanTypeMismatchDeclaredConstant Constant \NullableTypes::WRONG_NULL is declared with type ?int but has value 'not null' of type 'not null'
+%s:94 PhanConstantTypeMismatchInheritance Class constant \NonCovariantChild::STR is declared with type ?string which is not covariant with type string inherited from \NonCovariantParent (constant types must be invariant or covariant)

--- a/tests/php83_files/src/002_typed_class_constants.php
+++ b/tests/php83_files/src/002_typed_class_constants.php
@@ -88,8 +88,10 @@ class CovariantChild extends CovariantParent {
 // Test non-covariant inheritance: widening is not allowed
 class NonCovariantParent {
     const string STR = 'test';
+    const int NUM = 1;
 }
 
 class NonCovariantChild extends NonCovariantParent {
-    const ?string STR = null; // ERROR: ?string widens string (not covariant)
+    const ?string STR = null;    // ERROR: ?string widens string (not covariant)
+    const int|string NUM = 1;    // ERROR: int|string widens int (not covariant)
 }

--- a/tests/php83_files/src/002_typed_class_constants.php
+++ b/tests/php83_files/src/002_typed_class_constants.php
@@ -73,3 +73,23 @@ class NullableTypes {
     const ?string NULLABLE_STR = 'test'; // OK
     const ?int WRONG_NULL = 'not null'; // ERROR
 }
+
+// Test covariant inheritance: narrowing nullable to non-nullable is allowed
+class CovariantParent {
+    const ?string STR = null;
+    const ?int NUM = null;
+}
+
+class CovariantChild extends CovariantParent {
+    const string STR = 'Qux'; // OK: string is covariant with ?string
+    const int NUM = 42;       // OK: int is covariant with ?int
+}
+
+// Test non-covariant inheritance: widening is not allowed
+class NonCovariantParent {
+    const string STR = 'test';
+}
+
+class NonCovariantChild extends NonCovariantParent {
+    const ?string STR = null; // ERROR: ?string widens string (not covariant)
+}

--- a/tests/php83_files/src/002_typed_class_constants.php
+++ b/tests/php83_files/src/002_typed_class_constants.php
@@ -89,9 +89,11 @@ class CovariantChild extends CovariantParent {
 class NonCovariantParent {
     const string STR = 'test';
     const int NUM = 1;
+    const int MIXED_PARENT = 1;
 }
 
 class NonCovariantChild extends NonCovariantParent {
     const ?string STR = null;    // ERROR: ?string widens string (not covariant)
     const int|string NUM = 1;    // ERROR: int|string widens int (not covariant)
+    const mixed MIXED_PARENT = 1; // ERROR: mixed widens int (not covariant)
 }


### PR DESCRIPTION
Fixes #5528 — `PhanConstantTypeMismatchInheritance` was incorrectly flagged when a subclass constant's type is a covariant (narrower) override of the parent's type.

Example that was wrongly reported:
```php
class Foo { public const ?string BAZ = null; }
class Bar extends Foo { public const string BAZ = 'Qux'; } // false positive
```

PHP allows typed class constant overrides where the child's type is a subtype of the parent's type (covariant). Only widening overrides (e.g., `string` → `?string`) are rejected by PHP at compile time.

`ClassConstantTypesAnalyzer::checkConstantInheritance()` used `isEqualTo()` to compare types, enforcing strict invariance. The check should allow any child type that is a subtype of the parent type.

Replace `isEqualTo()` with `isStrictSubtypeOf()`, which checks that every type in the child's union is a strict subtype of some type in the parent's union — the correct covariance check.

Two alternatives were considered and rejected:
- `canCastToUnionType()`: ANY-ANY overlap check. `int|string` overriding `int` would pass via the shared `int`
- `canStrictCastToUnionType()`: ALL-ANY but uses the cast matrix. `mixed` and `string→callable` would incorrectly pass

`isStrictSubtypeOf()` uses `isSubtypeOfAnyTypeInSet()` (proper subtype semantics), which correctly rejects all widening overrides.