### PR TITLE
Fixes #5535

### DIFF
--- a/src/Phan/Analysis/BlockExitStatusChecker.php
+++ b/src/Phan/Analysis/BlockExitStatusChecker.php
@@ -81,15 +81,6 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
         self::STATUS_PROCEED |
         self::STATUS_GOTO;
 
-    // A metadata bit stored alongside the cached status in Node::$flags (it is
-    // not itself an exit status). It records that the cached status was computed
-    // with a CodeBase available, so the userland never-return check in
-    // computeStatusOfCall() was able to run. A status cached by a context-less
-    // checker lacks this bit and must be recomputed once a CodeBase is available,
-    // otherwise a stale STATUS_PROCEED would hide a nested call to a
-    // never-returning function. See https://github.com/phan/phan/issues/5535
-    public const STATUS_COMPUTED_WITH_CODE_BASE = (1 << 27);
-
     /** @var ?CodeBase */
     private $code_base;
 
@@ -128,39 +119,6 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
     public function visit(Node $node): int
     {
         return self::STATUS_PROCEED;
-    }
-
-    /**
-     * Reads the status previously cached on $node->flags, if any.
-     *
-     * Returns 0 (forcing a recompute) when this checker has a CodeBase but the
-     * cached value was computed without one, since that value may be a stale
-     * STATUS_PROCEED that misses a call to a never-returning function.
-     */
-    private function getCachedStatus(Node $node): int
-    {
-        $status = $node->flags & self::STATUS_BITMASK;
-        if (!$status) {
-            return 0;
-        }
-        if ($this->code_base !== null && !($node->flags & self::STATUS_COMPUTED_WITH_CODE_BASE)) {
-            return 0;
-        }
-        return $status;
-    }
-
-    /**
-     * Caches the computed $status on $node->flags, preserving any real AST flags,
-     * and records whether a CodeBase was available when it was computed.
-     *
-     * @return int the status that was passed in (for convenient chaining)
-     */
-    private function setCachedStatus(Node $node, int $status): int
-    {
-        $node->flags = ($node->flags & ~(self::STATUS_BITMASK | self::STATUS_COMPUTED_WITH_CODE_BASE))
-            | $status
-            | ($this->code_base !== null ? self::STATUS_COMPUTED_WITH_CODE_BASE : 0);
-        return $status;
     }
 
     private static function isTruthyLiteral(Node|float|int|string $cond): bool
@@ -210,12 +168,12 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
      */
     public function visitTry(Node $node): int
     {
-        $status = $this->getCachedStatus($node);
+        $status = $node->flags & self::STATUS_BITMASK;
         if ($status) {
             return $status;
         }
         $status = $this->computeStatusOfTry($node);
-        $this->setCachedStatus($node, $status);
+        $node->flags = $status;
         return $status;
     }
 
@@ -255,12 +213,12 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
      */
     public function visitCatchList(Node $node): int
     {
-        $status = $this->getCachedStatus($node);
+        $status = $node->flags & self::STATUS_BITMASK;
         if ($status) {
             return $status;
         }
         $status = $this->computeStatusOfCatchList($node);
-        $this->setCachedStatus($node, $status);
+        $node->flags = $status;
         return $status;
     }
 
@@ -319,12 +277,12 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
      */
     public function visitSwitchList(Node $node): int
     {
-        $status = $this->getCachedStatus($node);
+        $status = $node->flags & self::STATUS_BITMASK;
         if ($status) {
             return $status;
         }
         $status = $this->computeStatusOfSwitchList($node);
-        $this->setCachedStatus($node, $status);
+        $node->flags = $status;
         return $status;
     }
 
@@ -361,12 +319,12 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
      */
     private function getStatusOfSwitchCase(Node $case_node, int $index, array $siblings): int
     {
-        $status = $this->getCachedStatus($case_node);
+        $status = $case_node->flags & self::STATUS_BITMASK;
         if ($status) {
             return $status;
         }
         $status = $this->computeStatusOfSwitchCase($case_node, $index, $siblings);
-        $this->setCachedStatus($case_node, $status);
+        $case_node->flags = $status;
         return $status;
     }
 
