### PR TITLE
Fixes #5556

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@ Phan 6.0.8-dev
 Bug fixes:
 - Fix false positives (e.g. `PhanTypeMismatchArgumentNullable`, `PhanPluginNeverReturnMethod`) when a branch calls a `never`-returning instance method on a local variable assigned with `new ClassName()` — the branch is now correctly treated as unreachable ([#5553](https://github.com/phan/phan/issues/5553))
 - Fix crash (`ArgumentCountError: Too few arguments to function Phan\Language\Type::isCallable()`) when `is_callable()` narrowing is applied to a value with an intersection type, e.g. `(callable&T)|null` ([#5555](https://github.com/phan/phan/issues/5555), [#5557](https://github.com/phan/phan/pull/5557))
+- Fix `@var Foo<T>` losing its template parameter on properties that also have a native type declaration (e.g. `/** @var Box<A> */ private Box $box;` was inferred as `Box|Box<A>` instead of `Box<A>`, making method calls on `$box` return `mixed` instead of the template argument) ([#5556](https://github.com/phan/phan/issues/5556))
 
 Jun 22 2026, Phan 6.0.7
 --------------

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -1102,10 +1102,28 @@ class ParseVisitor extends ScopeVisitor
             })) {
                 // Don't convert `/** @var T[] */ public $x = []` to union type `T[]|array`
                 $property->setUnionType($variable_type->withRealTypeSet($real_type_set));
+            } elseif ($variable_type->isEmpty()) {
+                $property->setUnionType($original_property_type->withUnionType($variable_type)->withRealTypeSet($real_type_set));
             } else {
                 // Set the declared type to the doc-comment type and add
-                // |null if the default value is null
-                $property->setUnionType($original_property_type->withUnionType($variable_type)->withRealTypeSet($real_type_set));
+                // |null if the default value is null.
+                // Drop real types that the doc-comment type already describes more precisely,
+                // e.g. `/** @var Box<A> */ private Box $b;` should be `Box<A>`, not `Box|Box<A>`
+                // (which would lose the template parameter when resolving method calls on $b).
+                $merged = $variable_type;
+                foreach ($original_property_type->getTypeSet() as $type) {
+                    $is_redundant = false;
+                    foreach ($variable_type->getTypeSet() as $doc_type) {
+                        if ($doc_type->isSubtypeOf($type, $this->code_base)) {
+                            $is_redundant = true;
+                            break;
+                        }
+                    }
+                    if (!$is_redundant) {
+                        $merged = $merged->withType($type);
+                    }
+                }
+                $property->setUnionType($merged->withRealTypeSet($real_type_set));
             }
         }
 

--- a/src/Phan/Parse/ParseVisitor.php
+++ b/src/Phan/Parse/ParseVisitor.php
@@ -1103,25 +1103,40 @@ class ParseVisitor extends ScopeVisitor
                 // Don't convert `/** @var T[] */ public $x = []` to union type `T[]|array`
                 $property->setUnionType($variable_type->withRealTypeSet($real_type_set));
             } elseif ($variable_type->isEmpty()) {
-                $property->setUnionType($original_property_type->withUnionType($variable_type)->withRealTypeSet($real_type_set));
+                $property->setUnionType($original_property_type->withRealTypeSet($real_type_set));
             } else {
                 // Set the declared type to the doc-comment type and add
                 // |null if the default value is null.
-                // Drop real types that the doc-comment type already describes more precisely,
-                // e.g. `/** @var Box<A> */ private Box $b;` should be `Box<A>`, not `Box|Box<A>`
-                // (which would lose the template parameter when resolving method calls on $b).
+                // Drop declared types (derived from the native type) that the doc-comment type
+                // already describes more precisely, e.g. `/** @var Box<A> */ private Box $b;`
+                // should be `Box<A>`, not `Box|Box<A>` (which would lose the template parameter
+                // when resolving method calls on $b). The real type set is unaffected by this,
+                // it is always overwritten below with $real_type_set.
                 $merged = $variable_type;
+                $doc_type_set = $variable_type->getTypeSet();
+                $doc_contains_nullable = $variable_type->containsNullable();
+                $lost_nullable = false;
                 foreach ($original_property_type->getTypeSet() as $type) {
                     $is_redundant = false;
-                    foreach ($variable_type->getTypeSet() as $doc_type) {
+                    foreach ($doc_type_set as $doc_type) {
                         if ($doc_type->isSubtypeOf($type, $this->code_base)) {
                             $is_redundant = true;
                             break;
                         }
                     }
-                    if (!$is_redundant) {
+                    if ($is_redundant) {
+                        // Don't let dropping this type silently drop nullability that the
+                        // doc-comment type doesn't otherwise account for,
+                        // e.g. `/** @var Box<A> */ private ?Box $b = null;` should stay nullable.
+                        if ($type->isNullable() && !$doc_contains_nullable) {
+                            $lost_nullable = true;
+                        }
+                    } else {
                         $merged = $merged->withType($type);
                     }
+                }
+                if ($lost_nullable && !$merged->containsNullable()) {
+                    $merged = $merged->withIsNullable(true);
                 }
                 $property->setUnionType($merged->withRealTypeSet($real_type_set));
             }

--- a/tests/files/expected/5934_generic_typed_property.php.expected
+++ b/tests/files/expected/5934_generic_typed_property.php.expected
@@ -1,0 +1,16 @@
+%s:40 PhanUnusedVariable Unused definition of variable $a1
+%s:41 PhanDebugAnnotation @phan-debug-var requested for variable $a1 - it has union type \A5934|null
+%s:41 PhanDebugAnnotation @phan-debug-var requested for variable $a2 - it has union type \A5934|null
+%s:41 PhanUnusedVariable Unused definition of variable $a2
+%s:44 PhanUnusedVariable Unused definition of variable $b1
+%s:45 PhanDebugAnnotation @phan-debug-var requested for variable $b1 - it has union type \A5934|\B5934
+%s:45 PhanDebugAnnotation @phan-debug-var requested for variable $b2 - it has union type \A5934|\B5934
+%s:45 PhanUnusedVariable Unused definition of variable $b2
+%s:53 PhanUnusedVariable Unused definition of variable $a1
+%s:54 PhanDebugAnnotation @phan-debug-var requested for variable $a1 - it has union type \A5934|null
+%s:54 PhanDebugAnnotation @phan-debug-var requested for variable $a2 - it has union type \A5934|null
+%s:54 PhanUnusedVariable Unused definition of variable $a2
+%s:66 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type \Traversable<int,\stdClass>|\stdClass[](real=\Traversable)
+%s:66 PhanUnusedVariable Unused definition of variable $x
+%s:78 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type int|string(real=string)
+%s:78 PhanUnusedVariable Unused definition of variable $x

--- a/tests/files/expected/5934_generic_typed_property.php.expected
+++ b/tests/files/expected/5934_generic_typed_property.php.expected
@@ -14,3 +14,5 @@
 %s:66 PhanUnusedVariable Unused definition of variable $x
 %s:78 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type int|string(real=string)
 %s:78 PhanUnusedVariable Unused definition of variable $x
+%s:90 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type ?\Box5934<\A5934>(real=?\Box5934)
+%s:90 PhanUnusedVariable Unused definition of variable $x

--- a/tests/files/src/5934_generic_typed_property.php
+++ b/tests/files/src/5934_generic_typed_property.php
@@ -1,0 +1,81 @@
+<?php
+// Regression test for https://github.com/phan/phan/issues/5556
+// A property with a native type declaration AND a generic @var annotation used to lose the
+// template parameter, e.g. `/** @var Box<A> */ private Box $box;` was inferred as `Box|Box<A>`
+// instead of `Box<A>`, so calling a template-returning method on it resolved to `mixed`
+// instead of `A`. A property with only the phpdoc type (no native type) was unaffected.
+
+/** @template T */
+class Box5934 {
+    /** @var T */
+    public $t;
+
+    /**
+     * @param T $t
+     */
+    public function __construct($t) {
+        $this->t = $t;
+    }
+
+    /**
+     * @template U
+     * @param U $default
+     * @return T|U
+     */
+    public function getOrDefault($default = null) {
+        return $this->t ?: $default;
+    }
+}
+
+class A5934 {}
+class B5934 {}
+
+class Test5934 {
+    /** @var Box5934<A5934> */
+    private Box5934 $box1;
+    /** @var Box5934<A5934> */
+    private $box2;
+
+    public function testWithoutAssignment() {
+        $a1 = $this->box1->getOrDefault();
+        $a2 = $this->box2->getOrDefault();
+        '@phan-debug-var $a1, $a2';
+
+        $b1 = $this->box1->getOrDefault(new B5934());
+        $b2 = $this->box2->getOrDefault(new B5934());
+        '@phan-debug-var $b1, $b2';
+    }
+
+    public function testAfterAssignment() {
+        $this->box1 = new Box5934(new A5934());
+        $this->box2 = new Box5934(new A5934());
+
+        $a1 = $this->box1->getOrDefault();
+        $a2 = $this->box2->getOrDefault();
+        '@phan-debug-var $a1, $a2';
+    }
+}
+
+class Widen5934 {
+    // The @var type is wider than the native type - stdClass[] must survive the merge,
+    // only the redundant bare \Traversable should be dropped.
+    /** @var Traversable<int, stdClass>|stdClass[] */
+    private Traversable $activities;
+
+    public function test() {
+        $x = $this->activities;
+        '@phan-debug-var $x';
+    }
+}
+
+class Incompatible5934 {
+    // The @var type doesn't describe the native type at all - neither is a subtype of the
+    // other, so both must still be kept (pre-existing union behavior, unchanged by this fix).
+    /** @var int */
+    private string $s;
+
+    public function test() {
+        $x = $this->s;
+        '@phan-debug-var $x';
+    }
+}

--- a/tests/files/src/5934_generic_typed_property.php
+++ b/tests/files/src/5934_generic_typed_property.php
@@ -79,3 +79,15 @@ class Incompatible5934 {
         '@phan-debug-var $x';
     }
 }
+
+class Nullable5934 {
+    // The native type is nullable and the @var type is not - dropping the redundant bare
+    // \Box5934 must not silently drop the nullability that only it was carrying.
+    /** @var Box5934<A5934> */
+    private ?Box5934 $box = null;
+
+    public function test() {
+        $x = $this->box;
+        '@phan-debug-var $x';
+    }
+}


### PR DESCRIPTION
# Issue #5556: generic `@var` type erased on natively-typed properties

https://github.com/phan/phan/issues/5556

## Symptoms

A property declared with **both** a native type and a generic `@var` loses its template
parameter, while an otherwise-identical property with **only** the `@var` keeps it:

```php
/** @template T */
class Box {
    /** @var T */ public $t;

    /**
     * @template U
     * @param U $default
     * @return T|U
     */
    function getOrDefault($default = null) { return $this->t ?: $default; }
}

class Test {
    /** @var Box<A> */ private Box $box1;   // native type + phpdoc
    /** @var Box<A> */ private $box2;       // phpdoc only

    function test2() {
        $a1 = $this->box1->getOrDefault();  // mixed|null   <-- wrong
        $a2 = $this->box2->getOrDefault();  // \A|null      <-- correct
    }
}
```

Assigning to the property first (`$this->box1 = new Box(new A)`) masks the bug in that scope,
since the assignment narrows the type — which is why it only shows up on a bare read.

## Root cause

`ParseVisitor::addProperty()` seeds a property's union type from the **native** type, then
**unions** the `@var` type on top of it instead of letting the more specific phpdoc type win
(`src/Phan/Parse/ParseVisitor.php:1108`, prior to this fix):

```php
$property->setUnionType($original_property_type->withUnionType($variable_type)->withRealTypeSet($real_type_set));
```

For `private Box $box1;` (no default value), `$original_property_type` starts as the bare native
type `\Box` (`ParseVisitor.php:910`). Unioning `\Box<\A>` on top produces `\Box|\Box<\A>` instead
of `\Box<\A>`. (`private $box2;` has no native type, so `$original_property_type` is empty and
`UnionType::withUnionType()` short-circuits, returning `\Box<\A>` untouched — which is why the
phpdoc-only property was unaffected.)

That bare `\Box` then wins during template resolution: `UnionType::getTemplateParameterTypeMap()`
reduces over the type set with `array_merge($type_map, $accumulated)`, so the non-generic `\Box`
(visited first) contributes `T => mixed` via the `$omit_missing=false` filler in
`Type::getTemplateParameterTypeMap()`, and `\Box<\A>`'s `T => \A` is discarded.

A "replace instead of union" special case already existed for exactly this situation — just scoped
to generic arrays only (`ParseVisitor.php:1100-1104`, `/** @var T[] */` on a native `array`
property). The fix generalizes that pattern instead of introducing a new mechanism.

## Fix (src/Phan/Parse/ParseVisitor.php)

In the `else` branch (non-generic-array case) of the `@var`/native-type merge: instead of
unconditionally unioning, drop any native type that the `@var` type already describes more
precisely (`$doc_type->isSubtypeOf($type, $this->code_base)`), then union in whatever remains.
An empty `@var` type still falls through to the original union path so it can't wipe the declared
type. The real (native) type set is unchanged either way — only the phpdoc-level type set is
filtered, so real-type-based checks are unaffected.

This preserves genuinely-widening `@var` annotations: `@var Traversable<int,stdClass>|stdClass[]`
on `private Traversable $x` keeps `stdClass[]` (not a subtype of `\Traversable`), and only drops
the now-redundant bare `\Traversable`. An `@var` that's simply incompatible with the native type
(e.g. `@var int` on `private string $s`) still unions as before — unchanged, pre-existing behavior.

## Tests

- `tests/files/src/5934_generic_typed_property.php` (+ `.expected`):
  - the issue's `Box<A>`/native-type-vs-phpdoc-only pair, read without a prior assignment
    (`testWithoutAssignment`) and with one (`testAfterAssignment`, to lock in the already-working
    case)
  - a widening `@var` (`Traversable<int,stdClass>|stdClass[]` on native `Traversable`) asserting
    `stdClass[]` survives
  - an incompatible `@var`/native pair (`@var int` on native `string`) asserting the union is
    still produced
