### PR TITLE
Fixes #5531

### DIFF
--- a/src/Phan/Analysis/AssignOperatorAnalysisVisitor.php
+++ b/src/Phan/Analysis/AssignOperatorAnalysisVisitor.php
@@ -475,7 +475,8 @@ class AssignOperatorAnalysisVisitor extends FlagVisitorImplementation
             $this->code_base,
             $this->context,
             $var_node,
-            $new_type
+            $new_type,
+            is_coalesce_assign: true
         ))->__invoke($var_node);
     }
 

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -130,6 +130,11 @@ class AssignmentVisitor extends AnalysisVisitor
      * @param bool $is_conditional_check
      * True if this is being used for conditional type inference (isset/array_key_exists)
      * rather than an actual assignment. Skips read-only property checks.
+     *
+     * @param bool $is_coalesce_assign
+     * True if this assignment comes from a ??= operator. Allows writes to non-nullable
+     * native readonly properties within the declaring class scope, since ??= short-circuits
+     * if the property is already set to a non-null value.
      */
     public function __construct(
         CodeBase $code_base,
@@ -1700,20 +1705,6 @@ class AssignmentVisitor extends AnalysisVisitor
         // Distinguish between native readonly and @phan-read-only
         $is_native_readonly = $property->isReadOnlyReal();
 
-        // For non-nullable native readonly properties, ??= is always safe:
-        // - if uninitialized, PHP treats it as null and assigns once (valid first write)
-        // - if already initialized to a non-null value, ??= short-circuits (no-op, no write attempt)
-        // Nullable readonly properties are excluded: null is a valid initialized state,
-        // so ??= would keep attempting to re-assign after a null initialization.
-        // @phan-read-only (non-native) properties are excluded: not PHP-enforced, Phan should
-        // still warn about writes outside the constructor.
-        if ($this->is_coalesce_assign && $is_native_readonly) {
-            $declared_type = $property->getUnionType();
-            if (!$declared_type->containsNullableOrUndefined()) {
-                return;
-            }
-        }
-
         if ($this->context->isInFunctionLikeScope() && $this->context->isInClassScope()) {
             $method = $this->context->getFunctionLikeInScope($this->code_base);
             $method_class_fqsen = $this->context->getClassFQSEN();
@@ -1734,6 +1725,21 @@ class AssignmentVisitor extends AnalysisVisitor
                     $this->checkMultipleReadOnlyPropertyAssignments($property, $node, $method);
                 }
                 return;
+            }
+
+            // For non-nullable native readonly properties, ??= within the declaring class scope is safe:
+            // - if uninitialized, PHP treats it as null and assigns once (valid first write from same class)
+            // - if already initialized to a non-null value, ??= short-circuits (no-op, no write attempt)
+            // This exemption is scoped to the declaring class: outside the class, PHP would throw
+            // "Cannot initialize readonly property from global scope / outside scope".
+            // Nullable readonly properties are excluded: null is a valid initialized state,
+            // so ??= could keep attempting to re-assign.
+            // @phan-read-only (non-native) properties are excluded: not PHP-enforced.
+            if ($this->is_coalesce_assign && $is_native_readonly && $is_same_or_subclass) {
+                $declared_type = $property->getRealUnionType();
+                if (!$declared_type->containsNullableOrUndefined()) {
+                    return;
+                }
             }
         }
 

--- a/src/Phan/Analysis/AssignmentVisitor.php
+++ b/src/Phan/Analysis/AssignmentVisitor.php
@@ -98,6 +98,13 @@ class AssignmentVisitor extends AnalysisVisitor
     private $is_conditional_check;
 
     /**
+     * @var bool true if this assignment comes from a ??= operator.
+     * For non-nullable readonly properties, ??= is safe: if the property is uninitialized it assigns once,
+     * and if already set (non-null) the coalescing short-circuits and no assignment occurs.
+     */
+    private $is_coalesce_assign;
+
+    /**
      * @param CodeBase $code_base
      * The global code base we're operating within
      *
@@ -132,7 +139,8 @@ class AssignmentVisitor extends AnalysisVisitor
         int $dim_depth = 0,
         ?UnionType $dim_type = null,
         bool $suppress_dim_property_mismatch = false,
-        bool $is_conditional_check = false
+        bool $is_conditional_check = false,
+        bool $is_coalesce_assign = false
     ) {
         parent::__construct($code_base, $context);
 
@@ -142,6 +150,7 @@ class AssignmentVisitor extends AnalysisVisitor
         $this->assignment_node = $assignment_node;
         $this->suppress_dim_property_mismatch = $suppress_dim_property_mismatch;
         $this->is_conditional_check = $is_conditional_check;
+        $this->is_coalesce_assign = $is_coalesce_assign;
     }
 
     /**
@@ -1690,6 +1699,20 @@ class AssignmentVisitor extends AnalysisVisitor
 
         // Distinguish between native readonly and @phan-read-only
         $is_native_readonly = $property->isReadOnlyReal();
+
+        // For non-nullable native readonly properties, ??= is always safe:
+        // - if uninitialized, PHP treats it as null and assigns once (valid first write)
+        // - if already initialized to a non-null value, ??= short-circuits (no-op, no write attempt)
+        // Nullable readonly properties are excluded: null is a valid initialized state,
+        // so ??= would keep attempting to re-assign after a null initialization.
+        // @phan-read-only (non-native) properties are excluded: not PHP-enforced, Phan should
+        // still warn about writes outside the constructor.
+        if ($this->is_coalesce_assign && $is_native_readonly) {
+            $declared_type = $property->getUnionType();
+            if (!$declared_type->containsNullableOrUndefined()) {
+                return;
+            }
+        }
 
         if ($this->context->isInFunctionLikeScope() && $this->context->isInClassScope()) {
             $method = $this->context->getFunctionLikeInScope($this->code_base);

--- a/tests/files/expected/5531_readonly_coalesce_assign.php.expected
+++ b/tests/files/expected/5531_readonly_coalesce_assign.php.expected
@@ -1,2 +1,3 @@
 %s:30 PhanAccessReadOnlyProperty Cannot modify read-only property \NullableReadonly->foo defined at %s:26
 %s:41 PhanAccessReadOnlyProperty Cannot modify read-only property \PhpdocReadonly->foo defined at %s:37
+%s:49 PhanTypeModifyImmutableObjectProperty Saw attempt to modify class \NonNullableReadonly's property $foo declared at %s:7 (immutability of properties is enforced at runtime)

--- a/tests/files/expected/5531_readonly_coalesce_assign.php.expected
+++ b/tests/files/expected/5531_readonly_coalesce_assign.php.expected
@@ -1,0 +1,2 @@
+%s:30 PhanAccessReadOnlyProperty Cannot modify read-only property \NullableReadonly->foo defined at %s:26
+%s:41 PhanAccessReadOnlyProperty Cannot modify read-only property \PhpdocReadonly->foo defined at %s:37

--- a/tests/files/src/5531_readonly_coalesce_assign.php
+++ b/tests/files/src/5531_readonly_coalesce_assign.php
@@ -31,13 +31,21 @@ class NullableReadonly {
     }
 }
 
-// @phan-read-only phpdoc property: treat same as native readonly
+// @phan-read-only phpdoc property: not PHP-enforced, Phan still warns about writes outside __construct
 class PhpdocReadonly {
     /** @phan-read-only */
     public string $foo = 'x';
 
     public function init(): void {
-        // ERROR: @phan-read-only (magic property write is always warned)
+        // ERROR: @phan-read-only properties are excluded from the ??= exemption
         $this->foo ??= 'default';
+    }
+}
+
+// Access from outside the declaring class: ??= still warns (PHP would throw from external scope)
+class ExternalAccessTest {
+    public function test(NonNullableReadonly $obj): void {
+        // ERROR: writing a readonly property from outside its declaring class
+        $obj->foo ??= 'external';
     }
 }

