### PR TITLE
Fixes #5551

### DIFF
--- a/src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php
+++ b/src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php
@@ -229,31 +229,39 @@ final class DependentReturnTypeOverridePlugin extends PluginV3 implements
         $str_replace_types = UnionType::fromFullyQualifiedPHPDocString('string|string[]');
         $str_array_type = UnionType::fromFullyQualifiedPHPDocString('string[]');
 
-        /**
-         * @param array<int,Node|int|float|string> $args
-         */
-        $third_argument_string_or_array_handler = static function (
-            CodeBase $code_base,
-            Context $context,
-            Func $unused_function,
-            array $args
-        ) use (
+        $make_subject_string_or_array_handler = static function (int $subject_index) use (
             $string_union_type,
             $str_replace_types,
             $str_array_type
-        ): UnionType {
-            // Handler for functions such as str_replace()/preg_replace*() where the 3rd argument ($subject)
-            // determines whether the return type is string, string[], or string|string[].
-            if (!array_key_exists(2, $args)) {
-                return $str_replace_types;
-            }
-            $union_type = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $args[2]);
-            $has_array = $union_type->hasArray();
-            if ($union_type->canCastToUnionType($string_union_type, $code_base)) {
-                return $has_array ? $str_replace_types : $string_union_type;
-            }
-            return $has_array ? $str_array_type : $str_replace_types;
+        ): Closure {
+            /**
+             * Handler for functions such as str_replace()/preg_replace*()/substr_replace() where the
+             * $subject argument determines whether the return type is string, string[], or string|string[].
+             * @param array<int,Node|int|float|string> $args
+             */
+            return static function (
+                CodeBase $code_base,
+                Context $context,
+                Func $unused_function,
+                array $args
+            ) use (
+                $subject_index,
+                $string_union_type,
+                $str_replace_types,
+                $str_array_type
+            ): UnionType {
+                if (!array_key_exists($subject_index, $args)) {
+                    return $str_replace_types;
+                }
+                $union_type = UnionTypeVisitor::unionTypeFromNode($code_base, $context, $args[$subject_index]);
+                $has_array = $union_type->hasArray();
+                if ($union_type->canCastToUnionType($string_union_type, $code_base)) {
+                    return $has_array ? $str_replace_types : $string_union_type;
+                }
+                return $has_array ? $str_array_type : $str_replace_types;
+            };
         };
+        $third_argument_string_or_array_handler = $make_subject_string_or_array_handler(2);
         /**
          * @param array<int,Node|int|float|string> $args
          */
@@ -480,9 +488,11 @@ final class DependentReturnTypeOverridePlugin extends PluginV3 implements
             'count'                       => $count_handler,
             // Functions with dependent return types
             'str_replace'                 => $third_argument_string_or_array_handler,
+            'str_ireplace'                => $third_argument_string_or_array_handler,
             'preg_replace'                => $third_argument_string_or_array_handler,
             'preg_replace_callback'       => $third_argument_string_or_array_handler,
-            'preg_replace_callback_array' => $third_argument_string_or_array_handler,
+            'preg_replace_callback_array' => $make_subject_string_or_array_handler(1),
+            'substr_replace'              => $make_subject_string_or_array_handler(0),
             'microtime'                   => $make_dependent_type_method(0, $float_union_type, $string_union_type, $string_or_float_union_type),
             'hrtime'                      => $make_dependent_type_method(0, $int_union_type, $hrtime_array_union_type, $int_or_hrtime_array_union_type),
             // misc

