### PR TITLE
Fixes #5544

### DIFF
--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -32,6 +32,7 @@ use Phan\IssueFixSuggester;
 use Phan\Language\Context;
 use Phan\Language\Element\Clazz;
 use Phan\Language\Element\FunctionInterface;
+use Phan\Language\Element\Property;
 use Phan\Language\Element\Variable;
 use Phan\Language\FQSEN\FullyQualifiedClassName;
 use Phan\Language\FQSEN\FullyQualifiedFunctionLikeName;
@@ -3261,24 +3262,27 @@ class UnionTypeVisitor extends AnalysisVisitor
                 // Inherit any new additional inferred union types from the declaring class,
                 // unless the property type has template types.
                 $defining_fqsen = $property->getDefiningFQSEN();
+                $declaring_property = $property;
                 if ($property->getFQSEN() !== $defining_fqsen) {
+                    $declaring_property = null;
                     if ($this->code_base->hasPropertyWithFQSEN($defining_fqsen)) {
-                        $declaring_union_type = $this->code_base->getPropertyByFQSEN($defining_fqsen)->getUnionType();
+                        $declaring_property = $this->code_base->getPropertyByFQSEN($defining_fqsen);
+                        $declaring_union_type = $declaring_property->getUnionType();
                         if ($declaring_union_type !== $union_type && !$declaring_union_type->hasTemplateTypeRecursive()) {
                             $union_type = $union_type->withUnionType($declaring_union_type);
                         }
                     }
-                } else {
-                    // This property redeclares (overrides) an ancestor's property, e.g. to widen
-                    // visibility or via @inheritDoc. When it declares no type of its own, inherit
-                    // the ancestor's declared/inferred type.
-                    $overridden_fqsen = $property->getOverriddenFQSEN();
-                    if ($overridden_fqsen && $property->getPHPDocUnionType()->isEmpty() && $property->getRealUnionType()->isEmpty()
-                        && $this->code_base->hasPropertyWithFQSEN($overridden_fqsen)) {
-                        $overridden_union_type = $this->code_base->getPropertyByFQSEN($overridden_fqsen)->getUnionType();
-                        if ($overridden_union_type !== $union_type && !$overridden_union_type->hasTemplateTypeRecursive()) {
-                            $union_type = $union_type->withUnionType($overridden_union_type);
-                        }
+                }
+                // If the declaring property redeclares (overrides) an ancestor's property,
+                // e.g. to widen visibility or via @inheritDoc, and declares no type of its own,
+                // inherit the ancestor's declared/inferred type (following the override chain).
+                if ($declaring_property &&
+                    $declaring_property->getPHPDocUnionType()->isEmpty() &&
+                    $declaring_property->getRealUnionType()->isEmpty()) {
+                    $overridden_union_type = $this->getOverriddenPropertyUnionType($declaring_property);
+                    if (!$overridden_union_type->isEmpty() && $overridden_union_type !== $union_type
+                        && !$overridden_union_type->hasTemplateTypeRecursive()) {
+                        $union_type = $union_type->withUnionType($overridden_union_type);
                     }
                 }
             }
@@ -3353,6 +3357,34 @@ class UnionTypeVisitor extends AnalysisVisitor
         }
 
         return UnionType::empty();