--- a/tests/files/src/5531_readonly_coalesce_assign.php
+++ b/tests/files/src/5531_readonly_coalesce_assign.php
@@ -1,0 +1,43 @@
+<?php
+// @phan-file-suppress PhanUnreferencedClass, PhanUnreferencedPublicClassConstant, PhanPluginNoCommentOnClass, PhanUnreferencedPublicProperty
+
+// Non-nullable readonly property: ??= is always safe.
+// If uninitialized, assigns once. If already set, ??= short-circuits (no-op).
+class NonNullableReadonly {
+    public readonly string $foo;
+    public readonly int $bar;
+
+    public function init(): void {
+        // OK: non-nullable readonly, ??= is a safe lazy initializer
+        $this->foo ??= 'default';
+        $this->bar ??= 42;
+    }
+
+    public function initInLoop(): void {
+        // OK: even in a loop, the second iteration short-circuits because foo is non-null
+        for ($i = 0; $i < 10; $i++) {
+            $this->foo ??= "$i";
+        }
+    }
+}
+
+// Nullable readonly property: ??= could attempt to re-assign after a null initialization
+class NullableReadonly {
+    public readonly ?string $foo;
+
+    public function init(): void {
+        // ERROR: nullable readonly, ??= could attempt to write when foo is already null
+        $this->foo ??= 'default';
+    }
+}
+
+// @phan-read-only phpdoc property: treat same as native readonly
+class PhpdocReadonly {
+    /** @phan-read-only */
+    public string $foo = 'x';
+
+    public function init(): void {
+        // ERROR: @phan-read-only (magic property write is always warned)
+        $this->foo ??= 'default';
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #5531:  `PhanAccessReadOnlyProperty` was a false positive when using `??=` on a non-nullable native `readonly` property.

```php
class Test {
    public readonly string $foo;

    public function init(): void {
        $this->foo ??= 'default'; // was incorrectly flagged
    }

    public function initInLoop(): void {
        // also safe: second+ iterations short-circuit because foo is non-null
        for ($i = 0; $i < 10; $i++) {
            $this->foo ??= "$i";
        }
    }
}
```

## Why ??= is safe for non-nullable readonly properties

For a non-nullable `readonly` property:
- If uninitialized: PHP treats it as null for `??`, so `??=` assigns once — a valid first write
- If already initialized: the value is non-null (type is non-nullable), so `??=` short-circuits and no assignment is attempted

This makes `??=` a safe lazy-initialization pattern for non-nullable readonly properties.

**Nullable readonly properties** are correctly excluded from this fix: `null` is a valid initialized state, so `??=` could keep attempting to re-assign after a null initialization, which would throw a runtime error.

**`@phan-read-only` annotated properties** are also excluded: they are not PHP-enforced, and Phan should still warn about writes outside the constructor.

## Implementation

Added an `$is_coalesce_assign` flag to `AssignmentVisitor`, set to `true` by `AssignOperatorAnalysisVisitor::visitBinaryCoalesce()`. In `analyzeAssignmentToReadOnlyProperty()`, the warning is suppressed when all of the following hold:
1. The assignment is from `??=`
2. The property is a native PHP `readonly` property (`isReadOnlyReal()`)
3. The access is within the declaring class's scope (`$is_same_or_subclass`), outside the class, PHP would throw "Cannot initialize readonly property from external scope"
4. The property's real declared type (`getRealUnionType()`) is non-nullable