### PR TITLE
fixes #5553

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@
 Phan 6.0.8-dev
 --------------
 
+Bug fixes:
+- Fix false positives (e.g. `PhanTypeMismatchArgumentNullable`, `PhanPluginNeverReturnMethod`) when a branch calls a `never`-returning instance method on a local variable assigned with `new ClassName()` — the branch is now correctly treated as unreachable ([#5553](https://github.com/phan/phan/issues/5553))
+
 Jun 22 2026, Phan 6.0.7
 --------------
 

--- a/src/Phan/Analysis/BlockExitStatusChecker.php
+++ b/src/Phan/Analysis/BlockExitStatusChecker.php
@@ -882,6 +882,15 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
                     if ($normalized_class_name === 'parent') {
                         return null;
                     }
+                    // Bail if an earlier statement of this list may have created a reference
+                    // to $var_name (e.g. `$alias =& $var;`) - a later write through the alias
+                    // would rebind the variable without a direct assignment.
+                    for ($j = $i - 1; $j >= 0; $j--) {
+                        $earlier_stmt = $this->current_block[$j] ?? null;
+                        if ($earlier_stmt instanceof Node && self::statementMayCreateReferenceToVariable($earlier_stmt, $var_name)) {
+                            return null;
+                        }
+                    }
                     try {
                         return FullyQualifiedClassName::fromStringInContext($class_name, $this->context);
                     } catch (FQSENException $e) {
@@ -905,9 +914,30 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
     private static function statementMayModifyVariable(Node $node, string $var_name): bool
     {
         switch ($node->kind) {
-            case ast\AST_ASSIGN:
             case ast\AST_ASSIGN_REF:
+                // `$alias =& $var` makes subsequent writes through $alias rebind $var.
+                if (self::assignmentTargetMayBeVariable($node->children['expr'], $var_name)) {
+                    return true;
+                }
+                if (self::assignmentTargetMayBeVariable($node->children['var'], $var_name)) {
+                    return true;
+                }
+                break;
+            case ast\AST_ASSIGN:
             case ast\AST_ASSIGN_OP:
+                if (self::assignmentTargetMayBeVariable($node->children['var'], $var_name)) {
+                    return true;
+                }
+                break;
+            case ast\AST_FOREACH:
+                // foreach rebinds its value/key variables.
+                if (self::assignmentTargetMayBeVariable($node->children['value'], $var_name)
+                    || self::assignmentTargetMayBeVariable($node->children['key'], $var_name)) {
+                    return true;
+                }
+                break;
+            case ast\AST_CATCH:
+                // catch binds the caught exception to its variable.
                 if (self::assignmentTargetMayBeVariable($node->children['var'], $var_name)) {
                     return true;
                 }
@@ -951,6 +981,50 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
         }
         foreach ($node->children as $child) {
             if ($child instanceof Node && self::statementMayModifyVariable($child, $var_name)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Conservatively checks whether executing $node may create a reference to the variable $var_name
+     * (making it possible for a later statement to rebind the variable without directly assigning to it).
+     * (does not attempt to account for functions taking arguments by reference)
+     */
+    private static function statementMayCreateReferenceToVariable(Node $node, string $var_name): bool
+    {
+        switch ($node->kind) {
+            case ast\AST_ASSIGN_REF:
+                if (self::assignmentTargetMayBeVariable($node->children['var'], $var_name)
+                    || self::assignmentTargetMayBeVariable($node->children['expr'], $var_name)) {
+                    return true;
+                }
+                break;
+            case ast\AST_GLOBAL:
+            case ast\AST_STATIC:
+                $var = $node->children['var'];
+                if ($var instanceof Node && self::assignmentTargetMayBeVariable($var, $var_name)) {
+                    return true;
+                }
+                break;
+            case ast\AST_CLOSURE:
+            case ast\AST_ARROW_FUNC:
+                foreach ($node->children['uses']->children ?? [] as $use) {
+                    if ($use instanceof Node
+                        && ($use->flags & ast\flags\CLOSURE_USE_REF)
+                        && ($use->children['name'] === $var_name || !\is_string($use->children['name']))) {
+                        return true;
+                    }
+                }
+                // Arrow functions capture by value; assignments inside closure bodies don't escape.
+                return false;
+            case ast\AST_FUNC_DECL:
+            case ast\AST_CLASS:
+                return false;
+        }
+        foreach ($node->children as $child) {
+            if ($child instanceof Node && self::statementMayCreateReferenceToVariable($child, $var_name)) {
                 return true;
             }
         }

--- a/src/Phan/Analysis/BlockExitStatusChecker.php
+++ b/src/Phan/Analysis/BlockExitStatusChecker.php
@@ -87,6 +87,15 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
     /** @var ?Context */
     private $context;
 
+    /**
+     * @var list<Node|string|int|float|null> the statement list currently being analyzed by computeStatusOfBlock,
+     * used to resolve `$var = new ClassName(); $var->methodReturningNever();`
+     */
+    private $current_block = [];
+
+    /** @var int the index within $current_block of the statement currently being analyzed */
+    private $current_block_index = -1;
+
     public function __construct(
         ?CodeBase $code_base = null,
         ?Context $context = null
@@ -808,8 +817,14 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
                 return self::STATUS_PROCEED;
             }
         } else {
-            // TODO not yet handled
-            return self::STATUS_PROCEED;
+            // Handle `$foo = new Foo(); $foo->neverReturns();` by scanning
+            // earlier statements of the statement list being analyzed (issue #5553).
+            // A `never` return type can only be overridden by `never` in subclasses,
+            // so resolving through the statically known class is sound.
+            $class_fqsen = $this->findClassOfPrecedingNewAssignment($var_name);
+            if ($class_fqsen === null) {
+                return self::STATUS_PROCEED;
+            }
         }
         $method_fqsen = FullyQualifiedMethodName::make(
             $class_fqsen,
@@ -827,6 +842,149 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
         }
         // TODO: Could allow .phan/config.php or plugins to define additional behaviors
         return self::STATUS_PROCEED;
+    }
+
+    /**
+     * Searches the preceding statements of the statement list being analyzed for
+     * `$var_name = new ClassName(...)` and returns ClassName's FQSEN if the class name
+     * can be statically resolved and no intervening statement may reassign $var_name.
+     */
+    private function findClassOfPrecedingNewAssignment(string $var_name): ?FullyQualifiedClassName
+    {
+        if ($this->context === null) {
+            return null;
+        }
+        for ($i = $this->current_block_index - 1; $i >= 0; $i--) {
+            $stmt = $this->current_block[$i] ?? null;
+            if (!($stmt instanceof Node)) {
+                continue;
+            }
+            if ($stmt->kind === ast\AST_ASSIGN) {
+                $target = $stmt->children['var'];
+                if ($target instanceof Node && $target->kind === ast\AST_VAR && $target->children['name'] === $var_name) {
+                    // Found the most recent assignment to $var_name in this statement list.
+                    $value = $stmt->children['expr'];
+                    if (!($value instanceof Node) || $value->kind !== ast\AST_NEW) {
+                        return null;
+                    }
+                    $class_node = $value->children['class'];
+                    if (!($class_node instanceof Node) || $class_node->kind !== ast\AST_NAME) {
+                        return null;
+                    }
+                    $class_name = $class_node->children['name'];
+                    if (!\is_string($class_name)) {
+                        return null;
+                    }
+                    $normalized_class_name = \strtolower($class_name);
+                    if ($normalized_class_name === 'self' || $normalized_class_name === 'static') {
+                        return $this->context->getClassFQSENOrNull();
+                    }
+                    if ($normalized_class_name === 'parent') {
+                        return null;
+                    }
+                    try {
+                        return FullyQualifiedClassName::fromStringInContext($class_name, $this->context);
+                    } catch (FQSENException $e) {
+                        // @phan-suppress-previous-line PhanUnusedVariableCaughtException
+                        return null;
+                    }
+                }
+            }
+            if (self::statementMayModifyVariable($stmt, $var_name)) {
+                // e.g. a nested assignment inside an if block, a by-reference closure use, unset(), etc.
+                return null;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Conservatively checks whether executing $node may reassign the variable $var_name.
+     * (does not attempt to account for functions modifying variables by reference)
+     */
+    private static function statementMayModifyVariable(Node $node, string $var_name): bool
+    {
+        switch ($node->kind) {
+            case ast\AST_ASSIGN:
+            case ast\AST_ASSIGN_REF:
+            case ast\AST_ASSIGN_OP:
+                if (self::assignmentTargetMayBeVariable($node->children['var'], $var_name)) {
+                    return true;
+                }
+                break;
+            case ast\AST_PRE_INC:
+            case ast\AST_PRE_DEC:
+            case ast\AST_POST_INC:
+            case ast\AST_POST_DEC:
+                if (self::assignmentTargetMayBeVariable($node->children['var'], $var_name)) {
+                    return true;
+                }
+                break;
+            case ast\AST_UNSET:
+                if (self::assignmentTargetMayBeVariable($node->children['var'], $var_name)) {
+                    return true;
+                }
+                break;
+            case ast\AST_GLOBAL:
+            case ast\AST_STATIC:
+                $var = $node->children['var'];
+                if ($var instanceof Node && self::assignmentTargetMayBeVariable($var, $var_name)) {
+                    return true;
+                }
+                break;
+            case ast\AST_CLOSURE:
+            case ast\AST_ARROW_FUNC:
+                // Assignments inside a closure body don't affect the outer scope
+                // unless the variable is imported by reference.
+                foreach ($node->children['uses']->children ?? [] as $use) {
+                    if ($use instanceof Node
+                        && ($use->flags & ast\flags\CLOSURE_USE_REF)
+                        && ($use->children['name'] === $var_name || !\is_string($use->children['name']))) {
+                        return true;
+                    }
+                }
+                // Arrow functions capture by value.
+                return false;
+            case ast\AST_FUNC_DECL:
+            case ast\AST_CLASS:
+                return false;
+        }
+        foreach ($node->children as $child) {
+            if ($child instanceof Node && self::statementMayModifyVariable($child, $var_name)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Checks whether an assignment/unset target $target may refer to the variable $var_name.
+     * @param Node|string|int|float|null $target
+     */
+    private static function assignmentTargetMayBeVariable(Node|string|int|float|null $target, string $var_name): bool
+    {
+        if (!($target instanceof Node)) {
+            return false;
+        }
+        switch ($target->kind) {
+            case ast\AST_VAR:
+                $name = $target->children['name'];
+                // A dynamic variable name (e.g. $$x) may refer to any variable.
+                return !\is_string($name) || $name === $var_name;
+            case ast\AST_ARRAY:
+                // list()/array destructuring
+                foreach ($target->children as $elem) {
+                    if ($elem instanceof Node && self::assignmentTargetMayBeVariable($elem->children['value'] ?? null, $var_name)) {
+                        return true;
+                    }
+                }
+                return false;
+            case ast\AST_REF:
+                return self::assignmentTargetMayBeVariable($target->children['var'], $var_name);
+            default:
+                // Property/dim assignments ($x->prop = ..., $x[0] = ...) don't rebind the variable itself.
+                return false;
+        }
     }
 
     /**
@@ -991,24 +1149,33 @@ final class BlockExitStatusChecker extends KindVisitorImplementation
      */
     private function computeStatusOfBlock(array $block): int
     {
-        $maybe_status = 0;
-        foreach ($block as $child) {
-            if ($child === null) {
-                continue;
+        $outer_block = $this->current_block;
+        $outer_block_index = $this->current_block_index;
+        $this->current_block = $block;
+        try {
+            $maybe_status = 0;
+            foreach ($block as $i => $child) {
+                if ($child === null) {
+                    continue;
+                }
+                // e.g. can be non-Node for statement lists such as `if ($a) { return; }echo "X";2;` (under unknown conditions)
+                if (!($child instanceof Node)) {
+                    continue;
+                }
+                $this->current_block_index = $i;
+                $status = $this->check($child);
+                if (($status & self::STATUS_PROCEED) === 0) {
+                    // If it's guaranteed we won't proceed after this statement,
+                    // then skip the subsequent statements.
+                    return $status | ($maybe_status & ~self::STATUS_PROCEED);
+                }
+                $maybe_status |= $status;
             }
-            // e.g. can be non-Node for statement lists such as `if ($a) { return; }echo "X";2;` (under unknown conditions)
-            if (!($child instanceof Node)) {
-                continue;
-            }
-            $status = $this->check($child);
-            if (($status & self::STATUS_PROCEED) === 0) {
-                // If it's guaranteed we won't proceed after this statement,
-                // then skip the subsequent statements.
-                return $status | ($maybe_status & ~self::STATUS_PROCEED);
-            }
-            $maybe_status |= $status;
+            return self::STATUS_PROCEED | $maybe_status;
+        } finally {
+            $this->current_block = $outer_block;
+            $this->current_block_index = $outer_block_index;
         }
-        return self::STATUS_PROCEED | $maybe_status;
     }
 
     /**

--- a/tests/files/expected/5932_never_instance_method_unreachable.php.expected
+++ b/tests/files/expected/5932_never_instance_method_unreachable.php.expected
@@ -1,3 +1,6 @@
 %s:37 PhanUnusedVariable Unused definition of variable $foo
-%s:42 PhanTypeMismatchArgumentNullable Argument 1 ($param1) is $param1 of type ?object but \Runner5932::requiresObject() takes object defined at %s:58 (expected type to be non-nullable)
-%s:55 PhanTypeMismatchArgumentNullable Argument 1 ($param1) is $param1 of type ?object but \Runner5932::requiresObject() takes object defined at %s:58 (expected type to be non-nullable)
+%s:42 PhanTypeMismatchArgumentNullable Argument 1 ($param1) is $param1 of type ?object but \Runner5932::requiresObject() takes object defined at %s:97 (expected type to be non-nullable)
+%s:55 PhanTypeMismatchArgumentNullable Argument 1 ($param1) is $param1 of type ?object but \Runner5932::requiresObject() takes object defined at %s:97 (expected type to be non-nullable)
+%s:68 PhanTypeMismatchArgumentNullable Argument 1 ($param1) is $param1 of type ?object but \Runner5932::requiresObject() takes object defined at %s:97 (expected type to be non-nullable)
+%s:80 PhanTypeMismatchArgumentNullable Argument 1 ($param1) is $param1 of type ?object but \Runner5932::requiresObject() takes object defined at %s:97 (expected type to be non-nullable)
+%s:94 PhanTypeMismatchArgumentNullable Argument 1 ($param1) is $param1 of type ?object but \Runner5932::requiresObject() takes object defined at %s:97 (expected type to be non-nullable)

--- a/tests/files/expected/5932_never_instance_method_unreachable.php.expected
+++ b/tests/files/expected/5932_never_instance_method_unreachable.php.expected
@@ -1,0 +1,3 @@
+%s:37 PhanUnusedVariable Unused definition of variable $foo
+%s:42 PhanTypeMismatchArgumentNullable Argument 1 ($param1) is $param1 of type ?object but \Runner5932::requiresObject() takes object defined at %s:58 (expected type to be non-nullable)
+%s:55 PhanTypeMismatchArgumentNullable Argument 1 ($param1) is $param1 of type ?object but \Runner5932::requiresObject() takes object defined at %s:58 (expected type to be non-nullable)

--- a/tests/files/src/5932_never_instance_method_unreachable.php
+++ b/tests/files/src/5932_never_instance_method_unreachable.php
@@ -1,0 +1,66 @@
+<?php
+
+class Fatal5932
+{
+    public function neverReturns(): never {
+        exit();
+    }
+}
+
+class NotFatal5932
+{
+    public function neverReturns(): void {
+    }
+}
+
+class Runner5932
+{
+    // Issue #5553: a branch calling a never-returning instance method should be treated as unreachable.
+    public function method(?object $param1): void {
+        if (!is_object($param1)) {
+            $foo = new Fatal5932();
+            $foo->neverReturns();
+        }
+
+        $this->requiresObject($param1);
+    }
+
+    // A never-returning method whose body ends in a call to another class's never-returning instance method.
+    public function neverReturns(): never {
+        $foo = new Fatal5932();
+        $foo->neverReturns();
+    }
+
+    // The variable was reassigned to an instance whose method does return - should still warn about ?object.
+    public function methodReassigned(?object $param1): void {
+        if (!is_object($param1)) {
+            $foo = new Fatal5932();
+            $foo = new NotFatal5932();
+            $foo->neverReturns();
+        }
+
+        $this->requiresObject($param1);
+    }
+
+    // The variable may be reassigned in a nested block - should still warn about ?object.
+    public function methodConditionallyReassigned(?object $param1, bool $cond): void {
+        if (!is_object($param1)) {
+            $foo = new Fatal5932();
+            if ($cond) {
+                $foo = new NotFatal5932();
+            }
+            $foo->neverReturns();
+        }
+
+        $this->requiresObject($param1);
+    }
+
+    protected function requiresObject(object $param1): void {
+        echo get_class($param1);
+    }
+}
+
+$runner = new Runner5932();
+$runner->method(new stdClass());
+$runner->methodReassigned(new stdClass());
+$runner->methodConditionallyReassigned(new stdClass(), true);

--- a/tests/files/src/5932_never_instance_method_unreachable.php
+++ b/tests/files/src/5932_never_instance_method_unreachable.php
@@ -55,6 +55,45 @@ class Runner5932
         $this->requiresObject($param1);
     }
 
+    // A foreach between rebinds $foo - should still warn about ?object.
+    public function methodForeachRebinds(?object $param1): void {
+        if (!is_object($param1)) {
+            $foo = new Fatal5932();
+            foreach ([new NotFatal5932()] as $foo) {
+                echo get_class($foo);
+            }
+            $foo->neverReturns();
+        }
+
+        $this->requiresObject($param1);
+    }
+
+    // A reference alias between allows rebinding $foo - should still warn about ?object.
+    public function methodReferenceAlias(?object $param1): void {
+        if (!is_object($param1)) {
+            $foo = new Fatal5932();
+            $bar =& $foo;
+            $bar = new NotFatal5932();
+            $foo->neverReturns();
+        }
+
+        $this->requiresObject($param1);
+    }
+
+    // A catch between rebinds $foo - should still warn about ?object.
+    public function methodCatchRebinds(?object $param1): void {
+        if (!is_object($param1)) {
+            $foo = new Fatal5932();
+            try {
+                echo "trying";
+            } catch (Exception $foo) {
+            }
+            $foo->neverReturns();
+        }
+
+        $this->requiresObject($param1);
+    }
+
     protected function requiresObject(object $param1): void {
         echo get_class($param1);
     }
@@ -64,3 +103,6 @@ $runner = new Runner5932();
 $runner->method(new stdClass());
 $runner->methodReassigned(new stdClass());
 $runner->methodConditionallyReassigned(new stdClass(), true);
+$runner->methodForeachRebinds(new stdClass());
+$runner->methodReferenceAlias(new stdClass());
+$runner->methodCatchRebinds(new stdClass());

--- a/tests/plugin_test/expected/217_noreturn_control_flow_extra.php.expected
+++ b/tests/plugin_test/expected/217_noreturn_control_flow_extra.php.expected
@@ -1,3 +1,4 @@
+src/217_noreturn_control_flow_extra.php:10 PhanPluginNeverReturnFunction Function \test8() never returns and has a return type of void, but phpdoc type never could be used instead
 src/217_noreturn_control_flow_extra.php:10 PhanUnreferencedFunction Possibly zero references to function \test8()
 src/217_noreturn_control_flow_extra.php:15 PhanDebugAnnotation @phan-debug-var requested for variable $unknown - it has union type string(real=string)
 src/217_noreturn_control_flow_extra.php:15 PhanPluginNonBoolInLogicalArith Non bool value of type never in logical arithmetic

--- a/tests/plugin_test/src/321_noreturn_method_instance_variable.php
+++ b/tests/plugin_test/src/321_noreturn_method_instance_variable.php
@@ -1,0 +1,18 @@
+<?php
+
+// Regression test for issue #5553: a never-returning instance method called on a
+// local variable with a statically known class should be treated as unreachable.
+class Fatal321 {
+    public function neverReturns(): never {
+        exit();
+    }
+}
+
+class Runner321 {
+    public function neverReturns(): never {
+        $foo = new Fatal321();
+        $foo->neverReturns();
+    }
+}
+
+(new Runner321())->neverReturns();


### PR DESCRIPTION
# Issue #5553: `never` return type not always interpreted correctly on instance methods

https://github.com/phan/phan/issues/5553

## Symptoms

Two false positives, both from the same root cause:

1. `PhanTypeMismatchArgumentNullable` — a branch that calls a never-returning instance
   method on a local variable is not treated as unreachable, so the null type is not
   eliminated after the `if`:

   ```php
   public function method(?object $param1): void {
       if (!is_object($param1)) {
           $foo = new Foo();
           $foo->neverReturns();   // : never — branch should be unreachable after this
       }
       $this->fatalErrorOnNull($param1);  // FP: "?object but takes object"
   }
   ```

2. `PhanPluginNeverReturnMethod` (AlwaysReturnPlugin) — a `never` method whose body ends
   in `$foo = new Foo(); $foo->neverReturns();` is flagged as "may try to return a value".

Making the callee static made both go away, which was the reporter's clue.

## Root cause

`BlockExitStatusChecker::computeStatusOfMethodCall()` only resolved instance calls on
`$this`; for any other receiver variable it hit a `// TODO not yet handled` branch and
returned `STATUS_PROCEED`.

Two things prevented the existing mitigation (UseReturnValuePlugin marks call-node flags
with `STATUS_THROW` when the callee returns `never`) from covering these cases:

- `phan -n` runs no plugins, so the flags are never set (case 1 as reported).
- Plugin `analyzeMethod` hooks (AlwaysReturnPlugin) run in `Analysis::analyzeFunctions`
  (Phan.php:646), *before* `analyzeFile` (Phan.php:691) performs the post-order analysis
  that would set the flags — so case 2 warned even with UseReturnValuePlugin enabled.

## Fix (src/Phan/Analysis/BlockExitStatusChecker.php)

- `computeStatusOfBlock()` now records the statement list and current index in instance
  state (save/restore around the loop for nesting).
- `computeStatusOfMethodCall()` resolves `$var->method()` by scanning *preceding sibling
  statements* for `$var = new ClassName(...)` (`findClassOfPrecedingNewAssignment`).
  Resolution is sound because PHP covariance only permits `never` to override `never`.
- The scan bails conservatively (`statementMayModifyVariable`) if any intervening
  statement might reassign the variable: nested assignments (incl. destructuring and
  `AST_REF` targets), `unset()`, `global`/`static`, inc/dec, dynamic variable names
  (`$$x`), `foreach` value/key bindings, `catch` variable bindings, reference
  assignments (`=&` on either side), and closures with by-reference `use`.
  Closure/arrow-fn bodies are otherwise skipped since their assignments don't escape.
- After matching the `new` assignment, earlier statements of the same list are scanned
  (`statementMayCreateReferenceToVariable`) for anything that could have created an alias
  to the variable beforehand (`=&`, `global`/`static`, by-ref closure `use`), since a
  later write through the alias would rebind it without a direct assignment.
- By-reference modification through function call arguments and aliases created outside
  the current statement list are knowingly not modeled (consistent with the rest of the file).
- `new self()`/`new static()` map to the context class FQSEN; `new parent()` bails.

## Tests

- `tests/files/src/5932_never_instance_method_unreachable.php` (+ .expected): case 1,
  plus must-still-warn variants: direct reassignment, conditional reassignment inside a
  nested `if`, `foreach` rebinding, reference alias (`=&`), and `catch` rebinding.
- `tests/plugin_test/src/321_noreturn_method_instance_variable.php`: case 2, expects no
  output (no `.expected` file needed).
- `tests/plugin_test/expected/217_noreturn_control_flow_extra.php.expected`: gained a
  *new correct* `PhanPluginNeverReturnFunction` suggestion — the fix now sees through
  `$custom = new Checker8(); $custom->customExit();` (`@return no-return`), and that test
  file already had `echo "Done\n"; // unreachable` after it.

## Verification

- Both reduced cases from the issue are clean; static variant still clean.
- Reassignment variants still warn (no new false negatives... i.e. no wrong unreachability).
- `./vendor/bin/phpunit`: 2361 tests OK.
- `__FakeSelfTest` (self-analysis): OK.
- `__FakePluginTest`: identical output after the 217 expected update.

## PR #5554 review follow-up (Codex, both valid P2s — fixed)

1. **foreach rebinding**: `foreach ([...] as $foo)` between the `new` and the call wasn't
   treated as a reassignment (bare `AST_VAR` under `AST_FOREACH` isn't an assignment node).
   Fixed with an `AST_FOREACH` case checking `value`/`key`; also added the analogous
   `AST_CATCH` case (`catch (Exception $foo)`).
2. **Reference alias**: `$bar =& $foo;` between the `new` and the call was missed since only
   the assignment *target* was checked. `AST_ASSIGN_REF` now checks both sides. Additionally
   closed the adjacent hole Codex didn't flag: an alias created *before* the `new` assignment —
   after matching the `new`, earlier same-block statements are scanned with
   `statementMayCreateReferenceToVariable` (`=&` either side, `global`/`static`, by-ref closure use).

Known remaining (documented) limitation: aliases created outside the current statement list
and by-reference modification through function-call arguments are not modeled.

New must-warn variants added to tests/files/src/5932_never_instance_method_unreachable.php
(foreach, reference alias, catch). Full suite re-run: all pass.