### PR TITLE
Fixes 5547

### DIFF
--- a/src/Phan/Plugin/Internal/StringFunctionPlugin.php
+++ b/src/Phan/Plugin/Internal/StringFunctionPlugin.php
@@ -82,7 +82,7 @@ final class StringFunctionPlugin extends PluginV3 implements
                 $expected_const_pos,
                 $expected_variable_pos
             ): void {
-                if (!array_key_exists($expected_const_pos, $args) || !array_key_exists($expected_variable_pos, $args)) {
+                if (!\array_key_exists($expected_const_pos, $args) || !\array_key_exists($expected_variable_pos, $args)) {
                     return;
                 }
                 if (!self::isSimpleExpression($args[$expected_const_pos])) {

--- a/src/Phan/Plugin/Internal/StringFunctionPlugin.php
+++ b/src/Phan/Plugin/Internal/StringFunctionPlugin.php
@@ -70,7 +70,7 @@ final class StringFunctionPlugin extends PluginV3 implements
     {
         $make_order_warner = static function (int $expected_const_pos, int $expected_variable_pos): Closure {
             /**
-             * @param list<Node|int|float|string> $args
+             * @param array<int, Node|int|float|string> $args
              */
             return static function (
                 CodeBase $code_base,

--- a/src/Phan/Plugin/Internal/StringFunctionPlugin.php
+++ b/src/Phan/Plugin/Internal/StringFunctionPlugin.php
@@ -69,7 +69,6 @@ final class StringFunctionPlugin extends PluginV3 implements
     private static function getAnalyzeFunctionCallClosuresStatic(): array
     {
         $make_order_warner = static function (int $expected_const_pos, int $expected_variable_pos): Closure {
-            $expected_arg_count = 1 + (int)\max($expected_const_pos, $expected_variable_pos);
             /**
              * @param list<Node|int|float|string> $args
              */
@@ -81,10 +80,9 @@ final class StringFunctionPlugin extends PluginV3 implements
                 ?Node $_
             ) use (
                 $expected_const_pos,
-                $expected_variable_pos,
-                $expected_arg_count
+                $expected_variable_pos
             ): void {
-                if (\count($args) < $expected_arg_count) {
+                if (!array_key_exists($expected_const_pos, $args) || !array_key_exists($expected_variable_pos, $args)) {
                     return;
                 }
                 if (!self::isSimpleExpression($args[$expected_const_pos])) {

--- a/tests/files/src/0381_wrong_order.php
+++ b/tests/files/src/0381_wrong_order.php
@@ -6,3 +6,6 @@ $value = 'value';
 preg_replace($value, 'subst', '/v/');  // Phan should warn
 $result = stripos('v', $value);  // Phan should warn
 $result = mb_stripos('v', $value);  // Phan should warn
+
+// Named arguments make $args sparse - should not crash (issue #5533)
+$csv = str_getcsv("abc,def", escape: '');

--- a/tests/files/src/0381_wrong_order.php
+++ b/tests/files/src/0381_wrong_order.php
@@ -7,5 +7,5 @@ preg_replace($value, 'subst', '/v/');  // Phan should warn
 $result = stripos('v', $value);  // Phan should warn
 $result = mb_stripos('v', $value);  // Phan should warn
 
-// Named arguments make $args sparse - should not crash (issue #5533)
+// Named arguments make $args sparse - should not crash (issue #5547)
 $csv = str_getcsv("abc,def", escape: '');


### PR DESCRIPTION
`StringFunctionPlugin` crashed with `Undefined array key 1` when a function it checks was called with named arguments that skip over positional parameters.

`str_getcsv(string $string, string $separator, string $enclosure, string $escape)` called as `str_getcsv("abc,def", escape: '')` produces a sparse `$args` array `[0 => "abc,def", 3 => '']`. The previous guard used `count($args) < $expected_arg_count` — count returns 2, threshold is 2, so it passed — then accessed `$args[1]` which doesn't exist.

The same class of bug was fixed in `DependentReturnTypeOverridePlugin` by #5502. The fix is the same: replace `count()` with `array_key_exists()` for each expected position.

## Changes

- `src/Phan/Plugin/Internal/StringFunctionPlugin.php`: Replace `count($args) < $expected_arg_count` with `array_key_exists()` checks on both expected positions; remove now-unused `$expected_arg_count`.
- `tests/files/src/0381_wrong_order.php`: Add `str_getcsv("abc,def", escape: '')` as a regression test (produces no warning, no crash).