--- a/tests/files/expected/substr_replace_dependent_return.php.expected
+++ b/tests/files/expected/substr_replace_dependent_return.php.expected
@@ -1,0 +1,8 @@
+%s:9 PhanDebugAnnotation @phan-debug-var requested for variable $string - it has union type string(real=array|string)
+%s:9 PhanDebugAnnotation @phan-debug-var requested for variable $string2 - it has union type string[](real=array|string)
+%s:13 PhanDebugAnnotation @phan-debug-var requested for variable $subString - it has union type string(real=array|string)
+%s:13 PhanDebugAnnotation @phan-debug-var requested for variable $subString2 - it has union type string[](real=array|string)
+%s:18 PhanDebugAnnotation @phan-debug-var requested for variable $iString - it has union type string(real=array|string)
+%s:18 PhanDebugAnnotation @phan-debug-var requested for variable $iString2 - it has union type string[](real=array|string)
+%s:22 PhanDebugAnnotation @phan-debug-var requested for variable $cbString - it has union type string(real=array|null|string)
+%s:22 PhanDebugAnnotation @phan-debug-var requested for variable $cbString2 - it has union type string[](real=array|null|string)

--- a/tests/files/src/substr_replace_dependent_return.php
+++ b/tests/files/src/substr_replace_dependent_return.php
@@ -1,0 +1,23 @@
+<?php
+
+// Regression test for https://github.com/phan/phan/issues/5551
+// The return type of substr_replace()/str_ireplace()/preg_replace_callback_array()
+// should narrow to string or string[] based on the $subject argument.
+$search = 'te::st';
+
+$string = str_replace('::', '--', $search);
+$string2 = str_replace('::', '--', [$search]);
+'@phan-debug-var $string, $string2';
+
+$subString = substr_replace($search, '--', 2, 2);
+$subString2 = substr_replace([$search], '--', 2, 2);
+'@phan-debug-var $subString, $subString2';
+echo strtolower($subString);
+
+$iString = str_ireplace('::', '--', $search);
+$iString2 = str_ireplace('::', '--', [$search]);
+'@phan-debug-var $iString, $iString2';
+
+$cbString = preg_replace_callback_array(['/t/' => static fn(array $m): string => 'T'], $search);
+$cbString2 = preg_replace_callback_array(['/t/' => static fn(array $m): string => 'T'], [$search]);
+'@phan-debug-var $cbString, $cbString2';


### PR DESCRIPTION
# Fix #5551: Make substr_replace() return type depend on the $string argument

Fixes #5551

## Problem

`substr_replace()` always returned `string|string[]` from the function signature map, even when the subject is known to be a string or an array:

```php
$search = 'te::st';

$subString = substr_replace($search, '--', 2, 2);      // string|string[]  (should be string)
$subString2 = substr_replace([$search], '--', 2, 2);   // string|string[]  (should be string[])

echo strtolower($subString);
// PhanPartialTypeMismatchArgumentInternal Argument 1 ($string) is $subString of type
// string|string[] but \strtolower() takes string (string[] is incompatible)
```

`str_replace()` already handles this via `DependentReturnTypeOverridePlugin`, but that handler was hardcoded to read the subject from argument index 2, and `substr_replace()` takes its subject as argument 0.

## Fix

In `src/Phan/Plugin/Internal/DependentReturnTypeOverridePlugin.php`, the existing `$third_argument_string_or_array_handler` closure is refactored into a factory `$make_subject_string_or_array_handler(int $subject_index)` parameterized by the position of the `$subject` argument. Behavior for the existing registrations is unchanged.

New/corrected registrations:

- **`substr_replace`** (subject index 0) — the fix for this issue.
- **`str_ireplace`** (subject index 2) — same semantics as `str_replace`, but it had no handler in the basic plugin. (`ExtendedDependentReturnTypeOverridePlugin` had a constant-folding wrapper for it; that wrapper falls back to the basic plugin's handler per function name, so the new handler now serves as its fallback for non-constant arguments.)
- **`preg_replace_callback_array`** (subject index 1) — fixes a pre-existing bug: it was registered with the third-argument handler, but its signature is `preg_replace_callback_array($callbacks, $subject, $limit, ...)`, so the handler was inspecting `$limit` instead of `$subject` and never narrowed the return type based on the actual subject.

After the fix:

```php
$subString = substr_replace($search, '--', 2, 2);      // string(real=array|string)
$subString2 = substr_replace([$search], '--', 2, 2);   // string[](real=array|string)
echo strtolower($subString);                           // no warning
```