@@ -398,7 +356,7 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
      */
     public function visitMatch(Node $node): int
     {
-        $status = $this->getCachedStatus($node);
+        $status = $node->flags & self::STATUS_BITMASK;
         if ($status) {
             return $status;
         }
@@ -414,12 +372,12 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
      */
     public function visitMatchArmList(Node $node): int
     {
-        $status = $this->getCachedStatus($node);
+        $status = $node->flags & self::STATUS_BITMASK;
         if ($status) {
             return $status;
         }
         $status = $this->computeStatusOfMatchArmList($node);
-        $this->setCachedStatus($node, $status);
+        $node->flags = $status;
         return $status;
     }
 
@@ -428,12 +386,12 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
      */
     public function visitMatchArm(Node $node): int
     {
-        $status = $this->getCachedStatus($node);
+        $status = $node->flags & self::STATUS_BITMASK;
         if ($status) {
             return $status;
         }
         $status = $this->computeMatchArmStatus($node);
-        $this->setCachedStatus($node, $status);
+        $node->flags |= $status;
         return $status;
     }
 
@@ -592,12 +550,12 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
      */
     public function visitCall(Node $node): int
     {
-        $status = $this->getCachedStatus($node);
+        $status = $node->flags & self::STATUS_BITMASK;
         if ($status) {
             return $status;
         }
         $status = $this->computeStatusOfCall($node);
-        $this->setCachedStatus($node, $status);
+        $node->flags = $status;
         return $status;
     }
 
@@ -608,12 +566,12 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
      */
     public function visitStaticCall(Node $node): int
     {
-        $status = $this->getCachedStatus($node);
+        $status = $node->flags & self::STATUS_BITMASK;
         if ($status) {
             return $status;
         }
         $status = $this->computeStatusOfStaticCall($node);
-        $this->setCachedStatus($node, $status);
+        $node->flags = $status;
         return $status;
     }
 
@@ -626,12 +584,12 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
      */
     public function visitMethodCall(Node $node): int
     {
-        $status = $this->getCachedStatus($node);
+        $status = $node->flags & self::STATUS_BITMASK;
         if ($status) {
             return $status;
         }
         $status = $this->computeStatusOfMethodCall($node);
-        $this->setCachedStatus($node, $status);
+        $node->flags = $status;
         return $status;
     }
 
@@ -911,12 +869,12 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
      */
     public function visitStmtList(Node $node): int
     {
-        $status = $this->getCachedStatus($node);
+        $status = $node->flags & self::STATUS_BITMASK;
         if ($status) {
             return $status;
         }
         $status = $this->computeStatusOfBlock($node->children);
-        $this->setCachedStatus($node, $status);
+        $node->flags = $status;
         return $status;
     }
 
@@ -927,12 +885,12 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
      */
     public function visitExprList(Node $node): int
     {
-        $status = $this->getCachedStatus($node);
+        $status = $node->flags & self::STATUS_BITMASK;
         if ($status) {
             return $status;
         }
         $status = $this->computeStatusOfBlock($node->children);
-        $this->setCachedStatus($node, $status);
+        $node->flags = $status;
         return $status;
     }
 
@@ -943,12 +901,12 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
      */
     public function visitIf(Node $node): int
     {
-        $status = $this->getCachedStatus($node);
+        $status = $node->flags & self::STATUS_BITMASK;
         if ($status) {
             return $status;
         }
         $status = $this->computeStatusOfIf($node);
-        $this->setCachedStatus($node, $status);
+        $node->flags = $status;
         return $status;
     }
 
@@ -1009,13 +967,13 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
      */
     public function visitIfElem(Node $node): int
     {
-        $status = $this->getCachedStatus($node);
+        $status = $node->flags & self::STATUS_BITMASK;
         if ($status) {
             return $status;
         }
         // @phan-suppress-next-line PhanTypeMismatchArgumentNullable this is never null
         $status = $this->visitStmtList($node->children['stmts']);
-        $this->setCachedStatus($node, $status);
+        $node->flags = $status;
         return $status;
     }
 

--- a/src/Phan/Analysis/BlockExitStatusChecker.php
+++ b/src/Phan/Analysis/BlockExitStatusChecker.php
@@ -81,6 +81,15 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
         self::STATUS_PROCEED |
         self::STATUS_GOTO;
 
+    // A metadata bit stored alongside the cached status in Node::$flags (it is
+    // not itself an exit status). It records that the cached status was computed
+    // with a CodeBase available, so the userland never-return check in
+    // computeStatusOfCall() was able to run. A status cached by a context-less
+    // checker lacks this bit and must be recomputed once a CodeBase is available,
+    // otherwise a stale STATUS_PROCEED would hide a nested call to a
+    // never-returning function. See https://github.com/phan/phan/issues/5535
+    public const STATUS_COMPUTED_WITH_CODE_BASE = (1 << 27);
+
     /** @var ?CodeBase */
     private $code_base;
 
@@ -119,6 +128,39 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
     public function visit(Node $node): int
     {
         return self::STATUS_PROCEED;
+    }
+
+    /**
+     * Reads the status previously cached on $node->flags, if any.
+     *
+     * Returns 0 (forcing a recompute) when this checker has a CodeBase but the
+     * cached value was computed without one, since that value may be a stale
+     * STATUS_PROCEED that misses a call to a never-returning function.
+     */
+    private function getCachedStatus(Node $node): int
+    {
+        $status = $node->flags & self::STATUS_BITMASK;
+        if (!$status) {
+            return 0;
+        }
+        if ($this->code_base !== null && !($node->flags & self::STATUS_COMPUTED_WITH_CODE_BASE)) {
+            return 0;
+        }
+        return $status;
+    }
+
+    /**
+     * Caches the computed $status on $node->flags, preserving any real AST flags,
+     * and records whether a CodeBase was available when it was computed.
+     *
+     * @return int the status that was passed in (for convenient chaining)
+     */
+    private function setCachedStatus(Node $node, int $status): int
+    {
+        $node->flags = ($node->flags & ~(self::STATUS_BITMASK | self::STATUS_COMPUTED_WITH_CODE_BASE))
+            | $status
+            | ($this->code_base !== null ? self::STATUS_COMPUTED_WITH_CODE_BASE : 0);
+        return $status;
     }
 
     private static function isTruthyLiteral(Node|float|int|string $cond): bool
@@ -168,12 +210,12 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
      */
     public function visitTry(Node $node): int
     {
-        $status = $node->flags & self::STATUS_BITMASK;
+        $status = $this->getCachedStatus($node);
         if ($status) {
             return $status;
         }
         $status = $this->computeStatusOfTry($node);
-        $node->flags = $status;
+        $this->setCachedStatus($node, $status);
         return $status;
     }
 
@@ -213,12 +255,12 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
      */
     public function visitCatchList(Node $node): int
     {
-        $status = $node->flags & self::STATUS_BITMASK;
+        $status = $this->getCachedStatus($node);
         if ($status) {
             return $status;
         }
         $status = $this->computeStatusOfCatchList($node);
-        $node->flags = $status;
+        $this->setCachedStatus($node, $status);
         return $status;
     }
 
@@ -277,12 +319,12 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
      */
     public function visitSwitchList(Node $node): int
     {
-        $status = $node->flags & self::STATUS_BITMASK;
+        $status = $this->getCachedStatus($node);
         if ($status) {
             return $status;
         }
         $status = $this->computeStatusOfSwitchList($node);
-        $node->flags = $status;
+        $this->setCachedStatus($node, $status);
         return $status;
     }
 
@@ -319,12 +361,12 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
      */
     private function getStatusOfSwitchCase(Node $case_node, int $index, array $siblings): int
     {
-        $status = $case_node->flags & self::STATUS_BITMASK;
+        $status = $this->getCachedStatus($case_node);
         if ($status) {
             return $status;
         }
         $status = $this->computeStatusOfSwitchCase($case_node, $index, $siblings);
-        $case_node->flags = $status;
+        $this->setCachedStatus($case_node, $status);
         return $status;
     }
 
@@ -356,7 +398,7 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
      */
     public function visitMatch(Node $node): int
     {
-        $status = $node->flags & self::STATUS_BITMASK;
+        $status = $this->getCachedStatus($node);
         if ($status) {
             return $status;
         }
@@ -372,12 +414,12 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
      */
     public function visitMatchArmList(Node $node): int
     {
-        $status = $node->flags & self::STATUS_BITMASK;
+        $status = $this->getCachedStatus($node);
         if ($status) {
             return $status;
         }
         $status = $this->computeStatusOfMatchArmList($node);
-        $node->flags = $status;
+        $this->setCachedStatus($node, $status);
         return $status;
     }
 
@@ -386,12 +428,12 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
      */
     public function visitMatchArm(Node $node): int
     {
-        $status = $node->flags & self::STATUS_BITMASK;
+        $status = $this->getCachedStatus($node);
         if ($status) {
             return $status;
         }
         $status = $this->computeMatchArmStatus($node);
-        $node->flags |= $status;
+        $this->setCachedStatus($node, $status);
         return $status;
     }
 
@@ -550,12 +592,12 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
      */
     public function visitCall(Node $node): int
     {
-        $status = $node->flags & self::STATUS_BITMASK;
+        $status = $this->getCachedStatus($node);
         if ($status) {
             return $status;
         }
         $status = $this->computeStatusOfCall($node);
-        $node->flags = $status;
+        $this->setCachedStatus($node, $status);
         return $status;
     }
 
@@ -566,12 +608,12 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
      */
     public function visitStaticCall(Node $node): int
     {
-        $status = $node->flags & self::STATUS_BITMASK;
+        $status = $this->getCachedStatus($node);
         if ($status) {
             return $status;
         }
         $status = $this->computeStatusOfStaticCall($node);
-        $node->flags = $status;
+        $this->setCachedStatus($node, $status);
         return $status;
     }
 
@@ -584,12 +626,12 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
      */
     public function visitMethodCall(Node $node): int
     {
-        $status = $node->flags & self::STATUS_BITMASK;
+        $status = $this->getCachedStatus($node);
         if ($status) {
             return $status;
         }
         $status = $this->computeStatusOfMethodCall($node);
-        $node->flags = $status;
+        $this->setCachedStatus($node, $status);
         return $status;
     }
 
@@ -869,12 +911,12 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
      */
     public function visitStmtList(Node $node): int
     {
-        $status = $node->flags & self::STATUS_BITMASK;
+        $status = $this->getCachedStatus($node);
         if ($status) {
             return $status;
         }
         $status = $this->computeStatusOfBlock($node->children);
-        $node->flags = $status;
+        $this->setCachedStatus($node, $status);
         return $status;
     }
 
@@ -885,12 +927,12 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
      */
     public function visitExprList(Node $node): int
     {
-        $status = $node->flags & self::STATUS_BITMASK;
+        $status = $this->getCachedStatus($node);
         if ($status) {
             return $status;
         }
         $status = $this->computeStatusOfBlock($node->children);
-        $node->flags = $status;
+        $this->setCachedStatus($node, $status);
         return $status;
     }
 
@@ -901,12 +943,12 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
      */
     public function visitIf(Node $node): int
     {
-        $status = $node->flags & self::STATUS_BITMASK;
+        $status = $this->getCachedStatus($node);
         if ($status) {
             return $status;
         }
         $status = $this->computeStatusOfIf($node);
-        $node->flags = $status;
+        $this->setCachedStatus($node, $status);
         return $status;
     }
 
@@ -967,13 +1009,13 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
      */
     public function visitIfElem(Node $node): int
     {
-        $status = $node->flags & self::STATUS_BITMASK;
+        $status = $this->getCachedStatus($node);
         if ($status) {
             return $status;
         }
         // @phan-suppress-next-line PhanTypeMismatchArgumentNullable this is never null
         $status = $this->visitStmtList($node->children['stmts']);
-        $node->flags = $status;
+        $this->setCachedStatus($node, $status);
         return $status;
     }
 

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -5509,11 +5509,12 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
 
     /**
      * @param Node $node
-     * A decl to check to see if its only effect
-     * is the throw an exception
+     * A decl to check to see whether it can never return normally
      *
      * @return bool
-     * True when the decl can only throw an exception or return or exit()
+     * True when no path through the decl returns normally - i.e. every path
+     * throws an exception, exits (exit()/die()), or loops forever.
+     * A path that reaches a `return` (or falls off the end) makes this false.
      */
     private function declNeverReturns(Node $node): bool
     {

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -1668,7 +1668,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
 
         if (!$return_type->isEmpty()
             && !$func->hasReturn()
-            && !self::declNeverReturns($node)
+            && !$this->declNeverReturns($node)
             && !$return_type->isNull()
             && !$return_type->isNeverType()
         ) {
@@ -3398,7 +3398,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
             && !$has_interface_class
             && !$return_type->isEmpty()
             && !$method->hasReturn()
-            && !self::declNeverReturns($node)
+            && !$this->declNeverReturns($node)
             && !$return_type->hasType(VoidType::instance(false))
             && !$return_type->hasType(NullType::instance(false))
             && !$return_type->hasType(NeverType::instance(false))
@@ -3461,7 +3461,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
 
         if (!$return_type->isEmpty()
             && !$function->hasReturn()
-            && !self::declNeverReturns($node)
+            && !$this->declNeverReturns($node)
             && !$return_type->hasType(VoidType::instance(false))
             && !$return_type->hasType(NullType::instance(false))
         ) {
@@ -5515,12 +5515,12 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
      * @return bool
      * True when the decl can only throw an exception or return or exit()
      */
-    private static function declNeverReturns(Node $node): bool
+    private function declNeverReturns(Node $node): bool
     {
         // Work around fallback parser generating methods without statements list.
         // Otherwise, 'stmts' would always be a Node due to preconditions.
         $stmts_node = $node->children['stmts'];
-        return $stmts_node instanceof Node && BlockExitStatusChecker::willUnconditionallyNeverReturn($stmts_node);
+        return $stmts_node instanceof Node && BlockExitStatusChecker::willUnconditionallyNeverReturn($stmts_node, $this->code_base, $this->context);
     }
 
     private function canApplyStaticPropertyOverride(FullyQualifiedClassName $calling_class, FullyQualifiedClassName $target_class): bool

--- a/src/Phan/Debug.php
+++ b/src/Phan/Debug.php
@@ -279,7 +279,7 @@ class Debug
             }
 
             if (ast\kind_uses_flags($ast->kind)) {
-                $flags_without_phan_additions = $ast->flags & ~BlockExitStatusChecker::STATUS_BITMASK;
+                $flags_without_phan_additions = $ast->flags & ~(BlockExitStatusChecker::STATUS_BITMASK | BlockExitStatusChecker::STATUS_COMPUTED_WITH_CODE_BASE);
                 if ($flags_without_phan_additions !== 0) {
                     $result .= "\n    flags: " . self::formatFlags($ast->kind, $flags_without_phan_additions);
                 }

--- a/src/Phan/Debug.php
+++ b/src/Phan/Debug.php
@@ -279,7 +279,7 @@ class Debug
             }
 
             if (ast\kind_uses_flags($ast->kind)) {
-                $flags_without_phan_additions = $ast->flags & ~(BlockExitStatusChecker::STATUS_BITMASK | BlockExitStatusChecker::STATUS_COMPUTED_WITH_CODE_BASE);
+                $flags_without_phan_additions = $ast->flags & ~BlockExitStatusChecker::STATUS_BITMASK;
                 if ($flags_without_phan_additions !== 0) {
                     $result .= "\n    flags: " . self::formatFlags($ast->kind, $flags_without_phan_additions);
                 }

--- a/tests/files/src/5929_never_calls_never.php
+++ b/tests/files/src/5929_never_calls_never.php
@@ -51,8 +51,10 @@ function never_in_if5929(bool $x): never
     }
 }
 
-// A closure/arrow-function body that ends by calling a never-returning function
-// must likewise be recognized as never returning (visitClosure path).
+// A closure body that ends by calling a never-returning function must likewise
+// be recognized as never returning (visitClosure path). Arrow functions are not
+// covered here: an arrow function implicitly returns its expression, so a
+// `: never` arrow function is a syntax error (PhanSyntaxReturnStatementInNever).
 $never_closure5929 = function (): never {
     redirect_any5929("/closure");
 };

--- a/tests/files/src/5929_never_calls_never.php
+++ b/tests/files/src/5929_never_calls_never.php
@@ -1,0 +1,41 @@
+<?php
+
+// Regression test for https://github.com/phan/phan/issues/5535
+// A function/method declared `: never` whose only/last statement is a call to
+// another `never`-returning userland function must not be flagged with
+// PhanTypeMissingReturnReal, since the inner call provably never returns.
+
+function redirect_any5929(string $url): never
+{
+    header("Location: " . $url, true, 301);
+    exit;
+}
+
+function redirect5929(string $url): never
+{
+    redirect_any5929($url);
+}
+
+function doRedirectAndExit5929(): never
+{
+    $url = "...";
+    redirect5929($url);
+}
+
+class Redirector5929
+{
+    public function bail(): never
+    {
+        redirect_any5929("/login");
+    }
+
+    public function bailStatic(): never
+    {
+        self::doExit();
+    }
+
+    public static function doExit(): never
+    {
+        exit;
+    }
+}

--- a/tests/files/src/5929_never_calls_never.php
+++ b/tests/files/src/5929_never_calls_never.php
@@ -39,3 +39,43 @@ class Redirector5929
         exit;
     }
 }
+
+// The never-returning call may be nested under a switch, match, or other
+// control-flow construct whose exit status is cached by a context-less
+// BlockExitStatusChecker before this check runs. The cached status must not
+// hide the inner never-returning call. See review of PR #5541.
+function never_in_switch5929(int $x): never
+{
+    switch ($x) {
+        case 1:
+            redirect_any5929("/one");
+            // fallthrough to default; both branches never return
+        default:
+            redirect_any5929("/x");
+    }
+}
+
+function never_in_match5929(int $x): never
+{
+    match ($x) {
+        1 => redirect_any5929("/one"),
+        default => redirect_any5929("/x"),
+    };
+}
+
+function never_in_if5929(bool $x): never
+{
+    if ($x) {
+        redirect_any5929("/a");
+    } else {
+        redirect_any5929("/b");
+    }
+}
+
+// A closure/arrow-function body that ends by calling a never-returning function
+// must likewise be recognized as never returning (visitClosure path).
+$never_closure5929 = function (): never {
+    redirect_any5929("/closure");
+};
+$never_closure5929();
+

--- a/tests/files/src/5929_never_calls_never.php
+++ b/tests/files/src/5929_never_calls_never.php
@@ -40,29 +40,8 @@ class Redirector5929
     }
 }
 
