### PR TITLE
Perf/method phase micro opts

### DIFF
--- a/src/Phan/Analysis.php
+++ b/src/Phan/Analysis.php
@@ -28,6 +28,7 @@ use Phan\Internal\InternalStubCacheEntry;
 use Phan\Language\Context;
 use Phan\Language\Element\Clazz;
 use Phan\Language\Element\ClassConstant;
+use Phan\Language\Element\Comment;
 use Phan\Language\Element\Func;
 use Phan\Language\Element\FunctionInterface;
 use Phan\Language\Element\Method;
@@ -249,9 +250,55 @@ class Analysis
             $functions,
             $global_constants,
             $file_level_suppressions,
-            $class_members
+            $class_members,
+            self::stubHasMandatoryPHPDocParam($functions, $class_members)
         );
         self::$internal_stub_cache_misses++;
+    }
+
+    /**
+     * Does any cached function or method of a stub document a `@phan-mandatory-param`?
+     *
+     * Replaying a cached stub does not re-parse doc comments, so this is recorded with the
+     * cache entry and restored, keeping CodeBase::sawMandatoryParamAnnotation() accurate for
+     * every CodeBase that reuses the entry.
+     *
+     * @param list<Func> $functions
+     * @param array<string,array{methods:list<Method>,properties:list<Property>,constants:list<ClassConstant>}> $class_members
+     */
+    private static function stubHasMandatoryPHPDocParam(array $functions, array $class_members): bool
+    {
+        foreach ($functions as $function) {
+            if (self::commentHasMandatoryPHPDocParam($function->getComment())) {
+                return true;
+            }
+        }
+        foreach ($class_members as $members) {
+            foreach ($members['methods'] as $method) {
+                if (self::commentHasMandatoryPHPDocParam($method->getComment())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static function commentHasMandatoryPHPDocParam(?Comment $comment): bool
+    {
+        if (!$comment) {
+            return false;
+        }
+        foreach ($comment->getParameterList() as $parameter) {
+            if ($parameter->isMandatoryInPHPDoc()) {
+                return true;
+            }
+        }
+        foreach ($comment->getParameterMap() as $parameter) {
+            if ($parameter->isMandatoryInPHPDoc()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static function normalizeInternalStubPath(string $file_path): string

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -354,12 +354,17 @@ class CodeBase
     }
 
     /**
-     * Did any doc comment in this CodeBase use `@phan-mandatory-param`?
+     * Has any doc comment parsed into this CodeBase used `@phan-mandatory-param`?
      *
-     * Doc comments are parsed during the parse phase, which finishes before the analysis
-     * phases that read this, so by then this is true if and only if the annotation occurs
-     * somewhere in the parsed codebase. Used to skip a per-parameter walk over ancestor
-     * methods that can only find something when the annotation is actually used.
+     * Doc comments are parsed before the analysis phases that read this, so a false value
+     * means the annotation was absent from everything parsed so far. The flag is only ever
+     * set, never cleared, so in a long-lived CodeBase (daemon mode, the language server, or
+     * an incremental reparse) it can stay true after edits remove the last occurrence. That
+     * is deliberate: a stale true only costs the work this flag is meant to skip, while a
+     * stale false would change analysis results.
+     *
+     * Used to skip a per-parameter walk over ancestor methods that can only find something
+     * when the annotation is actually used.
      * @see \Phan\Language\Element\FunctionTrait::addParamToScopeOfFunctionOrMethod()
      */
     public function sawMandatoryParamAnnotation(): bool

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -183,6 +183,12 @@ class CodeBase
     private $should_hydrate_requested_elements = false;
 
     /**
+     * @var bool
+     * True if any doc comment parsed into this CodeBase used `@phan-mandatory-param`.
+     */
+    private $saw_mandatory_param_annotation = false;
+
+    /**
      * @var UndoTracker|null - undoes the addition of global constants, classes, functions, and methods.
      */
     private $undo_tracker;
@@ -334,6 +340,31 @@ class CodeBase
     public function shouldHydrateRequestedElements(): bool
     {
         return $this->should_hydrate_requested_elements;
+    }
+
+    /**
+     * Record that a parsed doc comment used `@phan-mandatory-param`.
+     *
+     * Called while parsing doc comments.
+     * @internal
+     */
+    public function recordSawMandatoryParamAnnotation(): void
+    {
+        $this->saw_mandatory_param_annotation = true;
+    }
+
+    /**
+     * Did any doc comment in this CodeBase use `@phan-mandatory-param`?
+     *
+     * Doc comments are parsed during the parse phase, which finishes before the analysis
+     * phases that read this, so by then this is true if and only if the annotation occurs
+     * somewhere in the parsed codebase. Used to skip a per-parameter walk over ancestor
+     * methods that can only find something when the annotation is actually used.
+     * @see \Phan\Language\Element\FunctionTrait::addParamToScopeOfFunctionOrMethod()
+     */
+    public function sawMandatoryParamAnnotation(): bool
+    {
+        return $this->saw_mandatory_param_annotation;
     }
 
     /**

--- a/src/Phan/Internal/InternalStubCacheEntry.php
+++ b/src/Phan/Internal/InternalStubCacheEntry.php
@@ -29,6 +29,8 @@ final class InternalStubCacheEntry
      * @param list<GlobalConstant> $global_constants
      * @param list<string> $file_level_suppressions
      * @param array<string,array{methods:list<Method>,properties:list<Property>,constants:list<ClassConstant>}> $class_members
+     * @param bool $saw_mandatory_param_annotation whether any cached function or method
+     *        documents a `@phan-mandatory-param`, so that replaying can restore the marker.
      */
     public function __construct(
         private string $hash,
@@ -37,7 +39,8 @@ final class InternalStubCacheEntry
         private array $functions,
         private array $global_constants,
         private array $file_level_suppressions,
-        private array $class_members
+        private array $class_members,
+        private bool $saw_mandatory_param_annotation = false
     ) {
     }
 
@@ -78,6 +81,13 @@ final class InternalStubCacheEntry
             foreach ($members['methods'] as $method) {
                 $code_base->addMethod(clone $method);
             }
+        }
+        // Replaying elements skips Comment\Builder, so any `@phan-mandatory-param` in this
+        // stub would otherwise go unnoticed by the new CodeBase, and methods overriding a
+        // cached stub method would stop inheriting the mandatory parameter.
+        // @see \Phan\Language\Element\FunctionTrait::addParamToScopeOfFunctionOrMethod()
+        if ($this->saw_mandatory_param_annotation) {
+            $code_base->recordSawMandatoryParamAnnotation();
         }
         $file = $this->context->getFile();
         foreach ($this->file_level_suppressions as $issue_type) {

--- a/src/Phan/Language/Element/Comment/Builder.php
+++ b/src/Phan/Language/Element/Comment/Builder.php
@@ -215,6 +215,10 @@ final class Builder
             $is_output_parameter = str_contains($line, '@phan-output-reference');
             $is_ignored_parameter = str_contains($line, '@phan-ignore-reference');
             $is_mandatory_in_phpdoc = str_contains($line, '@phan-mandatory-param');
+            if ($is_mandatory_in_phpdoc) {
+                // @phan-suppress-next-line PhanAccessMethodInternal
+                $this->code_base->recordSawMandatoryParamAnnotation();
+            }
 
             return new Parameter(
                 $variable_name,

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -878,7 +878,11 @@ trait FunctionTrait
         }
 
         // Check overridden methods (from parent classes/interfaces) for @phan-mandatory-param
-        if (!$is_mandatory_in_phpdoc && $function instanceof Method) {
+        //
+        // This walk runs for every parameter of every method, so skip it entirely when the
+        // annotation does not occur anywhere in the parsed codebase - in that case it cannot
+        // find anything. Parsing is complete before this runs, so the flag is final here.
+        if (!$is_mandatory_in_phpdoc && $function instanceof Method && $code_base->sawMandatoryParamAnnotation()) {
             foreach ($function->getOverriddenMethods($code_base) as $overridden_method) {
                 $overridden_comment = $overridden_method->getComment();
                 if ($overridden_comment && $overridden_comment->hasParameterWithNameOrOffset($parameter_name, $parameter_offset)) {

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -1207,9 +1207,15 @@ class UnionType implements Serializable, Stringable
      */
     public function hasTemplateTypeRecursive(): bool
     {
-        return $this->hasTypeMatchingCallback(static function (Type $type): bool {
-            return $type->hasTemplateTypeRecursive();
-        });
+        // Inlined instead of hasTypeMatchingCallback() to avoid allocating a closure.
+        // Method::checkForTemplateTypes() calls this once per parameter of every
+        // method in the codebase, so the allocation is measurable.
+        foreach ($this->type_set as $type) {
+            if ($type->hasTemplateTypeRecursive()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/tests/Phan/InternalStubCacheTest.php
+++ b/tests/Phan/InternalStubCacheTest.php
@@ -51,6 +51,9 @@ final class InternalStubCacheTest extends TestCase
      * Replaying a cached stub does not re-parse doc comments, so the cache entry has to carry
      * the `@phan-mandatory-param` marker over to the new CodeBase. Without that, a method
      * overriding a cached stub method would silently stop inheriting the mandatory parameter.
+     *
+     * @throws \InvalidArgumentException
+     * @throws \Phan\Exception\FQSENException
      */
     public function testInternalStubCacheRestoresMandatoryParamMarker(): void
     {

--- a/tests/Phan/InternalStubCacheTest.php
+++ b/tests/Phan/InternalStubCacheTest.php
@@ -46,4 +46,54 @@ final class InternalStubCacheTest extends TestCase
             Analysis::clearInternalStubCache();
         }
     }
+
+    /**
+     * Replaying a cached stub does not re-parse doc comments, so the cache entry has to carry
+     * the `@phan-mandatory-param` marker over to the new CodeBase. Without that, a method
+     * overriding a cached stub method would silently stop inheriting the mandatory parameter.
+     */
+    public function testInternalStubCacheRestoresMandatoryParamMarker(): void
+    {
+        Analysis::clearInternalStubCache();
+        $stub_file = \tempnam(\sys_get_temp_dir(), 'phan_stub_cache_mandatory_');
+        if ($stub_file === false) {
+            $this->fail('Failed to create a temporary stub file for cache test');
+        }
+        \file_put_contents($stub_file, <<<'PHP'
+<?php
+class StubCacheMandatoryExample
+{
+    /**
+     * @param ?string $value @phan-mandatory-param
+     */
+    public function withMandatoryParam($value = null)
+    {
+    }
+}
+PHP);
+
+        try {
+            $first_code_base = new CodeBase([], [], [], [], []);
+            Analysis::parseFile($first_code_base, $stub_file, false, null, true);
+            $this->assertTrue(
+                $first_code_base->sawMandatoryParamAnnotation(),
+                'Parsing the stub should record the @phan-mandatory-param marker'
+            );
+
+            $second_code_base = new CodeBase([], [], [], [], []);
+            Analysis::parseFile($second_code_base, $stub_file, false, null, true);
+            $this->assertSame(
+                1,
+                Analysis::getInternalStubCacheStats()['hits'],
+                'Second parse should have been served from the stub cache'
+            );
+            $this->assertTrue(
+                $second_code_base->sawMandatoryParamAnnotation(),
+                'Replaying a cached stub must restore the @phan-mandatory-param marker'
+            );
+        } finally {
+            @\unlink($stub_file);
+            Analysis::clearInternalStubCache();
+        }
+    }
 }


### PR DESCRIPTION
Avoid a closure allocation in `UnionType::hasTemplateTypeRecursive()`

`Method::checkForTemplateTypes()` calls this once per parameter of every method in
the codebase, plus once each for the return type and the comment parameters, so
it is one of the most frequently called predicates in the serial "method"
analysis phase. Inline the loop instead of allocating a closure to pass to
`hasTypeMatchingCallback()`.

Semantically identical: the same iteration over the same type_set with the same
short-circuit.

Skip the `@phan-mandatory-param` ancestor walk when the annotation is unused

`FunctionTrait::addParamToScopeOfFunctionOrMethod()` runs once per parameter of
every method and loops over every overridden method in the class hierarchy for
the sole purpose of looking for @phan-mandatory-param. Record on the CodeBase
whether any parsed doc comment used that annotation, and skip the loop when
none did - it provably cannot find anything in that case.

Doc comments are parsed during the parse phase, which completes before the
analysis phases that read the flag, so the value is final by the time it is
used.

Note the win is modest: `Method::getOverriddenMethods()` memoizes, and
`ParameterTypesAnalyzer` calls it regardless, so the ancestor walk and the
`ensureScopeInitialized()` cascade still happen - this removes the repeated
memo lookups and comment probes, not the walk itself.