### PR TITLE
Fixes #5536

### DIFF
--- a/src/Phan/Analysis/AttributeAnalyzer.php
+++ b/src/Phan/Analysis/AttributeAnalyzer.php
@@ -291,6 +291,10 @@ class AttributeAnalyzer
                 $attribute_node = $attribute->getNode();
 
                 if ($attribute_node) {
+                    $attribute_context = $declaration instanceof Clazz
+                        ? $declaration->getInternalContext()
+                        : $declaration->getContext();
+
                     foreach ($attribute_node->children['args']->children ?? [] as $arg_node) {
                         if (!$arg_node instanceof Node) {
                             continue;
@@ -300,10 +304,10 @@ class AttributeAnalyzer
                         }
 
                         if ($arg_node instanceof Node) {
-                            (new ParseVisitor($code_base, $declaration->getContext()))->checkNodeIsConstExprOrWarn($arg_node, ParseVisitor::CONSTANT_EXPRESSION_IN_ATTRIBUTE);
+                            (new ParseVisitor($code_base, $attribute_context))->checkNodeIsConstExprOrWarn($arg_node, ParseVisitor::CONSTANT_EXPRESSION_IN_ATTRIBUTE);
                         }
                     }
-                    ArgumentType::analyze($constructor, $attribute_node, $declaration->getContext(), $code_base);
+                    ArgumentType::analyze($constructor, $attribute_node, $attribute_context, $code_base);
                 }
             } else {
                 Issue::maybeEmit(

--- a/tests/files/src/5929_self_reference_in_class_attribute.php
+++ b/tests/files/src/5929_self_reference_in_class_attribute.php
@@ -1,0 +1,14 @@
+<?php
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class FoobarAttribute
+{
+    public function __construct(public string $string) {}
+}
+
+#[FoobarAttribute(self::FOOBAR_CLASS_CONST)]
+class FoobarClass
+{
+    public const FOOBAR_CLASS_CONST = 'foobar';
+}
+


### PR DESCRIPTION
Fixes #5536

### Problem
Attributes applied to classes are given the scope of the attribute declaration, not the class scope. PHP however gives attributes applied to classes the class scope. The result of this is that Phan does not allow referencing `self` within the arguments for a class-applied attribute.

### Fix
When attribute declaration is a class, pass the context as `$declaration->getInternalContext()` instead of `$declaration->getContext()`

---

This also adds a new test for this under `tests/files/src/5929_self_reference_in_class_attribute.php`