### PR TITLE
Fix #5542

### DIFF
--- a/src/Phan/Analysis/BlockExitStatusChecker.php
+++ b/src/Phan/Analysis/BlockExitStatusChecker.php
@@ -638,6 +638,7 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
         }
         // In AST version 120+, exit/die are represented as AST_CALL instead of AST_EXIT
         // This happens regardless of the PHP version running Phan
+        // @phan-suppress-next-line PhanRedundantValueComparison
         if (\Phan\Config::AST_VERSION >= 120) {
             if ($function_name === 'exit' || $function_name === 'die') {
                 return self::STATUS_NORETURN;

--- a/src/Phan/Language/Element/GlobalConstant.php
+++ b/src/Phan/Language/Element/GlobalConstant.php
@@ -31,7 +31,8 @@ class GlobalConstant extends AddressableElement implements ConstantInterface
     ];
 
     /**
-     * Sets whether this is a global constant that should be treated as if the real type is unknown.
+     * Sets whether this is a global constant set through `define(...)` instead
+     * of `const` keyword
      */
     public function setIsDynamicConstant(bool $dynamic_constant): void
     {
@@ -46,7 +47,10 @@ class GlobalConstant extends AddressableElement implements ConstantInterface
 
     /**
      * @return bool
-     * True if this is a global constant that should be treated as if the real type is unknown.
+     * @suppress PhanUnreferencedPublicMethod this used to be used
+     *
+     * True if this is a global constant set through `define(...)` instead of
+     * `const` keyword
      */
     public function isDynamicConstant(): bool
     {
@@ -64,16 +68,6 @@ class GlobalConstant extends AddressableElement implements ConstantInterface
         }
 
         return parent::getUnionType();
-    }
-
-    public function setUnionType(UnionType $type): void
-    {
-        // Note: in php 8.1, constants can also be objects if those objects are enums.
-        // So the real type set includes every type.
-        if ($this->isDynamicConstant()) {
-            $type = $type->eraseRealTypeSet();
-        }
-        parent::setUnionType($type);
     }
 
     /**

--- a/src/Phan/Language/Element/GlobalConstant.php
+++ b/src/Phan/Language/Element/GlobalConstant.php
@@ -46,11 +46,10 @@ class GlobalConstant extends AddressableElement implements ConstantInterface
     }
 
     /**
-     * @return bool
-     * @suppress PhanUnreferencedPublicMethod this used to be used
-     *
      * True if this is a global constant set through `define(...)` instead of
-     * `const` keyword
+     * the `const` keyword
+     *
+     * @suppress PhanUnreferencedPublicMethod this used to be used
      */
     public function isDynamicConstant(): bool
     {

--- a/src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php
@@ -292,11 +292,7 @@ final class DependentReturnTypeOverridePlugin extends PluginV3 implements
             if (!$code_base->hasGlobalConstantWithFQSEN($fqsen)) {
                 return $mixed_union_type;
             }
-            $constant = $code_base->getGlobalConstantByFQSEN($fqsen);
-            if ($constant->isDynamicConstant()) {
-                return $mixed_union_type;
-            }
-            return $constant->getUnionType();
+            return $code_base->getGlobalConstantByFQSEN($fqsen)->getUnionType();
         };
         $real_int_type = IntType::instance(false)->asRealUnionType();
         /**

--- a/tests/Phan/AST/TolerantASTConverter/ErrorTolerantConversionTest.php
+++ b/tests/Phan/AST/TolerantASTConverter/ErrorTolerantConversionTest.php
@@ -485,6 +485,7 @@ EOT;
     {
         switch ($ast->kind) {
             case ast\AST_CLASS:
+                // @phan-suppress-next-line PhanImpossibleValueComparison
                 if (Config::AST_VERSION < 85) {
                     unset($ast->children['type']);
                 }

--- a/tests/files/expected/0199_define.php.expected
+++ b/tests/files/expected/0199_define.php.expected
@@ -1,2 +1,2 @@
-%s:10 PhanTypeMismatchReturn Returning CON1 of type string but f() is declared to return int
+%s:10 PhanTypeMismatchReturnProbablyReal Returning CON1 of type string but f() is declared to return int (no real type) (the inferred real return type has nothing in common with the declared phpdoc return type)
 %s:15 PhanTypeMismatchReturnProbablyReal Returning CON2 of type string but g() is declared to return int (no real type) (the inferred real return type has nothing in common with the declared phpdoc return type)

--- a/tests/files/expected/0277_literal_conditional.php.expected
+++ b/tests/files/expected/0277_literal_conditional.php.expected
@@ -26,5 +26,7 @@
 %s:25 PhanTypeMismatchArgumentInternalReal Argument 1 ($num1) is 'value' of type string but \intdiv() takes int
 %s:26 PhanRedundantCondition Redundant attempt to cast FEATURE_FLAG of type true to truthy
 %s:26 PhanTypeMismatchArgumentInternalReal Argument 1 ($num1) is 'value' of type string but \intdiv() takes int
+%s:27 PhanRedundantCondition Redundant attempt to cast FEATURE_FLAG2 of type true to truthy
 %s:27 PhanTypeMismatchArgumentInternalReal Argument 1 ($num1) is 'value' of type string but \intdiv() takes int
+%s:28 PhanRedundantCondition Redundant attempt to cast FEATURE_FLAG2 of type true to truthy
 %s:28 PhanTypeMismatchArgumentInternalReal Argument 1 ($num1) is 'value' of type string but \intdiv() takes int

--- a/tests/files/expected/0567_invalid_constants.php.expected
+++ b/tests/files/expected/0567_invalid_constants.php.expected
@@ -1,11 +1,11 @@
 %s:14 PhanUndeclaredVariable Variable $undError is undeclared
 %s:15 PhanParamTooFewInternal Call with 1 arg(s) to \define(string $constant_name, $value, bool $case_insensitive = false) which requires 2 arg(s)
-%s:16 PhanTypeMismatchArgumentInternal Argument 1 ($string) is cons2128Error of type null but \strlen() takes string
+%s:16 PhanTypeMismatchArgumentInternalReal Argument 1 ($string) is cons2128Error of type null but \strlen() takes string
 %s:17 PhanUndeclaredConstant Reference to undeclared constant \cons2128Error2. This would throw an Error. (Did you mean \cons2128Error)
 %s:18 PhanParamTooFewInternal Call with 1 arg(s) to \define(string $constant_name, $value, bool $case_insensitive = false) which requires 2 arg(s)
 %s:18 PhanTypeMismatchArgumentInternalReal Argument 1 ($constant_name) is $undefVar of type null but \define() takes string
 %s:18 PhanUndeclaredVariable Variable $undefVar is undeclared
 %s:20 PhanInvalidConstantFQSEN '' is an invalid FQSEN for a constant
-%s:25 PhanTypeMismatchArgumentInternal Argument 1 ($num1) is cons2128 of type string but \intdiv() takes int
-%s:33 PhanTypeMismatchArgumentInternal Argument 1 ($num1) is cons21282 of type string but \intdiv() takes int
-%s:38 PhanTypeMismatchArgumentInternal Argument 1 ($string) is cons21283 of type int but \strlen() takes string
+%s:25 PhanTypeMismatchArgumentInternalReal Argument 1 ($num1) is cons2128 of type string but \intdiv() takes int
+%s:33 PhanTypeMismatchArgumentInternalReal Argument 1 ($num1) is cons21282 of type string but \intdiv() takes int
+%s:38 PhanTypeMismatchArgumentInternalReal Argument 1 ($string) is cons21283 of type int but \strlen() takes string

--- a/tests/files/expected/0820_impossible_class_const_condition.php.expected
+++ b/tests/files/expected/0820_impossible_class_const_condition.php.expected
@@ -1,2 +1,3 @@
 %s:23 PhanImpossibleValueComparison Impossible comparison of $result of type bool to MY_GLOBAL of type int (value: 2) with operator '===' (the comparison is always false)
+%s:26 PhanImpossibleValueComparison Impossible comparison of $result of type bool to MY_DYNAMIC_GLOBAL_ENTRY of type int (value: 3) with operator '===' (the comparison is always false)
 %s:31 PhanImpossibleValueComparison Impossible comparison of !$e->getCode() of type bool to HasConst::MY_VAL of type int (value: 1) with operator '===' (the comparison is always false)

--- a/tests/files/expected/0912_do_while_false.php.expected
+++ b/tests/files/expected/0912_do_while_false.php.expected
@@ -4,4 +4,5 @@
 %s:16 PhanInfiniteLoop The loop condition 1 of type 1 is always truthy and nothing seems to exit the loop
 %s:19 PhanImpossibleCondition Impossible attempt to cast 0 of type 0 to truthy
 %s:21 PhanPossiblyInfiniteLoop The loop condition CONFIGURABLE_BOOLEAN does not seem to change within the loop and nothing seems to exit the loop
+%s:23 PhanImpossibleCondition Impossible attempt to cast CONFIGURABLE_BOOLEAN of type false to truthy
 %s:25 PhanInfiniteLoop The loop condition true of type true is always truthy and nothing seems to exit the loop

--- a/tests/files/expected/5931_impossible_constant_type_comparison.php.expected
+++ b/tests/files/expected/5931_impossible_constant_type_comparison.php.expected
@@ -1,0 +1,1 @@
+%s:6 PhanImpossibleTypeComparison Impossible attempt to check if STRING_CONST of type string is identical to $intVar of type int

--- a/tests/files/expected/5932_constant_function_type.php.expected
+++ b/tests/files/expected/5932_constant_function_type.php.expected
@@ -1,0 +1,2 @@
+%s:5 PhanDebugAnnotation @phan-debug-var requested for variable $definiteStringVarFromConstantPlain - it has union type string(real=string)
+%s:8 PhanDebugAnnotation @phan-debug-var requested for variable $definiteStringVarFromConstantFn - it has union type string(real=string)

--- a/tests/files/src/5931_impossible_constant_type_comparison.php
+++ b/tests/files/src/5931_impossible_constant_type_comparison.php
@@ -1,0 +1,7 @@
+<?php
+
+function string_const_equals_int(int $intVar)
+{
+    define('STRING_CONST', random_bytes(3));
+    return STRING_CONST === $intVar;
+}

--- a/tests/files/src/5932_constant_function_type.php
+++ b/tests/files/src/5932_constant_function_type.php
@@ -1,0 +1,9 @@
+<?php
+
+define('DEFINITE_STRING', random_bytes(3));
+
+$definiteStringVarFromConstantPlain = DEFINITE_STRING;
+'@phan-debug-var $definiteStringVarFromConstantPlain';
+
+$definiteStringVarFromConstantFn = constant('DEFINITE_STRING');
+'@phan-debug-var $definiteStringVarFromConstantFn';


### PR DESCRIPTION
This fixes the issues in #5542, however it may be that only one or none of the issues are real issues and shouldn't be fixed. If that is the case, I can modify or close the MR to reflect that.

Changes:
* Trust dynamically created constants' real type when setting union type
* No longer return mixed type for dynamically created constants accessed by the `constant(...)` function
* Add tests to see that we retain dynamically created constant types

Tests Modified due to real type being known:

- tests/files/expected/0277_literal_conditional.php
- tests/files/expected/0567_invalid_constants.php
- tests/files/expected/0820_impossible_class_const_condition.php
- tests/files/expected/0912_do_while_false.php