+    }
+
+    /**
+     * Compute the union type inherited from the ancestor property that $property redeclares
+     * (overrides), following the override chain. The defining property's union type is used so
+     * that types declared or inferred on the original definition (e.g. from assignments) are
+     * included. Returns the empty union type if $property does not redeclare an ancestor property.
+     */
+    private function getOverriddenPropertyUnionType(Property $property): UnionType
+    {
+        $overridden_fqsen = $property->getOverriddenFQSEN();
+        if (!$overridden_fqsen || !$this->code_base->hasPropertyWithFQSEN($overridden_fqsen)) {
+            return UnionType::empty();
+        }
+        $overridden_property = $this->code_base->getPropertyByFQSEN($overridden_fqsen);
+        // Prefer the defining property so that types inferred on the original definition
+        // (e.g. from assignments within the ancestor class) are included.
+        $defining_fqsen = $overridden_property->getDefiningFQSEN();
+        if ($defining_fqsen !== $overridden_property->getFQSEN() && $this->code_base->hasPropertyWithFQSEN($defining_fqsen)) {
+            $union_type = $this->code_base->getPropertyByFQSEN($defining_fqsen)->getUnionType();
+        } else {
+            $union_type = $overridden_property->getUnionType();
+        }
+        // If the overridden property is itself an untyped redeclaration, keep walking the chain.
+        if ($overridden_property->getPHPDocUnionType()->isEmpty() && $overridden_property->getRealUnionType()->isEmpty()) {
+            $union_type = $union_type->withUnionType($this->getOverriddenPropertyUnionType($overridden_property));
+        }
+        return $union_type;
     }
 
     private function inferStdClassShapePropertyType(?Node $expr_node, string $property_name): ?UnionType

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -3279,7 +3279,8 @@ class UnionTypeVisitor extends AnalysisVisitor
                 if ($declaring_property &&
                     $declaring_property->getPHPDocUnionType()->isEmpty() &&
                     $declaring_property->getRealUnionType()->isEmpty()) {
-                    $overridden_union_type = $this->getOverriddenPropertyUnionType($declaring_property);
+                    $overridden_union_type = $this->getOverriddenPropertyUnionType($declaring_property)
+                        ->withStaticResolvedInContext($property->getContext());
                     if (!$overridden_union_type->isEmpty() && $overridden_union_type !== $union_type
                         && !$overridden_union_type->hasTemplateTypeRecursive()) {
                         $union_type = $union_type->withUnionType($overridden_union_type);

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -3268,6 +3268,18 @@ class UnionTypeVisitor extends AnalysisVisitor
                             $union_type = $union_type->withUnionType($declaring_union_type);
                         }
                     }
