### PR TITLE
Fixes #5558

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ Bug fixes:
 - Fix false positives (e.g. `PhanTypeMismatchArgumentNullable`, `PhanPluginNeverReturnMethod`) when a branch calls a `never`-returning instance method on a local variable assigned with `new ClassName()` — the branch is now correctly treated as unreachable ([#5553](https://github.com/phan/phan/issues/5553))
 - Fix crash (`ArgumentCountError: Too few arguments to function Phan\Language\Type::isCallable()`) when `is_callable()` narrowing is applied to a value with an intersection type, e.g. `(callable&T)|null` ([#5555](https://github.com/phan/phan/issues/5555), [#5557](https://github.com/phan/phan/pull/5557))
 - Fix `@var Foo<T>` losing its template parameter on properties that also have a native type declaration (e.g. `/** @var Box<A> */ private Box $box;` was inferred as `Box|Box<A>` instead of `Box<A>`, making method calls on `$box` return `mixed` instead of the template argument) ([#5556](https://github.com/phan/phan/issues/5556))
+- Fix static calls (`$class::method()`) not resolving when `$class` is typed `class-string<Foo>` — the return type was inferred as empty and typos in the method name went completely unchecked (no `PhanUndeclaredStaticMethod`), unlike an actual `Foo`-typed variable or `new $class()`, both of which already resolved correctly ([#5558](https://github.com/phan/phan/issues/5558))
 
 Jun 22 2026, Phan 6.0.7
 --------------

--- a/internal/Issue-Types-Caught-by-Phan.md
+++ b/internal/Issue-Types-Caught-by-Phan.md
@@ -4278,6 +4278,8 @@ e.g. [this issue](https://github.com/phan/phan/tree/v6/tests/files/expected/0158
 Call to possibly undeclared method {METHOD} on type {TYPE} ({TYPE} does not declare the method)
 ```
 
+e.g. [this issue](https://github.com/phan/phan/tree/v6/tests/plugin_test/expected/322_class_string_strict_method_checking.php.expected#L4) is emitted when analyzing [this PHP file](https://github.com/phan/phan/tree/v6/tests/plugin_test/src/322_class_string_strict_method_checking.php#L21).
+
 ## PhanPossiblyUndeclaredProperty
 
 ```

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -1139,10 +1139,21 @@ class ContextNode
                     continue;
                 }
                 // The represented type may itself be a union (`class-string<A|B>`), in which case
-                // the string could name any of them at runtime - so *every* represented class must
-                // declare the method, not merely one of them.
-                foreach ($class_union_type->asClassList($this->code_base, $this->context) as $class) {
-                    if (!$class->hasMethodWithName($this->code_base, $method_name, $is_direct)) {
+                // the string could name either at runtime, so *every* alternative must declare the
+                // method. An individual alternative may in turn be an intersection (e.g.
+                // `@template T of I&J`), where the runtime class implements all constituents, so
+                // there *any* constituent supplying the method is enough - matching the
+                // non-class-string handling below. asClassList() flattens an intersection into its
+                // parts, the same way member lookup resolves it.
+                foreach ($class_union_type->getTypeSet() as $represented_type) {
+                    $alternative_has_method = false;
+                    foreach ($represented_type->asPHPDocUnionType()->asClassList($this->code_base, $this->context) as $class) {
+                        if ($class->hasMethodWithName($this->code_base, $method_name, $is_direct)) {
+                            $alternative_has_method = true;
+                            break;
+                        }
+                    }
+                    if (!$alternative_has_method) {
                         return false;
                     }
                 }

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -651,6 +651,13 @@ class ContextNode
                         // Only reached when $expected_type_categories accepts a class name
                         // (not for instance-call syntax like `$class->method()`), since
                         // $class is genuinely a string at runtime.
+                        if ($type->isNullable()) {
+                            // Don't treat this as resolved - $class could be null, in which
+                            // case `$class::method()` fatals. Leave $class_list as-is so the
+                            // existing "possibly non-class type" checks below still apply,
+                            // instead of silently accepting a call that can crash.
+                            continue;
+                        }
                         try {
                             foreach ($type->getClassUnionType()->asClassList($this->code_base, $this->context) as $clazz) {
                                 $class_list[] = $clazz;

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -42,6 +42,7 @@ use Phan\Language\FQSEN\FullyQualifiedGlobalConstantName;
 use Phan\Language\FQSEN\FullyQualifiedMethodName;
 use Phan\Language\FQSEN\FullyQualifiedPropertyName;
 use Phan\Language\Type;
+use Phan\Language\Type\ClassStringType;
 use Phan\Language\Type\LiteralStringType;
 use Phan\Language\Type\MixedType;
 use Phan\Language\Type\NullType;
@@ -642,6 +643,29 @@ class ContextNode
                                     $this->node->lineno ?? $this->context->getLineNumberStart(),
                                     $e->getFQSEN()
                                 );
+                            }
+                        }
+                    } elseif ($type instanceof ClassStringType) {
+                        // Resolve `class-string<Foo>` the same way `Foo` itself would resolve,
+                        // e.g. for `$class::method()` where $class is `class-string<Foo>`.
+                        // Only reached when $expected_type_categories accepts a class name
+                        // (not for instance-call syntax like `$class->method()`), since
+                        // $class is genuinely a string at runtime.
+                        try {
+                            foreach ($type->getClassUnionType()->asClassList($this->code_base, $this->context) as $clazz) {
+                                $class_list[] = $clazz;
+                            }
+                        } catch (CodeBaseException $e) {
+                            if ($warn_if_wrong_type) {
+                                $this->emitIssue(
+                                    Issue::UndeclaredClass,
+                                    $this->node->lineno ?? $this->context->getLineNumberStart(),
+                                    (string)$e->getFQSEN()
+                                );
+                            }
+                        } catch (IssueException $e) {
+                            if ($warn_if_wrong_type) {
+                                Issue::maybeEmitInstance($this->code_base, $this->context, $e->getIssueInstance());
                             }
                         }
                     }

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -581,6 +581,41 @@ class ContextNode
             return [];
         }
 
+        if ($expected_type_categories !== self::CLASS_LIST_ACCEPT_OBJECT) {
+            // Resolve any `class-string<Foo>` in the union the same way `Foo` itself would
+            // resolve, e.g. for `$class::method()` where $class is `class-string<Foo>`. Done
+            // unconditionally (not just when $class_list is otherwise empty), since a
+            // class-string alternative can be the only union member with the member being
+            // looked up, e.g. `A|class-string<B>` where only B declares the method.
+            // Only reached when $expected_type_categories accepts a class name (not for
+            // instance-call syntax like `$class->method()`), since $class is genuinely a
+            // string at runtime - deliberately not special-cased on nullability, to match how
+            // a nullable object receiver (`?Foo $obj; $obj::method();`) is already resolved and
+            // fully validated without a "possibly null" warning.
+            foreach ($union_type->getTypeSet() as $type) {
+                if (!($type instanceof ClassStringType)) {
+                    continue;
+                }
+                try {
+                    foreach ($type->getClassUnionType()->asClassList($this->code_base, $this->context) as $clazz) {
+                        $class_list[] = $clazz;
+                    }
+                } catch (CodeBaseException $e) {
+                    if ($warn_if_wrong_type) {
+                        $this->emitIssue(
+                            Issue::UndeclaredClass,
+                            $this->node->lineno ?? $this->context->getLineNumberStart(),
+                            (string)$e->getFQSEN()
+                        );
+                    }
+                } catch (IssueException $e) {
+                    if ($warn_if_wrong_type) {
+                        Issue::maybeEmitInstance($this->code_base, $this->context, $e->getIssueInstance());
+                    }
+                }
+            }
+        }
+
         if (\count($class_list) === 0) {
             if (!$union_type->hasTypeMatchingCallback(function (Type $type) use ($expected_type_categories): bool {
                 if ($this->node instanceof Node) {
@@ -643,36 +678,6 @@ class ContextNode
                                     $this->node->lineno ?? $this->context->getLineNumberStart(),
                                     $e->getFQSEN()
                                 );
-                            }
-                        }
-                    } elseif ($type instanceof ClassStringType) {
-                        // Resolve `class-string<Foo>` the same way `Foo` itself would resolve,
-                        // e.g. for `$class::method()` where $class is `class-string<Foo>`.
-                        // Only reached when $expected_type_categories accepts a class name
-                        // (not for instance-call syntax like `$class->method()`), since
-                        // $class is genuinely a string at runtime.
-                        if ($type->isNullable()) {
-                            // Don't treat this as resolved - $class could be null, in which
-                            // case `$class::method()` fatals. Leave $class_list as-is so the
-                            // existing "possibly non-class type" checks below still apply,
-                            // instead of silently accepting a call that can crash.
-                            continue;
-                        }
-                        try {
-                            foreach ($type->getClassUnionType()->asClassList($this->code_base, $this->context) as $clazz) {
-                                $class_list[] = $clazz;
-                            }
-                        } catch (CodeBaseException $e) {
-                            if ($warn_if_wrong_type) {
-                                $this->emitIssue(
-                                    Issue::UndeclaredClass,
-                                    $this->node->lineno ?? $this->context->getLineNumberStart(),
-                                    (string)$e->getFQSEN()
-                                );
-                            }
-                        } catch (IssueException $e) {
-                            if ($warn_if_wrong_type) {
-                                Issue::maybeEmitInstance($this->code_base, $this->context, $e->getIssueInstance());
                             }
                         }
                     }
@@ -1010,10 +1015,17 @@ class ContextNode
                 $method = $class->getMethodByName($this->code_base, $method_name);
                 if ($method->hasTemplateType()) {
                     try {
-                        $method = $method->resolveTemplateType(
-                            $this->code_base,
-                            UnionTypeVisitor::unionTypeFromNode($this->code_base, $this->context, $node->children['expr'] ?? $node->children['class'])
-                        );
+                        $object_union_type = UnionTypeVisitor::unionTypeFromNode($this->code_base, $this->context, $node->children['expr'] ?? $node->children['class']);
+                        if ($is_static && isset($node->children['class'])) {
+                            // e.g. for `$class::method()` where $class is `class-string<Box<int>>`,
+                            // resolve template types (e.g. T) against `Box<int>`, not against the
+                            // class-string type itself (not an object with a known FQSEN, so it
+                            // contributes nothing to the template parameter map) - this affects the
+                            // Method object used for argument validation, separately from the
+                            // equivalent expansion in UnionTypeVisitor used for return type inference.
+                            $object_union_type = UnionTypeVisitor::expandClassStringTypes($object_union_type);
+                        }
+                        $method = $method->resolveTemplateType($this->code_base, $object_union_type);
                     } catch (RecursionDepthException) {
                     }
                 }

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -1138,12 +1138,15 @@ class ContextNode
                 if ($class_union_type->isEmpty()) {
                     continue;
                 }
+                // The represented type may itself be a union (`class-string<A|B>`), in which case
+                // the string could name any of them at runtime - so *every* represented class must
+                // declare the method, not merely one of them.
                 foreach ($class_union_type->asClassList($this->code_base, $this->context) as $class) {
-                    if ($class->hasMethodWithName($this->code_base, $method_name, $is_direct)) {
-                        continue 2;
+                    if (!$class->hasMethodWithName($this->code_base, $method_name, $is_direct)) {
+                        return false;
                     }
                 }
-                return false;
+                continue;
             }
             if (!$type->hasObjectWithKnownFQSEN()) {
                 continue;

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -558,6 +558,12 @@ class ContextNode
      * If this exists, emit the given issue type (passing in the class's union type as format arg) instead of the default issue type.
      * The issue type passed in must have exactly one template string parameter (e.g. {CLASS}, {TYPE})
      *
+     * @param bool $expand_class_string
+     * If false, don't resolve `class-string<Foo>` to `Foo`. Callers resolving `$class::class`
+     * (`AST_CLASS_NAME`) must pass false: PHP allows `::class` on an object or a literal class
+     * name, but throws a TypeError for a plain string receiver, so a class-string-typed
+     * variable must not be treated as valid here even though it is for e.g. `$class::method()`.
+     *
      * @return list<Clazz>
      * A list of classes representing the non-native types
      * associated with the given node
@@ -574,14 +580,15 @@ class ContextNode
         bool $ignore_missing_classes = false,
         int $expected_type_categories = self::CLASS_LIST_ACCEPT_ANY,
         ?string $custom_issue_type = null,
-        bool $warn_if_wrong_type = true
+        bool $warn_if_wrong_type = true,
+        bool $expand_class_string = true
     ): array {
         [$union_type, $class_list] = $this->getClassListInner($ignore_missing_classes);
         if ($union_type->isEmpty()) {
             return [];
         }
 
-        if ($expected_type_categories !== self::CLASS_LIST_ACCEPT_OBJECT) {
+        if ($expand_class_string && $expected_type_categories !== self::CLASS_LIST_ACCEPT_OBJECT) {
             // Resolve any `class-string<Foo>` in the union the same way `Foo` itself would
             // resolve, e.g. for `$class::method()` where $class is `class-string<Foo>`. Done
             // unconditionally (not just when $class_list is otherwise empty), since a
@@ -597,7 +604,7 @@ class ContextNode
                     continue;
                 }
                 try {
-                    foreach ($type->getClassUnionType()->asClassList($this->code_base, $this->context) as $clazz) {
+                    foreach ($type->getClassUnionTypeResolvingBounds()->asClassList($this->code_base, $this->context) as $clazz) {
                         $class_list[] = $clazz;
                     }
                 } catch (CodeBaseException $e) {

--- a/src/Phan/AST/ContextNode.php
+++ b/src/Phan/AST/ContextNode.php
@@ -1129,6 +1129,22 @@ class ContextNode
         }
         // Typically, this should only return false for intersection types that include a mix of types that have and don't have the method.
         foreach ($union_type->getTypeSet() as $type) {
+            if ($type instanceof ClassStringType) {
+                // `class-string<Foo>` isn't itself an object with a known FQSEN, but getClassList()
+                // resolves it to Foo for static calls, so check the class it represents here too -
+                // otherwise a union such as `A|class-string<B>` would silently suppress this
+                // warning when only A declares the method.
+                $class_union_type = $type->getClassUnionTypeResolvingBounds();
+                if ($class_union_type->isEmpty()) {
+                    continue;
+                }
+                foreach ($class_union_type->asClassList($this->code_base, $this->context) as $class) {
+                    if ($class->hasMethodWithName($this->code_base, $method_name, $is_direct)) {
+                        continue 2;
+                    }
+                }
+                return false;
+            }
             if (!$type->hasObjectWithKnownFQSEN()) {
                 continue;
             }

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -3678,7 +3678,11 @@ class UnionTypeVisitor extends AnalysisVisitor
                         } else {
                             continue;
                         }
-                        foreach ($reduces_to_union_type->getTypeSet() as $reduced_type) {
+                        // getUniqueFlattenedTypeSet() splits an intersection bound (e.g.
+                        // `@template T of I&J`) into its constituents, matching how member lookup
+                        // flattens it - an IntersectionType itself has no single FQSEN, so it must
+                        // be associated with each part it can be resolved through.
+                        foreach ($reduces_to_union_type->getUniqueFlattenedTypeSet() as $reduced_type) {
                             if (!$reduced_type->isObjectWithKnownFQSEN()) {
                                 continue;
                             }

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -3625,7 +3625,7 @@ class UnionTypeVisitor extends AnalysisVisitor
                 return UnionType::empty();
             }
             $combined_union_type = null;
-            foreach ($this->classListFromNode($class_node) as $class) {
+            foreach ($this->classListFromNode($class_node, $static_class_node !== null) as $class) {
                 if (!$class->hasMethodWithName($this->code_base, $method_name, true)) {
                     continue;
                 }
@@ -4211,9 +4211,9 @@ class UnionTypeVisitor extends AnalysisVisitor
     /**
      * @return \Generator|Clazz[]
      */
-    public static function classListFromNodeAndContext(CodeBase $code_base, Context $context, Node $node): \Generator|array
+    public static function classListFromNodeAndContext(CodeBase $code_base, Context $context, Node $node, bool $expand_class_string_type = false): \Generator|array
     {
-        return (new UnionTypeVisitor($code_base, $context, true))->classListFromNode($node);
+        return (new UnionTypeVisitor($code_base, $context, true))->classListFromNode($node, $expand_class_string_type);
     }
 
     /**
@@ -4225,7 +4225,7 @@ class UnionTypeVisitor extends AnalysisVisitor
      * An exception is thrown if we can't find a class for
      * the given type
      */
-    private function classListFromNode(Node $node): \Generator
+    private function classListFromNode(Node $node, bool $expand_class_string_type = false): \Generator
     {
         // Get the types associated with the node
         $union_type = self::unionTypeFromNode(
@@ -4236,21 +4236,28 @@ class UnionTypeVisitor extends AnalysisVisitor
         )->withStaticResolvedInContext($this->context);
 
         // Expand `class-string<Foo>` into the classes it represents, so that e.g.
-        // `$class::method()` resolves the same way `$obj::method()` would for an
+        // `$class::method()` resolves the same way `$obj::method()` would for a
         // Foo-typed $obj (nonNativeTypes() below would otherwise drop it, since
         // class-string is itself a native/string type).
-        $expanded_union_type = UnionType::empty();
-        foreach ($union_type->getTypeSet() as $type) {
-            if ($type instanceof ClassStringType) {
-                $expanded_union_type = $expanded_union_type->withUnionType($type->getClassUnionType());
-            } else {
-                $expanded_union_type = $expanded_union_type->withType($type);
+        // Only do this when the caller tells us $node is used in class-name syntax
+        // (e.g. the class part of a static call) - $class is genuinely a string at
+        // runtime, so e.g. `$class->method()` (instance-call syntax) must not resolve
+        // this as if it were an instance of Foo.
+        if ($expand_class_string_type && $union_type->hasTypeMatchingCallback(static fn(Type $type): bool => $type instanceof ClassStringType)) {
+            $expanded_union_type = UnionType::empty();
+            foreach ($union_type->getTypeSet() as $type) {
+                if ($type instanceof ClassStringType) {
+                    $expanded_union_type = $expanded_union_type->withUnionType($type->getClassUnionType());
+                } else {
+                    $expanded_union_type = $expanded_union_type->withType($type);
+                }
             }
+            $union_type = $expanded_union_type;
         }
 
         // Iterate over each viable class type to see if any
         // have the constant we're looking for
-        foreach ($expanded_union_type->nonNativeTypes()->getUniqueFlattenedTypeSet() as $class_type) {
+        foreach ($union_type->nonNativeTypes()->getUniqueFlattenedTypeSet() as $class_type) {
             if (!$class_type->isObjectWithKnownFQSEN()) {
                 continue;
             }

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -3625,6 +3625,28 @@ class UnionTypeVisitor extends AnalysisVisitor
                 return UnionType::empty();
             }
             $combined_union_type = null;
+            // If $class_node is `class-string<T>` for an unresolved (bounded) template T,
+            // classListFromNode() below resolves it through T's bound for member lookup - but
+            // a `static`/`self` return type must resolve back to T itself, not to the bound,
+            // to preserve genericity for a template-aware caller (e.g. `@return T`).
+            $represented_template_type = null;
+            if ($static_class_node !== null) {
+                foreach (UnionTypeVisitor::unionTypeFromNode(
+                    $this->code_base,
+                    $this->context,
+                    $class_node,
+                    $this->should_catch_issue_exception
+                )->getTypeSet() as $type) {
+                    if (!($type instanceof ClassStringType)) {
+                        continue;
+                    }
+                    foreach ($type->getClassUnionType()->getTypeSet() as $inner_type) {
+                        if ($inner_type instanceof TemplateType) {
+                            $represented_template_type = $inner_type;
+                        }
+                    }
+                }
+            }
             foreach ($this->classListFromNode($class_node, $static_class_node !== null) as $class) {
                 if (!$class->hasMethodWithName($this->code_base, $method_name, true)) {
                     continue;
@@ -3728,6 +3750,17 @@ class UnionTypeVisitor extends AnalysisVisitor
                         \strcasecmp($static_class_node->children['name'], 'parent') === 0) {
                         // If parent::foo() returns `static`, then use the current class instead of the parent class
                         $union_type = $union_type->withStaticResolvedInContext($this->context);
+                    } elseif ($represented_template_type !== null && $union_type->hasTypeMatchingCallback(
+                        function (Type $type): bool {
+                            return $type->hasStaticOrSelfTypesRecursive($this->code_base);
+                        }
+                    )) {
+                        // Remove the base class type if present (Method::getUnionType() may add it
+                        // alongside the abstract `static` marker) before substituting - otherwise
+                        // the un-substituted base class type and the substituted template type
+                        // would combine into a spurious union, e.g. `T|Foo` instead of just `T`.
+                        $union_type = $union_type->withoutType($class->getFQSEN()->asType())
+                            ->withStaticResolvedTo($represented_template_type);
                     } else {
                         $union_type = $union_type->withStaticResolvedInContext($class->getInternalContext());
                     }

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -4230,7 +4230,7 @@ class UnionTypeVisitor extends AnalysisVisitor
      * only doing this in contexts that accept a class name (not instance-call syntax), since
      * $class is genuinely a string at runtime.
      */
-    private static function expandClassStringTypes(UnionType $union_type): UnionType
+    public static function expandClassStringTypes(UnionType $union_type): UnionType
     {
         if (!$union_type->hasTypeMatchingCallback(static fn(Type $type): bool => $type instanceof ClassStringType)) {
             return $union_type;

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -3827,9 +3827,23 @@ class UnionTypeVisitor extends AnalysisVisitor
                         // `Base::make(): self` called through `class-string<Child>` stays `Base`.
                         // Several distinct templates may share this bound, in which case the call
                         // could return any of them, so union the substitution for each.
-                        $base_union_type = $method->hasDependentReturnType()
-                            ? $union_type->withoutType($class->getFQSEN()->asType())
-                            : $method->getUnionTypeWithUnmodifiedStatic();
+                        if ($method->hasDependentReturnType()) {
+                            // The dependent result must be kept - it carries the
+                            // argument-derived template substitutions - but such closures
+                            // typically derive it from Method::getUnionType(), so it has the same
+                            // expansion appended. Subtract exactly the types that expansion added
+                            // (comparing against the unmodified return type), which also covers
+                            // nested forms like `static[]` that a bare-class-type removal misses.
+                            $base_union_type = $union_type;
+                            $unmodified_union_type = $method->getUnionTypeWithUnmodifiedStatic();
+                            foreach ($method->getUnionType()->getTypeSet() as $expanded_type) {
+                                if (!$unmodified_union_type->hasType($expanded_type)) {
+                                    $base_union_type = $base_union_type->withoutType($expanded_type);
+                                }
+                            }
+                        } else {
+                            $base_union_type = $method->getUnionTypeWithUnmodifiedStatic();
+                        }
                         $self_context = $class->getInternalContext();
                         if ($method->hasDefiningFQSEN()) {
                             $defining_class_fqsen = $method->getDefiningClassFQSEN();

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -3627,9 +3627,12 @@ class UnionTypeVisitor extends AnalysisVisitor
             $combined_union_type = null;
             // If $class_node is `class-string<T>` for an unresolved (bounded) template T,
             // classListFromNode() below resolves it through T's bound for member lookup - but
-            // a `static`/`self` return type must resolve back to T itself, not to the bound,
-            // to preserve genericity for a template-aware caller (e.g. `@return T`).
-            $represented_template_type = null;
+            // a `static` return type must resolve back to T itself, not to the bound, to
+            // preserve genericity for a template-aware caller (e.g. `@return T`).
+            // Keyed by the FQSEN of the bound each template resolves to, so that a union such as
+            // `class-string<T>|class-string<U>` maps each resolved class back to its own template
+            // rather than applying whichever was seen last to all of them.
+            $represented_template_types = [];
             if ($static_class_node !== null) {
                 foreach (UnionTypeVisitor::unionTypeFromNode(
                     $this->code_base,
@@ -3641,8 +3644,17 @@ class UnionTypeVisitor extends AnalysisVisitor
                         continue;
                     }
                     foreach ($type->getClassUnionType()->getTypeSet() as $inner_type) {
-                        if ($inner_type instanceof TemplateType) {
-                            $represented_template_type = $inner_type;
+                        if (!($inner_type instanceof TemplateType)) {
+                            continue;
+                        }
+                        $bound_union_type = $inner_type->getBoundUnionType();
+                        if (!$bound_union_type) {
+                            continue;
+                        }
+                        foreach ($bound_union_type->getTypeSet() as $bound_type) {
+                            if ($bound_type->isObjectWithKnownFQSEN()) {
+                                $represented_template_types[(string)$bound_type->asFQSEN()] = $inner_type;
+                            }
                         }
                     }
                 }
@@ -3750,17 +3762,22 @@ class UnionTypeVisitor extends AnalysisVisitor
                         \strcasecmp($static_class_node->children['name'], 'parent') === 0) {
                         // If parent::foo() returns `static`, then use the current class instead of the parent class
                         $union_type = $union_type->withStaticResolvedInContext($this->context);
-                    } elseif ($represented_template_type !== null && $union_type->hasTypeMatchingCallback(
-                        function (Type $type): bool {
-                            return $type->hasStaticOrSelfTypesRecursive($this->code_base);
-                        }
-                    )) {
+                    } elseif (($represented_template_type = $represented_template_types[(string)$class->getFQSEN()] ?? null)
+                        && $union_type->hasTypeMatchingCallback(
+                            function (Type $type): bool {
+                                return $type->hasStaticOrSelfTypesRecursive($this->code_base);
+                            }
+                        )
+                    ) {
                         // Remove the base class type if present (Method::getUnionType() may add it
                         // alongside the abstract `static` marker) before substituting - otherwise
                         // the un-substituted base class type and the substituted template type
                         // would combine into a spurious union, e.g. `T|Foo` instead of just `T`.
+                        // Only `static` maps to the template; a `self` return type always means
+                        // the declaring class, so resolve any remaining `self` normally.
                         $union_type = $union_type->withoutType($class->getFQSEN()->asType())
-                            ->withStaticResolvedTo($represented_template_type);
+                            ->withStaticResolvedTo($represented_template_type)
+                            ->withSelfResolvedInContext($class->getInternalContext());
                     } else {
                         $union_type = $union_type->withStaticResolvedInContext($class->getInternalContext());
                     }

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -3653,9 +3653,17 @@ class UnionTypeVisitor extends AnalysisVisitor
                     $this->should_catch_issue_exception
                 )->getTypeSet() as $type) {
                     if (!($type instanceof ClassStringType)) {
-                        if ($type->isObjectWithKnownFQSEN()) {
+                        // getUniqueFlattenedTypeSet() splits an intersection alternative (e.g.
+                        // `(Foo&Marker)|class-string<T>`) into its constituents - an
+                        // IntersectionType has no single FQSEN of its own, but classListFromNode()
+                        // flattens it and resolves the same classes, so each part counts as
+                        // concretely referenced.
+                        foreach ($type->asPHPDocUnionType()->getUniqueFlattenedTypeSet() as $concrete_type) {
+                            if (!$concrete_type->isObjectWithKnownFQSEN()) {
+                                continue;
+                            }
                             try {
-                                $concretely_referenced_fqsens[(string)$type->asFQSEN()] = true;
+                                $concretely_referenced_fqsens[(string)$concrete_type->asFQSEN()] = true;
                             } catch (FQSENException) {
                                 // A malformed class name such as `('??')::foo()` - it can't
                                 // correspond to any resolved class, so nothing to record.

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -3834,12 +3834,34 @@ class UnionTypeVisitor extends AnalysisVisitor
                             // expansion appended. Subtract exactly the types that expansion added
                             // (comparing against the unmodified return type), which also covers
                             // nested forms like `static[]` that a bare-class-type removal misses.
+                            //
+                            // The two origins are indistinguishable by equality alone: for
+                            // `@return static|U`, if an argument makes U resolve to the declaring
+                            // class, the genuine result type coincides with the expansion type and
+                            // must not be dropped. Keep any type that an argument could have
+                            // produced - erring toward a wider (sound) type rather than silently
+                            // discarding a real one.
                             $base_union_type = $union_type;
                             $unmodified_union_type = $method->getUnionTypeWithUnmodifiedStatic();
+                            $argument_union_types = [];
+                            foreach ($node->children['args']->children ?? [] as $argument_node) {
+                                $argument_union_types[] = UnionTypeVisitor::unionTypeFromNode(
+                                    $this->code_base,
+                                    $this->context,
+                                    $argument_node,
+                                    $this->should_catch_issue_exception
+                                );
+                            }
                             foreach ($method->getUnionType()->getTypeSet() as $expanded_type) {
-                                if (!$unmodified_union_type->hasType($expanded_type)) {
-                                    $base_union_type = $base_union_type->withoutType($expanded_type);
+                                if ($unmodified_union_type->hasType($expanded_type)) {
+                                    continue;
                                 }
+                                foreach ($argument_union_types as $argument_union_type) {
+                                    if ($argument_union_type->hasType($expanded_type)) {
+                                        continue 2;
+                                    }
+                                }
+                                $base_union_type = $base_union_type->withoutType($expanded_type);
                             }
                         } else {
                             $base_union_type = $method->getUnionTypeWithUnmodifiedStatic();

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -3814,18 +3814,26 @@ class UnionTypeVisitor extends AnalysisVisitor
                         // unmodified return type, which keeps `static` abstract and has no
                         // expansion to strip. Fall back to removing just the bare class type when
                         // the return type came from a dependent-return-type plugin instead.
-                        // Only `static` maps to the template; a `self` return type always means
-                        // the declaring class, so resolve any remaining `self` normally.
+                        // Only `static` maps to the template; a `self` return type always means the
+                        // class that *declared* the method - not the receiver - so an inherited
+                        // `Base::make(): self` called through `class-string<Child>` stays `Base`.
                         // Several distinct templates may share this bound, in which case the call
                         // could return any of them, so union the substitution for each.
                         $base_union_type = $method->hasDependentReturnType()
                             ? $union_type->withoutType($class->getFQSEN()->asType())
                             : $method->getUnionTypeWithUnmodifiedStatic();
+                        $self_context = $class->getInternalContext();
+                        if ($method->hasDefiningFQSEN()) {
+                            $defining_class_fqsen = $method->getDefiningClassFQSEN();
+                            if ($this->code_base->hasClassWithFQSEN($defining_class_fqsen)) {
+                                $self_context = $this->code_base->getClassByFQSEN($defining_class_fqsen)->getInternalContext();
+                            }
+                        }
                         $substituted_union_types = [];
                         foreach ($class_template_types as $class_template_type) {
                             $substituted_union_types[] = $base_union_type
                                 ->withStaticResolvedTo($class_template_type)
-                                ->withSelfResolvedInContext($class->getInternalContext());
+                                ->withSelfResolvedInContext($self_context);
                         }
                         // Note: UnionType::merge() is used instead of folding with withUnionType()
                         // because the latter erases the real type set when starting from an empty

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -3631,7 +3631,10 @@ class UnionTypeVisitor extends AnalysisVisitor
             // preserve genericity for a template-aware caller (e.g. `@return T`).
             // Keyed by the FQSEN of the bound each template resolves to, so that a union such as
             // `class-string<T>|class-string<U>` maps each resolved class back to its own template
-            // rather than applying whichever was seen last to all of them.
+            // rather than applying whichever was seen last to all of them. Each entry is a *list*,
+            // since distinct templates may share a bound (e.g. `@template T of Foo` and
+            // `@template U of Foo` both key on `\Foo` and must both be preserved).
+            // @var array<string,non-empty-list<TemplateType>> $represented_template_types
             $represented_template_types = [];
             if ($static_class_node !== null) {
                 foreach (UnionTypeVisitor::unionTypeFromNode(
@@ -3652,8 +3655,12 @@ class UnionTypeVisitor extends AnalysisVisitor
                             continue;
                         }
                         foreach ($bound_union_type->getTypeSet() as $bound_type) {
-                            if ($bound_type->isObjectWithKnownFQSEN()) {
-                                $represented_template_types[(string)$bound_type->asFQSEN()] = $inner_type;
+                            if (!$bound_type->isObjectWithKnownFQSEN()) {
+                                continue;
+                            }
+                            $bound_fqsen_string = (string)$bound_type->asFQSEN();
+                            if (!\in_array($inner_type, $represented_template_types[$bound_fqsen_string] ?? [], true)) {
+                                $represented_template_types[$bound_fqsen_string][] = $inner_type;
                             }
                         }
                     }
@@ -3762,7 +3769,7 @@ class UnionTypeVisitor extends AnalysisVisitor
                         \strcasecmp($static_class_node->children['name'], 'parent') === 0) {
                         // If parent::foo() returns `static`, then use the current class instead of the parent class
                         $union_type = $union_type->withStaticResolvedInContext($this->context);
-                    } elseif (($represented_template_type = $represented_template_types[(string)$class->getFQSEN()] ?? null)
+                    } elseif (($class_template_types = $represented_template_types[(string)$class->getFQSEN()] ?? null)
                         && $union_type->hasTypeMatchingCallback(
                             function (Type $type): bool {
                                 return $type->hasStaticOrSelfTypesRecursive($this->code_base);
@@ -3775,9 +3782,18 @@ class UnionTypeVisitor extends AnalysisVisitor
                         // would combine into a spurious union, e.g. `T|Foo` instead of just `T`.
                         // Only `static` maps to the template; a `self` return type always means
                         // the declaring class, so resolve any remaining `self` normally.
-                        $union_type = $union_type->withoutType($class->getFQSEN()->asType())
-                            ->withStaticResolvedTo($represented_template_type)
-                            ->withSelfResolvedInContext($class->getInternalContext());
+                        // Several distinct templates may share this bound, in which case the call
+                        // could return any of them, so union the substitution for each.
+                        $base_union_type = $union_type->withoutType($class->getFQSEN()->asType());
+                        $union_type = null;
+                        foreach ($class_template_types as $class_template_type) {
+                            $substituted_union_type = $base_union_type
+                                ->withStaticResolvedTo($class_template_type)
+                                ->withSelfResolvedInContext($class->getInternalContext());
+                            $union_type = $union_type
+                                ? $union_type->withUnionType($substituted_union_type)
+                                : $substituted_union_type;
+                        }
                     } else {
                         $union_type = $union_type->withStaticResolvedInContext($class->getInternalContext());
                     }

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -4235,9 +4235,22 @@ class UnionTypeVisitor extends AnalysisVisitor
             $this->should_catch_issue_exception
         )->withStaticResolvedInContext($this->context);
 
+        // Expand `class-string<Foo>` into the classes it represents, so that e.g.
+        // `$class::method()` resolves the same way `$obj::method()` would for an
+        // Foo-typed $obj (nonNativeTypes() below would otherwise drop it, since
+        // class-string is itself a native/string type).
+        $expanded_union_type = UnionType::empty();
+        foreach ($union_type->getTypeSet() as $type) {
+            if ($type instanceof ClassStringType) {
+                $expanded_union_type = $expanded_union_type->withUnionType($type->getClassUnionType());
+            } else {
+                $expanded_union_type = $expanded_union_type->withType($type);
+            }
+        }
+
         // Iterate over each viable class type to see if any
         // have the constant we're looking for
-        foreach ($union_type->nonNativeTypes()->getUniqueFlattenedTypeSet() as $class_type) {
+        foreach ($expanded_union_type->nonNativeTypes()->getUniqueFlattenedTypeSet() as $class_type) {
             if (!$class_type->isObjectWithKnownFQSEN()) {
                 continue;
             }

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -3785,15 +3785,17 @@ class UnionTypeVisitor extends AnalysisVisitor
                         // Several distinct templates may share this bound, in which case the call
                         // could return any of them, so union the substitution for each.
                         $base_union_type = $union_type->withoutType($class->getFQSEN()->asType());
-                        $union_type = null;
+                        $substituted_union_types = [];
                         foreach ($class_template_types as $class_template_type) {
-                            $substituted_union_type = $base_union_type
+                            $substituted_union_types[] = $base_union_type
                                 ->withStaticResolvedTo($class_template_type)
                                 ->withSelfResolvedInContext($class->getInternalContext());
-                            $union_type = $union_type
-                                ? $union_type->withUnionType($substituted_union_type)
-                                : $substituted_union_type;
                         }
+                        // Note: UnionType::merge() is used instead of folding with withUnionType()
+                        // because the latter erases the real type set when starting from an empty
+                        // union type, and merge() short-circuits correctly for the single-template
+                        // case (which is by far the most common).
+                        $union_type = UnionType::merge($substituted_union_types);
                     } else {
                         $union_type = $union_type->withStaticResolvedInContext($class->getInternalContext());
                     }

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -3625,16 +3625,20 @@ class UnionTypeVisitor extends AnalysisVisitor
                 return UnionType::empty();
             }
             $combined_union_type = null;
-            // If $class_node is `class-string<T>` for an unresolved (bounded) template T,
-            // classListFromNode() below resolves it through T's bound for member lookup - but
-            // a `static` return type must resolve back to T itself, not to the bound, to
-            // preserve genericity for a template-aware caller (e.g. `@return T`).
-            // Keyed by the FQSEN of the bound each template resolves to, so that a union such as
-            // `class-string<T>|class-string<U>` maps each resolved class back to its own template
-            // rather than applying whichever was seen last to all of them. Each entry is a *list*,
-            // since distinct templates may share a bound (e.g. `@template T of Foo` and
-            // `@template U of Foo` both key on `\Foo` and must both be preserved).
-            // @var array<string,non-empty-list<TemplateType>> $represented_template_types
+            // If $class_node is a class-string whose represented type carries information that
+            // classListFromNode() discards when reducing it to a Clazz for member lookup, a
+            // `static` return type must resolve back to that richer type rather than to the
+            // resolved class. Two cases:
+            //  - `class-string<T>` for an unresolved (bounded) template T - resolve to T, not to
+            //    T's bound, to preserve genericity for a template-aware caller (e.g. `@return T`).
+            //  - `class-string<Box<int>>` - resolve to `Box<int>`, not to bare `Box`, to preserve
+            //    the generic arguments.
+            // Keyed by the FQSEN the type reduces to, so that a union such as
+            // `class-string<T>|class-string<U>` maps each resolved class back to its own
+            // represented type rather than applying whichever was seen last to all of them. Each
+            // entry is a *list*, since distinct represented types may reduce to the same class
+            // (e.g. `@template T of Foo` and `@template U of Foo` both key on `\Foo`).
+            // @var array<string,non-empty-list<Type>> $represented_template_types
             $represented_template_types = [];
             if ($static_class_node !== null) {
                 // FQSENs also reachable through a *non*-class-string alternative of the receiver
@@ -3660,20 +3664,27 @@ class UnionTypeVisitor extends AnalysisVisitor
                         continue;
                     }
                     foreach ($type->getClassUnionType()->getTypeSet() as $inner_type) {
-                        if (!($inner_type instanceof TemplateType)) {
-                            continue;
-                        }
-                        $bound_union_type = $inner_type->getBoundUnionType();
-                        if (!$bound_union_type) {
-                            continue;
-                        }
-                        foreach ($bound_union_type->getTypeSet() as $bound_type) {
-                            if (!$bound_type->isObjectWithKnownFQSEN()) {
+                        if ($inner_type instanceof TemplateType) {
+                            // A bounded template reduces to (each type in) its bound.
+                            $reduces_to_union_type = $inner_type->getBoundUnionType();
+                            if (!$reduces_to_union_type) {
                                 continue;
                             }
-                            $bound_fqsen_string = (string)$bound_type->asFQSEN();
-                            if (!\in_array($inner_type, $represented_template_types[$bound_fqsen_string] ?? [], true)) {
-                                $represented_template_types[$bound_fqsen_string][] = $inner_type;
+                        } elseif ($inner_type->getTemplateParameterTypeList() && $inner_type->isObjectWithKnownFQSEN()) {
+                            // A generic type such as `Box<int>` reduces to bare `Box`. Types
+                            // without generic arguments are skipped: they reduce to themselves,
+                            // so the normal resolution below already produces the right answer.
+                            $reduces_to_union_type = $inner_type->asPHPDocUnionType();
+                        } else {
+                            continue;
+                        }
+                        foreach ($reduces_to_union_type->getTypeSet() as $reduced_type) {
+                            if (!$reduced_type->isObjectWithKnownFQSEN()) {
+                                continue;
+                            }
+                            $reduced_fqsen_string = (string)$reduced_type->asFQSEN();
+                            if (!\in_array($inner_type, $represented_template_types[$reduced_fqsen_string] ?? [], true)) {
+                                $represented_template_types[$reduced_fqsen_string][] = $inner_type;
                             }
                         }
                     }

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -3807,15 +3807,20 @@ class UnionTypeVisitor extends AnalysisVisitor
                             }
                         )
                     ) {
-                        // Remove the base class type if present (Method::getUnionType() may add it
-                        // alongside the abstract `static` marker) before substituting - otherwise
-                        // the un-substituted base class type and the substituted template type
-                        // would combine into a spurious union, e.g. `T|Foo` instead of just `T`.
+                        // Method::getUnionType() unions the declared return type with its own
+                        // declaring-class resolution of `static` - `static` becomes `static|Foo`,
+                        // and `static[]` becomes `static[]|Foo[]`. Substituting on that would
+                        // leave the resolved counterpart behind (`T|Foo`, `T[]|Foo[]`), so use the
+                        // unmodified return type, which keeps `static` abstract and has no
+                        // expansion to strip. Fall back to removing just the bare class type when
+                        // the return type came from a dependent-return-type plugin instead.
                         // Only `static` maps to the template; a `self` return type always means
                         // the declaring class, so resolve any remaining `self` normally.
                         // Several distinct templates may share this bound, in which case the call
                         // could return any of them, so union the substitution for each.
-                        $base_union_type = $union_type->withoutType($class->getFQSEN()->asType());
+                        $base_union_type = $method->hasDependentReturnType()
+                            ? $union_type->withoutType($class->getFQSEN()->asType())
+                            : $method->getUnionTypeWithUnmodifiedStatic();
                         $substituted_union_types = [];
                         foreach ($class_template_types as $class_template_type) {
                             $substituted_union_types[] = $base_union_type

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -3069,7 +3069,7 @@ class UnionTypeVisitor extends AnalysisVisitor
                 $this->code_base,
                 $this->context,
                 $class_node
-            ))->getClassList(false, ContextNode::CLASS_LIST_ACCEPT_OBJECT_OR_CLASS_NAME);
+            ))->getClassList(false, ContextNode::CLASS_LIST_ACCEPT_OBJECT_OR_CLASS_NAME, null, true, false);
         } catch (IssueException $exception) {
             if ($this->should_catch_issue_exception) {
                 Issue::maybeEmitInstance($this->code_base, $this->context, $exception->getIssueInstance());
@@ -4238,7 +4238,7 @@ class UnionTypeVisitor extends AnalysisVisitor
         $expanded_union_type = UnionType::empty();
         foreach ($union_type->getTypeSet() as $type) {
             if ($type instanceof ClassStringType) {
-                $expanded_union_type = $expanded_union_type->withUnionType($type->getClassUnionType());
+                $expanded_union_type = $expanded_union_type->withUnionType($type->getClassUnionTypeResolvingBounds());
             } else {
                 $expanded_union_type = $expanded_union_type->withType($type);
             }

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -3639,14 +3639,22 @@ class UnionTypeVisitor extends AnalysisVisitor
 
                     if ($method->hasTemplateType()) {
                         try {
+                            $object_union_type = UnionTypeVisitor::unionTypeFromNode(
+                                $this->code_base,
+                                $this->context,
+                                $class_node,
+                                $this->should_catch_issue_exception
+                            );
+                            if ($static_class_node !== null) {
+                                // e.g. for `$class::method()` where $class is `class-string<Box<int>>`,
+                                // resolve template types (e.g. T) against `Box<int>`, not against
+                                // the class-string type itself (which isn't an object with a known
+                                // FQSEN, and so contributes nothing to the template parameter map).
+                                $object_union_type = self::expandClassStringTypes($object_union_type);
+                            }
                             $method = $method->resolveTemplateType(
                                 $this->code_base,
-                                UnionTypeVisitor::unionTypeFromNode(
-                                    $this->code_base,
-                                    $this->context,
-                                    $class_node,
-                                    $this->should_catch_issue_exception
-                                )
+                                $object_union_type
                             );
                         } catch (RecursionDepthException) {
                         }
@@ -4217,6 +4225,28 @@ class UnionTypeVisitor extends AnalysisVisitor
     }
 
     /**
+     * Expand any `class-string<Foo>` in $union_type into `Foo`, e.g. for the class part of a
+     * static call `$class::method()` used in class-name syntax. Callers are responsible for
+     * only doing this in contexts that accept a class name (not instance-call syntax), since
+     * $class is genuinely a string at runtime.
+     */
+    private static function expandClassStringTypes(UnionType $union_type): UnionType
+    {
+        if (!$union_type->hasTypeMatchingCallback(static fn(Type $type): bool => $type instanceof ClassStringType)) {
+            return $union_type;
+        }
+        $expanded_union_type = UnionType::empty();
+        foreach ($union_type->getTypeSet() as $type) {
+            if ($type instanceof ClassStringType) {
+                $expanded_union_type = $expanded_union_type->withUnionType($type->getClassUnionType());
+            } else {
+                $expanded_union_type = $expanded_union_type->withType($type);
+            }
+        }
+        return $expanded_union_type;
+    }
+
+    /**
      * @phan-return \Generator<Clazz>
      * @return \Generator|Clazz[]
      * A list of classes associated with the given node
@@ -4235,24 +4265,14 @@ class UnionTypeVisitor extends AnalysisVisitor
             $this->should_catch_issue_exception
         )->withStaticResolvedInContext($this->context);
 
-        // Expand `class-string<Foo>` into the classes it represents, so that e.g.
-        // `$class::method()` resolves the same way `$obj::method()` would for a
-        // Foo-typed $obj (nonNativeTypes() below would otherwise drop it, since
-        // class-string is itself a native/string type).
-        // Only do this when the caller tells us $node is used in class-name syntax
-        // (e.g. the class part of a static call) - $class is genuinely a string at
-        // runtime, so e.g. `$class->method()` (instance-call syntax) must not resolve
-        // this as if it were an instance of Foo.
-        if ($expand_class_string_type && $union_type->hasTypeMatchingCallback(static fn(Type $type): bool => $type instanceof ClassStringType)) {
-            $expanded_union_type = UnionType::empty();
-            foreach ($union_type->getTypeSet() as $type) {
-                if ($type instanceof ClassStringType) {
-                    $expanded_union_type = $expanded_union_type->withUnionType($type->getClassUnionType());
-                } else {
-                    $expanded_union_type = $expanded_union_type->withType($type);
-                }
-            }
-            $union_type = $expanded_union_type;
+        // Expand `class-string<Foo>` into the classes it represents (nonNativeTypes() below
+        // would otherwise drop it, since class-string is itself a native/string type).
+        // Only do this when the caller tells us $node is used in class-name syntax (e.g. the
+        // class part of a static call) - $class is genuinely a string at runtime, so e.g.
+        // `$class->method()` (instance-call syntax) must not resolve this as if it were an
+        // instance of Foo.
+        if ($expand_class_string_type) {
+            $union_type = self::expandClassStringTypes($union_type);
         }
 
         // Iterate over each viable class type to see if any

--- a/src/Phan/AST/UnionTypeVisitor.php
+++ b/src/Phan/AST/UnionTypeVisitor.php
@@ -3637,6 +3637,11 @@ class UnionTypeVisitor extends AnalysisVisitor
             // @var array<string,non-empty-list<TemplateType>> $represented_template_types
             $represented_template_types = [];
             if ($static_class_node !== null) {
+                // FQSENs also reachable through a *non*-class-string alternative of the receiver
+                // (e.g. `Foo|class-string<T>` where T is bounded by Foo). Both alternatives
+                // resolve to the same Clazz, so substituting `static` with T there would wrongly
+                // discard the plain `Foo` alternative's own result - leave those classes alone.
+                $concretely_referenced_fqsens = [];
                 foreach (UnionTypeVisitor::unionTypeFromNode(
                     $this->code_base,
                     $this->context,
@@ -3644,6 +3649,14 @@ class UnionTypeVisitor extends AnalysisVisitor
                     $this->should_catch_issue_exception
                 )->getTypeSet() as $type) {
                     if (!($type instanceof ClassStringType)) {
+                        if ($type->isObjectWithKnownFQSEN()) {
+                            try {
+                                $concretely_referenced_fqsens[(string)$type->asFQSEN()] = true;
+                            } catch (FQSENException) {
+                                // A malformed class name such as `('??')::foo()` - it can't
+                                // correspond to any resolved class, so nothing to record.
+                            }
+                        }
                         continue;
                     }
                     foreach ($type->getClassUnionType()->getTypeSet() as $inner_type) {
@@ -3664,6 +3677,9 @@ class UnionTypeVisitor extends AnalysisVisitor
                             }
                         }
                     }
+                }
+                foreach ($concretely_referenced_fqsens as $fqsen_string => $_) {
+                    unset($represented_template_types[$fqsen_string]);
                 }
             }
             foreach ($this->classListFromNode($class_node, $static_class_node !== null) as $class) {

--- a/src/Phan/Analysis/ArgumentType.php
+++ b/src/Phan/Analysis/ArgumentType.php
@@ -1895,7 +1895,8 @@ final class ArgumentType
                     foreach (UnionTypeVisitor::classListFromNodeAndContext(
                         $code_base,
                         $context,
-                        $class_node
+                        $class_node,
+                        $node_kind === ast\AST_STATIC_CALL
                     ) as $class) {
                         if (!$class->hasMethodWithName(
                             $code_base,

--- a/src/Phan/Analysis/PostOrderAnalysisVisitor.php
+++ b/src/Phan/Analysis/PostOrderAnalysisVisitor.php
@@ -1630,7 +1630,7 @@ class PostOrderAnalysisVisitor extends AnalysisVisitor
                 $this->code_base,
                 $this->context,
                 $node->children['class']
-            ))->getClassList(false, ContextNode::CLASS_LIST_ACCEPT_OBJECT_OR_CLASS_NAME) as $class) {
+            ))->getClassList(false, ContextNode::CLASS_LIST_ACCEPT_OBJECT_OR_CLASS_NAME, null, true, false) as $class) {
                 $class->addReference($this->context);
             }
         } catch (CodeBaseException $exception) {

--- a/src/Phan/Language/Type/ClassStringType.php
+++ b/src/Phan/Language/Type/ClassStringType.php
@@ -67,6 +67,34 @@ final class ClassStringType extends StringType
     }
 
     /**
+     * Like getClassUnionType(), but also resolves any bounded template type (e.g.
+     * `@template T of Foo`) to its bound, so `class-string<T>` resolves the same way
+     * `class-string<Foo>` would for the purposes of looking up members (methods, etc.) - unlike
+     * getClassUnionType(), which callers use to determine the *resulting value type* of an
+     * expression (e.g. `new $class()`), and must keep an unresolved T as T to preserve
+     * genericity for template-aware return type checks.
+     */
+    public function getClassUnionTypeResolvingBounds(): UnionType
+    {
+        $class_union_type = $this->getClassUnionType();
+        if (!$class_union_type->hasTypeMatchingCallback(static fn(Type $type): bool => $type instanceof TemplateType)) {
+            return $class_union_type;
+        }
+        $result = UnionType::empty();
+        foreach ($class_union_type->getTypeSet() as $type) {
+            if ($type instanceof TemplateType) {
+                $bound_union_type = $type->getBoundUnionType();
+                if ($bound_union_type && !$bound_union_type->isEmpty()) {
+                    $result = $result->withUnionType($bound_union_type);
+                    continue;
+                }
+            }
+            $result = $result->withType($type);
+        }
+        return $result;
+    }
+
+    /**
      * @param CodeBase $code_base may be used for resolving inheritance @phan-unused-param
      * @param TemplateType $template_type the template type that this union type is being searched for
      *

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -3166,6 +3166,12 @@ class UnionType implements Serializable, Stringable
         // Iterate over each viable class type to see if any
         // have the constant we're looking for
         foreach ($this->getUniqueFlattenedTypeSet() as $class_type) {
+            if ($class_type instanceof ClassStringType) {
+                // Resolve `class-string<Foo>` the same way `Foo` itself would resolve,
+                // e.g. for `$class::method()` where $class is `class-string<Foo>`.
+                yield from $class_type->getClassUnionType()->asClassList($code_base, $context);
+                continue;
+            }
             if ($class_type->isNativeType()) {
                 continue;
             }

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -3166,12 +3166,6 @@ class UnionType implements Serializable, Stringable
         // Iterate over each viable class type to see if any
         // have the constant we're looking for
         foreach ($this->getUniqueFlattenedTypeSet() as $class_type) {
-            if ($class_type instanceof ClassStringType) {
-                // Resolve `class-string<Foo>` the same way `Foo` itself would resolve,
-                // e.g. for `$class::method()` where $class is `class-string<Foo>`.
-                yield from $class_type->getClassUnionType()->asClassList($code_base, $context);
-                continue;
-            }
             if ($class_type->isNativeType()) {
                 continue;
             }

--- a/src/Phan/LanguageServer/CompletionResolver.php
+++ b/src/Phan/LanguageServer/CompletionResolver.php
@@ -239,7 +239,10 @@ class CompletionResolver
             $node->children['class'] ?? $node->children['expr']
         ))->getClassList(
             true,
-            ContextNode::CLASS_LIST_ACCEPT_OBJECT_OR_CLASS_NAME
+            // Only accept a class name (and so resolve `class-string<Foo>` to Foo) for static
+            // syntax. For `$class->` on a `class-string<Foo>` receiver, $class is a string at
+            // runtime and the call would fail, so don't suggest Foo's members.
+            $is_static ? ContextNode::CLASS_LIST_ACCEPT_OBJECT_OR_CLASS_NAME : ContextNode::CLASS_LIST_ACCEPT_OBJECT
         );
 
         // And find all of the instance/static properties that can be used as completions

--- a/tests/files/expected/0698_nullable_class_string.php.expected
+++ b/tests/files/expected/0698_nullable_class_string.php.expected
@@ -1,5 +1,3 @@
 %s:18 PhanUndeclaredClass Reference to undeclared class \SplObjectHash
 %s:19 PhanNonClassMethodCall Call to method __construct on non-class type ?class-string<\SplObjectHash>
-%s:19 PhanUndeclaredClass Reference to undeclared class \SplObjectHash
 %s:20 PhanNonClassMethodCall Call to method __construct on non-class type ?class-string<\SplObjectHash>
-%s:20 PhanUndeclaredClass Reference to undeclared class \SplObjectHash

--- a/tests/files/expected/0698_nullable_class_string.php.expected
+++ b/tests/files/expected/0698_nullable_class_string.php.expected
@@ -1,3 +1,5 @@
 %s:18 PhanUndeclaredClass Reference to undeclared class \SplObjectHash
 %s:19 PhanNonClassMethodCall Call to method __construct on non-class type ?class-string<\SplObjectHash>
+%s:19 PhanUndeclaredClass Reference to undeclared class \SplObjectHash
 %s:20 PhanNonClassMethodCall Call to method __construct on non-class type ?class-string<\SplObjectHash>
+%s:20 PhanUndeclaredClass Reference to undeclared class \SplObjectHash

--- a/tests/files/expected/0698_nullable_class_string.php.expected
+++ b/tests/files/expected/0698_nullable_class_string.php.expected
@@ -1,2 +1,3 @@
-%s:19 PhanNonClassMethodCall Call to method __construct on non-class type ?class-string<\SplObjectHash>
-%s:20 PhanNonClassMethodCall Call to method __construct on non-class type ?class-string<\SplObjectHash>
+%s:18 PhanUndeclaredClassMethod Call to method __construct from undeclared class \SplObjectHash
+%s:19 PhanUndeclaredClassMethod Call to method __construct from undeclared class \SplObjectHash
+%s:20 PhanUndeclaredClassMethod Call to method __construct from undeclared class \SplObjectHash

--- a/tests/files/expected/0698_nullable_class_string.php.expected
+++ b/tests/files/expected/0698_nullable_class_string.php.expected
@@ -1,3 +1,5 @@
-%s:18 PhanUndeclaredClassMethod Call to method __construct from undeclared class \SplObjectHash
-%s:19 PhanUndeclaredClassMethod Call to method __construct from undeclared class \SplObjectHash
-%s:20 PhanUndeclaredClassMethod Call to method __construct from undeclared class \SplObjectHash
+%s:18 PhanUndeclaredClass Reference to undeclared class \SplObjectHash
+%s:19 PhanNonClassMethodCall Call to method __construct on non-class type ?class-string<\SplObjectHash>
+%s:19 PhanUndeclaredClass Reference to undeclared class \SplObjectHash
+%s:20 PhanNonClassMethodCall Call to method __construct on non-class type ?class-string<\SplObjectHash>
+%s:20 PhanUndeclaredClass Reference to undeclared class \SplObjectHash

--- a/tests/files/expected/5935_class_string_static_call.php.expected
+++ b/tests/files/expected/5935_class_string_static_call.php.expected
@@ -42,3 +42,5 @@
 %s:287 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type \Foo5935c(real=\Foo5935c)
 %s:287 PhanUnusedVariable Unused definition of variable $x
 %s:306 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type \Box5935f<int>(real=\Box5935f<int>)
+%s:327 PhanAbstractStaticMethodCall Potentially calling an abstract static method \Maker5935g::make() in $class::make()
+%s:327 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type T(real=T)

--- a/tests/files/expected/5935_class_string_static_call.php.expected
+++ b/tests/files/expected/5935_class_string_static_call.php.expected
@@ -41,3 +41,4 @@
 %s:282 PhanTemplateTypeNotUsedInFunctionReturn Template type T not used in return value of function/method testConcreteAlternativeNotOverriddenByTemplate()
 %s:287 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type \Foo5935c(real=\Foo5935c)
 %s:287 PhanUnusedVariable Unused definition of variable $x
+%s:306 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type \Box5935f<int>(real=\Box5935f<int>)

--- a/tests/files/expected/5935_class_string_static_call.php.expected
+++ b/tests/files/expected/5935_class_string_static_call.php.expected
@@ -19,3 +19,8 @@
 %s:111 PhanUnusedVariable Unused definition of variable $value
 %s:120 PhanTemplateTypeStaticMethod static method \Box5935b::accept does not declare template type in its own comment and may not use the template type of class instances
 %s:134 PhanTypeMismatchArgumentProbablyReal Argument 1 ($value) is 'not_an_int' of type string but \Box5935b::accept() takes int (no real type) defined at %s:120 (the inferred real argument type has nothing in common with the parameter's phpdoc type)
+%s:164 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type class-string(real=class-string)
+%s:164 PhanUnusedVariable Unused definition of variable $x
+%s:172 PhanTemplateTypeNotUsedInFunctionReturn Template type T not used in return value of function/method testBoundedTemplateClassStringResolves()
+%s:177 PhanDebugAnnotation @phan-debug-var requested for variable $bar - it has union type \Bar5935(real=\Bar5935)
+%s:180 PhanUndeclaredStaticMethod Static call to undeclared method \Foo5935::not_a_real_method

--- a/tests/files/expected/5935_class_string_static_call.php.expected
+++ b/tests/files/expected/5935_class_string_static_call.php.expected
@@ -53,3 +53,6 @@
 %s:399 PhanTemplateTypeNotUsedInFunctionReturn Template type T not used in return value of function/method testIntersectionConcreteAlternativeNotOverridden()
 %s:404 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type \Foo5935c(real=\Foo5935c)
 %s:404 PhanUnusedVariable Unused definition of variable $x
+%s:427 PhanTemplateTypeNotUsedInFunctionReturn Template type T not used in return value of function/method testDependentReturnTypeNestedStatic()
+%s:431 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type 1|T[]
+%s:431 PhanUnusedVariable Unused definition of variable $x

--- a/tests/files/expected/5935_class_string_static_call.php.expected
+++ b/tests/files/expected/5935_class_string_static_call.php.expected
@@ -44,3 +44,6 @@
 %s:306 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type \Box5935f<int>(real=\Box5935f<int>)
 %s:327 PhanAbstractStaticMethodCall Potentially calling an abstract static method \Maker5935g::make() in $class::make()
 %s:327 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type T(real=T)
+%s:353 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type T[]
+%s:363 PhanTemplateTypeNotUsedInFunctionReturn Template type T not used in return value of function/method testNestedStaticInNullableReturn()
+%s:365 PhanDebugAnnotation @phan-debug-var requested for variable $y - it has union type ?T

--- a/tests/files/expected/5935_class_string_static_call.php.expected
+++ b/tests/files/expected/5935_class_string_static_call.php.expected
@@ -1,0 +1,10 @@
+%s:24 PhanDebugAnnotation @phan-debug-var requested for variable $bar - it has union type \Bar5935(real=\Bar5935)
+%s:33 PhanDebugAnnotation @phan-debug-var requested for variable $bar - it has union type (empty union type)
+%s:33 PhanUndeclaredStaticMethod Static call to undeclared method \Foo5935::not_a_function
+%s:33 PhanUnusedVariable Unused definition of variable $bar
+%s:43 PhanDebugAnnotation @phan-debug-var requested for variable $bar - it has union type (empty union type)
+%s:43 PhanUnusedVariable Unused definition of variable $bar
+%s:49 PhanDebugAnnotation @phan-debug-var requested for variable $bar - it has union type \Bar5935(real=\Bar5935)
+%s:55 PhanDebugAnnotation @phan-debug-var requested for variable $bar - it has union type (empty union type)
+%s:55 PhanUndeclaredStaticMethod Static call to undeclared method \Foo5935::not_a_function
+%s:55 PhanUnusedVariable Unused definition of variable $bar

--- a/tests/files/expected/5935_class_string_static_call.php.expected
+++ b/tests/files/expected/5935_class_string_static_call.php.expected
@@ -24,3 +24,6 @@
 %s:172 PhanTemplateTypeNotUsedInFunctionReturn Template type T not used in return value of function/method testBoundedTemplateClassStringResolves()
 %s:177 PhanDebugAnnotation @phan-debug-var requested for variable $bar - it has union type \Bar5935(real=\Bar5935)
 %s:180 PhanUndeclaredStaticMethod Static call to undeclared method \Foo5935::not_a_real_method
+%s:211 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type T(real=T)
+%s:220 PhanDebugAnnotation @phan-debug-var requested for variable $y - it has union type \Sub5935c
+%s:220 PhanUnusedVariable Unused definition of variable $y

--- a/tests/files/expected/5935_class_string_static_call.php.expected
+++ b/tests/files/expected/5935_class_string_static_call.php.expected
@@ -38,3 +38,6 @@
 %s:271 PhanTemplateTypeNotUsedInFunctionReturn Template type U not used in return value of function/method testUnionOfClassStringsSharingOneBound()
 %s:274 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type T|U(real=T|U)
 %s:274 PhanUnusedVariable Unused definition of variable $x
+%s:282 PhanTemplateTypeNotUsedInFunctionReturn Template type T not used in return value of function/method testConcreteAlternativeNotOverriddenByTemplate()
+%s:287 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type \Foo5935c(real=\Foo5935c)
+%s:287 PhanUnusedVariable Unused definition of variable $x

--- a/tests/files/expected/5935_class_string_static_call.php.expected
+++ b/tests/files/expected/5935_class_string_static_call.php.expected
@@ -50,3 +50,6 @@
 %s:384 PhanTemplateTypeNotUsedInFunctionReturn Template type T not used in return value of function/method testInheritedSelfResolvesToDeclaringClass()
 %s:388 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type \Base5935i
 %s:388 PhanUnusedVariable Unused definition of variable $x
+%s:399 PhanTemplateTypeNotUsedInFunctionReturn Template type T not used in return value of function/method testIntersectionConcreteAlternativeNotOverridden()
+%s:404 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type \Foo5935c(real=\Foo5935c)
+%s:404 PhanUnusedVariable Unused definition of variable $x

--- a/tests/files/expected/5935_class_string_static_call.php.expected
+++ b/tests/files/expected/5935_class_string_static_call.php.expected
@@ -12,8 +12,10 @@
 %s:69 PhanNonClassMethodCall Call to method instanceMethod on non-class type class-string<\Foo5935>
 %s:69 PhanUnusedVariable Unused definition of variable $x
 %s:81 PhanDebugAnnotation @phan-debug-var requested for variable $bar - it has union type \Bar5935(real=\Bar5935)
-%s:81 PhanNonClassMethodCall Call to method bar on non-class type ?class-string<\Foo5935>
 %s:81 PhanUnusedVariable Unused definition of variable $bar
-%s:90 PhanTemplateTypeStaticMethod static method \Box5935::make does not declare template type in its own comment and may not use the template type of class instances
-%s:102 PhanDebugAnnotation @phan-debug-var requested for variable $value - it has union type int
-%s:102 PhanUnusedVariable Unused definition of variable $value
+%s:91 PhanUndeclaredStaticMethod Static call to undeclared method \Foo5935::not_a_function
+%s:99 PhanTemplateTypeStaticMethod static method \Box5935::make does not declare template type in its own comment and may not use the template type of class instances
+%s:111 PhanDebugAnnotation @phan-debug-var requested for variable $value - it has union type int
+%s:111 PhanUnusedVariable Unused definition of variable $value
+%s:120 PhanTemplateTypeStaticMethod static method \Box5935b::accept does not declare template type in its own comment and may not use the template type of class instances
+%s:134 PhanTypeMismatchArgumentProbablyReal Argument 1 ($value) is 'not_an_int' of type string but \Box5935b::accept() takes int (no real type) defined at %s:120 (the inferred real argument type has nothing in common with the parameter's phpdoc type)

--- a/tests/files/expected/5935_class_string_static_call.php.expected
+++ b/tests/files/expected/5935_class_string_static_call.php.expected
@@ -56,3 +56,6 @@
 %s:427 PhanTemplateTypeNotUsedInFunctionReturn Template type T not used in return value of function/method testDependentReturnTypeNestedStatic()
 %s:431 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type 1|T[]
 %s:431 PhanUnusedVariable Unused definition of variable $x
+%s:451 PhanTemplateTypeNotUsedInFunctionReturn Template type T not used in return value of function/method testDependentReturnTypeColliding()
+%s:455 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type T|\Foo5935m
+%s:455 PhanUnusedVariable Unused definition of variable $x

--- a/tests/files/expected/5935_class_string_static_call.php.expected
+++ b/tests/files/expected/5935_class_string_static_call.php.expected
@@ -11,3 +11,9 @@
 %s:69 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type (empty union type)
 %s:69 PhanNonClassMethodCall Call to method instanceMethod on non-class type class-string<\Foo5935>
 %s:69 PhanUnusedVariable Unused definition of variable $x
+%s:81 PhanDebugAnnotation @phan-debug-var requested for variable $bar - it has union type \Bar5935(real=\Bar5935)
+%s:81 PhanNonClassMethodCall Call to method bar on non-class type ?class-string<\Foo5935>
+%s:81 PhanUnusedVariable Unused definition of variable $bar
+%s:90 PhanTemplateTypeStaticMethod static method \Box5935::make does not declare template type in its own comment and may not use the template type of class instances
+%s:102 PhanDebugAnnotation @phan-debug-var requested for variable $value - it has union type int
+%s:102 PhanUnusedVariable Unused definition of variable $value

--- a/tests/files/expected/5935_class_string_static_call.php.expected
+++ b/tests/files/expected/5935_class_string_static_call.php.expected
@@ -27,3 +27,10 @@
 %s:211 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type T(real=T)
 %s:220 PhanDebugAnnotation @phan-debug-var requested for variable $y - it has union type \Sub5935c
 %s:220 PhanUnusedVariable Unused definition of variable $y
+%s:235 PhanTemplateTypeNotUsedInFunctionReturn Template type T not used in return value of function/method testBoundedTemplateClassStringSelfReturn()
+%s:238 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type \Foo5935d
+%s:238 PhanUnusedVariable Unused definition of variable $x
+%s:259 PhanTemplateTypeNotUsedInFunctionReturn Template type T not used in return value of function/method testUnionOfClassStringsKeepsPerAlternativeTemplates()
+%s:259 PhanTemplateTypeNotUsedInFunctionReturn Template type U not used in return value of function/method testUnionOfClassStringsKeepsPerAlternativeTemplates()
+%s:262 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type T|U(real=T|U)
+%s:262 PhanUnusedVariable Unused definition of variable $x

--- a/tests/files/expected/5935_class_string_static_call.php.expected
+++ b/tests/files/expected/5935_class_string_static_call.php.expected
@@ -47,3 +47,6 @@
 %s:353 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type T[]
 %s:363 PhanTemplateTypeNotUsedInFunctionReturn Template type T not used in return value of function/method testNestedStaticInNullableReturn()
 %s:365 PhanDebugAnnotation @phan-debug-var requested for variable $y - it has union type ?T
+%s:384 PhanTemplateTypeNotUsedInFunctionReturn Template type T not used in return value of function/method testInheritedSelfResolvesToDeclaringClass()
+%s:388 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type \Base5935i
+%s:388 PhanUnusedVariable Unused definition of variable $x

--- a/tests/files/expected/5935_class_string_static_call.php.expected
+++ b/tests/files/expected/5935_class_string_static_call.php.expected
@@ -1,10 +1,13 @@
-%s:24 PhanDebugAnnotation @phan-debug-var requested for variable $bar - it has union type \Bar5935(real=\Bar5935)
-%s:33 PhanDebugAnnotation @phan-debug-var requested for variable $bar - it has union type (empty union type)
-%s:33 PhanUndeclaredStaticMethod Static call to undeclared method \Foo5935::not_a_function
-%s:33 PhanUnusedVariable Unused definition of variable $bar
-%s:43 PhanDebugAnnotation @phan-debug-var requested for variable $bar - it has union type (empty union type)
-%s:43 PhanUnusedVariable Unused definition of variable $bar
-%s:49 PhanDebugAnnotation @phan-debug-var requested for variable $bar - it has union type \Bar5935(real=\Bar5935)
-%s:55 PhanDebugAnnotation @phan-debug-var requested for variable $bar - it has union type (empty union type)
-%s:55 PhanUndeclaredStaticMethod Static call to undeclared method \Foo5935::not_a_function
-%s:55 PhanUnusedVariable Unused definition of variable $bar
+%s:27 PhanDebugAnnotation @phan-debug-var requested for variable $bar - it has union type \Bar5935(real=\Bar5935)
+%s:36 PhanDebugAnnotation @phan-debug-var requested for variable $bar - it has union type (empty union type)
+%s:36 PhanUndeclaredStaticMethod Static call to undeclared method \Foo5935::not_a_function
+%s:36 PhanUnusedVariable Unused definition of variable $bar
+%s:46 PhanDebugAnnotation @phan-debug-var requested for variable $bar - it has union type (empty union type)
+%s:46 PhanUnusedVariable Unused definition of variable $bar
+%s:52 PhanDebugAnnotation @phan-debug-var requested for variable $bar - it has union type \Bar5935(real=\Bar5935)
+%s:58 PhanDebugAnnotation @phan-debug-var requested for variable $bar - it has union type (empty union type)
+%s:58 PhanUndeclaredStaticMethod Static call to undeclared method \Foo5935::not_a_function
+%s:58 PhanUnusedVariable Unused definition of variable $bar
+%s:69 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type (empty union type)
+%s:69 PhanNonClassMethodCall Call to method instanceMethod on non-class type class-string<\Foo5935>
+%s:69 PhanUnusedVariable Unused definition of variable $x

--- a/tests/files/expected/5935_class_string_static_call.php.expected
+++ b/tests/files/expected/5935_class_string_static_call.php.expected
@@ -34,3 +34,7 @@
 %s:259 PhanTemplateTypeNotUsedInFunctionReturn Template type U not used in return value of function/method testUnionOfClassStringsKeepsPerAlternativeTemplates()
 %s:262 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type T|U(real=T|U)
 %s:262 PhanUnusedVariable Unused definition of variable $x
+%s:271 PhanTemplateTypeNotUsedInFunctionReturn Template type T not used in return value of function/method testUnionOfClassStringsSharingOneBound()
+%s:271 PhanTemplateTypeNotUsedInFunctionReturn Template type U not used in return value of function/method testUnionOfClassStringsSharingOneBound()
+%s:274 PhanDebugAnnotation @phan-debug-var requested for variable $x - it has union type T|U(real=T|U)
+%s:274 PhanUnusedVariable Unused definition of variable $x

--- a/tests/files/src/5935_class_string_static_call.php
+++ b/tests/files/src/5935_class_string_static_call.php
@@ -388,3 +388,19 @@ function testInheritedSelfResolvesToDeclaringClass(string $class) {
     $x = $class::makeSelf();
     '@phan-debug-var $x';
 }
+
+interface Marker5935j {
+}
+
+/**
+ * @template T of Foo5935c
+ * @param (Foo5935c&Marker5935j)|class-string<T> $receiver
+ */
+function testIntersectionConcreteAlternativeNotOverridden($receiver) {
+    // Like testConcreteAlternativeNotOverriddenByTemplate, but the concrete alternative is an
+    // intersection. An IntersectionType has no single FQSEN, yet classListFromNode() flattens it
+    // and resolves the same Foo5935c class - so its parts must still count as concretely
+    // referenced, or the template substitution would discard this alternative's own result.
+    $x = $receiver::make();
+    '@phan-debug-var $x';
+}

--- a/tests/files/src/5935_class_string_static_call.php
+++ b/tests/files/src/5935_class_string_static_call.php
@@ -287,3 +287,23 @@ function testConcreteAlternativeNotOverriddenByTemplate($receiver) {
     $x = $receiver::make();
     '@phan-debug-var $x';
 }
+
+/** @template T */
+class Box5935f {
+    public static function make(): static {
+        return new static();
+    }
+}
+
+/**
+ * @param class-string<Box5935f<int>> $class
+ * @return Box5935f<int>
+ */
+function testGenericArgumentsPreservedForStaticReturn(string $class) {
+    // classListFromNode() reduces `class-string<Box5935f<int>>` to the bare Box5935f class for
+    // member lookup, so resolving `static` against that class context would drop the <int>.
+    // The generic receiver type must be used for the substitution instead.
+    $x = $class::make();
+    '@phan-debug-var $x';
+    return $x;
+}

--- a/tests/files/src/5935_class_string_static_call.php
+++ b/tests/files/src/5935_class_string_static_call.php
@@ -73,13 +73,22 @@ function testInstanceSyntaxOnClassStringMustNotResolve(string $class) {
 /**
  * @param ?class-string<Foo5935> $class
  */
-function testNullableClassStringMustStillWarn(?string $class) {
-    // $class could be null at runtime, in which case $class::bar() fatals. The pre-existing
-    // "possibly non-class type" warning for this must keep firing, even though the return
-    // type can still be usefully inferred assuming the non-null case (matching how the
-    // codebase already treats other "possibly invalid, but useful if valid" call sites).
+function testNullableClassStringResolvesLikeNullableObject(?string $class) {
+    // $class could be null at runtime (so could a nullable Foo5935 $obj, and
+    // `$obj::bar()` fatals identically in that case) - deliberately not special-cased: a
+    // nullable class-string resolves fully (no "possibly null" warning), matching how a
+    // nullable object receiver is already resolved and validated elsewhere in Phan.
     $bar = $class::bar();
     '@phan-debug-var $bar';
+}
+
+/**
+ * @param ?class-string<Foo5935> $class
+ */
+function testNullableClassStringStillValidatesMembers(?string $class) {
+    // Full member validation must still happen for the nullable case, matching how
+    // `?Foo5935 $obj; $obj::not_a_function();` is already validated.
+    $class::not_a_function();
 }
 
 /**
@@ -101,4 +110,46 @@ function testTemplateResolvesFromClassString(string $class) {
     // type itself - which isn't an object with a known FQSEN and so would leave T unresolved.
     $value = $class::make();
     '@phan-debug-var $value';
+}
+
+/**
+ * @template T
+ */
+class Box5935b {
+    /** @param T $value */
+    public static function accept($value): void {
+    }
+}
+
+/**
+ * @param class-string<Box5935b<int>> $class
+ */
+function testTemplateArgumentValidationFromClassString(string $class) {
+    // The Method object resolved via a class-string<Box<int>> receiver must have class-level T
+    // substituted with int the same way argument validation would for an actual Box<int>
+    // instance - this exercises a separate resolveTemplateType() call site
+    // (ContextNode::getMethodListInternal(), used for argument/visibility checking) from
+    // testTemplateResolvesFromClassString() above (UnionTypeVisitor::visitMethodCall(), used
+    // only for return type inference).
+    $class::accept('not_an_int');
+}
+
+class UnionClassA5935 {
+    public function onlyOnA5935(): void {
+    }
+}
+
+class UnionClassB5935 {
+    public static function onlyOnB5935(): void {
+    }
+}
+
+/**
+ * @param UnionClassA5935|class-string<UnionClassB5935> $receiver
+ */
+function testClassStringAlternativeInUnion($receiver) {
+    // UnionClassA5935 resolves first and doesn't declare onlyOnB5935() - the class-string
+    // alternative (UnionClassB5935, which does) must still be considered, not discarded just
+    // because $class_list was already non-empty from the other union member.
+    $receiver::onlyOnB5935();
 }

--- a/tests/files/src/5935_class_string_static_call.php
+++ b/tests/files/src/5935_class_string_static_call.php
@@ -431,3 +431,27 @@ function testDependentReturnTypeNestedStatic(string $class) {
     $x = $class::makeMany(1);
     '@phan-debug-var $x';
 }
+
+class Foo5935m {
+    /**
+     * @template U
+     * @param U $u
+     * @return static|U
+     * @suppress PhanParamNameIndicatingUnused
+     */
+    public static function makeOrArg($u) {
+        return new static();
+    }
+}
+
+/**
+ * @template T of Foo5935m
+ * @param class-string<T> $class
+ */
+function testDependentReturnTypeColliding(string $class, Foo5935m $arg) {
+    // U resolves to Foo5935m - the SAME type Method::getUnionType() appends as the `static`
+    // expansion. The two origins are indistinguishable by equality, so the genuine U result
+    // must not be dropped: this is `T|Foo5935m`, not just `T`.
+    $x = $class::makeOrArg($arg);
+    '@phan-debug-var $x';
+}

--- a/tests/files/src/5935_class_string_static_call.php
+++ b/tests/files/src/5935_class_string_static_call.php
@@ -366,3 +366,25 @@ function testNestedStaticInNullableReturn(string $class) {
     '@phan-debug-var $y';
     return $y;
 }
+
+class Base5935i {
+    /** @return self */
+    public static function makeSelf() {
+        return new self();
+    }
+}
+
+class Child5935i extends Base5935i {
+}
+
+/**
+ * @template T of Child5935i
+ * @param class-string<T> $class
+ */
+function testInheritedSelfResolvesToDeclaringClass(string $class) {
+    // `self` means the class that DECLARED the method (Base5935i), not the receiver - even
+    // though the receiver is `class-string<T>` bounded by the subclass Child5935i, and even
+    // though `static` in the same position would resolve to T.
+    $x = $class::makeSelf();
+    '@phan-debug-var $x';
+}

--- a/tests/files/src/5935_class_string_static_call.php
+++ b/tests/files/src/5935_class_string_static_call.php
@@ -220,3 +220,45 @@ function testBoundedTemplateClassStringLateStaticBindingCallSite(): void {
     $y = testBoundedTemplateClassStringLateStaticBinding(Sub5935c::class);
     '@phan-debug-var $y';
 }
+
+class Foo5935d {
+    /** @return self */
+    public static function makeSelf() {
+        return new self();
+    }
+}
+
+/**
+ * @template T of Foo5935d
+ * @param class-string<T> $class
+ */
+function testBoundedTemplateClassStringSelfReturn(string $class) {
+    // Unlike `static`, a `self` return type always means the declaring class - it must NOT be
+    // substituted with the template T.
+    $x = $class::makeSelf();
+    '@phan-debug-var $x';
+}
+
+class Foo5935eA {
+    public static function make(): static {
+        return new static();
+    }
+}
+
+class Foo5935eB {
+    public static function make(): static {
+        return new static();
+    }
+}
+
+/**
+ * @template T of Foo5935eA
+ * @template U of Foo5935eB
+ * @param class-string<T>|class-string<U> $class
+ */
+function testUnionOfClassStringsKeepsPerAlternativeTemplates(string $class) {
+    // Each class-string alternative must map back to its OWN template - the result is T|U,
+    // not whichever template happened to be scanned last applied to both classes.
+    $x = $class::make();
+    '@phan-debug-var $x';
+}

--- a/tests/files/src/5935_class_string_static_call.php
+++ b/tests/files/src/5935_class_string_static_call.php
@@ -69,3 +69,36 @@ function testInstanceSyntaxOnClassStringMustNotResolve(string $class) {
     $x = $class->instanceMethod();
     '@phan-debug-var $x';
 }
+
+/**
+ * @param ?class-string<Foo5935> $class
+ */
+function testNullableClassStringMustStillWarn(?string $class) {
+    // $class could be null at runtime, in which case $class::bar() fatals. The pre-existing
+    // "possibly non-class type" warning for this must keep firing, even though the return
+    // type can still be usefully inferred assuming the non-null case (matching how the
+    // codebase already treats other "possibly invalid, but useful if valid" call sites).
+    $bar = $class::bar();
+    '@phan-debug-var $bar';
+}
+
+/**
+ * @template T
+ */
+class Box5935 {
+    /** @return T */
+    public static function make() {
+        throw new \RuntimeException("stub for testing template resolution, not called");
+    }
+}
+
+/**
+ * @param class-string<Box5935<int>> $class
+ */
+function testTemplateResolvesFromClassString(string $class) {
+    // Resolving the *class part* of the static call through class-string<Box5935<int>> must
+    // resolve class-level T against Box5935<int> (i.e. T=int), not against the class-string
+    // type itself - which isn't an object with a known FQSEN and so would leave T unresolved.
+    $value = $class::make();
+    '@phan-debug-var $value';
+}

--- a/tests/files/src/5935_class_string_static_call.php
+++ b/tests/files/src/5935_class_string_static_call.php
@@ -274,3 +274,16 @@ function testUnionOfClassStringsSharingOneBound(string $class) {
     $x = $class::make();
     '@phan-debug-var $x';
 }
+
+/**
+ * @template T of Foo5935c
+ * @param Foo5935c|class-string<T> $receiver
+ */
+function testConcreteAlternativeNotOverriddenByTemplate($receiver) {
+    // Both alternatives resolve to the same Foo5935c class, but the plain object alternative
+    // can genuinely return Foo5935c - substituting `static` with T for the whole class entry
+    // would unsoundly discard that. Keep the concrete resolution when the class is also
+    // reachable without going through a class-string.
+    $x = $receiver::make();
+    '@phan-debug-var $x';
+}

--- a/tests/files/src/5935_class_string_static_call.php
+++ b/tests/files/src/5935_class_string_static_call.php
@@ -191,3 +191,32 @@ function testBoundedTemplateClassStringPreservesGenericity(string $class) {
     // would falsely mismatch its own `@return T`.
     return new $class();
 }
+
+class Foo5935c {
+    public static function make(): static {
+        return new static();
+    }
+}
+
+/**
+ * @template T of Foo5935c
+ * @param class-string<T> $class
+ * @return T
+ */
+function testBoundedTemplateClassStringLateStaticBinding(string $class) {
+    // `make()`'s `static` return type must resolve back to T (the represented template), not
+    // to the concrete bound Foo5935c used only for member lookup - otherwise this legitimately
+    // generic factory would falsely mismatch its own `@return T`, and would lose subtype
+    // information at call sites that pass a narrower class-string (see the Sub5935c case below).
+    $x = $class::make();
+    '@phan-debug-var $x';
+    return $x;
+}
+
+class Sub5935c extends Foo5935c {
+}
+
+function testBoundedTemplateClassStringLateStaticBindingCallSite(): void {
+    $y = testBoundedTemplateClassStringLateStaticBinding(Sub5935c::class);
+    '@phan-debug-var $y';
+}

--- a/tests/files/src/5935_class_string_static_call.php
+++ b/tests/files/src/5935_class_string_static_call.php
@@ -153,3 +153,41 @@ function testClassStringAlternativeInUnion($receiver) {
     // because $class_list was already non-empty from the other union member.
     $receiver::onlyOnB5935();
 }
+
+/**
+ * @param class-string<Foo5935> $class
+ */
+function testDynamicClassConstMustNotResolve(string $class) {
+    // `$class::class` is a TypeError at runtime for a plain string receiver (unlike
+    // `$obj::class` for an object, or the literal `Foo::class`), so a class-string-typed
+    // variable must NOT be treated as valid here even though `$class::method()` is.
+    $x = $class::class;
+    '@phan-debug-var $x';
+}
+
+/**
+ * @template T of Foo5935
+ * @param class-string<T> $class
+ */
+function testBoundedTemplateClassStringResolves(string $class) {
+    // T has no concrete FQSEN of its own, but its bound (Foo5935) does - member lookup and
+    // return-type inference should go through the bound, the same as class-string<Foo5935>
+    // would, without collapsing the *result* of a generic call (see
+    // testBoundedTemplateClassStringPreservesGenericity below) to that concrete bound.
+    $bar = $class::bar();
+    '@phan-debug-var $bar';
+    $bar->output();
+    $class::not_a_real_method();
+}
+
+/**
+ * @template T of Foo5935
+ * @param class-string<T> $class
+ * @return T
+ */
+function testBoundedTemplateClassStringPreservesGenericity(string $class) {
+    // `new $class()` must still resolve to the (possibly narrower) template type T, not
+    // collapse to the concrete bound Foo5935 - otherwise this legitimately-generic factory
+    // would falsely mismatch its own `@return T`.
+    return new $class();
+}

--- a/tests/files/src/5935_class_string_static_call.php
+++ b/tests/files/src/5935_class_string_static_call.php
@@ -328,3 +328,41 @@ function testIntersectionBoundPreservesTemplate(string $class) {
     '@phan-debug-var $x';
     return $x;
 }
+
+class Foo5935h {
+    /** @return static[] */
+    public static function makeMany() {
+        return [new static()];
+    }
+
+    /** @return ?static */
+    public static function maybeMake() {
+        return new static();
+    }
+}
+
+/**
+ * @template T of Foo5935h
+ * @param class-string<T> $class
+ * @return T[]
+ */
+function testNestedStaticInArrayReturn(string $class) {
+    // Method::getUnionType() expands `static[]` to `static[]|Foo5935h[]`, so substituting on it
+    // while removing only the bare `Foo5935h` type would leave `Foo5935h[]` behind and infer
+    // `T[]|Foo5935h[]`. The substitution must run on the unmodified (still-abstract) return type.
+    $x = $class::makeMany();
+    '@phan-debug-var $x';
+    return $x;
+}
+
+/**
+ * @template T of Foo5935h
+ * @param class-string<T> $class
+ * @return ?T
+ */
+function testNestedStaticInNullableReturn(string $class) {
+    // Same for `?static`, which expands to `?static|?Foo5935h`.
+    $y = $class::maybeMake();
+    '@phan-debug-var $y';
+    return $y;
+}

--- a/tests/files/src/5935_class_string_static_call.php
+++ b/tests/files/src/5935_class_string_static_call.php
@@ -262,3 +262,15 @@ function testUnionOfClassStringsKeepsPerAlternativeTemplates(string $class) {
     $x = $class::make();
     '@phan-debug-var $x';
 }
+
+/**
+ * @template T of Foo5935eA
+ * @template U of Foo5935eA
+ * @param class-string<T>|class-string<U> $class
+ */
+function testUnionOfClassStringsSharingOneBound(string $class) {
+    // T and U share the same bound (Foo5935eA), so both map to the same resolved class - both
+    // must still be preserved (result T|U), rather than one overwriting the other.
+    $x = $class::make();
+    '@phan-debug-var $x';
+}

--- a/tests/files/src/5935_class_string_static_call.php
+++ b/tests/files/src/5935_class_string_static_call.php
@@ -9,6 +9,9 @@ class Foo5935 {
     public static function bar(): Bar5935 {
         return new Bar5935();
     }
+
+    public function instanceMethod(): void {
+    }
 }
 
 class Bar5935 {
@@ -54,4 +57,15 @@ function testValidMethodViaInstance(Foo5935 $class) {
 function testInvalidMethodViaInstance(Foo5935 $class) {
     $bar = $class::not_a_function();
     '@phan-debug-var $bar';
+}
+
+/**
+ * @param class-string<Foo5935> $class
+ */
+function testInstanceSyntaxOnClassStringMustNotResolve(string $class) {
+    // $class is genuinely a string at runtime - instance-call syntax on it must NOT resolve
+    // as if $class were a Foo5935 instance, unlike the static-call ($class::method()) cases
+    // above. Must warn (e.g. PhanNonClassMethodCall), not silently accept this.
+    $x = $class->instanceMethod();
+    '@phan-debug-var $x';
 }

--- a/tests/files/src/5935_class_string_static_call.php
+++ b/tests/files/src/5935_class_string_static_call.php
@@ -404,3 +404,30 @@ function testIntersectionConcreteAlternativeNotOverridden($receiver) {
     $x = $receiver::make();
     '@phan-debug-var $x';
 }
+
+class Foo5935k {
+    /**
+     * A method-level @template that IS used in the return type installs a dependent-return
+     * closure, which derives its result from Method::getUnionType() - so the result carries
+     * the same `static[]` -> `static[]|Foo5935k[]` expansion.
+     * @template U
+     * @param U $u
+     * @return static[]|U
+     * @suppress PhanParamNameIndicatingUnused
+     */
+    public static function makeMany($u) {
+        return [new static()];
+    }
+}
+
+/**
+ * @template T of Foo5935k
+ * @param class-string<T> $class
+ */
+function testDependentReturnTypeNestedStatic(string $class) {
+    // The dependent result (which carries the argument-derived substitution of U, here the
+    // literal 1) must be kept, while the declaring-class expansion `Foo5935k[]` is removed -
+    // so this is `1|T[]`, not `1|T[]|Foo5935k[]`.
+    $x = $class::makeMany(1);
+    '@phan-debug-var $x';
+}

--- a/tests/files/src/5935_class_string_static_call.php
+++ b/tests/files/src/5935_class_string_static_call.php
@@ -307,3 +307,24 @@ function testGenericArgumentsPreservedForStaticReturn(string $class) {
     '@phan-debug-var $x';
     return $x;
 }
+
+interface Maker5935g {
+    public static function make(): static;
+}
+interface Marker5935g {
+}
+
+/**
+ * @template T of Maker5935g&Marker5935g
+ * @param class-string<T> $class
+ * @return T
+ */
+function testIntersectionBoundPreservesTemplate(string $class) {
+    // The bound is an intersection, which has no single FQSEN - member lookup flattens it to
+    // find Maker5935g::make(), so the represented template must be associated with each
+    // flattened part. Otherwise `static` resolves to \Maker5935g, dropping the Marker5935g
+    // constraint and falsely mismatching this function's own `@return T`.
+    $x = $class::make();
+    '@phan-debug-var $x';
+    return $x;
+}

--- a/tests/files/src/5935_class_string_static_call.php
+++ b/tests/files/src/5935_class_string_static_call.php
@@ -1,0 +1,57 @@
+<?php
+// Regression test for https://github.com/phan/phan/issues/5558
+// A variable typed `class-string<Foo>` didn't resolve to Foo for static calls ($class::method()),
+// unlike an actual Foo-typed variable or `new $class()` (both already worked). This meant the
+// return type of a valid static call was inferred as empty, and typos in the method name went
+// completely unchecked (no PhanUndeclaredStaticMethod).
+
+class Foo5935 {
+    public static function bar(): Bar5935 {
+        return new Bar5935();
+    }
+}
+
+class Bar5935 {
+    public function output(): void {
+        echo "Hello";
+    }
+}
+
+/**
+ * @param class-string<Foo5935> $class
+ */
+function testValidMethodViaClassString(string $class) {
+    $bar = $class::bar();
+    '@phan-debug-var $bar';
+    $bar->output();
+}
+
+/**
+ * @param class-string<Foo5935> $class
+ */
+function testInvalidMethodViaClassString(string $class) {
+    $bar = $class::not_a_function();
+    '@phan-debug-var $bar';
+}
+
+/**
+ * @param class-string $class
+ */
+function testBareClassStringUnaffected(string $class) {
+    // No template parameter - Phan genuinely can't know the class, this must stay unresolved
+    // (no crash, no incorrect resolution).
+    $bar = $class::bar();
+    '@phan-debug-var $bar';
+}
+
+// Control cases: an actual object-typed parameter, to lock in unchanged behavior.
+function testValidMethodViaInstance(Foo5935 $class) {
+    $bar = $class::bar();
+    '@phan-debug-var $bar';
+    $bar->output();
+}
+
+function testInvalidMethodViaInstance(Foo5935 $class) {
+    $bar = $class::not_a_function();
+    '@phan-debug-var $bar';
+}

--- a/tests/plugin_test/expected/322_class_string_strict_method_checking.php.expected
+++ b/tests/plugin_test/expected/322_class_string_strict_method_checking.php.expected
@@ -1,0 +1,7 @@
+src/322_class_string_strict_method_checking.php:10 PhanPluginUseReturnValueNoopVoid The function/method \HasMethod322::shared() is declared to return void and it has no side effects
+src/322_class_string_strict_method_checking.php:14 PhanUnreferencedClass Possibly zero references to class \LacksMethod322
+src/322_class_string_strict_method_checking.php:20 PhanUnreferencedFunction Possibly zero references to function \test_class_string_alternative_322()
+src/322_class_string_strict_method_checking.php:21 PhanPossiblyUndeclaredMethod Call to possibly undeclared method shared on type \HasMethod322|\LacksMethod322 (\LacksMethod322 does not declare the method)
+src/322_class_string_strict_method_checking.php:28 PhanUnreferencedFunction Possibly zero references to function \test_plain_object_alternative_322()
+src/322_class_string_strict_method_checking.php:29 PhanPossiblyUndeclaredMethod Call to possibly undeclared method shared on type \HasMethod322|\LacksMethod322 (\LacksMethod322 does not declare the method)
+src/322_class_string_strict_method_checking.php:36 PhanUnreferencedFunction Possibly zero references to function \test_all_alternatives_declare_322()

--- a/tests/plugin_test/expected/322_class_string_strict_method_checking.php.expected
+++ b/tests/plugin_test/expected/322_class_string_strict_method_checking.php.expected
@@ -5,3 +5,5 @@ src/322_class_string_strict_method_checking.php:21 PhanPossiblyUndeclaredMethod 
 src/322_class_string_strict_method_checking.php:28 PhanUnreferencedFunction Possibly zero references to function \test_plain_object_alternative_322()
 src/322_class_string_strict_method_checking.php:29 PhanPossiblyUndeclaredMethod Call to possibly undeclared method shared on type \HasMethod322|\LacksMethod322 (\LacksMethod322 does not declare the method)
 src/322_class_string_strict_method_checking.php:36 PhanUnreferencedFunction Possibly zero references to function \test_all_alternatives_declare_322()
+src/322_class_string_strict_method_checking.php:45 PhanUnreferencedFunction Possibly zero references to function \test_class_string_inner_union_322()
+src/322_class_string_strict_method_checking.php:46 PhanPossiblyUndeclaredMethod Call to possibly undeclared method shared on type \HasMethod322|\LacksMethod322 (\LacksMethod322 does not declare the method)

--- a/tests/plugin_test/expected/322_class_string_strict_method_checking.php.expected
+++ b/tests/plugin_test/expected/322_class_string_strict_method_checking.php.expected
@@ -7,3 +7,7 @@ src/322_class_string_strict_method_checking.php:29 PhanPossiblyUndeclaredMethod 
 src/322_class_string_strict_method_checking.php:36 PhanUnreferencedFunction Possibly zero references to function \test_all_alternatives_declare_322()
 src/322_class_string_strict_method_checking.php:45 PhanUnreferencedFunction Possibly zero references to function \test_class_string_inner_union_322()
 src/322_class_string_strict_method_checking.php:46 PhanPossiblyUndeclaredMethod Call to possibly undeclared method shared on type \HasMethod322|\LacksMethod322 (\LacksMethod322 does not declare the method)
+src/322_class_string_strict_method_checking.php:52 PhanUnreferencedClass Possibly zero references to interface \Marker322
+src/322_class_string_strict_method_checking.php:62 PhanTemplateTypeNotUsedInFunctionReturn Template type T not used in return value of function/method test_class_string_intersection_bound_322()
+src/322_class_string_strict_method_checking.php:62 PhanUnreferencedFunction Possibly zero references to function \test_class_string_intersection_bound_322()
+src/322_class_string_strict_method_checking.php:63 PhanAbstractStaticMethodCall Potentially calling an abstract static method \HasShared322::sharedIface() in $class::sharedIface()

--- a/tests/plugin_test/src/322_class_string_strict_method_checking.php
+++ b/tests/plugin_test/src/322_class_string_strict_method_checking.php
@@ -1,0 +1,38 @@
+<?php
+// Regression test for https://github.com/phan/phan/issues/5558
+// With strict_method_checking, a `class-string<B>` alternative in a union receiver must be
+// checked like the class it represents. getClassList() resolves it to B for static calls, so
+// isDefinitelyPossiblyUndeclaredMethod() must consider B too - otherwise a union such as
+// `A|class-string<B>` where only A declares the method silently suppressed the expected
+// PhanPossiblyUndeclaredMethod.
+
+class HasMethod322 {
+    public static function shared(): void {
+    }
+}
+
+class LacksMethod322 {
+}
+
+/**
+ * @param HasMethod322|class-string<LacksMethod322> $receiver
+ */
+function test_class_string_alternative_322($receiver): void {
+    $receiver::shared();
+}
+
+/**
+ * Control case: the same shape with two plain object types, which has always warned.
+ * @param HasMethod322|LacksMethod322 $receiver
+ */
+function test_plain_object_alternative_322($receiver): void {
+    $receiver::shared();
+}
+
+/**
+ * Must NOT warn - every alternative declares the method.
+ * @param HasMethod322|class-string<HasMethod322> $receiver
+ */
+function test_all_alternatives_declare_322($receiver): void {
+    $receiver::shared();
+}

--- a/tests/plugin_test/src/322_class_string_strict_method_checking.php
+++ b/tests/plugin_test/src/322_class_string_strict_method_checking.php
@@ -45,3 +45,20 @@ function test_all_alternatives_declare_322($receiver): void {
 function test_class_string_inner_union_322($class): void {
     $class::shared();
 }
+
+interface HasShared322 {
+    public static function sharedIface(): void;
+}
+interface Marker322 {
+}
+
+/**
+ * An intersection bound: the runtime class implements BOTH constituents, so *any* of them
+ * supplying the method is enough - unlike a union, where every alternative must supply it.
+ * Must NOT warn even though Marker322 alone doesn't declare sharedIface().
+ * @template T of HasShared322&Marker322
+ * @param class-string<T> $class
+ */
+function test_class_string_intersection_bound_322($class): void {
+    $class::sharedIface();
+}

--- a/tests/plugin_test/src/322_class_string_strict_method_checking.php
+++ b/tests/plugin_test/src/322_class_string_strict_method_checking.php
@@ -36,3 +36,12 @@ function test_plain_object_alternative_322($receiver): void {
 function test_all_alternatives_declare_322($receiver): void {
     $receiver::shared();
 }
+
+/**
+ * The represented type is itself a union - the string could name either class at runtime,
+ * so EVERY represented class must declare the method, not merely one of them.
+ * @param class-string<HasMethod322|LacksMethod322> $class
+ */
+function test_class_string_inner_union_322($class): void {
+    $class::shared();
+}


### PR DESCRIPTION
# Issue #5558: `class-string<X>` doesn't resolve for static calls

## Symptoms

A variable typed `class-string<Foo>` doesn't resolve to `Foo` when used as the class part of a
static call — unlike an actual `Foo`-typed variable, or `new $class()`, both of which already
work correctly:

```php
class Foo {
    public static function bar(): Bar { return new Bar(); }
}
class Bar {
    public function output(): void { echo "Hello"; }
}

/** @param class-string<Foo> $class */
function test(string $class) {
    $bar = $class::bar();   // $bar inferred as (empty union type), should be \Bar
    $bar->output();          // -> PhanPluginUnknownObjectMethodCall (downstream noise)
}

/** @param class-string<Foo> $class */
function test2(string $class) {
    $class::not_a_real_method();  // silently swallowed - no PhanUndeclaredStaticMethod at all
}
```

Two independent symptoms from one root cause: return-type inference silently gives up, and
validation silently gives up too, so typos in static-call method names go completely unchecked.

## Root cause

`class-string<Foo>` is represented by `ClassStringType` (`src/Phan/Language/Type/ClassStringType.php`),
which `extends StringType` and `use NativeTypeTrait;`, so `isNativeType()` is true for it — same as
plain `string`. Every place that resolves "which classes does this expression's type refer to"
explicitly skips native types, so `class-string<Foo>` gets skipped too, even though it already
knows exactly which class it means (`ClassStringType::getClassUnionType()` extracts the `<Foo>`
template parameter as a union type).

Two independent call chains hit this:

1. **Return-type inference**: `UnionTypeVisitor::visitMethodCall()` → `classListFromNode()`
   (`src/Phan/AST/UnionTypeVisitor.php:4228`) filters via `$union_type->nonNativeTypes()` before
   even checking `isObjectWithKnownFQSEN()`, so `Foo` never gets looked up and the call's return
   type stays empty.
2. **Method validation / issue emission**: `PostOrderAnalysisVisitor::visitStaticCall()` →
   `getStaticMethodOrEmitIssue()` → `ContextNode::getMethod()` → `getMethodListInternal()` →
   `ContextNode::getClassList()` (`src/Phan/AST/ContextNode.php:572`) has the same skip, and its
   "wrong type" fallback check explicitly treats any `StringType` as an acceptable category for
   this kind of node — so method lookup just silently no-ops for both valid and invalid method
   names, no diagnostic either way.

**Why `new $class()` already worked**: `UnionTypeVisitor::visitNew()` → `visitClassNameNode()` →
`classTypesForNonName()` *does* special-case `ClassStringType` already, expanding it via
`getClassUnionType()`.

## First attempt: too broad (caught by Codex review, fixed before merge)

My first pass patched `UnionType::asClassList()` to unconditionally expand `ClassStringType` for
*every* caller. That's wrong: `asClassList()` also backs **instance**-call resolution
(`$class->method()`, `ContextNode::getMethodListInternal()` with `$is_static = false`). Since
`$class` is genuinely a *string* at runtime, `$class->method()` must be rejected (it's a fatal
error in PHP), but the unconditional expansion made Phan treat it as a valid call on `Foo` —
silently accepting code that crashes at runtime. Caught by Codex's review on the PR (two P1/P2
findings) before merging; reverted that approach in favor of the below.

## Fix (properly scoped to class-name contexts only)

The key distinction already exists in the codebase as `ContextNode::CLASS_LIST_ACCEPT_OBJECT`
(instance-only) vs `CLASS_LIST_ACCEPT_OBJECT_OR_CLASS_NAME` (`$is_static || $is_new_expression`).
Both fixes reuse that distinction instead of touching `asClassList()` globally:

- **`ContextNode::getClassList()`** (`src/Phan/AST/ContextNode.php`): added a `ClassStringType`
  resolution step gated on `$expected_type_categories !== self::CLASS_LIST_ACCEPT_OBJECT` — i.e.
  it only ever runs for static-call/`new`/class-name-accepting contexts, never for instance calls.
  Resolves via `$type->getClassUnionType()->asClassList(...)`, catching
  `CodeBaseException`/`IssueException` to emit the equivalent diagnostics the sibling
  `LiteralStringType` recovery branch already emits (`Issue::UndeclaredClass`,
  `Issue::EmptyFQSENInClasslike`/`InvalidFQSENInClasslike`) instead of letting them escape.
  (This step moved and lost its initial nullability guard in the third review round below —
  see that section for the final shape and why.)
- **`UnionTypeVisitor::classListFromNode()`** (`src/Phan/AST/UnionTypeVisitor.php:4228`): added a
  `bool $expand_class_string_type` parameter (default `false`, i.e. safe/unchanged unless a caller
  opts in). Only when `true` — and only when the union type actually contains a `ClassStringType`
  (avoids the rebuild entirely on the hot instance-call path, per Copilot's perf comment) — does it
  expand via `getClassUnionType()` before the existing `nonNativeTypes()` filter.
  - `UnionTypeVisitor::visitMethodCall()` passes `$static_class_node !== null` — true only for
    `AST_STATIC_CALL` (`$node->children['class']` is only populated for static-call syntax; an
    instance call has `$node->children['expr']` instead).
  - The public wrapper `classListFromNodeAndContext()` grew the same parameter, threaded through
    from its two callers: `ArgumentType.php` (passes `$node_kind === ast\AST_STATIC_CALL`, since
    that call site handles `AST_STATIC_CALL`/`AST_METHOD_CALL`/`AST_NULLSAFE_METHOD_CALL`
    uniformly) and `FallbackUnionTypeVisitor::visitStaticCall()` (left as `false`/default — that
    method already requires `$class_node->kind === ast\AST_NAME`, a literal class name, so a
    `class-string`-typed variable can never reach it in the first place).

Bare `class-string` (no `<T>`) is unaffected either way — `getClassUnionType()` returns
`UnionType::empty()` when there's no template parameter, contributing nothing, exactly as before.

## Second round of Codex findings (both valid, fixed before merge)

**P1 — nullability regression**: my `ContextNode::getClassList()` fix above resolved
`?class-string<Foo>` the same as non-nullable `class-string<Foo>`, so it made `$class_list`
non-empty regardless of nullability. That silently *removed* a pre-existing diagnostic:
`?class-string<Foo> $class; $class::bar();` used to correctly emit `PhanNonClassMethodCall`
(verified by temporarily reverting just this one change and re-running) — because
`ContextNode::getMethodListInternal()` has its own, unrelated nullability heuristic that only
suppresses that warning for *non-nullable* string-like receivers. With my fix making
`$class_list` non-empty, that whole check was bypassed and the call was silently accepted.

Fix: added `if ($type->isNullable()) { continue; }` at the top of the new `ClassStringType`
branch — a nullable `class-string` is left unresolved by this code exactly as before, so the
pre-existing nullability-based warning fires again. Return-type inference (`$bar = $class::bar()`)
is unaffected, since it's a separate code path — you now get both the warning *and* a usefully
inferred type for the case where the call doesn't fail, matching how the codebase already treats
other "possibly invalid, but useful if valid" call sites.

**P2 — template resolution ignored the represented class**: for
`class-string<Box<T>> $class; $class::make()` where `make()` returns class-level `T`,
`Method::resolveTemplateType()` is called with the *raw* type of `$class_node`
(`class-string<Box<int>>`), not the class it represents. Since `ClassStringType` isn't
`isObjectWithKnownFQSEN()`, its own template-parameter map is empty, so `T` stayed unresolved
instead of becoming `int`.

Fix: factored the class-string expansion logic out of `classListFromNode()` into a small shared
`UnionTypeVisitor::expandClassStringTypes()` helper, and reused it at the `resolveTemplateType()`
call site in `visitMethodCall()`, gated the same way (`$static_class_node !== null` — i.e. only
for genuine static-call syntax).

## Tests

`tests/files/src/5935_class_string_static_call.php` (+ `.expected`) covers, in addition to the
original cases (valid/invalid static call via `class-string<Foo>`, control cases via an actual
`Foo`-typed parameter, bare `class-string` staying unresolved):

- **instance-syntax** (`$class->instanceMethod()`) on a `class-string<Foo>` parameter — must still
  emit `PhanNonClassMethodCall` rather than resolving against `Foo` (added after the first Codex
  round).
- **nullable class-string, return-type inference** (`?class-string<Foo> $class; $class::bar();`)
  — resolves `\Bar` with no "possibly null" warning, matching nullable-object precedent (added
  after the second Codex round; behavior finalized in the third round — see below).
- **nullable class-string, member validation** (`?class-string<Foo> $class; $class::missing();`)
  — must still emit `PhanUndeclaredStaticMethod`, not silently no-op (added after the third Codex
  round, finding #1).
- **class-level template resolution, return type** (`class-string<Box<int>> $class; $class::make()`
  where `make(): T`) — must resolve to `int`, not raw `T` (added after the second Codex round).
- **class-level template resolution, argument validation** (`class-string<Box<int>> $class;
  $class::accept('not_an_int')` where `accept(T $value)`) — must flag the argument mismatch against
  `int`, exercising the *separate* `resolveTemplateType()` call site used for argument/visibility
  checking rather than return-type inference (added after the third Codex round, finding #3).
- **class-string alternative in a union already partially resolved** (`A|class-string<B> $receiver;
  $receiver::onlyOnB();` where only `B` declares the method) — must not report an undeclared method
  against `A` just because `A` resolved first (added after the third Codex round, finding #2).
- **dynamic `::class`** (`$class::class` where `$class` is `class-string<Foo>`) — must stay
  unresolved (`class-string`), not silently evaluate to the literal `'Foo'` (added after the
  fourth Codex round, finding #1).
- **bounded template class-string, member lookup** (`@template T of Foo` +
  `class-string<T> $class; $class::bar();` where `bar()` is declared on the bound `Foo`) — must
  resolve return type and validate members through the bound (added after the fourth Codex round,
  finding #2).
- **bounded template class-string, genericity preserved** (same bound, but
  `@return T; return new $class();`) — `new $class()` must stay `T`, not collapse to the concrete
  bound `Foo`, or a legitimately generic factory would falsely mismatch its own declared return
  type (added after the fourth Codex round, finding #2 — this is the regression-guard for the fix
  above).
- **bounded template class-string, late static binding** (`@template T of Foo` +
  `class-string<T> $class; $class::make();` where `Foo::make(): static`) — the method's own body
  (analyzed generically) must see `T`, not the concrete bound `Foo`, for `static`'s return type;
  and a caller passing `Sub::class` (a subclass of `Foo`) must see the wrapper's return type
  correctly narrow to `\Sub` (added after the fifth Codex round).
- **bounded template class-string, `self` return** (same shape but `Foo::makeSelf(): self`) —
  must stay the declaring class `\Foo`, *not* be substituted with `T` the way `static` is (added
  after the sixth Codex round, finding #2).
- **union of class-strings with distinct templates** (`class-string<T>|class-string<U> $class;
  $class::make();` where both bounds declare `make(): static`) — must infer `T|U`, with each
  alternative mapped back to its own template, not the last-scanned one applied to both (added
  after the sixth Codex round, finding #1).
- **union of class-strings whose templates share one bound** (`@template T of Foo`,
  `@template U of Foo`, `class-string<T>|class-string<U>`) — must still infer `T|U`; both
  templates key on the same resolved class and neither may overwrite the other (added after the
  seventh Codex round, finding #1).
- **concrete alternative alongside a template class-string** (`Foo|class-string<T>` where `T` is
  bounded by `Foo`, calling `Foo::make(): static`) — both alternatives resolve to the same class,
  so the template substitution must *not* apply; the plain `Foo` alternative's own result must
  survive (added after the eighth Codex round, finding #2).
- **generic arguments preserved for `static` returns** (`class-string<Box<int>> $class;
  $class::make();` where `Box<T>::make(): static`) — must infer `Box<int>`, not bare `Box`; the
  generic arguments must survive the reduction to a `Clazz` for member lookup (added after the
  ninth Codex round).
- **intersection template bound preserves the template** (`@template T of I&J`,
  `class-string<T> $class; $class::make();` where `I::make(): static`) — must infer `T`, not the
  single constituent `I` that member lookup happened to resolve through (added after the tenth
  Codex round, finding #2).
- **nested `static` returns** (`class-string<T> $class; $class::makeMany();` where
  `makeMany(): static[]`, plus a `?static` variant) — must infer `T[]` / `?T`, with no leftover
  `Foo[]` / `?Foo` from `getUnionType()`'s declaring-class expansion (added after the eleventh
  Codex round).
- **inherited `self` resolves to the declaring class** (`class-string<T>` bounded by `Child`,
  calling an inherited `Base::makeSelf(): self`) — must infer `Base`, not the receiver `Child`,
  even though `static` in the same position resolves to `T` (added after the twelfth Codex round).
- **intersection concrete alternative alongside a template class-string**
  (`(Foo&Marker)|class-string<T>` where `T` is bounded by `Foo`) — the intersection's parts must
  count as concretely referenced, so the result keeps `\Foo` rather than collapsing to `T`; the
  intersection analogue of the concrete-alternative case above (added after the thirteenth Codex
  round).
- **nested `static` through a dependent return type** (a static method with a method-level
  `@template U` used in its `@return static[]|U`, called via `class-string<T>`) — must infer
  `1|T[]`: the argument-derived substitution of `U` is kept while the declaring-class expansion
  `Foo[]` is removed (added after the fourteenth Codex round).
- **dependent return type colliding with the expansion** (`@return static|U` called with an
  argument that makes `U` resolve to the declaring class) — must infer `T|Foo`: the genuine `U`
  result must survive even though it is identical to the expansion type that gets subtracted
  (added after the fifteenth Codex round).

Additionally, `tests/plugin_test/src/322_class_string_strict_method_checking.php` (+ its per-file
`.expected`; that suite has `strict_method_checking` enabled, unlike the main one) covers finding
#2 of the seventh round — `A|class-string<B>` where only `A` declares the method must emit
`PhanPossiblyUndeclaredMethod` identically to the plain-object `A|B` control, while
`A|class-string<A>` must stay silent — plus finding #1 of the eighth round (`class-string<A|B>`
where only `A` declares the method must warn too) and finding #1 of the tenth round
(`@template T of I&J` calling a method declared only by `I` must *not* warn, since an intersection
requires only one constituent to supply it).

Note `tests/plugin_test/expected/all_output.expected` is gitignored and regenerated by
`tests/plugin_test/test.sh` from the per-file `expected/*.php.expected` files — only the per-file
one is committed. As a side effect, `internal/Issue-Types-Caught-by-Phan.md` gained an example
link for `PhanPossiblyUndeclaredMethod`, which previously had none (regenerated via the
`WikiIssueTypesTest` failure message's instructions).

## Verification

- Reproduced the exact issue snippet on `v6` tip before the fix: return type empty, no
  `PhanUndeclaredStaticMethod` for the typo'd method call.
- After the fix: return type is `\Bar`, and the typo'd call now emits `PhanUndeclaredStaticMethod`
  — matching the already-correct object-instance behavior exactly.
- Confirmed the instance-syntax case still correctly rejects with `PhanNonClassMethodCall`.
- Confirmed the nullable case: reverted just the `ContextNode.php` change temporarily to verify
  `PhanNonClassMethodCall` used to fire, confirmed my fix silenced it, then confirmed the
  `isNullable()` guard restores it exactly while leaving return-type inference intact.
- Confirmed the template case: `$value` debugged as literal `T` before the
  `expandClassStringTypes()` fix, `int` after.
- `./vendor/bin/phpunit`: one pre-existing test's expectations changed (see below, not a
  regression) — 2364 tests, 0 failures.
- `./phan` (self-analysis): clean.

## Third round of Codex/Copilot findings (all valid, fixed before merge)

On the commit that added the nullability guard from round 2, Codex and Copilot raised four more
issues with that same code:

1. **"Retain the represented class for nullable class strings"** (Codex P2): my `continue` for
   nullable `class-string` didn't just drop the "resolved" warning suppression — it dropped *all*
   member validation (`getMethodListInternal()` returns early once `$class_list` is empty), so
   `$class::missing()` got no `PhanUndeclaredStaticMethod` and `$class::bar('wrong')` got no
   argument-type check either.
2. **"Expand class strings when another class is already resolved"** (Codex P2): the whole
   `ClassStringType` branch was nested under `if (count($class_list) === 0)`, so for a union like
   `A|class-string<B>` where `A` was already resolved (`class_list` non-empty), `B` was never even
   considered — `$receiver::onlyOnB()` (a method only `B` has) incorrectly reported
   `PhanUndeclaredStaticMethod` against `A`.
3. **"Resolve method templates against the expanded receiver"** (Codex P2): I'd already fixed
   `UnionTypeVisitor`'s `resolveTemplateType()` call (used only for *return-type inference*), but
   missed the separate one in `ContextNode::getMethodListInternal()` (`:1013-1021`, used for the
   `Method` object that argument/visibility checking actually runs against). So
   `class-string<Box<int>> $class; $class::accept($wrongType)` never flagged the argument mismatch
   — `T` stayed unresolved for that specific `Method` object even though return-type inference
   correctly saw `int`.
4. **Copilot (suppressed comment): nullability check missed the pipe-null spelling** —
   `$type->isNullable()` only catches `?class-string<Foo>` (a single `ClassStringType` with
   `is_nullable=true`); the equivalent `class-string<Foo>|null` phpdoc is stored as *two* separate
   union members (`ClassStringType` + `NullType`), which my check didn't account for, so that
   spelling still silently resolved despite the guard.

**Resolution**: verified nullable OBJECT receivers already establish the target model —
`?Foo $obj; $obj::bar('wrong'); $obj::missing();` gets **no** "possibly null" warning at all, but
**full** argument/undeclared-method validation. Removed the nullability guard entirely (fixes #1
and #4 by construction — no more nullability special-casing to be inconsistent about), and
restructured the `ClassStringType` resolution to run **unconditionally** rather than nested under
`count($class_list) === 0` (fixes #2). For #3, made `UnionTypeVisitor::expandClassStringTypes()`
`public` and reused it at the `ContextNode.php:1013-1021` call site, gated on `$is_static` the same
way as the return-type-inference one.

This intentionally makes `class-string<Foo>` receivers behave exactly like `Foo`-typed nullable
receivers: no null-safety warning, but complete member validation. That's a deliberate design
choice (documented inline), not an oversight — see the code comment in `getClassList()`.

## Fourth round of Codex findings (both valid, fixed before merge)

1. **"Exclude string receivers from dynamic ::class expansion"** (Codex P2): my unconditional
   `ContextNode::getClassList()` expansion is also reached from `$class::class`
   (`AST_CLASS_NAME`, handled by two separate `visitClassName()` implementations — one in
   `UnionTypeVisitor.php` for type inference, one in `PostOrderAnalysisVisitor.php` for
   reference-tracking), which also uses `CLASS_LIST_ACCEPT_OBJECT_OR_CLASS_NAME`. Verified in
   plain PHP: `$str::class` on a string throws `TypeError: Cannot use "::class" on string`
   (unlike `$obj::class` on an object, or the literal `Foo::class`). My fix was making
   `$class::class` (where `$class` is `class-string<Foo>`) incorrectly resolve to the literal
   string `'Foo'`, silently accepting an expression that fatals at runtime.

   Fix: added an `$expand_class_string` parameter to `getClassList()` (default `true`,
   unchanged everywhere else), passed `false` from both `visitClassName()` call sites.

2. **"Expand bounded template class strings through their bounds"** (Codex P2): for
   `@template T of Foo` + `@param class-string<T> $class`, `ClassStringType::getClassUnionType()`
   returns the raw `TemplateType` `T` (its `isObjectWithKnownFQSEN()` is false), so neither
   `asClassList()` nor `expandClassStringTypes()` could resolve anything — `$class::foo()` (where
   `foo()` is declared on the bound `Foo`) had empty return-type inference and no member
   validation, confirmed by reproduction.

   My first fix made `ClassStringType::getClassUnionType()` itself resolve bounded templates to
   their bound — too broad: that same method backs `new $class()`'s *resulting value type*
   (`UnionTypeVisitor::classTypesForNonName()`), and collapsing `T` to its concrete bound there
   breaks legitimately generic factories (`@return T` where `T` might be a narrower subtype than
   the bound) — caused 3 regressions (`4650_template_return_type_match.php`,
   `5258_template_mixed_types.php`, `template_class_string_constraint.php`, all
   `PhanTypeMismatchReturn`-family false positives).

   Fixed by keeping `getClassUnionType()` unchanged, and adding a separate
   `getClassUnionTypeResolvingBounds()` method used only at the two *member-lookup* call sites
   (`ContextNode::getClassList()`'s new block, `UnionTypeVisitor::expandClassStringTypes()`) —
   not at the `new $class()` resulting-type call site, which must keep `T` unresolved to preserve
   genericity.

## Fifth round of Codex findings (valid, fixed before merge)

**"Preserve bounded templates for late-static returns"** (Codex P2): for `@template T of Foo` +
`class-string<T> $class` calling a method declared `Foo::make(): static`, the fourth round's fix
correctly finds `make()` via the bound `Foo` — but `visitMethodCall()`'s late-static-binding step
(`src/Phan/AST/UnionTypeVisitor.php:3752`) then resolves the returned `static` against *that
discovered class* (`$class->getInternalContext()`), producing concrete `\Foo` instead of the
represented template `T`. A generic wrapper declared `@return T` then gets a false
`PhanTypeMismatchReturn`, and — more importantly — loses subtype information: calling the wrapper
with `Sub::class` (a subclass of `Foo`) should narrow the wrapper's return type to `\Sub` at the
call site, but internally the wrapper's own body sees a hardcoded `\Foo`, discarding genericity.

Reproduced, confirmed against a working baseline (a plain `@param T $obj` version doesn't hit this,
though only because it fails to resolve *anything* — `T` alone isn't `isObjectWithKnownFQSEN()`, so
`classListFromNode()` finds no method at all and returns an unhelpful empty type; that's the
"nothing" baseline this fix improves on without regressing).

Fix: before the `classListFromNode()` loop, extract the *original* (unresolved) template type
represented by `class_node`'s `class-string<T>`, if any. In the late-static-binding step, when
that's set and the method's return type involves `static`/`self`, substitute `static` with `T`
directly (`UnionType::withStaticResolvedTo()`) instead of resolving it against the discovered
class's context — mirroring the *existing* instance-call handling a few lines above, which already
does exactly this pattern (`withoutType($class_fqsen->asType())->withStaticResolvedTo(...)`) for a
different reason (preserving the caller's own object type on `$foo->returnThis()`).

Hit one additional subtlety while implementing: `Method::getUnionType()` represents a native
`: static` return type as `Foo|static` (the literal defining class *and* the abstract `static`
marker together, not `static` alone) — so substituting `static → T` alone left a spurious
`T|\Foo` union (the un-substituted `\Foo` didn't collapse with `T`, unlike the working
non-template case where resolving `static → Foo` trivially dedupes with the existing `\Foo`).
Fixed by also stripping the base class type before substituting, matching the existing
instance-call code's `withoutType(...)` step exactly.

## Sixth round of Codex findings (one confirmed, one defensive; both addressed)

1. **"Keep represented templates associated with each union alternative"** (Codex P2) —
   **confirmed by reproduction.** The fifth round stored the represented template in a single
   `$represented_template_type` variable, so for a receiver like
   `class-string<T>|class-string<U>` the scan overwrote it and the later per-class loop applied
   whichever template was seen *last* to *every* resolved class. Verified: `$class::make()`
   inferred just `U` instead of `T|U`.

   Fix: track the represented template per class, keyed by the FQSEN of the bound it resolves to
   (`$represented_template_types[(string)$bound_type->asFQSEN()] = $inner_type`), and look it up
   by `$class->getFQSEN()` inside the loop. Now correctly yields `T|U`.

2. **"Resolve `self` against the method's declaring class"** (Codex P2) — **mechanism is real,
   but I could not construct a case that triggers it.** The reasoning is sound in isolation:
   `hasStaticOrSelfTypesRecursive()` returns true for `SelfType` (via `StaticOrSelfType`), while
   `SelfType` does not override `withStaticResolvedTo()` and so inherits `Type`'s implementation,
   which returns `$this` unchanged for a type with no template parameters — meaning a `SelfType`
   reaching that branch would be left unresolved *and* would skip the normal
   `withStaticResolvedInContext()` resolution.

   However, every `self`-return spelling I tried still resolved correctly to the declaring class
   (native `: self`, phpdoc `@return self`, and the trait case — traits are the one place
   `Method::fromNode()` deliberately skips `withSelfResolvedInContext()` at parse time, but
   `Clazz.php:3489` resolves it again when importing trait methods into the using class). So
   `SelfType` appears not to survive into this code path in practice.

   Applied the fix anyway, since it is free and unambiguously correct: after substituting
   `static → T`, also `->withSelfResolvedInContext($class->getInternalContext())` so any residual
   `self` resolves to the declaring class rather than to the template. Added a regression test
   pinning `self`'s behavior so it stays correct if the parse-time resolution ever changes.

## Seventh round of Codex findings (both valid and confirmed, fixed before merge)

1. **"Preserve all templates that share a bound"** (Codex P2) — a direct follow-up on the sixth
   round's own fix. Keying the map by the bound's FQSEN still conflates alternatives when *distinct
   templates share the same bound*: for `@template T of Foo`, `@template U of Foo`, and
   `class-string<T>|class-string<U>`, both entries key on `\Foo` and the second overwrote the first.
   Verified: inferred `U` instead of `T|U`.

   Fix: each map entry is now a *list* of templates rather than a single value, and the
   substitution step unions the result of substituting each one. Now correctly yields `T|U` for
   both the distinct-bound case (sixth round) and the shared-bound case.

2. **"Check expanded alternatives during strict method validation"** (Codex P2) — with
   `strict_method_checking` enabled, `ContextNode::isDefinitelyPossiblyUndeclaredMethod()` iterates
   the *unexpanded* union and skips any `ClassStringType` (its `hasObjectWithKnownFQSEN()` is
   false). Since `getClassList()` now resolves that alternative for static calls, the two
   disagreed: a receiver `A|class-string<B>` where only `A` declares the method had its expected
   `PhanPossiblyUndeclaredMethod` silently suppressed. Verified against a plain-object control
   (`A|B`) that correctly warns.

   Fix: added a `ClassStringType` branch to that predicate resolving via
   `getClassUnionTypeResolvingBounds()` — the same helper the `getClassList()` expansion uses, so
   the two paths stay consistent. Confirmed `A|class-string<B>` now warns identically to `A|B`,
   while `A|class-string<A>` (all alternatives declare the method) correctly stays silent.

## CI failure on the seventh-round commit (self-analysis), and the real-type regression it exposed

CI failed on all five PHP versions with `__FakeSelfFallbackTest` — Phan analyzing *itself* with
the polyfill parser. The offending code was my own seventh-round loop:

```
src/Phan/AST/UnionTypeVisitor.php:3794 PhanPluginUnknownObjectMethodCall
Phan could not infer any class/interface types for the object of the method call
$union_type->withUnionType($substituted_union_type) - inferred a type of non-empty-mixed
```

I had written the multi-template fold as `$union_type = null;` followed by a
`$union_type ? $union_type->withUnionType(...) : $substituted_union_type` ternary. Assigning
`null` to a variable that is a `UnionType` everywhere else defeated Phan's own inference.

**Why I missed it locally:** I had been running `./vendor/bin/phpunit` plus `./phan`, but *not*
`./tests/run_all_tests`, which is what CI runs — it covers 17 suites including `__FakeSelfTest`
and `__FakeSelfFallbackTest`. Reproduced locally with
`./tests/run_test __FakeSelfFallbackTest` once pointed at it.

**First fix attempt was wrong in a way the type-only check wouldn't catch:** rewriting the fold as
`$acc = UnionType::empty(); ... $acc = $acc->withUnionType($x);` silenced the self-analysis error
but silently *dropped the real type set* — `UnionType::withUnionType()` deliberately calls
`eraseRealTypeSetRecursively()` when the receiver is empty (`UnionType.php:1023-1028`, the same
short-circuit that made the phpdoc-only property case work in #5556). `5935`'s expectations caught
it: `T(real=T)` degraded to bare `T`.

**Final fix:** collect the substituted union types into a list and combine with
`UnionType::merge()`, which preserves real types and short-circuits for the single-element case
(by far the most common). Verified the full `./tests/run_all_tests` suite now passes end to end.

## Eighth round of Codex findings (all three valid and confirmed, fixed before merge)

These were posted against commit `5e81a1938` (before the CI/merge fix above), so they are separate
findings, not follow-ups on it.

1. **"Require every represented union member to declare the method"** — my
   `isDefinitelyPossiblyUndeclaredMethod()` `ClassStringType` branch used `continue 2` as soon as
   *one* represented class declared the method. For `class-string<A|B>` the string could name
   either at runtime, so *all* of them must declare it. Verified: `class-string<A|B>` was silently
   suppressed while the semantically equivalent `class-string<A>|class-string<B>` control correctly
   warned. Fixed by inverting the loop to `return false` on the first class that lacks the method.

2. **"Preserve concrete alternatives during template substitution"** — for `Foo|class-string<T>`
   where `T` is bounded by `Foo`, both receiver alternatives resolve to the *same* `Clazz`, so my
   FQSEN-keyed lookup substituted `static → T` for that single entry and discarded the plain `Foo`
   alternative's own result. Verified: inferred just `T`, unsound at a call site where `T` is a
   subclass but the receiver is actually a plain `Foo`. Fixed by recording which FQSENs are also
   reachable through a non-class-string alternative and skipping template substitution for those
   (falling back to the normal concrete resolution).

3. **"Keep completion expansion out of instance-call syntax"** — my category-based gating in
   `getClassList()` doesn't cover `CompletionResolver::locateMethodCompletion()`, which hardcoded
   `CLASS_LIST_ACCEPT_OBJECT_OR_CLASS_NAME` while *having* an `$is_static` parameter it ignored for
   that call (it's called with `false` for `AST_PROP`). So LSP completion on
   `class-string<Foo> $class; $class->` would suggest `Foo`'s instance methods. Confirmed by
   inspection; fixed by passing `CLASS_LIST_ACCEPT_OBJECT` when `$is_static` is false.

### A crash my fix for #2 introduced, caught by the full suite

`$type->isObjectWithKnownFQSEN()` is *not* a sufficient guard before `$type->asFQSEN()` — the
existing test `0467_name_not_empty.php` exercises malformed literal class names like
`('??')::foo()`, which produce a type that passes that check but throws
`InvalidFQSENException: Invalid namespaced name for FQSEN '\??'`. Fixed with a `catch (FQSENException)`
around the FQSEN lookup (such a name can never correspond to a resolved class, so there is nothing
to record). This is the same defensive pattern `classListFromNode()` already uses nearby.

## Ninth round of Codex findings (valid and confirmed, fixed before merge)

**"Preserve generic arguments when resolving `static` returns"** — the represented-type map only
recorded direct `TemplateType` members, so a receiver typed `class-string<Box<int>>` (where generic
`Box<T>` declares `make(): static`) recorded nothing and fell through to the declaring-class
fallback, resolving `static` to bare `Box` and dropping `<int>`. Verified: `$x` inferred as
`\Box9` instead of `\Box9<int>`.

Fix: generalized the scan from "template types only" to "any represented type that *reduces* to a
different class when `classListFromNode()` turns it into a `Clazz`" — i.e. a bounded template
(reduces to its bound, as before) *or* a generic object type like `Box<int>` (reduces to bare
`Box`). Types that reduce to themselves are still skipped, so the common non-generic
`class-string<Foo>` case is untouched by design and keeps its existing resolution path — this keeps
the blast radius of the change minimal.

## Tenth round of Codex findings (both valid and confirmed, fixed before merge)

Both concern an *intersection*-typed template bound (`@template T of I&J`), where the key insight
is that unions and intersections have opposite requirements: for a union alternative *every*
member must supply a member, but for an intersection the runtime class implements *all*
constituents, so *any* constituent supplying it is enough.

1. **"Preserve intersection semantics in strict method checks"** — the eighth round's
   "every represented class must declare the method" rule (correct for `class-string<A|B>`) was
   applied to intersections too, because `asClassList()` flattens `I&J` into `I` and `J`. Verified:
   `class-string<T>` with `@template T of I&J` calling a method declared only by `I` emitted a
   false `PhanPossiblyUndeclaredMethod`. Fixed by iterating the represented union's *alternatives*
   and requiring only that each alternative supply the method — flattening an intersection
   alternative and accepting any constituent, exactly mirroring the pre-existing non-class-string
   branch immediately below it.

2. **"Preserve intersection-bound templates for `static` returns"** — an `IntersectionType` bound
   has no single FQSEN (`isObjectWithKnownFQSEN()` is false), so the represented-type scan never
   associated the discovered classes with `T`. Member lookup flattens the same bound and finds
   `I::make(): static`, so return resolution fell back to `I`, dropping the `J` constraint.
   Verified: `$x` inferred as `\I10` instead of `T`, plus a resulting false
   `PhanTypeMismatchReturn` in an `@return T` wrapper. Fixed by using
   `getUniqueFlattenedTypeSet()` when keying the map, so the template is associated with each
   constituent that member lookup can resolve through, while `T` remains the substitution result.

## Eleventh round of Codex findings (valid and confirmed, fixed before merge)

**"Substitute nested `static` from the unexpanded return type"** — `Method::getUnionType()` unions
the declared return type with its *own* declaring-class resolution of `static`
(`Method.php:766-783`): `static` becomes `static|Foo`, and correspondingly `static[]` becomes
`static[]|Foo[]` and `?static` becomes `?static|?Foo`. My substitution stripped only the exact bare
non-nullable `Foo` type before substituting, which is sufficient for a plain `static` return but
leaves the resolved counterpart behind for any *nested* occurrence. Verified: a
`class-string<T>` receiver calling `makeMany(): static[]` inferred `T[]|\Foo11[]` instead of `T[]`
(and `?static` gave `?T|?\Foo11`), which would falsely mismatch an `@return T[]` wrapper.

Fix: substitute from `Method::getUnionTypeWithUnmodifiedStatic()` (`Method.php:785-788`, which
returns `parent::getUnionType()` — the declared type with `static` still abstract and no expansion
appended) rather than trying to subtract the expansion after the fact. This removes the whole class
of "did I strip every resolved counterpart?" problems instead of patching the array/nullable cases
individually.

The previous `withoutType()` path is kept only for methods with a dependent return type (plugin
provided), where the return type doesn't come from `getUnionType()` and so has no expansion to
avoid — those are no worse off than before. Note this branch is only reachable for static calls,
where `visitMethodCall()`'s earlier `isset($node->children['expr'])` template-mapping block is
skipped, so `$union_type` here is exactly `getDependentReturnTypeOfCall()`'s result.

## Twelfth round of Codex findings (mechanism real, not reachable today; fixed defensively)

**"Resolve inherited `self` against its declaring class"** — my substitution branch called
`->withSelfResolvedInContext($class->getInternalContext())`, i.e. it resolved `self` against the
**receiver** class. `self` means the class that *declared* the method, so for an inherited
`Base::make(): self` called through `class-string<Child>` that would unsoundly infer `Child`.

The argument was genuinely wrong, but — as in the sixth round, where I first added this defensive
call — I could not construct a case that reaches it. Tried phpdoc `@return self`, native `: self`,
`@return self[]`, and a trait-declared `self`, each through a `class-string<T>` receiver bounded by
a subclass: all already infer the declaring class. The reason is unchanged from round 6: `self` is
resolved to the declaring class at parse time (`Method::fromNode()` →
`withSelfResolvedInContext()`) and again on trait import (`Clazz.php:3489`), so no `SelfType`
survives to this point and the call is a no-op.

Fixed anyway, since it costs nothing and the argument should be correct if a `SelfType` ever does
reach here: look up the method's defining class via `hasDefiningFQSEN()`/`getDefiningClassFQSEN()`
and use *its* `getInternalContext()`, falling back to the receiver class only when the defining
class isn't resolvable. Added a regression test pinning inherited-`self` behavior so it stays
correct if the parse-time resolution ever changes.

## Thirteenth round of Codex findings (valid and confirmed, fixed before merge)

**"Track concrete intersection alternatives before substituting static"** — the intersection
analogue of the eighth round's finding #2, and the mirror image of the tenth round's #2 (which
fixed the same blind spot on the *class-string* side). The `$concretely_referenced_fqsens` guard
only recorded a type when `isObjectWithKnownFQSEN()` was true, which an `IntersectionType` is not —
so for `(Foo&Marker)|class-string<T>`, `Foo` was never marked as concretely referenced,
the template substitution applied to the whole class entry, and the concrete alternative's own
result was discarded. Verified: inferred `T` where the plain (non-intersection) control
`Foo|class-string<T>` correctly gives `\Foo`.

Fix: flatten each non-class-string alternative with `getUniqueFlattenedTypeSet()` before recording
its FQSENs, matching how `classListFromNode()` resolves it — the same flattening already applied to
the class-string side in round 10. The round-8 `catch (FQSENException)` guard for malformed names
like `('??')::foo()` is retained inside the loop (re-verified against `0467_name_not_empty.php`).

## Fourteenth round of Codex findings (valid and confirmed, fixed before merge)

**"Remove recursively resolved dependent-return counterparts"** — the eleventh round fixed nested
`static` for the normal path by substituting from `getUnionTypeWithUnmodifiedStatic()`, but left
the *dependent-return* fallback still doing `withoutType($class->getFQSEN()->asType())`, which only
strips the bare class type. Since dependent-return closures typically derive their result from
`Method::getUnionType()`, they carry the same `static[]` → `static[]|Foo[]` expansion, so the
leftover `Foo[]` survived there.

Reachability took some digging: `FunctionTrait::addClosureForDependentTemplateType()` only installs
the closure when *every* method-level `@template` is used in the return type
(`FunctionTrait.php:1693-1725` — otherwise it emits `TemplateTypeNotUsedInFunctionReturn` and bails).
My first attempt at a repro therefore had `hasDependentReturnType() === false` and passed for the
wrong reason; instrumenting the branch showed that directly. With `@return static[]|U` (U used in
the return) the closure installs and the bug reproduces: `1|T[]|\Foo14b[]` instead of `1|T[]`.

The eleventh round's fix can't simply be reused here — `getUnionTypeWithUnmodifiedStatic()` would
discard the argument-derived substitutions that are the entire point of a dependent return type
(the literal `1` for `U` above). Fixed instead by subtracting exactly the types the expansion
added: any type in `$method->getUnionType()` that isn't in
`$method->getUnionTypeWithUnmodifiedStatic()`. That handles nested forms automatically, and
correctly preserves an explicitly declared `Foo[]` (it appears in the unmodified type, so it is
never subtracted).

## Fifteenth round of Codex findings (one fixed, one respectfully disputed)

### Fixed: "Preserve dependent types that match the static expansion"

The fourteenth round subtracted expansion types from the dependent-return result *by equality*, but
the two origins are indistinguishable that way. For `@return static|U` where an argument makes `U`
resolve to the declaring class, the genuine `Foo` result coincides exactly with the `Foo` that the
`static` expansion appended, so it was dropped: inferred `T` instead of `T|Foo`. That is unsound —
the method really can return the plain argument, which is not necessarily a `T`. Confirmed by
reproduction.

Exact separation is impossible after the fact (the closure is opaque and internally derives from
`Method::getUnionType()`). Fixed with a deliberately conservative heuristic: keep any expansion
type that one of the call's *argument* types could have produced, and only subtract the rest. That
resolves both cases correctly — round 14's `1|T[]` (argument is `1`, nothing matches `Foo[]`) and
this round's `T|Foo` (argument is a `Foo`) — and where the heuristic is imprecise it errs toward a
*wider* type rather than silently discarding a real one.

### Disputed: "Preserve both concrete and represented static-return alternatives"

The claim is that for `Foo|class-string<T>` (T bounded by `Foo`, `Foo::make(): static`) the result
should be `Foo|T` rather than the current `Foo`. I don't think this is a defect:

- This branch is only reached when the concrete alternative and `T`'s bound resolve to the *same*
  class, so `T ⊆ Foo` by construction and `Foo|T` is semantically just `Foo`. No information that
  affects correctness is lost.
- The suggestion would make results *less* sound in the direction that matters. If the receiver is
  the plain `Foo` object alternative, `make()` genuinely returns a `Foo` that need not be a `T`.
  Verified with a wrapper declared `@return T`: the resulting `PhanTypeMismatchReturn` is a **true**
  positive — that signature is unsound for the plain-object input — and would remain unsatisfied by
  `Foo|T` anyway, since `Foo` still isn't a `T`.

So the current behavior is both sound and equivalent; I've left it as is rather than adding a
redundant union member. Happy to revisit if a concrete case shows real precision loss.

## Test fallout: `0698_nullable_class_string.php` (improvement, not a regression)

`/** @param class-string<SplObjectHash> $s */` where `SplObjectHash` is a deliberately undeclared
class (typo of `SplObjectStorage`), used to test that converting `?class-string<UndeclaredClass>`
doesn't crash. After the full fix (including the nullability guard above), the result is exactly
the original pre-#5558 output, plus one new correct diagnostic for the previously-silent
non-nullable case:

```
:18 PhanUndeclaredClass Reference to undeclared class \SplObjectHash
:19 PhanNonClassMethodCall Call to method __construct on non-class type ?class-string<\SplObjectHash>
:20 PhanNonClassMethodCall Call to method __construct on non-class type ?class-string<\SplObjectHash>
```

Line 18 (`new $s()`, the non-nullable `class-string<SplObjectHash>`) now correctly reports the
undeclared class — previously silently unflagged, a pre-existing false negative unrelated to this
change. Lines 19-20 (the nullable variants `$s2`/`$s3`) are back to their original, unchanged
message — the nullability guard means my new code path never even attempts to resolve them, so no
new diagnostic is added there either. No crash either before or after. Regenerated the `.expected`
file via `PHAN_DUMP_NEW_TEST_EXPECTATION=1`.