### PR TITLE
Fixes #5534

### DIFF
--- a/src/Phan/Language/Type/IntersectionType.php
+++ b/src/Phan/Language/Type/IntersectionType.php
@@ -31,6 +31,12 @@ final class IntersectionType extends Type
     /** @var non-empty-list<Type> the parts of the intersection type */
     protected $type_parts;
 
+    /**
+     * @var array<string, IntersectionType> cache of interned intersection types
+     * @phan-suppress PhanReadOnlyPrivateProperty (see https://github.com/phan/phan/issues/5538)
+     */
+    private static $canonical_intersection_map = [];
+
     /** @param non-empty-list<Type> $type_parts */
     private function __construct(array $type_parts)
     {
@@ -49,6 +55,19 @@ final class IntersectionType extends Type
         }
         $this->type_parts = $type_parts;
         parent::__construct('\\', '', [], $is_nullable);
+    }
+
+    /**
+     * Create or retrieve a cached canonicalized IntersectionType instance.
+     * Sorts type parts alphabetically for consistent display, matching UnionType behavior.
+     *
+     * @param non-empty-list<Type> $type_parts
+     */
+    private static function makeCanonicalized(array $type_parts): IntersectionType
+    {
+        \usort($type_parts, static fn(Type $a, Type $b): int => \strcmp((string)$a, (string)$b));
+        $key = \implode(',', \array_map('spl_object_id', $type_parts));
+        return self::$canonical_intersection_map[$key] ??= new self($type_parts);
     }
 
     /**
@@ -72,7 +91,7 @@ final class IntersectionType extends Type
         foreach ($this->type_parts as $type) {
             $new_types[] = $type->withIsNullable($is_nullable);
         }
-        return new self($new_types);
+        return self::makeCanonicalized($new_types);
     }
 
     /**
@@ -114,13 +133,8 @@ final class IntersectionType extends Type
             }
             $new_types = \array_values($new_types);
         }
-        // avoid storing an equivalent copy of an array that may already be referenced elsewhere
-        // to reduce memory usage
-        if ($types !== $new_types) {
-            return new self($new_types);
-        }
-        // @phan-suppress-next-line PhanPartialTypeMismatchArgument
-        return new self($types);
+
+        return self::makeCanonicalized($new_types);
     }
 
     /**
@@ -637,7 +651,7 @@ final class IntersectionType extends Type
         if ($type_parts === $this->type_parts) {
             return $this;
         }
-        return new self($type_parts);
+        return self::makeCanonicalized($type_parts);
     }
 
     /**
@@ -654,7 +668,7 @@ final class IntersectionType extends Type
         if ($type_parts === $this->type_parts) {
             return $this;
         }
-        return new self($type_parts);
+        return self::makeCanonicalized($type_parts);
     }
 
     /**

--- a/tests/Phan/Language/UnionTypeTest.php
+++ b/tests/Phan/Language/UnionTypeTest.php
@@ -894,7 +894,7 @@ final class UnionTypeTest extends TestBase
         $intersection1 = self::makePHPDocUnionType('Countable&ArrayAccess');
         $intersection2 = self::makePHPDocUnionType('\ArrayAccess&\Countable');
         $this->assertSame(1, $intersection1->typeCount());
-        $this->assertSame('(\Countable&\ArrayAccess)|\ArrayAccess|\Countable', $intersection1->asExpandedTypes($code_base)->__toString());
+        $this->assertSame('(\ArrayAccess&\Countable)|\ArrayAccess|\Countable', $intersection1->asExpandedTypes($code_base)->__toString());
 
         $this->assertTrue($intersection1->canCastToUnionType($intersection2, $code_base), 'expected intersection type to cast to itself');
         $this->assertTrue($intersection1->hasSubtypeOf($intersection2, $code_base), 'expect hasSubtypeOf to be true for intersection type');

--- a/tests/files/expected/0578_narrow_types.php.expected
+++ b/tests/files/expected/0578_narrow_types.php.expected
@@ -4,4 +4,4 @@
 %s:28 PhanTypeSuspiciousEcho Suspicious argument $c of type \Subclass578A for an echo/print statement
 %s:31 PhanTypeSuspiciousEcho Suspicious argument $d of type \Subclass578A for an echo/print statement
 %s:34 PhanTypeSuspiciousEcho Suspicious argument $e of type \SubInterface578|\Subclass578A for an echo/print statement
-%s:39 PhanTypeSuspiciousEcho Suspicious argument $f of type (\stdClass&\BaseInterface578)|\SubInterface578|\Subclass578A for an echo/print statement
+%s:39 PhanTypeSuspiciousEcho Suspicious argument $f of type (\BaseInterface578&\stdClass)|\SubInterface578|\Subclass578A for an echo/print statement

--- a/tests/files/expected/0653_instanceof_array_field.php.expected
+++ b/tests/files/expected/0653_instanceof_array_field.php.expected
@@ -1,10 +1,10 @@
 %s:10 PhanUndeclaredMethod Call to undeclared method \ArrayAccess::someMethod
 %s:13 PhanTypeMismatchArgumentInternal Argument 1 ($string) is $array['field'] of type object but \strlen() takes string
 %s:22 PhanNonClassMethodCall Call to method count on non-class type null
-%s:22 PhanTypeInvalidDimOffset Invalid offset "field" of $array of array type array{0:(\stdClass&\Countable)|\Countable}
+%s:22 PhanTypeInvalidDimOffset Invalid offset "field" of $array of array type array{0:(\Countable&\stdClass)|\Countable}
 %s:25 PhanUndeclaredMethod Call to undeclared method \stdClass::count
 %s:36 PhanNonClassMethodCall Call to method count on non-class type null
-%s:36 PhanTypeInvalidDimOffset Invalid offset 4 of $array of array type array{5:(\stdClass&\Countable)|\Countable}
+%s:36 PhanTypeInvalidDimOffset Invalid offset 4 of $array of array type array{5:(\Countable&\stdClass)|\Countable}
 %s:39 PhanUndeclaredMethod Call to undeclared method \stdClass::count
 %s:47 PhanTypeMismatchReturnReal Returning $o of type \stdClass but check_var_negate() is declared to return string
 %s:49 PhanTypeMismatchReturn Returning $o of type int but check_var_negate() is declared to return string

--- a/tests/files/expected/0784_switch_constant.php.expected
+++ b/tests/files/expected/0784_switch_constant.php.expected
@@ -1,6 +1,6 @@
 %s:26 PhanUndeclaredMethod Call to undeclared method \NSConstantSwitch\T1::f2 (Did you mean expr->f1())
 %s:30 PhanUndeclaredMethod Call to undeclared method \NSConstantSwitch\T2::f1 (Did you mean expr->f2())
-%s:34 PhanTypeMismatchArgumentInternal%SReal Argument 1 ($num1) is $arg of type (\NSConstantSwitch\I&\Traversable&\stdClass)|(\NSConstantSwitch\I&\Traversable)|(\NSConstantSwitch\I&\stdClass)|\NSConstantSwitch\I|\Traversable|\stdClass|iterable (real type (\NSConstantSwitch\I&\Traversable&\stdClass)|(\NSConstantSwitch\I&\Traversable)|(\NSConstantSwitch\I&\stdClass)) but \intdiv() takes int
+%s:34 PhanTypeMismatchArgumentInternal%SReal Argument 1 ($num1) is $arg of type (\NSConstantSwitch\I&\Traversable&\stdClass)|(\NSConstantSwitch\I&\Traversable)|(\NSConstantSwitch\I&\stdClass)|\NSConstantSwitch\I|\Traversable|\stdClass|iterable but \intdiv() takes int
 %s:42 PhanImpossibleCondition Impossible attempt to cast [$x] of type array{0:mixed|null} to falsey
 %s:46 PhanTypeMismatchArgumentInternal Argument 1 ($string) is $arg of type true but \strlen() takes string
 %s:48 PhanImpossibleCondition Impossible attempt to cast $arg of type false to truthy

--- a/tests/files/expected/0858_intersection_type_phpdoc_fallback.php.expected
+++ b/tests/files/expected/0858_intersection_type_phpdoc_fallback.php.expected
@@ -1,7 +1,7 @@
-%s:20 PhanUndeclaredMethod Call to undeclared method \MyClass858::missingMethod
-%s:30 PhanTypeMismatchArgument Argument 1 ($param) is $x of type (\MyClass858&\ArrayAccess)|\ArrayAccess|\MyClass858 but \test() takes \MyClass858&\Countable defined at %s:17
-%s:41 PhanUndeclaredMethod Call to undeclared method \MyClass858::otherMissingMethod
-%s:44 PhanTypeMismatchArgument Argument 1 ($param) is new stdClass() of type \stdClass but \test() takes \MyClass858&\Countable defined at %s:17
-%s:45 PhanTypeMismatchArgumentSuperType Argument 1 ($param) is new MyClass858() of type \MyClass858 but \test() takes \MyClass858&\Countable defined at %s:17 (expected type to be the same or a subtype, but saw a supertype instead)
-%s:47 PhanTypeMismatchArgument Argument 1 ($values) is [new stdClass()] of type array{0:\stdClass} but \test_list() takes list<\MyClass858&\Countable> defined at %s:37
-%s:48 PhanTypeMismatchArgument Argument 1 ($values) is [new MyClass858()] of type array{0:\MyClass858} but \test_list() takes list<\MyClass858&\Countable> defined at %s:37
+%s:20 PhanUndeclaredMethod Call to undeclared method \Countable::missingMethod
+%s:30 PhanTypeMismatchArgument Argument 1 ($param) is $x of type (\ArrayAccess&\MyClass858)|\ArrayAccess|\MyClass858 but \test() takes \Countable&\MyClass858 defined at %s:17
+%s:41 PhanUndeclaredMethod Call to undeclared method \Countable::otherMissingMethod
+%s:44 PhanTypeMismatchArgument Argument 1 ($param) is new stdClass() of type \stdClass but \test() takes \Countable&\MyClass858 defined at %s:17
+%s:45 PhanTypeMismatchArgumentSuperType Argument 1 ($param) is new MyClass858() of type \MyClass858 but \test() takes \Countable&\MyClass858 defined at %s:17 (expected type to be the same or a subtype, but saw a supertype instead)
+%s:47 PhanTypeMismatchArgument Argument 1 ($values) is [new stdClass()] of type array{0:\stdClass} but \test_list() takes list<\Countable&\MyClass858> defined at %s:37
+%s:48 PhanTypeMismatchArgument Argument 1 ($values) is [new MyClass858()] of type array{0:\MyClass858} but \test_list() takes list<\Countable&\MyClass858> defined at %s:37

--- a/tests/files/expected/0936_intersection.php.expected
+++ b/tests/files/expected/0936_intersection.php.expected
@@ -2,4 +2,4 @@
 %s:9 PhanUndeclaredMethod Call to undeclared method \ArrayAccess::count
 %s:11 PhanTypeMismatchArgumentInternal Argument 1 ($num1) is $t->returnsString() of type string but \intdiv() takes int
 %s:13 PhanDebugAnnotation @phan-debug-var requested for variable $t - it has union type (\ArrayAccess&\I936)|\ArrayAccess(real=(\ArrayAccess&\I936)|\ArrayAccess)
-%s:19 PhanDebugAnnotation @phan-debug-var requested for variable $this - it has union type static&\C936(real=static&\C936)
+%s:19 PhanDebugAnnotation @phan-debug-var requested for variable $this - it has union type \C936&static(real=\C936&static)

--- a/tests/files/expected/0937_intersection_redundant.php.expected
+++ b/tests/files/expected/0937_intersection_redundant.php.expected
@@ -1,2 +1,2 @@
-%s:11 PhanRedundantCondition Redundant attempt to cast $value of type \NS937\I3&\NS937\I2 to \NS937\I2
-%s:17 PhanRedundantCondition Redundant attempt to cast $value of type \NS937\I3&\NS937\I2 to \NS937\I1
+%s:11 PhanRedundantCondition Redundant attempt to cast $value of type \NS937\I2&\NS937\I3 to \NS937\I2
+%s:17 PhanRedundantCondition Redundant attempt to cast $value of type \NS937\I2&\NS937\I3 to \NS937\I1

--- a/tests/files/expected/0938_intersection_property.php.expected
+++ b/tests/files/expected/0938_intersection_property.php.expected
@@ -2,6 +2,6 @@
 %s:18 PhanTypeMismatchArgumentInternal Argument 1 ($string) is $x->xProp of type \stdClass but \strlen() takes string
 %s:19 PhanTypeMismatchArgumentInternal Argument 1 ($string) is $x->iProp of type int but \strlen() takes string
 %s:28 PhanSyntaxReturnExpectedValue Syntax error: Function test_exclude() with return type \NS938\X must return a value (did you mean "return null" instead of "return"?)
-%s:30 PhanDebugAnnotation @phan-debug-var requested for variable $z - it has union type (\NS938\X&\NS938\I)|\stdClass(real=(\NS938\X&\NS938\I)|\stdClass)
-%s:32 PhanDebugAnnotation @phan-debug-var requested for variable $z - it has union type (\NS938\X&\NS938\I)|(\stdClass&\NS938\I)(real=(\NS938\X&\NS938\I)|(\stdClass&\NS938\I))
+%s:30 PhanDebugAnnotation @phan-debug-var requested for variable $z - it has union type (\NS938\I&\NS938\X)|\stdClass(real=(\NS938\I&\NS938\X)|\stdClass)
+%s:32 PhanDebugAnnotation @phan-debug-var requested for variable $z - it has union type (\NS938\I&\NS938\X)|(\NS938\I&\stdClass)(real=(\NS938\I&\NS938\X)|(\NS938\I&\stdClass))
 %s:36 PhanTypeMismatchReturnReal Returning $z of type \stdClass but test_exclude() is declared to return \NS938\X

--- a/tests/files/expected/0939_intersection_phpdoc.php.expected
+++ b/tests/files/expected/0939_intersection_phpdoc.php.expected
@@ -1,7 +1,7 @@
-%s:10 PhanImpossibleIntersectionType Intersection type \SplObjectStorage&\Error contains part \SplObjectStorage which cannot cast to the declared type \Error
-%s:10 PhanImpossibleIntersectionType Intersection type \stdClass&\ArrayObject contains part \stdClass which cannot cast to the declared type \ArrayObject
-%s:10 PhanImpossibleIntersectionType Intersection type int&bool contains part int which cannot cast to the declared type bool
-%s:11 PhanTypeMismatchReturn Returning $value of type int&bool but test939() is declared to return \SplObjectStorage&\Error
-%s:13 PhanTypeMismatchArgumentProbablyReal Argument 1 ($value) is 123 of type int (value: 123) but \test939() takes int&bool (no real type) defined at %s:10 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
-%s:13 PhanTypeMismatchArgumentSuperType Argument 2 ($object) is new stdClass() of type \stdClass but \test939() takes \stdClass&\ArrayObject defined at %s:10 (expected type to be the same or a subtype, but saw a supertype instead)
+%s:10 PhanImpossibleIntersectionType Intersection type \ArrayObject&\stdClass contains part \ArrayObject which cannot cast to the declared type \stdClass
+%s:10 PhanImpossibleIntersectionType Intersection type \Error&\SplObjectStorage contains part \Error which cannot cast to the declared type \SplObjectStorage
+%s:10 PhanImpossibleIntersectionType Intersection type bool&int contains part bool which cannot cast to the declared type int
+%s:11 PhanTypeMismatchReturn Returning $value of type bool&int but test939() is declared to return \Error&\SplObjectStorage
+%s:13 PhanTypeMismatchArgumentProbablyReal Argument 1 ($value) is 123 of type int (value: 123) but \test939() takes bool&int (no real type) defined at %s:10 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
+%s:13 PhanTypeMismatchArgumentSuperType Argument 2 ($object) is new stdClass() of type \stdClass but \test939() takes \ArrayObject&\stdClass defined at %s:10 (expected type to be the same or a subtype, but saw a supertype instead)
 %s:17 PhanImpossibleIntersectionType Intersection type \stdClass&false contains part \stdClass which cannot cast to the declared type false

--- a/tests/files/expected/0945_callable_object_intersection.php.expected
+++ b/tests/files/expected/0945_callable_object_intersection.php.expected
@@ -1,4 +1,4 @@
-%s:14 PhanDebugAnnotation @phan-debug-var requested for variable $a - it has union type callable-object&\Countable
+%s:14 PhanDebugAnnotation @phan-debug-var requested for variable $a - it has union type \Countable&callable-object
 %s:14 PhanDebugAnnotation @phan-debug-var requested for variable $b - it has union type \Closure
 %s:14 PhanDebugAnnotation @phan-debug-var requested for variable $c - it has union type \A945
-%s:14 PhanDebugAnnotation @phan-debug-var requested for variable $d - it has union type callable-object&\stdClass
+%s:14 PhanDebugAnnotation @phan-debug-var requested for variable $d - it has union type \stdClass&callable-object

--- a/tests/files/expected/0996_generic_type_leak.php.expected
+++ b/tests/files/expected/0996_generic_type_leak.php.expected
@@ -6,8 +6,8 @@
 %s:28 PhanTemplateTypeNotDeclaredInFunctionParams Template type U not declared in parameters of function/method getX2() (or Phan can't extract template types for this use case)
 %s:32 PhanDebugAnnotation @phan-debug-var requested for variable $x2 - it has union type \X<mixed>(real=\X)
 %s:32 PhanDebugAnnotation @phan-debug-var requested for variable $y2 - it has union type mixed
-%s:41 PhanTypeMismatchReturn Returning new X() of type \X<mixed> but getX3() is declared to return \X&\I
-%s:44 PhanDebugAnnotation @phan-debug-var requested for variable $x3 - it has union type \X&\I
+%s:41 PhanTypeMismatchReturn Returning new X() of type \X<mixed> but getX3() is declared to return \I&\X
+%s:44 PhanDebugAnnotation @phan-debug-var requested for variable $x3 - it has union type \I&\X
 %s:44 PhanDebugAnnotation @phan-debug-var requested for variable $y3 - it has union type mixed
 %s:51 PhanCommentParamOnEmptyParamList Saw an @param annotation for $x, but the param list of function getX4() : \X|\X<U>; is empty
 %s:54 PhanTemplateTypeNotDeclaredInFunctionParams Template type U not declared in parameters of function/method getX4() (or Phan can't extract template types for this use case)

--- a/tests/files/expected/1036_intersection_countable.php.expected
+++ b/tests/files/expected/1036_intersection_countable.php.expected
@@ -1,10 +1,10 @@
-%s:5 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type (\Traversable&\Countable)|array(real=(\Traversable&\Countable)|array)
-%s:7 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type \Traversable&\Countable(real=\Traversable&\Countable)
-%s:9 PhanRedundantCondition Redundant attempt to cast $x of type \Traversable&\Countable to \Traversable
+%s:5 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type (\Countable&\Traversable)|array(real=(\Countable&\Traversable)|array)
+%s:7 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type \Countable&\Traversable(real=\Countable&\Traversable)
+%s:9 PhanRedundantCondition Redundant attempt to cast $x of type \Countable&\Traversable to \Traversable
 %s:12 PhanTypeMismatchReturnReal Returning $x of type array but test_iterable941() is declared to return object
 %s:14 PhanTypeMismatchReturn Returning $x of type iterable but test_iterable941() is declared to return object
-%s:18 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type (\Traversable<string,\stdClass>&\Countable)|array<string,\stdClass>(real=(\Traversable&\Countable)|array)
-%s:20 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type \Traversable<string,\stdClass>&\Countable(real=\Traversable&\Countable)
+%s:18 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type (\Countable&\Traversable<string,\stdClass>)|array<string,\stdClass>(real=(\Countable&\Traversable)|array)
+%s:20 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type \Countable&\Traversable<string,\stdClass>(real=\Countable&\Traversable)
 %s:22 PhanDebugAnnotation @phan-debug-var requested for variable $key - it has union type string(real=string)
 %s:22 PhanDebugAnnotation @phan-debug-var requested for variable $value - it has union type \stdClass
 %s:24 PhanTypeMismatchArgumentInternal Argument 1 ($num1) is $key of type string but \intdiv() takes int

--- a/tests/files/expected/1113_intersection_type_phpdoc.php.expected
+++ b/tests/files/expected/1113_intersection_type_phpdoc.php.expected
@@ -5,7 +5,7 @@
 %s:10 PhanDebugAnnotation @phan-debug-var requested for variable $c - it has union type callable-string
 %s:22 PhanDebugAnnotation @phan-debug-var requested for variable $a - it has union type callable-object
 %s:22 PhanDebugAnnotation @phan-debug-var requested for variable $ba - it has union type callable-array
-%s:22 PhanDebugAnnotation @phan-debug-var requested for variable $bb - it has union type non-empty-array<mixed,string>&callable-array
+%s:22 PhanDebugAnnotation @phan-debug-var requested for variable $bb - it has union type callable-array&non-empty-array<mixed,string>
 %s:22 PhanDebugAnnotation @phan-debug-var requested for variable $bc - it has union type callable-array
 %s:22 PhanDebugAnnotation @phan-debug-var requested for variable $c - it has union type callable-string
 %s:35 PhanTypeMismatchArgumentProbablyReal Argument 1 ($a) is [A41::class,'method'] of type array{0:'A41',1:'method'} but \test41a() takes callable-object (no real type) defined at %s:10 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
@@ -15,6 +15,6 @@
 %s:35 PhanTypeMismatchArgumentProbablyReal Argument 5 ($c) is (function) of type Closure():void but \test41a() takes callable-string (no real type) defined at %s:10 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
 %s:36 PhanTypeMismatchArgumentProbablyReal Argument 1 ($a) is [A41::class,'method'] of type array{0:'A41',1:'method'} but \test41b() takes callable-object (no real type) defined at %s:22 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
 %s:36 PhanTypeMismatchArgumentProbablyReal Argument 2 ($ba) is 'A41::method' of type string but \test41b() takes callable-array (no real type) defined at %s:22 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
-%s:36 PhanTypeMismatchArgumentProbablyReal Argument 3 ($bb) is [new A41(),'method'] of type array{0:\A41,1:'method'} but \test41b() takes non-empty-array<mixed,string>&callable-array (no real type) defined at %s:22 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
+%s:36 PhanTypeMismatchArgumentProbablyReal Argument 3 ($bb) is [new A41(),'method'] of type array{0:\A41,1:'method'} but \test41b() takes callable-array&non-empty-array<mixed,string> (no real type) defined at %s:22 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
 %s:36 PhanTypeMismatchArgumentProbablyReal Argument 4 ($bc) is 'A41::method' of type string but \test41b() takes callable-array (no real type) defined at %s:22 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
 %s:36 PhanTypeMismatchArgumentProbablyReal Argument 5 ($c) is (function) of type Closure():void but \test41b() takes callable-string (no real type) defined at %s:22 (the inferred real argument type has nothing in common with the parameter's phpdoc type)

--- a/tests/files/expected/1114_intersection_type_phpdoc_invalid.php.expected
+++ b/tests/files/expected/1114_intersection_type_phpdoc_invalid.php.expected
@@ -1,9 +1,9 @@
-%s:9 PhanImpossibleIntersectionType Intersection type \stdClass&\ArrayObject contains part \stdClass which cannot cast to the declared type \ArrayObject
+%s:9 PhanImpossibleIntersectionType Intersection type \ArrayObject&\stdClass contains part \ArrayObject which cannot cast to the declared type \stdClass
 %s:9 PhanImpossibleIntersectionType Intersection type int&null contains part int which cannot cast to the declared type null
 %s:9 PhanImpossibleIntersectionType Intersection type int&string contains part int which cannot cast to the declared type string
-%s:11 PhanTypeMismatchArgumentProbablyReal Argument 1 ($p0) is 1 of type int (value: 1) but Closure(int&string):\stdClass&\ArrayObject takes int&string (no real type) defined at %s:9 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
-%s:12 PhanTypeMismatchArgumentProbablyReal Argument 1 ($p0) is new stdClass() of type \stdClass but Closure(int&string):\stdClass&\ArrayObject takes int&string (no real type) defined at %s:9 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
+%s:11 PhanTypeMismatchArgumentProbablyReal Argument 1 ($p0) is 1 of type int (value: 1) but Closure(int&string):\ArrayObject&\stdClass takes int&string (no real type) defined at %s:9 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
+%s:12 PhanTypeMismatchArgumentProbablyReal Argument 1 ($p0) is new stdClass() of type \stdClass but Closure(int&string):\ArrayObject&\stdClass takes int&string (no real type) defined at %s:9 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
 %s:13 PhanDebugAnnotation @phan-debug-var requested for variable $other - it has union type int&null
-%s:13 PhanTypeMismatchArgument Argument 1 ($p0) is $other of type (int&null)|int|null but Closure(int&string):\stdClass&\ArrayObject takes int&string defined at %s:9
-%s:17 PhanTypeMismatchArgumentSuperType Argument 1 ($value) is (function) of type Closure(int):\stdClass but \test42() takes Closure(int&string):\stdClass&\ArrayObject defined at %s:9 (expected type to be the same or a subtype, but saw a supertype instead)
+%s:13 PhanTypeMismatchArgument Argument 1 ($p0) is $other of type (int&null)|int|null but Closure(int&string):\ArrayObject&\stdClass takes int&string defined at %s:9
+%s:17 PhanTypeMismatchArgumentSuperType Argument 1 ($value) is (function) of type Closure(int):\stdClass but \test42() takes Closure(int&string):\ArrayObject&\stdClass defined at %s:9 (expected type to be the same or a subtype, but saw a supertype instead)
 %s:20 PhanTypeMismatchArgumentProbablyReal Argument 2 ($other) is null of type null but \test42() takes int&null (no real type) defined at %s:9 (the inferred real argument type has nothing in common with the parameter's phpdoc type)

--- a/tests/files/src/5930_intersection_types_for_class_property.php
+++ b/tests/files/src/5930_intersection_types_for_class_property.php
@@ -1,0 +1,12 @@
+<?php
+
+interface A {}
+interface B {}
+
+class ParentIntersectionClass {
+    public A&B $parentVar;
+}
+
+class ChildIntersectionClass extends ParentIntersectionClass {
+    public A&B $parentVar;
+}

--- a/tests/php82_files/expected/005_dnf_type_property.php.expected
+++ b/tests/php82_files/expected/005_dnf_type_property.php.expected
@@ -1,3 +1,3 @@
-%s:12 PhanTypeMismatchPropertyReal Assigning new C5() of type \C5 to property but \X5->value is (\Countable&\ArrayAccess)|\stdClass
-%s:14 PhanTypeMismatchPropertyReal Assigning null of type null to property but \X5->value is (\Countable&\ArrayAccess)|\stdClass
-%s:16 PhanTypeMismatchPropertyReal Assigning $v2 of type \X5 to property but \X5->value is (\Countable&\ArrayAccess)|\stdClass
+%s:12 PhanTypeMismatchPropertyReal Assigning new C5() of type \C5 to property but \X5->value is (\ArrayAccess&\Countable)|\stdClass
+%s:14 PhanTypeMismatchPropertyReal Assigning null of type null to property but \X5->value is (\ArrayAccess&\Countable)|\stdClass
+%s:16 PhanTypeMismatchPropertyReal Assigning $v2 of type \X5 to property but \X5->value is (\ArrayAccess&\Countable)|\stdClass


### PR DESCRIPTION
Fixes #5534

### Problem

Phan incorrectly reported `PhanIncompatibleRealPropertyType` when a child class redeclared a property with the same intersection type as the parent. This happened because intersection types were not interned/cached like regular types, so `isEqualTo()` comparisons using `spl_object_id()` failed even for semantically identical types.

### Fix

Added interning for `IntersectionType` via a new `makeCanonicalized()`` factory method. Identical intersection types now share the same object instance, allowing object identity comparisons to work correctly.

### Side effects

This MR normalizes intersection type ordering to be alphabetically ordered. This matches UnionType behavior. However, this has some impact on existing test expectations, as the issues have now changed the order. Here is a description of the expectation files changed:

Expectations remain the same aside from intersection type order differences:

- `005_dnf_type_property.php.expected`
- `0578_narrow_types.php.expected`
- `0653_instanceof_array_field.php.expected`
- `0936_intersection.php.expected`
- `0937_intersection_redundant.php.expected`
- `0938_intersection_property.php.expected`
- `0939_intersection_phpdoc.php.expected`
- `0945_callable_object_intersection.php.expected`
- `0996_generic_type_leak.php.expected`
- `1036_intersection_countable.php.expected`
- `1113_intersection_type_phpdoc.php.expected`
- `1114_intersection_type_phpdoc_invalid.php.expected`
- `tests/Phan/Language/UnionTypeTest.php#testIntersectionTypeCasting`

Real type no longer reported, types were semantically equal and are now the same canonical object:

- `0784_switch_constant.php.expected`

Undeclared method error displays different class of intersection type. Phan reports the first type in the intersection
for undeclared method errors, so order normalization changes behavior here. Perhaps the issue emitted should be more descriptive for intersection types, but that is outside of this scope.

- `0858_intersection_type_phpdoc_fallback.php.expected`

---
This also adds a new test for this under tests/files/src/5930_intersection_types_for_class_property.php