-// The never-returning call may be nested under a switch, match, or other
-// control-flow construct whose exit status is cached by a context-less
-// BlockExitStatusChecker before this check runs. The cached status must not
-// hide the inner never-returning call. See review of PR #5541.
-function never_in_switch5929(int $x): never
-{
-    switch ($x) {
-        case 1:
-            redirect_any5929("/one");
-            // fallthrough to default; both branches never return
-        default:
-            redirect_any5929("/x");
-    }
-}
-
-function never_in_match5929(int $x): never
-{
-    match ($x) {
-        1 => redirect_any5929("/one"),
-        default => redirect_any5929("/x"),
-    };
-}
-
+// The never-returning call may be nested under an if/else and must still be
+// recognized as never returning.
 function never_in_if5929(bool $x): never
 {
     if ($x) {


### PR DESCRIPTION
Fixes #5535: `PhanTypeMissingReturnReal` was a false positive for a function/method declared `: never` whose only (or last) statement is a call to another `never`-returning userland function.

```php
function redirect_any(string $url): never {
    header("Location: $url", true, 301);
    exit;                       // OK: literal exit, never flagged
}

function redirect(string $url): never {
    redirect_any($url);         // was flagged: PhanTypeMissingReturnReal
}

function doRedirectAndExit(): never {
    $url = "...";
    redirect($url);             // was flagged: PhanTypeMissingReturnReal
}
```

The report noted it "doesn't always happen" — see *Why it was intermittent* below.

## Root cause

`BlockExitStatusChecker::computeStatusOfCall()` already knows how to detect that a called userland function returns `never` (it looks the callee up in the `CodeBase` and checks its return type). But that detection is gated on `$this->code_base !== null && $this->context !== null`.

`PostOrderAnalysisVisitor::declNeverReturns()` — used to suppress the missing-return warning when the body provably never returns — invoked the checker without those arguments:

```php
BlockExitStatusChecker::willUnconditionallyNeverReturn($stmts_node);
```

With `code_base`/`context` both `null`, the callee-`never` detection became dead code on this path. Only `exit`/`die`/`trigger_error`/`throw`/infinite-loops were recognized — which is why a function ending in a literal `exit;` passed, but one ending in a call to another `never` function did not.

## Why it was intermittent

`BlockExitStatusChecker` caches a node's computed exit status in `$node->flags`. If the call node's status had already been computed by some other analysis path that *did* carry a `CodeBase`, `declNeverReturns` would read the cached `never` status and behave correctly. Otherwise it would recompute with a `null` code base and miss it. Whether the cache was warm depended on analysis/file ordering, making the false positive appear and disappear.

## Fix

Make `declNeverReturns()` an instance method and forward the visitor's `code_base` and `context` to the checker:

```php
return $stmts_node instanceof Node
    && BlockExitStatusChecker::willUnconditionallyNeverReturn($stmts_node, $this->code_base, $this->context);
```

Its three call sites (in `visitMethod`, `visitFuncDecl`, and the closure path) were updated from `self::declNeverReturns(...)` to `$this->declNeverReturns(...)`. This makes detection deterministic regardless of whether the exit status was previously cached.