### PR TITLE
Use Composer 2.9.8 in a Docker container to fix vulnerabilities of Composer

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -2,8 +2,7 @@ ARG PHP_IMAGE
 ARG PHP_VERSION
 FROM $PHP_IMAGE:$PHP_VERSION
 RUN pecl install ast-1.1.3 && docker-php-ext-enable ast
-# Use Composer 2.8.x for PHP 8.5 compatibility (symfony/process __serialize support)
-RUN curl https://getcomposer.org/download/2.8.3/composer.phar -o /usr/bin/composer.phar && chmod a+x /usr/bin/composer.phar
+RUN curl https://getcomposer.org/download/2.9.8/composer.phar -o /usr/bin/composer.phar && echo "59b2c50e10cafa0d8efc19ede9a326d782f096c674a26baf98cf042ce23de890  /usr/bin/composer.phar" | sha256sum -c && chmod a+x /usr/bin/composer.phar
 WORKDIR /phan
 RUN apt-get update && apt-get install -y unzip parallel colordiff sqlite3 && apt-get clean
 

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -2,7 +2,7 @@ ARG PHP_IMAGE
 ARG PHP_VERSION
 FROM $PHP_IMAGE:$PHP_VERSION
 RUN pecl install ast-1.1.3 && docker-php-ext-enable ast
-RUN curl https://getcomposer.org/download/2.9.8/composer.phar -o /usr/bin/composer.phar && echo "59b2c50e10cafa0d8efc19ede9a326d782f096c674a26baf98cf042ce23de890  /usr/bin/composer.phar" | sha256sum -c && chmod a+x /usr/bin/composer.phar
+RUN curl -fSL https://getcomposer.org/download/2.10.1/composer.phar -o /usr/bin/composer.phar && echo "345b9c6a98da5c30dcbd4b0d99fc8710bf0ae98a3898eea18f7b2ad9dec93f06  /usr/bin/composer.phar" | sha256sum -c && chmod a+x /usr/bin/composer.phar
 WORKDIR /phan
 RUN apt-get update && apt-get install -y unzip parallel colordiff sqlite3 && apt-get clean
 


### PR DESCRIPTION
This PR updates the Composer version used in the Docker test environment from 2.8.3 to 2.9.8.

The update includes:
- Fixes for Composer vulnerabilities addressed in newer releases
- Avoidance of PHP 8.5 deprecation warnings emitted by older Composer versions
- Checksum verification for the installer to improve software supply chain security

Thank you.