+                } else {
+                    // This property redeclares (overrides) an ancestor's property, e.g. to widen
+                    // visibility or via @inheritDoc. When it declares no type of its own, inherit
+                    // the ancestor's declared/inferred type.
+                    $overridden_fqsen = $property->getOverriddenFQSEN();
+                    if ($overridden_fqsen && $property->getPHPDocUnionType()->isEmpty() && $property->getRealUnionType()->isEmpty()
+                        && $this->code_base->hasPropertyWithFQSEN($overridden_fqsen)) {
+                        $overridden_union_type = $this->code_base->getPropertyByFQSEN($overridden_fqsen)->getUnionType();
+                        if ($overridden_union_type !== $union_type && !$overridden_union_type->hasTemplateTypeRecursive()) {
+                            $union_type = $union_type->withUnionType($overridden_union_type);
+                        }
+                    }
                 }
             }
 

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -950,6 +950,12 @@ class Clazz extends AddressableElement
         Property $overriding_property
     ): void {
         $overriding_property->setIsOverride(true);
+        // Record the overridden ancestor property so that, when the overriding property
+        // declares no type of its own (e.g. it only widens visibility, or uses @inheritDoc),
+        // it can inherit the ancestor's declared/inferred type.
+        if (!$overriding_property->isStatic() && !$inherited_property->isStatic()) {
+            $overriding_property->setOverriddenFQSEN($inherited_property->getRealDefiningFQSEN());
+        }
         if ($inherited_property->isFromPHPDoc() || $inherited_property->isDynamicProperty() ||
             $overriding_property->isFromPHPDoc() || $overriding_property->isDynamicProperty()) {
             return;

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -950,12 +950,6 @@ class Clazz extends AddressableElement
         Property $overriding_property
     ): void {
         $overriding_property->setIsOverride(true);
-        // Record the overridden ancestor property so that, when the overriding property
-        // declares no type of its own (e.g. it only widens visibility, or uses @inheritDoc),
-        // it can inherit the ancestor's declared/inferred type.
-        if (!$overriding_property->isStatic() && !$inherited_property->isStatic()) {
-            $overriding_property->setOverriddenFQSEN($inherited_property->getRealDefiningFQSEN());
-        }
         if ($inherited_property->isFromPHPDoc() || $inherited_property->isDynamicProperty() ||
             $overriding_property->isFromPHPDoc() || $overriding_property->isDynamicProperty()) {
             return;
@@ -995,6 +989,18 @@ class Clazz extends AddressableElement
         // However, trait properties are merged into the class, not inherited, so they must remain compatible.
         $is_private_from_ancestor_class = $inherited_property->isPrivate() &&
             !$code_base->getClassByFQSEN($inherited_property->getDefiningFQSEN()->getFullyQualifiedClassName())->isTrait();
+        // Record the overridden ancestor property so that, when the overriding property
+        // declares no type of its own (e.g. it only widens visibility, or uses @inheritDoc),
+        // it can inherit the ancestor's declared/inferred type.
+        // A private property in a (non-trait) ancestor class is not actually overridden in
+        // PHP -- the child declares an independent property -- so do not link to it.
+        // Use the inherited property's own FQSEN (its instance in the ancestor class) rather
+        // than getRealDefiningFQSEN(), which would point at a trait and lose the ancestor
+        // class's accumulated/inferred type.
+        if (!$is_private_from_ancestor_class &&
+            !$overriding_property->isStatic() && !$inherited_property->isStatic()) {
+            $overriding_property->setOverriddenFQSEN($inherited_property->getFQSEN());
+        }
         if ($overriding_property->isStatic() != $inherited_property->isStatic() &&
             !$is_private_from_ancestor_class) {
             Issue::maybeEmit(

--- a/src/Phan/Language/Element/Property.php
+++ b/src/Phan/Language/Element/Property.php
@@ -38,6 +38,13 @@ class Property extends ClassElement
     private $real_defining_fqsen;
 
     /**
+     * @var ?FullyQualifiedPropertyName If this property redeclares a property from an ancestor class
+     * (e.g. to widen visibility), this is the FQSEN of the ancestor property it overrides.
+     * Used to inherit the ancestor's declared/inferred type when this property has no type of its own.
+     */
+    private $overridden_fqsen;
+
+    /**
      * @var UnionType The real union type of this property
      * This does not change.
      */
@@ -121,6 +128,24 @@ class Property extends ClassElement
     public function getRealDefiningFQSEN(): FullyQualifiedPropertyName
     {
         return $this->real_defining_fqsen ?? $this->getDefiningFQSEN();
+    }
+
+    /**
+     * Records that this property redeclares (overrides) the property with the given FQSEN
+     * from an ancestor class.
+     */
+    public function setOverriddenFQSEN(FullyQualifiedPropertyName $fqsen): void
+    {
+        $this->overridden_fqsen = $fqsen;
+    }
+
+    /**
+     * @return ?FullyQualifiedPropertyName the FQSEN of the ancestor property this property overrides,
+     * or null if this property does not redeclare an ancestor property.
+     */
+    public function getOverriddenFQSEN(): ?FullyQualifiedPropertyName
+    {
+        return $this->overridden_fqsen;
     }
 
     /**

--- a/tests/files/expected/5931_property_override_inherit_type.php.expected
+++ b/tests/files/expected/5931_property_override_inherit_type.php.expected
@@ -8,3 +8,9 @@
 %s:31 PhanUnusedVariable Unused definition of variable $p2
 %s:42 PhanDebugAnnotation @phan-debug-var requested for variable $p2 - it has union type int
 %s:42 PhanUnusedVariable Unused definition of variable $p2
+%s:51 PhanUnusedVariable Unused definition of variable $p
+%s:52 PhanDebugAnnotation @phan-debug-var requested for variable $p - it has union type string
+%s:52 PhanDebugAnnotation @phan-debug-var requested for variable $p2 - it has union type string
+%s:52 PhanUnusedVariable Unused definition of variable $p2
+%s:68 PhanDebugAnnotation @phan-debug-var requested for variable $s - it has union type (empty union type)
+%s:68 PhanUnusedVariable Unused definition of variable $s

--- a/tests/files/expected/5931_property_override_inherit_type.php.expected
+++ b/tests/files/expected/5931_property_override_inherit_type.php.expected
@@ -1,0 +1,10 @@
+%s:18 PhanUnusedVariable Unused definition of variable $p
+%s:19 PhanDebugAnnotation @phan-debug-var requested for variable $p - it has union type string
+%s:19 PhanDebugAnnotation @phan-debug-var requested for variable $p2 - it has union type string
+%s:19 PhanUnusedVariable Unused definition of variable $p2
+%s:30 PhanUnusedVariable Unused definition of variable $p
+%s:31 PhanDebugAnnotation @phan-debug-var requested for variable $p - it has union type string
+%s:31 PhanDebugAnnotation @phan-debug-var requested for variable $p2 - it has union type string
+%s:31 PhanUnusedVariable Unused definition of variable $p2
+%s:42 PhanDebugAnnotation @phan-debug-var requested for variable $p2 - it has union type int
+%s:42 PhanUnusedVariable Unused definition of variable $p2

--- a/tests/files/src/5931_property_override_inherit_type.php
+++ b/tests/files/src/5931_property_override_inherit_type.php
@@ -43,3 +43,29 @@ class C5931 extends A5931 {
         '@phan-debug-var $p2';
     }
 }
+
+// Inheritance through a multi-level chain: D5931 inherits B5931's untyped override,
+// so it should still resolve to the ancestor's type.
+class D5931 extends B5931 {
+    public function runD() {
+        $p = $this->property;
+        $p2 = $this->property2;
+        '@phan-debug-var $p, $p2';
+    }
+}
+
+// A private property in an ancestor class is NOT overridden in PHP -- the child declares
+// an independent property -- so its untyped redeclaration must not inherit the parent type.
+class E5931 {
+    /** @var string */
+    private $secret = 'x';
+}
+
+class F5931 extends E5931 {
+    public $secret;
+
+    public function runF() {
+        $s = $this->secret;
+        '@phan-debug-var $s';
+    }
+}

--- a/tests/files/src/5931_property_override_inherit_type.php
+++ b/tests/files/src/5931_property_override_inherit_type.php
@@ -1,0 +1,45 @@
+<?php
+
+// Regression test for https://github.com/phan/phan/issues/5544
+// A child class that redeclares a property (e.g. to widen visibility, or via
+// @inheritDoc) and declares no type of its own should inherit the ancestor's
+// declared/inferred type.
+class A5931 {
+    protected $property;
+    /** @var string */
+    protected $property2;
+
+    public function __construct() {
+        $this->property = 'a';
+        $this->property2 = 'a2';
+    }
+
+    public function runA() {
+        $p = $this->property;
+        $p2 = $this->property2;
+        '@phan-debug-var $p, $p2';
+    }
+}
+
+class B5931 extends A5931 {
+    public $property;
+    /** @inheritDoc */
+    public $property2;
+
+    public function runB() {
+        $p = $this->property;
+        $p2 = $this->property2;
+        '@phan-debug-var $p, $p2';
+    }
+}
+
+// A child that declares its own type must keep it (not widen to the ancestor's type).
+class C5931 extends A5931 {
+    /** @var int */
+    public $property2;
+
+    public function runC() {
+        $p2 = $this->property2;
+        '@phan-debug-var $p2';
+    }
+}


### PR DESCRIPTION
When a child class redeclares a property — for example to widen its visibility, or
using `@inheritDoc` — without giving it a type of its own, Phan inferred an **empty
union type** for that property instead of the type declared (or inferred) on the
ancestor.

```php
class A {
    protected $property;
    /** @var string */
    protected $property2;

    public function __construct() {
        $this->property = 'a';
        $this->property2 = 'a2';
    }
}

class B extends A {
    public $property;          // widens visibility
    /** @inheritDoc */
    public $property2;

    public function runB() {
        $p  = $this->property;   // before: (empty union type),  after: string
        $p2 = $this->property2;  // before: (empty union type),  after: string
    }
}
```

This matches the PHP semantics described in the manual: a child may redefine a
property and widen its visibility, and doing so should not throw away the type
information from the parent.

## Root cause

`UnionTypeVisitor` already inherits additional inferred types from the declaring
class, but that logic is keyed on `$property->getFQSEN() !== $property->getDefiningFQSEN()`.
A property that is redeclared in the child class *is its own definition*, so the two
FQSENs are equal and the inheritance path was skipped entirely. The override had no
link back to the property it was overriding, so it never picked up the ancestor's type.

## Fix

Three small changes:

1. **`Property.php`** — added an `$overridden_fqsen` field plus `setOverriddenFQSEN()`
   / `getOverriddenFQSEN()` to record the ancestor property that a redeclaration
   overrides.

2. **`Clazz.php`** (`checkPropertyCompatibility()`) — when a child property is detected
   as overriding an inherited property, store the ancestor's real defining FQSEN on the
   overriding property (non-static properties only).

3. **`UnionTypeVisitor.php`** — when a property overrides an ancestor and declares
   **no type of its own** (both its phpdoc and real union types are empty), merge in the
   overridden property's union type. The lookup is performed live during analysis, so it
   captures both phpdoc types (`@inheritDoc`) and types inferred from assignments on the
   ancestor.

The empty-type guard is important: a child that *does* declare its own type (e.g.
`/** @var int */`) keeps that narrower type and is **not** widened back to the
ancestor's type. A child that supplies only a default value (e.g. `public $x = 5;`)
without an annotation widens safely (e.g. `int|string`), which introduces no false
positives.